### PR TITLE
Export create populator compatible datavolumes from VM

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -1429,6 +1429,9 @@ func (ctrl *VMExportController) createExportHttpDvFromPVC(namespace, name string
 	if pvc != nil {
 		pvc.Spec.VolumeName = ""
 		pvc.Spec.StorageClassName = nil
+		// Don't copy datasources, will be populated by CDI with the datavolume
+		pvc.Spec.DataSource = nil
+		pvc.Spec.DataSourceRef = nil
 		return &cdiv1.DataVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -1310,12 +1310,16 @@ var _ = Describe("Export controller", func() {
 
 	It("Should generate DataVolumes from VM", func() {
 		pvc := createPVC("pvc", string(cdiv1.DataVolumeKubeVirt))
+		pvc.Spec.DataSource = &k8sv1.TypedLocalObjectReference{}
+		pvc.Spec.DataSourceRef = &k8sv1.TypedObjectReference{}
 		pvcInformer.GetStore().Add(pvc)
 		vm := createVMWithDVTemplateAndPVC()
 		dvs := controller.generateDataVolumesFromVm(vm)
 		Expect(dvs).To(HaveLen(1))
 		Expect(dvs[0]).ToNot(BeNil())
 		Expect(dvs[0].Name).To((Equal("pvc")))
+		Expect(dvs[0].Spec.PVC.DataSource).To(BeNil())
+		Expect(dvs[0].Spec.PVC.DataSourceRef).To(BeNil())
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The generated DataVolumes were not compatible with populator populated sources. In particular the populators would have a datasource or datasourceRef set.

This PR clears the values so that the target CDI can properly generate PVCs from the Datavolume
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
