### PR TITLE
Expose kubevirt_vmi_vcpu_delay_seconds_total metric.

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -219,6 +219,9 @@ Total time (ms) spent on write operations. Type: Counter.
 ### kubevirt_vmi_storage_write_traffic_bytes_total
 Total number of written bytes. Type: Counter.
 
+### kubevirt_vmi_vcpu_delay_seconds_total
+Amount of time spent by each vcpu waiting in the queue instead of running. Type: Counter.
+
 ### kubevirt_vmi_vcpu_seconds
 Total amount of time spent in each state by each vcpu (cpu_time excluding hypervisor time). Where `id` is the vcpu identifier and `state` can be one of the following: [`OFFLINE`, `RUNNING`, `BLOCKED`]. Type: Counter.
 

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -301,6 +301,16 @@ func (metrics *vmiMetrics) updateVcpu(vcpuStats []stats.DomainStatsVcpu) {
 				[]string{stringVcpuIdx},
 			)
 		}
+		if vcpu.DelaySet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_vcpu_delay_seconds_total",
+				"Amount of time spent by each vcpu waiting in the queue instead of running.",
+				prometheus.CounterValue,
+				float64(vcpu.Delay)/float64(1000000000),
+				[]string{"id"},
+				[]string{stringVcpuIdx},
+			)
+		}
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -89,6 +89,8 @@ type DomainStatsVcpu struct {
 	Time     uint64
 	WaitSet  bool
 	Wait     uint64
+	DelaySet bool
+	Delay    uint64
 }
 
 type DomainStatsNet struct {

--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -130,6 +130,8 @@ func Convert_libvirt_DomainStatsVcpu_To_stats_DomainStatsVcpu(in []libvirt.Domai
 			Time:     inItem.Time,
 			WaitSet:  inItem.WaitSet,
 			Wait:     inItem.Wait,
+			Delay:    inItem.Delay,
+			DelaySet: inItem.DelaySet,
 		})
 	}
 	return ret

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -16,7 +16,9 @@ var Testdata = `[
             "State" : 1,
             "Time" : 23810000000,
             "WaitSet": false,
-            "Wait": 0
+            "Wait": 0,
+            "DelaySet": false,
+            "Delay": 0
             
          },
          {
@@ -25,7 +27,9 @@ var Testdata = `[
             "TimeSet" : true,
             "Time" : 17800000000,
             "WaitSet": false,
-            "Wait": 0
+            "Wait": 0,
+            "DelaySet": false,
+            "Delay": 0
          },
          {
             "State" : 1,
@@ -33,7 +37,9 @@ var Testdata = `[
             "TimeSet" : true,
             "Time" : 23310000000,
             "WaitSet": false,
-            "Wait": 0
+            "Wait": 0,
+            "DelaySet": false,
+            "Delay": 0
          },
          {
             "State" : 1,
@@ -41,7 +47,9 @@ var Testdata = `[
             "TimeSet" : true,
             "Time" : 17360000000,
             "WaitSet": true,
-            "Wait": 1500
+            "Wait": 1500,
+            "DelaySet": true,
+            "Delay": 100
          }
       ],
       "Perf" : null,
@@ -228,7 +236,9 @@ var Testdataexpected = `{
        "Time": 23810000000, 
        "TimeSet": true,
        "WaitSet": false,
-       "Wait": 0
+       "Wait": 0,
+       "DelaySet": false,
+       "Delay": 0
      }, 
      {
        "State": 1, 
@@ -236,7 +246,9 @@ var Testdataexpected = `{
        "Time": 17800000000, 
        "TimeSet": true,
        "WaitSet": false,
-       "Wait": 0
+       "Wait": 0,
+       "DelaySet": false,
+       "Delay": 0
        
      }, 
      {
@@ -245,7 +257,9 @@ var Testdataexpected = `{
        "Time": 23310000000, 
        "TimeSet": true,
        "WaitSet": false,
-       "Wait": 0
+       "Wait": 0,
+       "DelaySet": false,
+       "Delay": 0
      }, 
      {
        "State": 1, 
@@ -253,7 +267,9 @@ var Testdataexpected = `{
        "Time": 17360000000, 
        "TimeSet": true,
        "WaitSet": true,
-       "Wait": 1500
+       "Wait": 1500,
+       "DelaySet": true,
+       "Delay": 100
      }
    ],
    "CPUMapSet": false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add vcpu delay domain metrics, which reports amount of seconds VM spent in  waiting in the queue instead of running.

According to libvirt docs:
```
vcpu.<num>.delay - time the vCPU <num> thread was enqueued by the host scheduler, but was waiting in the queue instead of running. Exposed to the VM as a steal time.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose kubevirt_vmi_vcpu_delay_seconds_total reporting amount of seconds VM spent in  waiting in the queue instead of running.
```
