### PR TITLE
Fix flaky SEV test

### DIFF
--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -284,9 +284,9 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			Eventually(func() bool {
 				node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				val, ok := node.Status.Capacity[sevResourceName]
+				val, ok := node.Status.Allocatable[sevResourceName]
 				return ok && !val.IsZero()
-			}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("SEV capacity should not be zero on %s", nodeName))
+			}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Allocatable SEV should not be zero on %s", nodeName))
 		})
 
 		AfterEach(func() {
@@ -298,15 +298,15 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			}
 		})
 
-		It("[QUARANTINE] should reset SEV capacity when the feature gate is disabled", func() {
+		It("[QUARANTINE] should reset SEV allocatable devices when the feature gate is disabled", func() {
 			By(fmt.Sprintf("Disabling %s feature gate", virtconfig.WorkloadEncryptionSEV))
 			tests.DisableFeatureGate(virtconfig.WorkloadEncryptionSEV)
 			Eventually(func() bool {
 				node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				val, ok := node.Status.Capacity[sevResourceName]
+				val, ok := node.Status.Allocatable[sevResourceName]
 				return !ok || val.IsZero()
-			}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("SEV capacity should be zero on %s", nodeName))
+			}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Allocatable SEV should be zero on %s", nodeName))
 		})
 	})
 

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -252,6 +252,11 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 	})
 
 	Context("[Serial]device management", Serial, func() {
+		const (
+			sevResourceName = "devices.kubevirt.io/sev"
+			sevDevicePath   = "/proc/1/root/dev/sev"
+		)
+
 		var (
 			virtClient      kubecli.KubevirtClient
 			nodeName        string
@@ -265,13 +270,13 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			nodeName = tests.NodeNameWithHandler()
 			Expect(nodeName).ToNot(BeEmpty())
 
-			checkCmd := []string{"ls", "/dev/sev"}
+			checkCmd := []string{"ls", sevDevicePath}
 			_, err = tests.ExecuteCommandInVirtHandlerPod(nodeName, checkCmd)
 			isDevicePresent = (err == nil)
 
 			if !isDevicePresent {
-				// Create a fake SEV device
-				mknodCmd := []string{"mknod", "/dev/sev", "c", "10", "124"}
+				By(fmt.Sprintf("Creating a fake SEV device on %s", nodeName))
+				mknodCmd := []string{"mknod", sevDevicePath, "c", "10", "124"}
 				_, err = tests.ExecuteCommandInVirtHandlerPod(nodeName, mknodCmd)
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -279,20 +284,18 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			Eventually(func() bool {
 				node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				val, ok := node.Status.Capacity["devices.kubevirt.io/sev"]
+				val, ok := node.Status.Capacity[sevResourceName]
 				return ok && !val.IsZero()
-			}, 180*time.Second, 1*time.Second).Should(BeTrue(), "SEV capacity should not be zero")
+			}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("SEV capacity should not be zero on %s", nodeName))
 		})
 
 		AfterEach(func() {
 			if !isDevicePresent {
-				// Remove the fake SEV device
-				rmCmd := []string{"rm", "-f", "/dev/sev"}
+				By(fmt.Sprintf("Removing the fake SEV device from %s", nodeName))
+				rmCmd := []string{"rm", "-f", sevDevicePath}
 				_, err = tests.ExecuteCommandInVirtHandlerPod(nodeName, rmCmd)
 				Expect(err).ToNot(HaveOccurred())
 			}
-
-			tests.EnableFeatureGate(virtconfig.WorkloadEncryptionSEV)
 		})
 
 		It("[QUARANTINE] should reset SEV capacity when the feature gate is disabled", func() {
@@ -301,9 +304,9 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			Eventually(func() bool {
 				node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				val, ok := node.Status.Capacity["devices.kubevirt.io/sev"]
+				val, ok := node.Status.Capacity[sevResourceName]
 				return !ok || val.IsZero()
-			}, 180*time.Second, 1*time.Second).Should(BeTrue(), "SEV capacity should be zero")
+			}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("SEV capacity should be zero on %s", nodeName))
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR is supposed to fix the SEV test which was added to quarantine https://github.com/kubevirt/kubevirt/pull/9996

Considering that we want to ensure SEV devices are not advertised when the feature gate is disabled, probably it makes more sense to check the allocatable resources. Since the capacity just reflects the maximum number observed at some point in time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
