### PR TITLE
virt-launcher, notify: Fix seg-fault due to too early metadata handling

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -440,22 +440,26 @@ func (n *Notifier) StartDomainNotifier(
 				n.SendDomainEvent(newWatchEventError(fmt.Errorf("Libvirt reconnect, domain %s", domainName)))
 
 			case <-metadataCache.Listen():
-				domainCache = util.NewDomainFromName(
-					util.DomainFromNamespaceName(domainCache.ObjectMeta.Namespace, domainCache.ObjectMeta.Name),
-					vmi.UID,
-				)
-				eventCallback(
-					domainConn,
-					domainCache,
-					libvirtEvent{},
-					n,
-					deleteNotificationSent,
-					interfaceStatuses,
-					guestOsInfo,
-					vmi,
-					fsFreezeStatus,
-					metadataCache,
-				)
+				// Metadata cache updates should be processed only *after* at least one
+				// libvirt event arrived (which creates the first domainCache).
+				if domainCache != nil {
+					domainCache = util.NewDomainFromName(
+						util.DomainFromNamespaceName(domainCache.ObjectMeta.Namespace, domainCache.ObjectMeta.Name),
+						vmi.UID,
+					)
+					eventCallback(
+						domainConn,
+						domainCache,
+						libvirtEvent{},
+						n,
+						deleteNotificationSent,
+						interfaceStatuses,
+						guestOsInfo,
+						vmi,
+						fsFreezeStatus,
+						metadataCache,
+					)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:

It is expected to first receive notifications/events from libvirt and create the initial domain object (which is used throughout the go-routine).
But it seems there are incidents where the metadata cache notification arrives before and crashes the virt-launcher.

Fixed by ignoring such early notifications on the metadata cache. Only after the first libvirt event arrives the processing of metadata events is handled.

Fixes: https://github.com/kubevirt/kubevirt/issues/9839

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9839 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
