### PR TITLE
Network, setup: Remove redundant lookup of interface by network

### DIFF
--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -55,12 +55,17 @@ func (v VMNetworkConfigurator) getPhase1NICs(launcherPID *int, networks []v1.Net
 	var nics []podNIC
 
 	for i := range networks {
-		// SR-IOV devices are not part of the phases.
-		if iface := vmispec.LookupInterfaceByName(v.vmi.Spec.Domain.Devices.Interfaces, networks[i].Name); iface.SRIOV != nil {
+		iface := vmispec.LookupInterfaceByName(v.vmi.Spec.Domain.Devices.Interfaces, networks[i].Name)
+		if iface == nil {
+			return nil, fmt.Errorf("no iface matching with network %s", networks[i].Name)
+		}
+
+		// SR-IOV devices are not part of the phases
+		if iface.SRIOV != nil {
 			continue
 		}
 
-		nic, err := newPhase1PodNIC(v.vmi, &networks[i], v.handler, v.cacheCreator, launcherPID)
+		nic, err := newPhase1PodNIC(v.vmi, &networks[i], iface, v.handler, v.cacheCreator, launcherPID)
 		if err != nil {
 			return nil, err
 		}
@@ -73,12 +78,17 @@ func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain, networks []v1.N
 	var nics []podNIC
 
 	for i := range networks {
-		// SR-IOV devices are not part of the phases.
-		if iface := vmispec.LookupInterfaceByName(v.vmi.Spec.Domain.Devices.Interfaces, networks[i].Name); iface.SRIOV != nil {
+		iface := vmispec.LookupInterfaceByName(v.vmi.Spec.Domain.Devices.Interfaces, networks[i].Name)
+		if iface == nil {
+			return nil, fmt.Errorf("no iface matching with network %s", networks[i].Name)
+		}
+
+		// SR-IOV devices are not part of the phases
+		if iface.SRIOV != nil {
 			continue
 		}
 
-		nic, err := newPhase2PodNIC(v.vmi, &networks[i], v.handler, v.cacheCreator, domain)
+		nic, err := newPhase2PodNIC(v.vmi, &networks[i], iface, v.handler, v.cacheCreator, domain)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/network/setup/podnic_test.go
+++ b/pkg/network/setup/podnic_test.go
@@ -32,7 +32,7 @@ var _ = Describe("podNIC", func() {
 	)
 
 	newPhase2PodNICWithMocks := func(vmi *v1.VirtualMachineInstance) (*podNIC, error) {
-		podnic, err := newPodNIC(vmi, &vmi.Spec.Networks[0], mockNetwork, &baseCacheCreator, nil)
+		podnic, err := newPodNIC(vmi, &vmi.Spec.Networks[0], &vmi.Spec.Domain.Devices.Interfaces[0], mockNetwork, &baseCacheCreator, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following PRs https://github.com/kubevirt/kubevirt/pull/9268 and https://github.com/kubevirt/kubevirt/pull/9890, we now look up an interface by its network name
in `getPhase1NICs()` and in `getPhase2NICs()`.

The same lookup operation also occurs at `newPodNIC()` which is called from both
`getPhase1NICs()` and `getPhase2NICs()`.

Pass the interface found in `getPhase1NICs()` and `getPhase2NICs()`
down the stack to `newPodNIC()`, so it could be used instead of performing the
same operation again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on PR #9890, please review only the last commit.~~

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
