### PR TITLE
DHCPv6 server should handle request without iana option

### DIFF
--- a/pkg/network/dhcp/serverv6/serverv6.go
+++ b/pkg/network/dhcp/serverv6/serverv6.go
@@ -81,7 +81,7 @@ func (h *DHCPv6Handler) ServeDHCPv6(conn net.PacketConn, peer net.Addr, m dhcpv6
 	response, err := h.buildResponse(m)
 	if err != nil {
 		log.Log.Reason(err).Error("DHCPv6 failed building a response to the client")
-
+		return
 	}
 
 	if _, err := conn.WriteTo(response.ToBytes(), peer); err != nil {
@@ -113,9 +113,11 @@ func (h *DHCPv6Handler) buildResponse(msg dhcpv6.DHCPv6) (*dhcpv6.Message, error
 	}
 
 	ianaRequest := dhcpv6Msg.Options.OneIANA()
-	ianaResponse := response.Options.OneIANA()
-	ianaResponse.IaId = ianaRequest.IaId
-	response.UpdateOption(ianaResponse)
+	if ianaRequest != nil {
+		ianaResponse := response.Options.OneIANA()
+		ianaResponse.IaId = ianaRequest.IaId
+		response.UpdateOption(ianaResponse)
+	}
 	return response, nil
 }
 

--- a/pkg/network/dhcp/serverv6/serverv6_test.go
+++ b/pkg/network/dhcp/serverv6/serverv6_test.go
@@ -111,6 +111,16 @@ var _ = Describe("DHCPv6", func() {
 			expectedLength := len(handler.modifiers) + 1
 			Expect(replyMessage.Options.Options).To(HaveLen(expectedLength))
 		})
+		It("handle request without iana option", func() {
+			clientMac, _ := net.ParseMAC("34:56:78:9A:BC:DE")
+			duid := dhcpv6.Duid{Type: dhcpv6.DUID_LL, HwType: iana.HWTypeEthernet, LinkLayerAddr: clientMac}
+			clientMessage, err := dhcpv6.NewMessage(dhcpv6.WithClientID(duid))
+			Expect(err).ToNot(HaveOccurred())
+			clientMessage.MessageType = dhcpv6.MessageTypeInformationRequest
+
+			_, err = handler.buildResponse(clientMessage)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9843

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
DHCPv6 server handle request without iana option
```
