### PR TITLE
feat(virtctl): build for mac arm64

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -353,6 +353,16 @@ genrule(
 )
 
 genrule(
+    name = "build-virtctl-darwin-arm64",
+    srcs = [
+        "//cmd/virtctl:virtctl-darwin-arm64",
+    ],
+    outs = ["virtctl-copier-darwin-arm64"],
+    cmd = "echo '#!/bin/sh\n\ncp -f $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)
+
+genrule(
     name = "build-virtctl-windows",
     srcs = [
         "//cmd/virtctl:virtctl-windows",

--- a/cmd/virtctl/BUILD.bazel
+++ b/cmd/virtctl/BUILD.bazel
@@ -39,6 +39,15 @@ go_binary(
 )
 
 go_binary(
+    name = "virtctl-darwin-arm64",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "darwin",
+    visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
+)
+
+go_binary(
     name = "virtctl-windows",
     embed = [":go_default_library"],
     goarch = "amd64",

--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -77,6 +77,11 @@ bazel run \
     --config=${HOST_ARCHITECTURE} \
     :build-virtctl-darwin -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-darwin-amd64
 
+# darwin arm64
+bazel run \
+    --config=${HOST_ARCHITECTURE} \
+    :build-virtctl-darwin-arm64 -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-darwin-arm64
+
 # windows
 bazel run \
     --config=${HOST_ARCHITECTURE} \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the necessary code to build and release `virtctl` for the `darwin-arm64` architecture for Macs with Apple Silicon. After running `make bazel-build` a new binary `virtctl-4d1925c86-darwin-arm64` is created that can be executed on a Mac with an Apple Silicon processor.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7305

Also related to #9253

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204723999139645