### PR TITLE
Reduce kubevirt-ci loads by removing redundant operations 

### DIFF
--- a/automation/postsubmit-main.sh
+++ b/automation/postsubmit-main.sh
@@ -17,9 +17,6 @@ make manifests DOCKER_PREFIX="$DOCKER_PREFIX" DOCKER_TAG="$DOCKER_TAG" # skip ge
 make olm-verify
 make prom-rules-verify
 
-make manifests
-make build-functests
-
 bash hack/gen-swagger-doc/deploy.sh
 bash hack/gen-client-python/deploy.sh
 hack/publish-staging.sh


### PR DESCRIPTION
Doesn't make sense to run make manifests and make build-functests For postsubmit job that publish the api to seperated repo

/cc @rmohr 
/cc @dhiller 
/cc @enp0s3 
/cc @xpivarc 
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
