### PR TITLE
tests: don't assume the custom SELinux policy file is present

### DIFF
--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -284,11 +284,13 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 			if policyRemovedByTest {
 				By("Re-installing custom SELinux policy on all nodes")
 				err = runOnAllSchedulableNodes(virtClient, []string{"cp", "/var/run/kubevirt/virt_launcher.cil", "/proc/1/root/tmp/"}, "")
-				Expect(err).ToNot(HaveOccurred())
-				err = runOnAllSchedulableNodes(virtClient, []string{"chroot", "/proc/1/root", "semodule", "-i", "/tmp/virt_launcher.cil"}, "")
-				Expect(err).ToNot(HaveOccurred())
-				err = runOnAllSchedulableNodes(virtClient, []string{"rm", "-f", "/proc/1/root/tmp/virt_launcher.cil"}, "")
-				Expect(err).ToNot(HaveOccurred())
+				// That file may not be deployed on clusters that don't need the policy anymore
+				if err == nil {
+					err = runOnAllSchedulableNodes(virtClient, []string{"chroot", "/proc/1/root", "semodule", "-i", "/tmp/virt_launcher.cil"}, "")
+					Expect(err).ToNot(HaveOccurred())
+					err = runOnAllSchedulableNodes(virtClient, []string{"rm", "-f", "/proc/1/root/tmp/virt_launcher.cil"}, "")
+					Expect(err).ToNot(HaveOccurred())
+				}
 			}
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It's possible that a test node still has our custom SELinux policy installed from a previous version of KubeVirt, but now uses a version that doesn't include it anymore.
In that specific scenario, the corresponding test will fail. This PR makes it succeed if the file is missing, since there's nothing more to do.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
