### PR TITLE
Improve the IOError condition description.

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1448,7 +1448,7 @@ func calculatePausedCondition(vmi *v1.VirtualMachineInstance, reason api.StateCh
 			LastProbeTime:      now,
 			LastTransitionTime: now,
 			Reason:             "PausedIOError",
-			Message:            "VMI was paused, IO error",
+			Message:            "VMI was paused, low-level IO error detected",
 		})
 	default:
 		log.Log.Object(vmi).V(3).Infof("Domain is paused for unknown reason, %s", reason)


### PR DESCRIPTION
Important to note that the io error is the cause the cause for pausing, and that it comes from the low-levels.

**What this PR does / why we need it**:
Explain a condition better

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
