### PR TITLE
Fix bad cast of int to string

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter.go
@@ -18,7 +18,7 @@ import (
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )
 
-const percentValueMustBeInRangeMessagePattern = "%s '%s': must be in range between 0 and 100."
+const percentValueMustBeInRangeMessagePattern = "%s '%d': must be in range between 0 and 100."
 
 var supportedInstancetypeVersions = []string{
 	instancetypev1alpha1.SchemeGroupVersion.Version,
@@ -48,7 +48,7 @@ func validateMemoryOvercommitPercentSetting(field *k8sfield.Path, spec *instance
 		causes = append(causes, metav1.StatusCause{
 			Type: metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf(percentValueMustBeInRangeMessagePattern, field.Child("memory", "overcommitPercent").String(),
-				string(spec.Memory.OvercommitPercent)),
+				spec.Memory.OvercommitPercent),
 			Field: field.Child("memory", "overcommitPercent").String(),
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Int is being casted to string in a wrong way.
In some environments, it leads to a compilation error: `conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
