### PR TITLE
Disable DataVolume GC by default in cluster-deploy

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -21,7 +21,8 @@ set -ex pipefail
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
 KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-true}
-CDI_DV_GC=${CDI_DV_GC:-0}
+CDI_DV_GC_DEFAULT=0
+CDI_DV_GC=${CDI_DV_GC:--1}
 
 source hack/common.sh
 # shellcheck disable=SC1090
@@ -57,8 +58,8 @@ function _ensure_cdi_deployment() {
     override="https://127.0.0.1:$host_port"
     _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"uploadProxyURLOverride": "'"$override"'"}}}'
 
-    # Enable succeeded DataVolume garbage collection
-    if [[ $CDI_DV_GC != "0" ]]; then
+    # Configure DataVolume garbage collection
+    if [[ $CDI_DV_GC != $CDI_DV_GC_DEFAULT ]]; then
         _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"dataVolumeTTLSeconds": '"$CDI_DV_GC"'}}}'
     fi
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent DV-related CI failures in the next kubevirt-bot kubevirtci bump PR (with bump-cdi), due to:
https://github.com/kubevirt/containerized-data-importer/pull/2754

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
