### PR TITLE
virt-handler, VMI iface status: Fix detached interfaces status reporting

### DIFF
--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -128,30 +128,3 @@ func LookupInterfaceByName(ifaces []v1.Interface, name string) *v1.Interface {
 	}
 	return nil
 }
-
-// InterfacesNames returns slice with the names of the given interfaces.
-func InterfacesNames(interfaces []v1.Interface) []string {
-	var ifaceNames []string
-	for _, iface := range interfaces {
-		ifaceNames = append(ifaceNames, iface.Name)
-	}
-	return ifaceNames
-}
-
-// FilterStatusInterfacesByNames returns filtered slice of interfaces by the given slice of names.
-// Matching by the interface 'Name' attribute.
-func FilterStatusInterfacesByNames(interfaces []v1.VirtualMachineInstanceNetworkInterface, names []string) []v1.VirtualMachineInstanceNetworkInterface {
-	lookupNameSet := map[string]struct{}{}
-	for _, name := range names {
-		lookupNameSet[name] = struct{}{}
-	}
-
-	var filtered []v1.VirtualMachineInstanceNetworkInterface
-	for _, iface := range interfaces {
-		if _, exists := lookupNameSet[iface.Name]; exists {
-			filtered = append(filtered, iface)
-		}
-	}
-
-	return filtered
-}

--- a/pkg/network/vmispec/interface_test.go
+++ b/pkg/network/vmispec/interface_test.go
@@ -94,15 +94,6 @@ var _ = Describe("VMI network spec", func() {
 
 	const iface1, iface2, iface3, iface4, iface5 = "iface1", "iface2", "iface3", "iface4", "iface5"
 
-	DescribeTable("return VMI spec interface names, given",
-		func(interfaces []v1.Interface, expectedNames []string) {
-			Expect(netvmispec.InterfacesNames(interfaces)).To(Equal(expectedNames))
-		},
-		Entry("no interfaces", nil, nil),
-		Entry("single interface", vmiSpecInterfaces(iface1), []string{iface1}),
-		Entry("more then one interface", vmiSpecInterfaces(iface1, iface2, iface3), []string{iface1, iface2, iface3}),
-	)
-
 	Context("pop interface by network", func() {
 		const netName = "net1"
 		network := podNetwork(netName)
@@ -134,24 +125,6 @@ var _ = Describe("VMI network spec", func() {
 			Entry("last", vmiStatusInterfaces(iface1, iface2, netName)),
 			Entry("mid", vmiStatusInterfaces(iface1, netName, iface2)),
 		)
-	})
-
-	It("filter status interfaces, given 0 interfaces and 0 names", func() {
-		Expect(netvmispec.FilterStatusInterfacesByNames(nil, nil)).To(BeEmpty())
-	})
-	It("filter status interfaces, given 0 interfaces and 3 names", func() {
-		names := []string{iface1, iface2, iface3}
-		Expect(netvmispec.FilterStatusInterfacesByNames(nil, names)).To(BeEmpty())
-	})
-	It("filter status interfaces, given 3 interfaces and 0 names", func() {
-		statusInterfaces := vmiStatusInterfaces(iface1, iface2, iface3)
-		Expect(netvmispec.FilterStatusInterfacesByNames(statusInterfaces, nil)).To(BeEmpty())
-	})
-	It("filter status interfaces, given 5 interfaces and 2 names", func() {
-		statusInterfaces := vmiStatusInterfaces(iface1, iface4, iface3, iface5, iface2)
-		names := []string{iface4, iface5}
-		expectedInterfaces := vmiStatusInterfaces(names...)
-		Expect(netvmispec.FilterStatusInterfacesByNames(statusInterfaces, names)).To(Equal(expectedInterfaces))
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -113,8 +113,8 @@ func (vim *virtIOInterfaceManager) hotUnplugVirtioInterface(vmi *v1.VirtualMachi
 }
 
 func interfacesToHotUnplug(vmiSpecInterfaces []v1.Interface, domainSpecInterfaces []api.Interface) []api.Interface {
-	ifaces2remove := netvmispec.FilterInterfacesSpec(vmiSpecInterfaces, func(i v1.Interface) bool {
-		return i.State == v1.InterfaceStateAbsent
+	ifaces2remove := netvmispec.FilterInterfacesSpec(vmiSpecInterfaces, func(iface v1.Interface) bool {
+		return iface.State == v1.InterfaceStateAbsent
 	})
 	var domainIfacesToRemove []api.Interface
 	for _, vmiIface := range ifaces2remove {
@@ -151,7 +151,7 @@ func networksToHotplugWhoseInterfacesAreNotInTheDomain(vmi *v1.VirtualMachineIns
 
 			return netvmispec.ContainsInfoSource(
 				ifaceStatus.InfoSource, netvmispec.InfoSourceMultusStatus,
-			) && !exists && vmiSpecIface.State != v1.InterfaceStateAbsent
+			) && !exists && vmiSpecIface.State != v1.InterfaceStateAbsent && vmiSpecIface.SRIOV == nil
 		},
 	)
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently an unplugged iface reporting is flaky due to a race between virt-handler and virt-controller, where virt-handler set the VMI iface status according to the domain which dosent include detached interfaces.

On the other hande virt-controller see the subject external interface stil exist (according to the CNI annotation) and add it to the VMI status.

The end result is unpluged interfaces status is flaky, where it keeps get deleted and added.

To fix this, keep detached interfaces status whos  external iface exist in pod (have info-source mutlus-status) and also exist in the spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
