### PR TITLE
Remove invalid email reference

### DIFF
--- a/hack/gen-client-python/deploy.sh
+++ b/hack/gen-client-python/deploy.sh
@@ -19,8 +19,8 @@ cp -rf "${PYTHON_CLIENT_OUT_DIR}"/* "${CLIENT_PYTHON_DIR}/"
 
 cd "${CLIENT_PYTHON_DIR}"
 
-git config user.email "${GIT_AUTHOR_NAME:-kubevirt-bot}"
-git config user.name "${GIT_AUTHOR_EMAIL:-rmohr+kubebot@redhat.com}"
+git config user.email "${GIT_AUTHOR_EMAIL:-kubevirtbot@redhat.com}"
+git config user.name "${GIT_AUTHOR_NAME:-kubevirt-bot}"
 
 CLIENT_UPDATED="false"
 # Check api_client.py and configuration.py whether there are other changes

--- a/hack/gen-swagger-doc/deploy.sh
+++ b/hack/gen-swagger-doc/deploy.sh
@@ -35,8 +35,8 @@ __EOF__
 find * -type d -regex "^v[0-9.]*" \
     -exec echo "* [{}](${GITHUB_IO_FQDN}/{}/index.html)" \; | sort -r --version-sort -t '[' --key 2 >>README.md
 
-git config user.email "${GIT_AUTHOR_NAME:-kubevirt-bot}"
-git config user.name "${GIT_AUTHOR_EMAIL:-rmohr+kubebot@redhat.com}"
+git config user.email "${GIT_AUTHOR_EMAIL:-kubevirtbot@redhat.com}"
+git config user.name "${GIT_AUTHOR_NAME:-kubevirt-bot}"
 
 # NOTE: exclude index.html from match, because it is static except commit hash.
 if git status --porcelain | grep -v "index[.]html" | grep --quiet "^ [AM]"; then

--- a/hack/publish-staging.sh
+++ b/hack/publish-staging.sh
@@ -48,8 +48,8 @@ function commit_repo() {
     NAME=$1
     API_REF_DIR=/tmp/${NAME}
     pushd ${API_REF_DIR}
-    git config user.email "${GIT_AUTHOR_NAME:-kubevirt-bot}"
-    git config user.name "${GIT_AUTHOR_EMAIL:-rmohr+kubebot@redhat.com}"
+    git config user.email "${GIT_AUTHOR_EMAIL:-kubevirtbot@redhat.com}"
+    git config user.name "${GIT_AUTHOR_NAME:-kubevirt-bot}"
 
     git add -A
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Replace old bot user email with new `kubevirtbot@redhat.com`. Also swap git `user.name` and `user.email` configurations to use correct defaults.

The old email was removed from the kubevirt-bot GitHub account, thus the publish job for nightly build failed:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-build-main/1669510740576309248#1:build-log.txt%3A1510


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc @brianmcarey 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
