### PR TITLE
virt-handler, network setup: Do not create podNIC for SR-IOV networks

### DIFF
--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -58,6 +58,9 @@ var _ = Describe("netconf", func() {
 
 	It("fails the setup run", func() {
 		netConf := netsetup.NewNetConfWithCustomFactory(nsFailureFactory, &tempCacheCreator{})
+		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name: "default",
+		}}
 		vmi.Spec.Networks = []v1.Network{{
 			Name:          "default",
 			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -53,13 +53,14 @@ func (v VMNetworkConfigurator) getPhase1NICs(launcherPID *int, networks []v1.Net
 	var nics []podNIC
 
 	for i := range networks {
+		// SR-IOV devices are not part of the phases.
+		if iface := vmispec.LookupInterfaceByName(v.vmi.Spec.Domain.Devices.Interfaces, networks[i].Name); iface.SRIOV != nil {
+			continue
+		}
+
 		nic, err := newPhase1PodNIC(v.vmi, &networks[i], v.handler, v.cacheCreator, launcherPID)
 		if err != nil {
 			return nil, err
-		}
-		// SR-IOV devices are not part of the phases.
-		if nic.vmiSpecIface.SRIOV != nil {
-			continue
 		}
 		nics = append(nics, *nic)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Kubevirt expects SR-IOV interfaces to be set with userspace driver (vfio-pci) in order to attach them to VMs.
The interfaces are passthroughed to the VM using Libvirt API. 
Thus SR-IOV networks should not be part of the network setup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a follow-up PR to resolve https://github.com/kubevirt/kubevirt/pull/9268#discussion_r1199753143

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
