### PR TITLE
build virtctl also for arm64 for linux, darwin and windows

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -363,6 +363,26 @@ genrule(
 )
 
 genrule(
+    name = "build-virtctl-arm64",
+    srcs = [
+        "//cmd/virtctl:virtctl-arm64",
+    ],
+    outs = ["virtctl-copier-arm64"],
+    cmd = "echo '#!/bin/sh\n\ncp -f $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)
+
+genrule(
+    name = "build-virtctl-darwin-arm64",
+    srcs = [
+        "//cmd/virtctl:virtctl-darwin-arm64",
+    ],
+    outs = ["virtctl-copier-darwin-arm64"],
+    cmd = "echo '#!/bin/sh\n\ncp -f $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)
+
+genrule(
     name = "build-ginkgo",
     srcs = [
         "//vendor/github.com/onsi/ginkgo/v2/ginkgo",

--- a/cmd/virtctl/BUILD.bazel
+++ b/cmd/virtctl/BUILD.bazel
@@ -46,3 +46,21 @@ go_binary(
     visibility = ["//visibility:public"],
     x_defs = version_x_defs(),
 )
+
+go_binary(
+    name = "virtctl-arm64",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "linux",
+    visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
+)
+
+go_binary(
+    name = "virtctl-darwin-arm64",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "darwin",
+    visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
+)

--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -65,17 +65,25 @@ bazel run \
     --config=${HOST_ARCHITECTURE} \
     :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl
 
-# cross-compile virtctl for
+# compile virtctl for amd64 and arm64
 
 # linux
 bazel run \
     --config=${HOST_ARCHITECTURE} \
     :build-virtctl-amd64 -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-linux-amd64
 
+bazel run \
+    --config=${HOST_ARCHITECTURE} \
+    :build-virtctl-arm64 -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-linux-arm64
+
 # darwin
 bazel run \
     --config=${HOST_ARCHITECTURE} \
     :build-virtctl-darwin -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-darwin-amd64
+
+bazel run \
+    --config=${HOST_ARCHITECTURE} \
+    :build-virtctl-darwin-arm64 -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-darwin-arm64
 
 # windows
 bazel run \

--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -62,30 +62,24 @@ bazel run \
 
 # build platform native virtctl explicitly
 bazel run \
-    --config=${HOST_ARCHITECTURE} \
     :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl
 
 # compile virtctl for amd64 and arm64
 
 # linux
 bazel run \
-    --config=${HOST_ARCHITECTURE} \
     :build-virtctl-amd64 -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-linux-amd64
 
 bazel run \
-    --config=${HOST_ARCHITECTURE} \
     :build-virtctl-arm64 -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-linux-arm64
 
 # darwin
 bazel run \
-    --config=${HOST_ARCHITECTURE} \
     :build-virtctl-darwin -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-darwin-amd64
 
 bazel run \
-    --config=${HOST_ARCHITECTURE} \
     :build-virtctl-darwin-arm64 -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-darwin-arm64
 
 # windows
 bazel run \
-    --config=${HOST_ARCHITECTURE} \
     :build-virtctl-windows -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-windows-amd64.exe

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -126,11 +126,14 @@ for arg in $args; do
             kubevirt::version::get_version_vars
             echo "$KUBEVIRT_GIT_VERSION" >${CMD_OUT_DIR}/${BIN_NAME}/.version
 
-            # build virtctl also for darwin and windows on amd64
+            # build virtctl also for darwin and windows and for arm64 when on amd64 on linux
             if [ "${BIN_NAME}" = "virtctl" -a "${ARCH}" = "amd64" -a -z "${LINUX_ONLY}" ]; then
                 GOOS=darwin GOARCH=amd64 go_build -tags "${KUBEVIRT_GO_BUILD_TAGS}" -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin amd64)
                 GOOS=windows GOARCH=amd64 go_build -tags "${KUBEVIRT_GO_BUILD_TAGS}" -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir windows amd64)
-                # Create symlinks to the latest binary of each architecture
+                GOOS=linux GOARCH=arm64 go_build -tags "${KUBEVIRT_GO_BUILD_TAGS}" -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-linux-arm64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux arm64)
+                GOOS=windows GOARCH=arm64 go_build -tags "${KUBEVIRT_GO_BUILD_TAGS}" -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-arm64.exe -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir windows arm64)
+                GOOS=darwin GOARCH=arm64 go_build -tags "${KUBEVIRT_GO_BUILD_TAGS}" -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-arm64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin arm64)
+                # Create symlinks to the latest binary of amd64 architecture
                 (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCH_BASENAME}-darwin-amd64 ${BIN_NAME}-darwin)
                 (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCH_BASENAME}-windows-amd64.exe ${BIN_NAME}-windows.exe)
             fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When we build on linux on amd64 we are already
building virtctl also for darwin and windows
OSs but still only for amd64.
But client architecture could differ the cluster ones.

kubectl for instance is shipped for linux, darwin
and windows in both amd64 and arm64 architectures. Check as a reference:
- https://dl.k8s.io/release/v1.27.2/bin/linux/amd64/kubectl
- https://dl.k8s.io/release/v1.27.0/bin/linux/arm64/kubectl
- https://dl.k8s.io/release/v1.27.2/bin/darwin/amd64/kubectl
- https://dl.k8s.io/release/v1.27.2/bin/darwin/arm64/kubectl
- https://dl.k8s.io/release/v1.27.2/bin/windows/amd64/kubectl.exe
- https://dl.k8s.io/release/v1.27.2/bin/windows/arm64/kubectl.exe

Let's start taking the same approach for virtctl.

Address also the `bazel` based release process. Thanks @zhlhahaha

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
build virtctl also for arm64 for linux, darwin and windows
```
