### PR TITLE
Don't mount docker config if cred helpers are required

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -113,7 +113,7 @@ volumes="$volumes -v ${HOME}/.docker/secrets:/root/.docker/secrets:ro${selinux_b
 # Use a bind-mount to expose docker/podman auth file to the container
 if [[ $KUBEVIRT_CRI = podman* ]] && [[ -f "${XDG_RUNTIME_DIR}/containers/auth.json" ]]; then
     volumes="$volumes --mount type=bind,source=${XDG_RUNTIME_DIR}/containers/auth.json,target=/root/.docker/config.json,readonly"
-elif [[ -f "${HOME}/.docker/config.json" ]]; then
+elif [[ -f "${HOME}/.docker/config.json" && "$(cat ${HOME}/.docker/config.json | jq 'has("credHelpers")')" != "true" ]]; then
     volumes="$volumes --mount type=bind,source=${HOME}/.docker/config.json,target=/root/.docker/config.json,readonly"
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If cred helpers are required, they will very likely not work from within the build container, since we don't install any cred helpers, and we don't know what information they need to work.

This should help developer flows when cred helpers are configured in docker. Otherwise `make cluster-sync` breaks due to missing cred helpers, even if the cred helper related repos are not even in use.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
