### PR TITLE
Add Component and PartOf labels to virt-launcher pods

### DIFF
--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Export controller", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			caCertManager:               bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/pvc-source_test.go
+++ b/pkg/storage/export/export/pvc-source_test.go
@@ -151,7 +151,7 @@ var _ = Describe("PVC source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			caCertManager:               bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -149,7 +149,7 @@ var _ = Describe("PVC source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			caCertManager:               bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -153,7 +153,7 @@ var _ = Describe("VMSnapshot source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			caCertManager:               bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -120,6 +120,8 @@ var _ = Describe("Template", func() {
 				config,
 				qemuGid,
 				"kubevirt/vmexport",
+				"test-name",
+				"test-component",
 			)
 			// Set up mock clients
 			networkClient := fakenetworkclient.NewSimpleClientset()
@@ -403,6 +405,8 @@ var _ = Describe("Template", func() {
 					v1.AppLabel:                "virt-launcher",
 					v1.CreatedByLabel:          "1234",
 					v1.VirtualMachineNameLabel: "testvmi",
+					v1.AppPartOfLabel:          "test-name",
+					v1.AppComponentLabel:       "test-component",
 				}))
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
 					v1.DomainAnnotation:                       "testvmi",
@@ -1228,6 +1232,8 @@ var _ = Describe("Template", func() {
 					v1.AppLabel:                "virt-launcher",
 					v1.CreatedByLabel:          "1234",
 					v1.VirtualMachineNameLabel: "testvmi",
+					v1.AppPartOfLabel:          "test-name",
+					v1.AppComponentLabel:       "test-component",
 				}))
 				Expect(pod.ObjectMeta.GenerateName).To(Equal("virt-launcher-testvmi-"))
 				Expect(pod.Spec.NodeSelector).To(Equal(map[string]string{
@@ -1895,6 +1901,8 @@ var _ = Describe("Template", func() {
 						v1.AppLabel:                "virt-launcher",
 						v1.CreatedByLabel:          "1234",
 						v1.VirtualMachineNameLabel: "testvmi",
+						v1.AppPartOfLabel:          "test-name",
+						v1.AppComponentLabel:       "test-component",
 					},
 				))
 			})

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -21,14 +21,11 @@ package watch
 
 import (
 	"context"
-	"fmt"
 	golog "log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
-
-	v1 "kubevirt.io/api/core/v1"
 
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 
@@ -256,6 +253,8 @@ type VirtControllerApp struct {
 	restoreControllerThreads          int
 	snapshotControllerResyncPeriod    time.Duration
 	cloneControllerThreads            int
+	productName                       string
+	productComponent                  string
 
 	caConfigMapName          string
 	promCertFilePath         string
@@ -594,8 +593,6 @@ func (vca *VirtControllerApp) initCommon() {
 		log.Log.Warningf("failed to create ephemeral disk dir: %v", err)
 	}
 
-	productName, productComponent := vca.getProductNameAndComponent()
-
 	vca.templateService = services.NewTemplateService(vca.launcherImage,
 		vca.launcherQemuTimeout,
 		vca.virtShareDir,
@@ -609,8 +606,8 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.clusterConfig,
 		vca.launcherSubGid,
 		vca.exporterImage,
-		productName,
-		productComponent,
+		vca.productName,
+		vca.productComponent,
 	)
 
 	topologyHinter := topology.NewTopologyHinter(vca.nodeInformer.GetStore(), vca.vmiInformer.GetStore(), vca.clusterConfig)
@@ -961,6 +958,12 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.IntVar(&vca.cloneControllerThreads, "clone-controller-threads", defaultControllerThreads,
 		"Number of goroutines to run for clone controller")
+
+	flag.StringVar(&vca.productName, "product-name", "",
+		"Designate the apps.kubevirt.io/part-of label for KubeVirt components. Useful if KubeVirt is included as part of a product.")
+
+	flag.StringVar(&vca.productComponent, "product-component", "",
+		"Designate the apps.kubevirt.io/component label for KubeVirt components. Useful if KubeVirt is included as part of a product.")
 }
 
 func (vca *VirtControllerApp) setupLeaderElector() (err error) {
@@ -1008,28 +1011,4 @@ func (vca *VirtControllerApp) setupLeaderElector() (err error) {
 		})
 
 	return
-}
-
-func (vca *VirtControllerApp) getProductNameAndComponent() (string, string) {
-	productName := ""
-	productComponent := ""
-
-	stop := context.Background().Done()
-	vca.informerFactory.Start(stop)
-	cache.WaitForCacheSync(stop, vca.kvPodInformer.HasSynced)
-
-	key := fmt.Sprintf("%s/%s", vca.kubevirtNamespace, vca.host)
-	item, exists, err := vca.kvPodInformer.GetStore().GetByKey(key)
-	if err != nil {
-		log.Log.Warningf("failed to get pod %s from informer store: %v", key, err)
-	}
-	if exists {
-		pod := item.(*k8sv1.Pod)
-		productName = pod.Labels[v1.AppPartOfLabel]
-		productComponent = pod.Labels[v1.AppComponentLabel]
-	} else {
-		log.Log.Warningf("pod %s does not exist in informer store", key)
-	}
-
-	return productName, productComponent
 }

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Application", func() {
 		app.evacuationController, _ = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
 		app.disruptionBudgetController, _ = disruptionbudget.NewDisruptionBudgetController(vmiInformer, pdbInformer, podInformer, migrationInformer, recorder, virtClient, config)
 		app.nodeController, _ = NewNodeController(virtClient, nodeInformer, vmiInformer, recorder)
-		app.vmiController, _ = NewVMIController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+		app.vmiController, _ = NewVMIController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			vmiInformer,
 			vmInformer,
 			podInformer,
@@ -153,7 +153,7 @@ var _ = Describe("Application", func() {
 			recorder,
 			virtClient,
 			config)
-		app.migrationController, _ = NewMigrationController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+		app.migrationController, _ = NewMigrationController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			vmiInformer,
 			podInformer,
 			migrationInformer,
@@ -196,7 +196,7 @@ var _ = Describe("Application", func() {
 		_ = app.restoreController.Init()
 		app.exportController = &export.VMExportController{
 			Client:                      virtClient,
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			VMExportInformer:            vmExportInformer,
 			PVCInformer:                 pvcInformer,
 			PodInformer:                 podInformer,

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -293,7 +293,7 @@ var _ = Describe("Migration watcher", func() {
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kvConfig)
 
 		controller, _ = NewMigrationController(
-			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			vmiInformer,
 			podInformer,
 			migrationInformer,

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -264,7 +264,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		cdiInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		cdiConfigInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		controller, _ = NewVMIController(
-			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", "", ""),
 			vmiInformer,
 			vmInformer,
 			podInformer,

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -427,6 +427,13 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 		verbosity,
 	}
 
+	if productName != "" {
+		container.Args = append(container.Args, "--product-name", productName)
+	}
+	if productComponent != "" {
+		container.Args = append(container.Args, "--product-component", productComponent)
+	}
+
 	container.Ports = []corev1.ContainerPort{
 		{
 			Name:          "metrics",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Pod ingestion mechanisms such as Loki show `virt-launcher` logs as application logs. All "infrastructure" logs, like for` virt-handler`, `virt-controller`, etc. include the labels `app.kubevirt.io/part-of` and `app.kubevirt.io/component`.

This PR adds this labels to new `virt-launcher` pods

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Component and PartOf labels to virt-launcher pods
```
