### PR TITLE
virt-controller, vm: Refactor dynamic interface handling

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2717,21 +2717,20 @@ func (c *VMController) handleDynamicInterfaceRequests(vm *virtv1.VirtualMachine,
 	for i := range vm.Status.InterfaceRequests {
 		vmTemplateCopy = controller.ApplyNetworkInterfaceRequestOnVMISpec(
 			vmTemplateCopy, &vm.Status.InterfaceRequests[i])
+	}
+	vm.Spec.Template.Spec = *vmTemplateCopy
 
-		if vmi == nil || vmi.DeletionTimestamp != nil {
-			continue
-		}
-
+	if vmi != nil && vmi.DeletionTimestamp == nil {
 		vmiSpecCopy := vmi.Spec.DeepCopy()
-		vmiSpecCopy = controller.ApplyNetworkInterfaceRequestOnVMISpec(
-			vmiSpecCopy, &vm.Status.InterfaceRequests[i])
-
+		for i := range vm.Status.InterfaceRequests {
+			vmiSpecCopy = controller.ApplyNetworkInterfaceRequestOnVMISpec(
+				vmiSpecCopy, &vm.Status.InterfaceRequests[i])
+		}
 		if err := c.vmiInterfacesPatch(vmiSpecCopy, vmi); err != nil {
 			return err
 		}
 	}
 
-	vm.Spec.Template.Spec = *vmTemplateCopy
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

 Perform a single patch operation for an object instead of multiple
 patching (one per interface).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
