### PR TITLE
instancetype: Apply defaults before checking preference requirements

### DIFF
--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -2267,6 +2267,38 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				},
 				"insufficient Memory resources",
 			),
+			Entry("VirtualMachine meets 1 vCPU requirement through defaults but fails - bug #10047",
+				nil,
+				&instancetypev1beta1.VirtualMachinePreference{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "preference-",
+					},
+					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+						Requirements: &instancetypev1beta1.PreferenceRequirements{
+							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
+								Guest: uint32(1),
+							},
+						},
+					},
+				},
+				&v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "vm-",
+					},
+					Spec: v1.VirtualMachineSpec{
+						Running: pointer.Bool(false),
+						Preference: &v1.PreferenceMatcher{
+							Kind: "VirtualMachinePreference",
+						},
+						Template: &v1.VirtualMachineInstanceTemplateSpec{
+							Spec: v1.VirtualMachineInstanceSpec{
+								Domain: v1.DomainSpec{},
+							},
+						},
+					},
+				},
+				"no CPU resources provided by VirtualMachine, preference requires 1 vCPU",
+			),
 			Entry("VirtualMachine does not meet CPU (preferSockets default) requirements",
 				nil,
 				&instancetypev1beta1.VirtualMachinePreference{

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -2086,6 +2086,37 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 				},
 			),
+			Entry("VirtualMachine meets 1 vCPU requirement through defaults - bug #10047",
+				nil,
+				&instancetypev1beta1.VirtualMachinePreference{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "preference-",
+					},
+					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+						Requirements: &instancetypev1beta1.PreferenceRequirements{
+							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
+								Guest: uint32(1),
+							},
+						},
+					},
+				},
+				&v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "vm-",
+					},
+					Spec: v1.VirtualMachineSpec{
+						Running: pointer.Bool(false),
+						Preference: &v1.PreferenceMatcher{
+							Kind: "VirtualMachinePreference",
+						},
+						Template: &v1.VirtualMachineInstanceTemplateSpec{
+							Spec: v1.VirtualMachineInstanceSpec{
+								Domain: v1.DomainSpec{},
+							},
+						},
+					},
+				},
+			),
 			Entry("VirtualMachine meets CPU (preferThreads) requirements",
 				nil,
 				&instancetypev1beta1.VirtualMachinePreference{
@@ -2266,38 +2297,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 				},
 				"insufficient Memory resources",
-			),
-			Entry("VirtualMachine meets 1 vCPU requirement through defaults but fails - bug #10047",
-				nil,
-				&instancetypev1beta1.VirtualMachinePreference{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "preference-",
-					},
-					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
-						Requirements: &instancetypev1beta1.PreferenceRequirements{
-							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(1),
-							},
-						},
-					},
-				},
-				&v1.VirtualMachine{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "vm-",
-					},
-					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
-						Preference: &v1.PreferenceMatcher{
-							Kind: "VirtualMachinePreference",
-						},
-						Template: &v1.VirtualMachineInstanceTemplateSpec{
-							Spec: v1.VirtualMachineInstanceSpec{
-								Domain: v1.DomainSpec{},
-							},
-						},
-					},
-				},
-				"no CPU resources provided by VirtualMachine, preference requires 1 vCPU",
 			),
 			Entry("VirtualMachine does not meet CPU (preferSockets default) requirements",
 				nil,


### PR DESCRIPTION
/area instancetype

**What this PR does / why we need it**:

As set out in bug https://github.com/kubevirt/kubevirt/issues/10047 and demonstrated by the functional test in the
previous commit previously defaults were not applied before we would
check that preference requirements were met by a VirtualMachine.

This change extracts the preference check from applyInstancetypeToVm and
calls it directly after SetDefaultVirtualMachine has been called.

Ultimately this should allow preference requirements of a single vCPU to
to pass when no vCPUs have been provided by the original VirtualMachine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10047

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
