### PR TITLE
Updating link for release notes labels to new file

### DIFF
--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -27,7 +27,7 @@ Make a few passes over the code you want to review.
 
 PRs have a ```release-notes``` section of their description and we use GitHub labels to filter release notes when we generate them at release time. For some PRs, kubevirt-bot is able to apply one of more of these labels but in general they need to be manually added.
 
-If a release note is included in the PR, ensure that it has a `kind/` label and, if relevant, a 'sig/' label as well. For more information on these labels, see the [release.md](https://github.com/kubevirt/kubevirt/blob/main/docs/release.md) doc in this repo.
+If a release note is included in the PR, ensure that it has a `kind/` label and, if relevant, a 'sig/' label as well. For more information on these labels, see the [release-procedure.md](release-procedure.md#using-github-labels-for-release-notes) doc in this repo.
 
 ## Pull Request structure
 


### PR DESCRIPTION
Updating because this content was moved to a new file in #9982 
This is also a cleaner link.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
