### PR TITLE
tests, skips: Use patch instead of update

### DIFF
--- a/pkg/apimachinery/patch/patch.go
+++ b/pkg/apimachinery/patch/patch.go
@@ -28,7 +28,7 @@ import (
 type PatchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
-	Value interface{} `json:"value"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 const (

--- a/tests/framework/checks/BUILD.bazel
+++ b/tests/framework/checks/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/framework/checks",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -22,5 +23,6 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Using `Update` has the potential of failing if another change has been done on the object.
Patch is less sensitive to such issues, especially when the change is not dependent on any other data.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
