### PR TITLE
virt-controller, vm: Avoid unplugging interfaces on older running VMs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -390,17 +390,26 @@ func AttachmentPods(ownerPod *k8sv1.Pod, podInformer cache.SharedIndexInformer) 
 func ApplyNetworkInterfaceRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request *v1.VirtualMachineInterfaceRequest) *v1.VirtualMachineInstanceSpec {
 	switch {
 	case request.AddInterfaceOptions != nil:
-		if iface := vmispec.LookupInterfaceByName(vmiSpec.Domain.Devices.Interfaces, request.AddInterfaceOptions.Name); iface == nil {
-			newNetwork, newIface := newNetworkInterface(request.AddInterfaceOptions.Name, request.AddInterfaceOptions.NetworkAttachmentDefinitionName)
-			vmiSpec.Networks = append(vmiSpec.Networks, newNetwork)
-			vmiSpec.Domain.Devices.Interfaces = append(vmiSpec.Domain.Devices.Interfaces, newIface)
-		}
+		vmiSpec = ApplyNetworkInterfaceAddRequest(vmiSpec, request.AddInterfaceOptions)
 	case request.RemoveInterfaceOptions != nil:
-		if iface := vmispec.LookupInterfaceByName(vmiSpec.Domain.Devices.Interfaces, request.RemoveInterfaceOptions.Name); iface != nil {
-			iface.State = v1.InterfaceStateAbsent
-		}
+		vmiSpec = ApplyNetworkInterfaceRemoveRequest(vmiSpec, request.RemoveInterfaceOptions)
 	}
+	return vmiSpec
+}
 
+func ApplyNetworkInterfaceAddRequest(vmiSpec *v1.VirtualMachineInstanceSpec, options *v1.AddInterfaceOptions) *v1.VirtualMachineInstanceSpec {
+	if iface := vmispec.LookupInterfaceByName(vmiSpec.Domain.Devices.Interfaces, options.Name); iface == nil {
+		newNetwork, newIface := newNetworkInterface(options.Name, options.NetworkAttachmentDefinitionName)
+		vmiSpec.Networks = append(vmiSpec.Networks, newNetwork)
+		vmiSpec.Domain.Devices.Interfaces = append(vmiSpec.Domain.Devices.Interfaces, newIface)
+	}
+	return vmiSpec
+}
+
+func ApplyNetworkInterfaceRemoveRequest(vmiSpec *v1.VirtualMachineInstanceSpec, options *v1.RemoveInterfaceOptions) *v1.VirtualMachineInstanceSpec {
+	if iface := vmispec.LookupInterfaceByName(vmiSpec.Domain.Devices.Interfaces, options.Name); iface != nil {
+		iface.State = v1.InterfaceStateAbsent
+	}
 	return vmiSpec
 }
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -690,6 +690,7 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 		vca.dataVolumeInformer,
 		vca.persistentVolumeClaimInformer,
 		vca.controllerRevisionInformer,
+		vca.kvPodInformer,
 		instancetypeMethods,
 		recorder,
 		vca.clientSet,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -143,6 +143,7 @@ var _ = Describe("Application", func() {
 			dataVolumeInformer,
 			pvcInformer,
 			crInformer,
+			podInformer,
 			instancetypeMethods,
 			recorder,
 			virtClient,

--- a/pkg/virt-controller/watch/network_test.go
+++ b/pkg/virt-controller/watch/network_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Network interface hot{un}plug", func() {
 	DescribeTable("calculate if changes are required",
 
 		func(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod, expIfaces []v1.Interface, expNets []v1.Network, expToChange bool) {
-			ifaces, nets, exists := calculateDynamicInterfaces(vmi, pod)
+			ifaces, nets, exists := calculateDynamicInterfaces(vmi)
 			Expect(ifaces).To(Equal(expIfaces))
 			Expect(nets).To(Equal(expNets))
 			Expect(exists).To(Equal(expToChange))
@@ -103,46 +103,6 @@ var _ = Describe("Network interface hot{un}plug", func() {
 			},
 			[]v1.Interface{{Name: testNetworkName1}},
 			[]v1.Network{{Name: testNetworkName1}},
-			expectToChange,
-		),
-		Entry("when a vmi interface has state set to `absent`, but pod iface name is ordinal",
-			libvmi.New(
-				libvmi.WithInterface(v1.Interface{Name: testNetworkName1}),
-				libvmi.WithInterface(v1.Interface{Name: testNetworkName2, State: v1.InterfaceStateAbsent}),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
-				withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName1}),
-				withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName2}),
-			),
-			&k8sv1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					networkv1.NetworkStatusAnnot: `[
-						{"interface":"net1", "name":"red-net", "namespace": "default"},
-						{"interface":"net2", "name":"blue-net", "namespace": "default"}
-					]`,
-				}},
-			},
-			nil,
-			nil,
-			expectNoChange,
-		),
-		Entry("when vmi interfaces have an interface to hotplug and one to hot-unplug, given ordinal names",
-			libvmi.New(
-				libvmi.WithInterface(v1.Interface{Name: testNetworkName1, State: v1.InterfaceStateAbsent}),
-				libvmi.WithInterface(v1.Interface{Name: testNetworkName2}),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-				libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
-				withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName1}),
-			),
-			&k8sv1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-					networkv1.NetworkStatusAnnot: `[
-						{"interface":"net1", "name":"red-net", "namespace": "default"}
-					]`,
-				}},
-			},
-			[]v1.Interface{{Name: testNetworkName1, State: v1.InterfaceStateAbsent}, {Name: testNetworkName2}},
-			[]v1.Network{{Name: testNetworkName1}, {Name: testNetworkName2}},
 			expectToChange,
 		),
 		Entry("when vmi interfaces have an interface to hotplug and one to hot-unplug, given hashed names",

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2717,21 +2717,20 @@ func (c *VMController) handleDynamicInterfaceRequests(vm *virtv1.VirtualMachine,
 	for i := range vm.Status.InterfaceRequests {
 		vmTemplateCopy = controller.ApplyNetworkInterfaceRequestOnVMISpec(
 			vmTemplateCopy, &vm.Status.InterfaceRequests[i])
+	}
+	vm.Spec.Template.Spec = *vmTemplateCopy
 
-		if vmi == nil || vmi.DeletionTimestamp != nil {
-			continue
-		}
-
+	if vmi != nil && vmi.DeletionTimestamp == nil {
 		vmiSpecCopy := vmi.Spec.DeepCopy()
-		vmiSpecCopy = controller.ApplyNetworkInterfaceRequestOnVMISpec(
-			vmiSpecCopy, &vm.Status.InterfaceRequests[i])
-
+		for i := range vm.Status.InterfaceRequests {
+			vmiSpecCopy = controller.ApplyNetworkInterfaceRequestOnVMISpec(
+				vmiSpecCopy, &vm.Status.InterfaceRequests[i])
+		}
 		if err := c.vmiInterfacesPatch(vmiSpecCopy, vmi); err != nil {
 			return err
 		}
 	}
 
-	vm.Spec.Template.Spec = *vmTemplateCopy
 	return nil
 }
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -68,6 +68,7 @@ var _ = Describe("VirtualMachine", func() {
 		var dataVolumeSource *framework.FakeControllerSource
 		var pvcInformer cache.SharedIndexInformer
 		var crInformer cache.SharedIndexInformer
+		var podInformer cache.SharedIndexInformer
 		var instancetypeMethods *testutils.MockInstancetypeMethods
 		var stop chan struct{}
 		var controller *VMController
@@ -119,6 +120,7 @@ var _ = Describe("VirtualMachine", func() {
 					return nil, nil
 				},
 			})
+			podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 
 			instancetypeMethods = testutils.NewMockInstancetypeMethods()
 
@@ -132,6 +134,7 @@ var _ = Describe("VirtualMachine", func() {
 				dataVolumeInformer,
 				pvcInformer,
 				crInformer,
+				podInformer,
 				instancetypeMethods,
 				recorder,
 				virtClient,

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1267,7 +1267,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 			}
 		}
 
-		if vmiSpecIfaces, vmiSpecNets, dynamicIfacesExist := calculateDynamicInterfaces(vmi, pod); dynamicIfacesExist {
+		if vmiSpecIfaces, vmiSpecNets, dynamicIfacesExist := calculateDynamicInterfaces(vmi); dynamicIfacesExist {
 			if err := c.handleDynamicInterfaceRequests(vmi.Namespace, vmiSpecIfaces, vmiSpecNets, pod); err != nil {
 				return &syncErrorImpl{
 					err:    fmt.Errorf("failed to hot{un}plug network interfaces for vmi [%s/%s]: %w", vmi.GetNamespace(), vmi.GetName(), err),


### PR DESCRIPTION
**What this PR does / why we need it**:

When marking a network interface for removal, the VM controller is
patching the VMI object to reflect the same on the running VM.

However, for older VMs where its pod interfaces use ordered naming, the
unplug operation is not supported.

Therefore, the VM controller now checks against the pod network
annotation about the naming of the pod interfaces and if detected as
ordered, it will not patch the VMI.

The change assures VMI objects which do not support interface hot-unplug
will not be marked as such in the first place.
Therefore, code which the VMI controller has to cancel the unplug
request and code in the virt-handler and virt-launcher, can be removed
as followup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~This PR is a followup on #9954 and suggests to never path an old VMI in the first place.~~
The change also depends on #9975

**Release note**:
```release-note
NONE
```
