### PR TITLE
Fix and deprecate `machineType` in KubeVirt CR Config

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17766,6 +17766,7 @@
       "$ref": "#/definitions/v1.LiveUpdateConfiguration"
      },
      "machineType": {
+      "description": "Deprecated. Use architectureConfiguration instead.",
       "type": "string"
      },
      "mediatedDevicesConfiguration": {

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -461,6 +461,7 @@ spec:
                         type: integer
                     type: object
                   machineType:
+                    description: Deprecated. Use architectureConfiguration instead.
                     type: string
                   mediatedDevicesConfiguration:
                     description: MediatedDevicesConfiguration holds information about
@@ -3459,6 +3460,7 @@ spec:
                         type: integer
                     type: object
                   machineType:
+                    description: Deprecated. Use architectureConfiguration instead.
                     type: string
                   mediatedDevicesConfiguration:
                     description: MediatedDevicesConfiguration holds information about

--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -175,7 +175,7 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 		Product:      SmbiosConfigDefaultProduct,
 	}
 	supportedQEMUGuestAgentVersions := strings.Split(strings.TrimRight(SupportedGuestAgentVersions, ","), ",")
-	DefaultOVMFPath, DefaultMachineType, emulatedMachinesDefault := getCPUArchSpecificDefault(cpuArch)
+	DefaultOVMFPath, _, emulatedMachinesDefault := getCPUArchSpecificDefault(cpuArch)
 	defaultDiskVerification := &v1.DiskVerification{
 		MemoryLimit: resource.NewScaledQuantity(DefaultDiskVerificationMemoryLimitMBytes, resource.Mega),
 	}
@@ -209,7 +209,6 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 			AllowAutoConverge:                 &allowAutoConverge,
 			AllowPostCopy:                     &allowPostCopy,
 		},
-		MachineType:      DefaultMachineType,
 		CPURequest:       &cpuRequestDefault,
 		EmulatedMachines: emulatedMachinesDefault,
 		NetworkConfiguration: &v1.NetworkConfiguration{

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -162,6 +162,33 @@ var _ = Describe("test configuration", func() {
 		Entry("when ppc64le unset, GetMachineType should return the default with ppc64le", "ppc64le", "", "", "", virtconfig.DefaultPPC64LEMachineType),
 	)
 
+	Context("when deprecated machineType is set", func() {
+		It("it should have higher priority than the architectureConfiguration", func() {
+			const machineType = "quantum-qc35"
+			const cpuArch = "amd64"
+
+			clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVWithCPUArch(&v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubevirt",
+					Namespace: "kubevirt",
+				},
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						MachineType: machineType,
+						ArchitectureConfiguration: &v1.ArchConfiguration{
+							Amd64: &v1.ArchSpecificConfiguration{MachineType: virtconfig.DefaultAMD64MachineType},
+						},
+					},
+				},
+				Status: v1.KubeVirtStatus{
+					Phase: "Deployed",
+				},
+			}, cpuArch)
+
+			Expect(clusterConfig.GetMachineType(cpuArch)).To(Equal(machineType))
+		})
+	})
+
 	DescribeTable(" when cpuModel", func(value string, result string) {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 			CPUModel: value,

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -130,6 +130,10 @@ func (c *ClusterConfig) GetResourceVersion() string {
 }
 
 func (c *ClusterConfig) GetMachineType(arch string) string {
+	if c.GetConfig().MachineType != "" {
+		return c.GetConfig().MachineType
+	}
+
 	switch arch {
 	case "arm64":
 		return c.GetConfig().ArchitectureConfiguration.Arm64.MachineType

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1064,6 +1064,7 @@ var CRDsValidation map[string]string = map[string]string{
                   type: integer
               type: object
             machineType:
+              description: Deprecated. Use architectureConfiguration instead.
               type: string
             mediatedDevicesConfiguration:
               description: MediatedDevicesConfiguration holds information about MDEV

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2305,19 +2305,20 @@ type ReloadableComponentConfiguration struct {
 
 // KubeVirtConfiguration holds all kubevirt configurations
 type KubeVirtConfiguration struct {
-	CPUModel                  string                  `json:"cpuModel,omitempty"`
-	CPURequest                *resource.Quantity      `json:"cpuRequest,omitempty"`
-	DeveloperConfiguration    *DeveloperConfiguration `json:"developerConfiguration,omitempty"`
-	EmulatedMachines          []string                `json:"emulatedMachines,omitempty"`
-	ImagePullPolicy           k8sv1.PullPolicy        `json:"imagePullPolicy,omitempty"`
-	MigrationConfiguration    *MigrationConfiguration `json:"migrations,omitempty"`
-	MachineType               string                  `json:"machineType,omitempty"`
-	NetworkConfiguration      *NetworkConfiguration   `json:"network,omitempty"`
-	OVMFPath                  string                  `json:"ovmfPath,omitempty"`
-	SELinuxLauncherType       string                  `json:"selinuxLauncherType,omitempty"`
-	DefaultRuntimeClass       string                  `json:"defaultRuntimeClass,omitempty"`
-	SMBIOSConfig              *SMBiosConfiguration    `json:"smbios,omitempty"`
-	ArchitectureConfiguration *ArchConfiguration      `json:"architectureConfiguration,omitempty"`
+	CPUModel               string                  `json:"cpuModel,omitempty"`
+	CPURequest             *resource.Quantity      `json:"cpuRequest,omitempty"`
+	DeveloperConfiguration *DeveloperConfiguration `json:"developerConfiguration,omitempty"`
+	EmulatedMachines       []string                `json:"emulatedMachines,omitempty"`
+	ImagePullPolicy        k8sv1.PullPolicy        `json:"imagePullPolicy,omitempty"`
+	MigrationConfiguration *MigrationConfiguration `json:"migrations,omitempty"`
+	// Deprecated. Use architectureConfiguration instead.
+	MachineType               string                `json:"machineType,omitempty"`
+	NetworkConfiguration      *NetworkConfiguration `json:"network,omitempty"`
+	OVMFPath                  string                `json:"ovmfPath,omitempty"`
+	SELinuxLauncherType       string                `json:"selinuxLauncherType,omitempty"`
+	DefaultRuntimeClass       string                `json:"defaultRuntimeClass,omitempty"`
+	SMBIOSConfig              *SMBiosConfiguration  `json:"smbios,omitempty"`
+	ArchitectureConfiguration *ArchConfiguration    `json:"architectureConfiguration,omitempty"`
 	// EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be
 	// migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific
 	// field is set it overrides the cluster level one.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -714,6 +714,7 @@ func (ReloadableComponentConfiguration) SwaggerDoc() map[string]string {
 func (KubeVirtConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                                   "KubeVirtConfiguration holds all kubevirt configurations",
+		"machineType":                        "Deprecated. Use architectureConfiguration instead.",
 		"evictionStrategy":                   "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be\nmigrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific\nfield is set it overrides the cluster level one.",
 		"additionalGuestMemoryOverheadRatio": "AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure\noverhead. This is useful, since the calculation of this overhead is not accurate and cannot\nbe entirely known in advance. The ratio that is being set determines by which factor to increase\nthe overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised\nby node pressures, but would mean that fewer VMs could be scheduled to a node.\nIf not set, the default is 1.",
 		"supportContainerResources":          "+listType=map\n+listMapKey=type\nSupportContainerResources specifies the resource requirements for various types of supporting containers such as container disks/virtiofs/sidecars and hotplug attachment pods. If omitted a sensible default will be supplied.",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18871,8 +18871,9 @@ func schema_kubevirtio_api_core_v1_KubeVirtConfiguration(ref common.ReferenceCal
 					},
 					"machineType": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Deprecated. Use architectureConfiguration instead.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"network": {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1804,6 +1804,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			kv := util.GetCurrentKv(virtClient)
 
 			config := kv.Spec.Configuration
+			config.MachineType = ""
 			config.ArchitectureConfiguration = &v1.ArchConfiguration{Amd64: &v1.ArchSpecificConfiguration{}, Arm64: &v1.ArchSpecificConfiguration{}, Ppc64le: &v1.ArchSpecificConfiguration{}}
 			config.ArchitectureConfiguration.Amd64.EmulatedMachines = testEmulatedMachines
 			config.ArchitectureConfiguration.Arm64.EmulatedMachines = testEmulatedMachines


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`spec.config.machineType` got obsoleted by https://github.com/kubevirt/kubevirt/pull/8293 but it still exist and should therefore be honored if set to not break compatibility.

The field is now also marked as deprecated so that it can be removed in the future.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate `spec.config.machineType` in KubeVirt CR.
```
