### PR TITLE
[e2e] Improve events deletion in AfterEach

### DIFF
--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -283,11 +283,7 @@ func CleanNamespaces() {
 		util.PanicOnError(virtCli.VirtualMachineRestore(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 
 		// Remove events
-		eventList, err := virtCli.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
-		util.PanicOnError(err)
-		for _, event := range eventList.Items {
-			util.PanicOnError(virtCli.CoreV1().Events(namespace).Delete(context.Background(), event.Name, metav1.DeleteOptions{}))
-		}
+		util.PanicOnError(virtCli.CoreV1().Events(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, we are deleting every events in a namespace after each test. The way we are doing this increased the runtime of the e2e lanes by a considerable amount.
Let's use delete collection instead of retrieving the events and delete one by one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Alternative for https://github.com/kubevirt/kubevirt/pull/9960
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
