### PR TITLE
[e2e] cleanup libwait utility functions

### DIFF
--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -50,14 +50,11 @@ var _ = Describe("[sig-compute]Guest Access Credentials", decorators.SigCompute,
 	var virtClient kubecli.KubevirtClient
 
 	var (
-		LaunchVMI         func(*v1.VirtualMachineInstance) *v1.VirtualMachineInstance
 		ExecutingBatchCmd func(*v1.VirtualMachineInstance, []expect.Batcher, time.Duration)
 	)
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		LaunchVMI = tests.VMILauncherIgnoreWarnings(virtClient)
 	})
 
 	ExecutingBatchCmd = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
@@ -111,7 +108,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", decorators.SigCompute,
 			_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			LaunchVMI(vmi)
+			tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -177,7 +174,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", decorators.SigCompute,
 			_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			LaunchVMI(vmi)
+			tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -238,7 +235,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", decorators.SigCompute,
 			_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			LaunchVMI(vmi)
+			tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -286,7 +283,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", decorators.SigCompute,
 			_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			LaunchVMI(vmi)
+			tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -342,7 +339,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", decorators.SigCompute,
 			_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			LaunchVMI(vmi)
+			tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 			By("Verifying all three pub ssh keys in secret are in VMI guest")
 			ExecutingBatchCmd(vmi, []expect.Batcher{

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 				By("Creating a windows VM")
 				reEnlightenmentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), reEnlightenmentVMI)
 				Expect(err).ToNot(HaveOccurred())
-				reEnlightenmentVMI = libwait.WaitForSuccessfulVMIStartWithTimeout(reEnlightenmentVMI, 360)
+				reEnlightenmentVMI = libwait.WaitForSuccessfulVMIStart(reEnlightenmentVMI)
 
 				By("Migrating the VM")
 				migration := tests.NewRandomMigration(reEnlightenmentVMI.Name, reEnlightenmentVMI.Namespace)
@@ -96,7 +96,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 				By("Creating a windows VM")
 				reEnlightenmentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), reEnlightenmentVMI)
 				Expect(err).ToNot(HaveOccurred())
-				reEnlightenmentVMI = libwait.WaitForSuccessfulVMIStartWithTimeout(reEnlightenmentVMI, 360)
+				reEnlightenmentVMI = libwait.WaitForSuccessfulVMIStart(reEnlightenmentVMI)
 
 				virtLauncherPod := tests.GetPodByVirtualMachineInstance(reEnlightenmentVMI)
 
@@ -145,7 +145,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 				By("Creating a windows VM")
 				reEnlightenmentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), reEnlightenmentVMI)
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(reEnlightenmentVMI, 360)
+				libwait.WaitForSuccessfulVMIStart(reEnlightenmentVMI)
 				Expect(console.LoginToAlpine(reEnlightenmentVMI)).To(Succeed())
 			})
 
@@ -154,7 +154,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 				By("Creating a windows VM")
 				reEnlightenmentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), reEnlightenmentVMI)
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(reEnlightenmentVMI, 360)
+				libwait.WaitForSuccessfulVMIStart(reEnlightenmentVMI)
 
 				conditionManager := controller.NewVirtualMachineInstanceConditionManager()
 				isNonMigratable := func() error {

--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -168,67 +168,24 @@ func (w *Waiting) watchVMIForPhase(vmi *v1.VirtualMachineInstance) *v1.VirtualMa
 	return vmi
 }
 
-// WaitForVMIStartOrFailed blocks until the specified VirtualMachineInstance reaches either Failed or Running states
-func WaitForVMIStartOrFailed(vmi *v1.VirtualMachineInstance, seconds int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
-	return WaitForVMIPhase(vmi,
-		[]v1.VirtualMachineInstancePhase{v1.Running, v1.Failed},
-		WithWarningsPolicy(&wp),
-		WithTimeout(seconds),
-		WithWaitForFail(true),
-	)
-}
-
-// WaitForVMIScheduling blocks until the specified VirtualMachineInstance scheduled and return the target node name.
-func WaitForVMIScheduling(vmi *v1.VirtualMachineInstance, seconds int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
-	return WaitForVMIPhase(vmi,
-		[]v1.VirtualMachineInstancePhase{v1.Scheduling, v1.Scheduled, v1.Running},
-		WithWarningsPolicy(&wp),
-		WithTimeout(seconds),
-	)
-}
-
 // WaitForSuccessfulVMIStart blocks until the specified VirtualMachineInstance reaches the Running state
-func WaitForSuccessfulVMIStart(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+// using the passed options
+func WaitForSuccessfulVMIStart(vmi *v1.VirtualMachineInstance, opts ...Option) *v1.VirtualMachineInstance {
 	return WaitForVMIPhase(vmi,
 		[]v1.VirtualMachineInstancePhase{v1.Running},
+		opts...,
 	)
 }
 
-// WaitForSuccessfulVMIStartIgnoreWarnings blocks until the specified VirtualMachineInstance reaches the Running state ignoring the warnings
-func WaitForSuccessfulVMIStartIgnoreWarnings(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
-	return WaitForVMIPhase(vmi,
+// WaitUntilVMIReady blocks until the specified VirtualMachineInstance reaches the Running state using the passed
+// options, and the login succeed
+func WaitUntilVMIReady(vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction, opts ...Option) *v1.VirtualMachineInstance {
+	vmi = WaitForVMIPhase(vmi,
 		[]v1.VirtualMachineInstancePhase{v1.Running},
-		WithFailOnWarnings(false),
-		WithTimeout(180),
+		opts...,
 	)
-}
-
-// WaitForSuccessfulVMIStartWithTimeout blocks for the passed seconds until the specified VirtualMachineInstance reaches the Running state
-func WaitForSuccessfulVMIStartWithTimeout(vmi *v1.VirtualMachineInstance, seconds int) *v1.VirtualMachineInstance {
-	return WaitForVMIPhase(vmi,
-		[]v1.VirtualMachineInstancePhase{v1.Running},
-		WithTimeout(seconds),
-	)
-}
-
-// WaitForSuccessfulVMIStartWithTimeoutIgnoreSelectedWarnings blocks for the passed seconds until the specified VirtualMachineInstance reaches the Running state,
-// ignoring the warning list passed
-func WaitForSuccessfulVMIStartWithTimeoutIgnoreSelectedWarnings(vmi *v1.VirtualMachineInstance, seconds int, warningsIgnoreList []string) *v1.VirtualMachineInstance {
-	return WaitForVMIPhase(vmi,
-		[]v1.VirtualMachineInstancePhase{v1.Running},
-		WithWarningsIgnoreList(warningsIgnoreList),
-		WithTimeout(seconds),
-	)
-}
-
-// WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings blocks for the passed seconds until the specified VirtualMachineInstance reaches the Running state,
-// ignoring all the warnings
-func WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi *v1.VirtualMachineInstance, seconds int) *v1.VirtualMachineInstance {
-	return WaitForVMIPhase(vmi,
-		[]v1.VirtualMachineInstancePhase{v1.Running},
-		WithFailOnWarnings(false),
-		WithTimeout(seconds),
-	)
+	gomega.Expect(loginTo(vmi)).To(gomega.Succeed())
+	return vmi
 }
 
 // WaitForVirtualMachineToDisappearWithTimeout blocks for the passed seconds until the specified VirtualMachineInstance disappears
@@ -249,24 +206,4 @@ func WaitForMigrationToDisappearWithTimeout(migration *v1.VirtualMachineInstance
 		_, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
 		return errors.IsNotFound(err)
 	}, seconds, 1*time.Second).Should(gomega.BeTrue(), fmt.Sprintf("migration %s was expected to dissapear after %d seconds, but it did not", migration.Name, seconds))
-}
-
-// WaitUntilVMIReady blocks until the specified VirtualMachineInstance reaches the Running state and the login succeed
-func WaitUntilVMIReady(vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction) *v1.VirtualMachineInstance {
-	vmi = WaitForVMIPhase(vmi,
-		[]v1.VirtualMachineInstancePhase{v1.Running},
-	)
-	gomega.Expect(loginTo(vmi)).To(gomega.Succeed())
-	return vmi
-}
-
-// WaitUntilVMIReadyIgnoreSelectedWarnings blocks until the specified VirtualMachineInstance reaches the Running state and the login succeed,
-// ignoring the warning list passed
-func WaitUntilVMIReadyIgnoreSelectedWarnings(vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction, warningsIgnoreList []string) *v1.VirtualMachineInstance {
-	vmi = WaitForVMIPhase(vmi,
-		[]v1.VirtualMachineInstancePhase{v1.Running},
-		WithWarningsIgnoreList(warningsIgnoreList),
-	)
-	gomega.Expect(loginTo(vmi)).To(gomega.Succeed())
-	return vmi
 }

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3372,8 +3372,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Eventually(AllPDBs(vmi.Namespace), 3*time.Second, 500*time.Millisecond).Should(HaveLen(1))
 
 					By("waiting for VMI")
-					libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 60)
-
+					libwait.WaitForSuccessfulVMIStart(vmi,
+						libwait.WithTimeout(60),
+					)
 					By("deleting the VMI")
 					Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 					By("checking that the PDB disappeared")
@@ -3392,7 +3393,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("checking that the PDB appeared, with extra time since schedulability needs to be determined first in the cluster")
 				Eventually(AllPDBs(vmi.Namespace), 60*time.Second, 500*time.Millisecond).Should(HaveLen(1))
 				By("waiting for VMI")
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 60)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(60),
+				)
 
 				By("deleting the VMI")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
@@ -3405,7 +3408,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				createdVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred())
 				By("waiting for VMI")
-				libwait.WaitForSuccessfulVMIStartWithTimeout(createdVMI, 60)
+				libwait.WaitForSuccessfulVMIStart(createdVMI,
+					libwait.WithTimeout(60),
+				)
 
 				By("Adding a fake old virt-controller PDB")
 				two := intstr.FromInt(2)
@@ -3763,7 +3768,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("waiting until the VMIs are ready")
 				for _, vmi := range vmis {
-					libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 180)
+					libwait.WaitForSuccessfulVMIStart(vmi,
+						libwait.WithTimeout(180),
+					)
 				}
 
 				By("selecting a node as the target")
@@ -4354,7 +4361,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			vmi := tests.CreateVmiOnNodeLabeled(migratableVMI, testLabel1, "true")
 
 			By("waiting until the VirtualMachineInstance starts")
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 120)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(120),
+			)
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -106,7 +106,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				By(specifyingVMReadinessProbe)
 				vmi = libvmi.NewFedora(
 					withMasqueradeNetworkingAndFurtherUserConfig(withReadinessProbe(readinessProbe))...)
-				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
+				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 				By("Waiting for agent to connect")
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -131,7 +131,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 					withMasqueradeNetworkingAndFurtherUserConfig(
 						withReadinessProbe(
 							createGuestAgentPingProbe(period, initialSeconds)))...)
-				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
+				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 				By("Waiting for agent to connect")
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
@@ -157,7 +157,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		DescribeTable("should fail", func(readinessProbe *v1.Probe, vmiFactory func(opts ...libvmi.Option) *v1.VirtualMachineInstance) {
 			By(specifyingVMReadinessProbe)
 			vmi = vmiFactory(withReadinessProbe(readinessProbe))
-			vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
+			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 			By("Checking that the VMI is consistently non-ready")
 			Consistently(matcher.ThisVMI(vmi), 30*time.Second, 100*time.Millisecond).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceReady))
@@ -208,7 +208,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				vmi = libvmi.NewFedora(
 					withMasqueradeNetworkingAndFurtherUserConfig(
 						withLivelinessProbe(livenessProbe))...)
-				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
+				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 				By("Waiting for agent to connect")
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -233,7 +233,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				vmi = libvmi.NewFedora(withMasqueradeNetworkingAndFurtherUserConfig(
 					withLivelinessProbe(createGuestAgentPingProbe(period, initialSeconds)),
 				)...)
-				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
+				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 				By("Waiting for agent to connect")
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -252,7 +252,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		DescribeTable("should fail the VMI", func(livenessProbe *v1.Probe, vmiFactory func(opts ...libvmi.Option) *v1.VirtualMachineInstance) {
 			By("Specifying a VMI with a livenessProbe probe")
 			vmi = vmiFactory(withLivelinessProbe(livenessProbe))
-			vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
+			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 			By("Checking that the VMI is in a final state after a while")
 			Eventually(func() bool {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -712,7 +712,7 @@ func waitVMI(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 	// Kubevirt re-enqueue the request once it happens, so its safe to ignore this warning.
 	// see https://github.com/kubevirt/kubevirt/issues/5027
 	warningsIgnoreList := []string{"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
-	libwait.WaitUntilVMIReadyIgnoreSelectedWarnings(vmi, console.LoginToFedora, warningsIgnoreList)
+	libwait.WaitUntilVMIReady(vmi, console.LoginToFedora, libwait.WithWarningsIgnoreList(warningsIgnoreList))
 
 	virtClient := kubevirt.Client()
 

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -89,7 +89,11 @@ var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
 
 					serverVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), serverVMI)
 					Expect(err).ToNot(HaveOccurred())
-					serverVMI = libwait.WaitForSuccessfulVMIStartIgnoreWarnings(serverVMI)
+					serverVMI = libwait.WaitForSuccessfulVMIStart(
+						serverVMI,
+						libwait.WithFailOnWarnings(false),
+						libwait.WithTimeout(180),
+					)
 					Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
 				}
 
@@ -136,7 +140,10 @@ var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
 
 						clientVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI)
 						Expect(err).ToNot(HaveOccurred())
-						clientVMI = libwait.WaitForSuccessfulVMIStartIgnoreWarnings(clientVMI)
+						clientVMI = libwait.WaitForSuccessfulVMIStart(clientVMI,
+							libwait.WithFailOnWarnings(false),
+							libwait.WithTimeout(180),
+						)
 						Expect(console.LoginToAlpine(clientVMI)).To(Succeed())
 					}
 					DescribeTable("Client server connectivity", func(ports []v1.Port, tcpPort int, ipFamily k8sv1.IPFamily) {
@@ -208,7 +215,10 @@ EOL`, inetSuffix, serverIP, serverPort)
 
 						By("Starting server VMI")
 						startServerVMI([]v1.Port{{Port: SERVER_PORT, Protocol: "UDP"}})
-						serverVMI = libwait.WaitForSuccessfulVMIStartIgnoreWarnings(serverVMI)
+						serverVMI = libwait.WaitForSuccessfulVMIStart(serverVMI,
+							libwait.WithFailOnWarnings(false),
+							libwait.WithTimeout(180),
+						)
 						Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
 
 						By("Starting a UDP server")
@@ -221,7 +231,10 @@ EOL`, inetSuffix, serverIP, serverPort)
 						)
 						clientVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI)
 						Expect(err).ToNot(HaveOccurred())
-						clientVMI = libwait.WaitForSuccessfulVMIStartIgnoreWarnings(clientVMI)
+						clientVMI = libwait.WaitForSuccessfulVMIStart(clientVMI,
+							libwait.WithFailOnWarnings(false),
+							libwait.WithTimeout(180),
+						)
 						Expect(console.LoginToAlpine(clientVMI)).To(Succeed())
 
 						By("Starting and verifying UDP client")
@@ -257,7 +270,10 @@ EOL`, inetSuffix, serverIP, serverPort)
 				)
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred())
-				vmi = libwait.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
+				vmi = libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithFailOnWarnings(false),
+					libwait.WithTimeout(180),
+				)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking ping (IPv4)")
@@ -282,7 +298,10 @@ EOL`, inetSuffix, serverIP, serverPort)
 				Expect(err).ToNot(HaveOccurred())
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred())
-				vmi = libwait.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
+				vmi = libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithFailOnWarnings(false),
+					libwait.WithTimeout(180),
+				)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking ping (IPv6) from VM to cluster nodes gateway")

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -112,7 +112,10 @@ var _ = SIGDescribe("Slirp Networking", decorators.Networking, func() {
 			vmi := *vmiRef
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithFailOnWarnings(false),
+				libwait.WithTimeout(180),
+			)
 			tests.GenerateHelloWorldServer(vmi, 80, "tcp", console.LoginToCirros, true)
 
 			By("have containerPort in the pod manifest")
@@ -169,7 +172,10 @@ var _ = SIGDescribe("Slirp Networking", decorators.Networking, func() {
 			vmi := *vmiRef
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
 			Expect(err).ToNot(HaveOccurred())
-			vmi = libwait.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
+			vmi = libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithFailOnWarnings(false),
+				libwait.WithTimeout(180),
+			)
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 			dns := "google.com"

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -349,7 +349,9 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				newVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(newVMI, 300)
+				libwait.WaitForSuccessfulVMIStart(newVMI,
+					libwait.WithTimeout(300),
+				)
 
 				By("Ensuring unpaused state")
 				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))

--- a/tests/portforward_test.go
+++ b/tests/portforward_test.go
@@ -30,7 +30,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
@@ -42,21 +41,14 @@ var _ = Describe("[sig-compute]PortForward", decorators.SigCompute, func() {
 
 	var virtClient kubecli.KubevirtClient
 
-	var (
-		LaunchVMI func(*v1.VirtualMachineInstance) *v1.VirtualMachineInstance
-	)
-
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		LaunchVMI = tests.VMILauncherIgnoreWarnings(virtClient)
 	})
 
 	It("should successfully open connection to guest", func() {
 		vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 		vmi.Namespace = util.NamespaceTestDefault
-
-		LaunchVMI(vmi)
+		tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 		By("Opening PortForward Tunnel to SSH port")
 		var (

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -297,7 +297,10 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				}
 
 				for idx := 0; idx < numVmis; idx++ {
-					libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmis[idx], 500)
+					libwait.WaitForSuccessfulVMIStart(vmis[idx],
+						libwait.WithFailOnWarnings(false),
+						libwait.WithTimeout(500),
+					)
 					By(checkingVMInstanceConsoleExpectedOut)
 					Expect(console.LoginToAlpine(vmis[idx])).To(Succeed())
 

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -89,7 +89,10 @@ var _ = SIGDescribe("[Serial]K8s IO events", Serial, func() {
 			return err
 		}, 100*time.Second, time.Second).Should(BeNil(), "Failed to create vmi")
 
-		libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 240)
+		libwait.WaitForSuccessfulVMIStart(vmi,
+			libwait.WithFailOnWarnings(false),
+			libwait.WithTimeout(240),
+		)
 
 		By("Expecting  paused event on VMI ")
 		Eventually(func() bool {

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -513,7 +513,9 @@ var _ = SIGDescribe("Hotplug", func() {
 		vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		if waitToStart {
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(240),
+			)
 		}
 		By(addingVolumeRunningVM)
 		addVolumeFunc(vm.Name, vm.Namespace, "testvolume", dv.Name, v1.DiskBusSCSI, false, "")
@@ -593,7 +595,9 @@ var _ = SIGDescribe("Hotplug", func() {
 			checks.SkipIfNonRoot("root owned disk.img")
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(240),
+			)
 			dvNames := make([]string, 0)
 			for i := 0; i < numPVs; i++ {
 				dv := libdv.NewDataVolume(
@@ -694,7 +698,9 @@ var _ = SIGDescribe("Hotplug", func() {
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				getVmiConsoleAndLogin(vmi)
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(240),
+				)
 				testVolumes := make([]string, 0)
 				for i := 0; i < 5; i++ {
 					volumeName := fmt.Sprintf("volume%d", i)
@@ -734,7 +740,9 @@ var _ = SIGDescribe("Hotplug", func() {
 			DescribeTable("Should be able to add and remove and re-add multiple volumes", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, volumeMode corev1.PersistentVolumeMode, vmiOnly bool) {
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(240),
+				)
 				testVolumes := make([]string, 0)
 				dvNames := make([]string, 0)
 				for i := 0; i < 5; i++ {
@@ -822,7 +830,9 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(240),
+				)
 
 				By(addingVolumeRunningVM)
 				addDVVolumeVM(vm.Name, vm.Namespace, "testvolume", dvBlock.Name, v1.DiskBusSCSI, false, "")
@@ -868,7 +878,9 @@ var _ = SIGDescribe("Hotplug", func() {
 				dvBlock := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(240),
+				)
 
 				By(addingVolumeRunningVM)
 				err = virtClient.VirtualMachine(vm.Namespace).AddVolume(context.Background(), vm.Name, getAddVolumeOptions("disk0", v1.DiskBusSCSI, &v1.HotplugVolumeSource{
@@ -884,7 +896,9 @@ var _ = SIGDescribe("Hotplug", func() {
 				dvBlock := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(240),
+				)
 
 				By(addingVolumeRunningVM)
 				addPVCVolumeVMI(vmi.Name, vmi.Namespace, "testvolume", dvBlock.Name, v1.DiskBusSCSI, false, "")
@@ -908,7 +922,9 @@ var _ = SIGDescribe("Hotplug", func() {
 			DescribeTable("should reject removing a volume", func(volName, expectedErr string) {
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(240),
+				)
 
 				By(removingVolumeFromVM)
 				err = virtClient.VirtualMachine(vm.Namespace).RemoveVolume(context.Background(), vm.Name, &v1.RemoveVolumeOptions{Name: volName})
@@ -925,7 +941,9 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(240),
+				)
 				getVmiConsoleAndLogin(vmi)
 
 				By(addingVolumeRunningVM)
@@ -1020,7 +1038,9 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(240),
+				)
 				By("Verifying the VMI is migrateable")
 				Eventually(matcher.ThisVMI(vmi), 90*time.Second, 1*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceIsMigratable))
 
@@ -1351,7 +1371,9 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(240),
+			)
 
 			By(addingVolumeRunningVM)
 			addDVVolumeVM(vm.Name, vm.Namespace, "testvolume", dv.Name, v1.DiskBusSCSI, false, "")
@@ -1464,7 +1486,9 @@ var _ = SIGDescribe("Hotplug", func() {
 		It("should attach a hostpath based volume to running VM", func() {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(240),
+			)
 
 			By(addingVolumeRunningVM)
 			name := fmt.Sprintf("disk-%s", tests.CustomHostPath)
@@ -1520,7 +1544,9 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(240),
+			)
 
 			By(addingVolumeRunningVM)
 			addPVCVolumeVMI(vm.Name, vm.Namespace, "testvolume", dv.Name, v1.DiskBusSCSI, false, "")
@@ -1575,7 +1601,9 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(240),
+			)
 
 			By(addingVolumeRunningVM)
 			addPVCVolumeVMI(vm.Name, vm.Namespace, "testvolume", dv.Name, v1.DiskBusSCSI, false, "")
@@ -1614,7 +1642,9 @@ var _ = SIGDescribe("Hotplug", func() {
 		DescribeTable("should add volume according to options", func(dryRun bool) {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(240),
+			)
 
 			dv := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
@@ -1648,7 +1678,9 @@ var _ = SIGDescribe("Hotplug", func() {
 		DescribeTable("should remove volume according to options", func(dryRun bool) {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(240),
+			)
 			dv := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
 				libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -190,7 +190,10 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 					err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}()
-				libwait.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithFailOnWarnings(false),
+					libwait.WithTimeout(180),
+				)
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -225,7 +225,10 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 			)
 			vmi.Namespace = util.NamespaceTestDefault
 			vmi = tests.CreateVmiOnNode(vmi, node)
-			libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 180)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithFailOnWarnings(false),
+				libwait.WithTimeout(180),
+			)
 			By("Requesting SCSI persistent reservation")
 			Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 			Expect(checkResultCommand(vmi, "sg_persist -i -k /dev/sda",
@@ -249,14 +252,20 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 			)
 			vmi.Namespace = util.NamespaceTestDefault
 			vmi = tests.CreateVmiOnNode(vmi, node)
-			libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 180)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithFailOnWarnings(false),
+				libwait.WithTimeout(180),
+			)
 
 			vmi2 := libvmi.NewFedora(
 				libvmi.WithPersistentVolumeClaimLun("lun0", pvc.Name, true),
 			)
 			vmi2.Namespace = util.NamespaceTestDefault
 			vmi2 = tests.CreateVmiOnNode(vmi2, node)
-			libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi2, 180)
+			libwait.WaitForSuccessfulVMIStart(vmi2,
+				libwait.WithFailOnWarnings(false),
+				libwait.WithTimeout(180),
+			)
 
 			By("Requesting SCSI persistent reservation from the first VM")
 			Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1480,7 +1480,9 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				})
 
 				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				doRestore("/dev/vdc", console.LoginToFedora, onlineSnapshot, getTargetVMName(restoreToNewVM, newVmName))

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -445,7 +445,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				})
 
 				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				initialMemory := vmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
@@ -524,7 +526,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				})
 
 				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
 
 				snapshot = newSnapshot()
 
@@ -546,7 +550,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				vm = tests.NewRandomVirtualMachine(vmi, false)
 
 				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				snapshot = newSnapshot()
@@ -724,7 +730,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				vm = tests.NewRandomVirtualMachine(vmi, false)
 
 				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Logging into Fedora")
@@ -782,7 +790,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				vm.Spec.Running = &running
 
 				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
 
 				By("Calling Velero pre-backup hook")
 				_, stderr, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)
@@ -802,7 +812,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				vm = tests.NewRandomVirtualMachine(vmi, false)
 
 				vm, vmi = createAndStartVM(vm)
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Logging into Fedora")

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -164,7 +164,10 @@ var _ = SIGDescribe("Storage", func() {
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)
 
-				libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 180)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithFailOnWarnings(false),
+					libwait.WithTimeout(180),
+				)
 
 				By("Reading from disk")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed(), "Should login")
@@ -1474,7 +1477,10 @@ var _ = SIGDescribe("Storage", func() {
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)
 
-				libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 180)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithFailOnWarnings(false),
+					libwait.WithTimeout(180),
+				)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
@@ -1509,7 +1515,10 @@ var _ = SIGDescribe("Storage", func() {
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)
 
-				libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 240)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithFailOnWarnings(false),
+					libwait.WithTimeout(240),
+				)
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				By(fmt.Sprintf("Checking that %s has a capacity of 8Mi", device))

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -316,7 +316,9 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 					Expect(err).ToNot(HaveOccurred())
 					return vmi.Status.Phase == v1.Running
 				}, 180*time.Second, time.Second).Should(BeTrue())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 180)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(180),
+				)
 			})
 
 			It("[test_id:7476]Freeze without guest agent", func() {
@@ -352,7 +354,9 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 					Expect(err).ToNot(HaveOccurred())
 					return vmi.Status.Phase == v1.Running
 				}, 180*time.Second, time.Second).Should(BeTrue())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			})
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -328,7 +328,9 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 			windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), windowsVMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			libwait.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 720)
+			libwait.WaitForSuccessfulVMIStart(windowsVMI,
+				libwait.WithTimeout(720),
+			)
 
 			windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(context.Background(), windowsVMI.Name, &metav1.GetOptions{})
 			vmiIp = windowsVMI.Status.Interfaces[0].IP

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2180,26 +2180,6 @@ func RandTmpDir() string {
 	return filepath.Join(tmpPath, rand.String(10))
 }
 
-// VMILauncherIgnoreWarnings waiting for the VMI to be up but ignoring warnings like a disconnected guest-agent
-func VMILauncherIgnoreWarnings(virtClient kubecli.KubevirtClient) func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
-	return func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
-		By(StartingVMInstance)
-		obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Get()
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Waiting the VirtualMachineInstance start")
-		vmi, ok := obj.(*v1.VirtualMachineInstance)
-		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
-		// Warnings are okay. We'll receive a warning that the agent isn't connected
-		// during bootup, but that is transient
-		Expect(libwait.WaitForSuccessfulVMIStart(vmi,
-			libwait.WithFailOnWarnings(false),
-			libwait.WithTimeout(180),
-		).Status.NodeName).ToNot(BeEmpty())
-		return vmi
-	}
-}
-
 func CheckCloudInitMetaData(vmi *v1.VirtualMachineInstance, testFile, testData string) {
 	cmdCheck := "cat " + filepath.Join("/mnt", testFile) + "\n"
 	res, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -624,7 +624,12 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			wp := watcher.WarningsPolicy{FailOnWarnings: false}
-			libwait.WaitForVMIStartOrFailed(vmi, 180, wp)
+			libwait.WaitForVMIPhase(vmi,
+				[]v1.VirtualMachineInstancePhase{v1.Running, v1.Failed},
+				libwait.WithWarningsPolicy(&wp),
+				libwait.WithTimeout(180),
+				libwait.WithWaitForFail(true),
+			)
 			vmiMeta, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -727,7 +727,10 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 				// Ensure that the VMI is running. This is necessary to ensure that virt-handler is fully responsible for
 				// the VMI. Otherwise virt-controller may move the VMI to failed instead of the node controller.
-				nodeName = libwait.WaitForSuccessfulVMIStartIgnoreWarnings(vmi).Status.NodeName
+				nodeName = libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithFailOnWarnings(false),
+					libwait.WithTimeout(180),
+				).Status.NodeName
 
 				virtHandler, err = libnode.GetVirtHandlerPod(virtClient, nodeName)
 				Expect(err).ToNot(HaveOccurred(), "Should get virthandler client")

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -79,7 +79,7 @@ var _ = Describe("[sig-compute]MultiQueue", decorators.SigCompute, func() {
 			By("Creating and starting the VMI")
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 			Expect(err).ToNot(HaveOccurred())
-			vmi = libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
+			vmi = libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Checking if we can login")
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -143,7 +143,7 @@ var _ = Describe("[sig-compute]MultiQueue", decorators.SigCompute, func() {
 			By("Creating and starting the VMI")
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
+			libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Fetching Domain XML from running pod")
 			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)

--- a/tests/vmi_tpm_test.go
+++ b/tests/vmi_tpm_test.go
@@ -129,7 +129,9 @@ var _ = Describe("[sig-storage]vTPM", decorators.SigStorage, func() {
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
 				return err
 			}, 300*time.Second, 1*time.Second).Should(Succeed())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 60)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(60),
+			)
 
 			By("Logging in as root")
 			err = console.LoginToFedora(vmi)
@@ -175,7 +177,9 @@ var _ = Describe("[sig-storage]vTPM", decorators.SigStorage, func() {
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
 				return err
 			}, 300*time.Second, 1*time.Second).Should(Succeed())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 60)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(60),
+			)
 
 			By("Logging in as root")
 			err = console.LoginToFedora(vmi)
@@ -238,7 +242,9 @@ var _ = Describe("[sig-storage]vTPM", decorators.SigStorage, func() {
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &k8smetav1.GetOptions{})
 				return err
 			}, 300*time.Second, 1*time.Second).Should(Succeed())
-			libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 60)
+			libwait.WaitForSuccessfulVMIStart(vmi,
+				libwait.WithTimeout(60),
+			)
 
 			By("Removing the VMI")
 			err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.Name, &k8smetav1.DeleteOptions{})

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -102,7 +102,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, 
 				var err error
 				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), windowsVMI)
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
+				libwait.WaitForSuccessfulVMIStart(windowsVMI)
 
 				cli = winrnLoginCommand(virtClient, windowsVMI)
 			})
@@ -164,7 +164,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, 
 				var err error
 				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), windowsVMI)
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
+				libwait.WaitForSuccessfulVMIStart(windowsVMI)
 
 				cli = winrnLoginCommand(virtClient, windowsVMI)
 			})
@@ -189,7 +189,9 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, 
 				var err error
 				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), windowsVMI)
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 420)
+				libwait.WaitForSuccessfulVMIStart(windowsVMI,
+					libwait.WithTimeout(420),
+				)
 
 				cli = winrnLoginCommand(virtClient, windowsVMI)
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a followup PR of https://github.com/kubevirt/kubevirt/pull/9901
`libwait` package exposed several utility functions that can be generalized using variadic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Addressing https://github.com/kubevirt/kubevirt/pull/9901#discussion_r1230732096

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @dhiller @acardace @EdDev