### PR TITLE
Fix quarantined tests that is failing 100% of the time

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1034,11 +1034,11 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			return dv
 		}
 		addThickProvisionedTrueAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-			dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "true"}
+			dv.Annotations["user.custom.annotation/storage.thick-provisioned"] = "true"
 			return dv
 		}
 		addThickProvisionedFalseAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-			dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "false"}
+			dv.Annotations["user.custom.annotation/storage.thick-provisioned"] = "false"
 			return dv
 		}
 		DescribeTable("[QUARANTINE][rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img", func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {


### PR DESCRIPTION
Don't override annotations, append to it. We now have a force bind annotation, and if we override it, the DV will wait for the first consumer and not succeed as the test expects.

**What this PR does / why we need it**:
I caused this regression with #9752 - it wasn't noticed because these tests are quarantined, and I only tested locally with a few of the tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
