### PR TITLE
[release-0.58] Bugfix: target virt-launcher pod hangs when migration is cancelled

### DIFF
--- a/pkg/virt-launcher/BUILD.bazel
+++ b/pkg/virt-launcher/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/virt-launcher/virtwrap/cmd-server:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -28,6 +28,8 @@ import (
 	"syscall"
 	"time"
 
+	cmdserver "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cmd-server"
+
 	"kubevirt.io/client-go/log"
 
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
@@ -109,6 +111,10 @@ func (mon *monitor) isGracePeriodExpired() bool {
 func (mon *monitor) refresh() {
 	if mon.isDone {
 		log.Log.Error("Called refresh after done!")
+		return
+	} else if cmdserver.ReceivedEarlyExitSignal() {
+		log.Log.Infof("received early exit signal - stop waiting for %s", mon.domainName)
+		mon.isDone = true
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/10099.

The automated cherry-pick failed because of a function moved to `libwait` which didn't exist in this branch.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: target virt-launcher pod hangs when migration is cancelled.
```
