### PR TITLE
[e2e] Ignore LiveMigrate warning

### DIFF
--- a/tests/libwait/BUILD.bazel
+++ b/tests/libwait/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/console:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/testsuite:go_default_library",
         "//tests/watcher:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/testsuite"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
@@ -69,6 +71,7 @@ func WaitForVMIPhase(vmi *v1.VirtualMachineInstance, phases []v1.VirtualMachineI
 		waiting.ctx = ctx
 	}
 
+	WithWarningsIgnoreList(testsuite.TestRunConfiguration.WarningToIgnoreList)(&waiting)
 	return waiting.watchVMIForPhase(vmi)
 }
 

--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "kubevirtresource.go",
         "manifest.go",
         "namespace.go",
+        "runconfiguration.go",
         "serviceaccount.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/testsuite",

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -95,6 +95,7 @@ func SynchronizedBeforeTestSetup() []byte {
 	EnsureKVMPresent()
 	AdjustKubeVirtResource()
 	EnsureKubevirtReady()
+	InitRunConfiguration()
 
 	return nil
 }

--- a/tests/testsuite/runconfiguration.go
+++ b/tests/testsuite/runconfiguration.go
@@ -1,0 +1,23 @@
+package testsuite
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var (
+	TestRunConfiguration RunConfiguration
+)
+
+type RunConfiguration struct {
+	WarningToIgnoreList []string
+}
+
+func InitRunConfiguration() {
+	runConfig := RunConfiguration{}
+	if KubeVirtDefaultConfig.EvictionStrategy != nil &&
+		*KubeVirtDefaultConfig.EvictionStrategy == v1.EvictionStrategyLiveMigrate {
+		runConfig.WarningToIgnoreList = append(runConfig.WarningToIgnoreList, "EvictionStrategy is set but vmi is not migratable")
+	}
+
+	TestRunConfiguration = runConfig
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -272,20 +272,10 @@ func RunVMI(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInsta
 
 func RunVMIAndExpectLaunch(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
 	vmi = RunVMI(vmi, timeout)
-	virtCli := kubevirt.Client()
-	kv := util2.GetCurrentKv(virtCli)
 	By(WaitingVMInstanceStart)
-	opts := []libwait.Option{
-		libwait.WithTimeout(timeout),
-	}
-	if kv.Spec.Configuration.EvictionStrategy != nil &&
-		*kv.Spec.Configuration.EvictionStrategy == v1.EvictionStrategyLiveMigrate {
-		opts = append(opts, libwait.WithWarningsIgnoreList([]string{"EvictionStrategy is set but vmi is not migratable"}))
-	}
-
 	return libwait.WaitForVMIPhase(vmi,
 		[]v1.VirtualMachineInstancePhase{v1.Running},
-		opts...,
+		libwait.WithTimeout(timeout),
 	)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
EvictionStrategy can be set at cluster level.
When it is `LiveMigrate` and a vmi which is not live migratable is started, a warning event is emitted. This warning can cause the failure of the test because the utility function that wait for the vmi to start, generally, does not tolerate any warning.
Set the specific warning in the warning ignore list when we detect that the cluster level eviction strategy is `LiveMigrate`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/cc @xpivarc @acardace 