### PR TITLE
instancetype: Fix overcommit percent calculation

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -989,7 +989,8 @@ func applyMemory(field *k8sfield.Path, instancetypeSpec *instancetypev1beta1.Vir
 		if vmiSpec.Domain.Resources.Requests == nil {
 			vmiSpec.Domain.Resources.Requests = k8sv1.ResourceList{}
 		}
-		podRequestedMemory := instancetypeMemoryGuest.Value() * (1 - int64(instancetypeMemoryOvercommit)/int64(totalPercentage))
+		podRequestedMemory := int64(float32(instancetypeSpec.Memory.Guest.Value()) * (1 - float32(instancetypeSpec.Memory.OvercommitPercent)/totalPercentage))
+
 		vmiSpec.Domain.Resources.Requests[k8sv1.ResourceMemory] = *resource.NewQuantity(podRequestedMemory, instancetypeMemoryGuest.Format)
 	}
 

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1121,7 +1121,8 @@ var _ = Describe("Instancetype and Preferences", func() {
 				instancetypeSpec.Memory.Hugepages = nil
 				instancetypeSpec.Memory.OvercommitPercent = 15
 
-				expectedOverhead := instancetypeSpec.Memory.Guest.Value() * (1 - int64(instancetypeSpec.Memory.OvercommitPercent)/int64(100))
+				expectedOverhead := int64(float32(instancetypeSpec.Memory.Guest.Value()) * (1 - float32(instancetypeSpec.Memory.OvercommitPercent)/100))
+				Expect(expectedOverhead).ToNot(Equal(instancetypeSpec.Memory.Guest.Value()))
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
 				Expect(conflicts).To(BeEmpty())

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -240,7 +240,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(*vmi.Spec.Domain.Memory.Guest).To(Equal(instancetype.Spec.Memory.Guest))
-			expectedOverhead := instancetype.Spec.Memory.Guest.Value() * (1 - int64(instancetype.Spec.Memory.OvercommitPercent)/int64(100))
+			expectedOverhead := int64(float32(instancetype.Spec.Memory.Guest.Value()) * (1 - float32(instancetype.Spec.Memory.OvercommitPercent)/100))
+			Expect(expectedOverhead).ToNot(Equal(instancetype.Spec.Memory.Guest.Value()))
 			memRequest := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
 			Expect(memRequest.Value()).To(Equal(expectedOverhead))
 
@@ -406,7 +407,9 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(*vmi.Spec.Domain.Memory.Guest).To(Equal(instancetype.Spec.Memory.Guest))
-			expectedOverhead := instancetype.Spec.Memory.Guest.Value() * (1 - int64(instancetype.Spec.Memory.OvercommitPercent)/int64(100))
+
+			expectedOverhead := int64(float32(instancetype.Spec.Memory.Guest.Value()) * (1 - float32(instancetype.Spec.Memory.OvercommitPercent)/100))
+			Expect(expectedOverhead).ToNot(Equal(instancetype.Spec.Memory.Guest.Value()))
 			memRequest := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
 			Expect(memRequest.Value()).To(Equal(expectedOverhead))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As mentioned in #9912 the overcommit value is not calculated correctly.
This fix makes the value actually calculated.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9912

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
