### PR TITLE
automation: Add check license script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,9 @@ lint:
 	  tests/libvmi/... \
 	"
 
+check-license:
+	./hack/check_license.sh
+
 lint-metrics:
 	hack/dockerized "./hack/prom-metric-linter/metrics_collector.sh > metrics.json"
 	./hack/prom-metric-linter/metric_name_linter.sh --operator-name="kubevirt" --sub-operator-name="kubevirt" --metrics-file=metrics.json

--- a/hack/check_license.sh
+++ b/hack/check_license.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+
+git remote add upstream https://github.com/kubevirt/kubevirt.git > /dev/null 2>&1
+git fetch upstream > /dev/null
+
+diff_output=$(git diff upstream/main --name-only --diff-filter=A)
+missing_license=false
+
+while IFS= read -r file; do
+  if [ -f "$file" ] && ! grep -q "http://www.apache.org/licenses/LICENSE-2.0" "$file"; then
+    echo "Missing license header: $file"
+    missing_license=true
+  fi
+done <<< "$diff_output"
+
+if [ "$missing_license" = true ]; then
+  echo "License headers missing. Please add the license header to the listed files."
+  exit 1
+elif [ -z "$diff_output" ]; then
+  echo "No new files added."
+  exit 0
+else
+  echo "All added files have license headers."
+  exit 0
+fi
+


### PR DESCRIPTION
**What this PR does / why we need it**:
The script checks if new added files have a license header.

Note: it can't detect problems in itself because it has the header as part of the script itself.
Anyhow header was added to it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Still need to call it from project-infra once it is merged (unless we cal it from other make target).

**Release note**:
```release-note
None
```
