### PR TITLE
Remove redundant left-over k8s link in OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,3 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
 aliases:
   approvers:
     - davidvossel


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove redundant left-over k8s link in OWNERS_ALIASES

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
