### PR TITLE
[release-0.59]Indicate resource quota rejection

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -723,6 +723,13 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - ""
+          resources:
+          - resourcequotas
+          verbs:
+          - list
+          - watch
+        - apiGroups:
           - route.openshift.io
           resources:
           - routes

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -642,6 +642,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -297,6 +297,8 @@ type KubeInformerFactory interface {
 	// Pod returns an informer for ALL Pods in the system
 	Pod() cache.SharedIndexInformer
 
+	ResourceQuota() cache.SharedIndexInformer
+
 	K8SInformerFactory() informers.SharedInformerFactory
 }
 
@@ -1268,6 +1270,13 @@ func (f *kubeInformerFactory) Pod() cache.SharedIndexInformer {
 	return f.getInformer("podInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "pods", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &k8sv1.Pod{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	})
+}
+
+func (f *kubeInformerFactory) ResourceQuota() cache.SharedIndexInformer {
+	return f.getInformer("resourceQuotaInformer", func() cache.SharedIndexInformer {
+		lw := cache.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "resourcequotas", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &k8sv1.ResourceQuota{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -200,6 +200,7 @@ type VirtControllerApp struct {
 	vmRestoreInformer            cache.SharedIndexInformer
 	storageClassInformer         cache.SharedIndexInformer
 	allPodInformer               cache.SharedIndexInformer
+	resourceQuotaInformer        cache.SharedIndexInformer
 
 	crdInformer cache.SharedIndexInformer
 
@@ -383,6 +384,7 @@ func Execute() {
 	app.unmanagedSecretInformer = app.informerFactory.UnmanagedSecrets()
 	app.allPodInformer = app.informerFactory.Pod()
 	app.exportServiceInformer = app.informerFactory.ExportService()
+	app.resourceQuotaInformer = app.informerFactory.ResourceQuota()
 
 	if app.hasCDI {
 		app.dataVolumeInformer = app.informerFactory.DataVolume()
@@ -622,6 +624,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.persistentVolumeClaimInformer,
 		vca.pdbInformer,
 		vca.migrationPolicyInformer,
+		vca.resourceQuotaInformer,
 		vca.vmiRecorder,
 		vca.clientSet,
 		vca.clusterConfig,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -92,6 +92,7 @@ var _ = Describe("Application", func() {
 		pdbInformer, _ := testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
 		migrationPolicyInformer, _ := testutils.NewFakeInformerFor(&migrationsv1.MigrationPolicy{})
 		podInformer, _ := testutils.NewFakeInformerFor(&kubev1.Pod{})
+		resourceQuotaInformer, _ := testutils.NewFakeInformerFor(&kubev1.ResourceQuota{})
 		pvcInformer, _ := testutils.NewFakeInformerFor(&kubev1.PersistentVolumeClaim{})
 		crInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 		dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
@@ -156,6 +157,7 @@ var _ = Describe("Application", func() {
 			pvcInformer,
 			pdbInformer,
 			migrationPolicyInformer,
+			resourceQuotaInformer,
 			recorder,
 			virtClient,
 			config,

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -335,7 +335,7 @@ func (c *MigrationController) execute(key string) error {
 		syncErr = c.sync(key, migration, vmi, targetPods)
 	}
 
-	err = c.updateStatus(migration, vmi, targetPods)
+	err = c.updateStatus(migration, vmi, targetPods, syncErr)
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func (c *MigrationController) canMigrateVMI(migration *virtv1.VirtualMachineInst
 
 }
 
-func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, pods []*k8sv1.Pod) error {
+func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, pods []*k8sv1.Pod, syncError error) error {
 
 	var pod *k8sv1.Pod = nil
 	var attachmentPod *k8sv1.Pod = nil
@@ -508,8 +508,18 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 				} else {
 					migrationCopy.Status.Phase = virtv1.MigrationScheduling
 				}
+			} else if syncError != nil && strings.Contains(syncError.Error(), "exceeded quota") && !conditionManager.HasCondition(migration, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota) {
+				condition := virtv1.VirtualMachineInstanceMigrationCondition{
+					Type:          virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota,
+					Status:        k8sv1.ConditionTrue,
+					LastProbeTime: v1.Now(),
+				}
+				migrationCopy.Status.Conditions = append(migrationCopy.Status.Conditions, condition)
 			}
 		case virtv1.MigrationScheduling:
+			if conditionManager.HasCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota) {
+				conditionManager.RemoveCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota)
+			}
 			if isPodReady(pod) {
 				if controller.VMIHasHotplugVolumes(vmi) {
 					if attachmentPodExists && isPodReady(attachmentPod) {

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -101,6 +101,7 @@ type MigrationController struct {
 	pdbInformer             cache.SharedIndexInformer
 	migrationPolicyInformer cache.SharedIndexInformer
 	namespaceStore          cache.Store
+	resourceQuotaInformer   cache.SharedIndexInformer
 	recorder                record.EventRecorder
 	podExpectations         *controller.UIDTrackingControllerExpectations
 	migrationStartLock      *sync.Mutex
@@ -126,6 +127,7 @@ func NewMigrationController(templateService services.TemplateService,
 	pvcInformer cache.SharedIndexInformer,
 	pdbInformer cache.SharedIndexInformer,
 	migrationPolicyInformer cache.SharedIndexInformer,
+	resourceQuotaInformer cache.SharedIndexInformer,
 	recorder record.EventRecorder,
 	clientset kubecli.KubevirtClient,
 	clusterConfig *virtconfig.ClusterConfig,
@@ -142,6 +144,7 @@ func NewMigrationController(templateService services.TemplateService,
 		nodeInformer:            nodeInformer,
 		pvcInformer:             pvcInformer,
 		pdbInformer:             pdbInformer,
+		resourceQuotaInformer:   resourceQuotaInformer,
 		migrationPolicyInformer: migrationPolicyInformer,
 		recorder:                recorder,
 		clientset:               clientset,
@@ -180,6 +183,11 @@ func NewMigrationController(templateService services.TemplateService,
 		UpdateFunc: c.updatePDB,
 	})
 
+	c.resourceQuotaInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: c.updateResourceQuota,
+		DeleteFunc: c.deleteResourceQuota,
+	})
+
 	return c
 }
 
@@ -189,8 +197,7 @@ func (c *MigrationController) Run(threadiness int, stopCh <-chan struct{}) {
 	log.Log.Info("Starting migration controller.")
 
 	// Wait for cache sync before we start the pod controller
-	cache.WaitForCacheSync(stopCh, c.vmiInformer.HasSynced, c.podInformer.HasSynced, c.migrationInformer.HasSynced, c.pdbInformer.HasSynced)
-
+	cache.WaitForCacheSync(stopCh, c.vmiInformer.HasSynced, c.podInformer.HasSynced, c.migrationInformer.HasSynced, c.pdbInformer.HasSynced, c.resourceQuotaInformer.HasSynced)
 	// Start the actual work
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
@@ -1414,6 +1421,46 @@ func (c *MigrationController) updatePod(old, cur interface{}) {
 	}
 	log.Log.V(4).Object(curPod).Infof("Pod updated")
 	c.enqueueMigration(migration)
+	return
+}
+
+// When a resourceQuota is updated, figure out if there are pending migration in the namespace
+// if there are we should push them into the queue to accelerate the target creation process
+func (c *MigrationController) updateResourceQuota(_, cur interface{}) {
+	curResourceQuota := cur.(*k8sv1.ResourceQuota)
+	log.Log.V(4).Object(curResourceQuota).Infof("ResourceQuota updated")
+	objs, _ := c.migrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, curResourceQuota.Namespace)
+	for _, obj := range objs {
+		migration := obj.(*virtv1.VirtualMachineInstanceMigration)
+		if migration.Status.Conditions == nil {
+			continue
+		}
+		for _, cond := range migration.Status.Conditions {
+			if cond.Type == virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota {
+				c.enqueueMigration(migration)
+			}
+		}
+	}
+	return
+}
+
+// When a resourceQuota is deleted, figure out if there are pending migration in the namespace
+// if there are we should push them into the queue to accelerate the target creation process
+func (c *MigrationController) deleteResourceQuota(obj interface{}) {
+	resourceQuota := obj.(*k8sv1.ResourceQuota)
+	log.Log.V(4).Object(resourceQuota).Infof("ResourceQuota deleted")
+	objs, _ := c.migrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, resourceQuota.Namespace)
+	for _, obj := range objs {
+		migration := obj.(*virtv1.VirtualMachineInstanceMigration)
+		if migration.Status.Conditions == nil {
+			continue
+		}
+		for _, cond := range migration.Status.Conditions {
+			if cond.Type == virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota {
+				c.enqueueMigration(migration)
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Migration watcher", func() {
 	var pdbInformer cache.SharedIndexInformer
 	var migrationPolicyInformer cache.SharedIndexInformer
 	var namespaceStore cache.Store
+	var resourceQuotaInformer cache.SharedIndexInformer
 	var stop chan struct{}
 	var controller *MigrationController
 	var recorder *record.FakeRecorder
@@ -260,6 +261,7 @@ var _ = Describe("Migration watcher", func() {
 		go nodeInformer.Run(stop)
 		go pdbInformer.Run(stop)
 		go migrationPolicyInformer.Run(stop)
+		go resourceQuotaInformer.Run(stop)
 
 		Expect(cache.WaitForCacheSync(stop,
 			vmiInformer.HasSynced,
@@ -267,7 +269,9 @@ var _ = Describe("Migration watcher", func() {
 			migrationInformer.HasSynced,
 			nodeInformer.HasSynced,
 			pdbInformer.HasSynced,
+			resourceQuotaInformer.HasSynced,
 			migrationPolicyInformer.HasSynced)).To(BeTrue())
+
 	}
 
 	initController := func(kvConfig *virtv1.KubeVirtConfiguration) {
@@ -282,6 +286,7 @@ var _ = Describe("Migration watcher", func() {
 			pvcInformer,
 			pdbInformer,
 			migrationPolicyInformer,
+			resourceQuotaInformer,
 			recorder,
 			virtClient,
 			config,
@@ -305,6 +310,7 @@ var _ = Describe("Migration watcher", func() {
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		pdbInformer, _ = testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
+		resourceQuotaInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		migrationPolicyInformer, _ = testutils.NewFakeInformerFor(&migrationsv1.MigrationPolicy{})
 		namespaceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 		recorder = record.NewFakeRecorder(100)

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -504,6 +504,18 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"get",
 				},
 			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"resourcequotas",
+				},
+				Verbs: []string{
+					"list",
+					"watch",
+				},
+			},
 		},
 	}
 }

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -506,7 +506,7 @@ type VirtualMachineInstanceMigrationConditionType string
 // These are valid conditions of VMIs.
 const (
 	// VirtualMachineInstanceMigrationAbortRequested indicates that live migration abort has been requested
-	VirtualMachineInstanceMigrationAbortRequested VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
+	VirtualMachineInstanceMigrationAbortRequested          VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
 	VirtualMachineInstanceMigrationRejectedByResourceQuota VirtualMachineInstanceMigrationConditionType = "migrationRejectedByResourceQuota"
 )
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -507,6 +507,7 @@ type VirtualMachineInstanceMigrationConditionType string
 const (
 	// VirtualMachineInstanceMigrationAbortRequested indicates that live migration abort has been requested
 	VirtualMachineInstanceMigrationAbortRequested VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
+	VirtualMachineInstanceMigrationRejectedByResourceQuota VirtualMachineInstanceMigrationConditionType = "migrationRejectedByResourceQuota"
 )
 
 type VirtualMachineInstanceCondition struct {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -25,11 +25,13 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnet/service"
 
@@ -4509,7 +4511,64 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 		})
 	})
+	Context("ResourceQuota rejection", func() {
+		It("Should contain condition when migrating with quota that doesn't have resources for both source and target", func() {
+			vmiRequest := resource.MustParse("200Mi")
+			vmi := libvmi.NewCirros(
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithResourceMemory(vmiRequest.String()),
+			)
+
+			vmiRequest.Add(resource.MustParse("50Mi")) //add 50Mi memoryOverHead to make sure vmi creation won't be blocked
+			enoughMemoryToStartVmiButNotEnoughForMigration := services.GetMemoryOverhead(vmi, runtime.GOARCH, nil)
+			enoughMemoryToStartVmiButNotEnoughForMigration.Add(vmiRequest)
+			resourcesToLimit := k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse(enoughMemoryToStartVmiButNotEnoughForMigration.String()),
+			}
+
+			By("Creating ResourceQuota with enough memory for the vmi but not enough for migration")
+			resourceQuota := newResourceQuota(resourcesToLimit, testsuite.GetTestNamespace(vmi))
+			_ = createResourceQuota(resourceQuota)
+
+			By("Starting the VirtualMachineInstance")
+			_ = tests.RunVMIAndExpectLaunch(vmi, 240)
+
+			By("Trying to migrate the VirtualMachineInstance")
+			migration := tests.NewRandomMigration(vmi.Name, testsuite.GetTestNamespace(vmi))
+			migration = tests.RunMigration(virtClient, migration)
+			Eventually(func() *v1.VirtualMachineInstanceMigration {
+				migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+				if err != nil {
+					return nil
+				}
+				return migration
+			}, 60*time.Second, 1*time.Second).Should(HaveConditionTrue(v1.VirtualMachineInstanceMigrationRejectedByResourceQuota))
+		})
+	})
 })
+
+func createResourceQuota(resourceQuota *k8sv1.ResourceQuota) *k8sv1.ResourceQuota {
+	virtCli := kubevirt.Client()
+
+	var obj *k8sv1.ResourceQuota
+	var err error
+	obj, err = virtCli.CoreV1().ResourceQuotas(resourceQuota.Namespace).Create(context.Background(), resourceQuota, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	return obj
+}
+
+func newResourceQuota(hardResourcesLimitation k8sv1.ResourceList, namespace string) *k8sv1.ResourceQuota {
+	return &k8sv1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test-quota",
+		},
+		Spec: k8sv1.ResourceQuotaSpec{
+			Hard: hardResourcesLimitation,
+		},
+	}
+}
 
 func fedoraVMIWithEvictionStrategy() *v1.VirtualMachineInstance {
 	vmi := tests.NewRandomFedoraVMIWithGuestAgent()

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -146,6 +146,17 @@ func CleanNamespaces() {
 			Expect(err).ToNot(HaveOccurred())
 		}
 
+		// Remove all ResourceQuota
+		rqList, err := virtCli.CoreV1().ResourceQuotas(namespace).List(context.Background(), metav1.ListOptions{})
+		util.PanicOnError(err)
+		for _, rq := range rqList.Items {
+			err := virtCli.CoreV1().ResourceQuotas(namespace).Delete(context.Background(), rq.Name, metav1.DeleteOptions{})
+			if errors.IsNotFound(err) {
+				continue
+			}
+			Expect(err).ToNot(HaveOccurred())
+		}
+
 		// Remove PVCs
 		util.PanicOnError(virtCli.CoreV1().RESTClient().Delete().Namespace(namespace).Resource("persistentvolumeclaims").Do(context.Background()).Error())
 		if libstorage.HasCDI() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backport PR of: https://github.com/kubevirt/kubevirt/pull/9738
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add condition to migrations that indicates that migration was rejected by ResourceQuot
```
