### PR TITLE
Fix qemu-system-* process lookup

### DIFF
--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -185,13 +185,13 @@ func AdjustQemuProcessMemoryLimits(podIsoDetector PodIsolationDetector, vmi *v1.
 	return nil
 }
 
-var qemuProcessExecutables = []string{"qemu-system", "qemu-kvm"}
+var qemuProcessExecutablePrefixes = []string{"qemu-system", "qemu-kvm"}
 
 // findIsolatedQemuProcess Returns the first occurrence of the QEMU process whose parent is PID"
 func findIsolatedQemuProcess(processes []ps.Process, pid int) (ps.Process, error) {
 	processes = childProcesses(processes, pid)
-	for _, exec := range qemuProcessExecutables {
-		if qemuProcess := lookupProcessByExecutable(processes, exec); qemuProcess != nil {
+	for _, execPrefix := range qemuProcessExecutablePrefixes {
+		if qemuProcess := lookupProcessByExecutablePrefix(processes, execPrefix); qemuProcess != nil {
 			return qemuProcess, nil
 		}
 	}

--- a/pkg/virt-handler/isolation/detector_test.go
+++ b/pkg/virt-handler/isolation/detector_test.go
@@ -132,7 +132,7 @@ var _ = Describe("findIsolatedQemuProcess", func() {
 		fakeProcess3}
 
 	qemuKvmProc := ProcessStub{pid: 101, ppid: virtLauncherPid, binary: "qemu-kvm"}
-	qemuSystemProc := ProcessStub{pid: 101, ppid: virtLauncherPid, binary: "qemu-system"}
+	qemuSystemProc := ProcessStub{pid: 101, ppid: virtLauncherPid, binary: "qemu-system-x86_64"}
 
 	DescribeTable("should return QEMU process",
 		func(processes []ps.Process, pid int, expectedProcess ps.Process) {

--- a/pkg/virt-handler/isolation/process.go
+++ b/pkg/virt-handler/isolation/process.go
@@ -19,7 +19,11 @@
 
 package isolation
 
-import "github.com/mitchellh/go-ps"
+import (
+	"strings"
+
+	"github.com/mitchellh/go-ps"
+)
 
 // childProcesses given a list of processes, it returns the ones that are children
 // of the given PID.
@@ -34,11 +38,14 @@ func childProcesses(processes []ps.Process, pid int) []ps.Process {
 	return childProcesses
 }
 
-// lookupProcessByExecutable given list of processes, it return the first occurrence
-// of a process that runs the given executable.
-func lookupProcessByExecutable(processes []ps.Process, exectutable string) ps.Process {
+// lookupProcessByExecutablePrefix given list of processes, it return the first occurrence
+// of a process with the given executable prefix.
+func lookupProcessByExecutablePrefix(processes []ps.Process, execPrefix string) ps.Process {
+	if execPrefix == "" {
+		return nil
+	}
 	for _, process := range processes {
-		if process.Executable() == exectutable {
+		if strings.HasPrefix(process.Executable(), execPrefix) {
 			return process
 		}
 	}

--- a/pkg/virt-handler/isolation/process_test.go
+++ b/pkg/virt-handler/isolation/process_test.go
@@ -57,17 +57,17 @@ var _ = Describe("process", func() {
 		)
 	})
 
-	Context("lookup process by executable", func() {
+	Context("lookup process by executable prefix", func() {
 		procStub5 := ProcessStub{ppid: 100, pid: 220, binary: processTestExecPath}
 
 		DescribeTable("should find no process",
-			func(processes []ps.Process, executable string) {
-				Expect(lookupProcessByExecutable(processes, executable)).To(BeNil())
+			func(processes []ps.Process, executablePrefix string) {
+				Expect(lookupProcessByExecutablePrefix(processes, executablePrefix)).To(BeNil())
 			},
-			Entry("given no input processes and empty string as executable",
+			Entry("given no input processes and empty string as executable prefix",
 				emptyProcessList, "",
 			),
-			Entry("given no input processes and executable",
+			Entry("given no input processes and executable prefix",
 				emptyProcessList, "processA",
 			),
 			Entry("given processes list and empty string",
@@ -75,15 +75,15 @@ var _ = Describe("process", func() {
 			),
 		)
 
-		DescribeTable("should return the first occurrence of a process that runs the given executable",
-			func(processes []ps.Process, executable string, expectedProcess ps.Process) {
-				Expect(lookupProcessByExecutable(processes, executable)).
+		DescribeTable("should return the first occurrence of a process with the given executable prefix",
+			func(processes []ps.Process, executablePrefix string, expectedProcess ps.Process) {
+				Expect(lookupProcessByExecutablePrefix(processes, executablePrefix)).
 					To(Equal(expectedProcess))
 			},
-			Entry("given processes list that includes exactly one process that runs the executable",
+			Entry("given processes list that includes exactly one process with the executable prefix",
 				testProcesses, processTestExecPath, procStub1,
 			),
-			Entry("given processes list that includes more than one process that runs the executable",
+			Entry("given processes list that includes more than one process with the executable prefix",
 				append(testProcesses, procStub5), processTestExecPath, procStub1,
 			),
 		)

--- a/tests/realtime/BUILD.bazel
+++ b/tests/realtime/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/libwait:go_default_library",
+        "//tests/testsuite:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -129,9 +129,9 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 				Expect(err).ToNot(HaveOccurred())
 				libwait.WaitForSuccessfulVMIStart(vmi)
 
-				domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
+				emulator, err := tests.GetRunningVMIEmulator(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				emulator := "[/]" + strings.TrimPrefix(domSpec.Devices.Emulator, "/")
+				emulator = "[/]" + strings.TrimPrefix(emulator, "/")
 
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				qemuProcessSelinuxContext, err := exec.ExecuteCommandOnPod(
@@ -142,10 +142,10 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 				)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Checking that qemu-kvm process is of the SELinux type container_t")
+				By("Checking that qemu process is of the SELinux type container_t")
 				Expect(strings.Split(qemuProcessSelinuxContext, ":")[2]).To(Equal("container_t"))
 
-				By("Checking that qemu-kvm process has SELinux category_set")
+				By("Checking that qemu process has SELinux category_set")
 				Expect(strings.Split(qemuProcessSelinuxContext, ":")).To(HaveLen(5))
 
 				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
@@ -205,9 +205,9 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 				libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				By("Fetching virt-launcher Pod")
-				domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
+				emulator, err := tests.GetRunningVMIEmulator(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				emulator := "[/]" + strings.TrimPrefix(domSpec.Devices.Emulator, "/")
+				emulator = "[/]" + strings.TrimPrefix(emulator, "/")
 
 				pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, testsuite.NamespacePrivileged)
 				Expect(err).ToNot(HaveOccurred())
@@ -219,7 +219,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 				)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Checking that qemu-kvm process is of the SELinux type virt_launcher.process")
+				By("Checking that qemu process is of the SELinux type virt_launcher.process")
 				Expect(strings.Split(qemuProcessSelinuxContext, ":")[2]).To(Equal(launcherType))
 
 				By("Verifying SELinux context contains custom type in pod")

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2574,18 +2574,22 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					&expect.BExp{R: "2"},
 				}, 15)).To(Succeed())
 
+				emulator, err := tests.GetRunningVMIEmulator(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				emulator = filepath.Base(emulator)
+
 				virtClient := kubevirt.Client()
-				pscmd := []string{"ps", "-C", "qemu-kvm", "-o", "pid", "--noheader"}
+				pscmd := []string{"ps", "-C", emulator, "-o", "pid", "--noheader"}
 				_, err = exec.ExecuteCommandOnPod(
 					virtClient, readyPod, "compute", pscmd)
-				// do not check for kvm-pit thread if qemu-kvm is not in use
+				// do not check for kvm-pit thread if qemu is not in use
 				if err != nil {
 					return
 				}
-				kvmpitmask, err := tests.GetKvmPitMask(readyPod, node)
+				kvmpitmask, err := tests.GetKvmPitMask(readyPod, emulator, node)
 				Expect(err).ToNot(HaveOccurred())
 
-				vcpuzeromask, err := tests.GetVcpuMask(readyPod, "0")
+				vcpuzeromask, err := tests.GetVcpuMask(readyPod, emulator, "0")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(kvmpitmask).To(Equal(vcpuzeromask))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- Lookup qemu process by executable prefix
    
  Exact matching with `qemu-system` does not work since the executable name also includes a suffix with current architecture, e.g. qemu-system-x86_64. This leads to errors of type:
    
        no QEMU process found under process 16427 child processes


- Detect the qemu emulator binary in runtime during e2e testing
    
  Avoid hardcoding qemu-kvm since the underlying images may use e.g. qemu-system-*.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
