### PR TITLE
Stop considering nodes without `kubevirt.io/schedulable` label when finding lowest TSC frequency on the cluster

### DIFF
--- a/pkg/virt-controller/watch/topology/filter.go
+++ b/pkg/virt-controller/watch/topology/filter.go
@@ -3,6 +3,8 @@ package topology
 import (
 	"math"
 
+	"k8s.io/client-go/tools/cache"
+
 	v1 "k8s.io/api/core/v1"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -75,6 +77,17 @@ func Not(f FilterPredicateFunc) FilterPredicateFunc {
 	}
 }
 
+func Or(predicates ...FilterPredicateFunc) FilterPredicateFunc {
+	return func(node *v1.Node) bool {
+		for _, p := range predicates {
+			if p(node) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 func FilterNodesFromCache(objs []interface{}, predicates ...FilterPredicateFunc) []*v1.Node {
 	match := []*v1.Node{}
 	for _, obj := range objs {
@@ -91,6 +104,22 @@ func FilterNodesFromCache(objs []interface{}, predicates ...FilterPredicateFunc)
 		}
 	}
 	return match
+}
+
+func IsNodeRunningVmis(vmiStore cache.Store) FilterPredicateFunc {
+	return func(node *v1.Node) bool {
+		if node == nil {
+			return false
+		}
+
+		for _, vmi := range vmiStore.List() {
+			vmi := vmi.(*virtv1.VirtualMachineInstance)
+			if vmi.Status.NodeName == node.Name {
+				return true
+			}
+		}
+		return false
+	}
 }
 
 // ToleranceForFrequency returns TSCTolerancePPM parts per million of freq, rounded down to the nearest Hz

--- a/pkg/virt-controller/watch/topology/filter.go
+++ b/pkg/virt-controller/watch/topology/filter.go
@@ -21,19 +21,7 @@ func IsSchedulable(node *v1.Node) bool {
 		return false
 	}
 
-	if node.Labels[virtv1.NodeSchedulable] != "true" || node.Spec.Unschedulable {
-		return false
-	}
-
-	if node.Spec.Taints != nil {
-		for _, taint := range node.Spec.Taints {
-			if taint.Effect == v1.TaintEffectNoSchedule {
-				return false
-			}
-		}
-	}
-
-	return true
+	return node.Labels[virtv1.NodeSchedulable] == "true"
 }
 
 func HasInvTSCFrequency(node *v1.Node) bool {

--- a/pkg/virt-controller/watch/topology/filter_test.go
+++ b/pkg/virt-controller/watch/topology/filter_test.go
@@ -30,40 +30,6 @@ var _ = Describe("Filter", func() {
 		))
 	})
 
-	It("should filter out nodes with a noschedule taint", func() {
-		nodeWithUnschedulableTaint := node("node0", true)
-		nodeWithUnschedulableTaint.Spec.Taints = []v1.Taint{{Key: "noschedule", Effect: v1.TaintEffectNoSchedule}}
-
-		nodes := topology.NodesToObjects(
-			nodeWithUnschedulableTaint,
-			node("node1", false),
-			node("node2", true),
-			nil,
-		)
-		Expect(topology.FilterNodesFromCache(nodes,
-			topology.IsSchedulable,
-		)).To(ConsistOf(
-			nodes[2],
-		))
-	})
-
-	It("should filter out nodes with spec.unschedulable == true", func() {
-		nodeWithUnschedulableField := node("node0", true)
-		nodeWithUnschedulableField.Spec.Unschedulable = true
-
-		nodes := topology.NodesToObjects(
-			nodeWithUnschedulableField,
-			node("node1", false),
-			node("node2", true),
-			nil,
-		)
-		Expect(topology.FilterNodesFromCache(nodes,
-			topology.IsSchedulable,
-		)).To(ConsistOf(
-			nodes[2],
-		))
-	})
-
 	It("should inverse the search result", func() {
 		nodes := topology.NodesToObjects(
 			node("node0", true),

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -56,6 +56,7 @@ func (t *topologyHinter) LowestTSCFrequencyOnCluster() (int64, error) {
 	}
 	nodes := FilterNodesFromCache(t.nodeStore.List(),
 		HasInvTSCFrequency,
+		IsSchedulable,
 	)
 	freq := LowestTSCFrequency(nodes)
 	return freq, nil

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -56,7 +56,6 @@ func (t *topologyHinter) LowestTSCFrequencyOnCluster() (int64, error) {
 	}
 	nodes := FilterNodesFromCache(t.nodeStore.List(),
 		HasInvTSCFrequency,
-		IsSchedulable,
 	)
 	freq := LowestTSCFrequency(nodes)
 	return freq, nil

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -56,7 +56,10 @@ func (t *topologyHinter) LowestTSCFrequencyOnCluster() (int64, error) {
 	}
 	nodes := FilterNodesFromCache(t.nodeStore.List(),
 		HasInvTSCFrequency,
-		IsSchedulable,
+		Or(
+			IsSchedulable,
+			IsNodeRunningVmis(t.vmiStore),
+		),
 	)
 	freq := LowestTSCFrequency(nodes)
 	return freq, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up to https://github.com/kubevirt/kubevirt/pull/10169.
It basically reverts the previous changes and instead filters nodes without `kubevirt.io/schedulable` label from the TSC discovery.

For more info:
- https://github.com/kubevirt/kubevirt/pull/10169#issuecomment-1651537898
- https://github.com/kubevirt/kubevirt/issues/10181

Fixes #10181

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop considering nodes without `kubevirt.io/schedulable` label when finding lowest TSC frequency on the cluster
```
