### PR TITLE
[virt-controller] Fix warning about ephemeral dir creation

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -114,8 +114,16 @@ func GetKernelBootArtifactPathFromLauncherView(artifact string) string {
 	return filepath.Join(mountBaseDir, KernelBootName, artifactBase)
 }
 
-func SetLocalDirectory(dir string) error {
+// SetLocalDirectoryOnly TODO: Refactor this package. This package is used by virt-controller
+// to set proper paths on the virt-launcher template and by virt-launcher to create directories
+// at the right location. The functions have side-effects and mix path setting and creation
+// which makes it hard to differentiate the usage per component.
+func SetLocalDirectoryOnly(dir string) {
 	mountBaseDir = dir
+}
+
+func SetLocalDirectory(dir string) error {
+	SetLocalDirectoryOnly(dir)
 	return os.MkdirAll(dir, 0750)
 }
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"time"
 
+	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 
 	"kubevirt.io/kubevirt/pkg/monitoring/migration"
@@ -69,7 +70,6 @@ import (
 	clientutil "kubevirt.io/client-go/util"
 
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
-	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/controller"
 	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
 
@@ -280,7 +280,7 @@ func init() {
 
 func Execute() {
 	var err error
-	var app VirtControllerApp = VirtControllerApp{}
+	var app = VirtControllerApp{}
 
 	app.LeaderElection = leaderelectionconfig.DefaultLeaderElectionConfiguration()
 
@@ -587,9 +587,7 @@ func (vca *VirtControllerApp) initCommon() {
 		golog.Fatal(err)
 	}
 
-	if err := containerdisk.SetLocalDirectory(filepath.Join(vca.ephemeralDiskDir, "container-disk-data")); err != nil {
-		log.Log.Warningf("failed to create ephemeral disk dir: %v", err)
-	}
+	containerdisk.SetLocalDirectoryOnly(filepath.Join(vca.ephemeralDiskDir, "container-disk-data"))
 	vca.templateService = services.NewTemplateService(vca.launcherImage,
 		vca.launcherQemuTimeout,
 		vca.virtShareDir,


### PR DESCRIPTION
**What this PR does / why we need it**:

The ephemeral directory for containerdisks needs to be known by virt-controller to create the right pod templates. By mistake the controller also tries to create the ephemeral directory.

By accident virt-controller also tries to create this directory in its own image without actually using it. If that fails (e.g. permission issues since untested and no functional difference) we get a warning which can lead to confusions.

Removing the code which tries for no reason to create the directory which look like this:

```
failed to create ephemeral disk dir: mkdir /var/run/kubevirt-ephemeral-disk
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Stop trying to create unused directory /var/run/kubevirt-ephemeral-disk in virt-controller
```
