### PR TITLE
tests: Run helper pod as qemu (107) user

### DIFF
--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -52,7 +52,7 @@ const (
 
 func RenderPodWithPVC(name string, cmd []string, args []string, pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
 	volumeName := "disk0"
-	nonRootUser := int64(1042)
+	nonRootUser := int64(107)
 
 	// Change to 'pod := RenderPod(name, cmd, args)' once we have a libpod package
 	pod := &k8sv1.Pod{
@@ -102,6 +102,10 @@ func RenderPodWithPVC(name string, cmd []string, args []string, pvc *k8sv1.Persi
 	if volumeMode != nil && *volumeMode == k8sv1.PersistentVolumeBlock {
 		pod.Spec.Containers[0].VolumeDevices = addVolumeDevices(volumeName)
 	} else {
+		if pod.Spec.SecurityContext == nil {
+			pod.Spec.SecurityContext = &k8sv1.PodSecurityContext{}
+		}
+		pod.Spec.SecurityContext.FSGroup = &nonRootUser
 		pod.Spec.Containers[0].VolumeMounts = addVolumeMounts(volumeName)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The helper pod needs permissions to access the PVC data. In most cases, it is owned by the qemu (107) user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Found during **downstream** testing of v1.0.0. Currently, some of the storage hotplug tests fail:

https://github.com/kubevirt/kubevirt/blob/90e08909ac8b67dbb9902062abef21b26a667ec3/tests/storage/hotplug.go#L1099

The tests import a containerdisk with cirros image to a Filesystem PVC using a DataVolume. Then a helper pod is started to rename the image file from `disk.img` to smth different. The renaming fails with `Permission denied`:
```
mv: cannot move '/pvc/disk.img' to '/pvc/kubevirt-disk.img': Permission denied
```
The tests pass successfully in the CI where local volume provisioner is used. However, with other storage providers the permissions on the mounted volume might be different and that will cause failure. So adjust the user and fsGroup to make the test more generic.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
