### PR TITLE
cpu hot plug: improve cpu hot plug validation and tests

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -717,6 +717,11 @@ func (admitter *VMsAdmitter) shouldAllowCPUHotPlug(vm *v1.VirtualMachine) error 
 		!vmi.Status.MigrationState.Completed {
 		return fmt.Errorf("cannot update CPU sockets while VMI migration is in progress")
 	}
+
+	err = EnsureNoMigrationConflict(admitter.VirtClient, vm.Name, vm.Namespace)
+	if err != nil {
+		return fmt.Errorf("cannot update CPU sockets while VMI migration is in progress: %v", err)
+	}
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -156,6 +156,13 @@ func generateDomainForTargetCPUSetAndTopology(vmi *v1.VirtualMachineInstance, do
 	domain.Spec = *domSpec
 	cpuTopology := vcpu.GetCPUTopology(vmi)
 	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
+
+	// update cpu count to maximum hot plugable CPUs
+	vmiCPU := vmi.Spec.Domain.CPU
+	if vmiCPU != nil && vmiCPU.MaxSockets != 0 {
+		cpuTopology.Sockets = vmiCPU.MaxSockets
+		cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
+	}
 	domain.Spec.CPU.Topology = cpuTopology
 	domain.Spec.VCPU = &api.VCPU{
 		Placement: "static",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow-up to #9757; It addresses some immediate issues.

 - It adds validation to prevent live updating of the VMI sockets during an inflight live migration.
    Before this PR, it was theoretically possible to change the VMI sockets count before the migration hand-off; That way the target pod could be created with inadequate CPU resources.

 - Fixes some validation webhook tests.
 - Fixes migration of VMs with dedicated CPUs and defined MaxSockets
   - The original PR has an issue that prevents VM with dedicated CPUs from migrating because MaxSockets was not taken into account when calculating target CPU topology.
 
A functional test has been adjusted to verify that it's not possible to migrate hot-pluggable VMs with dedicated CPUs and that it's not possible to initiate a CPU hot plug during an inflight migration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
