### PR TITLE
builder: Add a simple script to bump `KUBEVIRT_BUILDER_IMAGE`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ deps-sync:
 rpm-deps:
 	SYNC_VENDOR=true hack/dockerized "CUSTOM_REPO=${CUSTOM_REPO} SINGLE_ARCH=${SINGLE_ARCH} BASESYSTEM=${BASESYSTEM} LIBVIRT_VERSION=${LIBVIRT_VERSION} QEMU_VERSION=${QEMU_VERSION} SEABIOS_VERSION=${SEABIOS_VERSION} EDK2_VERSION=${EDK2_VERSION} LIBGUESTFS_VERSION=${LIBGUESTFS_VERSION} GUESTFSTOOLS_VERSION=${GUESTFSTOOLS_VERSION} PASST_VERSION=${PASST_VERSION} VIRTIOFSD_VERSION=${VIRTIOFSD_VERSION} SWTPM_VERSION=${SWTPM_VERSION} ./hack/rpm-deps.sh"
 
-bump-images:
+bump-images: builder-bump
 	hack/dockerized "./hack/rpm-deps.sh && ./hack/bump-distroless.sh"
 
 verify-rpm-deps:
@@ -166,6 +166,9 @@ builder-build:
 
 builder-publish:
 	./hack/builder/publish.sh
+
+builder-bump:
+	./hack/builder/bump.sh
 
 olm-verify:
 	hack/dockerized "./hack/olm.sh verify"

--- a/hack/builder/bump.sh
+++ b/hack/builder/bump.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+source "$(dirname "$0")"/../common.sh
+source "$(dirname "$0")"/../config.sh
+
+# FIXME(lyarwood): This is pretty dumb, replace if/when other tooling becomes available to determine this
+KUBEVIRT_BUILDER_IMAGE_TAG=${KUBEVIRT_BUILDER_IMAGE_TAG:-$(${KUBEVIRT_CRI} search --list-tags --limit 500 quay.io/kubevirt/builder | awk '{print $2}' | sort -rn | head -n3 | grep -Ev "arm64|amd64")}
+sed -i "s/KUBEVIRT_BUILDER_IMAGE\=.*/KUBEVIRT_BUILDER_IMAGE=\${KUBEVIRT_BUILDER_IMAGE\:\-\"quay.io\/kubevirt\/builder:${KUBEVIRT_BUILDER_IMAGE_TAG}\"}/g" hack/dockerized

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,7 +12,7 @@ fi
 
 fail_if_cri_bin_missing
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2306271234-e00d9fcf9"
+KUBEVIRT_BUILDER_IMAGE=${KUBEVIRT_BUILDER_IMAGE:-"quay.io/kubevirt/builder:2306271234-e00d9fcf9"}
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,7 +12,7 @@ fi
 
 fail_if_cri_bin_missing
 
-KUBEVIRT_BUILDER_IMAGE=${KUBEVIRT_BUILDER_IMAGE:-"quay.io/kubevirt/builder:2306271234-e00d9fcf9"}
+KUBEVIRT_BUILDER_IMAGE=${KUBEVIRT_BUILDER_IMAGE:-"quay.io/kubevirt/builder:2308030851-9ae62631c"}
 
 SYNC_OUT=${SYNC_OUT:-true}
 


### PR DESCRIPTION
/cc @brianmcarey 

**What this PR does / why we need it**:

This PR provides a simple script and Makefile target that can be used by the existing `bump-images` periodic job to bump `KUBEVIRT_BUILDER_IMAGE` to the latest available version. 

`KUBEVIRT_BUILDER_IMAGE` can also be overridden during testing as an environment variable. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
