### PR TITLE
cleanup: Rename deprecated API alert to singular

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -859,15 +859,15 @@ tests:
 
     alert_rule_test:
       - eval_time: 1m
-        alertname: KubeVirtDeprecatedAPIsRequested
+        alertname: KubeVirtDeprecatedAPIRequested
         exp_alerts: []
       - eval_time: 2m
-        alertname: KubeVirtDeprecatedAPIsRequested
+        alertname: KubeVirtDeprecatedAPIRequested
         exp_alerts:
           - exp_annotations:
               description: "Detected requests to the deprecated virtualmachines.kubevirt.io/v1alpha3 API."
               summary: "Detected 1 requests in the last 10 minutes."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtDeprecatedAPIsRequested"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtDeprecatedAPIRequested"
             exp_labels:
               severity: "info"
               operator_health_impact: "none"
@@ -877,12 +877,12 @@ tests:
               group: "kubevirt.io"
               version: "v1alpha3"
       - eval_time: 3m
-        alertname: KubeVirtDeprecatedAPIsRequested
+        alertname: KubeVirtDeprecatedAPIRequested
         exp_alerts:
           - exp_annotations:
               description: "Detected requests to the deprecated virtualmachines.kubevirt.io/v1alpha3 API."
               summary: "Detected 2 requests in the last 10 minutes."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtDeprecatedAPIsRequested"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtDeprecatedAPIRequested"
             exp_labels:
               severity: "info"
               operator_health_impact: "none"
@@ -892,5 +892,5 @@ tests:
               group: "kubevirt.io"
               version: "v1alpha3"
       - eval_time: 13m
-        alertname: KubeVirtDeprecatedAPIsRequested
+        alertname: KubeVirtDeprecatedAPIRequested
         exp_alerts: []

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -479,12 +479,12 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 			},
 		},
 		{
-			Alert: "KubeVirtDeprecatedAPIsRequested",
+			Alert: "KubeVirtDeprecatedAPIRequested",
 			Expr:  intstr.FromString("sum by (resource,group,version) ((round(increase(kubevirt_api_request_deprecated_total{verb!~\"LIST|WATCH\"}[10m])) > 0 and kubevirt_api_request_deprecated_total{verb!~\"LIST|WATCH\"} offset 10m) or (kubevirt_api_request_deprecated_total{verb!~\"LIST|WATCH\"} != 0 unless kubevirt_api_request_deprecated_total{verb!~\"LIST|WATCH\"} offset 10m))"),
 			Annotations: map[string]string{
 				"description": "Detected requests to the deprecated {{ $labels.resource }}.{{ $labels.group }}/{{ $labels.version }} API.",
 				"summary":     "Detected {{ $value }} requests in the last 10 minutes.",
-				"runbook_url": fmt.Sprintf(runbookURLTemplate, "KubeVirtDeprecatedAPIsRequested"),
+				"runbook_url": fmt.Sprintf(runbookURLTemplate, "KubeVirtDeprecatedAPIRequested"),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "info",

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -174,7 +174,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 	})
 
 	Context("Deprecation Alerts", decorators.SigComputeMigrations, func() {
-		It("KubeVirtDeprecatedAPIsRequested should be triggered when a deprecated API is requested", func() {
+		It("KubeVirtDeprecatedAPIRequested should be triggered when a deprecated API is requested", func() {
 			By("Creating a VMI with deprecated API version")
 			vmi := libvmi.NewCirros()
 			vmi.APIVersion = "v1alpha3"
@@ -183,10 +183,10 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying the alert exists")
-			verifyAlertExist(virtClient, "KubeVirtDeprecatedAPIsRequested")
+			verifyAlertExist(virtClient, "KubeVirtDeprecatedAPIRequested")
 
 			By("Verifying the alert disappears")
-			waitUntilAlertDoesNotExistWithCustomTime(virtClient, 15*time.Minute, "KubeVirtDeprecatedAPIsRequested")
+			waitUntilAlertDoesNotExistWithCustomTime(virtClient, 15*time.Minute, "KubeVirtDeprecatedAPIRequested")
 		})
 	})
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Renaming KubeVirtDeprecatedAPIsRequested to
KubeVirtDeprecatedAPIRequested avoids confusion about use of singular or plural.

See https://github.com/kubevirt/monitoring/pull/172#discussion_r1219942486 and https://github.com/kubevirt/monitoring/pull/178.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
