### PR TITLE
Fix for libvirt >= 9.1.0: Support multiple watchdogs in the domain schema

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -736,10 +736,12 @@ func (in *Devices) DeepCopyInto(out *Devices) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Watchdog != nil {
-		in, out := &in.Watchdog, &out.Watchdog
-		*out = new(Watchdog)
-		(*in).DeepCopyInto(*out)
+	if in.Watchdogs != nil {
+		in, out := &in.Watchdogs, &out.Watchdogs
+		*out = make([]Watchdog, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Rng != nil {
 		in, out := &in.Rng, &out.Rng

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -478,7 +478,7 @@ type Devices struct {
 	Inputs      []Input            `xml:"input"`
 	Serials     []Serial           `xml:"serial"`
 	Consoles    []Console          `xml:"console"`
-	Watchdog    *Watchdog          `xml:"watchdog,omitempty"`
+	Watchdogs   []Watchdog         `xml:"watchdog,omitempty"`
 	Rng         *Rng               `xml:"rng,omitempty"`
 	Filesystems []FilesystemDevice `xml:"filesystem,omitempty"`
 	Redirs      []RedirectedDevice `xml:"redirdev,omitempty"`

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -348,10 +348,12 @@ var _ = ginkgo.Describe("Schema", func() {
 		exampleDomain.Spec.Devices.Consoles = []Console{
 			{Type: "pty"},
 		}
-		exampleDomain.Spec.Devices.Watchdog = &Watchdog{
-			Model:  "i6300esb",
-			Action: "poweroff",
-			Alias:  NewUserDefinedAlias("mywatchdog"),
+		exampleDomain.Spec.Devices.Watchdogs = []Watchdog{
+			{
+				Model:  "i6300esb",
+				Action: "poweroff",
+				Alias:  NewUserDefinedAlias("mywatchdog"),
+			},
 		}
 		exampleDomain.Spec.Devices.Rng = &Rng{
 			Model:   v1.VirtIO,

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1604,7 +1604,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		if err != nil {
 			return err
 		}
-		domain.Spec.Devices.Watchdog = newWatchdog
+		domain.Spec.Devices.Watchdogs = append(domain.Spec.Devices.Watchdogs, *newWatchdog)
 	}
 
 	if vmi.Spec.Domain.Devices.Rng != nil {

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -53,8 +53,8 @@ func PlacePCIDevicesOnRootComplex(spec *api.DomainSpec) (err error) {
 			return err
 		}
 	}
-	if spec.Devices.Watchdog != nil {
-		spec.Devices.Watchdog.Address, err = assigner.PlacePCIDeviceAtNextSlot(spec.Devices.Watchdog.Address)
+	for i, watchdog := range spec.Devices.Watchdogs {
+		spec.Devices.Watchdogs[i].Address, err = assigner.PlacePCIDeviceAtNextSlot(watchdog.Address)
 		if err != nil {
 			return err
 		}

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -92,6 +92,20 @@ func WithRng() Option {
 	}
 }
 
+// WithWatchdog adds a watchdog to the vmi devices.
+func WithWatchdog(action v1.WatchdogAction) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{
+			Name: "watchdog",
+			WatchdogDevice: v1.WatchdogDevice{
+				I6300ESB: &v1.I6300ESBWatchdog{
+					Action: action,
+				},
+			},
+		}
+	}
+}
+
 // WithResourceMemory specifies the vmi memory resource.
 func WithResourceMemory(value string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -750,6 +750,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 					vmi.ObjectMeta.Labels = map[string]string{"downwardTestLabelKey": "downwardTestLabelVal"}
 				}
 				tests.AddLabelDownwardAPIVolume(vmi, downwardAPIName)
+				tests.AddWatchdog(vmi, v1.WatchdogActionPoweroff)
 
 				vmis = append(vmis, vmi)
 			}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1121,6 +1121,17 @@ func AddExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 }
 
+func AddWatchdog(vmi *v1.VirtualMachineInstance, action v1.WatchdogAction) {
+	vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{
+		Name: "watchdog",
+		WatchdogDevice: v1.WatchdogDevice{
+			I6300ESB: &v1.I6300ESBWatchdog{
+				Action: action,
+			},
+		},
+	}
+}
+
 func NewInt32(x int32) *int32 {
 	return &x
 }

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -124,9 +124,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			vmi := libvmi.NewCirros(
 				libvmi.WithAnnotation(v1.PlacePCIDevicesOnRootComplex, "true"),
 				libvmi.WithRng(),
+				libvmi.WithWatchdog(v1.WatchdogActionPoweroff),
 			)
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.VirtIO, Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
-			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
 			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
@@ -143,9 +143,11 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 	Context("when requesting virtio-transitional models", func() {
 		It("[test_id:6957]should start and run the guest", func() {
-			vmi := libvmi.NewCirros(libvmi.WithRng())
+			vmi := libvmi.NewCirros(
+				libvmi.WithRng(),
+				libvmi.WithWatchdog(v1.WatchdogActionPoweroff),
+			)
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.VirtIO, Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
-			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi.Spec.Domain.Devices.UseVirtioTransitional = pointer.BoolPtr(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(console.LoginToCirros(vmi)).To(Succeed())

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -50,7 +50,7 @@ var _ = Describe("[sig-compute]Health Monitoring", decorators.SigCompute, func()
 	Describe("A VirtualMachineInstance with a watchdog device", func() {
 		It("[test_id:4641]should be shut down when the watchdog expires", func() {
 			vmi := tests.RunVMIAndExpectLaunch(
-				libvmi.NewAlpine(withWatchdog()), 360)
+				libvmi.NewAlpine(libvmi.WithWatchdog(v1.WatchdogActionPoweroff)), 360)
 
 			By("Expecting the VirtualMachineInstance console")
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -77,16 +77,3 @@ var _ = Describe("[sig-compute]Health Monitoring", decorators.SigCompute, func()
 		})
 	})
 })
-
-func withWatchdog() libvmi.Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{
-			Name: "mywatchdog",
-			WatchdogDevice: v1.WatchdogDevice{
-				I6300ESB: &v1.I6300ESBWatchdog{
-					Action: v1.WatchdogActionPoweroff,
-				},
-			},
-		}
-	}
-}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

The issue has been found while testing a downstream build of KubeVirt v1.0.0 with libvirt **9.5.0**. Currently, it is not reproducible with the latest upstream images, since the libvirt version there is **9.0.0**. However, this issue is likely to emerge after an update of the virt stack.

The failing test with a watchdog device:

https://github.com/kubevirt/kubevirt/blob/d16161124f3008a0404de663f678f5a1b463ce5a/tests/vmi_configuration_test.go#L145-L155

**What this PR does / why we need it**:

Starting from version **9.1.0**, Libvirt adds an implicit watchdog device for q35 machine:

https://gitlab.com/libvirt/libvirt/-/commit/926594dcc82b40f483010cebe5addbf1d7f58b24

https://libvirt.org/formatdomain.html#watchdog-devices

> Having multiple watchdogs is usually not something very common, but be aware that this might happen, for example, when an implicit watchdog device is added as part of another device. For example the iTCO watchdog being part of the ich9 southbridge, which is used with the q35 machine type. Since 9.1.0


With the introduction of nic hotplug feature, we now call `define domain` twice (the actual call is done inside `l.setDomainSpecWithHooks(v, s)` callback):

https://github.com/kubevirt/kubevirt/blob/d16161124f3008a0404de663f678f5a1b463ce5a/pkg/virt-launcher/virtwrap/manager.go#L993-L998

https://github.com/kubevirt/kubevirt/blob/d16161124f3008a0404de663f678f5a1b463ce5a/pkg/virt-launcher/virtwrap/nichotplug.go#L180-L201

If the VMI spec requires a watchdog, then after the first call, the xml returned from `util.GetDomainSpecWithFlags(dom, libvirt.DOMAIN_XML_INACTIVE)` will include two devices (the requested and an implicit one):

```xml
    <watchdog model='i6300esb' action='poweroff'>
      <alias name='ua-watchdog'/>
      <address type='pci' domain='0x0000' bus='0x02' slot='0x0b' function='0x0'/>
    </watchdog>
    <watchdog model='itco' action='poweroff'/>

```

However, the current schema supports only a single watchdog device:

https://github.com/kubevirt/kubevirt/blob/d16161124f3008a0404de663f678f5a1b463ce5a/pkg/virt-launcher/virtwrap/api/schema.go#L481

This leads to a malformed unmarshaled domain object (here `itco` watchdog should not have an address):

```xml
    <watchdog model="itco" action="poweroff">
        <alias name="ua-watchdog"></alias>
        <address type="pci" domain="0x0000" bus="0x02" slot="0x0b" function="0x0"></address>
    </watchdog>
```

 and on the second call of `define domain` it results in the following error:

```
unsupported configuration: itco model of watchdog is part of the machine and cannot have any address set.
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
