### PR TITLE
instancetype: Label ControllerRevisions with stored object metadata

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -105,6 +105,13 @@ func CreateControllerRevision(vm *virtv1.VirtualMachine, object runtime.Object) 
 			Name:            revisionName,
 			Namespace:       vm.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(vm, virtv1.VirtualMachineGroupVersionKind)},
+			Labels: map[string]string{
+				apiinstancetype.ControllerRevisionObjectGenerationLabel: fmt.Sprintf("%d", metaObj.GetGeneration()),
+				apiinstancetype.ControllerRevisionObjectKindLabel:       obj.GetObjectKind().GroupVersionKind().Kind,
+				apiinstancetype.ControllerRevisionObjectNameLabel:       metaObj.GetName(),
+				apiinstancetype.ControllerRevisionObjectUIDLabel:        string(metaObj.GetUID()),
+				apiinstancetype.ControllerRevisionObjectVersionLabel:    obj.GetObjectKind().GroupVersionKind().Version,
+			},
 		},
 		Data: runtime.RawExtension{
 			Object: obj,

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -648,6 +648,7 @@ func (t *vmRestoreTarget) restoreInstancetypeControllerRevision(vmSnapshotRevisi
 	restoredCRName := strings.Replace(vmSnapshotRevisionName, vmSnapshotName, vm.Name, 1)
 	restoredCR := snapshotCR.DeepCopy()
 	restoredCR.ObjectMeta.Reset()
+	restoredCR.ObjectMeta.SetLabels(snapshotCR.Labels)
 	restoredCR.Name = restoredCRName
 
 	// If the target VirtualMachine already exists it's likely that the original ControllerRevision is already present.

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -2502,6 +2502,16 @@ func createInstancetypeVirtualMachineSnapshotCR(vm *v1.VirtualMachine, vmSnapsho
 	return cr
 }
 
+func expectControllerRevisionToEqualExpected(controllerRevision, expectedControllerRevision *appsv1.ControllerRevision) {
+	// This is already covered by the below assertion but be explicit here to ensure coverage
+	Expect(controllerRevision.Labels).To(HaveKey(instancetypeapi.ControllerRevisionObjectGenerationLabel))
+	Expect(controllerRevision.Labels).To(HaveKey(instancetypeapi.ControllerRevisionObjectKindLabel))
+	Expect(controllerRevision.Labels).To(HaveKey(instancetypeapi.ControllerRevisionObjectNameLabel))
+	Expect(controllerRevision.Labels).To(HaveKey(instancetypeapi.ControllerRevisionObjectUIDLabel))
+	Expect(controllerRevision.Labels).To(HaveKey(instancetypeapi.ControllerRevisionObjectVersionLabel))
+	Expect(*controllerRevision).To(Equal(*expectedControllerRevision))
+}
+
 func expectControllerRevisionCreate(client *k8sfake.Clientset, expectedCR *appsv1.ControllerRevision) {
 	client.Fake.PrependReactor("create", "controllerrevisions", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 		create, ok := action.(testing.CreateAction)
@@ -2512,7 +2522,7 @@ func expectControllerRevisionCreate(client *k8sfake.Clientset, expectedCR *appsv
 		expectedCR.ResourceVersion = ""
 
 		createObj := create.GetObject().(*appsv1.ControllerRevision)
-		Expect(*createObj).To(Equal(*expectedCR))
+		expectControllerRevisionToEqualExpected(createObj, expectedCR)
 
 		return true, createObj, nil
 	})
@@ -2528,7 +2538,7 @@ func expectCreateControllerRevisionAlreadyExists(client *k8sfake.Clientset, expe
 		expectedCR.ResourceVersion = ""
 
 		createObj := create.GetObject().(*appsv1.ControllerRevision)
-		Expect(*createObj).To(Equal(*expectedCR))
+		expectControllerRevisionToEqualExpected(createObj, expectedCR)
 
 		return true, create.GetObject(), errors.NewAlreadyExists(schema.GroupResource{}, expectedCR.Name)
 	})
@@ -2540,7 +2550,7 @@ func expectControllerRevisionUpdate(client *k8sfake.Clientset, expectedCR *appsv
 		Expect(ok).To(BeTrue())
 
 		updateObj := update.GetObject().(*appsv1.ControllerRevision)
-		Expect(*updateObj).To(Equal(*expectedCR))
+		expectControllerRevisionToEqualExpected(updateObj, expectedCR)
 
 		return true, update.GetObject(), nil
 	})

--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -208,6 +208,7 @@ func (s *vmSnapshotSource) captureInstancetypeControllerRevision(namespace, revi
 
 	snapshotCR := existingCR.DeepCopy()
 	snapshotCR.ObjectMeta.Reset()
+	snapshotCR.ObjectMeta.SetLabels(existingCR.Labels)
 
 	// We strip out the source VM name from the CR name and replace it with the snapshot name
 	snapshotCR.Name = strings.Replace(existingCR.Name, s.snapshot.Spec.Source.Name, s.snapshot.Name, 1)

--- a/staging/src/kubevirt.io/api/instancetype/register.go
+++ b/staging/src/kubevirt.io/api/instancetype/register.go
@@ -42,3 +42,11 @@ const (
 	DefaultPreferenceLabel       = "instancetype.kubevirt.io/default-preference"
 	DefaultPreferenceKindLabel   = "instancetype.kubevirt.io/default-preference-kind"
 )
+
+const (
+	ControllerRevisionObjectGenerationLabel = "instancetype.kubevirt.io/object-generation"
+	ControllerRevisionObjectKindLabel       = "instancetype.kubevirt.io/object-kind"
+	ControllerRevisionObjectNameLabel       = "instancetype.kubevirt.io/object-name"
+	ControllerRevisionObjectUIDLabel        = "instancetype.kubevirt.io/object-uid"
+	ControllerRevisionObjectVersionLabel    = "instancetype.kubevirt.io/object-version"
+)


### PR DESCRIPTION
/area instancetype

**What this PR does / why we need it**:

ControllerRevisions are used to store point in time copies of instance
type and preference objects for each VirtualMachine making use of the
feature, see the following user-guide docs for more on this:

Instance types and preferences - Versioning
https://kubevirt.io/user-guide/virtual_machines/instancetypes/#versioning

This change adds labels to these ControllerRevision, exposing metadata
of the stored objects. With this in place it becomes easier to track the
objects stored within these ControllerRevisions and in the future
orchestrate the migration of these objects to newer versions of the API
and CRDs as these are introduced.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9925

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`ControllerRevisions` containing `instancetype.kubevirt.io` `CRDs` are now decorated with labels detailing specific metadata of the underlying stashed object
```
