### PR TITLE
fix SetGroupVersionKind function not work in kv,vm,vmi etc list inter…

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -114,8 +114,8 @@ func (o *kv) List(options *k8smetav1.ListOptions) (*v1.KubeVirtList, error) {
 		Do(context.Background()).
 		Into(newKvList)
 
-	for _, vm := range newKvList.Items {
-		vm.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
+	for i := range newKvList.Items {
+		newKvList.Items[i].SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
 	}
 
 	return newKvList, err

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -31,7 +31,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-        v1 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt Client", func() {
@@ -91,12 +91,12 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewKubeVirtList(*kubevirt)),
 		))
 		fetchedKubeVirtList, err := client.KubeVirt(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
-                apiVersion, kind := v1.KubeVirtGroupVersionKind.ToAPIVersionAndKind()
+		apiVersion, kind := v1.KubeVirtGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedKubeVirtList.Items).To(HaveLen(1))
-                Expect(fetchedKubeVirtList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedKubeVirtList.Items[0].APIVersion).To(Equal(apiVersion))
 		Expect(fetchedKubeVirtList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedKubeVirtList.Items[0]).To(Equal(*kubevirt))
 	},

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -31,6 +31,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+        v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt Client", func() {
@@ -90,10 +91,13 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewKubeVirtList(*kubevirt)),
 		))
 		fetchedKubeVirtList, err := client.KubeVirt(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
+                apiVersion, kind := v1.KubeVirtGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedKubeVirtList.Items).To(HaveLen(1))
+                Expect(fetchedKubeVirtList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedKubeVirtList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedKubeVirtList.Items[0]).To(Equal(*kubevirt))
 	},
 		Entry("with regular server URL", ""),

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -107,19 +107,19 @@ func (o *migration) Delete(name string, options *k8smetav1.DeleteOptions) error 
 
 // List all VirtualMachineInstanceMigrations in given namespace
 func (o *migration) List(options *k8smetav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error) {
-	newVmList := &v1.VirtualMachineInstanceMigrationList{}
+	newVmiMigrationList := &v1.VirtualMachineInstanceMigrationList{}
 	err := o.restClient.Get().
 		Resource(o.resource).
 		Namespace(o.namespace).
 		VersionedParams(options, scheme.ParameterCodec).
 		Do(context.Background()).
-		Into(newVmList)
+		Into(newVmiMigrationList)
 
-	for _, migration := range newVmList.Items {
-		migration.SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
+	for i := range newVmiMigrationList.Items {
+		newVmiMigrationList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
 	}
 
-	return newVmList, err
+	return newVmiMigrationList, err
 }
 
 func (v *migration) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -31,7 +31,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-        v1 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt Migration Client", func() {
@@ -91,12 +91,12 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewMigrationList(*migration)),
 		))
 		fetchedMigrationList, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
-                apiVersion, kind := v1.VirtualMachineInstanceMigrationGroupVersionKind.ToAPIVersionAndKind()
+		apiVersion, kind := v1.VirtualMachineInstanceMigrationGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedMigrationList.Items).To(HaveLen(1))
-                Expect(fetchedMigrationList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedMigrationList.Items[0].APIVersion).To(Equal(apiVersion))
 		Expect(fetchedMigrationList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedMigrationList.Items[0]).To(Equal(*migration))
 	},

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -31,6 +31,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+        v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt Migration Client", func() {
@@ -90,10 +91,13 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewMigrationList(*migration)),
 		))
 		fetchedMigrationList, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
+                apiVersion, kind := v1.VirtualMachineInstanceMigrationGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedMigrationList.Items).To(HaveLen(1))
+                Expect(fetchedMigrationList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedMigrationList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedMigrationList.Items[0]).To(Equal(*migration))
 	},
 		Entry("with regular server URL", ""),

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -87,8 +87,8 @@ func (v *rc) List(options k8smetav1.ListOptions) (replicasetList *v1.VirtualMach
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(context.Background()).
 		Into(replicasetList)
-	for _, replicaset := range replicasetList.Items {
-		replicaset.SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
+	for i := range replicasetList.Items {
+		replicasetList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
 	}
 
 	return

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+        virtv1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
@@ -90,10 +91,13 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVirtualMachineInstanceReplicaSetList(*rs)),
 		))
 		fetchedVMIReplicaSetList, err := client.ReplicaSet(k8sv1.NamespaceDefault).List(k8smetav1.ListOptions{})
+                apiVersion, kind := virtv1.VirtualMachineInstanceReplicaSetGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(fetchedVMIReplicaSetList.Items).To(HaveLen(1))
+                Expect(fetchedVMIReplicaSetList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedVMIReplicaSetList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedVMIReplicaSetList.Items[0]).To(Equal(*rs))
 	},
 		Entry("with regular server URL", ""),

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-        virtv1 "kubevirt.io/api/core/v1"
+	virtv1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
@@ -91,12 +91,12 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVirtualMachineInstanceReplicaSetList(*rs)),
 		))
 		fetchedVMIReplicaSetList, err := client.ReplicaSet(k8sv1.NamespaceDefault).List(k8smetav1.ListOptions{})
-                apiVersion, kind := virtv1.VirtualMachineInstanceReplicaSetGroupVersionKind.ToAPIVersionAndKind()
+		apiVersion, kind := virtv1.VirtualMachineInstanceReplicaSetGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(fetchedVMIReplicaSetList.Items).To(HaveLen(1))
-                Expect(fetchedVMIReplicaSetList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedVMIReplicaSetList.Items[0].APIVersion).To(Equal(apiVersion))
 		Expect(fetchedVMIReplicaSetList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedVMIReplicaSetList.Items[0]).To(Equal(*rs))
 	},

--- a/staging/src/kubevirt.io/client-go/kubecli/vm.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm.go
@@ -137,8 +137,8 @@ func (v *vm) List(ctx context.Context, options *k8smetav1.ListOptions) (*v1.Virt
 		Do(ctx).
 		Into(newVmList)
 
-	for _, vm := range newVmList.Items {
-		vm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
+	for i := range newVmList.Items {
+		newVmList.Items[i].SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
 	}
 
 	return newVmList, err

--- a/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
@@ -98,10 +98,13 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVMList(*vm)),
 		))
 		fetchedVMList, err := client.VirtualMachine(k8sv1.NamespaceDefault).List(context.Background(), &k8smetav1.ListOptions{})
+                apiVersion, kind := v1.VirtualMachineGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedVMList.Items).To(HaveLen(1))
+                Expect(fetchedVMList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedVMList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedVMList.Items[0]).To(Equal(*vm))
 	},
 		Entry("with regular server URL", ""),

--- a/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
@@ -98,12 +98,12 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVMList(*vm)),
 		))
 		fetchedVMList, err := client.VirtualMachine(k8sv1.NamespaceDefault).List(context.Background(), &k8smetav1.ListOptions{})
-                apiVersion, kind := v1.VirtualMachineGroupVersionKind.ToAPIVersionAndKind()
+		apiVersion, kind := v1.VirtualMachineGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedVMList.Items).To(HaveLen(1))
-                Expect(fetchedVMList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedVMList.Items[0].APIVersion).To(Equal(apiVersion))
 		Expect(fetchedVMList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedVMList.Items[0]).To(Equal(*vm))
 	},

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -309,8 +309,8 @@ func (v *vmis) List(ctx context.Context, options *k8smetav1.ListOptions) (vmiLis
 		VersionedParams(options, scheme.ParameterCodec).
 		Do(ctx).
 		Into(vmiList)
-	for _, vmi := range vmiList.Items {
-		vmi.SetGroupVersionKind(v1.VirtualMachineInstanceGroupVersionKind)
+	for i := range vmiList.Items {
+		vmiList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstanceGroupVersionKind)
 	}
 
 	return

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
@@ -100,12 +100,12 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVMIList(*vmi)),
 		))
 		fetchedVMIList, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).List(context.Background(), &k8smetav1.ListOptions{})
-                apiVersion, kind := v1.VirtualMachineInstanceGroupVersionKind.ToAPIVersionAndKind()
+		apiVersion, kind := v1.VirtualMachineInstanceGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedVMIList.Items).To(HaveLen(1))
-                Expect(fetchedVMIList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedVMIList.Items[0].APIVersion).To(Equal(apiVersion))
 		Expect(fetchedVMIList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedVMIList.Items[0]).To(Equal(*vmi))
 	},

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
@@ -100,10 +100,13 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVMIList(*vmi)),
 		))
 		fetchedVMIList, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).List(context.Background(), &k8smetav1.ListOptions{})
+                apiVersion, kind := v1.VirtualMachineInstanceGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedVMIList.Items).To(HaveLen(1))
+                Expect(fetchedVMIList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedVMIList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedVMIList.Items[0]).To(Equal(*vmi))
 	},
 		Entry("with regular server URL", ""),

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
@@ -53,16 +53,16 @@ func (v *vmiPresets) Get(name string, options k8smetav1.GetOptions) (vmi *v1.Vir
 	return
 }
 
-func (v *vmiPresets) List(options k8smetav1.ListOptions) (vmiList *v1.VirtualMachineInstancePresetList, err error) {
-	vmiList = &v1.VirtualMachineInstancePresetList{}
+func (v *vmiPresets) List(options k8smetav1.ListOptions) (vmiPresetList *v1.VirtualMachineInstancePresetList, err error) {
+	vmiPresetList = &v1.VirtualMachineInstancePresetList{}
 	err = v.restClient.Get().
 		Resource(v.resource).
 		Namespace(v.namespace).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(context.Background()).
-		Into(vmiList)
-	for _, vmi := range vmiList.Items {
-		vmi.SetGroupVersionKind(v1.VirtualMachineInstancePresetGroupVersionKind)
+		Into(vmiPresetList)
+	for i := range vmiPresetList.Items {
+		vmiPresetList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstancePresetGroupVersionKind)
 	}
 
 	return

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-        v1 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
@@ -90,12 +90,12 @@ var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVirtualMachineInstancePresetList(*preset)),
 		))
 		fetchedVMIPresetList, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).List(k8smetav1.ListOptions{})
-                apiVersion, kind := v1.VirtualMachineInstancePresetGroupVersionKind.ToAPIVersionAndKind()
+		apiVersion, kind := v1.VirtualMachineInstancePresetGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(fetchedVMIPresetList.Items).To(HaveLen(1))
-                Expect(fetchedVMIPresetList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedVMIPresetList.Items[0].APIVersion).To(Equal(apiVersion))
 		Expect(fetchedVMIPresetList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedVMIPresetList.Items[0]).To(Equal(*preset))
 	},

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+        v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
@@ -89,10 +90,13 @@ var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVirtualMachineInstancePresetList(*preset)),
 		))
 		fetchedVMIPresetList, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).List(k8smetav1.ListOptions{})
+                apiVersion, kind := v1.VirtualMachineInstancePresetGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(fetchedVMIPresetList.Items).To(HaveLen(1))
+                Expect(fetchedVMIPresetList.Items[0].APIVersion).To(Equal(apiVersion))
+		Expect(fetchedVMIPresetList.Items[0].Kind).To(Equal(kind))
 		Expect(fetchedVMIPresetList.Items[0]).To(Equal(*preset))
 	},
 		Entry("with regular server URL", ""),


### PR DESCRIPTION
…face

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

when I use the vm list interface to get vmlist, in items apiVersion is v1alpha3.
if vm list interface, SetGroupVersionKind func used to set apiVersion to v1，but it not works because a incorrect use golang for range.

same in Kv、Migration、Replicaset、Vmi List interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
