### PR TITLE
[e2e] Refactoring libwait & ignore EvictionStrategy warning

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -60,9 +60,9 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	})
 
 	verifyContainerDiskVMI := func(vmi *v1.VirtualMachineInstance, obj runtime.Object) {
-		_, ok := obj.(*v1.VirtualMachineInstance)
+		vmiObj, ok := obj.(*v1.VirtualMachineInstance)
 		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
-		libwait.WaitForSuccessfulVMIStart(obj)
+		libwait.WaitForSuccessfulVMIStart(vmiObj)
 
 		// Verify Registry Disks are Online
 		pods, err := virtClient.CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
@@ -112,7 +112,9 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					By("Starting the VirtualMachineInstance")
 					obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Get()
 					Expect(err).ToNot(HaveOccurred())
-					libwait.WaitForSuccessfulVMIStart(obj)
+					vmiObj, ok := obj.(*v1.VirtualMachineInstance)
+					Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
+					libwait.WaitForSuccessfulVMIStart(vmiObj)
 
 					By("Stopping the VirtualMachineInstance")
 					_, err = virtClient.RestClient().Delete().Resource("virtualmachineinstances").Namespace(vmi.GetObjectMeta().GetNamespace()).Name(vmi.GetObjectMeta().GetName()).Do(context.Background()).Get()

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -477,9 +477,11 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, decorators.SigCo
 			Body(vmi).
 			Do(context.Background()).Get()
 		Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+		vmiObj, ok := obj.(*v1.VirtualMachineInstance)
+		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
 
 		By("Waiting until the VM is ready")
-		return libwait.WaitForSuccessfulVMIStart(obj).Status.NodeName
+		return libwait.WaitForSuccessfulVMIStart(vmiObj).Status.NodeName
 	}
 
 	Describe("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com][level:component]Taints and toleration", func() {
@@ -1206,7 +1208,9 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, decorators.SigCo
 				By("Starting a new VirtualMachineInstance")
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Get()
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStart(obj)
+				vmiObj, ok := obj.(*v1.VirtualMachineInstance)
+				Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
+				libwait.WaitForSuccessfulVMIStart(vmiObj)
 			})
 		})
 

--- a/tests/libwait/BUILD.bazel
+++ b/tests/libwait/BUILD.bazel
@@ -15,6 +15,5 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -29,8 +29,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -39,29 +37,95 @@ import (
 	"kubevirt.io/kubevirt/tests/watcher"
 )
 
-// WaitForVMIStartOrFailed blocks until the specified VirtualMachineInstance reached either Failed or Running states
-func WaitForVMIStartOrFailed(obj runtime.Object, seconds int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	return waitForVMIPhase(ctx, []v1.VirtualMachineInstancePhase{v1.Running, v1.Failed}, obj, seconds, wp, true)
+const defaultTimeout = 360
+
+// Option represents an action that enables an option.
+type Option func(waiting *Waiting)
+
+// Waiting represents the waiting struct.
+type Waiting struct {
+	ctx         context.Context
+	wp          *watcher.WarningsPolicy
+	timeout     int
+	waitForFail bool
+	phases      []v1.VirtualMachineInstancePhase
 }
 
-// Block until the specified VirtualMachineInstance started and return the target node name.
-func WaitForVMIStart(ctx context.Context, obj runtime.Object, seconds int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
-	return waitForVMIPhase(ctx, []v1.VirtualMachineInstancePhase{v1.Running}, obj, seconds, wp, false)
+// WaitForVMIPhase blocks until the specified VirtualMachineInstance reaches any of the phases.
+// By default, the waiting will fail if a warning is captured and a default timeout will be used.
+// These properties can be customized using With* options.
+// If no context is provided, a new one will be created.
+func WaitForVMIPhase(vmi *v1.VirtualMachineInstance, phases []v1.VirtualMachineInstancePhase, opts ...Option) *v1.VirtualMachineInstance {
+	wp := watcher.WarningsPolicy{FailOnWarnings: true}
+	gomega.ExpectWithOffset(1, phases).ToNot(gomega.BeEmpty())
+	waiting := Waiting{timeout: defaultTimeout, wp: &wp, phases: phases}
+	for _, f := range opts {
+		f(&waiting)
+	}
+
+	if waiting.ctx == nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		waiting.ctx = ctx
+	}
+
+	return waiting.watchVMIForPhase(vmi)
 }
 
-// Block until the specified VirtualMachineInstance scheduled and return the target node name.
-func WaitForVMIScheduling(obj runtime.Object, seconds int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	return waitForVMIPhase(ctx, []v1.VirtualMachineInstancePhase{v1.Scheduling, v1.Scheduled, v1.Running}, obj, seconds, wp, false)
+// WithContext adds a specific context to the waiting struct
+func WithContext(ctx context.Context) Option {
+	return func(waiting *Waiting) {
+		waiting.ctx = ctx
+	}
 }
 
-func waitForVMIPhase(ctx context.Context, phases []v1.VirtualMachineInstancePhase, obj runtime.Object, seconds int, wp watcher.WarningsPolicy, waitForFail bool) *v1.VirtualMachineInstance {
-	vmi, ok := obj.(*v1.VirtualMachineInstance)
-	gomega.ExpectWithOffset(1, ok).To(gomega.BeTrue(), "Object is not of type *v1.VMI")
+// WithTimeout adds a specific timeout to the waiting struct
+func WithTimeout(seconds int) Option {
+	return func(waiting *Waiting) {
+		waiting.timeout = seconds
+	}
+}
 
+// WithWarningsPolicy adds a specific warningPolicy to the waiting struct
+func WithWarningsPolicy(wp *watcher.WarningsPolicy) Option {
+	return func(waiting *Waiting) {
+		waiting.wp = wp
+	}
+}
+
+// WithFailOnWarnings sets if the waiting should fail on warning or not
+func WithFailOnWarnings(failOnWarnings bool) Option {
+	return func(waiting *Waiting) {
+		if waiting.wp == nil {
+			waiting.wp = &watcher.WarningsPolicy{}
+		}
+
+		waiting.wp.FailOnWarnings = failOnWarnings
+	}
+}
+
+// WithWarningsIgnoreList sets the warnings that will be ignored during the waiting for phase
+// This option will be ignored if a warning policy has been set before and the failOnWarnings is false
+// If no warning policy has been set before, a new one will be set implicitly with fail on warnings enabled and the ignore list added
+func WithWarningsIgnoreList(warningIgnoreList []string) Option {
+	return func(waiting *Waiting) {
+		if waiting.wp == nil {
+			waiting.wp = &watcher.WarningsPolicy{FailOnWarnings: true}
+		}
+
+		waiting.wp.WarningsIgnoreList = warningIgnoreList
+	}
+}
+
+// WithWaitForFail adds the specific waitForFail to the waiting struct
+func WithWaitForFail(waitForFail bool) Option {
+	return func(waiting *Waiting) {
+		waiting.waitForFail = waitForFail
+	}
+}
+
+// watchVMIForPhase looks at the vmi object and, after it is started, waits for it to satisfy the phases with the passed parameters
+func (w *Waiting) watchVMIForPhase(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 	virtClient, err := kubecli.GetKubevirtClient()
 	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
 
@@ -72,22 +136,22 @@ func waitForVMIPhase(ctx context.Context, phases []v1.VirtualMachineInstancePhas
 		gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
 	}
 
-	objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(seconds+2) * time.Second)
-	if wp.FailOnWarnings == true {
+	objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(w.timeout+2) * time.Second)
+	if w.wp.FailOnWarnings == true {
 		// let's ignore PSA events as kubernetes internally uses a namespace informer
 		// that might not be up to date after virt-controller relabeled the namespace
 		// to use a 'privileged' policy
 		// TODO: remove this when KubeVirt will be able to run VMs under the 'restricted' level
-		wp.WarningsIgnoreList = append(wp.WarningsIgnoreList, "violates PodSecurity")
-		objectEventWatcher.SetWarningsPolicy(wp)
+		w.wp.WarningsIgnoreList = append(w.wp.WarningsIgnoreList, "violates PodSecurity")
+		objectEventWatcher.SetWarningsPolicy(*w.wp)
 	}
 
 	go func() {
 		defer ginkgo.GinkgoRecover()
-		objectEventWatcher.WaitFor(ctx, watcher.NormalEvent, v1.Started)
+		objectEventWatcher.WaitFor(w.ctx, watcher.NormalEvent, v1.Started)
 	}()
 
-	timeoutMsg := fmt.Sprintf("Timed out waiting for VMI %s to enter %s phase(s)", vmi.Name, phases)
+	timeoutMsg := fmt.Sprintf("Timed out waiting for VMI %s to enter %s phase(s)", vmi.Name, w.phases)
 	// FIXME the event order is wrong. First the document should be updated
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) v1.VirtualMachineInstancePhase {
 		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
@@ -95,36 +159,79 @@ func waitForVMIPhase(ctx context.Context, phases []v1.VirtualMachineInstancePhas
 
 		g.Expect(vmi).ToNot(matcher.HaveSucceeded(), "VMI %s unexpectedly stopped. State: %s", vmi.Name, vmi.Status.Phase)
 		// May need to wait for Failed state
-		if !waitForFail {
+		if !w.waitForFail {
 			g.Expect(vmi).ToNot(matcher.BeInPhase(v1.Failed), "VMI %s unexpectedly stopped. State: %s", vmi.Name, vmi.Status.Phase)
 		}
 		return vmi.Status.Phase
-	}, time.Duration(seconds)*time.Second, 1*time.Second).Should(gomega.BeElementOf(phases), timeoutMsg)
+	}, time.Duration(w.timeout)*time.Second, 1*time.Second).Should(gomega.BeElementOf(w.phases), timeoutMsg)
 
 	return vmi
 }
 
-func WaitForSuccessfulVMIStartIgnoreWarnings(vmi runtime.Object) *v1.VirtualMachineInstance {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	wp := watcher.WarningsPolicy{FailOnWarnings: false}
-	return WaitForVMIStart(ctx, vmi, 180, wp)
+// WaitForVMIStartOrFailed blocks until the specified VirtualMachineInstance reaches either Failed or Running states
+func WaitForVMIStartOrFailed(vmi *v1.VirtualMachineInstance, seconds int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
+	return WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running, v1.Failed},
+		WithWarningsPolicy(&wp),
+		WithTimeout(seconds),
+		WithWaitForFail(true),
+	)
 }
 
-func WaitForSuccessfulVMIStartWithTimeout(vmi runtime.Object, seconds int) *v1.VirtualMachineInstance {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	wp := watcher.WarningsPolicy{FailOnWarnings: true}
-	return WaitForVMIStart(ctx, vmi, seconds, wp)
+// WaitForVMIScheduling blocks until the specified VirtualMachineInstance scheduled and return the target node name.
+func WaitForVMIScheduling(vmi *v1.VirtualMachineInstance, seconds int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
+	return WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Scheduling, v1.Scheduled, v1.Running},
+		WithWarningsPolicy(&wp),
+		WithTimeout(seconds),
+	)
 }
 
-func WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi runtime.Object, seconds int) *v1.VirtualMachineInstance {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	wp := watcher.WarningsPolicy{FailOnWarnings: false}
-	return WaitForVMIStart(ctx, vmi, seconds, wp)
+// WaitForSuccessfulVMIStart blocks until the specified VirtualMachineInstance reaches the Running state
+func WaitForSuccessfulVMIStart(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+	return WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running},
+	)
 }
 
+// WaitForSuccessfulVMIStartIgnoreWarnings blocks until the specified VirtualMachineInstance reaches the Running state ignoring the warnings
+func WaitForSuccessfulVMIStartIgnoreWarnings(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+	return WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running},
+		WithFailOnWarnings(false),
+		WithTimeout(180),
+	)
+}
+
+// WaitForSuccessfulVMIStartWithTimeout blocks for the passed seconds until the specified VirtualMachineInstance reaches the Running state
+func WaitForSuccessfulVMIStartWithTimeout(vmi *v1.VirtualMachineInstance, seconds int) *v1.VirtualMachineInstance {
+	return WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running},
+		WithTimeout(seconds),
+	)
+}
+
+// WaitForSuccessfulVMIStartWithTimeoutIgnoreSelectedWarnings blocks for the passed seconds until the specified VirtualMachineInstance reaches the Running state,
+// ignoring the warning list passed
+func WaitForSuccessfulVMIStartWithTimeoutIgnoreSelectedWarnings(vmi *v1.VirtualMachineInstance, seconds int, warningsIgnoreList []string) *v1.VirtualMachineInstance {
+	return WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running},
+		WithWarningsIgnoreList(warningsIgnoreList),
+		WithTimeout(seconds),
+	)
+}
+
+// WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings blocks for the passed seconds until the specified VirtualMachineInstance reaches the Running state,
+// ignoring all the warnings
+func WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi *v1.VirtualMachineInstance, seconds int) *v1.VirtualMachineInstance {
+	return WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running},
+		WithFailOnWarnings(false),
+		WithTimeout(seconds),
+	)
+}
+
+// WaitForVirtualMachineToDisappearWithTimeout blocks for the passed seconds until the specified VirtualMachineInstance disappears
 func WaitForVirtualMachineToDisappearWithTimeout(vmi *v1.VirtualMachineInstance, seconds int) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
@@ -134,6 +241,7 @@ func WaitForVirtualMachineToDisappearWithTimeout(vmi *v1.VirtualMachineInstance,
 	}, seconds, 1*time.Second).Should(gomega.SatisfyAll(gomega.HaveOccurred(), gomega.WithTransform(errors.IsNotFound, gomega.BeTrue())), "The VMI should be gone within the given timeout")
 }
 
+// WaitForMigrationToDisappearWithTimeout blocks for the passed seconds until the specified VirtualMachineInstanceMigration disappears
 func WaitForMigrationToDisappearWithTimeout(migration *v1.VirtualMachineInstanceMigration, seconds int) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
@@ -143,44 +251,22 @@ func WaitForMigrationToDisappearWithTimeout(migration *v1.VirtualMachineInstance
 	}, seconds, 1*time.Second).Should(gomega.BeTrue(), fmt.Sprintf("migration %s was expected to dissapear after %d seconds, but it did not", migration.Name, seconds))
 }
 
-func WaitForSuccessfulVMIStart(vmi runtime.Object) *v1.VirtualMachineInstance {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	return WaitForSuccessfulVMIStartWithContext(ctx, vmi)
-}
-
+// WaitUntilVMIReady blocks until the specified VirtualMachineInstance reaches the Running state and the login succeed
 func WaitUntilVMIReady(vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction) *v1.VirtualMachineInstance {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	return WaitUntilVMIReadyWithContext(ctx, vmi, loginTo)
+	vmi = WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running},
+	)
+	gomega.Expect(loginTo(vmi)).To(gomega.Succeed())
+	return vmi
 }
 
+// WaitUntilVMIReadyIgnoreSelectedWarnings blocks until the specified VirtualMachineInstance reaches the Running state and the login succeed,
+// ignoring the warning list passed
 func WaitUntilVMIReadyIgnoreSelectedWarnings(vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction, warningsIgnoreList []string) *v1.VirtualMachineInstance {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	return WaitUntilVMIReadyWithContextIgnoreSelectedWarnings(ctx, vmi, loginTo, warningsIgnoreList)
-}
-
-func WaitUntilVMIReadyWithContext(ctx context.Context, vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction) *v1.VirtualMachineInstance {
-	// Wait for VirtualMachineInstance start
-	vmi = WaitForSuccessfulVMIStartWithContext(ctx, vmi)
+	vmi = WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running},
+		WithWarningsIgnoreList(warningsIgnoreList),
+	)
 	gomega.Expect(loginTo(vmi)).To(gomega.Succeed())
 	return vmi
-}
-
-func WaitUntilVMIReadyWithContextIgnoreSelectedWarnings(ctx context.Context, vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction, warningsIgnoreList []string) *v1.VirtualMachineInstance {
-	// Wait for VirtualMachineInstance start
-	vmi = WaitForSuccessfulVMIStartWithContextIgnoreSelectedWarnings(ctx, vmi, warningsIgnoreList)
-	gomega.Expect(loginTo(vmi)).To(gomega.Succeed())
-	return vmi
-}
-
-func WaitForSuccessfulVMIStartWithContext(ctx context.Context, vmi runtime.Object) *v1.VirtualMachineInstance {
-	wp := watcher.WarningsPolicy{FailOnWarnings: true}
-	return WaitForVMIStart(ctx, vmi, 360, wp)
-}
-
-func WaitForSuccessfulVMIStartWithContextIgnoreSelectedWarnings(ctx context.Context, vmi runtime.Object, warningsIgnoreList []string) *v1.VirtualMachineInstance {
-	wp := watcher.WarningsPolicy{FailOnWarnings: true, WarningsIgnoreList: warningsIgnoreList}
-	return WaitForVMIStart(ctx, vmi, 360, wp)
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -281,11 +281,8 @@ func RunVMIAndExpectLaunchWithDataVolume(vmi *v1.VirtualMachineInstance, dv *cdi
 	By("Waiting until the DataVolume is ready")
 	libstorage.EventuallyDV(dv, timeout, HaveSucceeded())
 	By(WaitingVMInstanceStart)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	warningsIgnoreList := []string{"didn't find PVC", "unable to find datavolume"}
-	wp := watcher.WarningsPolicy{FailOnWarnings: true, WarningsIgnoreList: warningsIgnoreList}
-	return libwait.WaitForVMIStart(ctx, obj, timeout, wp)
+	return libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreSelectedWarnings(obj, timeout, warningsIgnoreList)
 }
 
 func RunVMIAndExpectLaunchIgnoreWarnings(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
@@ -2171,7 +2168,7 @@ func VMILauncherIgnoreWarnings(virtClient kubecli.KubevirtClient) func(vmi *v1.V
 		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
 		// Warnings are okay. We'll receive a warning that the agent isn't connected
 		// during bootup, but that is transient
-		Expect(libwait.WaitForSuccessfulVMIStartIgnoreWarnings(obj).Status.NodeName).ToNot(BeEmpty())
+		Expect(libwait.WaitForSuccessfulVMIStartIgnoreWarnings(vmi).Status.NodeName).ToNot(BeEmpty())
 		return vmi
 	}
 }

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -95,7 +95,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		By("Waiting the VirtualMachineInstance start")
 		vmi, ok := obj.(*v1.VirtualMachineInstance)
 		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
-		Expect(libwait.WaitForSuccessfulVMIStart(obj).Status.NodeName).ToNot(BeEmpty())
+		Expect(libwait.WaitForSuccessfulVMIStart(vmi).Status.NodeName).ToNot(BeEmpty())
 		return vmi
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With cluster level EvictionStrategy "LiveMigrate", during the start
of a non live migratable vmi, an event will be emitted.
Since most of the time we don't tolerate any warning during vmi startup,
this can cause a failure.
Let's ignore this warning when the cluster level eviction strategy is
`LiveMigrate`.
Also, a refactoring to `libwait` is proposed:
`libwait` contains many functions with duplicate code.
To reduce duplication and increase readability, the `Waiting` struct was introduced,
which allows to specify defaults and to easily override them.
In addition, a description of utility functions has been provided.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
