### PR TITLE
fix SetGroupVersionKind function not work in Kv、Migration、Replicaset、Vm、Vmi List interface

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -114,8 +114,8 @@ func (o *kv) List(options *k8smetav1.ListOptions) (*v1.KubeVirtList, error) {
 		Do(context.Background()).
 		Into(newKvList)
 
-	for _, vm := range newKvList.Items {
-		vm.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
+	for i := range newKvList.Items {
+		newKvList.Items[i].SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
 	}
 
 	return newKvList, err

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -107,19 +107,19 @@ func (o *migration) Delete(name string, options *k8smetav1.DeleteOptions) error 
 
 // List all VirtualMachineInstanceMigrations in given namespace
 func (o *migration) List(options *k8smetav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error) {
-	newVmList := &v1.VirtualMachineInstanceMigrationList{}
+	newVmiMigrationList := &v1.VirtualMachineInstanceMigrationList{}
 	err := o.restClient.Get().
 		Resource(o.resource).
 		Namespace(o.namespace).
 		VersionedParams(options, scheme.ParameterCodec).
 		Do(context.Background()).
-		Into(newVmList)
+		Into(newVmiMigrationList)
 
-	for _, migration := range newVmList.Items {
-		migration.SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
+	for i := range newVmiMigrationList.Items {
+		newVmiMigrationList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
 	}
 
-	return newVmList, err
+	return newVmiMigrationList, err
 }
 
 func (v *migration) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -87,8 +87,8 @@ func (v *rc) List(options k8smetav1.ListOptions) (replicasetList *v1.VirtualMach
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(context.Background()).
 		Into(replicasetList)
-	for _, replicaset := range replicasetList.Items {
-		replicaset.SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
+	for i := range replicasetList.Items {
+		replicasetList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
 	}
 
 	return

--- a/staging/src/kubevirt.io/client-go/kubecli/vm.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm.go
@@ -137,8 +137,8 @@ func (v *vm) List(ctx context.Context, options *k8smetav1.ListOptions) (*v1.Virt
 		Do(ctx).
 		Into(newVmList)
 
-	for _, vm := range newVmList.Items {
-		vm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
+	for i := range newVmList.Items {
+		newVmList.Items[i].SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
 	}
 
 	return newVmList, err

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -309,8 +309,8 @@ func (v *vmis) List(ctx context.Context, options *k8smetav1.ListOptions) (vmiLis
 		VersionedParams(options, scheme.ParameterCodec).
 		Do(ctx).
 		Into(vmiList)
-	for _, vmi := range vmiList.Items {
-		vmi.SetGroupVersionKind(v1.VirtualMachineInstanceGroupVersionKind)
+	for i := range vmiList.Items {
+		vmiList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstanceGroupVersionKind)
 	}
 
 	return

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
@@ -53,16 +53,16 @@ func (v *vmiPresets) Get(name string, options k8smetav1.GetOptions) (vmi *v1.Vir
 	return
 }
 
-func (v *vmiPresets) List(options k8smetav1.ListOptions) (vmiList *v1.VirtualMachineInstancePresetList, err error) {
-	vmiList = &v1.VirtualMachineInstancePresetList{}
+func (v *vmiPresets) List(options k8smetav1.ListOptions) (vmiPresetList *v1.VirtualMachineInstancePresetList, err error) {
+	vmiPresetList = &v1.VirtualMachineInstancePresetList{}
 	err = v.restClient.Get().
 		Resource(v.resource).
 		Namespace(v.namespace).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(context.Background()).
-		Into(vmiList)
-	for _, vmi := range vmiList.Items {
-		vmi.SetGroupVersionKind(v1.VirtualMachineInstancePresetGroupVersionKind)
+		Into(vmiPresetList)
+	for i := range vmiPresetList.Items {
+		vmiPresetList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstancePresetGroupVersionKind)
 	}
 
 	return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

when I use the vm list interface to get vmlist,  in items apiVersion is v1alpha3.   
if vm list interface, SetGroupVersionKind func used to set apiVersion to v1，but it not works because a incorrect use golang for range.

same in  Kv、Migration、Replicaset、Vmi List interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
