### PR TITLE
Add basic fuzz testing and fix an initial set of issues discovered by fuzzing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,8 +23,9 @@ build --define gotags=selinux
 # let our unit tests produce our own junit reports
 test --action_env=GO_TEST_WRAP=0
 
-test --test_tag_filters=-cov
-coverage --test_tag_filters=-nocov
+test --test_tag_filters=-cov,-fuzz
+test:fuzz --test_tag_filters=fuzz
+coverage --test_tag_filters=-nocov,-fuzz
 
 # Import user settings which may override the defaults
 try-import user.bazelrc

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ go-test: go-build
 
 test: bazel-test
 
+fuzz:
+	hack/dockerized "./hack/fuzz.sh"
+
 functest: build-functests
 	hack/functests.sh
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-github/v32 v32.0.0
 	github.com/google/goexpect v0.0.0-20190425035906-112704a48083
-	github.com/google/gofuzz v1.1.0
+	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.0
 	github.com/gordonklaus/ineffassign v0.0.0-20210209182638-d0e41b2fc8ed
 	github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -557,8 +557,9 @@ github.com/google/goexpect v0.0.0-20190425035906-112704a48083 h1:3HihP5rfhHoq48i
 github.com/google/goexpect v0.0.0-20190425035906-112704a48083/go.mod h1:qtE5aAEkt0vOSA84DBh8aJsz6riL8ONfqfULY7lBjqc=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/goterm v0.0.0-20190311235235-ce302be1d114 h1:Uy/xnk45iZMzPi2uZlOi3RxUGMxrn9afM9WhCAfYEyc=
 github.com/google/goterm v0.0.0-20190311235235-ce302be1d114/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/hack/fuzz.sh
+++ b/hack/fuzz.sh
@@ -1,0 +1,10 @@
+set -e
+
+source hack/common.sh
+source hack/bootstrap.sh
+source hack/config.sh
+
+bazel test \
+    --config=fuzz \
+    --features race \
+    --test_output=errors -- //pkg/...

--- a/pkg/virt-api/webhooks/fuzz/BUILD.bazel
+++ b/pkg/virt-api/webhooks/fuzz/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["fuzz_test.go"],
+    tags = ["fuzz"],
+    deps = [
+        "//pkg/testutils:go_default_library",
+        "//pkg/virt-api/webhooks:go_default_library",
+        "//pkg/virt-api/webhooks/validating-webhook/admitters:go_default_library",
+        "//pkg/virt-config:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/k8s.io/api/admission/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -1,0 +1,1 @@
+package fuzz

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -1,1 +1,299 @@
 package fuzz
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	gofuzz "github.com/google/gofuzz"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+)
+
+type fuzzOption int
+
+const withSyntaxErrors fuzzOption = 1
+
+type testCase struct {
+	name      string
+	fuzzFuncs []interface{}
+	gvk       metav1.GroupVersionResource
+	objType   interface{}
+	admit     func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
+	debug     bool
+	focus     bool
+}
+
+// FuzzAdmitter tests the Validation webhook execution logic with random input: It does schema validation (syntactic check), followed by executing the domain specific validation logic (semantic checks).
+func FuzzAdmitter(f *testing.F) {
+	testCases := []testCase{
+		{
+			name:    "SyntacticVirtualMachineInstanceFuzzing",
+			gvk:     webhooks.VirtualMachineInstanceGroupVersionResource,
+			objType: &v1.VirtualMachineInstance{},
+			admit: func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+				adm := &admitters.VMICreateAdmitter{ClusterConfig: config}
+				return adm.Admit(request)
+			},
+			fuzzFuncs: fuzzFuncs(withSyntaxErrors),
+		},
+		{
+			name:    "SemanticVirtualMachineInstanceFuzzing",
+			gvk:     webhooks.VirtualMachineInstanceGroupVersionResource,
+			objType: &v1.VirtualMachineInstance{},
+			admit: func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+				adm := &admitters.VMICreateAdmitter{ClusterConfig: config}
+				return adm.Admit(request)
+			},
+			fuzzFuncs: fuzzFuncs(),
+		},
+		{
+			name:    "SyntacticVirtualMachineFuzzing",
+			gvk:     webhooks.VirtualMachineGroupVersionResource,
+			objType: &v1.VirtualMachine{},
+			admit: func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+				adm := &admitters.VMsAdmitter{
+					ClusterConfig:       config,
+					InstancetypeMethods: testutils.NewMockInstancetypeMethods(),
+				}
+				return adm.Admit(request)
+			},
+			fuzzFuncs: fuzzFuncs(withSyntaxErrors),
+		},
+		{
+			name:    "SemanticVirtualMachineFuzzing",
+			gvk:     webhooks.VirtualMachineGroupVersionResource,
+			objType: &v1.VirtualMachine{},
+			admit: func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+				adm := &admitters.VMsAdmitter{
+					ClusterConfig:       config,
+					InstancetypeMethods: testutils.NewMockInstancetypeMethods(),
+				}
+				return adm.Admit(request)
+			},
+			fuzzFuncs: fuzzFuncs(),
+		},
+	}
+
+	for i := 0; i < 500; i++ {
+		f.Add(int64(i))
+	}
+	f.Fuzz(func(t *testing.T, seed int64) {
+		var focused []testCase
+		for idx, tc := range testCases {
+			if tc.focus {
+				focused = append(focused, testCases[idx])
+			}
+		}
+
+		if len(focused) == 0 {
+			focused = testCases
+		}
+
+		timeoutDuration := 500 * time.Millisecond
+
+		for _, tc := range focused {
+			t.Run(tc.name, func(t *testing.T) {
+				newObj := reflect.New(reflect.TypeOf(tc.objType))
+				obj := newObj.Interface()
+
+				gofuzz.NewWithSeed(seed).NilChance(0.1).NumElements(0, 15).Funcs(
+					tc.fuzzFuncs...,
+				).Fuzz(obj)
+				request := toAdmissionReview(obj, tc.gvk)
+				config := fuzzKubeVirtConfig(seed)
+				startTime := time.Now()
+				response := tc.admit(config, request)
+				endTime := time.Now()
+				if startTime.Add(timeoutDuration).Before(endTime) {
+					fmt.Printf("Execution time %v is more than %v\n", endTime.Sub(startTime), timeoutDuration)
+					fmt.Println(response.Result.Message)
+					j, err := json.MarshalIndent(obj, "", "  ")
+					if err != nil {
+						panic(err)
+					}
+					fmt.Println(string(j))
+					t.Fail()
+				}
+
+				if tc.debug && !response.Allowed {
+					fmt.Println(response.Result.Message)
+					j, err := json.MarshalIndent(obj, "", "  ")
+					if err != nil {
+						panic(err)
+					}
+					fmt.Println(string(j))
+				}
+			})
+		}
+	})
+}
+
+func toAdmissionReview(obj interface{}, gvr metav1.GroupVersionResource) *admissionv1.AdmissionReview {
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	return &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Resource: gvr,
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+		},
+	}
+}
+
+func fuzzKubeVirtConfig(seed int64) *virtconfig.ClusterConfig {
+	kv := &v1.KubeVirt{}
+	gofuzz.NewWithSeed(seed).Funcs(
+		func(dc *v1.DeveloperConfiguration, c gofuzz.Continue) {
+			c.FuzzNoCustom(dc)
+			featureGates := []string{
+				virtconfig.ExpandDisksGate,
+				virtconfig.CPUManager,
+				virtconfig.NUMAFeatureGate,
+				virtconfig.IgnitionGate,
+				virtconfig.LiveMigrationGate,
+				virtconfig.SRIOVLiveMigrationGate,
+				virtconfig.CPUNodeDiscoveryGate,
+				virtconfig.HypervStrictCheckGate,
+				virtconfig.SidecarGate,
+				virtconfig.GPUGate,
+				virtconfig.HostDevicesGate,
+				virtconfig.SnapshotGate,
+				virtconfig.VMExportGate,
+				virtconfig.HotplugVolumesGate,
+				virtconfig.HostDiskGate,
+				virtconfig.VirtIOFSGate,
+				virtconfig.MacvtapGate,
+				virtconfig.PasstGate,
+				virtconfig.DownwardMetricsFeatureGate,
+				virtconfig.NonRootDeprecated,
+				virtconfig.NonRoot,
+				virtconfig.Root,
+				virtconfig.ClusterProfiler,
+				virtconfig.WorkloadEncryptionSEV,
+				virtconfig.DockerSELinuxMCSWorkaround,
+				virtconfig.PSA,
+				virtconfig.VSOCKGate,
+			}
+
+			idxs := c.Perm(c.Int() % len(featureGates))
+			for idx := range idxs {
+				dc.FeatureGates = append(dc.FeatureGates, featureGates[idx])
+			}
+		},
+	).Fuzz(kv)
+	config, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
+	return config
+}
+
+func fuzzFuncs(options ...fuzzOption) []interface{} {
+	addSyntaxErrors := false
+	for _, opt := range options {
+		if opt == withSyntaxErrors {
+			addSyntaxErrors = true
+		}
+	}
+
+	enumFuzzers := []interface{}{
+		func(e *metav1.FieldsV1, c gofuzz.Continue) {},
+		func(objectmeta *metav1.ObjectMeta, c gofuzz.Continue) {
+			c.FuzzNoCustom(objectmeta)
+			objectmeta.DeletionGracePeriodSeconds = nil
+			objectmeta.Generation = 0
+			objectmeta.ManagedFields = nil
+		},
+		func(obj *corev1.URIScheme, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.URIScheme{corev1.URISchemeHTTP, corev1.URISchemeHTTPS}, c)
+		},
+		func(obj *corev1.TaintEffect, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.TaintEffect{corev1.TaintEffectNoExecute, corev1.TaintEffectNoSchedule, corev1.TaintEffectPreferNoSchedule}, c)
+		},
+		func(obj *corev1.NodeInclusionPolicy, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.NodeInclusionPolicy{corev1.NodeInclusionPolicyHonor, corev1.NodeInclusionPolicyIgnore}, c)
+		},
+		func(obj *corev1.UnsatisfiableConstraintAction, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.UnsatisfiableConstraintAction{corev1.DoNotSchedule, corev1.ScheduleAnyway}, c)
+		},
+		func(obj *corev1.PullPolicy, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.PullPolicy{corev1.PullAlways, corev1.PullNever, corev1.PullIfNotPresent}, c)
+		},
+		func(obj *corev1.NodeSelectorOperator, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.NodeSelectorOperator{corev1.NodeSelectorOpDoesNotExist, corev1.NodeSelectorOpExists, corev1.NodeSelectorOpGt, corev1.NodeSelectorOpIn, corev1.NodeSelectorOpLt, corev1.NodeSelectorOpNotIn}, c)
+		},
+		func(obj *corev1.TolerationOperator, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.TolerationOperator{corev1.TolerationOpExists, corev1.TolerationOpEqual}, c)
+		},
+		func(obj *corev1.PodQOSClass, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.PodQOSClass{corev1.PodQOSBestEffort, corev1.PodQOSGuaranteed, corev1.PodQOSBurstable}, c)
+		},
+		func(obj *corev1.PersistentVolumeMode, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.PersistentVolumeMode{corev1.PersistentVolumeBlock, corev1.PersistentVolumeFilesystem}, c)
+		},
+		func(obj *corev1.DNSPolicy, c gofuzz.Continue) {
+			pickType(addSyntaxErrors, obj, []corev1.DNSPolicy{corev1.DNSClusterFirst, corev1.DNSClusterFirstWithHostNet, corev1.DNSDefault, corev1.DNSNone}, c)
+		},
+		func(obj *corev1.TypedObjectReference, c gofuzz.Continue) {
+			c.FuzzNoCustom(obj)
+			str := c.RandString()
+			obj.APIGroup = &str
+		},
+		func(obj *corev1.TypedLocalObjectReference, c gofuzz.Continue) {
+			c.FuzzNoCustom(obj)
+			str := c.RandString()
+			obj.APIGroup = &str
+		},
+	}
+
+	typeFuzzers := []interface{}{}
+	if !addSyntaxErrors {
+		typeFuzzers = []interface{}{
+			func(obj *int, c gofuzz.Continue) {
+				*obj = c.Intn(100000)
+			},
+			func(obj *uint, c gofuzz.Continue) {
+				*obj = uint(c.Intn(100000))
+			},
+			func(obj *int32, c gofuzz.Continue) {
+				*obj = int32(c.Intn(100000))
+			},
+			func(obj *int64, c gofuzz.Continue) {
+				*obj = int64(c.Intn(100000))
+			},
+			func(obj *uint64, c gofuzz.Continue) {
+				*obj = uint64(c.Intn(100000))
+			},
+			func(obj *uint32, c gofuzz.Continue) {
+				*obj = uint32(c.Intn(100000))
+			},
+		}
+	}
+
+	return append(enumFuzzers, typeFuzzers...)
+}
+
+func pickType(withSyntaxError bool, target interface{}, arr interface{}, c gofuzz.Continue) {
+	arrPtr := reflect.ValueOf(arr)
+	targetPtr := reflect.ValueOf(target)
+
+	if withSyntaxError {
+		arrPtr = reflect.Append(arrPtr, reflect.ValueOf("fake").Convert(targetPtr.Elem().Type()))
+	}
+
+	idx := c.Int() % arrPtr.Len()
+
+	targetPtr.Elem().Set(arrPtr.Index(idx))
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1783,7 +1783,7 @@ func validatePodDNSConfig(dnsConfig *k8sv1.PodDNSConfig, dnsPolicy *k8sv1.DNSPol
 			if len(option.Name) == 0 {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("Option.Name must not be empty for value: %s", *option.Value),
+					Message: fmt.Sprintf("Option.Name must not be empty"),
 					Field:   "options",
 				})
 			}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2289,7 +2289,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Options: []k8sv1.PodDNSConfigOption{
 					{Value: &dnsConfigTestOption},
 				},
-			}, 1, []string{fmt.Sprintf("Option.Name must not be empty for value: %s", dnsConfigTestOption)}),
+			}, 1, []string{"Option.Name must not be empty"}),
 			Entry("with DNSPolicy None and nil DNSConfig", k8sv1.DNSNone, interface{}(nil), 1,
 				[]string{fmt.Sprintf("must provide `dnsConfig` when `dnsPolicy` is %s", k8sv1.DNSNone)}),
 		)

--- a/vendor/github.com/google/gofuzz/.travis.yml
+++ b/vendor/github.com/google/gofuzz/.travis.yml
@@ -1,13 +1,10 @@
 language: go
 
 go:
-  - 1.4
-  - 1.3
-  - 1.2
-  - tip
-
-install:
-  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - master
 
 script:
   - go test -cover

--- a/vendor/github.com/google/gofuzz/BUILD.bazel
+++ b/vendor/github.com/google/gofuzz/BUILD.bazel
@@ -9,4 +9,5 @@ go_library(
     importmap = "kubevirt.io/kubevirt/vendor/github.com/google/gofuzz",
     importpath = "github.com/google/gofuzz",
     visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/google/gofuzz/bytesource:go_default_library"],
 )

--- a/vendor/github.com/google/gofuzz/CONTRIBUTING.md
+++ b/vendor/github.com/google/gofuzz/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute #
 
 We'd love to accept your patches and contributions to this project.  There are
-a just a few small guidelines you need to follow.
+just a few small guidelines you need to follow.
 
 
 ## Contributor License Agreement ##

--- a/vendor/github.com/google/gofuzz/README.md
+++ b/vendor/github.com/google/gofuzz/README.md
@@ -68,4 +68,22 @@ f.Fuzz(&myObject) // Type will correspond to whether A or B info is set.
 
 See more examples in ```example_test.go```.
 
+You can use this library for easier [go-fuzz](https://github.com/dvyukov/go-fuzz)ing.
+go-fuzz provides the user a byte-slice, which should be converted to different inputs
+for the tested function. This library can help convert the byte slice. Consider for
+example a fuzz test for a the function `mypackage.MyFunc` that takes an int arguments:
+```go
+// +build gofuzz
+package mypackage
+
+import fuzz "github.com/google/gofuzz"
+
+func Fuzz(data []byte) int {
+        var i int
+        fuzz.NewFromGoFuzz(data).Fuzz(&i)
+        MyFunc(i)
+        return 0
+}
+```
+
 Happy testing!

--- a/vendor/github.com/google/gofuzz/bytesource/BUILD.bazel
+++ b/vendor/github.com/google/gofuzz/bytesource/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["bytesource.go"],
+    importmap = "kubevirt.io/kubevirt/vendor/github.com/google/gofuzz/bytesource",
+    importpath = "github.com/google/gofuzz/bytesource",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/google/gofuzz/bytesource/bytesource.go
+++ b/vendor/github.com/google/gofuzz/bytesource/bytesource.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bytesource provides a rand.Source64 that is determined by a slice of bytes.
+package bytesource
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math/rand"
+)
+
+// ByteSource implements rand.Source64 determined by a slice of bytes. The random numbers are
+// generated from each 8 bytes in the slice, until the last bytes are consumed, from which a
+// fallback pseudo random source is created in case more random numbers are required.
+// It also exposes a `bytes.Reader` API, which lets callers consume the bytes directly.
+type ByteSource struct {
+	*bytes.Reader
+	fallback rand.Source
+}
+
+// New returns a new ByteSource from a given slice of bytes.
+func New(input []byte) *ByteSource {
+	s := &ByteSource{
+		Reader:   bytes.NewReader(input),
+		fallback: rand.NewSource(0),
+	}
+	if len(input) > 0 {
+		s.fallback = rand.NewSource(int64(s.consumeUint64()))
+	}
+	return s
+}
+
+func (s *ByteSource) Uint64() uint64 {
+	// Return from input if it was not exhausted.
+	if s.Len() > 0 {
+		return s.consumeUint64()
+	}
+
+	// Input was exhausted, return random number from fallback (in this case fallback should not be
+	// nil). Try first having a Uint64 output (Should work in current rand implementation),
+	// otherwise return a conversion of Int63.
+	if s64, ok := s.fallback.(rand.Source64); ok {
+		return s64.Uint64()
+	}
+	return uint64(s.fallback.Int63())
+}
+
+func (s *ByteSource) Int63() int64 {
+	return int64(s.Uint64() >> 1)
+}
+
+func (s *ByteSource) Seed(seed int64) {
+	s.fallback = rand.NewSource(seed)
+	s.Reader = bytes.NewReader(nil)
+}
+
+// consumeUint64 reads 8 bytes from the input and convert them to a uint64. It assumes that the the
+// bytes reader is not empty.
+func (s *ByteSource) consumeUint64() uint64 {
+	var bytes [8]byte
+	_, err := s.Read(bytes[:])
+	if err != nil && err != io.EOF {
+		panic("failed reading source") // Should not happen.
+	}
+	return binary.BigEndian.Uint64(bytes[:])
+}

--- a/vendor/github.com/google/gofuzz/fuzz.go
+++ b/vendor/github.com/google/gofuzz/fuzz.go
@@ -22,6 +22,9 @@ import (
 	"reflect"
 	"regexp"
 	"time"
+
+	"github.com/google/gofuzz/bytesource"
+	"strings"
 )
 
 // fuzzFuncMap is a map from a type to a fuzzFunc that handles that type.
@@ -59,6 +62,34 @@ func NewWithSeed(seed int64) *Fuzzer {
 		maxDepth:    100,
 	}
 	return f
+}
+
+// NewFromGoFuzz is a helper function that enables using gofuzz (this
+// project) with go-fuzz (https://github.com/dvyukov/go-fuzz) for continuous
+// fuzzing. Essentially, it enables translating the fuzzing bytes from
+// go-fuzz to any Go object using this library.
+//
+// This implementation promises a constant translation from a given slice of
+// bytes to the fuzzed objects. This promise will remain over future
+// versions of Go and of this library.
+//
+// Note: the returned Fuzzer should not be shared between multiple goroutines,
+// as its deterministic output will no longer be available.
+//
+// Example: use go-fuzz to test the function `MyFunc(int)` in the package
+// `mypackage`. Add the file: "mypacakge_fuzz.go" with the content:
+//
+// // +build gofuzz
+// package mypacakge
+// import fuzz "github.com/google/gofuzz"
+// func Fuzz(data []byte) int {
+// 	var i int
+// 	fuzz.NewFromGoFuzz(data).Fuzz(&i)
+// 	MyFunc(i)
+// 	return 0
+// }
+func NewFromGoFuzz(data []byte) *Fuzzer {
+	return New().RandSource(bytesource.New(data))
 }
 
 // Funcs adds each entry in fuzzFuncs as a custom fuzzing function.
@@ -141,7 +172,7 @@ func (f *Fuzzer) genElementCount() int {
 }
 
 func (f *Fuzzer) genShouldFill() bool {
-	return f.r.Float64() > f.nilChance
+	return f.r.Float64() >= f.nilChance
 }
 
 // MaxDepth sets the maximum number of recursive fuzz calls that will be made
@@ -240,6 +271,7 @@ func (fc *fuzzerContext) doFuzz(v reflect.Value, flags uint64) {
 		fn(v, fc.fuzzer.r)
 		return
 	}
+
 	switch v.Kind() {
 	case reflect.Map:
 		if fc.fuzzer.genShouldFill() {
@@ -450,10 +482,10 @@ var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
 		v.SetFloat(r.Float64())
 	},
 	reflect.Complex64: func(v reflect.Value, r *rand.Rand) {
-		panic("unimplemented")
+		v.SetComplex(complex128(complex(r.Float32(), r.Float32())))
 	},
 	reflect.Complex128: func(v reflect.Value, r *rand.Rand) {
-		panic("unimplemented")
+		v.SetComplex(complex(r.Float64(), r.Float64()))
 	},
 	reflect.String: func(v reflect.Value, r *rand.Rand) {
 		v.SetString(randString(r))
@@ -465,38 +497,105 @@ var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
 
 // randBool returns true or false randomly.
 func randBool(r *rand.Rand) bool {
-	if r.Int()&1 == 1 {
-		return true
-	}
-	return false
+	return r.Int31()&(1<<30) == 0
 }
 
-type charRange struct {
-	first, last rune
+type int63nPicker interface {
+	Int63n(int64) int64
 }
+
+// UnicodeRange describes a sequential range of unicode characters.
+// Last must be numerically greater than First.
+type UnicodeRange struct {
+	First, Last rune
+}
+
+// UnicodeRanges describes an arbitrary number of sequential ranges of unicode characters.
+// To be useful, each range must have at least one character (First <= Last) and
+// there must be at least one range.
+type UnicodeRanges []UnicodeRange
 
 // choose returns a random unicode character from the given range, using the
 // given randomness source.
-func (r *charRange) choose(rand *rand.Rand) rune {
-	count := int64(r.last - r.first)
-	return r.first + rune(rand.Int63n(count))
+func (ur UnicodeRange) choose(r int63nPicker) rune {
+	count := int64(ur.Last - ur.First + 1)
+	return ur.First + rune(r.Int63n(count))
 }
 
-var unicodeRanges = []charRange{
+// CustomStringFuzzFunc constructs a FuzzFunc which produces random strings.
+// Each character is selected from the range ur. If there are no characters
+// in the range (cr.Last < cr.First), this will panic.
+func (ur UnicodeRange) CustomStringFuzzFunc() func(s *string, c Continue) {
+	ur.check()
+	return func(s *string, c Continue) {
+		*s = ur.randString(c.Rand)
+	}
+}
+
+// check is a function that used to check whether the first of ur(UnicodeRange)
+// is greater than the last one.
+func (ur UnicodeRange) check() {
+	if ur.Last < ur.First {
+		panic("The last encoding must be greater than the first one.")
+	}
+}
+
+// randString of UnicodeRange makes a random string up to 20 characters long.
+// Each character is selected form ur(UnicodeRange).
+func (ur UnicodeRange) randString(r *rand.Rand) string {
+	n := r.Intn(20)
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		sb.WriteRune(ur.choose(r))
+	}
+	return sb.String()
+}
+
+// defaultUnicodeRanges sets a default unicode range when user do not set
+// CustomStringFuzzFunc() but wants fuzz string.
+var defaultUnicodeRanges = UnicodeRanges{
 	{' ', '~'},           // ASCII characters
 	{'\u00a0', '\u02af'}, // Multi-byte encoded characters
 	{'\u4e00', '\u9fff'}, // Common CJK (even longer encodings)
 }
 
+// CustomStringFuzzFunc constructs a FuzzFunc which produces random strings.
+// Each character is selected from one of the ranges of ur(UnicodeRanges).
+// Each range has an equal probability of being chosen. If there are no ranges,
+// or a selected range has no characters (.Last < .First), this will panic.
+// Do not modify any of the ranges in ur after calling this function.
+func (ur UnicodeRanges) CustomStringFuzzFunc() func(s *string, c Continue) {
+	// Check unicode ranges slice is empty.
+	if len(ur) == 0 {
+		panic("UnicodeRanges is empty.")
+	}
+	// if not empty, each range should be checked.
+	for i := range ur {
+		ur[i].check()
+	}
+	return func(s *string, c Continue) {
+		*s = ur.randString(c.Rand)
+	}
+}
+
+// randString of UnicodeRanges makes a random string up to 20 characters long.
+// Each character is selected form one of the ranges of ur(UnicodeRanges),
+// and each range has an equal probability of being chosen.
+func (ur UnicodeRanges) randString(r *rand.Rand) string {
+	n := r.Intn(20)
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		sb.WriteRune(ur[r.Intn(len(ur))].choose(r))
+	}
+	return sb.String()
+}
+
 // randString makes a random string up to 20 characters long. The returned string
 // may include a variety of (valid) UTF-8 encodings.
 func randString(r *rand.Rand) string {
-	n := r.Intn(20)
-	runes := make([]rune, n)
-	for i := range runes {
-		runes[i] = unicodeRanges[r.Intn(len(unicodeRanges))].choose(r)
-	}
-	return string(runes)
+	return defaultUnicodeRanges.randString(r)
 }
 
 // randUint64 makes random 64 bit numbers.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -169,9 +169,10 @@ github.com/google/go-querystring/query
 # github.com/google/goexpect v0.0.0-20190425035906-112704a48083
 ## explicit
 github.com/google/goexpect
-# github.com/google/gofuzz v1.1.0
+# github.com/google/gofuzz v1.2.0
 ## explicit; go 1.12
 github.com/google/gofuzz
+github.com/google/gofuzz/bytesource
 # github.com/google/goterm v0.0.0-20190311235235-ce302be1d114
 ## explicit
 github.com/google/goterm/term


### PR DESCRIPTION
**What this PR does / why we need it**:

Fuzzing, done continuously, can reveal bugs in places where users are providing the input. The CNCF project [recommends](https://github.com/cncf/cncf-fuzzing) for CNCF project doing fuzzing and eventually integrating into [oss-fuzz](https://github.com/google/oss-fuzz).

This is a starting point, which makes use of the new built-in Fuzz support, starting with golang 1.18.

Right now this covers:

 * Syntactic validation of VMI and VM create admitters
 * 90% coverage on VMI semantic validation
 * 25% coverage of VM semantic validation
 
 At the moment, 500 iterations are executed on semantic and syntactic validation of VM and VMI (so 4 *500 overall).
 
 An optional presubmit prowjob will be introduced in https://github.com/kubevirt/project-infra/pull/2814.

The basic fuzz set already revealed two bugs:

 * virt-api could panic with a specially forged DNSOoptions struct
 * It was possible to forge huge admission response bodies which could be misused for DOS

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```

