### PR TITLE
[e2e] Relax prometheus cr operator test

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2526,8 +2526,10 @@ spec:
 			monv1 := virtClient.PrometheusClient().MonitoringV1()
 			prometheusRule, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
-			expectedPromRuleSpec := components.NewPrometheusRuleSpec(flags.KubeVirtInstallNamespace)
-			Expect(prometheusRule.Spec).To(Equal(*expectedPromRuleSpec))
+			Expect(prometheusRule.Spec).ToNot(BeNil())
+			Expect(prometheusRule.Spec.Groups).ToNot(BeEmpty())
+			Expect(prometheusRule.Spec.Groups[0].Rules).ToNot(BeEmpty())
+
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Checking if the kubevirt PrometheusRule cr exists, a comparison between the posted Cr and a generated one is done. This comparison is too strict, since some vendors could use a different `RUNBOOK_URL`, causing a failure.
From an operator functionality perspective, it is enough to check that the CR exists and the group contains a set of rules.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
