### PR TITLE
[multi-arch] Use formatted archname in push-container-manifest

### DIFF
--- a/hack/builder/publish.sh
+++ b/hack/builder/publish.sh
@@ -32,7 +32,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 ${KUBEVIRT_CRI} manifest create --amend quay.io/kubevirt/builder:${VERSION} ${TMP_IMAGES}
 
 if [ "${KUBEVIRT_CRI}" = "podman" ]; then
-    # Workaround https://github.com/containers/podman/issues/18360 and remove once https://github.com/containers/podman/commit/bab4217cd16be609ac35ccf3061d1e34f787856f is released
+    # FIXME: Workaround https://github.com/containers/podman/issues/18360 and remove once https://github.com/containers/podman/commit/bab4217cd16be609ac35ccf3061d1e34f787856f is released
     ${KUBEVIRT_CRI} manifest push quay.io/kubevirt/builder:${VERSION} quay.io/kubevirt/builder:${VERSION}
 else
     ${KUBEVIRT_CRI} manifest push quay.io/kubevirt/builder:${VERSION}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -104,3 +104,38 @@ function go_build() {
 
 DOCKER_CA_CERT_FILE="${DOCKER_CA_CERT_FILE:-}"
 DOCKERIZED_CUSTOM_CA_PATH="/etc/pki/ca-trust/source/anchors/custom-ca.crt"
+
+# We are formatting the architecture name here to ensure that
+# it is consistent with the platform name specified in ../.bazelrc
+# if the second argument is set, the function formats arch name for
+# image tag.
+function format_archname() {
+    local local_platform=$(uname -m)
+    local platform=$1
+    local tag=$2
+
+    if [ $# -lt 1 ]; then
+        echo ${local_platform}
+    else
+        case ${platform} in
+        x86_64 | amd64)
+            [[ $tag ]] && echo "amd64" && return
+            arch="x86_64"
+            echo ${arch}
+            ;;
+        crossbuild-aarch64 | aarch64 | arm64)
+            [[ $tag ]] && echo "arm64" && return
+            if [ ${local_platform} != "aarch64" ]; then
+                arch="crossbuild-aarch64"
+            else
+                arch="aarch64"
+            fi
+            echo ${arch}
+            ;;
+        *)
+            echo "ERROR: invalid Arch, ${platform}, only support x86_64 and aarch64"
+            exit 1
+            ;;
+        esac
+    fi
+}

--- a/hack/multi-arch.sh
+++ b/hack/multi-arch.sh
@@ -17,41 +17,9 @@
 # Copyright 2023 NVIDIA CORPORATION
 #
 
-COMMAND=$1
-# We are formatting the architecture name here to ensure that
-# it is consistent with the platform name specified in ../.bazelrc
-# if the second argument is set, the function would formating arch name for
-# image tag.
-function format_archname() {
-    local local_platform=$(uname -m)
-    local platform=$1
-    local tag=$2
+source hack/common.sh
 
-    if [ $# -lt 1 ]; then
-        echo ${local_platform}
-    else
-        case ${platform} in
-        x86_64 | amd64)
-            [[ $tag ]] && echo "amd64" && return
-            arch="x86_64"
-            echo ${arch}
-            ;;
-        crossbuild-aarch64 | aarch64 | arm64)
-            [[ $tag ]] && echo "arm64" && return
-            if [ ${local_platform} != "aarch64" ]; then
-                arch="crossbuild-aarch64"
-            else
-                arch="aarch64"
-            fi
-            echo ${arch}
-            ;;
-        *)
-            echo "ERROR: invalid Arch, ${platform}, only support x86_64 and aarch64"
-            exit 1
-            ;;
-        esac
-    fi
-}
+COMMAND=$1
 
 build_count=$(echo ${BUILD_ARCH//,/ } | wc -w)
 

--- a/hack/push-container-manifest.sh
+++ b/hack/push-container-manifest.sh
@@ -30,12 +30,25 @@ fail_if_cri_bin_missing
 export DOCKER_CLI_EXPERIMENTAL=enabled
 for image in $(find ${DIGESTS_DIR}/*/bazel-bin/ -name '*.digest' -printf '%f\n' | sed s/^push-//g | sed s/\.digest$//g | sort -u); do
     MANIFEST_IMAGES=""
-    for ARCH in ${BUILD_ARCH//,/ }; do
-        digest=$(cat ${DIGESTS_DIR}/${ARCH}/bazel-bin/push-$image.digest)
-        MANIFEST_IMAGES="${MANIFEST_IMAGES} --amend ${DOCKER_PREFIX}/${image}@${digest}"
-    done
+    if [ "${KUBEVIRT_CRI}" = "podman" ]; then
+        # FIXME: Workaround https://github.com/containers/podman/issues/18360 and remove once https://github.com/containers/podman/commit/bab4217cd16be609ac35ccf3061d1e34f787856f is released
+        echo ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
+        ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
+        for ARCH in ${BUILD_ARCH//,/ }; do
+            ARCH=$(format_archname ${ARCH})
+            digest=$(cat ${DIGESTS_DIR}/${ARCH}/bazel-bin/push-$image.digest)
+            ${KUBEVIRT_CRI} manifest add ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}@${digest}
+        done
+        ${KUBEVIRT_CRI} manifest push --all ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
+    else
+        for ARCH in ${BUILD_ARCH//,/ }; do
+            ARCH=$(format_archname ${ARCH})
+            digest=$(cat ${DIGESTS_DIR}/${ARCH}/bazel-bin/push-$image.digest)
+            MANIFEST_IMAGES="${MANIFEST_IMAGES} --amend ${DOCKER_PREFIX}/${image}@${digest}"
+        done
 
-    echo ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
-    ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
-    ${KUBEVIRT_CRI} manifest push ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
+        echo ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
+        ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${MANIFEST_IMAGES}
+        ${KUBEVIRT_CRI} manifest push ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
+    fi
 done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`bazel-push-images.sh` puts the digests files in paths based on the formatted arch names.
The same does not happen in `push-container-manifest.sh` which tries to find digests file using the plain arch names.
This results in a failure if you are building `aarch64` and `x86_64` together, as it happens for example in `automation/release.sh` Move the `format_archname` function to common.sh file, so that it can be also used by `push-container-manifest.sh`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubevirt/kubevirt/issues/9908

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @rmohr @rthallisey @zhlhahaha @dhiller 