### PR TITLE
bazel: Move to rules_pkg extracted version of pkg_tar

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -126,7 +126,7 @@ cc_library(
 )
 
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 passwd_entry(
     name = "nonroot-user",

--- a/cmd/libguestfs/BUILD.bazel
+++ b/cmd/libguestfs/BUILD.bazel
@@ -2,7 +2,7 @@ load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
 )
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "entrypoint",

--- a/cmd/pr-helper/BUILD.bazel
+++ b/cmd/pr-helper/BUILD.bazel
@@ -2,7 +2,7 @@ load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
 )
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "multipath",

--- a/cmd/virt-exportserver/BUILD.bazel
+++ b/cmd/virt-exportserver/BUILD.bazel
@@ -27,7 +27,7 @@ load(
     "container_image",
 )
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 passwd_entry(
     name = "nonroot-user",

--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -72,7 +72,7 @@ load(
 )
 load("@io_bazel_rules_docker//contrib:group.bzl", "group_entry", "group_file")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 passwd_entry(
     name = "root-user",

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "alpine-image-tar",

--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:group.bzl", "group_entry", "group_file")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 container_image(
     name = "kubevirt-testing-base",

--- a/images/disks-images-provider/BUILD.bazel
+++ b/images/disks-images-provider/BUILD.bazel
@@ -2,7 +2,7 @@ load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
 )
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 genrule(
     name = "alpine-img",


### PR DESCRIPTION
**What this PR does / why we need it**:
These rules have been extracted from the Bazel sources and are now available at bazelbuild/rules_pkg.

See the following issue for more details:

https://github.com/bazelbuild/bazel/issues/8857

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
