### PR TITLE
Revert "e2e: Remove events in the namespace after each test"

### DIFF
--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -281,13 +281,6 @@ func CleanNamespaces() {
 		}
 
 		util.PanicOnError(virtCli.VirtualMachineRestore(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
-
-		// Remove events
-		eventList, err := virtCli.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
-		util.PanicOnError(err)
-		for _, event := range eventList.Items {
-			util.PanicOnError(virtCli.CoreV1().Events(namespace).Delete(context.Background(), event.Name, metav1.DeleteOptions{}))
-		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit 5b0dc9254ea39ea1085ce643caa6425b1955e6c6.

This change increased the runtime of the e2e lanes by a considerable
amount.

For example - the sig-compute lanes went from around 3h 30m[1] to over 4
hours[2] - an increase of 30 minutes here is too expensive if this change is something that is not required for the lane to run.

The testsuite time in the sig-performance lane more than doubled after
this change from 21 minutes[3] to 45 minutes[4]

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9960/pull-kubevirt-e2e-k8s-1.27-sig-compute/1671593317155999744
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.27-sig-compute/1671609167153991680
[3] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9960/pull-kubevirt-e2e-k8s-1.25-sig-performance/1671593317080502272#1:build-log.txt%3A2793
[4] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.25-sig-performance/1671664532344279040#1:build-log.txt%3A2740

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
