### PR TITLE
virt-controller, VMController: Patch VMI interfaces mac address

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2612,7 +2612,6 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		}
 	}
 
-	var ifaceHotplugError syncError
 	// Must check needsSync again here because a VMI can be created or
 	// deleted in the startStop function which impacts how we process
 	// hotplugged volumes and interfaces
@@ -2655,9 +2654,6 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 	}
 	virtControllerVMWorkQueueTracer.StepTrace(key, "sync", trace.Field{Key: "VM Name", Value: vm.Name})
 
-	if syncErr == nil && ifaceHotplugError != nil {
-		syncErr = ifaceHotplugError
-	}
 	return vm, syncErr, nil
 }
 

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2065,7 +2065,7 @@ func (c *VMController) updateStatus(vmOrig *virtv1.VirtualMachine, vmi *virtv1.V
 	vm.Status.Ready = ready
 
 	c.trimDoneVolumeRequests(vm)
-	trimDoneInterfaceRequests(vm)
+	trimDoneInterfaceRequests(vm, vmi)
 	c.updateMemoryDumpRequest(vm, vmi)
 
 	if c.isTrimFirstChangeRequestNeeded(vm, vmi) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When KubeMacPool exists and opt-in to manage VMs MAC addresses, it patch **VirtualMachine** objects and add MAC address to their interfaces in the template spec. 

On VM creation,  the VM is patched by KubeMacPool and the interfaces in the spec will be set with the allocated MAC addresses.
The corresponding **VMI** will be created with the same MAC addresses as in the VM template spec (given by the user/KubeMacPool).

But for interface hotplug this is not the case, the MAC address in the VM template spec won't replicate to the VMI spec, and the interface in the guest ends up with a random MAC address.

Hotplug on VM flow:
```
- virt-api handles VM interface-add request and add interface request to the VM status.
- virt-controller realizes there is a new request in the VM status and handles it:
   - Add the new interface to the VM object
   - Add the new interface to the VMI object and patch the VMI.
   - Update the VM
-  virt-controller VMI controller realizes there is a new interface to hotplug and patch virt-launcher pod networks annotation.
- virt-controller VM update status, it realizes the new interface has been added **both to the VM and VMI spec** and removes the request.
```

Reasons for this behavior:
- On interface hotplug on a **VM**, virt-controller patch the VMI spec before the VM spec template.
   The order has to change so that the VM is patched first and the VMI afterward.
   It will enable replicating the requested MAC address in the VM template spec to the VMI spec.

---
This PR changes the hotplug on VM flow in a way that virt-controller patches VMs before VMIs, where the patch set the VMI interfaces MAC address as specified in the VM spec.
It will ensure the guest will have the correct MAC address as specified in the VM spec (by KubeMacPool, or in the future, by the user).

Hotplug on VM flow new flow:
```
- virt-api handles VM interface-add request and add interface request to the VM status.
- virt-controller realizes there is a new request in the VM status and handles it:
   - Add the new interface to the VM object
   - Add the new interface to the VMI object
   - Update the VM
   **- Copy the interface's MAC address from the VM template to the interfaces in the VMI spec.**
   **- Patch the VMI**
-  virt-controller VMI controller realizes there is a new interface to hotplug and patch virt-launcher pod networks annotation.
- virt-controller VM update status, it realizes the new interface has been added **both to the VM and VMI spec** and removes the request.
```

**Special notes for your reviewer**:
- Interface requests will not be removed from the queue (VM status.interfaceRequests) until the VMI is also patched with the request changes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The VM controller now replicates spec interfaces MAC addresses to the corresponding interfaces in the VMI spec.
```
