### PR TITLE
Allow lun disks to be mapped to DataVolume sources

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1016,10 +1016,10 @@ func validateBootOrder(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec
 		}
 
 		// Verify Lun disks are only mapped to network/block devices.
-		if disk.LUN != nil && volumeExists && matchingVolume.PersistentVolumeClaim == nil {
+		if disk.LUN != nil && volumeExists && matchingVolume.PersistentVolumeClaim == nil && matchingVolume.DataVolume == nil {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s can only be mapped to a PersistentVolumeClaim volume.", field.Child("domain", "devices", "disks").Index(idx).Child("lun").String()),
+				Message: fmt.Sprintf("%s can only be mapped to a DataVolume or PersistentVolumeClaim volume.", field.Child("domain", "devices", "disks").Index(idx).Child("lun").String()),
 				Field:   field.Child("domain", "devices", "disks").Index(idx).Child("lun").String(),
 			})
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1032,6 +1032,15 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
 					},
 				}, 0),
+			Entry("and accept DataVolume sources",
+				&v1.Volume{
+					Name: "testdisk",
+					VolumeSource: v1.VolumeSource{
+						DataVolume: &v1.DataVolumeSource{
+							Name: "testDV",
+						},
+					},
+				}, 0),
 		)
 		It("should accept a single interface and network", func() {
 			vm := api.NewMinimalVMI("testvm")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This pull request modifies the vmi admission webhook to allow using DataVolume sources for Lun Disks, instead of allowing only PVCs.

**Which issue(s) this PR fixes**:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2190171

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Allow lun disks to be mapped to DataVolume sources
```
