### PR TITLE
Stop considering master nodes when finding lowest TSC frequency on the cluster

### DIFF
--- a/pkg/virt-controller/watch/topology/filter.go
+++ b/pkg/virt-controller/watch/topology/filter.go
@@ -21,7 +21,19 @@ func IsSchedulable(node *v1.Node) bool {
 		return false
 	}
 
-	return node.Labels[virtv1.NodeSchedulable] == "true"
+	if node.Labels[virtv1.NodeSchedulable] != "true" || node.Spec.Unschedulable {
+		return false
+	}
+
+	if node.Spec.Taints != nil {
+		for _, taint := range node.Spec.Taints {
+			if taint.Effect == v1.TaintEffectNoSchedule {
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func HasInvTSCFrequency(node *v1.Node) bool {

--- a/pkg/virt-controller/watch/topology/filter_test.go
+++ b/pkg/virt-controller/watch/topology/filter_test.go
@@ -30,6 +30,40 @@ var _ = Describe("Filter", func() {
 		))
 	})
 
+	It("should filter out nodes with a noschedule taint", func() {
+		nodeWithUnschedulableTaint := node("node0", true)
+		nodeWithUnschedulableTaint.Spec.Taints = []v1.Taint{{Key: "noschedule", Effect: v1.TaintEffectNoSchedule}}
+
+		nodes := topology.NodesToObjects(
+			nodeWithUnschedulableTaint,
+			node("node1", false),
+			node("node2", true),
+			nil,
+		)
+		Expect(topology.FilterNodesFromCache(nodes,
+			topology.IsSchedulable,
+		)).To(ConsistOf(
+			nodes[2],
+		))
+	})
+
+	It("should filter out nodes with spec.unschedulable == true", func() {
+		nodeWithUnschedulableField := node("node0", true)
+		nodeWithUnschedulableField.Spec.Unschedulable = true
+
+		nodes := topology.NodesToObjects(
+			nodeWithUnschedulableField,
+			node("node1", false),
+			node("node2", true),
+			nil,
+		)
+		Expect(topology.FilterNodesFromCache(nodes,
+			topology.IsSchedulable,
+		)).To(ConsistOf(
+			nodes[2],
+		))
+	})
+
 	It("should inverse the search result", func() {
 		nodes := topology.NodesToObjects(
 			node("node0", true),

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -56,6 +56,7 @@ func (t *topologyHinter) LowestTSCFrequencyOnCluster() (int64, error) {
 	}
 	nodes := FilterNodesFromCache(t.nodeStore.List(),
 		HasInvTSCFrequency,
+		IsSchedulable,
 	)
 	freq := LowestTSCFrequency(nodes)
 	return freq, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, when virt-handler tries to find the lowest TSC frequency on the cluster, all nodes are being considered even if they're unschedulable. This makes no sense, and we shouldn't consider those when finding the lowest TSC frequency, or else some VMs on some environments would be stuck at "scheduling" forever.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
