### PR TITLE
tests, hotplug: Remove redundant migration

### DIFF
--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -206,10 +206,6 @@ var _ = SIGDescribe("nic-hotplug", func() {
 				),
 			).To(Succeed())
 
-			if plugMethod == migrationBased {
-				migrate(hotPluggedVMI)
-			}
-
 			By("wait for the second network to appear in the VMI spec")
 			EventuallyWithOffset(1, func() []v1.Network {
 				var err error


### PR DESCRIPTION
**What this PR does / why we need it**:

When testing multiple hotplug interfaces a redundant migration was executed after the second hotplug.

By executing the migration before the new interface propagated to the VMI, flakes are seen (pod interface missing on the target).

Therefore, drop one migration and depend on the one performed as part of the `verifyDynamicInterfaceChange` helper.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The problem is seen rarely.
Here is one occurrence of it:  https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9954/pull-kubevirt-e2e-k8s-1.26-sig-network/1672845055431282688

Note that local tests have not shown this problem at all.

**Release note**:
```release-note
NONE
```
