### PR TITLE
Make `examples/vmi-fedora.yaml` migratable

### DIFF
--- a/examples/vmi-fedora.yaml
+++ b/examples/vmi-fedora.yaml
@@ -15,10 +15,16 @@ spec:
       - disk:
           bus: virtio
         name: cloudinitdisk
+      interfaces:
+      - masquerade: {}
+        name: default
       rng: {}
     resources:
       requests:
         memory: 1024M
+  networks:
+  - name: default
+    pod: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -472,6 +472,7 @@ func GetVMISata() *v1.VirtualMachineInstance {
 func GetVMIEphemeralFedora() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiFedora)
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
+	makeMigratable(vmi)
 	initFedora(&vmi.Spec)
 	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 	return vmi

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -449,10 +449,7 @@ func addHostDisk(spec *v1.VirtualMachineInstanceSpec, path string, hostDiskType 
 
 func GetVMIMigratable() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiMigratable)
-	// having no network leads to adding a default interface that may be of type bridge on
-	// the pod network and that would make the VMI non-migratable. Therefore, adding a network.
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+	makeMigratable(vmi)
 
 	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageAlpine, DockerTag), v1.DiskBusVirtio)
 	return vmi
@@ -1478,4 +1475,11 @@ func GetVmWindowsInstancetypeComputeLargePreferencesWindows() *v1.VirtualMachine
 	vm.Spec.Template.Spec.Domain.Resources = v1.ResourceRequirements{}
 
 	return vm
+}
+
+func makeMigratable(vmi *v1.VirtualMachineInstance) {
+	// having no network leads to adding a default interface that may be of type bridge on
+	// the pod network and that would make the VMI non-migratable. Therefore, adding a network.
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Often I find it valuable to use `vmi-fedora` as a migratable VM instead of `vmi-migratable` which is alpine-based. As an example, in the fedora image we have several tools available like `stress-ng`.

WIth this in place, the `migration-job.yaml` can be changed to refer to `vmi-fedora`, and the user could choose which migratable vmi to use.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
