### PR TITLE
add patch of prometheusrule and servicemonitor

### DIFF
--- a/pkg/virt-operator/resource/apply/patches.go
+++ b/pkg/virt-operator/resource/apply/patches.go
@@ -148,6 +148,14 @@ func (c *Customizer) Apply(targetStrategy *install.Strategy) error {
 	if err != nil {
 		return err
 	}
+	err = c.GenericApplyPatches(targetStrategy.ServiceMonitors())
+	if err != nil {
+		return err
+	}
+	err = c.GenericApplyPatches(targetStrategy.PrometheusRules())
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With this PR, users can patch `PrometheusRules` and `ServiceMonitor` in `kubevirt` CRD via `spec.customizeComponents.patches`

```
apiVersion: kubevirt.io/v1
kind: KubeVirt
...
spec:
...
  customizeComponents:
    patches:
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/kubevirt/issues/9689

**Special notes for your reviewer**:

With this PR, via edit `kubevirt` like,
```
spec:
..
  customizeComponents:
    patches:
    - patch: '[{"op":"replace","path" : "/spec/groups/0/rules/37/expr","value":"((kube_pod_container_resource_requests{container=~\"virt-controller|virt-api|virt-handler|virt-operator\",namespace=\"harvester-system\",resource=\"memory\"})
        - on(pod) group_left(node) container_memory_working_set_bytes{container=~\"virt-controller|virt-api|virt-handler|virt-operator\",namespace=\"harvester-system\"})
        < 0"}]'
      resourceName: prometheus-kubevirt-rules
      resourceType: PrometheusRule
      type: json
 ```

We eliminate such complain in prometheus  (otherwise, it is reported each minute)

> ts=2023-06-02T20:12:58.528Z caller=manager.go:636 level=warn component="rule manager" file=/etc/prometheus/rules/prometheus-rancher-monitoring-prometheus-rulefiles-0/harvester-system-prometheus-kubevirt-rules-e77bab92-1a68-4d33-9658-f5875bfbc1ce.yaml group=kubevirt.rules name=KubeVirtComponentExceedsRequestedMemory index=37 msg="Evaluating rule failed" rule="alert: KubeVirtComponentExceedsRequestedMemory\nexpr: ((kube_pod_container_resource_requests{container=~\"virt-controller|virt-api|virt-handler|virt-operator\",namespace=\"harvester-system\",resource=\"memory\"})\n  - on (pod) group_left (node) container_memory_working_set_bytes{container=\"\",namespace=\"harvester-system\"})\n  < 0\nfor: 5m\nlabels:\n  kubernetes_operator_component: kubevirt\n  kubernetes_operator_part_of: kubevirt\n  severity: warning\nannotations:\n  description: Container {{ $labels.container }} in pod {{ $labels.pod }} memory usage\n    exceeds the memory requested\n  runbook_url: https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedMemory\n  summary: The container is using more memory than what is defined in the containers\n    resource requests\n" err="found duplicate series for the match group {pod=\"kube-vip-mq8nt\"} on the right hand-side of the operation: [{__name__=\"container_memory_working_set_bytes\", endpoint=\"https-metrics\", id=\"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod01ef6102_1027_4c4c_89d6_5f5c0159d3cd.slice/cri-containerd-2dcfa2af7d3fce0b202dfbe239d52cd398310ad22118a3f307ad33504f6169d6.scope\", image=\"docker.io/rancher/pause:3.6\", instance=\"192.168.122.141:10250\", job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", name=\"2dcfa2af7d3fce0b202dfbe239d52cd398310ad22118a3f307ad33504f6169d6\", namespace=\"harvester-system\", node=\"harv41\", pod=\"kube-vip-mq8nt\", service=\"rancher-monitoring-kubelet\"}, {__name__=\"container_memory_working_set_bytes\", endpoint=\"https-metrics\", id=\"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod01ef6102_1027_4c4c_89d6_5f5c0159d3cd.slice\", instance=\"192.168.122.141:10250\", job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", namespace=\"harvester-system\", node=\"harv41\", pod=\"kube-vip-mq8nt\", service=\"rancher-monitoring-kubelet\"}];many-to-many matching not allowed: matching labels must be unique on one side"

```
...
ts=2023-06-02T20:13:29.109Z caller=kubernetes.go:326 level=info component="discovery manager notify" discovery=kubernetes msg="Using pod service account via in-cluster config"
ts=2023-06-02T20:13:29.276Z caller=main.go:1218 level=info msg="Completed loading of configuration file" filename=/etc/prometheus/config_out/prometheus.env.yaml totalDuration=175.824395ms db_storage=652ns remote_storage=1.483µs web_handler=260ns query_engine=641ns scrape=1.856822ms scrape_sd=1.716689ms notify=14.346µs notify_sd=260.85µs rules=166.983007ms tracing=5.009µs
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

unit test:
```
//cmd/container-disk-v2alpha:go_default_test                    (cached) PASSED in 6.4s
//pkg/certificates:go_default_test                              (cached) PASSED in 0.1s
//pkg/certificates/bootstrap:go_default_test                    (cached) PASSED in 4.1s
...

//pkg/virtctl/vmexport:go_default_test                          (cached) PASSED in 0.1s
//pkg/watchdog:go_default_test                                  (cached) PASSED in 0.0s
//tests/framework/matcher:go_default_test                       (cached) PASSED in 0.2s

//pkg/virt-operator/resource/apply:go_default_test                       PASSED in 0.1s

Executed 1 out of 130 tests: 130 tests pass.
INFO: Build completed successfully, 187 total actions
```