### PR TITLE
[Bugfix][Evacuation Controller]: Make sure that the number of VMs to evacuate is never negative

### DIFF
--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -404,6 +404,8 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 	}
 
 	diff := int(math.Min(float64(freeSpots), float64(len(migrationCandidates))))
+	diff = int(math.Max(float64(diff), 0))
+
 	remaining := freeSpots - diff
 	remainingForNonMigrateableDiff := int(math.Min(float64(remaining), float64(len(nonMigrateable))))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Lately we encountered a bug where the number of VMs to evacuate was negative. This was probably caused by some kind of a race.

For example, if there are 123 migrations running on a node, and ParallelOutboundMigrationsPerNode is then changed to 1, than the free spots of migrations to create in this node is: `ParallelOutboundMigrationsPerNode-123 = 1-123 < 0`.

This should never happen. Therefore, this variable is always set to 0 if negative.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2212198

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bugfix][Evacuation Controller]: Make sure that the number of VMs to evacuate is never negative
```
