### PR TITLE
Adapt DV GC test to disabled by default

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -21,7 +21,7 @@ set -ex pipefail
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
 KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-true}
-CDI_DV_GC_DEFAULT=0
+CDI_DV_GC_DEFAULT=-1
 CDI_DV_GC=${CDI_DV_GC:--1}
 
 source hack/common.sh

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -172,7 +172,7 @@ func SetDataVolumeGC(virtCli kubecli.KubevirtClient, ttlSec *int32) {
 func IsDataVolumeGC(virtCli kubecli.KubevirtClient) bool {
 	config, err := virtCli.CdiClient().CdiV1beta1().CDIConfigs().Get(context.TODO(), "config", v12.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	return config.Spec.DataVolumeTTLSeconds == nil || *config.Spec.DataVolumeTTLSeconds >= 0
+	return config.Spec.DataVolumeTTLSeconds != nil && *config.Spec.DataVolumeTTLSeconds >= 0
 }
 
 func GetCDI(virtCli kubecli.KubevirtClient) *v1beta1.CDI {


### PR DESCRIPTION
**What this PR does / why we need it**:
DV GC was disabled by default in CDI 1.57

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
