### PR TITLE
[release-1.0] hotplug interface: Fixing VM with default interface bug

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -387,7 +387,7 @@ func AttachmentPods(ownerPod *k8sv1.Pod, podInformer cache.SharedIndexInformer) 
 	return attachmentPods, nil
 }
 
-func ApplyNetworkInterfaceRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request *v1.VirtualMachineInterfaceRequest) *v1.VirtualMachineInstanceSpec {
+func ApplyNetworkInterfaceRequestOnVMTemplateSpec(vmiSpec *v1.VirtualMachineInstanceSpec, request *v1.VirtualMachineInterfaceRequest) *v1.VirtualMachineInstanceSpec {
 	switch {
 	case request.AddInterfaceOptions != nil:
 		vmiSpec = ApplyNetworkInterfaceAddRequest(vmiSpec, request.AddInterfaceOptions)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2629,7 +2629,10 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 			vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces = ifaces
 			vmCopy.Spec.Template.Spec.Networks = networks
 
-			handleDynamicInterfaceRequests(vmCopy)
+			err := handleDynamicInterfaceRequests(vmCopy, vmi, c.clusterConfig)
+			if err != nil {
+				syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling interface hotplug requests: %v", err), HotPlugNetworkInterfaceErrorReason}
+			}
 		}
 
 		err = c.handleVolumeRequests(vmCopy, vmi)


### PR DESCRIPTION
This commit fixes the bug be explicitly adding the default interface to the VM on hotplug.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If a VM has no interfaces a default one may be automativally added to the VMI.
A VM with no interfaces (that has a default interface added to its VMI) ends up with only one interface after a hotplug although the VMI has two. Therefore, after the VM is restarted, the default interface disappear.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
hotplug API was changed on the main branch. 
The user is directly updating the VM spec template to hotplug. So the bug that this PR is fixing is not relevant there.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
hotplug interface bug fix- default interface won't disappear from a hotplugged VM after restart
```
