### PR TITLE
[functest 4747]: Stabilize and parallelize post-copy related functional tests

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1644,7 +1644,7 @@ var _ = Describe("Migration watcher", func() {
 				policies := make([]migrationsv1.MigrationPolicy, 0)
 
 				for _, info := range policiesToDefine {
-					policy := tests.PreparePolicyAndVMIWithNsAndVmiLabels(vmi, &namespace, info.vmiMatchingLabels, info.namespaceMatchingLabels)
+					policy := tests.PreparePolicyAndVMIWithNSAndVMILabels(vmi, &namespace, info.vmiMatchingLabels, info.namespaceMatchingLabels)
 					policy.Name = info.name
 					policies = append(policies, *policy)
 				}
@@ -1667,7 +1667,7 @@ var _ = Describe("Migration watcher", func() {
 			It("policy with one non-fitting label should not match", func() {
 				const labelKeyFmt = "%s-key-0"
 
-				policy := tests.PreparePolicyAndVMIWithNsAndVmiLabels(vmi, &namespace, 4, 3)
+				policy := tests.PreparePolicyAndVMIWithNSAndVMILabels(vmi, &namespace, 4, 3)
 				_, exists := policy.Spec.Selectors.VirtualMachineInstanceSelector[fmt.Sprintf(labelKeyFmt, policy.Name)]
 				Expect(exists).To(BeTrue())
 
@@ -1689,8 +1689,8 @@ var _ = Describe("Migration watcher", func() {
 				numberOfLabels := rand.Intn(5) + 1
 
 				By(fmt.Sprintf("Defining two policies with %d labels, one with VMI labels and one with NS labels", numberOfLabels))
-				policyWithNSLabels := tests.PreparePolicyAndVMIWithNsAndVmiLabels(vmi, &namespace, 0, numberOfLabels)
-				policyWithVmiLabels := tests.PreparePolicyAndVMIWithNsAndVmiLabels(vmi, &namespace, numberOfLabels, 0)
+				policyWithNSLabels := tests.PreparePolicyAndVMIWithNSAndVMILabels(vmi, &namespace, 0, numberOfLabels)
+				policyWithVmiLabels := tests.PreparePolicyAndVMIWithNSAndVMILabels(vmi, &namespace, numberOfLabels, 0)
 
 				policyList := kubecli.NewMinimalMigrationPolicyList(*policyWithNSLabels, *policyWithVmiLabels)
 
@@ -1702,7 +1702,7 @@ var _ = Describe("Migration watcher", func() {
 
 		DescribeTable("should override cluster-wide migration configurations when", func(defineMigrationPolicy func(*migrationsv1.MigrationPolicySpec), testMigrationConfigs func(configuration *virtv1.MigrationConfiguration), expectConfigUpdate bool) {
 			By("Defining migration policy, matching it to vmi to posting it into the cluster")
-			migrationPolicy := tests.PreparePolicyAndVMI(vmi)
+			migrationPolicy := tests.GeneratePolicyAndAlignVMI(vmi)
 			defineMigrationPolicy(&migrationPolicy.Spec)
 			addMigrationPolicies(*migrationPolicy)
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -200,6 +200,7 @@ go_test(
         "//staging/src/kubevirt.io/api/instancetype/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/pool:go_default_library",
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot:go_default_library",

--- a/tests/migration_policy.go
+++ b/tests/migration_policy.go
@@ -19,7 +19,7 @@ import (
 )
 
 // If matchingNSLabels is zero, namespace parameter is being ignored and can be nil
-func PreparePolicyAndVMIWithNsAndVmiLabelsWithPreexistingPolicy(vmi *v1.VirtualMachineInstance, namespace *k8sv1.Namespace, matchingVmiLabels, matchingNSLabels int, policy *migrationsv1.MigrationPolicy) *migrationsv1.MigrationPolicy {
+func PreparePolicyAndVMIWithNSAndVMILabelsWithPreexistingPolicy(vmi *v1.VirtualMachineInstance, namespace *k8sv1.Namespace, matchingVmiLabels, matchingNSLabels int, policy *migrationsv1.MigrationPolicy) *migrationsv1.MigrationPolicy {
 	ExpectWithOffset(1, vmi).ToNot(BeNil())
 	if matchingNSLabels > 0 {
 		ExpectWithOffset(1, namespace).ToNot(BeNil())
@@ -86,23 +86,23 @@ func PreparePolicyAndVMIWithNsAndVmiLabelsWithPreexistingPolicy(vmi *v1.VirtualM
 	return policy
 }
 
-func PreparePolicyAndVMIWithNsAndVmiLabels(vmi *v1.VirtualMachineInstance, namespace *k8sv1.Namespace, matchingVmiLabels, matchingNSLabels int) *migrationsv1.MigrationPolicy {
-	return PreparePolicyAndVMIWithNsAndVmiLabelsWithPreexistingPolicy(vmi, namespace, matchingVmiLabels, matchingNSLabels, nil)
+func PreparePolicyAndVMIWithNSAndVMILabels(vmi *v1.VirtualMachineInstance, namespace *k8sv1.Namespace, matchingVmiLabels, matchingNSLabels int) *migrationsv1.MigrationPolicy {
+	return PreparePolicyAndVMIWithNSAndVMILabelsWithPreexistingPolicy(vmi, namespace, matchingVmiLabels, matchingNSLabels, nil)
 }
 
-// PreparePolicyAndVMI mutates the given vmi parameter by adding labels to it. Therefore, it's recommended
+// GeneratePolicyAndAlignVMI mutates the given vmi parameter by adding labels to it. Therefore, it's recommended
 // to use this function before creating the vmi. Otherwise, its labels need to be updated.
-func PreparePolicyAndVMI(vmi *v1.VirtualMachineInstance) *migrationsv1.MigrationPolicy {
-	return PreparePolicyAndVMIWithNsAndVmiLabels(vmi, nil, 1, 0)
+func GeneratePolicyAndAlignVMI(vmi *v1.VirtualMachineInstance) *migrationsv1.MigrationPolicy {
+	return PreparePolicyAndVMIWithNSAndVMILabels(vmi, nil, 1, 0)
 }
 
-// MatchPolicyAndVmi is expected to be called on objects before they're created.
-func MatchPolicyAndVmi(vmi *v1.VirtualMachineInstance, policy *migrationsv1.MigrationPolicy) {
-	PreparePolicyAndVMIWithNsAndVmiLabelsWithPreexistingPolicy(vmi, nil, 1, 0, policy)
+// AlignPolicyAndVmi is expected to be called on objects before they're created.
+func AlignPolicyAndVmi(vmi *v1.VirtualMachineInstance, policy *migrationsv1.MigrationPolicy) {
+	PreparePolicyAndVMIWithNSAndVMILabelsWithPreexistingPolicy(vmi, nil, 1, 0, policy)
 }
 
 func PreparePolicyAndVMIWithBandwidthLimitation(vmi *v1.VirtualMachineInstance, bandwidth resource.Quantity) *migrationsv1.MigrationPolicy {
-	policy := PreparePolicyAndVMI(vmi)
+	policy := GeneratePolicyAndAlignVMI(vmi)
 	policy.Spec.BandwidthPerMigration = &bandwidth
 
 	return policy

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -561,7 +561,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	runStressTest := func(vmi *v1.VirtualMachineInstance, vmsize string, stressTimeoutSeconds int) {
 		By("Run a stress test to dirty some pages and slow down the migration")
-		stressCmd := fmt.Sprintf("stress-ng --vm 1 --vm-bytes %s --vm-keep --timeout %ds&\n", vmsize, stressTimeoutSeconds)
+		stressCmd := fmt.Sprintf("stress-ng --vm 1 --vm-bytes %s --vm-keep &\n", vmsize)
 		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: console.PromptExpression},

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -116,11 +116,11 @@ import (
 )
 
 const (
-	fedoraVMSize         = "256M"
-	secretDiskSerial     = "D23YZ9W6WA5DJ487"
-	stressDefaultVMSize  = "100"
-	stressLargeVMSize    = "400M"
-	stressDefaultTimeout = 1600
+	fedoraVMSize               = "256M"
+	secretDiskSerial           = "D23YZ9W6WA5DJ487"
+	stressDefaultVMSize        = "100"
+	stressLargeVMSize          = "400M"
+	stressDefaultSleepDuration = 1600
 )
 
 var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration", decorators.SigComputeMigrations, decorators.SigCompute, func() {
@@ -692,7 +692,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			if mode == v1.MigrationPostCopy {
 				By("Running stress test to allow transition to post-copy")
-				runStressTest(vmi, stressLargeVMSize, stressDefaultTimeout)
+				runStressTest(vmi, stressLargeVMSize, stressDefaultSleepDuration)
 			}
 
 			// execute a migration, wait for finalized state
@@ -1419,7 +1419,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-				runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
+				runStressTest(vmi, stressDefaultVMSize, stressDefaultSleepDuration)
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
@@ -2004,7 +2004,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					// Run
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-					runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
+					runStressTest(vmi, stressDefaultVMSize, stressDefaultSleepDuration)
 
 					// execute a migration, wait for finalized state
 					By("Starting the Migration")
@@ -2215,7 +2215,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// Need to wait for cloud init to finish and start the agent inside the vmi.
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-				runStressTest(vmi, "350M", stressDefaultTimeout)
+				runStressTest(vmi, "350M", stressDefaultSleepDuration)
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
@@ -2276,7 +2276,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					// Need to wait for cloud init to finish and start the agent inside the vmi.
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-					runStressTest(vmi, stressLargeVMSize, stressDefaultTimeout)
+					runStressTest(vmi, stressLargeVMSize, stressDefaultSleepDuration)
 
 					// execute a migration, wait for finalized state
 					By("Starting the Migration")
@@ -3443,7 +3443,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-				runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
+				runStressTest(vmi, stressDefaultVMSize, stressDefaultSleepDuration)
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
@@ -3563,7 +3563,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 					// Put VMI under load
-					runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
+					runStressTest(vmi, stressDefaultVMSize, stressDefaultSleepDuration)
 
 					// Mark the masters as schedulable so we can migrate there
 					setControlPlaneUnschedulable(false)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -35,8 +35,6 @@ import (
 
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
 
-	k6tpointer "kubevirt.io/kubevirt/pkg/pointer"
-
 	kvpointer "kubevirt.io/kubevirt/pkg/pointer"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
@@ -679,7 +677,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			disks[len(disks)-1].Serial = secretDiskSerial
 
 			if migrationPolicy != nil {
-				tests.MatchPolicyAndVmi(vmi, migrationPolicy)
+				tests.AlignPolicyAndVmi(vmi, migrationPolicy)
 				migrationPolicy = tests.CreateMigrationPolicy(virtClient, migrationPolicy)
 			}
 			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
@@ -2160,9 +2158,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Allowing post-copy and limit migration bandwidth")
 				policyName := fmt.Sprintf("testpolicy-%s", rand.String(5))
 				migrationPolicy = kubecli.NewMinimalMigrationPolicy(policyName)
-				migrationPolicy.Spec.AllowPostCopy = k6tpointer.P(true)
-				migrationPolicy.Spec.CompletionTimeoutPerGiB = k6tpointer.P(int64(1))
-				migrationPolicy.Spec.BandwidthPerMigration = k6tpointer.P(resource.MustParse("5Mi"))
+				migrationPolicy.Spec.AllowPostCopy = kvpointer.P(true)
+				migrationPolicy.Spec.CompletionTimeoutPerGiB = kvpointer.P(int64(1))
+				migrationPolicy.Spec.BandwidthPerMigration = kvpointer.P(resource.MustParse("5Mi"))
 			})
 
 			Context("with datavolume", func() {
@@ -2203,7 +2201,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 				vmi.Namespace = testsuite.NamespacePrivileged
 
-				tests.MatchPolicyAndVmi(vmi, migrationPolicy)
+				tests.AlignPolicyAndVmi(vmi, migrationPolicy)
 				migrationPolicy = tests.CreateMigrationPolicy(virtClient, migrationPolicy)
 
 				By("Starting the VirtualMachineInstance")
@@ -3205,7 +3203,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				var expectedPolicyName *string
 				if defineMigrationPolicy {
 					By("Creating a migration policy that overrides cluster policy")
-					policy := tests.PreparePolicyAndVMI(vmi)
+					policy := tests.GeneratePolicyAndAlignVMI(vmi)
 					policy.Spec.AllowAutoConverge = pointer.BoolPtr(false)
 
 					_, err := virtClient.MigrationPolicy().Create(context.Background(), policy, metav1.CreateOptions{})

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -119,7 +119,7 @@ const (
 	fedoraVMSize         = "256M"
 	secretDiskSerial     = "D23YZ9W6WA5DJ487"
 	stressDefaultVMSize  = "100"
-	stressLargeVMSize    = "400"
+	stressLargeVMSize    = "400M"
 	stressDefaultTimeout = 1600
 )
 
@@ -561,7 +561,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	runStressTest := func(vmi *v1.VirtualMachineInstance, vmsize string, stressTimeoutSeconds int) {
 		By("Run a stress test to dirty some pages and slow down the migration")
-		stressCmd := fmt.Sprintf("stress-ng --vm 1 --vm-bytes %sM --vm-keep --timeout %ds&\n", vmsize, stressTimeoutSeconds)
+		stressCmd := fmt.Sprintf("stress-ng --vm 1 --vm-bytes %s --vm-keep --timeout %ds&\n", vmsize, stressTimeoutSeconds)
 		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: console.PromptExpression},

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -116,7 +116,7 @@ import (
 const (
 	fedoraVMSize               = "256M"
 	secretDiskSerial           = "D23YZ9W6WA5DJ487"
-	stressDefaultVMSize        = "100"
+	stressDefaultVMSize        = "100M"
 	stressLargeVMSize          = "400M"
 	stressDefaultSleepDuration = 1600
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR parallelizes post-copy related functional tests by using migration policies (which apply a specific scope) instead of Kubevirt CR for configuration (which is cluster-wide).

In addition, it introduces many stabilization and improvements, such as:
* Tune bandwidth limitation and stress size properly. See commit description for more info.
* Tune stress sleep time properly. Reduced from ~26 minutes, which is completely exaggerated, to 30 seconds.
* Add a `AlignPolicyAndVmi()` function to match existing policy and VMI.
* General refactoring.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
