### PR TITLE
ksm: Access sysfs from the host filesystem

### DIFF
--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -51,7 +51,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 
-const ksmPath = "/sys/kernel/mm/ksm/run"
+// In some environments, sysfs is mounted read-only even for privileged
+// containers: https://github.com/containerd/containerd/issues/8445.
+// Use the path from the host filesystem.
+const ksmPath = "/proc/1/root/sys/kernel/mm/ksm/run"
 
 var nodeLabellerLabels = []string{
 	util.DeprecatedLabelNamespace + util.DeprecatedcpuModelPrefix,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In some environments, sysfs is mounted read-only even for privileged containers. Use the ksm path from the host filesystem.

Related issue: https://github.com/containerd/containerd/issues/8445

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
