### PR TITLE
[e2e] Fix FPR tests, supporting several cluster config

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3203,7 +3203,15 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		})
 
-		Context("with freePageReporting", func() {
+		Context("[Serial] with freePageReporting", Serial, func() {
+
+			BeforeEach(func() {
+				kv := util.GetCurrentKv(virtClient)
+				kvConfigurationCopy := kv.Spec.Configuration.DeepCopy()
+				kvConfigurationCopy.VirtualMachineOptions = nil
+				tests.UpdateKubeVirtConfigValueAndWait(*kvConfigurationCopy)
+			})
+
 			It("should be able to migrate", func() {
 				vmi := libvmi.NewAlpineWithTestTooling(
 					libvmi.WithMasqueradeNetworking()...,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, some memballoon and FPR e2e tests rely on the fact that FPR is enabled; this because FPR is enabled by default. Some installation can have FPR explicitly disabled, resulting in failures.

For memballon tests: Start considering the expected output based on the cluster kv config.
For migration test: Enable FPR before starting the test.

Also: Dropped a `tests.UpdateKubeVirtConfigValueAndWait(kvConfiguration)` function call in the AfterEach section, since the kv config is restored by global cleanup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @jean-edouard @xpivarc 