### PR TITLE
Add port-forward functionalities to virtctl vmexport

### DIFF
--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -49,6 +49,7 @@ const (
 	createClaimArg  = "create-claim"
 	storageClassArg = "storage-class"
 	accessModeArg   = "access-mode"
+	portForwardArg  = "port-forward"
 
 	configName         = "config"
 	filesystemOverhead = cdiv1.Percent("0.055")
@@ -61,6 +62,7 @@ const (
 var (
 	claimName    string
 	createClaim  bool
+	portForward  string
 	storageClass string
 	accessMode   string
 	outputFile   string
@@ -113,6 +115,7 @@ func NewMemoryDumpCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	cmd.Flags().StringVar(&claimName, claimNameArg, "", "pvc name to contain the memory dump")
 	cmd.Flags().BoolVar(&createClaim, createClaimArg, false, "Create the pvc that will conatin the memory dump")
+	cmd.Flags().StringVar(&portForward, portForwardArg, "", "Configure and set port-forward in the specified port to download the memory dump")
 	cmd.Flags().StringVar(&storageClass, storageClassArg, "", "The storage class for the PVC.")
 	cmd.Flags().StringVar(&accessMode, accessModeArg, "", "The access mode for the PVC.")
 	cmd.Flags().StringVar(&outputFile, "output", "", "Specifies the output path of the memory dump to be downloaded.")
@@ -327,6 +330,13 @@ func downloadMemoryDump(namespace, vmName string, virtClient kubecli.KubevirtCli
 		Namespace:    namespace,
 		Name:         vmexportName,
 		ExportSource: exportSource,
+	}
+	// Complete port-forward arguments
+	if portForward != "" {
+		vmExportInfo.PortForward = portForward
+		if vmExportInfo.ServiceURL == "" {
+			vmExportInfo.ServiceURL = fmt.Sprintf("127.0.0.1:%s", portForward)
+		}
 	}
 	// User wants the output in a file, create
 	output, err := os.Create(vmExportInfo.OutputFile)

--- a/pkg/virtctl/vmexport/BUILD.bazel
+++ b/pkg/virtctl/vmexport/BUILD.bazel
@@ -18,9 +18,13 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/client-go/tools/portforward:go_default_library",
+        "//vendor/k8s.io/client-go/transport/spdy:go_default_library",
+        "//vendor/k8s.io/kubectl/pkg/util:go_default_library",
     ],
 )
 

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//tests/libstorage:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/libwait:go_default_library",
-        "//tests/monitoring:go_default_library",
         "//tests/testsuite:go_default_library",
         "//tests/util:go_default_library",
         "//tests/watcher:go_default_library",

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2221,8 +2221,7 @@ var _ = SIGDescribe("Export", func() {
 				}
 
 				if !checks.IsOpenShift() {
-					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-					cmdArgs = append(cmdArgs, "--port-forward", targetPort)
+					cmdArgs = append(cmdArgs, "--port-forward")
 				}
 
 				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(cmdArgs...)
@@ -2276,8 +2275,7 @@ var _ = SIGDescribe("Export", func() {
 				}
 
 				if !checks.IsOpenShift() {
-					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-					cmdArgs = append(cmdArgs, "--port-forward", targetPort)
+					cmdArgs = append(cmdArgs, "--port-forward")
 				}
 
 				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(cmdArgs...)
@@ -2322,8 +2320,7 @@ var _ = SIGDescribe("Export", func() {
 				}
 
 				if !checks.IsOpenShift() {
-					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-					cmdArgs = append(cmdArgs, "--port-forward", targetPort)
+					cmdArgs = append(cmdArgs, "--port-forward")
 				}
 
 				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(cmdArgs...)
@@ -2348,8 +2345,8 @@ var _ = SIGDescribe("Export", func() {
 				export, err := virtClient.VirtualMachineExport(vmExport.Namespace).Get(context.Background(), vmExport.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if export.Status.Links.External == nil {
-					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.Internal.Volumes[0].Name, "--port-forward", targetPort, "--keep-vme")
+					localPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.Internal.Volumes[0].Name, "--port-forward", "--local-port", localPort, "--keep-vme")
 				} else {
 					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.External.Volumes[0].Name)
 				}
@@ -2385,8 +2382,8 @@ var _ = SIGDescribe("Export", func() {
 					"--namespace", testsuite.GetTestNamespace(export),
 				}
 				if export.Status.Links.External == nil {
-					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-					cmdArgs = append(cmdArgs, "--port-forward", targetPort,
+					localPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--port-forward", "--local-port", localPort,
 						"--insecure", "--keep-vme")
 				}
 				By("Running vmexport command")
@@ -2414,8 +2411,8 @@ var _ = SIGDescribe("Export", func() {
 				}
 				Expect(err).ToNot(HaveOccurred())
 				if vme.Status.Links.External == nil {
-					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.Internal.Volumes[0].Name, "--port-forward", targetPort)
+					localPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.Internal.Volumes[0].Name, "--port-forward", "--local-port", localPort)
 				} else {
 					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.External.Volumes[0].Name)
 				}
@@ -2487,8 +2484,8 @@ var _ = SIGDescribe("Export", func() {
 					testsuite.GetTestNamespace(vm),
 				}
 				if vme.Status.Links.External == nil {
-					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-					cmdArgs = append(cmdArgs, "--service-url", fmt.Sprintf("127.0.0.1:%s", targetPort), "--port-forward", targetPort)
+					localPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--service-url", fmt.Sprintf("127.0.0.1:%s", localPort), "--port-forward", "--local-port", localPort)
 				}
 				cmdArgs = append(cmdArgs, extraArgs...)
 				virtctlCmdOut := clientcmd.NewRepeatableVirtctlCommandWithOut(cmdArgs...)

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2398,7 +2398,7 @@ var _ = SIGDescribe("Export", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			FIt("Download succeeds and keeps the vmexport after finishing the download", func() {
+			It("Download succeeds and keeps the vmexport after finishing the download", func() {
 				vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 				vmeName = vmExport.Name
 				vme, err := virtClient.VirtualMachineExport(vmExport.Namespace).Get(context.Background(), vmeName, metav1.GetOptions{})

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -26,9 +26,7 @@ import (
 	"encoding/pem"
 	goerrors "errors"
 	"fmt"
-	"io"
 	"os"
-	osexec "os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -36,7 +34,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/monitoring"
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -1342,9 +1339,11 @@ var _ = SIGDescribe("Export", func() {
 
 	It("should create export from VMSnapshot", func() {
 		sc, err := libstorage.GetSnapshotStorageClass(virtClient)
-		if err != nil {
-			Skip("Skip test when Filesystem storage is not present")
+		Expect(err).ToNot(HaveOccurred())
+		if sc == "" {
+			Skip("Skip test when storage with snapshot is not present")
 		}
+
 		vm := createVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 			cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 			testsuite.GetTestNamespace(nil),
@@ -1407,7 +1406,8 @@ var _ = SIGDescribe("Export", func() {
 
 	It("should create export from VMSnapshot with multiple volumes", func() {
 		sc, err := libstorage.GetSnapshotStorageClass(virtClient)
-		if err != nil {
+		Expect(err).ToNot(HaveOccurred())
+		if sc == "" {
 			Skip("Skip test when storage with snapshot is not present")
 		}
 
@@ -1746,9 +1746,11 @@ var _ = SIGDescribe("Export", func() {
 		virtClient, err := kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 		sc, err := libstorage.GetSnapshotStorageClass(virtClient)
-		if err != nil {
-			Skip("Skip test when snapshot storage is not present")
+		Expect(err).ToNot(HaveOccurred())
+		if sc == "" {
+			Skip("Skip test when storage with snapshot is not present")
 		}
+
 		vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce)
 		vm.Spec.Running = pointer.BoolPtr(true)
 		vm = createVM(vm)
@@ -2081,7 +2083,8 @@ var _ = SIGDescribe("Export", func() {
 
 		It("Create succeeds using Snapshot source", func() {
 			sc, err := libstorage.GetSnapshotStorageClass(virtClient)
-			if err != nil {
+			Expect(err).ToNot(HaveOccurred())
+			if sc == "" {
 				Skip("Skip test when storage with snapshot is not present")
 			}
 			// Create a populated Snapshot
@@ -2191,40 +2194,38 @@ var _ = SIGDescribe("Export", func() {
 		})
 
 		Context("Download a volume with vmexport", func() {
-			var (
-				forwardCmd *osexec.Cmd
-			)
-
 			BeforeEach(func() {
 				outputFile = fmt.Sprintf(defaultOutput, rand.String(12))
 			})
 
 			AfterEach(func() {
-				err = monitoring.KillPortForwardCommand(forwardCmd)
-				Expect(err).ToNot(HaveOccurred())
 				if err := os.Remove(outputFile); err != nil && !goerrors.Is(err, os.ErrNotExist) {
 					Fail(err.Error())
 				}
 			})
 
 			It("Download succeeds creating and downloading a vmexport using PVC source", func() {
-				// Remove this once we can pass an argument to have virtctl start a port-forward
-				if !checks.IsOpenShift() {
-					Skip("Not on openshift")
-				}
 				// Create populated PVC
 				pvc, _ := populateKubeVirtContent(sc, k8sv1.PersistentVolumeFilesystem)
 				// Run vmexport
 				By("Running vmexport command")
-				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(commandName,
+				cmdArgs := []string{
+					commandName,
 					"download",
 					vmeName,
 					"--pvc", pvc.Name,
 					"--output", outputFile,
 					"--volume", pvc.Name,
 					"--insecure",
-					"--namespace", testsuite.GetTestNamespace(pvc))
+					"--namespace", testsuite.GetTestNamespace(pvc),
+				}
 
+				if !checks.IsOpenShift() {
+					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--port-forward", targetPort)
+				}
+
+				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(cmdArgs...)
 				err = virtctlCmd()
 				Expect(err).ToNot(HaveOccurred())
 				_, err := os.Stat(outputFile)
@@ -2232,12 +2233,9 @@ var _ = SIGDescribe("Export", func() {
 			})
 
 			It("Download succeeds creating and downloading a vmexport using Snapshot source", func() {
-				// Remove this once we can pass an argument to have virtctl start a port-forward
-				if !checks.IsOpenShift() {
-					Skip("Not on openshift")
-				}
 				sc, err := libstorage.GetSnapshotStorageClass(virtClient)
-				if err != nil {
+				Expect(err).ToNot(HaveOccurred())
+				if sc == "" {
 					Skip("Skip test when storage with snapshot is not present")
 				}
 
@@ -2266,15 +2264,23 @@ var _ = SIGDescribe("Export", func() {
 
 				// Run vmexport
 				By("Running vmexport command")
-				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(commandName,
+				cmdArgs := []string{
+					commandName,
 					"download",
 					vmeName,
 					"--snapshot", snapshot.Name,
 					"--output", outputFile,
-					"--volume", export.Status.Links.External.Volumes[0].Name,
+					"--volume", vm.Spec.Template.Spec.Volumes[0].DataVolume.Name,
 					"--insecure",
-					"--namespace", testsuite.GetTestNamespace(export))
+					"--namespace", testsuite.GetTestNamespace(export),
+				}
 
+				if !checks.IsOpenShift() {
+					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--port-forward", targetPort)
+				}
+
+				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(cmdArgs...)
 				err = virtctlCmd()
 				Expect(err).ToNot(HaveOccurred())
 				_, err = os.Stat(outputFile)
@@ -2282,10 +2288,6 @@ var _ = SIGDescribe("Export", func() {
 			})
 
 			It("Download succeeds creating and downloading a vmexport using VM source", func() {
-				// Remove this once we can pass an argument to have virtctl start a port-forward
-				if !checks.IsOpenShift() {
-					Skip("Not on openshift")
-				}
 				// Create a populated VM
 				vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
@@ -2308,15 +2310,23 @@ var _ = SIGDescribe("Export", func() {
 
 				// Run vmexport
 				By("Running vmexport command")
-				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(commandName,
+				cmdArgs := []string{
+					commandName,
 					"download",
 					vmeName,
 					"--vm", vm.Name,
 					"--output", outputFile,
 					"--volume", vm.Spec.Template.Spec.Volumes[0].DataVolume.Name,
 					"--insecure",
-					"--namespace", testsuite.GetTestNamespace(vm))
+					"--namespace", testsuite.GetTestNamespace(vm),
+				}
 
+				if !checks.IsOpenShift() {
+					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--port-forward", targetPort)
+				}
+
+				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(cmdArgs...)
 				err = virtctlCmd()
 				Expect(err).ToNot(HaveOccurred())
 				_, err := os.Stat(outputFile)
@@ -2338,10 +2348,8 @@ var _ = SIGDescribe("Export", func() {
 				export, err := virtClient.VirtualMachineExport(vmExport.Namespace).Get(context.Background(), vmExport.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if export.Status.Links.External == nil {
-					targetPort := 37548 + rand.Intn(6000)
-					forwardCmd = startPortForward(vmeName, vmExport.Namespace, targetPort)
-					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.Internal.Volumes[0].Name, "--service-url", fmt.Sprintf("127.0.0.1:%d", targetPort),
-						"--insecure", "--keep-vme")
+					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.Internal.Volumes[0].Name, "--port-forward", targetPort, "--keep-vme")
 				} else {
 					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.External.Volumes[0].Name)
 				}
@@ -2377,9 +2385,8 @@ var _ = SIGDescribe("Export", func() {
 					"--namespace", testsuite.GetTestNamespace(export),
 				}
 				if export.Status.Links.External == nil {
-					targetPort := 37548 + rand.Intn(6000)
-					forwardCmd = startPortForward(vmeName, pvc.Namespace, targetPort)
-					cmdArgs = append(cmdArgs, "--service-url", fmt.Sprintf("127.0.0.1:%d", targetPort),
+					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--port-forward", targetPort,
 						"--insecure", "--keep-vme")
 				}
 				By("Running vmexport command")
@@ -2391,7 +2398,7 @@ var _ = SIGDescribe("Export", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("Download succeeds and keeps the vmexport after finishing the download", func() {
+			FIt("Download succeeds and keeps the vmexport after finishing the download", func() {
 				vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 				vmeName = vmExport.Name
 				vme, err := virtClient.VirtualMachineExport(vmExport.Namespace).Get(context.Background(), vmeName, metav1.GetOptions{})
@@ -2407,10 +2414,8 @@ var _ = SIGDescribe("Export", func() {
 				}
 				Expect(err).ToNot(HaveOccurred())
 				if vme.Status.Links.External == nil {
-					targetPort := 37548 + rand.Intn(6000)
-					forwardCmd = startPortForward(vmeName, vmExport.Namespace, targetPort)
-					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.Internal.Volumes[0].Name, "--service-url", fmt.Sprintf("127.0.0.1:%d", targetPort),
-						"--insecure")
+					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.Internal.Volumes[0].Name, "--port-forward", targetPort)
 				} else {
 					cmdArgs = append(cmdArgs, "--volume", vmExport.Status.Links.External.Volumes[0].Name)
 				}
@@ -2428,15 +2433,6 @@ var _ = SIGDescribe("Export", func() {
 		})
 
 		Context("Get export manifest from vmexport", func() {
-			var (
-				forwardCmd *osexec.Cmd
-			)
-
-			AfterEach(func() {
-				err = monitoring.KillPortForwardCommand(forwardCmd)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
 			DescribeTable("manifest should be successfully retrieved on running VM export", func(expectedObjects int, extraArgs ...string) {
 				// Create a populated VM
 				vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(
@@ -2491,10 +2487,8 @@ var _ = SIGDescribe("Export", func() {
 					testsuite.GetTestNamespace(vm),
 				}
 				if vme.Status.Links.External == nil {
-					targetPort := 37548 + rand.Intn(6000)
-					forwardCmd = startPortForward(vmeName, vm.Namespace, targetPort)
-					cmdArgs = append(cmdArgs, "--service-url", fmt.Sprintf("127.0.0.1:%d", targetPort),
-						"--insecure")
+					targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+					cmdArgs = append(cmdArgs, "--service-url", fmt.Sprintf("127.0.0.1:%s", targetPort), "--port-forward", targetPort)
 				}
 				cmdArgs = append(cmdArgs, extraArgs...)
 				virtctlCmdOut := clientcmd.NewRepeatableVirtctlCommandWithOut(cmdArgs...)
@@ -2519,22 +2513,6 @@ var _ = SIGDescribe("Export", func() {
 		})
 	})
 })
-
-func startPortForward(vmeName, namespace string, targetPort int) *osexec.Cmd {
-	_, forwardCmd, err := clientcmd.CreateCommandWithNS(namespace, clientcmd.GetK8sCmdClient(),
-		"port-forward", fmt.Sprintf("service/virt-export-%s", vmeName), fmt.Sprintf("%d:443", targetPort))
-	Expect(err).ToNot(HaveOccurred())
-	go func() {
-		defer GinkgoRecover()
-		Expect(err).ToNot(HaveOccurred())
-		stdout, err := forwardCmd.StdoutPipe()
-		Expect(err).ToNot(HaveOccurred())
-		err = forwardCmd.Start()
-		Expect(err).ToNot(HaveOccurred())
-		waitForPortForwardCmd(stdout, 443, targetPort)
-	}()
-	return forwardCmd
-}
 
 func logToGinkgoWritter(format string, parameters ...interface{}) {
 	_, _ = fmt.Fprintf(GinkgoWriter, format, parameters...)
@@ -2568,14 +2546,4 @@ func (matcher *ConditionNoTimeMatcher) FailureMessage(actual interface{}) (messa
 
 func (matcher *ConditionNoTimeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	return format.Message(actual, "not to match without time", matcher.Cond)
-}
-
-func waitForPortForwardCmd(stdout io.ReadCloser, src, dst int) {
-	Eventually(func() string {
-		tmp := make([]byte, 1024)
-		_, err := stdout.Read(tmp)
-		Expect(err).NotTo(HaveOccurred())
-
-		return string(tmp)
-	}, 30*time.Second, 1*time.Second).Should(ContainSubstring(fmt.Sprintf("Handling connection for %d", dst)))
 }

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -64,7 +64,8 @@ const (
 	virtCtlCreate                    = "--create-claim"
 	virtCtlOutputFile                = "--output=%s"
 	virtCtlStorageClass              = "--storage-class=%s"
-	virtCtlPortForward               = "--port-forward=%s"
+	virtCtlPortForward               = "--port-forward"
+	virtCtlLocalPort                 = "--local-port=%s"
 	waitMemoryDumpRequest            = "waiting on memory dump request in vm status"
 	waitMemoryDumpPvcVolume          = "waiting on memory dump pvc in vm"
 	waitMemoryDumpRequestRemove      = "waiting on memory dump request to be remove from vm status"
@@ -635,8 +636,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			commandAndArgs := []string{commandMemoryDump, "download", name, virtCtlNamespace, namespace}
 			commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlOutputFile, outputFile))
 			if !checks.IsOpenShift() {
-				targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-				commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlPortForward, targetPort))
+				commandAndArgs = append(commandAndArgs, virtCtlPortForward)
 			}
 			memorydumpCommand := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
 			Eventually(func() error {
@@ -663,7 +663,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlOutputFile, outputFile))
 			if !checks.IsOpenShift() {
 				targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
-				commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlPortForward, targetPort))
+				commandAndArgs = append(commandAndArgs, virtCtlPortForward, fmt.Sprintf(virtCtlLocalPort, targetPort))
 			}
 			memorydumpCommand := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
 			Eventually(func() error {

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -64,6 +64,7 @@ const (
 	virtCtlCreate                    = "--create-claim"
 	virtCtlOutputFile                = "--output=%s"
 	virtCtlStorageClass              = "--storage-class=%s"
+	virtCtlPortForward               = "--port-forward=%s"
 	waitMemoryDumpRequest            = "waiting on memory dump request in vm status"
 	waitMemoryDumpPvcVolume          = "waiting on memory dump pvc in vm"
 	waitMemoryDumpRequestRemove      = "waiting on memory dump request to be remove from vm status"
@@ -633,6 +634,10 @@ var _ = SIGDescribe("Memory dump", func() {
 			By("Invoking virtctl memory dump download")
 			commandAndArgs := []string{commandMemoryDump, "download", name, virtCtlNamespace, namespace}
 			commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlOutputFile, outputFile))
+			if !checks.IsOpenShift() {
+				targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+				commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlPortForward, targetPort))
+			}
 			memorydumpCommand := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
 			Eventually(func() error {
 				return memorydumpCommand()
@@ -656,6 +661,10 @@ var _ = SIGDescribe("Memory dump", func() {
 			commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlClaimName, claimName))
 			commandAndArgs = append(commandAndArgs, virtCtlCreate)
 			commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlOutputFile, outputFile))
+			if !checks.IsOpenShift() {
+				targetPort := fmt.Sprintf("%d", 37548+rand.Intn(6000))
+				commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlPortForward, targetPort))
+			}
 			memorydumpCommand := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
 			Eventually(func() error {
 				err := memorydumpCommand()
@@ -674,9 +683,6 @@ var _ = SIGDescribe("Memory dump", func() {
 		}
 
 		BeforeEach(func() {
-			if !checks.IsOpenShift() {
-				Skip("Need ingress to run this test which we only have on openshift")
-			}
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
 				Skip("Skip no filesystem storage class available")

--- a/vendor/k8s.io/kubectl/pkg/util/BUILD.bazel
+++ b/vendor/k8s.io/kubectl/pkg/util/BUILD.bazel
@@ -1,0 +1,64 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "apply.go",
+        "pod_port.go",
+        "service_port.go",
+        "umask.go",
+        "umask_windows.go",
+        "util.go",
+    ],
+    importmap = "kubevirt.io/kubevirt/vendor/k8s.io/kubectl/pkg/util",
+    importpath = "k8s.io/kubectl/pkg/util",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:aix": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:illumos": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:js": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/vendor/k8s.io/kubectl/pkg/util/apply.go
+++ b/vendor/k8s.io/kubectl/pkg/util/apply.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var metadataAccessor = meta.NewAccessor()
+
+// GetOriginalConfiguration retrieves the original configuration of the object
+// from the annotation, or nil if no annotation was found.
+func GetOriginalConfiguration(obj runtime.Object) ([]byte, error) {
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annots == nil {
+		return nil, nil
+	}
+
+	original, ok := annots[v1.LastAppliedConfigAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	return []byte(original), nil
+}
+
+// SetOriginalConfiguration sets the original configuration of the object
+// as the annotation on the object for later use in computing a three way patch.
+func setOriginalConfiguration(obj runtime.Object, original []byte) error {
+	if len(original) < 1 {
+		return nil
+	}
+
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return err
+	}
+
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	annots[v1.LastAppliedConfigAnnotation] = string(original)
+	return metadataAccessor.SetAnnotations(obj, annots)
+}
+
+// GetModifiedConfiguration retrieves the modified configuration of the object.
+// If annotate is true, it embeds the result as an annotation in the modified
+// configuration. If an object was read from the command input, it will use that
+// version of the object. Otherwise, it will use the version from the server.
+func GetModifiedConfiguration(obj runtime.Object, annotate bool, codec runtime.Encoder) ([]byte, error) {
+	// First serialize the object without the annotation to prevent recursion,
+	// then add that serialization to it as the annotation and serialize it again.
+	var modified []byte
+
+	// Otherwise, use the server side version of the object.
+	// Get the current annotations from the object.
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	original := annots[v1.LastAppliedConfigAnnotation]
+	delete(annots, v1.LastAppliedConfigAnnotation)
+	if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
+	}
+
+	modified, err = runtime.Encode(codec, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annotate {
+		annots[v1.LastAppliedConfigAnnotation] = string(modified)
+		if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+			return nil, err
+		}
+
+		modified, err = runtime.Encode(codec, obj)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Restore the object to its original condition.
+	annots[v1.LastAppliedConfigAnnotation] = original
+	if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
+	}
+
+	return modified, nil
+}
+
+// updateApplyAnnotation calls CreateApplyAnnotation if the last applied
+// configuration annotation is already present. Otherwise, it does nothing.
+func updateApplyAnnotation(obj runtime.Object, codec runtime.Encoder) error {
+	if original, err := GetOriginalConfiguration(obj); err != nil || len(original) <= 0 {
+		return err
+	}
+	return CreateApplyAnnotation(obj, codec)
+}
+
+// CreateApplyAnnotation gets the modified configuration of the object,
+// without embedding it again, and then sets it on the object as the annotation.
+func CreateApplyAnnotation(obj runtime.Object, codec runtime.Encoder) error {
+	modified, err := GetModifiedConfiguration(obj, false, codec)
+	if err != nil {
+		return err
+	}
+	return setOriginalConfiguration(obj, modified)
+}
+
+// CreateOrUpdateAnnotation creates the annotation used by
+// kubectl apply only when createAnnotation is true
+// Otherwise, only update the annotation when it already exists
+func CreateOrUpdateAnnotation(createAnnotation bool, obj runtime.Object, codec runtime.Encoder) error {
+	if createAnnotation {
+		return CreateApplyAnnotation(obj, codec)
+	}
+	return updateApplyAnnotation(obj, codec)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/pod_port.go
+++ b/vendor/k8s.io/kubectl/pkg/util/pod_port.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+// LookupContainerPortNumberByName find containerPort number by its named port name
+func LookupContainerPortNumberByName(pod v1.Pod, name string) (int32, error) {
+	for _, ctr := range pod.Spec.Containers {
+		for _, ctrportspec := range ctr.Ports {
+			if ctrportspec.Name == name {
+				return ctrportspec.ContainerPort, nil
+			}
+		}
+	}
+
+	return int32(-1), fmt.Errorf("Pod '%s' does not have a named port '%s'", pod.Name, name)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/service_port.go
+++ b/vendor/k8s.io/kubectl/pkg/util/service_port.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// LookupContainerPortNumberByServicePort implements
+// the handling of resolving container named port, as well as ignoring targetPort when clusterIP=None
+// It returns an error when a named port can't find a match (with -1 returned), or when the service does not
+// declare such port (with the input port number returned).
+func LookupContainerPortNumberByServicePort(svc v1.Service, pod v1.Pod, port int32) (int32, error) {
+	for _, svcportspec := range svc.Spec.Ports {
+		if svcportspec.Port != port {
+			continue
+		}
+		if svc.Spec.ClusterIP == v1.ClusterIPNone {
+			return port, nil
+		}
+		if svcportspec.TargetPort.Type == intstr.Int {
+			if svcportspec.TargetPort.IntValue() == 0 {
+				// targetPort is omitted, and the IntValue() would be zero
+				return svcportspec.Port, nil
+			}
+			return int32(svcportspec.TargetPort.IntValue()), nil
+		}
+		return LookupContainerPortNumberByName(pod, svcportspec.TargetPort.String())
+	}
+	return port, fmt.Errorf("Service %s does not have a service port %d", svc.Name, port)
+}
+
+// LookupServicePortNumberByName find service port number by its named port name
+func LookupServicePortNumberByName(svc v1.Service, name string) (int32, error) {
+	for _, svcportspec := range svc.Spec.Ports {
+		if svcportspec.Name == name {
+			return svcportspec.Port, nil
+		}
+	}
+
+	return int32(-1), fmt.Errorf("Service '%s' does not have a named port '%s'", svc.Name, name)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/umask.go
+++ b/vendor/k8s.io/kubectl/pkg/util/umask.go
@@ -1,0 +1,29 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
+func Umask(mask int) (old int, err error) {
+	return unix.Umask(mask), nil
+}

--- a/vendor/k8s.io/kubectl/pkg/util/umask_windows.go
+++ b/vendor/k8s.io/kubectl/pkg/util/umask_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+)
+
+// Umask returns an error on Windows
+func Umask(mask int) (int, error) {
+	return 0, errors.New("platform and architecture is not supported")
+}

--- a/vendor/k8s.io/kubectl/pkg/util/util.go
+++ b/vendor/k8s.io/kubectl/pkg/util/util.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ParseRFC3339 parses an RFC3339 date in either RFC3339Nano or RFC3339 format.
+func ParseRFC3339(s string, nowFn func() metav1.Time) (metav1.Time, error) {
+	if t, timeErr := time.Parse(time.RFC3339Nano, s); timeErr == nil {
+		return metav1.Time{Time: t}, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return metav1.Time{}, err
+	}
+	return metav1.Time{Time: t}, nil
+}
+
+// HashObject returns the hash of a Object hash by a Codec
+func HashObject(obj runtime.Object, codec runtime.Codec) (string, error) {
+	data, err := runtime.Encode(codec, obj)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", md5.Sum(data)), nil
+}
+
+// ParseFileSource parses the source given.
+//
+//	Acceptable formats include:
+//	 1.  source-path: the basename will become the key name
+//	 2.  source-name=source-path: the source-name will become the key name and
+//	     source-path is the path to the key file.
+//
+// Key names cannot include '='.
+func ParseFileSource(source string) (keyName, filePath string, err error) {
+	numSeparators := strings.Count(source, "=")
+	switch {
+	case numSeparators == 0:
+		return path.Base(filepath.ToSlash(source)), source, nil
+	case numSeparators == 1 && strings.HasPrefix(source, "="):
+		return "", "", fmt.Errorf("key name for file path %v missing", strings.TrimPrefix(source, "="))
+	case numSeparators == 1 && strings.HasSuffix(source, "="):
+		return "", "", fmt.Errorf("file path for key name %v missing", strings.TrimSuffix(source, "="))
+	case numSeparators > 1:
+		return "", "", errors.New("key names or file paths cannot contain '='")
+	default:
+		components := strings.Split(source, "=")
+		return components[0], components[1], nil
+	}
+}
+
+// ParseLiteralSource parses the source key=val pair into its component pieces.
+// This functionality is distinguished from strings.SplitN(source, "=", 2) since
+// it returns an error in the case of empty keys, values, or a missing equals sign.
+func ParseLiteralSource(source string) (keyName, value string, err error) {
+	// leading equal is invalid
+	if strings.Index(source, "=") == 0 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
+	// split after the first equal (so values can have the = character)
+	items := strings.SplitN(source, "=", 2)
+	if len(items) != 2 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
+
+	return items[0], items[1], nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1128,6 +1128,7 @@ k8s.io/kube-openapi/pkg/validation/spec
 # k8s.io/kubectl v0.0.0-00010101000000-000000000000 => k8s.io/kubectl v0.26.3
 ## explicit; go 1.19
 k8s.io/kubectl/pkg/cmd/util/podcmd
+k8s.io/kubectl/pkg/util
 # k8s.io/utils v0.0.0-20230505201702-9f6742963106
 ## explicit; go 1.18
 k8s.io/utils/buffer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

VirtualMachineExport volumes are only downloadable outside the cluster when proper ingress or routes are configured.

In some cases, it's helpful to force a way to download the volumes without this configuration, so this pull request introduces an option to set port-forwarding using the vmexport service so that we can get the vmexport contents outside the cluster without additional configuration.

Usage examples:

```sh
# To download the contents of pvc-test into disk.img.gz through a random available local port
$ virtctl vmexport download vm1-export --pvc=pvc-test --output=disk.img.gz --port-forward

# To download the contents of pvc-test into disk.img.gz through the local port 4342
$ virtctl vmexport download vm1-export --pvc=pvc-test --output=disk.img.gz --port-forward --local-port=4342
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add port-forward functionalities to vmexport
```
