### PR TITLE
Add -tools suffix to libguestfs push rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -287,7 +287,7 @@ container_push(
 )
 
 container_push(
-    name = "push-libguestfs",
+    name = "push-libguestfs-tools",
     format = "Docker",
     image = "//cmd/libguestfs:libguestfs-tools-image",
     registry = "$(container_prefix)",

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -23,7 +23,7 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
-PUSH_TARGETS=(${PUSH_TARGETS:-other-images virt-operator virt-api virt-controller virt-handler virt-launcher virt-exportserver virt-exportproxy conformance libguestfs pr-helper})
+PUSH_TARGETS=(${PUSH_TARGETS:-other-images virt-operator virt-api virt-controller virt-handler virt-launcher virt-exportserver virt-exportproxy conformance libguestfs-tools pr-helper})
 
 for tag in ${docker_tag} ${docker_tag_alt}; do
     for target in ${PUSH_TARGETS[@]}; do

--- a/hack/parse-shasums.sh
+++ b/hack/parse-shasums.sh
@@ -40,5 +40,5 @@ VIRT_HANDLER_SHA=$(cat ${DIGESTS_DIR}/${ARCHITECTURE}/bazel-bin/push-virt-handle
 VIRT_LAUNCHER_SHA=$(cat ${DIGESTS_DIR}/${ARCHITECTURE}/bazel-bin/push-virt-launcher.digest)
 VIRT_EXPORTPROXY_SHA=$(cat ${DIGESTS_DIR}/${ARCHITECTURE}/bazel-bin/push-virt-exportproxy.digest)
 VIRT_EXPORTSERVER_SHA=$(cat ${DIGESTS_DIR}/${ARCHITECTURE}/bazel-bin/push-virt-exportserver.digest)
-GS_SHA=$(cat ${DIGESTS_DIR}/${ARCHITECTURE}/bazel-bin/push-libguestfs.digest)
+GS_SHA=$(cat ${DIGESTS_DIR}/${ARCHITECTURE}/bazel-bin/push-libguestfs-tools.digest)
 PR_HELPER_SHA=$(cat ${DIGESTS_DIR}/${ARCHITECTURE}/bazel-bin/push-pr-helper.digest)


### PR DESCRIPTION
Avoid any confusion and mismatches and always use `libguestfs-tools` name.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9908

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
