### PR TITLE
Fix pr leftover mount

### DIFF
--- a/cmd/virt-chroot/BUILD.bazel
+++ b/cmd/virt-chroot/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
+        "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -129,8 +129,6 @@ const (
 
 	// Default network-status downward API file path
 	defaultNetworkStatusFilePath = "/etc/podinfo/network-status"
-
-	unprivilegedContainerSELinuxLabel = "system_u:object_r:container_file_t:s0"
 )
 
 type virtHandlerApp struct {
@@ -420,7 +418,7 @@ func (app *virtHandlerApp) Run() {
 		if err != nil {
 			panic(err)
 		}
-		err = selinux.RelabelFiles(unprivilegedContainerSELinuxLabel, se.IsPermissive(), devTun, devNull)
+		err = selinux.RelabelFiles(util.UnprivilegedContainerSELinuxLabel, se.IsPermissive(), devTun, devNull)
 		if err != nil {
 			panic(fmt.Errorf("error relabeling required files: %v", err))
 		}
@@ -564,18 +562,7 @@ func (app *virtHandlerApp) shouldEnablePersistentReservation() {
 	if err != nil {
 		panic(err)
 	}
-	se, exists, err := selinux.NewSELinux()
-	if err == nil && exists {
-		err = selinux.RelabelFiles(unprivilegedContainerSELinuxLabel, se.IsPermissive(), prSockDir)
-		if err != nil {
-			panic(fmt.Errorf("error relabeling required files: %v", err))
-		}
-	} else if err != nil {
-		panic(fmt.Errorf("failed to detect the presence of selinux: %v", err))
-	}
-
 	log.DefaultLogger().Infof("set permission for %s", reservation.GetPrHelperHostSocketDir())
-
 }
 
 func (app *virtHandlerApp) runPrometheusServer(errCh chan error) {

--- a/pkg/storage/reservation/pr.go
+++ b/pkg/storage/reservation/pr.go
@@ -1,7 +1,6 @@
 package reservation
 
 import (
-	"fmt"
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -20,15 +19,15 @@ func GetPrResourceName() string {
 }
 
 func GetPrHelperSocketDir() string {
-	return fmt.Sprintf(filepath.Join(sourceDaemonsPath, prHelperDir))
+	return filepath.Join(sourceDaemonsPath, prHelperDir)
 }
 
 func GetPrHelperHostSocketDir() string {
-	return fmt.Sprintf(filepath.Join(hostSourceDaemonsPath, prHelperDir))
+	return filepath.Join(hostSourceDaemonsPath, prHelperDir)
 }
 
 func GetPrHelperSocketPath() string {
-	return fmt.Sprintf(filepath.Join(GetPrHelperSocketDir(), prHelperSocket))
+	return filepath.Join(GetPrHelperSocketDir(), prHelperSocket)
 }
 
 func GetPrHelperSocket() string {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,15 +27,17 @@ const (
 	HostRootMount                             = "/proc/1/root/"
 	CPUManagerOS3Path                         = HostRootMount + "var/lib/origin/openshift.local.volumes/cpu_manager_state"
 	CPUManagerPath                            = HostRootMount + "var/lib/kubelet/cpu_manager_state"
+
+	// Alphanums is the list of alphanumeric characters used to create a securely generated random string
+	Alphanums = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+	NonRootUID         = 107
+	NonRootUserString  = "qemu"
+	RootUser           = 0
+	memoryDumpOverhead = 100 * 1024 * 1024
+
+	UnprivilegedContainerSELinuxLabel = "system_u:object_r:container_file_t:s0"
 )
-
-// Alphanums is the list of alphanumeric characters used to create a securely generated random string
-const Alphanums = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-
-const NonRootUID = 107
-const NonRootUserString = "qemu"
-const RootUser = 0
-const memoryDumpOverhead = 100 * 1024 * 1024
 
 func IsNonRootVMI(vmi *v1.VirtualMachineInstance) bool {
 	_, ok := vmi.Annotations[v1.DeprecatedNonRootVMIAnnotation]

--- a/pkg/virt-operator/resource/generate/components/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/storage/reservation:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -13,6 +13,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
+	"kubevirt.io/kubevirt/pkg/util"
 	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
 
@@ -41,6 +42,7 @@ func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:  pointer.Int64(util.NonRootUID),
 			Privileged: pointer.Bool(true),
 		},
 	}

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -276,9 +276,6 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 		{"kubelet-pods", kubeletPodsPath, kubeletPodsPath, &bidi},
 		{"node-labeller", "/var/lib/kubevirt-node-labeller", "/var/lib/kubevirt-node-labeller", nil},
 	}
-	if enablePrHelper {
-		volumes = append(volumes, volume{prVolumeName, reservation.GetPrHelperSocketDir(), reservation.GetPrHelperSocketDir(), &bidi})
-	}
 
 	for _, volume := range volumes {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
@@ -328,6 +325,16 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 	}
 
 	if enablePrHelper {
+		directoryOrCreate := corev1.HostPathDirectoryOrCreate
+		pod.Volumes = append(pod.Volumes, corev1.Volume{
+			Name: prVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: reservation.GetPrHelperSocketDir(),
+					Type: &directoryOrCreate,
+				},
+			},
+		})
 		pod.Containers = append(pod.Containers, RenderPrHelperContainer(prHelperImage, pullPolicy))
 	}
 	return daemonset, nil

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -17,12 +17,14 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/storage/reservation"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -307,6 +309,16 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 				}
 				return len(ds.Spec.Template.Spec.Containers) == 1
 			}, time.Minute*5, time.Second*2).Should(BeTrue())
+
+			nodes := libnode.GetAllSchedulableNodes(virtClient)
+			for _, node := range nodes.Items {
+				output, err := tests.ExecuteCommandInVirtHandlerPod(node.Name, []string{"mount"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output).ToNot(ContainSubstring("kubevirt/daemons/pr"))
+				output, err = tests.ExecuteCommandInVirtHandlerPod(node.Name, []string{"ls", reservation.GetPrHelperSocketDir()})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output).To(BeEmpty())
+			}
 		})
 	})
 

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -211,6 +211,10 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 			pv, pvc, err = tests.CreatePVandPVCwithSCSIDisk(node, device, util.NamespaceTestDefault, "scsi-disks", "scsipv", "scsipvc")
 			Expect(err).ToNot(HaveOccurred())
 			waitForVirtHandlerWithPrHelperReadyOnNode(node)
+			// Switching the PersistentReservation feature gate on/off
+			// causes redeployment of all KubeVirt components.
+			By("Ensuring all KubeVirt components are ready")
+			testsuite.EnsureKubevirtReady()
 		})
 
 		AfterEach(func() {
@@ -309,6 +313,11 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 				}
 				return len(ds.Spec.Template.Spec.Containers) == 1
 			}, time.Minute*5, time.Second*2).Should(BeTrue())
+
+			// Switching the PersistentReservation feature gate on/off
+			// causes redeployment of all KubeVirt components.
+			By("Ensuring all KubeVirt components are ready")
+			testsuite.EnsureKubevirtReady()
 
 			nodes := libnode.GetAllSchedulableNodes(virtClient)
 			for _, node := range nodes.Items {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR fixes the issues outlined in https://github.com/kubevirt/kubevirt/issues/10172:

- The `pr-helper` container does not terminate properly and reports `Permission denied` error. This happens because the default user for the container is `1001` while the directory where it stores the socket is owned by `107:107 (qemu:qemu)`. Thus, the socket unlink fails.
- Leftover tmpfs mount point on the node. This is likely due to a redundant volume mount of the `pr-helper-socket-vol` in the `virt-handler` container.

Additionally, the PR extends the e2e testing by checking that the resources have been properly cleaned up and also ensures that KubeVirt CR is in ready state before running the actual tests (toggling `PersistentReservation` feature gates triggers redeployment of all the components virt-handler, virt-api, virt-controller, etc. hence it is not enough to wait only for virt-handler).

UPD: added a fix for the race condition mentioned here: https://github.com/kubevirt/kubevirt/pull/10186#issuecomment-1658170870

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10172

**Special notes for your reviewer**:

Please refer to the commit messages for details (each commit is atomic).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
