### PR TITLE
[e2e] Share KubeVirtDefaultConfig between all ginkgo nodes

### DIFF
--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -95,7 +95,6 @@ func SynchronizedBeforeTestSetup() []byte {
 	EnsureKVMPresent()
 	AdjustKubeVirtResource()
 	EnsureKubevirtReady()
-	InitRunConfiguration()
 
 	return nil
 }
@@ -120,6 +119,7 @@ func BeforeTestSuiteSetup(_ []byte) {
 
 	// Wait for schedulable nodes
 	virtClient := kubevirt.Client()
+	initRunConfiguration(virtClient)
 	Eventually(func() int {
 		nodes := libnode.GetAllSchedulableNodes(virtClient)
 		if len(nodes.Items) > 0 {

--- a/tests/testsuite/runconfiguration.go
+++ b/tests/testsuite/runconfiguration.go
@@ -2,6 +2,9 @@ package testsuite
 
 import (
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 var (
@@ -12,10 +15,11 @@ type RunConfiguration struct {
 	WarningToIgnoreList []string
 }
 
-func InitRunConfiguration() {
+func initRunConfiguration(virtClient kubecli.KubevirtClient) {
+	kv := util.GetCurrentKv(virtClient)
 	runConfig := RunConfiguration{}
-	if KubeVirtDefaultConfig.EvictionStrategy != nil &&
-		*KubeVirtDefaultConfig.EvictionStrategy == v1.EvictionStrategyLiveMigrate {
+	if kv.Spec.Configuration.EvictionStrategy != nil &&
+		*kv.Spec.Configuration.EvictionStrategy == v1.EvictionStrategyLiveMigrate {
 		runConfig.WarningToIgnoreList = append(runConfig.WarningToIgnoreList, "EvictionStrategy is set but vmi is not migratable")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`InitRunConfiguration` is executed in `SynchronizedBeforeTestSetup` function, which is executed only in the process#1 (https://onsi.github.io/ginkgo/#parallel-suite-setup-and-cleanup-synchronizedbeforesuite-and-synchronizedaftersuite). This causes that the `TestRunConfiguration` is misconfigured in the other processes, that can result in failures in case of `LiveMigrate` cluster level eviction strategy. Move the `InitRunConfiguration` function in `BeforeTestSuiteSetup` function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @xpivarc 