### PR TITLE
[e2e] Fix migration bandwidth

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1976,7 +1976,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				It("[test_id:6977]should not secure migrations with TLS", func() {
 					cfg := getCurrentKv()
-					cfg.MigrationConfiguration.BandwidthPerMigration = resource.NewMilliQuantity(1, resource.BinarySI)
+					cfg.MigrationConfiguration.BandwidthPerMigration = resource.NewQuantity(1, resource.BinarySI)
 					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
 					tests.UpdateKubeVirtConfigValueAndWait(cfg)
 					vmi := tests.NewRandomFedoraVMIWithGuestAgent()
@@ -2238,7 +2238,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				var timeout int64 = 5
 				cfg.MigrationConfiguration = &v1.MigrationConfiguration{
 					CompletionTimeoutPerGiB: &timeout,
-					BandwidthPerMigration:   resource.NewMilliQuantity(1, resource.BinarySI),
 				}
 				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})
@@ -2249,7 +2248,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					cfg.MigrationConfiguration = &v1.MigrationConfiguration{
 						ProgressTimeout:         pointer.Int64(5),
 						CompletionTimeoutPerGiB: pointer.Int64(5),
-						BandwidthPerMigration:   resource.NewMilliQuantity(1, resource.BinarySI),
+						BandwidthPerMigration:   resource.NewQuantity(1, resource.BinarySI),
 					}
 					tests.UpdateKubeVirtConfigValueAndWait(cfg)
 				})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to slow a migration, we set the `BandwidthPerMigration` to a very low value.
Currently, since this value is a `Millibyte`, when converting it to byte, it results that the migration params will be `BandwidthSet:false Bandwidth:0`, which means that we are not slowing the migration. Let's use `NewQuantity` instead of `NewMilliQuantity`, so that the result will be `BandwidthSet:true Bandwidth:1`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @xpivarc 