### PR TITLE
[e2e] Fix missing VMLiveUpdateFeaturesGate enabling

### DIFF
--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
 	"github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
 
@@ -55,6 +57,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			currentKv.ResourceVersion,
 			tests.ExpectResourceVersionToBeLessEqualThanConfigVersion,
 			time.Minute)
+		tests.EnableFeatureGate(virtconfig.VMLiveUpdateFeaturesGate)
 
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`VMLiveUpdateFeaturesGate` is enabled by default in `kubevirtresource.go`. The e2e default feature gates are not set in every cluster, since if `apply-default-e2e-configuration` is false, the default fg are not enabled, resulting in a failure.
We should ensure, during the setup of the test, that the VMLiveUpdateFeaturesGate is enabled.
Note that in the `EnableFeatureGate` function, there is a check that prevent the patch if the fg is already present, thus this will not delay the execution time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @jean-edouard @xpivarc 