### PR TITLE
e2e test: changing the default interface to masquesrade

### DIFF
--- a/tests/network/kubectl.go
+++ b/tests/network/kubectl.go
@@ -80,7 +80,7 @@ var _ = SIGDescribe("kubectl", func() {
 			libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeIfaceName1, linuxBridgeNetworkName)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeIfaceName2, linuxBridgeNetworkName)),
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeIfaceName1)),
-			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+			libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeIfaceName2)),
 		)
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -512,7 +512,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	It("VMI with an interface that has ACPI Index set", func() {
 		const acpiIndex = 101
 		const pciAddress = "0000:01:00.0"
-		iface := *v1.DefaultBridgeNetworkInterface()
+		iface := *v1.DefaultMasqueradeNetworkInterface()
 		iface.ACPIIndex = acpiIndex
 		iface.PciAddress = pciAddress
 		testVMI := libvmi.NewAlpine(


### PR DESCRIPTION
So the test can run on d/s.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The tests for on teir1 tests with - `EvictionStrategy is set but vmi is not migratable; cannot migrate VMI which does not use masquerade to connect to the pod network or bridge with kubevirt.io/allow-pod-bridge-network-live-migration VM annotation`.
To avboid this the primary interface of the tested VMs was changed to masquerade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
