### PR TITLE
Use vfprintf instead of fprintf to correctly log

### DIFF
--- a/cmd/container-disk-v2alpha/main.c
+++ b/cmd/container-disk-v2alpha/main.c
@@ -29,7 +29,7 @@ void error_log(const char *format, ...)
     fprintf(stderr, "%s",asctime(localtime(&ltime)));
     fprintf(stderr, "error: ");
     va_start(arglist, format);
-    fprintf(stderr, format, arglist);
+    vfprintf(stderr, format, arglist);
     va_end(arglist);
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug where logging an error in the container disk will turn out in a corrupted mix of characters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Bug fix - correct logging in container disk
```
