### PR TITLE
Clean up storage tests to reduce flakiness

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -173,6 +173,7 @@ func (r *KubernetesReporter) dumpNamespaces(duration time.Duration, vmiNamespace
 	r.logDaemonsets(virtCli)
 	r.logVolumeSnapshots(virtCli)
 	r.logVolumeSnapshotContents(virtCli)
+	r.logVolumeSnapshotClasses(virtCli)
 	r.logVirtualMachineSnapshots(virtCli)
 	r.logVirtualMachineSnapshotContents(virtCli)
 
@@ -770,6 +771,16 @@ func (r *KubernetesReporter) logVolumeSnapshotContents(virtCli kubecli.KubevirtC
 	r.logObjects(virtCli, volumeSnapshotContents, "volumesnapshotcontents")
 }
 
+func (r *KubernetesReporter) logVolumeSnapshotClasses(virtCli kubecli.KubevirtClient) {
+	volumeSnapshotClasses, err := virtCli.KubernetesSnapshotClient().SnapshotV1().VolumeSnapshotClasses().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch volume snapshot classes: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, volumeSnapshotClasses, "volumesnapshotclasses")
+}
+
 func (r *KubernetesReporter) logVirtualMachineSnapshots(virtCli kubecli.KubevirtClient) {
 	volumeSnapshots, err := virtCli.VirtualMachineSnapshot(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -1063,7 +1074,7 @@ func (r *KubernetesReporter) dumpK8sEntityToFile(virtCli kubecli.KubevirtClient,
 		fmt.Fprintf(os.Stderr, "Failed to marshall [%s] state objects\n", entityName)
 		return
 	}
-	fmt.Fprintln(f, string(prettyJson.Bytes()))
+	fmt.Fprintln(f, prettyJson.String())
 }
 
 func (r *KubernetesReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -171,6 +171,10 @@ func (r *KubernetesReporter) dumpNamespaces(duration time.Duration, vmiNamespace
 	r.logVMExports(virtCli)
 	r.logDeployments(virtCli)
 	r.logDaemonsets(virtCli)
+	r.logVolumeSnapshots(virtCli)
+	r.logVolumeSnapshotContents(virtCli)
+	r.logVirtualMachineSnapshots(virtCli)
+	r.logVirtualMachineSnapshotContents(virtCli)
 
 	r.logAuditLogs(virtCli, nodesDir, nodesWithTestPods, since)
 	r.logDMESG(virtCli, nodesDir, nodesWithTestPods, since)
@@ -744,6 +748,46 @@ func (r *KubernetesReporter) logDaemonsets(virtCli kubecli.KubevirtClient) {
 	}
 
 	r.logObjects(virtCli, daemonsets, "daemonsets")
+}
+
+func (r *KubernetesReporter) logVolumeSnapshots(virtCli kubecli.KubevirtClient) {
+	volumeSnapshots, err := virtCli.KubernetesSnapshotClient().SnapshotV1().VolumeSnapshots(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch volume snapshots: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, volumeSnapshots, "volumesnapshots")
+}
+
+func (r *KubernetesReporter) logVolumeSnapshotContents(virtCli kubecli.KubevirtClient) {
+	volumeSnapshotContents, err := virtCli.KubernetesSnapshotClient().SnapshotV1().VolumeSnapshotContents().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch volume snapshot contents: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, volumeSnapshotContents, "volumesnapshotcontents")
+}
+
+func (r *KubernetesReporter) logVirtualMachineSnapshots(virtCli kubecli.KubevirtClient) {
+	volumeSnapshots, err := virtCli.VirtualMachineSnapshot(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch virtual machine snapshots: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, volumeSnapshots, "virtualmachinesnapshots")
+}
+
+func (r *KubernetesReporter) logVirtualMachineSnapshotContents(virtCli kubecli.KubevirtClient) {
+	volumeSnapshotContents, err := virtCli.VirtualMachineSnapshotContent(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch virtual machine snapshot contents: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, volumeSnapshotContents, "virtualmachinenapshotcontents")
 }
 
 func (r *KubernetesReporter) logDVs(virtCli kubecli.KubevirtClient) {

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/format:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/openshift/api/route/v1:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -625,7 +625,7 @@ var _ = SIGDescribe("Export", func() {
 				Namespace: namespace,
 			},
 			Spec: exportv1.VirtualMachineExportSpec{
-				TokenSecretRef: pointer.StringPtr(token.Name),
+				TokenSecretRef: pointer.String(token.Name),
 				Source: k8sv1.TypedLocalObjectReference{
 					APIGroup: &apiGroup,
 					Kind:     "VirtualMachineSnapshot",
@@ -988,7 +988,7 @@ var _ = SIGDescribe("Export", func() {
 					Namespace: flags.KubeVirtInstallNamespace,
 				},
 				Spec: networkingv1.IngressSpec{
-					IngressClassName: pointer.StringPtr("ingress-class-name"),
+					IngressClassName: pointer.String("ingress-class-name"),
 					DefaultBackend: &networkingv1.IngressBackend{
 						Service: &networkingv1.IngressServiceBackend{
 							Name: "virt-exportproxy",
@@ -1105,7 +1105,7 @@ var _ = SIGDescribe("Export", func() {
 	waitForDisksComplete := func(vm *virtv1.VirtualMachine) {
 		for _, volume := range vm.Spec.Template.Spec.Volumes {
 			if volume.DataVolume != nil {
-				libstorage.EventuallyDVWith(vm.Namespace, volume.DataVolume.Name, 180, HaveSucceeded())
+				libstorage.EventuallyDVWith(vm.Namespace, volume.DataVolume.Name, 360, HaveSucceeded())
 			}
 		}
 	}
@@ -1154,7 +1154,7 @@ var _ = SIGDescribe("Export", func() {
 			if err != nil {
 				return err
 			}
-			vm.Spec.Running = pointer.BoolPtr(false)
+			vm.Spec.Running = pointer.Bool(false)
 			vm, err = virtClient.VirtualMachine(vmNamespace).Update(context.Background(), vm)
 			return err
 		}, 15*time.Second, time.Second).Should(BeNil())
@@ -1172,7 +1172,7 @@ var _ = SIGDescribe("Export", func() {
 		Eventually(func() error {
 			vm, err = virtClient.VirtualMachine(vmNamespace).Get(context.Background(), vmName, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			vm.Spec.Running = pointer.BoolPtr(true)
+			vm.Spec.Running = pointer.Bool(true)
 			vm, err = virtClient.VirtualMachine(vmNamespace).Update(context.Background(), vm)
 			return err
 		}, 15*time.Second, time.Second).Should(Succeed())
@@ -1424,7 +1424,7 @@ var _ = SIGDescribe("Export", func() {
 			testsuite.GetTestNamespace(nil),
 			sc,
 			k8sv1.ReadWriteOnce)
-		vm.Spec.Running = pointer.BoolPtr(true)
+		vm.Spec.Running = pointer.Bool(true)
 		vm = createVM(vm)
 		Eventually(func() virtv1.VirtualMachineInstancePhase {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
@@ -1653,7 +1653,7 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when Filesystem storage is not present")
 		}
 		vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce)
-		vm.Spec.Running = pointer.BoolPtr(true)
+		vm.Spec.Running = pointer.Bool(true)
 		vm = createVM(vm)
 		Expect(vm).ToNot(BeNil())
 		vm = stopVM(vm)
@@ -1686,7 +1686,7 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when snapshot storage is not present")
 		}
 		vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce)
-		vm.Spec.Running = pointer.BoolPtr(true)
+		vm.Spec.Running = pointer.Bool(true)
 		vm = createVM(vm)
 		Expect(vm).ToNot(BeNil())
 		vm = stopVM(vm)
@@ -1754,7 +1754,7 @@ var _ = SIGDescribe("Export", func() {
 		tests.AddUserData(vmi, "cloud-init", bashHelloScript)
 		vm := tests.NewRandomVirtualMachine(vmi, false)
 		addDataVolumeDisk(vm, "blankdisk", blankDv.Name)
-		vm.Spec.Running = pointer.BoolPtr(true)
+		vm.Spec.Running = pointer.Bool(true)
 		vm.Spec.Instancetype = &virtv1.InstancetypeMatcher{
 			Name: clusterInstancetype.Name,
 		}
@@ -1818,13 +1818,13 @@ var _ = SIGDescribe("Export", func() {
 		err = yaml.Unmarshal([]byte(split[2]), diskDV)
 		Expect(err).ToNot(HaveOccurred())
 		diskDV.Name = fmt.Sprintf("%s-clone", diskDV.Name)
-		diskDV.Spec.PVC.StorageClassName = pointer.StringPtr(sc)
+		diskDV.Spec.PVC.StorageClassName = pointer.String(sc)
 		Expect(diskDV.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage]).To(BeEquivalentTo(resource.MustParse(cd.CirrosVolumeSize)))
 		blankDv = &cdiv1.DataVolume{}
 		err = yaml.Unmarshal([]byte(split[3]), blankDv)
 		Expect(err).ToNot(HaveOccurred())
 		blankDv.Name = fmt.Sprintf("%s-clone", blankDv.Name)
-		blankDv.Spec.PVC.StorageClassName = pointer.StringPtr(sc)
+		blankDv.Spec.PVC.StorageClassName = pointer.String(sc)
 		Expect(blankDv.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage]).To(BeEquivalentTo(resource.MustParse(cd.BlankVolumeSize)))
 
 		By("Getting token secret header")
@@ -2053,7 +2053,7 @@ var _ = SIGDescribe("Export", func() {
 				testsuite.GetTestNamespace(nil),
 				sc,
 				k8sv1.ReadWriteOnce)
-			vm.Spec.Running = pointer.BoolPtr(true)
+			vm.Spec.Running = pointer.Bool(true)
 			vm = createVM(vm)
 			Eventually(func() virtv1.VirtualMachineInstancePhase {
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
@@ -2228,7 +2228,7 @@ var _ = SIGDescribe("Export", func() {
 					testsuite.GetTestNamespace(nil),
 					sc,
 					k8sv1.ReadWriteOnce)
-				vm.Spec.Running = pointer.BoolPtr(true)
+				vm.Spec.Running = pointer.Bool(true)
 				vm = createVM(vm)
 				Eventually(func() virtv1.VirtualMachineInstancePhase {
 					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
@@ -2380,7 +2380,7 @@ var _ = SIGDescribe("Export", func() {
 					testsuite.GetTestNamespace(nil),
 					sc,
 					k8sv1.ReadWriteOnce)
-				vm.Spec.Running = pointer.BoolPtr(true)
+				vm.Spec.Running = pointer.Bool(true)
 				vm = createVM(vm)
 				Eventually(func() virtv1.VirtualMachineInstancePhase {
 					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1050,7 +1050,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(cn).ToNot(BeNil())
 				vmSnapshotContent, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), *cn, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-
+				Expect(vmSnapshotContent.Spec.VolumeBackups).To(HaveLen(1))
 				vb := vmSnapshotContent.Spec.VolumeBackups[0]
 				Expect(vb.VolumeSnapshotName).ToNot(BeNil())
 
@@ -1083,7 +1083,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(cn).ToNot(BeNil())
 				vmSnapshotContent, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), *cn, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-
+				Expect(vmSnapshotContent.Spec.VolumeBackups).To(HaveLen(1))
 				vb := vmSnapshotContent.Spec.VolumeBackups[0]
 				Expect(vb.VolumeSnapshotName).ToNot(BeNil())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Increased some timeouts to allow longer times to finish tests. Cleaned up Ptr from deprecated functions to newer functions. Made condition checks order independent and return better state information if the test does fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
