### PR TITLE
reporter: move the message with the artifacts dir to `JustAfterEach`

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -87,11 +87,9 @@ func NewKubernetesReporter(artifactsDir string, maxFailures int) *KubernetesRepo
 	}
 }
 
-func (r *KubernetesReporter) JustBeforeEach(specReport types.SpecReport) {
-	fmt.Fprintf(GinkgoWriter, "On failure, artifacts will be collected in %s/%d_*\n", r.artifactsDir, r.failureCount+1)
-}
-
 func (r *KubernetesReporter) JustAfterEach(specReport types.SpecReport) {
+	fmt.Fprintf(GinkgoWriter, "On failure, artifacts will be collected in %s/%d_*\n", r.artifactsDir, r.failureCount+1)
+
 	if r.failureCount > r.maxFails {
 		return
 	}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -124,10 +124,6 @@ var _ = ReportAfterSuite("TestTests", func(report Report) {
 	}
 })
 
-var _ = JustBeforeEach(func() {
-	k8sReporter.JustBeforeEach(CurrentSpecReport())
-})
-
 var _ = JustAfterEach(func() {
 	k8sReporter.JustAfterEach(CurrentSpecReport())
 })


### PR DESCRIPTION
The message was in `JustBeforeEach` and if the test failed in one of its `BeforeEach`es it wasn't printed although the artifacts were collected. Moving the message to `JustAfterEach` makes sure that if the artifacts are collected the text is printed as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
