### PR TITLE
webhooks: Fix setPreferenceStorageClassName during mutation

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -196,10 +196,9 @@ func (mutator *VMsMutator) setPreferenceStorageClassName(vm *v1.VirtualMachine, 
 		return
 	}
 
-	if preferenceSpec != nil && preferenceSpec.Volumes != nil {
-		datavolumes := vm.Spec.DataVolumeTemplates
-		for _, dv := range datavolumes {
-			if dv.Spec.PVC.StorageClassName == nil {
+	if preferenceSpec != nil && preferenceSpec.Volumes != nil && preferenceSpec.Volumes.PreferredStorageClassName != "" {
+		for _, dv := range vm.Spec.DataVolumeTemplates {
+			if dv.Spec.PVC != nil && dv.Spec.PVC.StorageClassName == nil {
 				dv.Spec.PVC.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
 			}
 		}


### PR DESCRIPTION
/area instancetype
/cc @opokornyy 

**What this PR does / why we need it**:

PersistentVolumeClaimSpec is an optional attribute of DataVolumeSpec but wasn't previously checked by setPreferenceStorageClassName. This change fixes this and reworks unit tests that were also not correctly asserting the behaviour of setPreferenceStorageClassName as the VirtualMachine provided contained no DataVolumeTemplates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9868

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
