### PR TITLE
Fix not reporting vcpu wait metric when value is less than 1 second

### DIFF
--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -296,7 +296,7 @@ func (metrics *vmiMetrics) updateVcpu(vcpuStats []stats.DomainStatsVcpu) {
 				"kubevirt_vmi_vcpu_wait_seconds",
 				"Amount of time spent by each vcpu while waiting on I/O.",
 				prometheus.CounterValue,
-				float64(vcpu.Wait/1000000),
+				float64(vcpu.Wait)/float64(1000000),
 				[]string{"id"},
 				[]string{stringVcpuIdx},
 			)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fix not reporting vcpu wait metric when value is less than 1 second.

Currently we are converting `Wait` metric reported in microseconds into seconds, but we have a bug that if a metric is less than `1000000` it will always equal 0. This is happening due to us using `uint64` to calculate fraction of second instead of using `float64`.

Example:
```go
	shouldNotBeZero := float64(80) / float64(100)
	shouldNotBeZeroButWillBe := float64(80 / 100)

	fmt.Println(shouldNotBeZero) // prints 0.8
	fmt.Println(shouldNotBeZeroButWillBe) // prints 0
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
