### PR TITLE
controller: Remove VirtualMachineInstanceTemplateSpec check

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -283,12 +283,6 @@ func (c *VMController) execute(key string) error {
 		return err
 	}
 
-	//TODO default vm if necessary, the aggregated apiserver will do that in the future
-	if vm.Spec.Template == nil {
-		logger.Error("Invalid controller spec, will not re-enqueue.")
-		return nil
-	}
-
 	vmKey, err := controller.KeyFunc(vm)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

The VirtualMachine validation admission webhook should cover this case now as suggested by the also remove TODO comment:

https://github.com/kubevirt/kubevirt/blob/f737c5be56dc467f943bb5e3bd1e698ae94cfa05/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go#L321-L327

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
