### PR TITLE
host-disk: Check existence of capacity and request storage resource

### DIFF
--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -109,14 +109,22 @@ func replaceForHostDisk(volumeSource *v1.VolumeSource, volumeName string, pvcVol
 	volumeStatus := pvcVolume[volumeName]
 	isShared := types.HasSharedAccessMode(volumeStatus.PersistentVolumeClaimInfo.AccessModes)
 	file := getPVCDiskImgPath(volumeName, "disk.img")
-	capacity := volumeStatus.PersistentVolumeClaimInfo.Capacity[k8sv1.ResourceStorage]
-	requested := volumeStatus.PersistentVolumeClaimInfo.Requests[k8sv1.ResourceStorage]
-	// Use the requested size if it is smaller than the overall capacity of the PVC to ensure the created disks are the size requested by the user
-	if capacity.Value() > requested.Value() {
-		capacity = requested
+	capacity, capacityOk := volumeStatus.PersistentVolumeClaimInfo.Capacity[k8sv1.ResourceStorage]
+	requested, requestedOk := volumeStatus.PersistentVolumeClaimInfo.Requests[k8sv1.ResourceStorage]
+
+	if !capacityOk && !requestedOk {
+		return fmt.Errorf("unable to determine capacity of HostDisk from PVC that provides no storage capacity or requests")
 	}
-	// The host-disk must be 1MiB-aligned. If the volume specifies a misaligned size, shrink it down to the nearest multiple of 1MiB
-	size := util.AlignImageSizeTo1MiB(capacity.Value(), log.Log)
+
+	var size int64
+	// Use the requested size if it is smaller than the overall capacity of the PVC to ensure the created disks are the size requested by the user
+	if requestedOk && ((capacityOk && capacity.Value() > requested.Value()) || !capacityOk) {
+		// The host-disk must be 1MiB-aligned. If the volume specifies a misaligned size, shrink it down to the nearest multiple of 1MiB
+		size = util.AlignImageSizeTo1MiB(requested.Value(), log.Log)
+	} else {
+		size = util.AlignImageSizeTo1MiB(capacity.Value(), log.Log)
+	}
+
 	if size == 0 {
 		return fmt.Errorf("the size for volume %s is too low, must be at least 1MiB", volumeName)
 	}


### PR DESCRIPTION
/cc @xpivarc 

**What this PR does / why we need it**:

This is a follow up to #9810 where we started to limit the capacity of a HostDisk to the request storage resource size if smaller than the capacity storage resource size.

Both the requests and capacity are actually optional attributes of the PersistentVolumeClaimInfo[1] object used to pass them into this code. As such this change introduces some additional checks to ensure they are present before attempting to populate the capacity of the HostDisk.

[1] https://github.com/kubevirt/kubevirt/blob/0f4cbbf0cf273c7014a16d5e09fb3d3dee77444a/staging/src/kubevirt.io/api/core/v1/types.go#L298-L304

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
