### PR TITLE
[e2e tests]: Decorate vTPM tests with RWX FS storage requirement

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -24,23 +24,24 @@ var (
 	KSMRequired = []interface{}{Label("KSM-required")}
 
 	// Features
-	Sysprep                     = []interface{}{Label("Sysprep")}
-	Windows                     = []interface{}{Label("Windows")}
-	Networking                  = []interface{}{Label("Networking")}
-	VMIlifecycle                = []interface{}{Label("VMIlifecycle")}
-	Expose                      = []interface{}{Label("Expose")}
-	NonRoot                     = []interface{}{Label("verify-non-root")}
-	NativeSsh                   = []interface{}{Label("native-ssh")}
-	ExcludeNativeSsh            = []interface{}{Label("exclude-native-ssh")}
-	Reenlightenment             = []interface{}{Label("Reenlightenment")}
-	TscFrequencies              = []interface{}{Label("TscFrequencies")}
-	PasstGate                   = []interface{}{Label("PasstGate")}
-	VMX                         = []interface{}{Label("VMX")}
-	Upgrade                     = []interface{}{Label("Upgrade")}
-	CustomSELinux               = []interface{}{Label("CustomSELinux")}
-	Istio                       = []interface{}{Label("Istio")}
-	InPlaceHotplugNICs          = []interface{}{Label("in-place-hotplug-NICs")}
-	MigrationBasedHotplugNICs   = []interface{}{Label("migration-based-hotplug-NICs")}
-	RequiresTwoSchedulableNodes = []interface{}{Label("requires-two-schedulable-nodes")}
-	VMLiveUpdateFeaturesGate    = []interface{}{Label("VMLiveUpdateFeaturesGate")}
+	Sysprep                      = []interface{}{Label("Sysprep")}
+	Windows                      = []interface{}{Label("Windows")}
+	Networking                   = []interface{}{Label("Networking")}
+	VMIlifecycle                 = []interface{}{Label("VMIlifecycle")}
+	Expose                       = []interface{}{Label("Expose")}
+	NonRoot                      = []interface{}{Label("verify-non-root")}
+	NativeSsh                    = []interface{}{Label("native-ssh")}
+	ExcludeNativeSsh             = []interface{}{Label("exclude-native-ssh")}
+	Reenlightenment              = []interface{}{Label("Reenlightenment")}
+	TscFrequencies               = []interface{}{Label("TscFrequencies")}
+	PasstGate                    = []interface{}{Label("PasstGate")}
+	VMX                          = []interface{}{Label("VMX")}
+	Upgrade                      = []interface{}{Label("Upgrade")}
+	CustomSELinux                = []interface{}{Label("CustomSELinux")}
+	Istio                        = []interface{}{Label("Istio")}
+	InPlaceHotplugNICs           = []interface{}{Label("in-place-hotplug-NICs")}
+	MigrationBasedHotplugNICs    = []interface{}{Label("migration-based-hotplug-NICs")}
+	RequiresTwoSchedulableNodes  = []interface{}{Label("requires-two-schedulable-nodes")}
+	VMLiveUpdateFeaturesGate     = []interface{}{Label("VMLiveUpdateFeaturesGate")}
+	RequiresRWXFilesystemStorage = []interface{}{Label("rwxfs")}
 )

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -27,7 +27,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
-var _ = Describe("[sig-storage]VM state", decorators.SigStorage, func() {
+var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.RequiresRWXFilesystemStorage, func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 

--- a/tests/vmi_tpm_test.go
+++ b/tests/vmi_tpm_test.go
@@ -37,7 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-var _ = Describe("[sig-compute]vTPM", decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]vTPM", decorators.SigCompute, decorators.RequiresRWXFilesystemStorage, func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This way the kubevirt tests can not pick up these tests when
a cluster does not have an RWX FS storage solution.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
