### PR TITLE
Assign writer to output file when downloading memory dump

### DIFF
--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -22,6 +22,7 @@ package memorydump
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -327,6 +328,12 @@ func downloadMemoryDump(namespace, vmName string, virtClient kubecli.KubevirtCli
 		Name:         vmexportName,
 		ExportSource: exportSource,
 	}
+	// User wants the output in a file, create
+	output, err := os.Create(vmExportInfo.OutputFile)
+	if err != nil {
+		return err
+	}
+	vmExportInfo.OutputWriter = output
 	return vmexport.DownloadVirtualMachineExport(virtClient, vmExportInfo)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Changes to the VM export download code caused an npe in memory dump download because the writer was not assigned. This PR properly sets the output writer. However it does not allow the output to be written to stdout like VM export download.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I would have loved to create a functional test for this particular case, but memory-dump doesn't take a `--service-url` flag like `vmexport download` does, so I can't even manually port-forward to test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
