### PR TITLE
Replace/sanitize `ps` calls in isolated emulator thread tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -376,46 +376,34 @@ func GetProcessName(pod *k8sv1.Pod, pid string) (output string, err error) {
 func GetVcpuMask(pod *k8sv1.Pod, emulator, cpu string) (output string, err error) {
 	virtClient := kubevirt.Client()
 
-	pscmd := "ps -LC " + emulator + " -o lwp,comm| grep \"CPU " + cpu + "\"  | cut -f 1 -d \"C\""
-	output, err = exec.ExecuteCommandOnPod(
-		virtClient,
-		pod,
-		"compute",
-		[]string{BinBash, "-c", pscmd},
-	)
-	Expect(err).ToNot(HaveOccurred())
+	pscmd := `ps -LC ` + emulator + ` -o lwp,comm | grep "CPU ` + cpu + `"  | cut -f1 -dC`
+	args := []string{BinBash, "-c", pscmd}
+	Eventually(func() error {
+		output, err = exec.ExecuteCommandOnPod(virtClient, pod, "compute", args)
+		return err
+	}).Should(Succeed())
 	vcpupid := strings.TrimSpace(strings.Trim(output, "\n"))
-	tasksetcmd := "taskset -c -p " + vcpupid + " | cut -f 2 -d \":\""
-	args := []string{BinBash, "-c", tasksetcmd}
+	tasksetcmd := "taskset -c -p " + vcpupid + " | cut -f2 -d:"
+	args = []string{BinBash, "-c", tasksetcmd}
 	output, err = exec.ExecuteCommandOnPod(virtClient, pod, "compute", args)
 	Expect(err).ToNot(HaveOccurred())
 
-	return output, err
+	return strings.TrimSpace(output), err
 }
 
-func GetKvmPitMask(pod *k8sv1.Pod, emulator, nodeName string) (output string, err error) {
-	virtClient := kubevirt.Client()
-
-	output, err = exec.ExecuteCommandOnPod(
-		virtClient,
-		pod,
-		"compute",
-		[]string{"ps", "-C", emulator, "-o", "pid", "--noheader"},
-	)
-	Expect(err).ToNot(HaveOccurred())
-	qemupid := strings.TrimSpace(strings.Trim(output, "\n"))
+func GetKvmPitMask(qemupid, nodeName string) (output string, err error) {
 	kvmpitcomm := "kvm-pit/" + qemupid
-	args := []string{"ps", "-C", kvmpitcomm, "-o", "pid", "--noheader"}
+	args := []string{"pgrep", "-f", kvmpitcomm}
 	output, err = ExecuteCommandInVirtHandlerPod(nodeName, args)
 	Expect(err).ToNot(HaveOccurred())
 
-	kvmpitpid := strings.TrimSpace(strings.Trim(output, "\n"))
-	tasksetcmd := "taskset -c -p " + kvmpitpid + " | cut -f 2 -d \":\""
+	kvmpitpid := strings.TrimSpace(output)
+	tasksetcmd := "taskset -c -p " + kvmpitpid + " | cut -f2 -d:"
 	args = []string{BinBash, "-c", tasksetcmd}
 	output, err = ExecuteCommandInVirtHandlerPod(nodeName, args)
 	Expect(err).ToNot(HaveOccurred())
 
-	return output, err
+	return strings.TrimSpace(output), err
 }
 
 func ListCgroupThreads(pod *k8sv1.Pod) (output string, err error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The 2 tests under `test_id:4023` are flaky, one is even quarantined (quarantine removed to see if it still trips the flake finder).
They both make a bunch of calls to `ps`, which has proven unreliable in the past, although we never really pinpointed the exact issue.
This PR replaces most calls to `ps` with more reliable options, and puts the last one in an `Eventually()` loop just in case that helps...

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
