### PR TITLE
code cleanup: Simplify virtctl VM command files

### DIFF
--- a/pkg/virtctl/vm/add_volume.go
+++ b/pkg/virtctl/vm/add_volume.go
@@ -82,17 +82,12 @@ func usageAddVolume() string {
 }
 
 func (o *Command) addVolumeRun(args []string) error {
-	var dryRunOption []string
-
 	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
 	if err != nil {
 		return err
 	}
 
-	if dryRun {
-		dryRunOption = []string{metav1.DryRunAll}
-		fmt.Printf("Dry Run execution\n")
-	}
+	dryRunOption := setDryRunOption(dryRun)
 
 	return addVolume(args[0], volumeName, namespace, virtClient, &dryRunOption)
 }

--- a/pkg/virtctl/vm/common.go
+++ b/pkg/virtctl/vm/common.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/client-go/kubecli"
@@ -75,4 +76,13 @@ func GetNamespaceAndClient(clientConfig clientcmd.ClientConfig) (kubecli.Kubevir
 	}
 
 	return virtClient, namespace, nil
+}
+
+func setDryRunOption(dryRun bool) []string {
+	if dryRun {
+		fmt.Printf("Dry Run execution\n")
+		return []string{metav1.DryRunAll}
+	}
+
+	return nil
 }

--- a/pkg/virtctl/vm/migrate.go
+++ b/pkg/virtctl/vm/migrate.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	v1 "kubevirt.io/api/core/v1"
 
@@ -50,7 +49,6 @@ func NewMigrateCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 }
 
 func (o *Command) migrateRun(args []string) error {
-	var dryRunOption []string
 	vmiName := args[0]
 
 	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
@@ -58,10 +56,7 @@ func (o *Command) migrateRun(args []string) error {
 		return err
 	}
 
-	if dryRun {
-		dryRunOption = []string{metav1.DryRunAll}
-		fmt.Printf("Dry Run execution\n")
-	}
+	dryRunOption := setDryRunOption(dryRun)
 
 	err = virtClient.VirtualMachine(namespace).Migrate(context.Background(), vmiName, &v1.MigrateOptions{DryRun: dryRunOption})
 	if err != nil {

--- a/pkg/virtctl/vm/remove_volume.go
+++ b/pkg/virtctl/vm/remove_volume.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	v1 "kubevirt.io/api/core/v1"
 
@@ -63,7 +62,6 @@ func usageRemoveVolume() string {
 
 func (o *Command) removeVolumeRun(args []string) error {
 	var err error
-	var dryRunOption []string
 	vmiName := args[0]
 
 	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
@@ -71,10 +69,7 @@ func (o *Command) removeVolumeRun(args []string) error {
 		return err
 	}
 
-	if dryRun {
-		dryRunOption = []string{metav1.DryRunAll}
-		fmt.Printf("Dry Run execution\n")
-	}
+	dryRunOption := setDryRunOption(dryRun)
 
 	if !persist {
 		err = virtClient.VirtualMachineInstance(namespace).RemoveVolume(context.Background(), vmiName, &v1.RemoveVolumeOptions{

--- a/pkg/virtctl/vm/restart.go
+++ b/pkg/virtctl/vm/restart.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	v1 "kubevirt.io/api/core/v1"
 
@@ -52,7 +51,6 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 }
 
 func (o *Command) restartRun(args []string, cmd *cobra.Command) error {
-	var dryRunOption []string
 	vmiName := args[0]
 
 	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
@@ -60,11 +58,7 @@ func (o *Command) restartRun(args []string, cmd *cobra.Command) error {
 		return err
 	}
 
-	if dryRun {
-		dryRunOption = []string{metav1.DryRunAll}
-		fmt.Printf("Dry Run execution\n")
-	}
-
+	dryRunOption := setDryRunOption(dryRun)
 	gracePeriodChanged := cmd.Flags().Changed(gracePeriodArg)
 
 	if gracePeriodChanged != forceRestart {

--- a/pkg/virtctl/vm/start.go
+++ b/pkg/virtctl/vm/start.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	v1 "kubevirt.io/api/core/v1"
 
@@ -58,7 +57,6 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 }
 
 func (o *Command) startRun(args []string) error {
-	var dryRunOption []string
 	vmiName := args[0]
 
 	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
@@ -66,10 +64,7 @@ func (o *Command) startRun(args []string) error {
 		return err
 	}
 
-	if dryRun {
-		dryRunOption = []string{metav1.DryRunAll}
-		fmt.Printf("Dry Run execution\n")
-	}
+	dryRunOption := setDryRunOption(dryRun)
 
 	err = virtClient.VirtualMachine(namespace).Start(context.Background(), vmiName, &v1.StartOptions{Paused: startPaused, DryRun: dryRunOption})
 	if err != nil {

--- a/pkg/virtctl/vm/stop.go
+++ b/pkg/virtctl/vm/stop.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	v1 "kubevirt.io/api/core/v1"
 
@@ -53,7 +52,6 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 }
 
 func (o *Command) stopRun(args []string, cmd *cobra.Command) error {
-	var dryRunOption []string
 	vmiName := args[0]
 
 	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
@@ -61,11 +59,7 @@ func (o *Command) stopRun(args []string, cmd *cobra.Command) error {
 		return err
 	}
 
-	if dryRun {
-		dryRunOption = []string{metav1.DryRunAll}
-		fmt.Printf("Dry Run execution\n")
-	}
-	
+	dryRunOption := setDryRunOption(dryRun)
 	gracePeriodChanged := cmd.Flags().Changed(gracePeriodArg)
 
 	if gracePeriodChanged != forceRestart {

--- a/pkg/virtctl/vm/stop.go
+++ b/pkg/virtctl/vm/stop.go
@@ -65,19 +65,17 @@ func (o *Command) stopRun(args []string, cmd *cobra.Command) error {
 		dryRunOption = []string{metav1.DryRunAll}
 		fmt.Printf("Dry Run execution\n")
 	}
+	
+	gracePeriodChanged := cmd.Flags().Changed(gracePeriodArg)
 
-	if cmd.Flags().Changed(gracePeriodArg) && forceRestart == false {
-		return fmt.Errorf("Can not set gracePeriod without --force=true")
+	if gracePeriodChanged != forceRestart {
+		return fmt.Errorf("Must both use --force=true and set --grace-period.")
 	}
 
 	if forceRestart {
-		if cmd.Flags().Changed(gracePeriodArg) {
-			err = virtClient.VirtualMachine(namespace).ForceStop(context.Background(), vmiName, &v1.StopOptions{GracePeriod: &gracePeriod, DryRun: dryRunOption})
-			if err != nil {
-				return fmt.Errorf("Error force stopping VirtualMachine, %v", err)
-			}
-		} else if !cmd.Flags().Changed(gracePeriodArg) {
-			return fmt.Errorf("Can not force stop without gracePeriod")
+		err = virtClient.VirtualMachine(namespace).ForceStop(context.Background(), vmiName, &v1.StopOptions{GracePeriod: &gracePeriod, DryRun: dryRunOption})
+		if err != nil {
+			return fmt.Errorf("Error force stopping VirtualMachine, %v", err)
 		}
 	} else {
 		err = virtClient.VirtualMachine(namespace).Stop(context.Background(), vmiName, &v1.StopOptions{DryRun: dryRunOption})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As a follow up to #9183, simplified the nested if/else logic in the Stop and Restart command. Also moved the  code block for setting the dryRunOption to a common helper function and made dryRunOption a global variable as it used in multiple different commands.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig code-quality