### PR TITLE
Revert "[Migration-Controller]Indicate resource quota rejection"

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -748,13 +748,6 @@ spec:
           verbs:
           - get
         - apiGroups:
-          - ""
-          resources:
-          - resourcequotas
-          verbs:
-          - list
-          - watch
-        - apiGroups:
           - route.openshift.io
           resources:
           - routes

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -676,13 +676,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - ""
-  resources:
-  - resourcequotas
-  verbs:
-  - list
-  - watch
-- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -297,8 +297,6 @@ type KubeInformerFactory interface {
 	// Pod returns an informer for ALL Pods in the system
 	Pod() cache.SharedIndexInformer
 
-	ResourceQuota() cache.SharedIndexInformer
-
 	K8SInformerFactory() informers.SharedInformerFactory
 }
 
@@ -1270,13 +1268,6 @@ func (f *kubeInformerFactory) Pod() cache.SharedIndexInformer {
 	return f.getInformer("podInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "pods", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &k8sv1.Pod{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	})
-}
-
-func (f *kubeInformerFactory) ResourceQuota() cache.SharedIndexInformer {
-	return f.getInformer("resourceQuotaInformer", func() cache.SharedIndexInformer {
-		lw := cache.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "resourcequotas", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &k8sv1.ResourceQuota{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -199,7 +199,6 @@ type VirtControllerApp struct {
 	vmRestoreInformer            cache.SharedIndexInformer
 	storageClassInformer         cache.SharedIndexInformer
 	allPodInformer               cache.SharedIndexInformer
-	resourceQuotaInformer        cache.SharedIndexInformer
 
 	crdInformer cache.SharedIndexInformer
 
@@ -386,7 +385,6 @@ func Execute() {
 	app.unmanagedSecretInformer = app.informerFactory.UnmanagedSecrets()
 	app.allPodInformer = app.informerFactory.Pod()
 	app.exportServiceInformer = app.informerFactory.ExportService()
-	app.resourceQuotaInformer = app.informerFactory.ResourceQuota()
 
 	if app.hasCDI {
 		app.dataVolumeInformer = app.informerFactory.DataVolume()
@@ -635,7 +633,6 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.persistentVolumeClaimInformer,
 		vca.pdbInformer,
 		vca.migrationPolicyInformer,
-		vca.resourceQuotaInformer,
 		vca.vmiRecorder,
 		vca.clientSet,
 		vca.clusterConfig,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -92,7 +92,6 @@ var _ = Describe("Application", func() {
 		pdbInformer, _ := testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
 		migrationPolicyInformer, _ := testutils.NewFakeInformerFor(&migrationsv1.MigrationPolicy{})
 		podInformer, _ := testutils.NewFakeInformerFor(&kubev1.Pod{})
-		resourceQuotaInformer, _ := testutils.NewFakeInformerFor(&kubev1.ResourceQuota{})
 		pvcInformer, _ := testutils.NewFakeInformerFor(&kubev1.PersistentVolumeClaim{})
 		crInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 		dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
@@ -155,7 +154,6 @@ var _ = Describe("Application", func() {
 			pvcInformer,
 			pdbInformer,
 			migrationPolicyInformer,
-			resourceQuotaInformer,
 			recorder,
 			virtClient,
 			config,

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -82,7 +82,6 @@ var _ = Describe("Migration watcher", func() {
 	var nodeInformer cache.SharedIndexInformer
 	var pdbInformer cache.SharedIndexInformer
 	var migrationPolicyInformer cache.SharedIndexInformer
-	var resourceQuotaInformer cache.SharedIndexInformer
 	var stop chan struct{}
 	var controller *MigrationController
 	var recorder *record.FakeRecorder
@@ -276,7 +275,6 @@ var _ = Describe("Migration watcher", func() {
 		go nodeInformer.Run(stop)
 		go pdbInformer.Run(stop)
 		go migrationPolicyInformer.Run(stop)
-		go resourceQuotaInformer.Run(stop)
 
 		Expect(cache.WaitForCacheSync(stop,
 			vmiInformer.HasSynced,
@@ -284,9 +282,7 @@ var _ = Describe("Migration watcher", func() {
 			migrationInformer.HasSynced,
 			nodeInformer.HasSynced,
 			pdbInformer.HasSynced,
-			resourceQuotaInformer.HasSynced,
 			migrationPolicyInformer.HasSynced)).To(BeTrue())
-
 	}
 
 	initController := func(kvConfig *virtv1.KubeVirtConfiguration) {
@@ -301,7 +297,6 @@ var _ = Describe("Migration watcher", func() {
 			pvcInformer,
 			pdbInformer,
 			migrationPolicyInformer,
-			resourceQuotaInformer,
 			recorder,
 			virtClient,
 			config,
@@ -323,7 +318,6 @@ var _ = Describe("Migration watcher", func() {
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		pdbInformer, _ = testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
-		resourceQuotaInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		migrationPolicyInformer, _ = testutils.NewFakeInformerFor(&migrationsv1.MigrationPolicy{})
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -516,18 +516,6 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"get",
 				},
 			},
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"resourcequotas",
-				},
-				Verbs: []string{
-					"list",
-					"watch",
-				},
-			},
 		},
 	}
 }

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -535,8 +535,7 @@ type VirtualMachineInstanceMigrationConditionType string
 // These are valid conditions of VMIs.
 const (
 	// VirtualMachineInstanceMigrationAbortRequested indicates that live migration abort has been requested
-	VirtualMachineInstanceMigrationAbortRequested          VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
-	VirtualMachineInstanceMigrationRejectedByResourceQuota VirtualMachineInstanceMigrationConditionType = "migrationRejectedByResourceQuota"
+	VirtualMachineInstanceMigrationAbortRequested VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
 )
 
 type VirtualMachineInstanceCondition struct {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -27,13 +27,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
@@ -4624,64 +4622,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 		})
 	})
-	Context("ResourceQuota rejection", func() {
-		It("Should contain condition when migrating with quota that doesn't have resources for both source and target", func() {
-			vmiRequest := resource.MustParse("200Mi")
-			vmi := libvmi.NewCirros(
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-				libvmi.WithResourceMemory(vmiRequest.String()),
-			)
-
-			vmiRequest.Add(resource.MustParse("50Mi")) //add 50Mi memoryOverHead to make sure vmi creation won't be blocked
-			enoughMemoryToStartVmiButNotEnoughForMigration := services.GetMemoryOverhead(vmi, runtime.GOARCH, nil)
-			enoughMemoryToStartVmiButNotEnoughForMigration.Add(vmiRequest)
-			resourcesToLimit := k8sv1.ResourceList{
-				k8sv1.ResourceMemory: resource.MustParse(enoughMemoryToStartVmiButNotEnoughForMigration.String()),
-			}
-
-			By("Creating ResourceQuota with enough memory for the vmi but not enough for migration")
-			resourceQuota := newResourceQuota(resourcesToLimit, testsuite.GetTestNamespace(vmi))
-			_ = createResourceQuota(resourceQuota)
-
-			By("Starting the VirtualMachineInstance")
-			_ = tests.RunVMIAndExpectLaunch(vmi, 240)
-
-			By("Trying to migrate the VirtualMachineInstance")
-			migration := tests.NewRandomMigration(vmi.Name, testsuite.GetTestNamespace(vmi))
-			migration = tests.RunMigration(virtClient, migration)
-			Eventually(func() *v1.VirtualMachineInstanceMigration {
-				migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
-				if err != nil {
-					return nil
-				}
-				return migration
-			}, 60*time.Second, 1*time.Second).Should(HaveConditionTrue(v1.VirtualMachineInstanceMigrationRejectedByResourceQuota))
-		})
-	})
 })
-
-func createResourceQuota(resourceQuota *k8sv1.ResourceQuota) *k8sv1.ResourceQuota {
-	virtCli := kubevirt.Client()
-
-	var obj *k8sv1.ResourceQuota
-	var err error
-	obj, err = virtCli.CoreV1().ResourceQuotas(resourceQuota.Namespace).Create(context.Background(), resourceQuota, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	return obj
-}
-
-func newResourceQuota(hardResourcesLimitation k8sv1.ResourceList, namespace string) *k8sv1.ResourceQuota {
-	return &k8sv1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "test-quota",
-		},
-		Spec: k8sv1.ResourceQuotaSpec{
-			Hard: hardResourcesLimitation,
-		},
-	}
-}
 
 func fedoraVMIWithEvictionStrategy() *v1.VirtualMachineInstance {
 	vmi := tests.NewRandomFedoraVMIWithGuestAgent()

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -170,17 +170,6 @@ func CleanNamespaces() {
 			Expect(err).ToNot(HaveOccurred())
 		}
 
-		// Remove all ResourceQuota
-		rqList, err := virtCli.CoreV1().ResourceQuotas(namespace).List(context.Background(), metav1.ListOptions{})
-		util.PanicOnError(err)
-		for _, rq := range rqList.Items {
-			err := virtCli.CoreV1().ResourceQuotas(namespace).Delete(context.Background(), rq.Name, metav1.DeleteOptions{})
-			if errors.IsNotFound(err) {
-				continue
-			}
-			Expect(err).ToNot(HaveOccurred())
-		}
-
 		// Remove PVCs
 		util.PanicOnError(virtCli.CoreV1().RESTClient().Delete().Namespace(namespace).Resource("persistentvolumeclaims").Do(context.Background()).Error())
 		if libstorage.HasCDI() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert PR of: https://github.com/kubevirt/kubevirt/pull/9738
The newly added informer is never started and operator is missing permissions. This was missed in reviews by me.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
