### PR TITLE
fix guaranteed qos of virt-launcher pod broken when use virtiofs

### DIFF
--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -27,8 +27,8 @@ func generateVirtioFSContainers(vmi *v1.VirtualMachineInstance, image string, co
 	containers := []k8sv1.Container{}
 	for _, volume := range vmi.Spec.Volumes {
 		if _, isPassthroughFSVolume := passthroughFSVolumes[volume.Name]; isPassthroughFSVolume {
-
-			container := generateContainerFromVolume(&volume, image, config)
+			resources := resourcesForVirtioFSContainer(vmi.IsCPUDedicated(), vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed(), config)
+			container := generateContainerFromVolume(&volume, image, resources)
 			containers = append(containers, container)
 
 		}
@@ -153,8 +153,7 @@ func virtioFSMountPoint(volume *v1.Volume) string {
 	return volumeMountPoint
 }
 
-func generateContainerFromVolume(volume *v1.Volume, image string, config *virtconfig.ClusterConfig) k8sv1.Container {
-	resources := resourcesForVirtioFSContainer(false, false, config)
+func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv1.ResourceRequirements) k8sv1.Container {
 
 	socketPathArg := fmt.Sprintf("--socket-path=%s", virtiofs.VirtioFSSocketPath(volume.Name))
 	sourceArg := fmt.Sprintf("--shared-dir=%s", virtioFSMountPoint(volume))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: this PR is for the bug fix https://github.com/kubevirt/kubevirt/issues/10005, looks like there are some hardcode to prevent virt-launcher pod enter guaranteed qos group when use virtiofs, becasue virtiofs sidecar is not a guaranteed qos container

**Which issue(s) this PR fixes** :
Fixes # https://github.com/kubevirt/kubevirt/issues/10005

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix guaranteed qos of virt-launcher pod broken when use virtiofs
```