### PR TITLE
Fix VMSnapshot + Manual RunStrategy

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -1026,7 +1026,7 @@ func checkVMRunning(vm *kubevirtv1.VirtualMachine) (bool, error) {
 		return false, err
 	}
 
-	return rs != kubevirtv1.RunStrategyHalted, nil
+	return rs == kubevirtv1.RunStrategyAlways || rs == kubevirtv1.RunStrategyRerunOnFailure, nil
 }
 
 func updateSnapshotCondition(ss *snapshotv1.VirtualMachineSnapshot, c snapshotv1.Condition) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Runstrategy `Manual` + VM stopped would result in VMSnapshot hanging until VM started

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9944

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
