### PR TITLE
virt-controller, vmi: Cancel the removal of ordinal networks

### DIFF
--- a/pkg/virt-controller/services/multus_annotations.go
+++ b/pkg/virt-controller/services/multus_annotations.go
@@ -99,8 +99,10 @@ func newMultusAnnotationData(namespace string, interfaces []v1.Interface, networ
 
 func NonDefaultMultusNetworksIndexedByIfaceName(pod *k8sv1.Pod) map[string]networkv1.NetworkStatus {
 	indexedNetworkStatus := map[string]networkv1.NetworkStatus{}
+	if pod.Annotations == nil {
+		return indexedNetworkStatus
+	}
 	podNetworkStatus, found := pod.Annotations[networkv1.NetworkStatusAnnot]
-
 	if !found {
 		return indexedNetworkStatus
 	}

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -126,6 +126,7 @@ go_test(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/sriov:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

Older VMIs that are using ordinal pod interfaces cannot be unplug. The VMI controller will now remove the `absent` status of these interfaces, i.e. cancel the request to remove them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
