### PR TITLE
Clear absent ifaces

### DIFF
--- a/pkg/virt-controller/watch/network.go
+++ b/pkg/virt-controller/watch/network.go
@@ -62,3 +62,15 @@ func applyDynamicIfaceRequestOnVMI(vm *v1.VirtualMachine, vmi *v1.VirtualMachine
 	}
 	return vmiSpecCopy
 }
+
+func clearDetachedInterfaces(specIfaces []v1.Interface, specNets []v1.Network, statusIfaces map[string]v1.VirtualMachineInstanceNetworkInterface) ([]v1.Interface, []v1.Network) {
+	var ifaces []v1.Interface
+	for _, iface := range specIfaces {
+		if _, existInStatus := statusIfaces[iface.Name]; (existInStatus && iface.State == v1.InterfaceStateAbsent) ||
+			iface.State != v1.InterfaceStateAbsent {
+			ifaces = append(ifaces, iface)
+		}
+	}
+
+	return ifaces, vmispec.FilterNetworksByInterfaces(specNets, ifaces)
+}

--- a/pkg/virt-controller/watch/network_test.go
+++ b/pkg/virt-controller/watch/network_test.go
@@ -30,6 +30,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/tests/libvmi"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
 var _ = Describe("Network interface hot{un}plug", func() {
@@ -219,6 +221,53 @@ var _ = Describe("Network interface hot{un}plug", func() {
 				libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
 			),
 			!ordinal),
+	)
+
+	DescribeTable("spec interfaces",
+		func(specIfaces []v1.Interface, statusIfaces []v1.VirtualMachineInstanceNetworkInterface,
+			expectedInterfaces []v1.Interface, expectedNetworks []v1.Network) {
+			var testNetworks []v1.Network
+			for _, iface := range specIfaces {
+				testNetworks = append(testNetworks, v1.Network{Name: iface.Name})
+			}
+			testStatusIfaces := vmispec.IndexInterfacesFromStatus(statusIfaces,
+				func(i v1.VirtualMachineInstanceNetworkInterface) bool { return true })
+
+			ifaces, networks := clearDetachedInterfaces(specIfaces, testNetworks, testStatusIfaces)
+
+			Expect(ifaces).To(Equal(expectedInterfaces))
+			Expect(networks).To(Equal(expectedNetworks))
+		},
+		Entry("should remain, given non-absent interfaces, and no associated status ifaces (i.e.: plug pending)",
+			[]v1.Interface{{Name: "blue"}, {Name: "red"}},
+			[]v1.VirtualMachineInstanceNetworkInterface{},
+			[]v1.Interface{{Name: "blue"}, {Name: "red"}},
+			[]v1.Network{{Name: "blue"}, {Name: "red"}},
+		),
+		Entry("should remain, given non-absent interfaces, and associated status ifaces (i.e.: plugged iface)",
+			[]v1.Interface{{Name: "blue"}, {Name: "red"}},
+			[]v1.VirtualMachineInstanceNetworkInterface{{Name: "blue"}, {Name: "red"}},
+			[]v1.Interface{{Name: "blue"}, {Name: "red"}},
+			[]v1.Network{{Name: "blue"}, {Name: "red"}},
+		),
+		Entry("should remain, given absent iface and associated status ifaces (i.e.: unplug pending)",
+			[]v1.Interface{{Name: "blue", State: v1.InterfaceStateAbsent}, {Name: "red"}},
+			[]v1.VirtualMachineInstanceNetworkInterface{{Name: "blue"}, {Name: "red"}},
+			[]v1.Interface{{Name: "blue", State: v1.InterfaceStateAbsent}, {Name: "red"}},
+			[]v1.Network{{Name: "blue"}, {Name: "red"}},
+		),
+		Entry("should be cleared, given absent iface and no associated status iface (i.e.: unplugged iface)",
+			[]v1.Interface{{Name: "blue", State: v1.InterfaceStateAbsent}, {Name: "red"}},
+			[]v1.VirtualMachineInstanceNetworkInterface{{Name: "red"}},
+			[]v1.Interface{{Name: "red"}},
+			[]v1.Network{{Name: "red"}},
+		),
+		Entry("should remain, given status iface and no associated iface in spec",
+			[]v1.Interface{{Name: "blue"}},
+			[]v1.VirtualMachineInstanceNetworkInterface{{Name: "RED"}},
+			[]v1.Interface{{Name: "blue"}},
+			[]v1.Network{{Name: "blue"}},
+		),
 	)
 })
 

--- a/tests/libnet/interface.go
+++ b/tests/libnet/interface.go
@@ -36,3 +36,13 @@ func InterfaceExists(vmi *v1.VirtualMachineInstance, interfaceName string) error
 	}
 	return nil
 }
+
+func LookupNetworkByName(networks []v1.Network, name string) *v1.Network {
+	for i, net := range networks {
+		if net.Name == name {
+			return &networks[i]
+		}
+	}
+
+	return nil
+}

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -306,6 +306,23 @@ var _ = SIGDescribe("nic-hotunplug", func() {
 			By("verify unplugged interface is not reported in the VMI status")
 			vmi = verifyDynamicInterfaceChange(vmi, plugMethod)
 
+			By("verify unplugged iface cleared from VM & VMI spec")
+			Eventually(func(g Gomega) {
+				updatedVM, err := kubevirt.Client().VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				updatedVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(vmispec.LookupInterfaceByName(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces, linuxBridgeNetworkName2)).To(BeNil(),
+					"unplugged iface should be cleared from VM spec")
+				g.Expect(libnet.LookupNetworkByName(updatedVM.Spec.Template.Spec.Networks, linuxBridgeNetworkName2)).To(BeNil(),
+					"unplugged iface corresponding network should be cleared from VM spec")
+				g.Expect(vmispec.LookupInterfaceByName(updatedVMI.Spec.Domain.Devices.Interfaces, linuxBridgeNetworkName2)).To(BeNil(),
+					"unplugged iface should be cleared from VMI spec")
+				g.Expect(libnet.LookupNetworkByName(updatedVMI.Spec.Networks, linuxBridgeNetworkName2)).To(BeNil(),
+					"unplugged iface corresponding network should be cleared from VMI spec")
+			}, 30*time.Second, 3*time.Second).Should(Succeed())
+
 			By("restarting the VM")
 			Expect(kubevirt.Client().VirtualMachine(vm.Namespace).Restart(context.Background(), vm.Name, &v1.RestartOptions{})).To(Succeed())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, hot-unplugged interfaces are marked as absent and
remain in the VM & VMI spec even after the interface is no longer
exist in the guest or virt-launcher pod.

Remove detached interfaces with absent state from VM & VMI spec.

An interface is considered as detached if it exists in the VMI spec,
have 'absent' state, and are not being reported in the VMI status.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on #10063 (first 3 commits)~~

In the scenario in-place hotplug is performed using Multus V4,
since there is no indication regarding the wiring and cache files Kubevirt
sets in virt-launcher pod (e.g.: bridge and tap device), the subject
interface may be removed without the cleaning up the wiring.
This will be addresses in follow up PR.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Existing detached interfaces with 'absent' state will be cleared from VMI spec.
```
