### PR TITLE
Add missing error check to test

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -355,6 +355,8 @@ var _ = SIGDescribe("Export", func() {
 		)
 
 		dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
 		var pvc *k8sv1.PersistentVolumeClaim
 		Eventually(func() error {
 			pvc, err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(dv)).Get(context.Background(), dv.Name, metav1.GetOptions{})


### PR DESCRIPTION
**Special notes for your reviewer**:
This is not from a linter. I saw it happen on a test run that create likely failed and the next use of dv produced bogus results.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
