### PR TITLE
virt-launcher: access-credentials: Trim newlines from SSH keys in secret

### DIFF
--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -610,11 +610,12 @@ func (a *accessCredentialsInfo) addAccessCredential(accessCred *v1.AccessCredent
 				return fmt.Errorf("error occurred while reading the access credential secret file [%s]: %w", filepath.Join(secretDir, file.Name()), err)
 			}
 
-			pubKey := string(pubKeyBytes)
-			if pubKey == "" {
-				continue
+			for _, pubKey := range strings.Split(string(pubKeyBytes), "\n") {
+				trimmedKey := strings.TrimSpace(pubKey)
+				if trimmedKey != "" {
+					authorizedKeys = append(authorizedKeys, trimmedKey)
+				}
 			}
-			authorizedKeys = append(authorizedKeys, pubKey)
 		}
 
 		if len(authorizedKeys) > 0 {

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -66,6 +66,7 @@ type AccessCredentialManager struct {
 	secretWatcherStarted bool
 
 	stopCh                     chan struct{}
+	doneCh                     chan struct{}
 	resyncCheckIntervalSeconds int
 
 	watcher *fsnotify.Watcher
@@ -77,7 +78,6 @@ type AccessCredentialManager struct {
 func NewManager(connection cli.Connection, domainModifyLock *sync.Mutex, metadataCache *metadata.Cache) *AccessCredentialManager {
 	return &AccessCredentialManager{
 		virConn:                    connection,
-		stopCh:                     make(chan struct{}),
 		resyncCheckIntervalSeconds: 15,
 		domainModifyLock:           domainModifyLock,
 		metadataCache:              metadataCache,
@@ -537,14 +537,40 @@ func (l *AccessCredentialManager) HandleQemuAgentAccessCredentials(vmi *v1.Virtu
 	for _, dir := range secretDirs {
 		err = l.watcher.Add(dir)
 		if err != nil {
+			// Ignoring error returned by watcher.Close(),
+			// because another error will be returned.
+			_ = l.watcher.Close()
 			return err
 		}
 	}
 
-	go l.watchSecrets(vmi)
+	l.stopCh = make(chan struct{})
+	l.doneCh = make(chan struct{})
+
+	go func() {
+		defer close(l.doneCh)
+		// Ignoring the error, because the watch has stopped.
+		defer func() { _ = l.watcher.Close() }()
+		l.watchSecrets(vmi)
+	}()
+
 	l.secretWatcherStarted = true
 
 	return nil
+}
+
+func (l *AccessCredentialManager) Stop() {
+	l.watchLock.Lock()
+	defer l.watchLock.Unlock()
+
+	if !l.secretWatcherStarted {
+		return
+	}
+
+	close(l.stopCh)
+	<-l.doneCh
+
+	l.secretWatcherStarted = false
 }
 
 type accessCredentialsInfo struct {

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -150,6 +150,7 @@ var _ = Describe("AccessCredentials", func() {
 		}
 		domName := util.VMINamespaceKeyFunc(vmi)
 
+		manager.stopCh = make(chan struct{})
 		manager.watcher, err = fsnotify.NewWatcher()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -206,6 +207,7 @@ var _ = Describe("AccessCredentials", func() {
 			close(manager.stopCh)
 		}()
 
+		// TODO: Rewrite test to not call private functions.
 		manager.watchSecrets(vmi)
 		Expect(matched).To(BeTrue())
 

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -126,6 +126,62 @@ var _ = Describe("AccessCredentials", func() {
 		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
 	})
 
+	It("should support multiple ssh keys in one secret value", func() {
+		secretID := "some-secret-123"
+		user := "fakeuser"
+
+		vmi := &v1.VirtualMachineInstance{}
+		vmi.Spec.AccessCredentials = []v1.AccessCredential{{
+			SSHPublicKey: &v1.SSHPublicKeyAccessCredential{
+				Source: v1.SSHPublicKeyAccessCredentialSource{
+					Secret: &v1.AccessCredentialSecretSource{
+						SecretName: secretID,
+					},
+				},
+				PropagationMethod: v1.SSHPublicKeyAccessCredentialPropagationMethod{
+					QemuGuestAgent: &v1.QemuGuestAgentSSHPublicKeyAccessCredentialPropagation{
+						Users: []string{user},
+					},
+				},
+			},
+		}}
+
+		secretDirs := getSecretDirs(vmi)
+		Expect(secretDirs).To(HaveLen(1))
+
+		secretDir := secretDirs[0]
+		Expect(os.Mkdir(secretDir, 0755)).To(Succeed())
+
+		authorizedKeys := "first key\nsecond key\n"
+		Expect(os.WriteFile(filepath.Join(secretDirs[0], "authorized_keys"), []byte(authorizedKeys), 0644)).To(Succeed())
+
+		keysLoaded := make(chan struct{})
+
+		domName := util.VMINamespaceKeyFunc(vmi)
+
+		cmdPing := `{"execute":"guest-ping"}`
+		mockConn.EXPECT().QemuAgentCommand(cmdPing, domName).AnyTimes().Return("", nil)
+
+		mockConn.EXPECT().LookupDomainByName(domName).Return(mockDomain, nil).Times(1)
+		mockDomain.EXPECT().AuthorizedSSHKeysSet(user, gomock.Any(), gomock.Any()).Times(1).DoAndReturn(func(_ string, keys []string, _ any) error {
+			defer GinkgoRecover()
+
+			Expect(keys).To(Equal([]string{"first key", "second key"}))
+
+			close(keysLoaded)
+			return nil
+		})
+		mockDomain.EXPECT().Free().Times(1)
+
+		Expect(manager.HandleQemuAgentAccessCredentials(vmi)).To(Succeed())
+		DeferCleanup(func() {
+			manager.Stop()
+		})
+
+		// Wait until ssh keys reload is detected
+		Eventually(keysLoaded, 5*time.Second, 50*time.Millisecond).Should(BeClosed())
+	})
+
 	It("should trigger updating a credential when secret propagation change occurs.", func() {
 		var err error
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The secret that contains SSH keys for a VM can potentially contain multiple keys separated by newline, or just a single key with a newline at the end. This PR removes the newlines and splits the keys into a slice.

First commit in this PR add a `Stop()` method to the `AccessCredentialManager`, which is used in the new unit test to stop `fsnotify` and not leak it.

```release-note
None
```
