### PR TITLE
tests: leave some space for metadata on the backend PVC

### DIFF
--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -94,10 +94,13 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 		By(fmt.Sprintf("ldconfig: stdout: %v stderr: %v", stdout, stderr))
 		Expect(err).ToNot(HaveOccurred())
 
-		// Create backend file
+		// Create backend file. Let some room for metedata and create a
+		// slightly smaller backend image, we use 800M instead of 1G. In
+		// this case, the disk size doesn't matter as the disk is used
+		// mostly to test the SCSI persistent reservation ioctls.
 		executeTargetCli(podName, []string{
 			"backstores/fileio",
-			"create", backendDisk, "/disks/disk.img", "1G"})
+			"create", backendDisk, "/disks/disk.img", "800M"})
 		executeTargetCli(podName, []string{
 			"loopback/", "create", naa})
 		// Create LUN


### PR DESCRIPTION
In certain case, the targetcli backstores/fileio create command fails with:
 Could not expand file to 1073741824 bytes

We can try to avoid this issue by creating a smaller backend image. We simply hardcoded 800M instead of 1G as in these tests the size of the disk doesn't matter. This is used to test the SCSI persistent reservation ioctls.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
