### PR TITLE
instancetype: Fix default PreferredCPUTopology value in API docs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -21903,7 +21903,7 @@
       "type": "boolean"
      },
      "guest": {
-      "description": "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.",
+      "description": "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.",
       "type": "integer",
       "format": "int64",
       "default": 0

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7887,7 +7887,7 @@ var CRDsValidation map[string]string = map[string]string{
             guest:
               description: "Required number of vCPUs to expose to the guest. \n The
                 resulting CPU topology being derived from the optional PreferredCPUTopology
-                attribute of CPUPreferences that itself defaults to PreferCores."
+                attribute of CPUPreferences that itself defaults to PreferSockets."
               format: int32
               type: integer
             isolateEmulatorThread:
@@ -16649,7 +16649,7 @@ var CRDsValidation map[string]string = map[string]string{
             guest:
               description: "Required number of vCPUs to expose to the guest. \n The
                 resulting CPU topology being derived from the optional PreferredCPUTopology
-                attribute of CPUPreferences that itself defaults to PreferCores."
+                attribute of CPUPreferences that itself defaults to PreferSockets."
               format: int32
               type: integer
             isolateEmulatorThread:

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha2/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha2/types.go
@@ -111,7 +111,7 @@ type CPUInstancetype struct {
 
 	// Required number of vCPUs to expose to the guest.
 	//
-	// The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.
+	// The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.
 	Guest uint32 `json:"guest"`
 
 	// Model specifies the CPU model inside the VMI.

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha2/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha2/types_swagger_generated.go
@@ -43,7 +43,7 @@ func (VirtualMachineInstancetypeSpec) SwaggerDoc() map[string]string {
 func (CPUInstancetype) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                      "CPUInstancetype contains the CPU related configuration of a given VirtualMachineInstancetypeSpec.\n\nGuest is a required attribute and defines the number of vCPUs to be exposed to the guest by the instancetype.",
-		"guest":                 "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.",
+		"guest":                 "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.",
 		"model":                 "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map.\nIt is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nDefaults to host-model.\n+optional",
 		"dedicatedCPUPlacement": "DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node\nwith enough dedicated pCPUs and pin the vCPUs to it.\n+optional",
 		"numa":                  "NUMA allows specifying settings for the guest NUMA topology\n+optional",

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -111,7 +111,7 @@ type CPUInstancetype struct {
 
 	// Required number of vCPUs to expose to the guest.
 	//
-	// The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.
+	// The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.
 	Guest uint32 `json:"guest"`
 
 	// Model specifies the CPU model inside the VMI.

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -43,7 +43,7 @@ func (VirtualMachineInstancetypeSpec) SwaggerDoc() map[string]string {
 func (CPUInstancetype) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                      "CPUInstancetype contains the CPU related configuration of a given VirtualMachineInstancetypeSpec.\n\nGuest is a required attribute and defines the number of vCPUs to be exposed to the guest by the instancetype.",
-		"guest":                 "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.",
+		"guest":                 "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.",
 		"model":                 "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map.\nIt is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nDefaults to host-model.\n+optional",
 		"dedicatedCPUPlacement": "DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node\nwith enough dedicated pCPUs and pin the vCPUs to it.\n+optional",
 		"numa":                  "NUMA allows specifying settings for the guest NUMA topology\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -26242,7 +26242,7 @@ func schema_kubevirtio_api_instancetype_v1alpha2_CPUInstancetype(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"guest": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.",
+							Description: "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int64",
@@ -27194,7 +27194,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_CPUInstancetype(ref common.Refer
 				Properties: map[string]spec.Schema{
 					"guest": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.",
+							Description: "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int64",


### PR DESCRIPTION
/area instancetype
/cc @0xFelix 
/cc @cwilkers 

**What this PR does / why we need it**:

This was missed in 3e2ffba1797fa84c5f2751ef5504d337c9f492d9 as `v1alpha2` had already been copied from `v1alpha1` with the mistake in place.

https://github.com/kubevirt/kubevirt/blob/ab6645487f1a09abe33d5b1cadec0fb7811a6eeb/pkg/instancetype/instancetype.go#L71-L78

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
