### PR TITLE
network: Cleaning up `vmispec`

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -90,7 +90,7 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 		return nil
 	}
 
-	multusStatusNetworksByName := netvmispec.IndexInterfacesFromStatus(
+	multusStatusNetworksByName := netvmispec.IndexInterfaceStatusByName(
 		vmi.Status.Interfaces,
 		func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
 			return netvmispec.ContainsInfoSource(ifaceStatus.InfoSource, netvmispec.InfoSourceMultusStatus)

--- a/pkg/network/vmispec/hotplug.go
+++ b/pkg/network/vmispec/hotplug.go
@@ -25,22 +25,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-func NetworksToHotplug(networks []v1.Network, interfaceStatus []v1.VirtualMachineInstanceNetworkInterface) []v1.Network {
-	var networksToHotplug []v1.Network
-	indexedIfacesFromStatus := IndexInterfaceStatusByName(
-		interfaceStatus,
-		func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
-			return true
-		},
-	)
-	for _, iface := range networks {
-		if _, wasFound := indexedIfacesFromStatus[iface.Name]; !wasFound {
-			networksToHotplug = append(networksToHotplug, iface)
-		}
-	}
-	return networksToHotplug
-}
-
 func NetworksToHotplugWhosePodIfacesAreReady(vmi *v1.VirtualMachineInstance) []v1.Network {
 	var networksToHotplug []v1.Network
 	interfacesToHoplug := IndexInterfaceStatusByName(

--- a/pkg/network/vmispec/hotplug.go
+++ b/pkg/network/vmispec/hotplug.go
@@ -27,7 +27,7 @@ import (
 
 func NetworksToHotplug(networks []v1.Network, interfaceStatus []v1.VirtualMachineInstanceNetworkInterface) []v1.Network {
 	var networksToHotplug []v1.Network
-	indexedIfacesFromStatus := IndexInterfacesFromStatus(
+	indexedIfacesFromStatus := IndexInterfaceStatusByName(
 		interfaceStatus,
 		func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
 			return true
@@ -41,19 +41,9 @@ func NetworksToHotplug(networks []v1.Network, interfaceStatus []v1.VirtualMachin
 	return networksToHotplug
 }
 
-func IndexInterfacesFromStatus(interfaces []v1.VirtualMachineInstanceNetworkInterface, p func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool) map[string]v1.VirtualMachineInstanceNetworkInterface {
-	indexedInterfaceStatus := map[string]v1.VirtualMachineInstanceNetworkInterface{}
-	for _, iface := range interfaces {
-		if p == nil || p(iface) {
-			indexedInterfaceStatus[iface.Name] = iface
-		}
-	}
-	return indexedInterfaceStatus
-}
-
 func NetworksToHotplugWhosePodIfacesAreReady(vmi *v1.VirtualMachineInstance) []v1.Network {
 	var networksToHotplug []v1.Network
-	interfacesToHoplug := IndexInterfacesFromStatus(
+	interfacesToHoplug := IndexInterfaceStatusByName(
 		vmi.Status.Interfaces,
 		func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
 			return strings.Contains(ifaceStatus.InfoSource, InfoSourceMultusStatus) &&

--- a/pkg/network/vmispec/hotplug_test.go
+++ b/pkg/network/vmispec/hotplug_test.go
@@ -40,49 +40,6 @@ var _ = Describe("utilitary funcs to identify attachments to hotplug", func() {
 		networkName    = "n1"
 	)
 
-	DescribeTable("NetworksToHotplug", func(vmi *v1.VirtualMachineInstance, networksToHotplug ...v1.Network) {
-		Expect(vmispec.NetworksToHotplug(vmi.Spec.Networks, vmi.Status.Interfaces)).To(ConsistOf(networksToHotplug))
-	},
-		Entry("with no networks in spec and status, there is nothing to hotplug", newVMI()),
-		Entry("with a network in spec that is missing from the status, hotplug it",
-			dummyVMIWithoutStatus(networkName, nadName),
-			v1.Network{
-				Name: networkName,
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{
-						NetworkName: nadName,
-					},
-				},
-			},
-		),
-		Entry(
-			"with a network in spec and status, there is nothing to hotplug",
-			dummyVMIWithOneNetworkAndOneIfaceOnSpecAndStatus(networkName, nadName),
-		),
-		Entry("with a network in status that is missing from spec, there is nothing to hotplug",
-			dummyVMIWithStatusOnly(networkName, "eno123"),
-		),
-		Entry(
-			"when multiple networks available in spec are missing from status, they are hot-plugged",
-			dummyVMIWithMultipleNetworksAndIfacesOnSpec(networkName, nadName),
-			v1.Network{
-				Name: networkName,
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{
-						NetworkName: nadName,
-					},
-				},
-			},
-			v1.Network{
-				Name: extraNetworkName,
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{
-						NetworkName: extraNetworkAttachmentName,
-					}},
-			},
-		),
-	)
-
 	DescribeTable("NetworksToHotplugWhosePodIfacesAreReady", func(vmi *v1.VirtualMachineInstance, networksToHotplug ...v1.Network) {
 		Expect(vmispec.NetworksToHotplugWhosePodIfacesAreReady(vmi)).To(ConsistOf(networksToHotplug))
 	},

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -110,16 +110,6 @@ func IndexInterfaceSpecByName(interfaces []v1.Interface) map[string]v1.Interface
 	return ifacesByName
 }
 
-func IndexInterfaceSpecByMac(interfaces []v1.Interface) map[string]v1.Interface {
-	ifacesByMac := map[string]v1.Interface{}
-	for _, ifaceSpec := range interfaces {
-		if mac := ifaceSpec.MacAddress; mac != "" {
-			ifacesByMac[mac] = ifaceSpec
-		}
-	}
-	return ifacesByMac
-}
-
 func LookupInterfaceByName(ifaces []v1.Interface, name string) *v1.Interface {
 	for idx := range ifaces {
 		if ifaces[idx].Name == name {

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -118,3 +118,13 @@ func LookupInterfaceByName(ifaces []v1.Interface, name string) *v1.Interface {
 	}
 	return nil
 }
+
+func IndexInterfaceStatusByName(interfaces []v1.VirtualMachineInstanceNetworkInterface, p func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool) map[string]v1.VirtualMachineInstanceNetworkInterface {
+	indexedInterfaceStatus := map[string]v1.VirtualMachineInstanceNetworkInterface{}
+	for _, iface := range interfaces {
+		if p == nil || p(iface) {
+			indexedInterfaceStatus[iface.Name] = iface
+		}
+	}
+	return indexedInterfaceStatus
+}

--- a/pkg/virt-controller/watch/network.go
+++ b/pkg/virt-controller/watch/network.go
@@ -39,7 +39,11 @@ func calculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi *v1.VirtualMach
 
 	networksToAnnotate := vmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, ifacesToAnnotate)
 
-	ifacesToHotplugExist := len(vmispec.NetworksToHotplug(networksToAnnotate, vmi.Status.Interfaces)) > 0
+	ifacesToHotplug := vmispec.FilterInterfacesSpec(ifacesToAnnotate, func(iface v1.Interface) bool {
+		_, inStatus := ifacesStatusByName[iface.Name]
+		return !inStatus
+	})
+	ifacesToHotplugExist := len(ifacesToHotplug) > 0
 
 	isIfaceChangeRequired := ifacesToHotplugExist || ifacesToHotUnplugExist
 	if !isIfaceChangeRequired {

--- a/pkg/virt-controller/watch/network.go
+++ b/pkg/virt-controller/watch/network.go
@@ -30,7 +30,7 @@ func calculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi *v1.VirtualMach
 	})
 	ifacesToHotUnplugExist := len(vmi.Spec.Domain.Devices.Interfaces) > len(vmiNonAbsentSpecIfaces)
 
-	ifacesStatusByName := vmispec.IndexInterfacesFromStatus(vmi.Status.Interfaces, nil)
+	ifacesStatusByName := vmispec.IndexInterfaceStatusByName(vmi.Status.Interfaces, nil)
 	ifacesToAnnotate := vmispec.FilterInterfacesSpec(vmiNonAbsentSpecIfaces, func(iface v1.Interface) bool {
 		_, ifaceInStatus := ifacesStatusByName[iface.Name]
 		sriovIfaceNotPlugged := iface.SRIOV != nil && !ifaceInStatus

--- a/pkg/virt-controller/watch/network_test.go
+++ b/pkg/virt-controller/watch/network_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Network interface hot{un}plug", func() {
 			for _, iface := range specIfaces {
 				testNetworks = append(testNetworks, v1.Network{Name: iface.Name})
 			}
-			testStatusIfaces := vmispec.IndexInterfacesFromStatus(statusIfaces,
+			testStatusIfaces := vmispec.IndexInterfaceStatusByName(statusIfaces,
 				func(i v1.VirtualMachineInstanceNetworkInterface) bool { return true })
 
 			ifaces, networks := clearDetachedInterfaces(specIfaces, testNetworks, testStatusIfaces)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2649,7 +2649,7 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 			vmi != nil && vmi.DeletionTimestamp == nil {
 			vmiCopy := vmi.DeepCopy()
 
-			indexedStatusIfaces := vmispec.IndexInterfacesFromStatus(vmi.Status.Interfaces,
+			indexedStatusIfaces := vmispec.IndexInterfaceStatusByName(vmi.Status.Interfaces,
 				func(ifaceStatus virtv1.VirtualMachineInstanceNetworkInterface) bool { return true })
 
 			ifaces, networks := clearDetachedInterfaces(vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces, vmCopy.Spec.Template.Spec.Networks, indexedStatusIfaces)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -3051,13 +3051,13 @@ func (d *VirtualMachineController) hotplugSriovInterfaces(vmi *v1.VirtualMachine
 	sriovSpecInterfaces := netvmispec.FilterSRIOVInterfaces(vmi.Spec.Domain.Devices.Interfaces)
 
 	sriovSpecIfacesNames := netvmispec.IndexInterfaceSpecByName(sriovSpecInterfaces)
-	attachedSriovStatusIfaces := netvmispec.IndexInterfacesFromStatus(vmi.Status.Interfaces, func(iface v1.VirtualMachineInstanceNetworkInterface) bool {
+	attachedSriovStatusIfaces := netvmispec.IndexInterfaceStatusByName(vmi.Status.Interfaces, func(iface v1.VirtualMachineInstanceNetworkInterface) bool {
 		_, exist := sriovSpecIfacesNames[iface.Name]
 		return exist && netvmispec.ContainsInfoSource(iface.InfoSource, netvmispec.InfoSourceDomain) &&
 			netvmispec.ContainsInfoSource(iface.InfoSource, netvmispec.InfoSourceMultusStatus)
 	})
 
-	desiredSriovMultusPluggedIfaces := netvmispec.IndexInterfacesFromStatus(vmi.Status.Interfaces, func(iface v1.VirtualMachineInstanceNetworkInterface) bool {
+	desiredSriovMultusPluggedIfaces := netvmispec.IndexInterfaceStatusByName(vmi.Status.Interfaces, func(iface v1.VirtualMachineInstanceNetworkInterface) bool {
 		_, exist := sriovSpecIfacesNames[iface.Name]
 		return exist && netvmispec.ContainsInfoSource(iface.InfoSource, netvmispec.InfoSourceMultusStatus)
 	})

--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -143,7 +143,7 @@ func lookupDomainInterfaceByName(domainIfaces []api.Interface, networkName strin
 
 func networksToHotplugWhoseInterfacesAreNotInTheDomain(vmi *v1.VirtualMachineInstance, indexedDomainIfaces map[string]api.Interface) []v1.Network {
 	var networksToHotplug []v1.Network
-	interfacesToHoplug := netvmispec.IndexInterfacesFromStatus(
+	interfacesToHoplug := netvmispec.IndexInterfaceStatusByName(
 		vmi.Status.Interfaces,
 		func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
 			_, exists := indexedDomainIfaces[ifaceStatus.Name]


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor the `vmispec` and virt-controller dynamic interfaces calculation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
