### PR TITLE
[release-0.59]  affine kvm-pit kernel thread to vcpu-0 cpumask

### DIFF
--- a/pkg/virt-handler/isolation/generated_mock_isolation.go
+++ b/pkg/virt-handler/isolation/generated_mock_isolation.go
@@ -104,3 +104,14 @@ func (_m *MockIsolationResult) GetQEMUProcess() (go_ps.Process, error) {
 func (_mr *_MockIsolationResultRecorder) GetQEMUProcess() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetQEMUProcess")
 }
+
+func (_m *MockIsolationResult) KvmPitPid() (int, error) {
+	ret := _m.ctrl.Call(_m, "KvmPitPid")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIsolationResultRecorder) KvmPitPid() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "KvmPitPid")
+}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -35,6 +35,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 	"kubevirt.io/kubevirt/pkg/virt-handler/selinux"
 
@@ -2619,6 +2621,58 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 	return nil
 }
 
+func (d *VirtualMachineController) affinePitThread(vmi *v1.VirtualMachineInstance) error {
+	res, err := d.podIsolationDetector.Detect(vmi)
+	if err != nil {
+		return err
+	}
+	var Mask unix.CPUSet
+	Mask.Zero()
+	qemuprocess, err := res.GetQEMUProcess()
+	if err != nil {
+		return err
+	}
+	qemupid := qemuprocess.Pid()
+	if err != nil {
+		return err
+	}
+	if qemupid == -1 {
+		return nil
+	}
+
+	pitpid, err := res.KvmPitPid()
+	if err != nil {
+		return err
+	}
+	if pitpid == -1 {
+		return nil
+	}
+	if vmi.IsRealtimeEnabled() {
+		param := schedParam{priority: 2}
+		err = schedSetScheduler(pitpid, schedFIFO, param)
+		if err != nil {
+			return fmt.Errorf("failed to set FIFO scheduling and priority 2 for thread %d: %w", pitpid, err)
+		}
+	}
+	vcpus, err := getVCPUThreadIDs(qemupid)
+	if err != nil {
+		return err
+	}
+	vpid, ok := vcpus["0"]
+	if ok == false {
+		return nil
+	}
+	vcpupid, err := strconv.Atoi(vpid)
+	if err != nil {
+		return err
+	}
+	err = unix.SchedGetaffinity(vcpupid, &Mask)
+	if err != nil {
+		return err
+	}
+	return unix.SchedSetaffinity(pitpid, &Mask)
+}
+
 func (d *VirtualMachineController) configureHousekeepingCgroup(vmi *v1.VirtualMachineInstance) error {
 	cgroupManager, err := cgroup.NewManagerFromVM(vmi)
 	if err != nil {
@@ -2830,6 +2884,12 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 	if vmi.IsRealtimeEnabled() && !vmi.IsRunning() && !vmi.IsFinal() {
 		log.Log.Object(vmi).Info("Configuring vcpus for real time workloads")
 		if err := d.configureVCPUScheduler(vmi); err != nil {
+			return err
+		}
+	}
+	if vmi.IsCPUDedicated() && !vmi.IsRunning() && !vmi.IsFinal() {
+		log.Log.V(3).Object(vmi).Info("Affining PIT thread")
+		if err := d.affinePitThread(vmi); err != nil {
 			return err
 		}
 	}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -363,6 +363,51 @@ func GetProcessName(pod *k8sv1.Pod, pid string) (output string, err error) {
 	return
 }
 
+func GetVcpuMask(pod *k8sv1.Pod, cpu string) (output string, err error) {
+	virtClient := kubevirt.Client()
+
+	pscmd := "ps -LC qemu-kvm -o lwp,comm| grep \"CPU " + cpu + "\"  | cut -f 1 -d \"C\""
+	output, err = exec.ExecuteCommandOnPod(
+		virtClient,
+		pod,
+		"compute",
+		[]string{BinBash, "-c", pscmd},
+	)
+	Expect(err).ToNot(HaveOccurred())
+	vcpupid := strings.TrimSpace(strings.Trim(output, "\n"))
+	tasksetcmd := "taskset -c -p " + vcpupid + " | cut -f 2 -d \":\""
+	args := []string{BinBash, "-c", tasksetcmd}
+	output, err = exec.ExecuteCommandOnPod(virtClient, pod, "compute", args)
+	Expect(err).ToNot(HaveOccurred())
+
+	return output, err
+}
+
+func GetKvmPitMask(pod *k8sv1.Pod, nodeName string) (output string, err error) {
+	virtClient := kubevirt.Client()
+
+	output, err = exec.ExecuteCommandOnPod(
+		virtClient,
+		pod,
+		"compute",
+		[]string{"ps", "-C", "qemu-kvm", "-o", "pid", "--noheader"},
+	)
+	Expect(err).ToNot(HaveOccurred())
+	qemupid := strings.TrimSpace(strings.Trim(output, "\n"))
+	kvmpitcomm := "kvm-pit/" + qemupid
+	args := []string{"ps", "-C", kvmpitcomm, "-o", "pid", "--noheader"}
+	output, err = ExecuteCommandInVirtHandlerPod(nodeName, args)
+	Expect(err).ToNot(HaveOccurred())
+
+	kvmpitpid := strings.TrimSpace(strings.Trim(output, "\n"))
+	tasksetcmd := "taskset -c -p " + kvmpitpid + " | cut -f 2 -d \":\""
+	args = []string{BinBash, "-c", tasksetcmd}
+	output, err = ExecuteCommandInVirtHandlerPod(nodeName, args)
+	Expect(err).ToNot(HaveOccurred())
+
+	return output, err
+}
+
 func ListCgroupThreads(pod *k8sv1.Pod) (output string, err error) {
 	virtClient := kubevirt.Client()
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2505,6 +2505,23 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
 					&expect.BExp{R: "2"},
 				}, 15)).To(Succeed())
+
+				virtClient := kubevirt.Client()
+				pscmd := []string{"ps", "-C", "qemu-kvm", "-o", "pid", "--noheader"}
+				_, err = exec.ExecuteCommandOnPod(
+					virtClient, readyPod, "compute", pscmd)
+				// do not check for kvm-pit thread if qemu-kvm is not in use
+				if err != nil {
+					return
+				}
+				kvmpitmask, err := tests.GetKvmPitMask(readyPod, node)
+				Expect(err).ToNot(HaveOccurred())
+
+				vcpuzeromask, err := tests.GetVcpuMask(readyPod, "0")
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(kvmpitmask).To(Equal(vcpuzeromask))
+
 			},
 				Entry("with explicit resources set", &virtv1.ResourceRequirements{
 					Requests: kubev1.ResourceList{


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/9613

"""
Certain use-cases rely on injection of PIT interrupts to the guest in a timely fashion. Today, the kvm-pit kernel thread which is responsible for emulating PIT interrupts runs on housekeeping cores, sharing time with other kubernetes threads (such as kubelet). This has been found to be a problem for a particular workload requiring timely PIT interrupts (see trace below). The fix is to affine kvm-pit kernel thread to the same cpu as vcpu-0, when dedicated cpu placement is enabled in the guest configuration.

      <idle>-0     [000] d.h. 102470.847586: hrtimer_expire_entry: hrtimer=00000000e3dea339 function=pit_timer_fn [kvm] now=102463903132805
      <idle>-0     [000] d.h. 102470.847587: sched_waking: comm=kvm-pit/67 pid=1212317 prio=120 target_cpu=001
      <idle>-0     [001] d... 102470.847590: sched_switch: prev_comm=swapper/1 prev_pid=0 prev_prio=120 prev_state=S ==> next_comm=kvm-pit/67 next_pid=1212317 next_prio=120
  kvm-pit/67-1212317 [001] d... 102470.847594: sched_switch: prev_comm=kvm-pit/67 prev_pid=1212317 prev_prio=120 prev_state=D ==> next_comm=swapper/1 next_pid=0 next_prio=120
   CPU 0/KVM-1212312 [006] d... 102470.847596: kvm_entry: vcpu 0, rip 0x35fd
   CPU 0/KVM-1212312 [006] d... 102470.847597: kvm_exit: vcpu 0 reason EOI_INDUCED rip 0x1bab info1 0x0000000000000022 info2 0x0000000000000000 intr_info 0x00000000 error_code 0x00000000
   CPU 0/KVM-1212312 [006] d... 102470.847598: kvm_entry: vcpu 0, rip 0x1bab

...
CPU 0/KVM-1212312 [006] d... 102470.847622: kvm_exit: vcpu 0 reason HLT rip 0x35fc info1 0x0000000000000000 info2 0x0000000000000000 intr_info 0x00000000 error_code 0x00000000
<...>-64244 [000] d.h. 102470.857590: hrtimer_expire_entry: hrtimer=00000000e3dea339 function=pit_timer_fn [kvm] now=102463913135899
<...>-64244 [000] d.h. 102470.857599: sched_waking: comm=kvm-pit/67 pid=1212317 prio=120 target_cpu=001
kube-apiserver-64649 [004] d.h. 102470.860004: hrtimer_expire_entry: hrtimer=00000000f5450c52 function=pit_timer_fn [kvm] now=102463915550678
<...>-64245 [003] d.h. 102470.863029: hrtimer_expire_entry: hrtimer=000000004736fe96 function=pit_timer_fn [kvm] now=102463918575518
<...>-64244 [000] d.h. 102470.867587: hrtimer_expire_entry: hrtimer=00000000e3dea339 function=pit_timer_fn [kvm] now=102463923133350
<...>-64244 [000] d.h. 102470.869780: hrtimer_expire_entry: hrtimer=000000005deb41ca function=pit_timer_fn [kvm] now=102463925326017
<...>-64244 [000] d... 102470.877465: sched_switch: prev_comm=kube-apiserver prev_pid=64244 prev_prio=120 prev_state=S ==> next_comm=kvm-pit/67 next_pid=1212317 next_prio=120
kvm-pit/67-1212317 [000] d... 102470.877483: sched_switch: prev_comm=kvm-pit/67 prev_pid=1212317 prev_prio=120 prev_state=D ==> next_comm=cluster-policy- next_pid=60163 next_prio=120
CPU 0/KVM-1212312 [006] d... 102470.877486: kvm_entry: vcpu 0, rip 0x35fd
CPU 0/KVM-1212312 [006] d... 102470.877490: kvm_exit: vcpu 0 reason EOI_INDUCED rip 0x1bab info1 0x0000000000000022 info2 0x0000000000000000 intr_info 0x00000000 error_code 0x00000000
CPU 0/KVM-1212312 [006] d... 102470.877491: sched_waking: comm=kvm-pit/67 pid=1212317 prio=120 target_cpu=000
CPU 0/KVM-1212312 [006] d... 102470.877494: kvm_entry: vcpu 0, rip 0x1bab

"""

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The conflict was imports

**Release note**:

```release-note
NONE
```
