### PR TITLE
virtctl: Apply --namespace to created manifests

### DIFF
--- a/pkg/virtctl/create/BUILD.bazel
+++ b/pkg/virtctl/create/BUILD.bazel
@@ -12,5 +12,6 @@ go_library(
         "//pkg/virtctl/create/vm:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )

--- a/pkg/virtctl/create/clone/BUILD.bazel
+++ b/pkg/virtctl/create/clone/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/pkg/virtctl/create/clone/clone_test.go
+++ b/pkg/virtctl/create/clone/clone_test.go
@@ -206,6 +206,18 @@ var _ = Describe("create clone", func() {
 		Expect(*cloneObj.Spec.NewSMBiosSerial).To(Equal(newSerial))
 	})
 
+	It("sets the provided namespace", func() {
+		flags := getSourceNameFlags()
+
+		const namespace = "my-namespace"
+		flags = addFlag(flags, "namespace", namespace)
+
+		cloneObj, err := newCommand(flags...)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cloneObj.Namespace).To(Equal(namespace))
+	})
+
 })
 
 func addFlag(s []string, flag, value string) []string {

--- a/pkg/virtctl/create/create.go
+++ b/pkg/virtctl/create/create.go
@@ -21,6 +21,7 @@ package create
 
 import (
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/create/clone"
 
@@ -34,7 +35,7 @@ const (
 	CREATE = "create"
 )
 
-func NewCommand() *cobra.Command {
+func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   CREATE,
 		Short: "Create a manifest for the specified Kind.",
@@ -43,7 +44,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(vm.NewCommand())
+	cmd.AddCommand(vm.NewCommand(clientConfig))
 	cmd.AddCommand(preference.NewCommand())
 	cmd.AddCommand(instancetype.NewCommand())
 	cmd.AddCommand(clone.NewCommand())

--- a/pkg/virtctl/create/create.go
+++ b/pkg/virtctl/create/create.go
@@ -45,7 +45,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	}
 
 	cmd.AddCommand(vm.NewCommand(clientConfig))
-	cmd.AddCommand(preference.NewCommand())
+	cmd.AddCommand(preference.NewCommand(clientConfig))
 	cmd.AddCommand(instancetype.NewCommand())
 	cmd.AddCommand(clone.NewCommand())
 	cmd.SetUsageTemplate(templates.UsageTemplate())

--- a/pkg/virtctl/create/create.go
+++ b/pkg/virtctl/create/create.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/create/clone"
-
 	"kubevirt.io/kubevirt/pkg/virtctl/create/instancetype"
 	"kubevirt.io/kubevirt/pkg/virtctl/create/preference"
 	"kubevirt.io/kubevirt/pkg/virtctl/create/vm"
@@ -47,7 +46,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.AddCommand(vm.NewCommand(clientConfig))
 	cmd.AddCommand(preference.NewCommand(clientConfig))
 	cmd.AddCommand(instancetype.NewCommand(clientConfig))
-	cmd.AddCommand(clone.NewCommand())
+	cmd.AddCommand(clone.NewCommand(clientConfig))
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 
 	return cmd

--- a/pkg/virtctl/create/create.go
+++ b/pkg/virtctl/create/create.go
@@ -46,7 +46,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 	cmd.AddCommand(vm.NewCommand(clientConfig))
 	cmd.AddCommand(preference.NewCommand(clientConfig))
-	cmd.AddCommand(instancetype.NewCommand())
+	cmd.AddCommand(instancetype.NewCommand(clientConfig))
 	cmd.AddCommand(clone.NewCommand())
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 

--- a/pkg/virtctl/create/instancetype/BUILD.bazel
+++ b/pkg/virtctl/create/instancetype/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/pkg/virtctl/create/preference/BUILD.bazel
+++ b/pkg/virtctl/create/preference/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/pkg/virtctl/create/preference/preference_test.go
+++ b/pkg/virtctl/create/preference/preference_test.go
@@ -93,6 +93,21 @@ var _ = Describe("create", func() {
 			Entry("VirtualMachineClusterPreference", "", "preferThreads", false),
 		)
 
+		It("should create namespaced object and apply namespace when namespace is specified", func() {
+			const namespace = "my-namespace"
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create, Preference,
+				setFlag("namespace", namespace),
+			)()
+			Expect(err).ToNot(HaveOccurred())
+
+			decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), bytes)
+			Expect(err).ToNot(HaveOccurred())
+
+			preference, ok := decodedObj.(*instancetypev1beta1.VirtualMachinePreference)
+			Expect(ok).To(BeTrue())
+			Expect(preference.Namespace).To(Equal(namespace))
+		})
+
 		DescribeTable("should fail with invalid CPU topology values", func(namespacedFlag, CPUTopology string, namespaced bool) {
 			err := clientcmd.NewRepeatableVirtctlCommand(create, Preference, namespacedFlag,
 				setFlag(CPUTopologyFlag, CPUTopology),

--- a/pkg/virtctl/create/vm/BUILD.bazel
+++ b/pkg/virtctl/create/vm/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/pkg/virtctl/create/vm/vm_test.go
+++ b/pkg/virtctl/create/vm/vm_test.go
@@ -51,6 +51,15 @@ var _ = Describe("create vm", func() {
 			_ = unmarshalVM(out)
 		})
 
+		It("VM with specified namespace", func() {
+			const namespace = "my-namespace"
+			out, err := runCmd(setFlag("namespace", namespace))
+			Expect(err).ToNot(HaveOccurred())
+			vm := unmarshalVM(out)
+
+			Expect(vm.Namespace).To(Equal(namespace))
+		})
+
 		It("VM with specified name", func() {
 			const name = "my-vm"
 			out, err := runCmd(setFlag(NameFlag, name))
@@ -470,7 +479,6 @@ var _ = Describe("create vm", func() {
 			const terminationGracePeriod int64 = 123
 			const instancetypeKind = "virtualmachineinstancetype"
 			const instancetypeName = "my-instancetype"
-			const preferenceName = "my-preference"
 			const dsNamespace = "my-ns"
 			const dsName = "my-ds"
 			const dvtSize = "10Gi"

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -107,7 +107,7 @@ func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 		imageupload.NewImageUploadCommand(clientConfig),
 		guestfs.NewGuestfsShellCommand(clientConfig),
 		vmexport.NewVirtualMachineExportCommand(clientConfig),
-		create.NewCommand(),
+		create.NewCommand(clientConfig),
 		credentials.NewCommand(clientConfig),
 		optionsCmd,
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With this PR virtctl applies the namespace passed with the
--namespace flag to the following created manifests:

- VirtualMachine
- VirtualMachinePreferences
- VirtualMachineInstancetype
- VirtualMachineClone

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl: Apply namespace to created manifests
```
