### PR TITLE
Bug fix: `virtctl create clone` marshalling and replacement of `kubectl` with `kubectl virt`

### DIFF
--- a/pkg/virtctl/create/clone/BUILD.bazel
+++ b/pkg/virtctl/create/clone/BUILD.bazel
@@ -10,9 +10,9 @@ go_library(
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -24,11 +24,11 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
+	"sigs.k8s.io/yaml"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 )

--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -23,14 +23,14 @@ import (
 	"fmt"
 	"strings"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"sigs.k8s.io/yaml"
-
-	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 const (
@@ -179,7 +179,10 @@ func (c *createClone) newClone() (*clonev1alpha1.VirtualMachineClone, error) {
 		Target:            target,
 		AnnotationFilters: c.annotationFilters,
 		LabelFilters:      c.labelFilters,
-		NewSMBiosSerial:   pointer.P(c.newSmbiosSerial),
+	}
+
+	if c.newSmbiosSerial != "" {
+		clone.Spec.NewSMBiosSerial = pointer.P(c.newSmbiosSerial)
 	}
 
 	return clone, nil

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -52,8 +52,7 @@ func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 	cobra.AddTemplateFunc(
 		"prepare", func(s string) string {
 			// order matters!
-			result := strings.Replace(s, "kubectl", "kubectl virt", -1)
-			result = strings.Replace(result, "{{ProgramName}}", programName, -1)
+			result := strings.Replace(s, "{{ProgramName}}", programName, -1)
 			return result
 		},
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes two bugs regarding `virtctl create` commands.

### Replace marshaling package
Firstly, it replaces `"gopkg.in/yaml.v2"` with `"sigs.k8s.io/yaml"` in `virtctl create clone` command.
Before this PR, this is the command's output:
```yaml
$ virtctl create clone --source-name test-vm
typemeta:
  kind: VirtualMachineClone
  apiversion: clone.kubevirt.io/v1alpha1
objectmeta:
  name: clone-9txwp
  generatename: ""
  namespace: ""
  selflink: ""
  uid: ""
  resourceversion: ""
  generation: 0
  creationtimestamp: "0001-01-01T00:00:00Z"
  deletiontimestamp: null
  deletiongraceperiodseconds: null
  labels: {}
  annotations: {}
  ownerreferences: []
  finalizers: []
  managedfields: []
spec:
  source:
    apigroup: kubevirt.io
    kind: VirtualMachine
    name: test-vm
  target:
    apigroup: kubevirt.io
    kind: VirtualMachine
    name: ""
  annotationfilters: []
  labelfilters: []
  newmacaddresses: {}
  newsmbiosserial: ""
status:
  creationtime: null
  phase: ""
  conditions: []
  snapshotname: null
  restorename: null
  targetname: null
```

Now, the output is:
```yaml
$ virtctl create clone --source-name test-vm
apiVersion: clone.kubevirt.io/v1alpha1
kind: VirtualMachineClone
metadata:
  creationTimestamp: null
  name: clone-qjhh6
spec:
  source:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: test-vm
  target:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: ""
status: {}
```

### Stop replacing "kubectl" with "kubectl virt"
As of now, when executing virtctl create commands with the `--help` argument, for example `virtctl create clone --help`, it outputs the following:

```bash
  # Create a manifest for a clone and use it to create a resource with kubectl virt
  virtctl create clone --source-name sourceVM | kubectl virt create -f -
```

The above happens for other commands as well, e.g. `virtctl create instancetype --help`.

As of now, `kubectl` is being replaced with `kubectl virt`, although this is an invalid command that doesn't exist and cannot be used.

This PR stops replacing "kubectl" to "kubectl virt". After this commit, the output of `virtctl create clone --help` is:
```bash
  # Create a manifest for a clone and use it to create a resource with kubectl
  virtctl create clone --source-name sourceVM | kubectl create -f -
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: `virtctl create clone` marshalling and replacement of `kubectl` with `kubectl virt`
```
