### PR TITLE
Add BootMenu wait when starting a VM as paused

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -912,8 +912,8 @@ type Boot struct {
 }
 
 type BootMenu struct {
-	Enabled bool  `xml:"enabled,attr"`
-	Timeout *uint `xml:"timeout,attr,omitempty"`
+	Enable  string `xml:"enable,attr"`
+	Timeout *uint  `xml:"timeout,attr,omitempty"`
 }
 
 type Loader struct {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -84,6 +84,10 @@ const (
 	vhostNetPath = "/dev/vhost-net"
 )
 
+var (
+	BootMenuTimeoutMS = uint(10000)
+)
+
 type deviceNamer struct {
 	existingNameMap map[string]string
 	usedDeviceMap   map[string]string
@@ -1868,6 +1872,14 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 				Auto:    "no",
 				Address: *vmi.Status.VSOCKCID,
 			},
+		}
+	}
+
+	// set bootmenu to give time to access bios
+	if vmi.ShouldStartPaused() {
+		domain.Spec.OS.BootMenu = &api.BootMenu{
+			Enable:  "yes",
+			Timeout: &BootMenuTimeoutMS,
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This will help access the BIOS/EFI menu when starting the VMI as paused otherwise there's not enough actual time to get into it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
https://issues.redhat.com/browse/CNV-22801

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add boot-menu wait time when starting the VM as paused.
```
