### PR TITLE
virt-controller: always store evictionStrategy in Spec

### DIFF
--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	namespace = "kubevirt"
+	kvObjectNamespace = "kubevirt"
+	kvObjectName      = "kubevirt"
 )
 
 func NewFakeClusterConfigUsingKV(kv *KVv1.KubeVirt) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.SharedIndexInformer) {
@@ -32,15 +33,15 @@ func NewFakeClusterConfigUsingKVWithCPUArch(kv *KVv1.KubeVirt, CPUArch string) (
 	kubeVirtInformer.GetStore().Add(kv)
 
 	AddDataVolumeAPI(crdInformer)
-	cfg, _ := virtconfig.NewClusterConfigWithCPUArch(crdInformer, kubeVirtInformer, namespace, CPUArch)
+	cfg, _ := virtconfig.NewClusterConfigWithCPUArch(crdInformer, kubeVirtInformer, kvObjectNamespace, CPUArch)
 	return cfg, crdInformer, kubeVirtInformer
 }
 
 func NewFakeClusterConfigUsingKVConfig(config *KVv1.KubeVirtConfiguration) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.SharedIndexInformer) {
 	kv := &KVv1.KubeVirt{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubevirt",
-			Namespace: "kubevirt",
+			Name:      kvObjectName,
+			Namespace: kvObjectNamespace,
 		},
 		Spec: KVv1.KubeVirtSpec{
 			Configuration: *config,
@@ -94,11 +95,17 @@ func AddDataVolumeAPI(crdInformer cache.SharedIndexInformer) {
 	})
 }
 
+func GetFakeKubeVirtClusterConfig(kubeVirtInformer cache.SharedIndexInformer) *KVv1.KubeVirt {
+	obj, _, _ := kubeVirtInformer.GetStore().GetByKey(kvObjectNamespace + "/" + kvObjectName)
+	return obj.(*KVv1.KubeVirt)
+
+}
+
 func UpdateFakeKubeVirtClusterConfig(kubeVirtInformer cache.SharedIndexInformer, kv *KVv1.KubeVirt) {
 	clone := kv.DeepCopy()
 	clone.ResourceVersion = rand.String(10)
-	clone.Name = "kubevirt"
-	clone.Namespace = "kubevirt"
+	clone.Name = kvObjectName
+	clone.Namespace = kvObjectNamespace
 	clone.Status.Phase = "Deployed"
 
 	kubeVirtInformer.GetStore().Update(clone)

--- a/pkg/virt-api/webhooks/defaults.go
+++ b/pkg/virt-api/webhooks/defaults.go
@@ -83,11 +83,18 @@ func setDefaultVirtualMachineInstanceSpec(clusterConfig *virtconfig.ClusterConfi
 	setDefaultResourceRequests(clusterConfig, spec)
 	SetDefaultGuestCPUTopology(clusterConfig, spec)
 	setDefaultPullPoliciesOnContainerDisks(clusterConfig, spec)
+	setDefaultEvictionStrategy(clusterConfig, spec)
 	if err := clusterConfig.SetVMISpecDefaultNetworkInterface(spec); err != nil {
 		return err
 	}
 	util.SetDefaultVolumeDisk(spec)
 	return nil
+}
+
+func setDefaultEvictionStrategy(clusterConfig *virtconfig.ClusterConfig, spec *v1.VirtualMachineInstanceSpec) {
+	if spec.EvictionStrategy == nil {
+		spec.EvictionStrategy = clusterConfig.GetConfig().EvictionStrategy
+	}
 }
 
 func setDefaultMachineType(clusterConfig *virtconfig.ClusterConfig, spec *v1.VirtualMachineInstanceSpec) {

--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -179,6 +179,7 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 	defaultDiskVerification := &v1.DiskVerification{
 		MemoryLimit: resource.NewScaledQuantity(DefaultDiskVerificationMemoryLimitMBytes, resource.Mega),
 	}
+	defaultEvictionStrategy := v1.EvictionStrategyNone
 
 	return &v1.KubeVirtConfiguration{
 		ImagePullPolicy: DefaultImagePullPolicy,
@@ -198,6 +199,7 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 				VirtLauncher:   DefaultVirtLauncherLogVerbosity,
 			},
 		},
+		EvictionStrategy: &defaultEvictionStrategy,
 		MigrationConfiguration: &v1.MigrationConfiguration{
 			ParallelMigrationsPerCluster:      &parallelMigrationsPerClusterDefault,
 			ParallelOutboundMigrationsPerNode: &parallelOutboundMigrationsPerNodeDefault,


### PR DESCRIPTION
Store the VM assigned eviction strategy into the VMISpec, this
comes in handy as it's not always clear which evictionStrategy is
assigned to a VM if the cluster-wide setting was different
when the VM was first started.

https://bugzilla.redhat.com/show_bug.cgi?id=2228036

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
