### PR TITLE
Add Apparmor Support in Virt Launcher

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17522,6 +17522,9 @@
      "apiConfiguration": {
       "$ref": "#/definitions/v1.ReloadableComponentConfiguration"
      },
+     "appArmorLauncherProfile": {
+      "type": "string"
+     },
      "architectureConfiguration": {
       "$ref": "#/definitions/v1.ArchConfiguration"
      },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -131,6 +131,8 @@ spec:
                             type: object
                         type: object
                     type: object
+                  appArmorLauncherProfile:
+                    type: string
                   architectureConfiguration:
                     properties:
                       amd64:
@@ -3119,6 +3121,8 @@ spec:
                             type: object
                         type: object
                     type: object
+                  appArmorLauncherProfile:
+                    type: string
                   architectureConfiguration:
                     properties:
                       amd64:

--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -218,6 +218,7 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 			PermitBridgeInterfaceOnPodNetwork: pointer.BoolPtr(DefaultPermitBridgeInterfaceOnPodNetwork),
 		},
 		SMBIOSConfig:                SmbiosDefaultConfig,
+		AppArmorLauncherProfile:     DefaultAppArmorLauncherProfile,
 		SELinuxLauncherType:         DefaultSELinuxLauncherType,
 		SupportedGuestAgentVersions: supportedQEMUGuestAgentVersions,
 		OVMFPath:                    DefaultOVMFPath,

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -424,8 +424,18 @@ var _ = Describe("test configuration", func() {
 		Entry("when unset, GetSELinuxLauncherType should return the default", virtconfig.DefaultSELinuxLauncherType, virtconfig.DefaultSELinuxLauncherType),
 	)
 
-	DescribeTable(" when OVMFPath", func(cpuArch string, ovmfPathKeyAMD64 string, ovmfPathKeyARM64 string, ovmfPathKeyPPC64le64 string, result string) {
+	DescribeTable(" when AppArmorLauncherProfile", func(value string, result string) {
+		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
+			AppArmorLauncherProfile: value,
+		})
+		appArmorProfile := clusterConfig.GetAppArmorLauncherProfile()
+		Expect(appArmorProfile).To(Equal(result))
+	},
+		Entry("when set, GetAppArmorLauncherProfile should return the value", "defaultAAprofile", "defaultAAprofile"),
+		Entry("when unset, GetAppArmorLauncherProfile should return the default", virtconfig.DefaultAppArmorLauncherProfile, virtconfig.DefaultAppArmorLauncherProfile),
+	)
 
+	DescribeTable(" when OVMFPath", func(cpuArch string, ovmfPathKeyAMD64 string, ovmfPathKeyARM64 string, ovmfPathKeyPPC64le64 string, result string) {
 		kv := &v1.KubeVirt{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kubevirt",

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -66,6 +66,7 @@ const (
 	SupportedGuestAgentVersions                     = "2.*,3.*,4.*,5.*"
 	DefaultARCHOVMFPath                             = "/usr/share/OVMF"
 	DefaultAARCH64OVMFPath                          = "/usr/share/AAVMF"
+	DefaultAppArmorLauncherProfile                  = ""
 	DefaultMemBalloonStatsPeriod             uint32 = 10
 	DefaultCPUAllocationRatio                       = 10
 	DefaultDiskVerificationMemoryLimitMBytes        = 2000
@@ -239,6 +240,10 @@ func (c *ClusterConfig) GetSELinuxLauncherType() string {
 
 func (c *ClusterConfig) GetDefaultRuntimeClass() string {
 	return c.GetConfig().DefaultRuntimeClass
+}
+
+func (c *ClusterConfig) GetAppArmorLauncherProfile() string {
+	return c.GetConfig().AppArmorLauncherProfile
 }
 
 func (c *ClusterConfig) GetSupportedAgentVersions() []string {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -480,6 +480,12 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		podAnnotations[v1.EphemeralProvisioningObject] = "true"
 	}
 
+	// If AppArmorProfile was specified, add that to the compute container.
+	apparmorLauncherProfile := t.clusterConfig.GetAppArmorLauncherProfile()
+	if apparmorLauncherProfile != "" {
+		podAnnotations["container.apparmor.security.beta.kubernetes.io/compute"] = apparmorLauncherProfile
+	}
+
 	var initContainers []k8sv1.Container
 
 	if HaveContainerDiskVolume(vmi.Spec.Volumes) || util.HasKernelBootContainerImage(vmi) {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4345,6 +4345,31 @@ var _ = Describe("Template", func() {
 			Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().IsZero()).To(BeTrue())
 		})
 	})
+
+	Context("AppArmorProfile", func() {
+		It("should set the correct annotation when profile is present", func() {
+			config, kvInformer, svc = configFactory(defaultArch)
+			kvConfig := kv.DeepCopy()
+			kvConfig.Spec.Configuration.AppArmorLauncherProfile = "test_launcher_profile"
+			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
+
+			vmi := api.NewMinimalVMI("fake-vmi")
+
+			pod, err := svc.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod.Annotations).Should(HaveKeyWithValue("container.apparmor.security.beta.kubernetes.io/compute", "test_launcher_profile"))
+		})
+
+		It("should not set the annotation when the profile is not specified", func() {
+			config, kvInformer, svc = configFactory(defaultArch)
+
+			vmi := api.NewMinimalVMI("fake-vmi")
+
+			pod, err := svc.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod.Annotations).Should(Not(HaveKey("container.apparmor.security.beta.kubernetes.io/compute")))
+		})
+	})
 })
 
 var _ = Describe("getResourceNameForNetwork", func() {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -742,6 +742,8 @@ var CRDsValidation map[string]string = map[string]string{
                       type: object
                   type: object
               type: object
+            appArmorLauncherProfile:
+              type: string
             architectureConfiguration:
               properties:
                 amd64:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2306,6 +2306,8 @@ type KubeVirtConfiguration struct {
 	DefaultRuntimeClass       string                  `json:"defaultRuntimeClass,omitempty"`
 	SMBIOSConfig              *SMBiosConfiguration    `json:"smbios,omitempty"`
 	ArchitectureConfiguration *ArchConfiguration      `json:"architectureConfiguration,omitempty"`
+	AppArmorLauncherProfile   string                  `json:"appArmorLauncherProfile,omitempty"`
+
 	// EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be
 	// migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific
 	// field is set it overrides the cluster level one.

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18857,6 +18857,12 @@ func schema_kubevirtio_api_core_v1_KubeVirtConfiguration(ref common.ReferenceCal
 							Ref: ref("kubevirt.io/api/core/v1.ArchConfiguration"),
 						},
 					},
+					"appArmorLauncherProfile": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"evictionStrategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific field is set it overrides the cluster level one.",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds the ability to set the AppArmor Profile.

On the kuebvirt configuration, the apparmor profile string can now be set. This string will then be passed on to the virt-launcher pod annotation ("container.apparmor.security.beta.kubernetes.io/compute").

If the string is empty, the annotation will not be added.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Support setting the AppArmor profile on the virt-launcher pod. 

```
