### PR TITLE
[release-0.59]logs: Do not set verbosity for higher log levels

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -299,7 +299,7 @@ func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) erro
 					case libvirt.ERR_AGENT_UNRESPONSIVE:
 						const unresponsive = "failed to set time: QEMU agent unresponsive"
 						latestErr = fmt.Errorf("%s, %s", unresponsive, err)
-						log.Log.Object(vmi).Reason(err).V(9).Warning(unresponsive)
+						log.Log.Object(vmi).Reason(err).V(9).Info(unresponsive)
 					case libvirt.ERR_OPERATION_UNSUPPORTED:
 						// no need to retry as this opertaion is not supported
 						log.Log.Object(vmi).Reason(err).Warning("failed to set time: not supported")
@@ -310,7 +310,7 @@ func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) erro
 						return
 					default:
 						latestErr = fmt.Errorf("%s, %s", failedSyncGuestTime, err)
-						log.Log.Object(vmi).Reason(err).V(9).Warning(failedSyncGuestTime)
+						log.Log.Object(vmi).Reason(err).V(9).Info(failedSyncGuestTime)
 					}
 				} else {
 					latestErr = nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this PR a  `warning` will override the log level.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
