### PR TITLE
Fix prometheusrules evaluating rule failed

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -32,7 +32,7 @@ tests:
   # Pod is using more memory than expected
   - interval: 1m
     input_series:
-      - series: 'container_memory_working_set_bytes{namespace="ci",container="",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
+      - series: 'container_memory_working_set_bytes{namespace="ci",container="virt-controller",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
         values: "157286400+0x5"
       - series: 'kube_pod_container_resource_requests{namespace="ci",container="virt-controller",resource="memory",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
         values: "118325248+0x5"

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -426,7 +426,7 @@ func NewPrometheusRuleSpec(ns string) *v1.PrometheusRuleSpec {
 			Alert: "KubeVirtComponentExceedsRequestedMemory",
 			Expr: intstr.FromString(
 				// In 'container_memory_working_set_bytes', 'container=""' filters the accumulated metric for the pod slice to measure total Memory usage for all containers within the pod
-				fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="%s"}) < 0`, ns, ns)),
+				fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container=~"virt-controller|virt-api|virt-handler|virt-operator",namespace="%s"}) < 0`, ns, ns)),
 			For: "5m",
 			Annotations: map[string]string{
 				"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory usage exceeds the memory requested",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With this PR, we can eliminate the warning message prometheus, which occus in Harvester, reported every minute.

```
> level=warn ts=2023-04-19T08:56:37.628Z caller=manager.go:603 component="rule manager" 
group=kubevirt.rules 
msg="Evaluating rule failed" 
rule="alert: KubeVirtComponentExceedsRequestedMemory\nexpr: 
((kube_pod_container_resource_requests{container=~"virt-controller|virt-api|virt-handler|virt-operator",namespace="harvester-system",resource="memory"})\n - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="harvester-system"})
\n < 0\nfor: 5m\nlabels:\n kubernetes_operator_component: kubevirt\n kubernetes_operator_part_of: kubevirt\n severity: warning\nannotations:\n 
description: Container {{ $labels.container }} in pod {{ $labels.pod }} memory usage\n exceeds the memory requested\n 
runbook_url: https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedMemory\n 
summary: The container is using more memory than what is defined in the containers\n resource requests\n" 
err="found duplicate series for the match group {pod="kube-vip-cloud-provider-0"} on the right hand-side of the operation: 
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9689 

**Special notes for your reviewer**:

There are different ideas on the previous PR https://github.com/kubevirt/kubevirt/pull/9846, to solve issue #9689,   on the other hand, we can use this PR to fix prometheusrules definition in `KubeVirt` directly.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
