### PR TITLE
[go-build] Build virtctl for all architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ client-python:
 	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} ./hack/gen-client-python/generate.sh"
 
 go-build:
-	hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
+	hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} KUBEVIRT_RELEASE=${KUBEVIRT_RELEASE} ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
 
 go-build-functests:
 	hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} ./hack/go-build-functests.sh"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With https://github.com/kubevirt/kubevirt/pull/9832 we start shipping arm64 version of virtctl.
This happens only if the building machine is amd64. Let's start doing it in arm64 machine too.

In order to save time during normal development, to generate all versions of virtctl it is necessary to set an environment variable (`KUBEVIRT_RELEASE`).
In other words, when `KUBEVIRT_RELEASE` is true build-go.sh will generate virtclt binary for linux/darwin/windows and amd64/arm64; otherwise the only version(os/arch) of the local machine will be generated.
When KUBEVIRT_RELEASE is true, the outcome will be:
```
virtctl -> virtctl-0.59.1-linux-amd64
virtctl-0.59.1-darwin-amd64
virtctl-0.59.1-linux-amd64
virtctl-0.59.1-windows-amd64.exe
virtctl-0.59.1-darwin-arm64
virtctl-0.59.1-linux-arm64
virtctl-0.59.1-windows-arm64.exe
virtctl-linux-amd64 -> virtctl-0.59.1-linux-amd64
virtctl-darwin-amd64 -> virtctl-0.59.1-darwin-amd64
virtctl-windows-amd64.exe -> virtctl-0.59.1-windows-amd64.exe
virtctl-linux-arm64 -> virtctl-0.59.1-linux-arm64
virtctl-darwin-arm64 -> virtctl-0.59.1-darwin-arm64
virtctl-windows-arm64.exe -> virtctl-0.59.1-windows-arm64.exe
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This work is limited to the native go build only.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
build virtctl for all os/architectures when `KUBEVIRT_RELEASE` env var is true
```

/cc @tiraboschi @rmohr @zhlhahaha 