### PR TITLE
instancetype: Apply PreferredStorageClassName to StorageSpec if provided

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -201,6 +201,9 @@ func (mutator *VMsMutator) setPreferenceStorageClassName(vm *v1.VirtualMachine, 
 			if dv.Spec.PVC != nil && dv.Spec.PVC.StorageClassName == nil {
 				dv.Spec.PVC.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
 			}
+			if dv.Spec.Storage != nil && dv.Spec.Storage.StorageClassName == nil {
+				dv.Spec.Storage.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

DataVolumeSpec provides two mutually exclusive ways of defining attributes of the destination volume through either a PersistentVolumeClaimSpec [2] or StorageSpec [3].

Both provide ways of controlling the storageClass of the eventual PVC but as outlined in bug #10025 previously PreferredStorageClassName was only applied to the PersistentVolumeClaimSpec of a DataVolumeSpec.

This change corrects this ensuring PreferredStorageClassName is applied to the StorageSpec if provided within a DataVolumeSpec.

[1] http://kubevirt.io/api-reference/main/definitions.html#_v1beta1_datavolumespec
[2] http://kubevirt.io/api-reference/main/definitions.html#_k8s_io_api_core_v1_persistentvolumeclaimspec
[3] http://kubevirt.io/api-reference/main/definitions.html#_v1beta1_storagespec

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10025

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
