### PR TITLE
Set the deletion grace period to 1 on forced VM restarts

### DIFF
--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/pointer"
 
 	"kubevirt.io/kubevirt/pkg/util/status"
 
@@ -439,8 +440,8 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 				response.WriteHeader(http.StatusAccepted)
 				return
 			}
-			// set terminationGracePeriod and delete the VMI pod to trigger a forced restart
-			err = app.virtCli.CoreV1().Pods(namespace).Delete(context.Background(), vmiPodname, k8smetav1.DeleteOptions{GracePeriodSeconds: bodyStruct.GracePeriodSeconds})
+			// set terminationGracePeriod to 1 (which is the shorted safe restart period) and delete the VMI pod to trigger a swift restart.
+			err = app.virtCli.CoreV1().Pods(namespace).Delete(context.Background(), vmiPodname, k8smetav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(1)})
 			if err != nil {
 				if !errors.IsNotFound(err) {
 					writeError(errors.NewInternalError(err), response)


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to allow a swift and safe restart, set the deletion grace period to 1 on the pod delete when a force restart is requested.

One is the shortest safe restart period where we don't risk a split-brain scenario for VMs, since Zero effectively deletes the pod right away.

This leads to the following outcome:
 * If a guest OS is stuck, people get a swift restart.
 * Users don't risk data corruption.
 * Reserving a force pod delete for situations where the cluster is unhealthy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9830

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the possibility of data corruption when requestin a force-restart via "virtctl restart"
```
