### PR TITLE
[virt-operator]: always deploy the outdated VMI workload alert

### DIFF
--- a/hack/prom-rule-ci/rule-spec-dumper.go
+++ b/hack/prom-rule-ci/rule-spec-dumper.go
@@ -25,7 +25,7 @@ func main() {
 
 	targetFile := os.Args[1]
 
-	promRuleSpec := components.NewPrometheusRuleSpec("ci", true)
+	promRuleSpec := components.NewPrometheusRuleSpec("ci")
 	b, err := json.Marshal(promRuleSpec)
 	if err != nil {
 		panic(err)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1231,7 +1231,7 @@ func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymen
 		all = append(all, crd)
 	}
 	// cr
-	all = append(all, components.NewPrometheusRuleCR(config.GetNamespace(), config.WorkloadUpdatesEnabled()))
+	all = append(all, components.NewPrometheusRuleCR(config.GetNamespace()))
 	// sccs
 	all = append(all, components.NewKubeVirtControllerSCC(NAMESPACE))
 	all = append(all, components.NewKubeVirtHandlerSCC(NAMESPACE))

--- a/pkg/virt-operator/resource/apply/prometheus_test.go
+++ b/pkg/virt-operator/resource/apply/prometheus_test.go
@@ -34,8 +34,6 @@ var _ = Describe("Apply Prometheus", func() {
 	var kv *v1.KubeVirt
 	var stores util.Stores
 
-	config := getConfig("fake-registry", "v9.9.9")
-
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		kvInterface := kubecli.NewMockKubeVirtInterface(ctrl)
@@ -132,7 +130,7 @@ var _ = Describe("Apply Prometheus", func() {
 
 	It("should not patch PrometheusRules on sync when they are equal", func() {
 
-		pr := components.NewPrometheusRuleCR("namespace", config.WorkloadUpdatesEnabled())
+		pr := components.NewPrometheusRuleCR("namespace")
 
 		version, imageRegistry, id := getTargetVersionRegistryID(kv)
 		injectOperatorMetadata(kv, &pr.ObjectMeta, version, imageRegistry, id, true)
@@ -151,7 +149,7 @@ var _ = Describe("Apply Prometheus", func() {
 
 	It("should patch PrometheusRules on sync when they are equal", func() {
 
-		pr := components.NewPrometheusRuleCR("namespace", config.WorkloadUpdatesEnabled())
+		pr := components.NewPrometheusRuleCR("namespace")
 
 		version, imageRegistry, id := getTargetVersionRegistryID(kv)
 		injectOperatorMetadata(kv, &pr.ObjectMeta, version, imageRegistry, id, true)

--- a/pkg/virt-operator/resource/generate/components/prometheus_test.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Prometheus", func() {
 	})
 
 	It("should use the default runbook URL template when no ENV Variable is set", func() {
-		promRule := NewPrometheusRuleCR("mynamespace", true)
+		promRule := NewPrometheusRuleCR("mynamespace")
 
 		for _, group := range promRule.Spec.Groups {
 			for _, rule := range group.Rules {
@@ -35,7 +35,7 @@ var _ = Describe("Prometheus", func() {
 		desiredRunbookURLTemplate := "desired/runbookURL/template/%s"
 		os.Setenv(runbookURLTemplateEnv, desiredRunbookURLTemplate)
 
-		promRule := NewPrometheusRuleCR("mynamespace", true)
+		promRule := NewPrometheusRuleCR("mynamespace")
 
 		for _, group := range promRule.Spec.Groups {
 			for _, rule := range group.Rules {

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -428,11 +428,10 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 		if serviceMonitorNamespace == "" {
 			serviceMonitorNamespace = monitorNamespace
 		}
-		workloadUpdatesEnabled := config.WorkloadUpdatesEnabled()
 
 		rbaclist = append(rbaclist, rbac.GetAllServiceMonitor(config.GetNamespace(), monitorNamespace, monitorServiceAccount)...)
 		strategy.serviceMonitors = append(strategy.serviceMonitors, components.NewServiceMonitorCR(config.GetNamespace(), serviceMonitorNamespace, true))
-		strategy.prometheusRules = append(strategy.prometheusRules, components.NewPrometheusRuleCR(config.GetNamespace(), workloadUpdatesEnabled))
+		strategy.prometheusRules = append(strategy.prometheusRules, components.NewPrometheusRuleCR(config.GetNamespace()))
 	} else {
 		glog.Warningf("failed to create ServiceMonitor resources because couldn't find ServiceAccount %v in any monitoring namespaces : %v", monitorServiceAccount, strings.Join(config.GetPotentialMonitorNamespaces(), ", "))
 	}

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -93,9 +93,6 @@ const (
 	AdditionalPropertiesMonitorServiceAccount = "MonitorAccount"
 
 	// lookup key in AdditionalProperties
-	AdditionalPropertiesWorkloadUpdatesEnabled = "WorkloadUpdatesEnabled"
-
-	// lookup key in AdditionalProperties
 	AdditionalPropertiesMigrationNetwork = "MigrationNetwork"
 
 	// lookup key in AdditionalProperties
@@ -205,9 +202,6 @@ func GetTargetConfigFromKV(kv *v1.KubeVirt) *KubeVirtDeploymentConfig {
 
 func GetTargetConfigFromKVWithEnvVarManager(kv *v1.KubeVirt, envVarManager EnvVarManager) *KubeVirtDeploymentConfig {
 	additionalProperties := getKVMapFromSpec(kv.Spec)
-	if len(kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods) > 0 {
-		additionalProperties[AdditionalPropertiesWorkloadUpdatesEnabled] = ""
-	}
 	if kv.Spec.Configuration.MigrationConfiguration != nil &&
 		kv.Spec.Configuration.MigrationConfiguration.Network != nil {
 		additionalProperties[AdditionalPropertiesMigrationNetwork] = *kv.Spec.Configuration.MigrationConfiguration.Network
@@ -605,11 +599,6 @@ func (c *KubeVirtDeploymentConfig) GetImagePullSecrets() []k8sv1.LocalObjectRefe
 		return data
 	}
 	return data
-}
-
-func (c *KubeVirtDeploymentConfig) WorkloadUpdatesEnabled() bool {
-	_, enabled := c.AdditionalProperties[AdditionalPropertiesWorkloadUpdatesEnabled]
-	return enabled
 }
 
 func (c *KubeVirtDeploymentConfig) PersistentReservationEnabled() bool {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2527,11 +2527,7 @@ spec:
 			monv1 := virtClient.PrometheusClient().MonitoringV1()
 			prometheusRule, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
-			hasWorkloadUpdates := false
-			if len(originalKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods) > 0 {
-				hasWorkloadUpdates = true
-			}
-			expectedPromRuleSpec := components.NewPrometheusRuleSpec(flags.KubeVirtInstallNamespace, hasWorkloadUpdates)
+			expectedPromRuleSpec := components.NewPrometheusRuleSpec(flags.KubeVirtInstallNamespace)
 			Expect(prometheusRule.Spec).To(Equal(*expectedPromRuleSpec))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>

I don't see any harm in permanent deployment of that alert. The evaluation of `kubevirt_vmi_outdated_count != 0`
will remain false even the metric is stale, so I don't see any risk of false positives here.

**What this PR does / why we need it**:
In the current situation if we configure a workload update method in the Kubevirt CR it will
cause re-deployment of all the virt-components. That is because adding a method will populate the `additionalProperties` map, which in turn cause changes in kubevirt deployment config digest.
We can change the logic and to inject the alert in the virt-operator sync loop in the reconciler, but 
I think it is a redundant considering the fact the deployment of this alert anyway won't cause any
harm.


**Release note**:
```release-note
always deploy the outdated VMI workload alert
```
