### PR TITLE
[e2e] Set vm eviction strategy explicitly

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -174,6 +174,7 @@ go_test(
         "//pkg/hooks/v1alpha1:go_default_library",
         "//pkg/hooks/v1alpha2:go_default_library",
         "//pkg/network/dns:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -33,6 +33,8 @@ import (
 	"sync"
 	"time"
 
+	kvpointer "kubevirt.io/kubevirt/pkg/pointer"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 
@@ -3641,6 +3643,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					vmi_evict1 := alpineVMIWithEvictionStrategy()
 					vmi_evict2 := alpineVMIWithEvictionStrategy()
 					vmi_noevict := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+					vmi_noevict.Spec.EvictionStrategy = kvpointer.P(v1.EvictionStrategyNone)
 
 					labelKey := "testkey"
 					labels := map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
VMI eviction strategy is inherited from the cluster value if it is not explicitly set in the vmi spec.
Since, cluster level eviction strategy can also be `LiveMigrate` in some other test configuration, let's ensure the eviction strategy is `None` in those tests where we want to test it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
