### PR TITLE
virtctl: adm and logverbosity command initial commit

### DIFF
--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtctl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/virtctl/adm:go_default_library",
         "//pkg/virtctl/configuration:go_default_library",
         "//pkg/virtctl/console:go_default_library",
         "//pkg/virtctl/create:go_default_library",

--- a/pkg/virtctl/adm/BUILD.bazel
+++ b/pkg/virtctl/adm/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["adm.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/adm",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virtctl/adm/logverbosity:go_default_library",
+        "//pkg/virtctl/templates:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)

--- a/pkg/virtctl/adm/adm.go
+++ b/pkg/virtctl/adm/adm.go
@@ -1,0 +1,31 @@
+package adm
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/adm/logverbosity"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const (
+	ADM = "adm"
+)
+
+func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   ADM,
+		Short: "Administrate KubeVirt configuration.",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Printf(cmd.UsageString())
+		},
+	}
+
+	cmd.AddCommand(logverbosity.NewCommand(clientConfig))
+
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+
+	return cmd
+}

--- a/pkg/virtctl/adm/logverbosity/BUILD.bazel
+++ b/pkg/virtctl/adm/logverbosity/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["logverbosity.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/adm/logverbosity",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/virt-config:go_default_library",
+        "//pkg/virtctl/templates:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "logverbosity_suite_test.go",
+        "logverbosity_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/clientcmd:go_default_library",
+        "//vendor/github.com/evanphx/json-patch:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+    ],
+)

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -1,0 +1,422 @@
+package logverbosity
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+type Command struct {
+	clientConfig clientcmd.ClientConfig
+	command      string
+}
+
+// for command parsing
+const (
+	// Verbosity must be 0-9.
+	// https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-output-verbosity-and-debugging
+	minVerbosity = uint(0)
+	maxVerbosity = uint(9)
+	// noArg and NoFlag: Any number between 10 and MaxUint is fine.
+	// Select less weird numbers, because these numbers will be shown in the help menu.
+	// There is no option to hide the default value from the help menu.
+	// See pflag.FlagUsages, which calls the FlagUsagesWrapped function:
+	// https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L677
+	noArg         = 10    // Default value if no argument specified
+	NoFlag        = 11    // Default value if no flag is specified
+	allComponents = "all" // Use in multiple places, so make it a constant
+)
+
+// for receiving the flag argument
+var isReset bool
+
+// Log verbosity can be set per KubeVirt component.
+// https://kubevirt.io/user-guide/operations/debug/#setting-verbosity-per-kubevirt-component
+// TODO: set verbosity per nodes
+var virtComponents = map[string]*uint{
+	"virt-api":        new(uint),
+	"virt-controller": new(uint),
+	"virt-handler":    new(uint),
+	"virt-launcher":   new(uint),
+	"virt-operator":   new(uint),
+	allComponents:     new(uint),
+}
+
+// operation type of log-verbosity command
+type operation int
+
+const (
+	show operation = iota
+	set
+	nop
+)
+
+// for patch operation
+const (
+	// Just "add" is fine, no need of "replace" and "remove".
+	// https://www.rfc-editor.org/rfc/rfc6902
+	patchAdd = patch.PatchAddOp
+	dcPath   = "/spec/configuration/developerConfiguration"
+	lvPath   = "/spec/configuration/developerConfiguration/logVerbosity"
+)
+
+func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "log-verbosity",
+		Short: "Show, Set or Reset log verbosity. The verbosity value must be 0-9. The default cluster config is normally 2.\n",
+		Long: `- To show the log verbosity of one or more components
+  (when the log verbosity is unattended in the KubeVirt CR, show the default verbosity).
+- To set the log verbosity of one or more components.
+- To reset the log verbosity of all components
+  (empty the log verbosity field, which means reset to the default verbosity).
+
+- The components are <virt-api | virt-controller | virt-handler | virt-launcher | virt-operator>.
+- Show and Set/Reset cannot coexist.
+- The verbosity value must be 0-9. The default cluster config is normally 2.
+- The verbosity value 10 is accepted but the operation is "show" instead of "set" (e.g. "--virt-api=10" = "--virt-api").
+- Flag syntax must be "flag=arg" ("flag arg" not supported).`,
+		Example: usage(),
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			c := Command{command: "log-verbosity", clientConfig: clientConfig}
+			return c.RunE(cmd)
+		},
+	}
+
+	cmd.Flags().UintVar(virtComponents["virt-api"], "virt-api", NoFlag, "show/set virt-api log verbosity (0-9)")
+	// A flag without an argument should only be used for boolean flags.
+	// However, we want to use a flag without an argument (e.g. --virt-api) to show verbosity.
+	// To do this, we set the default value (NoOptDefVal=noArg) when the flag has no argument.
+	// Otherwise, the pflag package will return an error due to a missing argument.
+	// The caveat is that there is no way to distinguish between user-specified 10 and NoOptDefVal=noArg after the following point.
+	// https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L989
+	// So, we accept "flag=10" but the operation is "show" instead of "set".
+	cmd.Flags().Lookup("virt-api").NoOptDefVal = strconv.FormatUint(noArg, 10)
+
+	cmd.Flags().UintVar(virtComponents["virt-controller"], "virt-controller", NoFlag, "show/set virt-controller log verbosity (0-9)")
+	cmd.Flags().Lookup("virt-controller").NoOptDefVal = strconv.FormatUint(noArg, 10)
+
+	cmd.Flags().UintVar(virtComponents["virt-handler"], "virt-handler", NoFlag, "show/set virt-handler log verbosity (0-9)")
+	cmd.Flags().Lookup("virt-handler").NoOptDefVal = strconv.FormatUint(noArg, 10)
+
+	cmd.Flags().UintVar(virtComponents["virt-launcher"], "virt-launcher", NoFlag, "show/set virt-launcher log verbosity (0-9)")
+	cmd.Flags().Lookup("virt-launcher").NoOptDefVal = strconv.FormatUint(noArg, 10)
+
+	cmd.Flags().UintVar(virtComponents["virt-operator"], "virt-operator", NoFlag, "show/set virt-operator log verbosity (0-9)")
+	cmd.Flags().Lookup("virt-operator").NoOptDefVal = strconv.FormatUint(noArg, 10)
+
+	cmd.Flags().UintVar(virtComponents[allComponents], allComponents, NoFlag, "show/set all component log verbosity (0-9)")
+	cmd.Flags().Lookup(allComponents).NoOptDefVal = strconv.FormatUint(noArg, 10)
+
+	cmd.Flags().BoolVar(&isReset, "reset", false, "reset log verbosity to the default verbosity (2) (empty the log verbosity)")
+
+	// cannot specify "reset" and "all" flag at the same time
+	cmd.MarkFlagsMutuallyExclusive("reset", allComponents)
+
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+// Command line flag syntax:
+//
+//	OK: --flag=x
+//	NG: --flag x
+//
+// Another caveat of NoOptDefVal is that
+// we cannot use the "--flag x" syntax, because "--flag x" only applies to flags without a default value.
+// See vendor/github.com/spf13/pflag/flag.go, especially note the order of the if clause below.
+// https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L983C1-L998C3
+func usage() string {
+	return `  # reset (to default) log-verbosity for all components:
+  {{ProgramName}} adm logVerbosity --reset
+
+  # show log-verbosity for all components:
+  {{ProgramName}} adm log-verbosity --all
+  # set log-verbosity to 3 for all components:
+  {{ProgramName}} adm log-verbosity --all=3
+
+  # show log-verbosity for virt-handler:
+  {{ProgramName}} adm log-verbosity --virt-handler
+  # set log-verbosity to 7 for virt-handler:
+  {{ProgramName}} adm log-verbosity --virt-handler=7
+
+  # show log-verbosity for virt-handler and virt-launcher:
+  {{ProgramName}} adm log-verbosity --virt-handler --virt-launcher
+  # set log-verbosity for virt-handler to 7 and virt-launcher to 3:
+  {{ProgramName}} adm log-verbosity --virt-handler=7 --virt-launcher=3
+
+  # reset all components to default besides virt-handler which is 7:
+  {{ProgramName}} adm log-verbosity --reset --virt-handler=7
+  # set all components to 3 besides virt-handler which is 7:
+  {{ProgramName}} adm log-verbosity --all=3 --virt-handler=7`
+}
+
+// component name to JSON name
+func getJSONNameByComponentName(componentName string) string {
+	var componentNameToJSONName = map[string]string{
+		"virt-api":        "virtAPI",
+		"virt-controller": "virtController",
+		"virt-handler":    "virtHandler",
+		"virt-launcher":   "virtLauncher",
+		"virt-operator":   "virtOperator",
+		allComponents:     allComponents,
+	}
+	return componentNameToJSONName[componentName]
+}
+
+func detectInstallNamespaceAndName(virtClient kubecli.KubevirtClient) (string, string, error) {
+	kvs, err := virtClient.KubeVirt(k8smetav1.NamespaceAll).List(&k8smetav1.ListOptions{})
+	if err != nil {
+		return "", "", fmt.Errorf("could not list KubeVirt CRs across all namespaces: %v", err)
+	}
+	if len(kvs.Items) == 0 {
+		return "", "", errors.New("could not detect a KubeVirt installation")
+	}
+	if len(kvs.Items) > 1 {
+		return "", "", errors.New("invalid kubevirt installation, more than one KubeVirt resource found")
+	}
+	namespace := kvs.Items[0].Namespace
+	name := kvs.Items[0].Name
+	return namespace, name, nil
+}
+
+func hasVerbosityInKV(kv *v1.KubeVirt) (map[string]uint, bool, error) {
+	verbosityMap := map[string]uint{} // key: component name, value: verbosity
+	hasDeveloperConfiguration := true
+
+	if kv.Spec.Configuration.DeveloperConfiguration == nil {
+		// If DeveloperConfiguration is absent in the KubeVirt CR, need to add it before adding LogVerbosity.
+		// So set the hasDeveloperConfiguration flag to false.
+		hasDeveloperConfiguration = false
+	} else if kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity != nil {
+		// If LogVerbosity is present in the KubeVirt CR,
+		// get the logVerbosity field, and put it to verbosityMap.
+		lvJSON, err := json.Marshal(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity)
+		if err != nil {
+			return nil, hasDeveloperConfiguration, err
+		}
+		if err := json.Unmarshal(lvJSON, &verbosityMap); err != nil {
+			return nil, hasDeveloperConfiguration, err
+		}
+	}
+
+	return verbosityMap, hasDeveloperConfiguration, nil
+}
+
+func createOutputLines(verbosityVal map[string]uint) []string {
+	var lines []string
+
+	allIsSet := (*virtComponents[allComponents] != NoFlag)
+
+	for componentName, verbosity := range virtComponents {
+		if componentName == allComponents {
+			continue
+		}
+		JSONName := getJSONNameByComponentName(componentName)
+		if *verbosity != NoFlag || allIsSet {
+			line := fmt.Sprintf("%s=%d", componentName, verbosityVal[JSONName])
+			lines = append(lines, line)
+		}
+	}
+
+	// output message sorted by lexicographical order of component name
+	sort.Strings(lines)
+
+	return lines
+}
+
+func createShowMessage(currentLv map[string]uint) []string {
+	// fill the unattended verbosity with default verbosity
+	// key: JSONName, value: verbosity
+	var verbosityVal = map[string]uint{
+		"virtAPI":        virtconfig.DefaultVirtAPILogVerbosity,
+		"virtController": virtconfig.DefaultVirtControllerLogVerbosity,
+		"virtHandler":    virtconfig.DefaultVirtHandlerLogVerbosity,
+		"virtLauncher":   virtconfig.DefaultVirtLauncherLogVerbosity,
+		"virtOperator":   virtconfig.DefaultVirtOperatorLogVerbosity,
+	}
+
+	// update the verbosity based on the existing verbosity in the KubeVirt CR
+	for key, value := range currentLv {
+		verbosityVal[key] = value
+	}
+
+	lines := createOutputLines(verbosityVal)
+
+	return lines
+}
+
+func addPatch(patchData *[]patch.PatchOperation, op string, path string, value interface{}) {
+	*patchData = append(*patchData, patch.PatchOperation{
+		Op:    op,
+		Path:  path,
+		Value: value,
+	})
+}
+
+func setVerbosity(currentLv map[string]uint, patchData *[]patch.PatchOperation, hasDeveloperConfiguration bool) {
+	// update currentLv based on the user-specified verbosity for all components
+	if *virtComponents[allComponents] != NoFlag {
+		for componentName := range virtComponents {
+			if componentName == allComponents {
+				continue
+			}
+			JSONName := getJSONNameByComponentName(componentName)
+			currentLv[JSONName] = *virtComponents[allComponents]
+		}
+	}
+
+	// update currentLv based on the user-specified verbosity for each component
+	for componentName, verbosity := range virtComponents {
+		if componentName == allComponents || *verbosity == NoFlag {
+			continue
+		}
+		JSONName := getJSONNameByComponentName(componentName)
+		currentLv[JSONName] = *verbosity
+	}
+
+	// in case of just reset (no set operation after the reset), don't need to add another patch
+	if len(currentLv) != 0 {
+		if !hasDeveloperConfiguration {
+			// if DeveloperConfiguration is absent, add DeveloperConfiguration first
+			addPatch(patchData, patchAdd, dcPath, &v1.DeveloperConfiguration{})
+		}
+		addPatch(patchData, patchAdd, lvPath, currentLv)
+	}
+}
+
+func createPatch(currentLv map[string]uint, hasDeveloperConfiguration bool) ([]byte, error) {
+	patchData := []patch.PatchOperation{}
+
+	// reset only if verbosity exists, otherwise do nothing
+	if isReset && len(currentLv) != 0 {
+		if !hasDeveloperConfiguration {
+			// if DeveloperConfiguration is absent, add DeveloperConfiguration first
+			addPatch(&patchData, patchAdd, dcPath, &v1.DeveloperConfiguration{})
+			hasDeveloperConfiguration = true
+		}
+		// add an empty object
+		currentLv = map[string]uint{}
+		addPatch(&patchData, patchAdd, lvPath, currentLv)
+	}
+
+	setVerbosity(currentLv, &patchData, hasDeveloperConfiguration)
+
+	return json.Marshal(patchData)
+}
+
+func findOperation(cmd *cobra.Command) (operation, error) {
+	isShow, isSet := false, false
+
+	for componentName, verbosity := range virtComponents {
+		// check if the flag for the component is specified
+		// cannot use NoFlag to check, because user can accidentally specify the same number as NoFlag for the verbosity
+		if !cmd.Flags().Changed(componentName) {
+			continue
+		}
+
+		// if flag is specified, it means either set or show
+		// if the value = noArg, it means show
+		// if the value != noArg, it means set
+		isShow = isShow || *verbosity == noArg
+		isSet = isSet || *verbosity != noArg
+
+		// check whether the verbosity is in the range
+		// Note that noArg is acceptable but operation is show instead of set.
+		if *verbosity != noArg && *verbosity > maxVerbosity {
+			return nop, fmt.Errorf("%s: log verbosity must be %d-%d", componentName, minVerbosity, maxVerbosity)
+		}
+	}
+
+	// do not distinguish between set and reset at this point, because set and reset can coexist
+	if isReset {
+		isSet = true
+	}
+
+	switch {
+	case isShow && isSet:
+		return nop, errors.New("only show or set is allowed")
+	case isShow:
+		return show, nil
+	case isSet:
+		return set, nil
+	default:
+		return nop, nil
+	}
+}
+
+func (c *Command) RunE(cmd *cobra.Command) error {
+	virtClient, err := kubecli.GetKubevirtClientFromClientConfig(c.clientConfig)
+	if err != nil {
+		return err
+	}
+	namespace, name, err := detectInstallNamespaceAndName(virtClient)
+	if err != nil {
+		return err
+	}
+	kv, err := virtClient.KubeVirt(namespace).Get(name, &k8smetav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// check the operation type (nop/show/set)
+	op, err := findOperation(cmd)
+	if err != nil {
+		return err
+	}
+
+	switch op {
+	case nop:
+		if err := cmd.Help(); err != nil {
+			return err
+		}
+		return errors.New("no flag specified - expecting at least one flag")
+	case show:
+		// if verbosity has been set in the KubeVirt CR, use the verbosity
+		currentLv, _, err := hasVerbosityInKV(kv)
+		if err != nil {
+			return err
+		}
+		lines := createShowMessage(currentLv)
+		for _, line := range lines {
+			cmd.Println(line)
+		}
+	case set: // set and/or reset
+		// "Add" patch removes the value if we do not specify the value, even if we do not change the existing value.
+		// So, we need to get the existing verbosity in the KubeVirt CR.
+		// Also, "Add" patch needs a DeveloperConfiguration entry before adding a LogVerbosity entry.
+		// So, we need to know if DeveloperConfiguration is present or absent.
+		currentLv, hasDeveloperConfiguration, err := hasVerbosityInKV(kv)
+		if err != nil {
+			return err
+		}
+		patchData, err := createPatch(currentLv, hasDeveloperConfiguration)
+		if err != nil {
+			return err
+		}
+		_, err = virtClient.KubeVirt(namespace).Patch(name, types.JSONPatchType, patchData, &k8smetav1.PatchOptions{})
+		if err != nil {
+			return err
+		}
+		cmd.Println("successfully set/reset the log verbosity")
+	default:
+		return fmt.Errorf("op: an unknown operation: %v", op)
+	}
+
+	return nil
+}

--- a/pkg/virtctl/adm/logverbosity/logverbosity_suite_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_suite_test.go
@@ -1,0 +1,11 @@
+package logverbosity_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestLogverbosity(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -1,0 +1,414 @@
+package logverbosity_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+
+	"kubevirt.io/kubevirt/tests/clientcmd"
+
+	"kubevirt.io/client-go/kubecli"
+
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/adm/logverbosity"
+)
+
+var _ = Describe("Log Verbosity", func() {
+	var kvInterface *kubecli.MockKubeVirtInterface
+
+	var kv *v1.KubeVirt
+	var kvs *v1.KubeVirtList
+
+	const (
+		installNamespace = "kubevirt"
+		installName      = "kubevirt"
+	)
+
+	commonShowDescribeTable := func() {
+		DescribeTable("show operation", commonShowTest,
+			Entry("all components", []uint{2, 2, 2, 2, 2}, "--all"),
+			Entry(
+				"one component (1st component (i.e. virt-api))",
+				[]uint{2, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag},
+				"--virt-api",
+			),
+			Entry(
+				"one component (last component (i.e. virt-operator))",
+				[]uint{logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, 2},
+				"--virt-operator",
+			),
+			Entry(
+				"two components",
+				[]uint{logverbosity.NoFlag, 2, 2, logverbosity.NoFlag, logverbosity.NoFlag},
+				"--virt-controller",
+				"--virt-handler",
+			),
+			Entry("all + one component", []uint{2, 2, 2, 2, 2}, "--all", "--virt-launcher"),
+		)
+	}
+
+	commonSetDescribeTable := func() {
+		DescribeTable("set", func(output []uint, args ...string) {
+			// should set logVerbosity field for the specified components in the KubeVirt CR
+			commonSetCommand(args...)
+
+			expectAllComponentVerbosity(kv, output) // check the verbosity of all components if it is expected
+		},
+			Entry("one component (1st component (i.e. virt-api))", []uint{1, 0, 0, 0, 0}, "--virt-api=1"),
+			Entry("one component (last component (i.e. virt-operator))", []uint{0, 0, 0, 0, 2}, "--virt-operator=2"),
+			Entry("two components", []uint{0, 3, 4, 0, 0}, "--virt-controller=3", "--virt-handler=4"),
+			Entry("other two components", []uint{0, 0, 0, 5, 6}, "--virt-launcher=5", "--virt-operator=6"),
+			Entry("all components", []uint{7, 7, 7, 7, 7}, "--all=7"),
+			// corner case
+			Entry("same component different verbosity (last one is a winner)", []uint{4, 0, 0, 0, 0}, "--virt-api=3", "--virt-api=4"),
+		)
+	}
+
+	BeforeEach(func() {
+		kv = NewKubeVirtWithoutDeveloperConfiguration(installNamespace, installName)
+		kvs = kubecli.NewKubeVirtList(*kv)
+
+		ctrl := gomock.NewController(GinkgoT())
+		kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
+		kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
+
+		kvInterface = kubecli.NewMockKubeVirtInterface(ctrl)
+
+		kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(kvs.Items[0].Namespace).Return(kvInterface).AnyTimes() // Get & Patch
+		kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(k8smetav1.NamespaceAll).Return(kvInterface).AnyTimes() // List
+
+		kvInterface.EXPECT().Patch(gomock.Any(), types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(name string, _ any, patchData []byte, _ any, _ ...any) (*v1.KubeVirt, error) {
+				Expect(name).To(Equal(kvs.Items[0].Name))
+
+				patch, err := jsonpatch.DecodePatch(patchData)
+				Expect(err).ToNot(HaveOccurred())
+				kvJSON, err := json.Marshal(kv)
+				Expect(err).ToNot(HaveOccurred())
+				modifiedKvJSON, err := patch.Apply(kvJSON)
+				Expect(err).ToNot(HaveOccurred())
+
+				// reset the object in preparation for unmarshal,
+				// since unmarshal does not guarantee that fields in kv will be removed by the patch
+				kv = &v1.KubeVirt{}
+
+				err = json.Unmarshal(modifiedKvJSON, kv)
+				Expect(err).ToNot(HaveOccurred())
+				return kv, nil
+			}).AnyTimes()
+	})
+
+	When("with erroneous running environment", func() {
+		Context("client has an error", func() {
+			BeforeEach(func() {
+				// GET and LIST mock interfaces are not necessary, because an error is returned before GET and LIST are called
+				kubecli.GetKubevirtClientFromClientConfig = kubecli.GetInvalidKubevirtClientFromClientConfig
+			})
+
+			It("should fail (not executing the command)", func() {
+				cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--all")
+				Expect(cmd).NotTo(BeNil())
+			})
+		})
+
+		Context("detectInstallNamespaceAndName has en error", func() {
+			expectListError := func() {
+				kvInterface.EXPECT().List(gomock.Any()).DoAndReturn(
+					func(_ any) (*v1.KubeVirt, error) {
+						return nil, errors.New("List error")
+					}).AnyTimes()
+			}
+
+			It("should fail", func() {
+				expectListError() // simulate something like no permission to access the namespace
+				cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--all")
+				err := cmd()
+				Expect(err).NotTo(Succeed())
+				Expect(err).To(MatchError(ContainSubstring("could not list KubeVirt CRs across all namespaces: List error")))
+			})
+		})
+
+		Context("Get function has an error", func() {
+			BeforeEach(func() {
+				kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+			})
+
+			expectGetError := func() {
+				kvInterface.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(name string, _ any) (*v1.KubeVirt, error) {
+						Expect(name).To(Equal(kvs.Items[0].Name))
+						return nil, errors.New("Get error")
+					}).AnyTimes()
+			}
+
+			It("should fail", func() {
+				expectGetError() // for some reason, Get function returns an error
+				cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--all")
+				err := cmd()
+				Expect(err).NotTo(Succeed())
+				Expect(err).To(MatchError(ContainSubstring("Get error")))
+			})
+		})
+	})
+
+	When("with install namespace and name other than kubevirt", func() {
+		BeforeEach(func() {
+			kv = NewKubeVirtWithoutDeveloperConfiguration("foo", "foo")
+			kvs = kubecli.NewKubeVirtList(*kv)
+
+			kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(kvs.Items[0].Namespace).Return(kvInterface).AnyTimes() // Get & Patch
+			kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+		})
+
+		expectGetKv := func() {
+			kvInterface.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(name string, _ any) (*v1.KubeVirt, error) {
+					Expect(name).To(Equal(kvs.Items[0].Name))
+					return &kvs.Items[0], nil
+				}).AnyTimes()
+		}
+
+		It("show: should succeed", func() {
+			expectGetKv()
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut("adm", "log-verbosity", "--all")()
+			Expect(err).To(Succeed())
+			output := []uint{2, 2, 2, 2, 2}
+			message := createOutputMessage(output)
+			Expect(string(bytes)).To(ContainSubstring(*message))
+		})
+
+		It("set: should succeed", func() {
+			expectGetKv()
+			cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--all=7")
+			Expect(cmd()).To(Succeed())
+			output := []uint{7, 7, 7, 7, 7}
+			expectAllComponentVerbosity(kv, output)
+		})
+	})
+
+	When("with invalid set of flags", func() {
+		BeforeEach(func() {
+			commonSetup(kvInterface, kvs)
+		})
+
+		Context("with empty set of flags", func() {
+			It("should fail (return help)", func() {
+				cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity")
+				err := cmd()
+				Expect(err).NotTo(Succeed())
+				Expect(err).To(MatchError(ContainSubstring("no flag specified - expecting at least one flag")))
+			})
+		})
+
+		DescribeTable("should fail handled by the CLI package", func(args ...string) {
+			argStr := strings.Join(args, ",")
+			cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", argStr)
+			Expect(cmd()).NotTo(Succeed())
+		},
+			Entry("reset and all coexist", "--reset", "--all=3"),
+			Entry("invalid argument (negative verbosity)", "--virt-api=-1"),
+			Entry("invalid argument (character)", "--virt-api=a"),
+			Entry("unknown flag", "--node"),
+			Entry("invalid flag format", "--all", "3"),
+		)
+
+		DescribeTable("should fail handled by error handler", func(output string, args ...string) {
+			commandAndArgs := []string{"adm", "log-verbosity"}
+			commandAndArgs = append(commandAndArgs, args...)
+			_, err := clientcmd.NewRepeatableVirtctlCommandWithOut(commandAndArgs...)()
+			Expect(err).NotTo(Succeed())
+
+			Expect(err).To(MatchError(ContainSubstring(output)))
+		},
+			Entry("show and set mix", "only show or set is allowed", "--virt-handler", "--virt-launcher=3"),
+			Entry("show and reset mix", "only show or set is allowed", "--reset", "--virt-launcher"),
+			Entry("invalid verbosity (=noFlag)", "virt-api: log verbosity must be 0-9", "--virt-api=11"),
+			Entry("invalid verbosity", "virt-api: log verbosity must be 0-9", "--virt-api=20"),
+			Entry("one valid verbosity, one invalid verbosity", "virt-handler: log verbosity must be 0-9", "--virt-api=5", "--virt-handler=20"),
+		)
+	})
+
+	When("no DeveloperConfiguration field in the KubeVirt CR", func() {
+		BeforeEach(func() {
+			commonSetup(kvInterface, kvs)
+		})
+
+		// fill the unattended verbosity with default verbosity (2)
+		commonShowDescribeTable()
+
+		Describe("set operation", func() {
+			Context("reset", func() {
+				It("do nothing", func() {
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--reset")
+					Expect(cmd()).To(Succeed())
+					Expect(kv.Spec.Configuration.DeveloperConfiguration).To(BeNil())
+				})
+			})
+
+			commonSetDescribeTable()
+		})
+	})
+
+	When("no logVerbosity field in the KubeVirt CR", func() {
+		BeforeEach(func() {
+			dc := &v1.DeveloperConfiguration{}
+			kv.Spec.Configuration.DeveloperConfiguration = dc
+			kvs = kubecli.NewKubeVirtList(*kv)
+
+			commonSetup(kvInterface, kvs)
+		})
+
+		// fill the unattended verbosity with default verbosity (2)
+		commonShowDescribeTable()
+
+		Describe("set operation", func() {
+			Context("reset", func() {
+				It("do nothing", func() {
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--reset")
+					Expect(cmd()).To(Succeed())
+					Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity).To(BeNil())
+				})
+			})
+
+			commonSetDescribeTable()
+		})
+	})
+
+	When("existing logVerbosity in the KubeVirt CR", func() {
+		BeforeEach(func() {
+			dc := &v1.DeveloperConfiguration{
+				LogVerbosity: &v1.LogVerbosity{
+					VirtAPI:        5,
+					VirtController: 6,
+					VirtLauncher:   3,
+					VirtOperator:   4,
+				},
+			}
+			kv.Spec.Configuration.DeveloperConfiguration = dc
+			kvs = kubecli.NewKubeVirtList(*kv)
+
+			commonSetup(kvInterface, kvs)
+		})
+
+		// should show the verbosity for components from the KubeVirt CR
+		// get and show the attended verbosity
+		// show the default verbosity (2), when the logVerbosity is unattended
+		DescribeTable("show operation", commonShowTest,
+			Entry("all components", []uint{5, 6, 2, 3, 4}, "--all"),
+			Entry(
+				"one component attended verbosity",
+				[]uint{5, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag},
+				"--virt-api",
+			),
+			Entry(
+				"one component unattended verbosity",
+				[]uint{logverbosity.NoFlag, logverbosity.NoFlag, 2, logverbosity.NoFlag, logverbosity.NoFlag},
+				"--virt-handler",
+			),
+			Entry(
+				"two components with one unattended verbosity",
+				[]uint{logverbosity.NoFlag, 6, 2, logverbosity.NoFlag, logverbosity.NoFlag},
+				"--virt-handler",
+				"--virt-controller",
+			),
+			// corner case
+			Entry("all components with default argument (equals show operation)", []uint{5, 6, 2, 3, 4}, "--all=10"),
+		)
+
+		Describe("set operation", func() {
+			DescribeTable("set", func(output []uint, args ...string) {
+				// should set logVerbosity filed for the specified components in the KubeVirt CR
+				commonSetCommand(args...)
+
+				expectAllComponentVerbosity(kv, output)
+			},
+				Entry("reset", []uint{0, 0, 0, 0, 0}, "--reset"), // CR's logVerbosity field is replaced by {}. logVerbosity struct of each filed is 0.
+				Entry("one component (1st component (i.e. virt-api))", []uint{1, 6, 0, 3, 4}, "--virt-api=1"),
+				Entry("one component (last component (i.e. virt-operator))", []uint{5, 6, 0, 3, 2}, "--virt-operator=2"),
+				Entry("one component (filled in unattended verbosity)", []uint{5, 6, 8, 3, 4}, "--virt-handler=8"),
+				Entry("all components", []uint{7, 7, 7, 7, 7}, "--all=7"),
+				Entry("two components", []uint{5, 0, 9, 3, 4}, "--virt-controller=0", "--virt-handler=9"),
+				Entry("set all and then set two components", []uint{9, 0, 8, 8, 8}, "--all=8", "--virt-api=9", "--virt-controller=0"),
+				Entry("reset and then set two components", []uint{0, 0, 1, 2, 0}, "--reset", "--virt-handler=1", "--virt-launcher=2"),
+				// corner case
+				Entry("two same operations (come down to one operation)", []uint{3, 6, 0, 3, 4}, "--virt-api=3", "--virt-api=3"),
+				Entry("same component different verbosity (last one is a winner)", []uint{4, 6, 0, 3, 4}, "--virt-api=3", "--virt-api=4"),
+			)
+		})
+	})
+
+})
+
+func expectAllComponentVerbosity(kv *v1.KubeVirt, output []uint) {
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtAPI).To(Equal(output[0]))
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtController).To(Equal(output[1]))
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtHandler).To(Equal(output[2]))
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtLauncher).To(Equal(output[3]))
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtOperator).To(Equal(output[4]))
+}
+
+// create an expected output message
+func createOutputMessage(output []uint) *string {
+	var message string
+	var components = []string{"virt-api", "virt-controller", "virt-handler", "virt-launcher", "virt-operator"}
+	for component := 0; component < len(components); component++ {
+		if output[component] == logverbosity.NoFlag {
+			continue
+		}
+		// output format is [componentName]=[verbosity] like:
+		// 		virt-api=1
+		// 		virt-controller=2
+		componentName := components[component]
+		verbosity := output[component]
+		message += fmt.Sprintf("%s=%d\n", componentName, verbosity)
+	}
+	return &message
+}
+
+func NewKubeVirtWithoutDeveloperConfiguration(namespace, name string) *v1.KubeVirt {
+	return &v1.KubeVirt{
+		TypeMeta: k8smetav1.TypeMeta{
+			Kind:       "KubeVirt",
+			APIVersion: v1.GroupVersion.String(),
+		},
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1.KubeVirtSpec{
+			ImageTag:      "devel",
+			Configuration: v1.KubeVirtConfiguration{},
+		},
+	}
+}
+
+func commonSetup(kvInterface *kubecli.MockKubeVirtInterface, kvs *v1.KubeVirtList) {
+	kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+	kvInterface.EXPECT().Get(kvs.Items[0].Name, gomock.Any()).Return(&kvs.Items[0], nil).AnyTimes()
+}
+
+func commonShowTest(output []uint, args ...string) {
+	commandAndArgs := []string{"adm", "log-verbosity"}
+	commandAndArgs = append(commandAndArgs, args...)
+	bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(commandAndArgs...)()
+	Expect(err).To(Succeed())
+
+	message := createOutputMessage(output) // create an expected output message
+	Expect(string(bytes)).To(ContainSubstring(*message))
+}
+
+func commonSetCommand(args ...string) {
+	commandAndArgs := []string{"adm", "log-verbosity"}
+	commandAndArgs = append(commandAndArgs, args...)
+	cmd := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
+	Expect(cmd()).To(Succeed())
+}

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -13,6 +13,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/virtctl/adm"
 	"kubevirt.io/kubevirt/pkg/virtctl/configuration"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
 	"kubevirt.io/kubevirt/pkg/virtctl/create"
@@ -109,6 +110,7 @@ func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 		vmexport.NewVirtualMachineExportCommand(clientConfig),
 		create.NewCommand(clientConfig),
 		credentials.NewCommand(clientConfig),
+		adm.NewCommand(clientConfig),
 		optionsCmd,
 	)
 	return rootCmd, clientConfig


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `adm` subcommand under `virtctl`, and `log-verbosity` subcommand under `adm`.

`virtctl adm log-verbosity [flags]`

The `log-verbosity` command is:
- To show the log verbosity of one or more components (when the log verbosity is unattended in the KubeVirt CR, show the default verbosity)
- To set the log verbosity of one or more components
- To reset the log verbosity of all components (empty the log verbosity field, which means reset to the default verbosity)

Note:
- The components are `<virt-api | virt-controller | virt-handler | virt-launcher | virt-operator>`
- `Show` and `Set`/`Reset` cannot coexist
- The verbosity value must be `0-9`. The default cluster config is normally `2`.
- The verbosity value `10` is accepted but the operation is `show` instead of `set` (e.g. `--virt-api=10` = `--virt-api`).
- Flag syntax must be `flag=arg` (`flag arg` not supported)

Flags:
```
      --all uint[=10]              show/set all component log verbosity (0-9) (default 11)
-h, --help                              help for log-verbosity
      --reset                           reset log verbosity to the default verbosity (2) (empty the log verbosity)
      --virt-api uint[=10]         show/set virt-api log verbosity (0-9) (default 11)
      --virt-controller uint[=10]  show/set virt-controller log verbosity (0-9) (default 11)
      --virt-handler uint[=10]     show/set virt-handler log verbosity (0-9) (default 11)
      --virt-launcher uint[=10]    show/set virt-launcher log verbosity (0-9) (default 11)
      --virt-operator uint[=10]    show/set virt-operator log verbosity (0-9) (default 11)
```

Examples:
```
# reset (to default) log-verbosity for all components
virtctl adm logVerbosity –reset

# show log-verbosity for all components:
virtctl adm log-verbosity --all
# set log-verbosity to 3 for all components:
virtctl adm log-verbosity --all=3
  
# show log-verbosity for virt-handler:
virtctl adm log-verbosity --virt-handler
# set log-verbosity to 7 for virt-handler:
virtctl adm log-verbosity --virt-handler=7

# show log-verbosity for virt-handler and virt-launcher
virtctl adm log-verbosity --virt-handler --virt-launcher
# set log-verbosity for virt-handler to 7 and virt-launcher to 3
virtctl adm log-verbosity --virt-handler=7 --virt-launcher=3
```
Two or more different kinds of flags (chain reaction): Execute reset or all first, and then set component log verbosity. The order of options should not matter.
```
# reset all components to default besides virt-handler which is 7
virtctl adm log-verbosity --reset --virt-handler=7
  
# set all components to 3 besides virt-handler which is 7
virtctl adm log-verbosity --all=3 --virt-handler=7
```
Error case examples:
```
# mix of show and reset
virtctl adm log-verbosity --all=3 --reset

# mix of show and set
virtctl adm log-verbosity --virt-handler --virt-launcher 3

# no flag (return help)
virtctl adm log-verbosity
```

**Which issue(s) this PR fixes**:

Fixes #8155
- This PR supports verbosity per KubeVirt component.
- This PR does not support verbosity per node.

**Special notes for your reviewer**:

- We chose `10` for no argument (`noArg`) and `11` for no flag (`NoFlag`).
Any number between 10 and MaxUint is fine for the defaults. But, less wired numbers should be better, because these numbers will be shown in the help menu. There is no option to hide the default value from the help menu. See pflag.FlagUsages, which calls the FlagUsagesWrapped function: https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L677

- The verbosity value `10` is accepted but the operation is `show` instead of `set` (e.g. `--virt-api=10` = `--virt-api`).
A flag without an argument should only be used for boolean flags. However, we want to use a flag without an argument (e.g. `--virt-api`) to show verbosity. To do this, we set the default value (`NoOptDefVal`=`noArg`) when the flag has no argument. Otherwise, the pflag package will return an error due to a missing argument. The caveat is that there is no way to distinguish between user-specified `10` and `NoOptDefVal`=`noArg` after the following point.
https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L989
So, we accept `flag=10` but the operation is `show` instead of `set`.

- Flag syntax must be `flag=arg` (`flag arg` not supported)
Another caveat of `NoOptDefVal` is that we cannot use the `--flag x` syntax, because `--flag x` only applies to flags without a default value. See vendor/github.com/spf13/pflag/flag.go, especially note the order of the if clause below.
https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L983C1-L998C3

**Release note**:
```release-note
Added “adm” subcommand under “virtctl”, and “log-verbosity" subcommand under “adm”. The log-verbosity command is:
- To show the log verbosity of one or more components.
- To set the log verbosity of one or more components.
- To reset the log verbosity of all components (reset to the default verbosity (2)).
```