### PR TITLE
Bugfix: target virt-launcher pod hangs when migration is cancelled

### DIFF
--- a/pkg/virt-launcher/BUILD.bazel
+++ b/pkg/virt-launcher/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/virt-launcher/virtwrap/cmd-server:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -28,6 +28,8 @@ import (
 	"syscall"
 	"time"
 
+	cmdserver "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cmd-server"
+
 	"kubevirt.io/client-go/log"
 
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
@@ -109,6 +111,10 @@ func (mon *monitor) isGracePeriodExpired() bool {
 func (mon *monitor) refresh() {
 	if mon.isDone {
 		log.Log.Error("Called refresh after done!")
+		return
+	} else if cmdserver.ReceivedEarlyExitSignal() {
+		log.Log.Infof("received early exit signal - stop waiting for %s", mon.domainName)
+		mon.isDone = true
 		return
 	}
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2724,25 +2724,50 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Starting the VirtualMachineInstance")
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				sourcePod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 
-				migration = runAndImmediatelyCancelMigration(migration, vmi, with_virtctl, 180)
+				migration = runAndImmediatelyCancelMigration(migration, vmi, with_virtctl, 60)
 
 				// check VMI, confirm migration state
-				confirmVMIPostMigrationAborted(vmi, string(migration.UID), 180)
+				confirmVMIPostMigrationAborted(vmi, string(migration.UID), 60)
+
+				By("Waiting for the target virt-launcher pod to disappear")
+				labelSelector, err := labels.Parse(fmt.Sprintf("%s=virt-launcher,%s=%s", v1.AppLabel, v1.CreatedByLabel, string(vmi.GetUID())))
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() error {
+					vmiPods, err := virtClient.CoreV1().Pods(vmi.GetNamespace()).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(vmiPods.Items)).To(BeNumerically("<=", 2), "vmi has 3 active pods")
+
+					if len(vmiPods.Items) == 1 {
+						return nil
+					}
+
+					var targetPodPhase k8sv1.PodPhase
+					for _, pod := range vmiPods.Items {
+						if pod.Name == sourcePod.Name {
+							continue
+						}
+
+						targetPodPhase = pod.Status.Phase
+					}
+
+					Expect(targetPodPhase).ToNot(BeEmpty())
+
+					if targetPodPhase != k8sv1.PodSucceeded && targetPodPhase != k8sv1.PodFailed {
+						return fmt.Errorf("pod phase is not expected to be %v", targetPodPhase)
+					}
+
+					return nil
+				}, 30*time.Second, 2*time.Second).ShouldNot(HaveOccurred(), "target migration pod is expected to disappear after migration cancellation")
 
 				By("Waiting for the migration object to disappear")
-				libwait.WaitForMigrationToDisappearWithTimeout(migration, 240)
-
-				// delete VMI
-				By("Deleting the VMI")
-				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
-
-				By("Waiting for VMI to disappear")
-				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+				libwait.WaitForMigrationToDisappearWithTimeout(migration, 20)
 			},
 				Entry("[sig-compute][test_id:3241]cancel a migration by deleting vmim object", false),
 				Entry("[sig-compute][test_id:8583]cancel a migration with virtctl", true),


### PR DESCRIPTION
**What this PR does / why we need it**:
When virt-launcher starts, it searches for `qemu-kvm` PID.

If a virtual machine migration is created and then cancelled, before the virt-launcher detects the qemu-kvm process pid, the target virt-launcher is not cleaned up immediately and waits for the qemu-timeout (which is 3 minutes by default).

It will wait in the refresh monitor here https://github.com/kubevirt/kubevirt/blob/f77d50591ddd0f74c0c876e38fdf14ca3fe54be8/pkg/virt-launcher/monitor.go#L126.

This PR fixes this bug by stopping to search for the PID if the migration is cancelled.

This PR also adjusts a functional test that I confirm that fails without these changes and passes after them.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2161184

**How to reproduce**:
1. run `> ./cluster-up/kubectl.sh create -f examples/vmi-migratable.yaml`.
2. run `> ./cluster-up/kubectl.sh create -f examples/migration-job.yaml; sleep 5; ./cluster-up/kubectl.sh delete -f examples/migration-job.yaml`
3. See the target virt-launcher hangs for a few minutes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: target virt-launcher pod hangs when migration is cancelled.
```
