### PR TITLE
Remove affinities label from kubevirt_vmi_cpu_affinity and use sum as value

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -105,9 +105,6 @@ Virtual Machine last transition timestamp to running status. Type: Counter.
 ### kubevirt_vm_starting_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to starting status. Type: Counter.
 
-### kubevirt_vmi_cpu_affinity
-Details the cpu pinning map via boolean labels in the form of vcpu_X_cpu_Y. Type: Counter.
-
 ### kubevirt_vmi_cpu_system_usage_seconds
 Total CPU time spent in system mode. Type: Gauge.
 
@@ -185,6 +182,9 @@ The total number of tx packets dropped on vNIC interfaces. Type: Counter.
 
 ### kubevirt_vmi_network_transmit_packets_total
 Total network traffic transmitted packets. Type: Counter.
+
+### kubevirt_vmi_node_cpu_affinity
+Number of VMI CPU affinities to node physical cores. Type: Gauge.
 
 ### kubevirt_vmi_non_evictable
 Indication for a VirtualMachine that its eviction strategy is set to Live Migration but is not migratable. Type: Gauge.

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -224,22 +224,21 @@ func (metrics *vmiMetrics) updateMemory(mem *stats.DomainStatsMemory) {
 }
 
 func (metrics *vmiMetrics) updateCPUAffinity(cpuMap [][]bool) {
-	affinityLabels := []string{}
-	affinityValues := []string{}
+	affinityCount := 0.0
 
 	for vidx := 0; vidx < len(cpuMap); vidx++ {
 		for cidx := 0; cidx < len(cpuMap[vidx]); cidx++ {
-			affinityLabels = append(affinityLabels, fmt.Sprintf("vcpu_%v_cpu_%v", vidx, cidx))
-			affinityValues = append(affinityValues, fmt.Sprintf("%t", cpuMap[vidx][cidx]))
+			if cpuMap[vidx][cidx] {
+				affinityCount++
+			}
 		}
 	}
 
 	metrics.pushCustomMetric(
-		"kubevirt_vmi_cpu_affinity",
-		"Details the cpu pinning map via boolean labels in the form of vcpu_X_cpu_Y.",
-		prometheus.CounterValue, 1,
-		affinityLabels,
-		affinityValues,
+		"kubevirt_vmi_node_cpu_affinity",
+		"Number of VMI CPU affinities to node physical cores.",
+		prometheus.GaugeValue, affinityCount,
+		nil, nil,
 	)
 }
 

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -20,8 +20,6 @@
 package prometheus
 
 import (
-	"fmt"
-
 	"kubevirt.io/kubevirt/pkg/pointer"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -1179,14 +1177,8 @@ var _ = Describe("Prometheus", func() {
 			result.Write(dto)
 
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_cpu_affinity"))
-			s := ""
-			for _, lp := range dto.GetLabel() {
-				s += fmt.Sprintf("%v=%v ", lp.GetName(), lp.GetValue())
-			}
-			Expect(s).To(ContainSubstring("vcpu_0_cpu_0=true"))
-			Expect(s).To(ContainSubstring("vcpu_0_cpu_1=false"))
-			Expect(s).To(ContainSubstring("vcpu_0_cpu_2=true"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_node_cpu_affinity"))
+			Expect(dto.GetGauge().GetValue()).To(Equal(float64(2)))
 		})
 
 		It("should expose filesystem metrics", func() {

--- a/tools/prom-metrics-collector/metrics_collector.go
+++ b/tools/prom-metrics-collector/metrics_collector.go
@@ -45,7 +45,6 @@ var excludedMetrics = map[string]struct{}{
 	"kubevirt_virt_operator_leading_total":                 struct{}{},
 	"kubevirt_virt_operator_ready_total":                   struct{}{},
 	"kubevirt_virt_operator_up_total":                      struct{}{},
-	"kubevirt_vmi_cpu_affinity":                            struct{}{},
 	"kubevirt_vmi_filesystem_capacity_bytes_total":         struct{}{},
 	"kubevirt_vmi_memory_domain_bytes_total":               struct{}{},
 	"kubevirt_vmi_memory_pgmajfault":                       struct{}{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fixes: #9713

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

jira-ticket: https://issues.redhat.com/browse/CNV-28961

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove affinities label from kubevirt_vmi_cpu_affinity and use sum as value
```
