### PR TITLE
virt-api: dialer should wrap ipv6 address with square brackets to portfoward ipv6 VM

### DIFF
--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes/typed/authorization/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )
@@ -61,6 +62,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "authorizer_test.go",
+        "dialers_test.go",
         "expand_test.go",
         "interfacehotplug_test.go",
         "profiler_test.go",

--- a/pkg/virt-api/rest/dialers.go
+++ b/pkg/virt-api/rest/dialers.go
@@ -8,6 +8,7 @@ import (
 
 	restful "github.com/emicklei/go-restful/v3"
 	"k8s.io/apimachinery/pkg/api/errors"
+	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -69,6 +70,9 @@ func (n netDial) DialUnderlying(vmi *v1.VirtualMachineInstance) (net.Conn, *erro
 	}
 
 	addr := fmt.Sprintf("%s:%s", targetIP, port)
+	if netutils.IsIPv6String(targetIP) {
+		addr = fmt.Sprintf("[%s]:%s", targetIP, port)
+	}
 	conn, err := net.Dial(protocol, addr)
 	if err != nil {
 		logger.Reason(err).Errorf("Can't dial %s %s", protocol, addr)

--- a/pkg/virt-api/rest/dialers_test.go
+++ b/pkg/virt-api/rest/dialers_test.go
@@ -1,0 +1,88 @@
+package rest
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+
+	"github.com/emicklei/go-restful/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("NetDialer", func() {
+	const (
+		vmName      = "test-vm"
+		vmNamespace = "test-namespace"
+	)
+
+	var (
+		request *restful.Request
+	)
+
+	BeforeEach(func() {
+		httpReq := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/apis/subresources.kubevirt.io/v1alpha3/namespaces/%s/virtualmachineinstances/%s/ssh/22", vmNamespace, vmName), nil)
+		request = restful.NewRequest(httpReq)
+	})
+
+	makeVMIWithInterfaceStatus := func(interfaces []v1.VirtualMachineInstanceNetworkInterface) *v1.VirtualMachineInstance {
+		return &v1.VirtualMachineInstance{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vmName,
+				Namespace: vmNamespace,
+			},
+			Spec: v1.VirtualMachineInstanceSpec{},
+			Status: v1.VirtualMachineInstanceStatus{
+				Interfaces: interfaces,
+			},
+		}
+	}
+
+	It("Should fail if vmi has no network interfaces", func() {
+		dialer := netDial{
+			request: request,
+		}
+		_, statusErr := dialer.DialUnderlying(makeVMIWithInterfaceStatus(nil))
+		Expect(statusErr.Status().Message).To(Equal("no network interfaces are present"))
+	})
+
+	It("Should fail if request has no port", func() {
+		request.PathParameters()["port"] = ""
+		dialer := netDial{
+			request: request,
+		}
+		_, statusErr := dialer.DialUnderlying(makeVMIWithInterfaceStatus([]v1.VirtualMachineInstanceNetworkInterface{
+			{
+				IP: "192.168.0.1",
+			},
+		}))
+		Expect(statusErr.Status().Message).To(Equal("port must not be empty"))
+	})
+
+	DescribeTable("Should dial vmi", func(ipAddr string) {
+		ln, err := net.Listen("tcp", fmt.Sprintf("%s:0", ipAddr))
+		Expect(err).NotTo(HaveOccurred())
+		defer ln.Close()
+		tcpAddr := ln.Addr().(*net.TCPAddr)
+
+		request.PathParameters()["port"] = strconv.FormatInt(int64(tcpAddr.Port), 10)
+		dialer := netDial{
+			request: request,
+		}
+		conn, statusErr := dialer.DialUnderlying(makeVMIWithInterfaceStatus([]v1.VirtualMachineInstanceNetworkInterface{
+			{
+				IP: tcpAddr.IP.String(),
+			},
+		}))
+		Expect(statusErr).NotTo(HaveOccurred())
+		Expect(conn).NotTo(BeNil())
+	},
+		Entry("with ipv4 ip address", "127.0.0.1"),
+		Entry("with ipv6 ip address", "[::1]"),
+	)
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


Fixes #9850 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-api: portfowrad can handle IPv6 VM
```
