### PR TITLE
[e2e]: CPU hotplug e2e fixes

### DIFF
--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -63,8 +63,8 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 		}
 		countDomCPUs := func(vmi *v1.VirtualMachineInstance) (count cpuCount) {
 			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(domSpec.VCPUs).NotTo(BeNil())
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			ExpectWithOffset(1, domSpec.VCPUs).NotTo(BeNil())
 			for _, cpu := range domSpec.VCPUs.VCPU {
 				if cpu.Enabled == "yes" {
 					count.enabled++

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -252,9 +252,13 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 				migrations, err := virtClient.VirtualMachineInstanceMigration(vm.Namespace).List(&k8smetav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				for _, mig := range migrations.Items {
+					match := 0
 					if mig.Spec.VMIName == vmi.Name {
-						migration = mig.DeepCopy()
-						return true
+						match++
+						if !migration.IsFinal() || match == 2 {
+							migration = mig.DeepCopy()
+							return true
+						}
 					}
 				}
 				return false


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>

**What this PR does / why we need it**:
* The `countDomCPUs` helper function wasn't asserting with offset in some cases.
* In the dedicated CPU scenario there are two migrations that happen sequentially. The test was looking at the wrong migration object, since the object doesn't have any metadata about its originator, be it the hotplug mechanism or a manual trigger.

Fixes #
https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2023-06-26-168h.html#row3

**Release note**:
```release-note
NONE
```
