### PR TITLE
Test fix: Alert, usage of deprecated config map

### DIFF
--- a/tests/events/events.go
+++ b/tests/events/events.go
@@ -84,7 +84,7 @@ func expectEvent(object k8sObject, eventType, reason string, matcher types.Gomeg
 		)
 		ExpectWithOffset(3, err).ToNot(HaveOccurred())
 		return events.Items
-	}, 30*time.Second).Should(matcher, fmt.Sprintf("Used fieldselector %s", fieldSelector))
+	}, 30*time.Second, time.Second).Should(matcher, fmt.Sprintf("Used fieldselector %s", fieldSelector))
 }
 
 // constructFieldSelectorAndNamespace does best effort to overcome https://github.com/kubernetes/client-go/issues/861

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2952,6 +2952,8 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(ThisDeploymentWith(flags.KubeVirtInstallNamespace, components.VirtOperatorName), 180*time.Second, 1*time.Second).Should(HaveReadyReplicasNumerically("==", 0))
 
+			// Wait for at least one operator to be ready in order to observe an event
+			Eventually(ThisDeploymentWith(flags.KubeVirtInstallNamespace, components.VirtOperatorName), 180*time.Second, 1*time.Second).Should(HaveReadyReplicasNumerically(">", 0))
 			events.ExpectEvent(config, k8sv1.EventTypeWarning, "ObsoleteConfigMapExists")
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of the event handling overhaul the timeout
for tests was decreased drastically.
This specific test did require a longer timeout
because it can take some time in order for the operator to come up again and acquire a lock.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
