### PR TITLE
Remove hotplug VMI API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11241,57 +11241,6 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/addinterface": {
-    "put": {
-     "description": "Add a network interface to a running Virtual Machine Instance",
-     "operationId": "v1vmi-addinterface",
-     "parameters": [
-      {
-       "name": "body",
-       "in": "body",
-       "required": true,
-       "schema": {
-        "$ref": "#/definitions/v1.AddInterfaceOptions"
-       }
-      }
-     ],
-     "responses": {
-      "200": {
-       "description": "OK",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "400": {
-       "description": "Bad Request",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "401": {
-       "description": "Unauthorized"
-      }
-     }
-    },
-    "parameters": [
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Name of the resource",
-      "name": "name",
-      "in": "path",
-      "required": true
-     },
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Object name and auth scope, such as for teams and projects",
-      "name": "namespace",
-      "in": "path",
-      "required": true
-     }
-    ]
-   },
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
@@ -11621,57 +11570,6 @@
       "type": "string",
       "description": "The protocol for portforward on the VirtualMachineInstance.",
       "name": "protocol",
-      "in": "path",
-      "required": true
-     }
-    ]
-   },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/removeinterface": {
-    "put": {
-     "description": "Remove a network interface from a running Virtual Machine Instance",
-     "operationId": "v1vmi-removeinterface",
-     "parameters": [
-      {
-       "name": "body",
-       "in": "body",
-       "required": true,
-       "schema": {
-        "$ref": "#/definitions/v1.RemoveInterfaceOptions"
-       }
-      }
-     ],
-     "responses": {
-      "200": {
-       "description": "OK",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "400": {
-       "description": "Bad Request",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "401": {
-       "description": "Unauthorized"
-      }
-     }
-    },
-    "parameters": [
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Name of the resource",
-      "name": "name",
-      "in": "path",
-      "required": true
-     },
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Object name and auth scope, such as for teams and projects",
-      "name": "namespace",
       "in": "path",
       "required": true
      }
@@ -12849,57 +12747,6 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/addinterface": {
-    "put": {
-     "description": "Add a network interface to a running Virtual Machine Instance",
-     "operationId": "v1alpha3vmi-addinterface",
-     "parameters": [
-      {
-       "name": "body",
-       "in": "body",
-       "required": true,
-       "schema": {
-        "$ref": "#/definitions/v1.AddInterfaceOptions"
-       }
-      }
-     ],
-     "responses": {
-      "200": {
-       "description": "OK",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "400": {
-       "description": "Bad Request",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "401": {
-       "description": "Unauthorized"
-      }
-     }
-    },
-    "parameters": [
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Name of the resource",
-      "name": "name",
-      "in": "path",
-      "required": true
-     },
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Object name and auth scope, such as for teams and projects",
-      "name": "namespace",
-      "in": "path",
-      "required": true
-     }
-    ]
-   },
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
@@ -13229,57 +13076,6 @@
       "type": "string",
       "description": "The protocol for portforward on the VirtualMachineInstance.",
       "name": "protocol",
-      "in": "path",
-      "required": true
-     }
-    ]
-   },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/removeinterface": {
-    "put": {
-     "description": "Remove a network interface from a running Virtual Machine Instance",
-     "operationId": "v1alpha3vmi-removeinterface",
-     "parameters": [
-      {
-       "name": "body",
-       "in": "body",
-       "required": true,
-       "schema": {
-        "$ref": "#/definitions/v1.RemoveInterfaceOptions"
-       }
-      }
-     ],
-     "responses": {
-      "200": {
-       "description": "OK",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "400": {
-       "description": "Bad Request",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "401": {
-       "description": "Unauthorized"
-      }
-     }
-    },
-    "parameters": [
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Name of the resource",
-      "name": "name",
-      "in": "path",
-      "required": true
-     },
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Object name and auth scope, such as for teams and projects",
-      "name": "namespace",
       "in": "path",
       "required": true
      }

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -651,8 +651,6 @@ spec:
           - virtualmachineinstances/freeze
           - virtualmachineinstances/unfreeze
           - virtualmachineinstances/softreboot
-          - virtualmachineinstances/addinterface
-          - virtualmachineinstances/removeinterface
           verbs:
           - update
         - apiGroups:
@@ -898,7 +896,6 @@ spec:
           - virtualmachineinstances/freeze
           - virtualmachineinstances/unfreeze
           - virtualmachineinstances/softreboot
-          - virtualmachineinstances/addinterface
           verbs:
           - update
         - apiGroups:
@@ -1044,7 +1041,6 @@ spec:
           - virtualmachineinstances/freeze
           - virtualmachineinstances/unfreeze
           - virtualmachineinstances/softreboot
-          - virtualmachineinstances/addinterface
           verbs:
           - update
         - apiGroups:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -579,8 +579,6 @@ rules:
   - virtualmachineinstances/freeze
   - virtualmachineinstances/unfreeze
   - virtualmachineinstances/softreboot
-  - virtualmachineinstances/addinterface
-  - virtualmachineinstances/removeinterface
   verbs:
   - update
 - apiGroups:
@@ -826,7 +824,6 @@ rules:
   - virtualmachineinstances/freeze
   - virtualmachineinstances/unfreeze
   - virtualmachineinstances/softreboot
-  - virtualmachineinstances/addinterface
   verbs:
   - update
 - apiGroups:
@@ -972,7 +969,6 @@ rules:
   - virtualmachineinstances/freeze
   - virtualmachineinstances/unfreeze
   - virtualmachineinstances/softreboot
-  - virtualmachineinstances/addinterface
   verbs:
   - update
 - apiGroups:

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -504,24 +504,6 @@ func (app *virtAPIApp) composeSubresources() {
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusInternalServerError, httpStatusInternalServerError, ""))
 
-		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("addinterface")).
-			To(subresourceApp.VMIAddInterfaceRequestHandler).
-			Reads(v1.AddInterfaceOptions{}).
-			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
-			Operation(version.Version+"vmi-addinterface").
-			Doc("Add a network interface to a running Virtual Machine Instance").
-			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
-
-		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("removeinterface")).
-			To(subresourceApp.VMIRemoveInterfaceRequestHandler).
-			Reads(v1.RemoveInterfaceOptions{}).
-			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
-			Operation(version.Version+"vmi-removeinterface").
-			Doc("Remove a network interface from a running Virtual Machine Instance").
-			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
-
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("addinterface")).
 			To(subresourceApp.VMAddInterfaceRequestHandler).
 			Reads(v1.AddInterfaceOptions{}).
@@ -636,14 +618,6 @@ func (app *virtAPIApp) composeSubresources() {
 					},
 					{
 						Name:       "virtualmachineinstances/removevolume",
-						Namespaced: true,
-					},
-					{
-						Name:       "virtualmachineinstances/addinterface",
-						Namespaced: true,
-					},
-					{
-						Name:       "virtualmachineinstances/removeinterface",
 						Namespaced: true,
 					},
 				}

--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/monitoring/api:go_default_library",
-        "//pkg/network/vmispec:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/status:go_default_library",

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -164,7 +164,6 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					"virtualmachineinstances/freeze",
 					"virtualmachineinstances/unfreeze",
 					"virtualmachineinstances/softreboot",
-					"virtualmachineinstances/addinterface",
 				},
 				Verbs: []string{
 					"update",
@@ -344,7 +343,6 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					"virtualmachineinstances/freeze",
 					"virtualmachineinstances/unfreeze",
 					"virtualmachineinstances/softreboot",
-					"virtualmachineinstances/addinterface",
 				},
 				Verbs: []string{
 					"update",

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -373,8 +373,6 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"virtualmachineinstances/freeze",
 					"virtualmachineinstances/unfreeze",
 					"virtualmachineinstances/softreboot",
-					"virtualmachineinstances/addinterface",
-					"virtualmachineinstances/removeinterface",
 				},
 				Verbs: []string{
 					"update",

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1267,26 +1267,6 @@ func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) VSOCK(arg0, arg1 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "VSOCK", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInstanceInterface) AddInterface(ctx context.Context, name string, addInterfaceOptions *v120.AddInterfaceOptions) error {
-	ret := _m.ctrl.Call(_m, "AddInterface", ctx, name, addInterfaceOptions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) AddInterface(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddInterface", arg0, arg1, arg2)
-}
-
-func (_m *MockVirtualMachineInstanceInterface) RemoveInterface(ctx context.Context, name string, removeInterfaceOptions *v120.RemoveInterfaceOptions) error {
-	ret := _m.ctrl.Call(_m, "RemoveInterface", ctx, name, removeInterfaceOptions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) RemoveInterface(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveInterface", arg0, arg1, arg2)
-}
-
 // Mock of ReplicaSetInterface interface
 type MockReplicaSetInterface struct {
 	ctrl     *gomock.Controller

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -252,8 +252,6 @@ type VirtualMachineInstanceInterface interface {
 	AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error
 	RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error
 	VSOCK(name string, options *v1.VSOCKOptions) (StreamInterface, error)
-	AddInterface(ctx context.Context, name string, addInterfaceOptions *v1.AddInterfaceOptions) error
-	RemoveInterface(ctx context.Context, name string, removeInterfaceOptions *v1.RemoveInterfaceOptions) error
 }
 
 type ReplicaSetInterface interface {

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -506,25 +506,3 @@ func (v *vmis) VSOCK(name string, options *v1.VSOCKOptions) (StreamInterface, er
 	queryParams.Add("tls", strconv.FormatBool(useTLS))
 	return asyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vsock", queryParams)
 }
-
-func (v *vmis) AddInterface(ctx context.Context, name string, addInterfaceOptions *v1.AddInterfaceOptions) error {
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "addinterface")
-
-	JSON, err := json.Marshal(addInterfaceOptions)
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().RequestURI(uri).Body(JSON).Do(ctx).Error()
-}
-
-func (v *vmis) RemoveInterface(ctx context.Context, name string, removeInterfaceOptions *v1.RemoveInterfaceOptions) error {
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "removeinterface")
-
-	JSON, err := json.Marshal(removeInterfaceOptions)
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().RequestURI(uri).Body(JSON).Do(ctx).Error()
-}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR removes the rest-api and virctlcommands  for hotplugging/unplugging an interfaces to/from a VMI.
Interface hotplugging/unplugging will be supported via VMs only.

It was noticed that allowing users to access the VMI (through the virt-api) is introducing too many corner cases (for example interface hotplugged to a VMI didn't get MAC from kubemacpool) and complexity in the system. Users should have access only to their user facing API, which is the VM object. Allowing the system to apply the desired spec in the VM to the backend VMI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable network interface hotplug/unplug for VMIs. It will be supported for VMs only. 
```
