### PR TITLE
[e2e] Decorate hotplug tests with VMLiveUpdateFeaturesGate decorator.

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -42,4 +42,5 @@ var (
 	InPlaceHotplugNICs          = []interface{}{Label("in-place-hotplug-NICs")}
 	MigrationBasedHotplugNICs   = []interface{}{Label("migration-based-hotplug-NICs")}
 	RequiresTwoSchedulableNodes = []interface{}{Label("requires-two-schedulable-nodes")}
+	VMLiveUpdateFeaturesGate    = []interface{}{Label("VMLiveUpdateFeaturesGate")}
 )

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -36,7 +36,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
-var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, Serial, func() {
+var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateFeaturesGate, Serial, func() {
 	var (
 		virtClient  kubecli.KubevirtClient
 		workerLabel = "node-role.kubernetes.io/worker"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
CPUHotplug requires `VMLiveUpdateFeatures` fg.
Decorate the related tests with a proper decorator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
