### PR TITLE
[release-1.0] Clear absent ifaces

### DIFF
--- a/pkg/virt-controller/watch/network.go
+++ b/pkg/virt-controller/watch/network.go
@@ -105,3 +105,15 @@ func handleDynamicInterfaceRequests(vm *v1.VirtualMachine) {
 
 	return
 }
+
+func clearDetachedInterfaces(specIfaces []v1.Interface, specNets []v1.Network, statusIfaces map[string]v1.VirtualMachineInstanceNetworkInterface) ([]v1.Interface, []v1.Network) {
+	var ifaces []v1.Interface
+	for _, iface := range specIfaces {
+		if _, existInStatus := statusIfaces[iface.Name]; (existInStatus && iface.State == v1.InterfaceStateAbsent) ||
+			iface.State != v1.InterfaceStateAbsent {
+			ifaces = append(ifaces, iface)
+		}
+	}
+
+	return ifaces, vmispec.FilterNetworksByInterfaces(specNets, ifaces)
+}

--- a/tests/libnet/interface.go
+++ b/tests/libnet/interface.go
@@ -36,3 +36,13 @@ func InterfaceExists(vmi *v1.VirtualMachineInstance, interfaceName string) error
 	}
 	return nil
 }
+
+func LookupNetworkByName(networks []v1.Network, name string) *v1.Network {
+	for i, net := range networks {
+		if net.Name == name {
+			return &networks[i]
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Cherry-pick #10116 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
It's necessary to do this manually due to conflicts

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Existing detached interfaces with 'absent' state will be cleared from VMI spec.
```
