### PR TITLE
when export vm, pvc status not update

### DIFF
--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -430,7 +430,7 @@ var _ = Describe("PVC source", func() {
 
 		retry, err := controller.updateVMExport(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(retry).To(BeEquivalentTo(0))
+		Expect(retry).To(BeEquivalentTo(requeueTime))
 		testutils.ExpectEvent(recorder, serviceCreatedEvent)
 	})
 
@@ -476,7 +476,7 @@ var _ = Describe("PVC source", func() {
 
 		retry, err := controller.updateVMExport(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(retry).To(BeEquivalentTo(requeueTime))
+		Expect(retry).To(BeEquivalentTo(requeueTime * 2))
 		testutils.ExpectEvent(recorder, serviceCreatedEvent)
 	})
 
@@ -507,7 +507,7 @@ var _ = Describe("PVC source", func() {
 		})
 		retry, err := controller.updateVMExport(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(retry).To(BeEquivalentTo(0))
+		Expect(retry).To(BeEquivalentTo(requeueTime))
 		testutils.ExpectEvent(recorder, serviceCreatedEvent)
 		testutils.ExpectEvent(recorder, ExportPaused)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fix export error. when export vm, It just update export pod status condition, The PVC status is not updated

When i use ``` virtctl vmexport create vm1-export --vm=vm1 ```, It create a VirtualMachineExport CR, and it Status.Conditions of PVCReady always with status false and reason unknown as the picture below. After check the logs and source code, I find PVC status is not updated when source is vm.

<img width="617" alt="image" src="https://github.com/kubevirt/kubevirt/assets/101091030/46fe9011-2a74-4249-a11f-3b0c5c6dd6f8">

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
