### PR TITLE
[virtctl] Add support for an embedded novnc terminal

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,7 +18,7 @@ build:crossbuild-aarch64 --incompatible_enable_cc_toolchain_resolution --platfor
 run:crossbuild-aarch64  --incompatible_enable_cc_toolchain_resolution --platforms=//bazel/platforms:aarch64-none-linux-gnu --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo
 test:crossbuild-aarch64 --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64_cgo --host_javabase=@local_jdk//:jdk
 
-build --define gotags=selinux
+build --define gotags=selinux,includenovnc
 
 # let our unit tests produce our own junit reports
 test --action_env=GO_TEST_WRAP=0

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -84,11 +84,14 @@ nogo(
 )
 
 # gazelle:prefix kubevirt.io/kubevirt
-# gazelle:build_tags selinux
+# gazelle:build_tags selinux,includenovnc
 # gazelle:resolve go golang.org/x/tools/go/analysis @org_golang_x_tools//go/analysis:go_default_library
 gazelle(
     name = "gazelle",
-    build_tags = ["selinux"],
+    build_tags = [
+        "selinux",
+        "includenovnc",
+    ],
 )
 
 bazeldnf(name = "bazeldnf")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,6 +64,14 @@ http_archive(
     ],
 )
 
+http_file(
+    name = "novnc",
+    sha256 = "a2a3ebf0fda920339aebde719e9945e81524d46e00bdd59fdce32df9ceb9ac49",
+    urls = [
+        "https://github.com/novnc/noVNC/archive/refs/tags/v1.4.0.zip",
+    ],
+)
+
 http_archive(
     name = "io_bazel_rules_docker",
     sha256 = "95d39fd84ff4474babaf190450ee034d958202043e366b9fc38f438c9e6c3334",

--- a/cmd/virtctl/BUILD.bazel
+++ b/cmd/virtctl/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/virtctl:go_default_library",
+        "//pkg/virtctl/novnc:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
     ],
 )

--- a/cmd/virtctl/virtctl.go
+++ b/cmd/virtctl/virtctl.go
@@ -25,6 +25,9 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"kubevirt.io/kubevirt/pkg/virtctl" // Import to initialize client auth plugins.
+
+	// conditional commands
+	_ "kubevirt.io/kubevirt/pkg/virtctl/novnc" // build tag: "includenovnc"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8
 	github.com/cheggaaa/pb/v3 v3.1.0
+	github.com/cli/browser v1.2.0
 	github.com/containernetworking/plugins v1.1.1
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/prometheus-operator v0.38.3

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2u
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
+github.com/cli/browser v1.2.0 h1:yvU7e9qf97kZqGFX6n2zJPHsmSObY9ske+iCvKelvXg=
+github.com/cli/browser v1.2.0/go.mod h1:xFFnXLVcAyW9ni0cuo6NnrbCP75JxJ0RO7VtCBiH/oI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -1564,6 +1566,7 @@ golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -50,7 +50,8 @@
   "copylocks": {
     "exclude_files": {
       "vendor/": "vendor doesn't pass vet",
-      "external/": "externaldoesn't pass vet"
+      "external/": "externaldoesn't pass vet",
+      "pkg/virtctl/novnc/": "stdlib issue to work around"
     }
   },
   "httpresponse": {

--- a/pkg/virtctl/novnc/BUILD.bazel
+++ b/pkg/virtctl/novnc/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/virtctl/templates:go_default_library",
         "//staging/src/github.com/golang/glog:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/cli/browser:go_default_library",
         "//vendor/github.com/gorilla/websocket:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/golang.org/x/tools/godoc/vfs:go_default_library",

--- a/pkg/virtctl/novnc/BUILD.bazel
+++ b/pkg/virtctl/novnc/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "novnc.go",
+        "server.go",
+    ],
+    embedsrcs = ["novnc.zip"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/novnc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virtctl:go_default_library",
+        "//pkg/virtctl/templates:go_default_library",
+        "//staging/src/github.com/golang/glog:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/gorilla/websocket:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/golang.org/x/tools/godoc/vfs:go_default_library",
+        "//vendor/golang.org/x/tools/godoc/vfs/zipfs:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)
+
+copy_file(
+    name = "novnc.zip",
+    src = "@novnc//file",
+    out = "novnc.zip",
+)

--- a/pkg/virtctl/novnc/doc.go
+++ b/pkg/virtctl/novnc/doc.go
@@ -1,0 +1,1 @@
+package novnc

--- a/pkg/virtctl/novnc/novnc.go
+++ b/pkg/virtctl/novnc/novnc.go
@@ -41,6 +41,8 @@ var listenAddress = "127.0.0.1"
 var novncServer bool
 var customPort = 0
 
+var serveOnly bool
+
 func init() {
 	virtctl.CommandRegistrationCollback = append(virtctl.CommandRegistrationCollback, NewCommand)
 }
@@ -59,6 +61,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&listenAddress, "address", listenAddress, "--address=127.0.0.1: Setting this will change the listening address of the NOVNC server. Example: --address=0.0.0.0 will make the server listen on all interfaces.")
 	cmd.Flags().IntVar(&customPort, "port", customPort,
 		"--port=0: Assigning a port value to this will try to run the proxy on the given port if the port is accessible; If unassigned, the proxy will run on a random port")
+	cmd.Flags().BoolVar(&serveOnly, "serve-only", serveOnly, "--serve-only=false: Setting this true will run only serve novnc on the specified address and port and print the connection url, but will not open a browser")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -97,7 +100,7 @@ func (o *NOVNC) Run(cmd *cobra.Command, args []string) error {
 
 	go func() {
 		defer close(stopChan)
-		err = RunNOVNCWebserver(listenAddress, strconv.Itoa(customPort), vnc.AsConn())
+		err = RunNOVNCWebserver(listenAddress, strconv.Itoa(customPort), serveOnly, vnc.AsConn())
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -114,7 +117,11 @@ func (o *NOVNC) Run(cmd *cobra.Command, args []string) error {
 }
 
 func usage() string {
-	return `  # Connect to the testvmi and open the printed URL to connect via novnc :
+	return `  # Connect to the testvmi and open the printed URL to connect via novnc:
+   {{ProgramName}} vnc novnc --serve-only testvmi
+   Open http://127.0.0.1:39985?autoconnect=true to connect to the virtual machine.
+
+   # Connect to the testvmi and open a browser session automatically:
    {{ProgramName}} vnc novnc testvmi
-   Open http://127.0.0.1:39985?autoconnect=true to connect to the virtual machine.`
+`
 }

--- a/pkg/virtctl/novnc/novnc.go
+++ b/pkg/virtctl/novnc/novnc.go
@@ -1,0 +1,120 @@
+//go:build includenovnc
+
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017, 2018 Red Hat, Inc.
+ *
+ */
+
+package novnc
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/virtctl"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+var listenAddress = "127.0.0.1"
+
+var novncServer bool
+var customPort = 0
+
+func init() {
+	virtctl.CommandRegistrationCollback = append(virtctl.CommandRegistrationCollback, NewCommand)
+}
+
+func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "novnc (VMI)",
+		Short:   "Open a vnc connection to a virtual machine instance and access it via an embedded novnc instance",
+		Example: usage(),
+		Args:    templates.ExactArgs("novnc", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := NOVNC{clientConfig: clientConfig}
+			return c.Run(cmd, args)
+		},
+	}
+	cmd.Flags().StringVar(&listenAddress, "address", listenAddress, "--address=127.0.0.1: Setting this will change the listening address of the NOVNC server. Example: --address=0.0.0.0 will make the server listen on all interfaces.")
+	cmd.Flags().IntVar(&customPort, "port", customPort,
+		"--port=0: Assigning a port value to this will try to run the proxy on the given port if the port is accessible; If unassigned, the proxy will run on a random port")
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+type NOVNC struct {
+	clientConfig clientcmd.ClientConfig
+}
+
+func (o *NOVNC) Run(cmd *cobra.Command, args []string) error {
+	namespace, _, err := o.clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	vmi := args[0]
+
+	virtCli, err := kubecli.GetKubevirtClientFromClientConfig(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	// setup connection with VM
+	vnc, err := virtCli.VirtualMachineInstance(namespace).VNC(vmi)
+	if err != nil {
+		return fmt.Errorf("Can't access VMI %s: %s", vmi, err.Error())
+	}
+
+	stopChan := make(chan struct{}, 1)
+
+	go func() {
+		defer close(stopChan)
+		interrupt := make(chan os.Signal, 1)
+		signal.Notify(interrupt, os.Interrupt)
+		<-interrupt
+	}()
+
+	go func() {
+		defer close(stopChan)
+		err = RunNOVNCWebserver(listenAddress, strconv.Itoa(customPort), vnc.AsConn())
+		if err != nil {
+			fmt.Println(err)
+		}
+	}()
+
+	select {
+	case <-stopChan:
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error encountered: %s", err.Error())
+	}
+	return nil
+}
+
+func usage() string {
+	return `  # Connect to the testvmi and open the printed URL to connect via novnc :
+   {{ProgramName}} vnc novnc testvmi
+   Open http://127.0.0.1:39985?autoconnect=true to connect to the virtual machine.`
+}

--- a/pkg/virtctl/novnc/server.go
+++ b/pkg/virtctl/novnc/server.go
@@ -1,0 +1,153 @@
+//go:build includenovnc
+
+package novnc
+
+import (
+	"archive/zip"
+	"bytes"
+	_ "embed"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/gorilla/websocket"
+	"golang.org/x/tools/godoc/vfs"
+	"golang.org/x/tools/godoc/vfs/zipfs"
+	"kubevirt.io/client-go/kubecli"
+)
+
+//go:embed novnc.zip
+var novnc []byte
+
+var mimetypes = map[string]string{
+	".html": "text/html",
+	".js":   "text/javascript",
+	".svg":  "image/svg+xml",
+	".css":  "text/css",
+	".woff": "application/x-font-woff",
+	".oga":  "audio/ogg",
+	".json": "application/json",
+	".ico":  "image/x-icon",
+}
+
+func RunNOVNCWebserver(address, port string, vnc net.Conn) error {
+
+	reader, err := zip.NewReader(bytes.NewReader(novnc), int64(len(novnc)))
+	if err != nil {
+		panic(err)
+	}
+
+	rc := &zip.ReadCloser{
+		Reader: *reader,
+	}
+	fs := zipfs.New(rc, "novnc")
+
+	dirs, err := fs.ReadDir("/")
+	if err != nil {
+		return err
+	}
+	if len(dirs) != 1 {
+		return fmt.Errorf("exprected only one base directory, but got %v", len(dirs))
+	}
+	baseDir := strings.TrimSpace(dirs[0].Name())
+
+	writeChan := make(chan struct{})
+	readChan := make(chan struct{})
+
+	lnAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%s", address, port))
+	if err != nil {
+		return fmt.Errorf("Can't resolve the address: %s", err.Error())
+	}
+
+	// Listen early to be sure the http server is ready when we open the browser
+	l, err := net.ListenTCP("tcp", lnAddr)
+	if err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", serveNOVNC(baseDir, fs))
+	mux.HandleFunc("/websockify", func(writer http.ResponseWriter, request *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(writer, request, nil)
+		if err != nil {
+			glog.Errorf("failed to upgrade the websocket connection %v", err)
+			writer.WriteHeader(500)
+			return
+		}
+		defer conn.Close()
+		done := make(chan struct{})
+		defer close(done)
+		wsConn := kubecli.NewWebsocketStreamer(conn, done).AsConn()
+
+		go func() {
+			_, err := io.Copy(vnc, wsConn)
+			if err != nil {
+				glog.Errorf("failed to copy content from server to novnc: %v", err)
+			}
+			close(writeChan)
+		}()
+		go func() {
+			_, err := io.Copy(wsConn, vnc)
+			if err != nil {
+				glog.Errorf("failed to copy content from novnc to server: %v", err)
+			}
+			close(readChan)
+		}()
+
+		select {
+		case <-writeChan:
+		case <-readChan:
+		}
+
+	})
+
+	errChan := make(chan error, 1)
+
+	go func() {
+		errChan <- http.Serve(l, mux)
+	}()
+
+	fmt.Printf("Open http://%v:%v?autoconnect=true to connect to the virtual machine.\n", l.Addr().(*net.TCPAddr).IP, l.Addr().(*net.TCPAddr).Port)
+	select {
+	case <-writeChan:
+	case <-readChan:
+	case err := <-errChan:
+		return err
+	}
+	return nil
+}
+
+func serveNOVNC(baseDir string, fs vfs.FileSystem) func(writer http.ResponseWriter, request *http.Request) {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Cache-Control", "no-cache")
+
+		path := request.URL.Path
+		if path == "/" {
+			path = "/vnc.html"
+		}
+		if ext := filepath.Ext(path); ext != "" {
+			if _, exists := mimetypes[ext]; !exists {
+				glog.Warningf("unknown content-type for file with extension: %v", ext)
+			}
+			writer.Header().Set("Content-Type", mimetypes[ext])
+		}
+		path = filepath.Join("/", baseDir, path)
+		reader, err := fs.Open(path)
+		if err != nil {
+			glog.Errorf("failed to read path %v: %v", path, err)
+			writer.WriteHeader(500)
+			return
+		}
+		defer reader.Close()
+		if _, err := io.Copy(writer, reader); err != nil {
+			glog.Errorf("failed to serve path content %v: %v", path, err)
+			writer.WriteHeader(500)
+			return
+		}
+	}
+}

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -36,6 +36,10 @@ import (
 
 var programName string
 
+// CommandRegistrationCollback allows dynamic registration of virtctl commands based on
+// golang build tags.
+var CommandRegistrationCollback []func(clientConfig clientcmd.ClientConfig) *cobra.Command
+
 func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 
 	programName := GetProgramName(filepath.Base(os.Args[0]))
@@ -111,6 +115,9 @@ func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 		credentials.NewCommand(clientConfig),
 		optionsCmd,
 	)
+	for _, cmd := range CommandRegistrationCollback {
+		rootCmd.AddCommand(cmd(clientConfig))
+	}
 	return rootCmd, clientConfig
 }
 

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -35,7 +35,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
-
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
@@ -65,6 +64,7 @@ const (
 var listenAddressFmt string
 var listenAddress = "127.0.0.1"
 var proxyOnly bool
+
 var customPort = 0
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {

--- a/vendor/github.com/cli/browser/BUILD.bazel
+++ b/vendor/github.com/cli/browser/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "browser.go",
+        "browser_darwin.go",
+        "browser_freebsd.go",
+        "browser_linux.go",
+        "browser_netbsd.go",
+        "browser_openbsd.go",
+        "browser_unsupported.go",
+        "browser_windows.go",
+    ],
+    importmap = "kubevirt.io/kubevirt/vendor/github.com/cli/browser",
+    importpath = "github.com/cli/browser",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//vendor/golang.org/x/sys/windows:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/vendor/github.com/cli/browser/LICENSE
+++ b/vendor/github.com/cli/browser/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2014, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/cli/browser/README.md
+++ b/vendor/github.com/cli/browser/README.md
@@ -1,0 +1,20 @@
+
+# browser
+
+Helpers to open URLs, readers, or files in the system default web browser.
+
+This fork adds:
+
+- `OpenReader` error wrapping;
+- `ErrNotFound` error wrapping on BSD;
+- Go 1.13 support.
+
+## Usage
+
+``` go
+import "github.com/cli/browser"
+
+err = browser.OpenURL(url)
+err = browser.OpenFile(path)
+err = browser.OpenReader(reader)
+```

--- a/vendor/github.com/cli/browser/browser.go
+++ b/vendor/github.com/cli/browser/browser.go
@@ -1,0 +1,57 @@
+// Package browser provides helpers to open files, readers, and urls in a browser window.
+//
+// The choice of which browser is started is entirely client dependent.
+package browser
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// Stdout is the io.Writer to which executed commands write standard output.
+var Stdout io.Writer = os.Stdout
+
+// Stderr is the io.Writer to which executed commands write standard error.
+var Stderr io.Writer = os.Stderr
+
+// OpenFile opens new browser window for the file path.
+func OpenFile(path string) error {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	return OpenURL("file://" + path)
+}
+
+// OpenReader consumes the contents of r and presents the
+// results in a new browser window.
+func OpenReader(r io.Reader) error {
+	f, err := ioutil.TempFile("", "browser.*.html")
+	if err != nil {
+		return fmt.Errorf("browser: could not create temporary file: %w", err)
+	}
+	if _, err := io.Copy(f, r); err != nil {
+		f.Close()
+		return fmt.Errorf("browser: caching temporary file failed: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("browser: caching temporary file failed: %w", err)
+	}
+	return OpenFile(f.Name())
+}
+
+// OpenURL opens a new browser window pointing to url.
+func OpenURL(url string) error {
+	return openBrowser(url)
+}
+
+func runCmd(prog string, args ...string) error {
+	cmd := exec.Command(prog, args...)
+	cmd.Stdout = Stdout
+	cmd.Stderr = Stderr
+	return cmd.Run()
+}

--- a/vendor/github.com/cli/browser/browser_darwin.go
+++ b/vendor/github.com/cli/browser/browser_darwin.go
@@ -1,0 +1,5 @@
+package browser
+
+func openBrowser(url string) error {
+	return runCmd("open", url)
+}

--- a/vendor/github.com/cli/browser/browser_freebsd.go
+++ b/vendor/github.com/cli/browser/browser_freebsd.go
@@ -1,0 +1,15 @@
+package browser
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+func openBrowser(url string) error {
+	err := runCmd("xdg-open", url)
+	if errors.Is(err, exec.ErrNotFound) {
+		return fmt.Errorf("%w - install xdg-utils from ports(8)", err)
+	}
+	return err
+}

--- a/vendor/github.com/cli/browser/browser_linux.go
+++ b/vendor/github.com/cli/browser/browser_linux.go
@@ -1,0 +1,21 @@
+package browser
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func openBrowser(url string) error {
+	providers := []string{"xdg-open", "x-www-browser", "www-browser", "wslview"}
+
+	// There are multiple possible providers to open a browser on linux
+	// One of them is xdg-open, another is x-www-browser, then there's www-browser, etc.
+	// Look for one that exists and run it
+	for _, provider := range providers {
+		if _, err := exec.LookPath(provider); err == nil {
+			return runCmd(provider, url)
+		}
+	}
+
+	return &exec.Error{Name: strings.Join(providers, ","), Err: exec.ErrNotFound}
+}

--- a/vendor/github.com/cli/browser/browser_netbsd.go
+++ b/vendor/github.com/cli/browser/browser_netbsd.go
@@ -1,0 +1,14 @@
+package browser
+
+import (
+	"errors"
+	"os/exec"
+)
+
+func openBrowser(url string) error {
+	err := runCmd("xdg-open", url)
+	if e, ok := err.(*exec.Error); ok && e.Err == exec.ErrNotFound {
+		return errors.New("xdg-open: command not found - install xdg-utils from pkgsrc(7)")
+	}
+	return err
+}

--- a/vendor/github.com/cli/browser/browser_openbsd.go
+++ b/vendor/github.com/cli/browser/browser_openbsd.go
@@ -1,0 +1,15 @@
+package browser
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+func openBrowser(url string) error {
+	err := runCmd("xdg-open", url)
+	if errors.Is(err, exec.ErrNotFound) {
+		return fmt.Errorf("%w - install xdg-utils from ports(8)", err)
+	}
+	return err
+}

--- a/vendor/github.com/cli/browser/browser_unsupported.go
+++ b/vendor/github.com/cli/browser/browser_unsupported.go
@@ -1,0 +1,12 @@
+// +build !linux,!windows,!darwin,!openbsd,!freebsd,!netbsd
+
+package browser
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func openBrowser(url string) error {
+	return fmt.Errorf("openBrowser: unsupported operating system: %v", runtime.GOOS)
+}

--- a/vendor/github.com/cli/browser/browser_windows.go
+++ b/vendor/github.com/cli/browser/browser_windows.go
@@ -1,0 +1,7 @@
+package browser
+
+import "golang.org/x/sys/windows"
+
+func openBrowser(url string) error {
+	return windows.ShellExecute(0, nil, windows.StringToUTF16Ptr(url), nil, nil, windows.SW_SHOWNORMAL)
+}

--- a/vendor/golang.org/x/tools/godoc/vfs/BUILD.bazel
+++ b/vendor/golang.org/x/tools/godoc/vfs/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "emptyvfs.go",
+        "fs.go",
+        "namespace.go",
+        "os.go",
+        "vfs.go",
+    ],
+    importmap = "kubevirt.io/kubevirt/vendor/golang.org/x/tools/godoc/vfs",
+    importpath = "golang.org/x/tools/godoc/vfs",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/golang.org/x/tools/godoc/vfs/emptyvfs.go
+++ b/vendor/golang.org/x/tools/godoc/vfs/emptyvfs.go
@@ -1,0 +1,89 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vfs
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// NewNameSpace returns a NameSpace pre-initialized with an empty
+// emulated directory mounted on the root mount point "/". This
+// allows directory traversal routines to work properly even if
+// a folder is not explicitly mounted at root by the user.
+func NewNameSpace() NameSpace {
+	ns := NameSpace{}
+	ns.Bind("/", &emptyVFS{}, "/", BindReplace)
+	return ns
+}
+
+// type emptyVFS emulates a FileSystem consisting of an empty directory
+type emptyVFS struct{}
+
+// Open implements Opener. Since emptyVFS is an empty directory, all
+// attempts to open a file should returns errors.
+func (e *emptyVFS) Open(path string) (ReadSeekCloser, error) {
+	if path == "/" {
+		return nil, fmt.Errorf("open: / is a directory")
+	}
+	return nil, os.ErrNotExist
+}
+
+// Stat returns os.FileInfo for an empty directory if the path is
+// is root "/" or error. os.FileInfo is implemented by emptyVFS
+func (e *emptyVFS) Stat(path string) (os.FileInfo, error) {
+	if path == "/" {
+		return e, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (e *emptyVFS) Lstat(path string) (os.FileInfo, error) {
+	return e.Stat(path)
+}
+
+// ReadDir returns an empty os.FileInfo slice for "/", else error.
+func (e *emptyVFS) ReadDir(path string) ([]os.FileInfo, error) {
+	if path == "/" {
+		return []os.FileInfo{}, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (e *emptyVFS) String() string {
+	return "emptyVFS(/)"
+}
+
+func (e *emptyVFS) RootType(path string) RootType {
+	return ""
+}
+
+// These functions below implement os.FileInfo for the single
+// empty emulated directory.
+
+func (e *emptyVFS) Name() string {
+	return "/"
+}
+
+func (e *emptyVFS) Size() int64 {
+	return 0
+}
+
+func (e *emptyVFS) Mode() os.FileMode {
+	return os.ModeDir | os.ModePerm
+}
+
+func (e *emptyVFS) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (e *emptyVFS) IsDir() bool {
+	return true
+}
+
+func (e *emptyVFS) Sys() interface{} {
+	return nil
+}

--- a/vendor/golang.org/x/tools/godoc/vfs/fs.go
+++ b/vendor/golang.org/x/tools/godoc/vfs/fs.go
@@ -1,0 +1,80 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.16
+// +build go1.16
+
+package vfs
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+)
+
+// FromFS converts an fs.FS to the FileSystem interface.
+func FromFS(fsys fs.FS) FileSystem {
+	return &fsysToFileSystem{fsys}
+}
+
+type fsysToFileSystem struct {
+	fsys fs.FS
+}
+
+func (f *fsysToFileSystem) fsPath(name string) string {
+	name = path.Clean(name)
+	if name == "/" {
+		return "."
+	}
+	return strings.TrimPrefix(name, "/")
+}
+
+func (f *fsysToFileSystem) Open(name string) (ReadSeekCloser, error) {
+	file, err := f.fsys.Open(f.fsPath(name))
+	if err != nil {
+		return nil, err
+	}
+	if rsc, ok := file.(ReadSeekCloser); ok {
+		return rsc, nil
+	}
+	return &noSeekFile{f.fsPath(name), file}, nil
+}
+
+func (f *fsysToFileSystem) Lstat(name string) (os.FileInfo, error) {
+	return fs.Stat(f.fsys, f.fsPath(name))
+}
+
+func (f *fsysToFileSystem) Stat(name string) (os.FileInfo, error) {
+	return fs.Stat(f.fsys, f.fsPath(name))
+}
+
+func (f *fsysToFileSystem) RootType(name string) RootType { return "" }
+
+func (f *fsysToFileSystem) ReadDir(name string) ([]os.FileInfo, error) {
+	dirs, err := fs.ReadDir(f.fsys, f.fsPath(name))
+	var infos []os.FileInfo
+	for _, d := range dirs {
+		info, err1 := d.Info()
+		if err1 != nil {
+			if err == nil {
+				err = err1
+			}
+			continue
+		}
+		infos = append(infos, info)
+	}
+	return infos, err
+}
+
+func (f *fsysToFileSystem) String() string { return "io/fs" }
+
+type noSeekFile struct {
+	path string
+	fs.File
+}
+
+func (f *noSeekFile) Seek(offset int64, whence int) (int64, error) {
+	return 0, &fs.PathError{Op: "seek", Path: f.path, Err: fs.ErrInvalid}
+}

--- a/vendor/golang.org/x/tools/godoc/vfs/namespace.go
+++ b/vendor/golang.org/x/tools/godoc/vfs/namespace.go
@@ -1,0 +1,387 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vfs
+
+import (
+	"fmt"
+	"io"
+	"os"
+	pathpkg "path"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Setting debugNS = true will enable debugging prints about
+// name space translations.
+const debugNS = false
+
+// A NameSpace is a file system made up of other file systems
+// mounted at specific locations in the name space.
+//
+// The representation is a map from mount point locations
+// to the list of file systems mounted at that location.  A traditional
+// Unix mount table would use a single file system per mount point,
+// but we want to be able to mount multiple file systems on a single
+// mount point and have the system behave as if the union of those
+// file systems were present at the mount point.
+// For example, if the OS file system has a Go installation in
+// c:\Go and additional Go path trees in d:\Work1 and d:\Work2, then
+// this name space creates the view we want for the godoc server:
+//
+//	NameSpace{
+//		"/": {
+//			{old: "/", fs: OS(`c:\Go`), new: "/"},
+//		},
+//		"/src/pkg": {
+//			{old: "/src/pkg", fs: OS(`c:\Go`), new: "/src/pkg"},
+//			{old: "/src/pkg", fs: OS(`d:\Work1`), new: "/src"},
+//			{old: "/src/pkg", fs: OS(`d:\Work2`), new: "/src"},
+//		},
+//	}
+//
+// This is created by executing:
+//
+//	ns := NameSpace{}
+//	ns.Bind("/", OS(`c:\Go`), "/", BindReplace)
+//	ns.Bind("/src/pkg", OS(`d:\Work1`), "/src", BindAfter)
+//	ns.Bind("/src/pkg", OS(`d:\Work2`), "/src", BindAfter)
+//
+// A particular mount point entry is a triple (old, fs, new), meaning that to
+// operate on a path beginning with old, replace that prefix (old) with new
+// and then pass that path to the FileSystem implementation fs.
+//
+// If you do not explicitly mount a FileSystem at the root mountpoint "/" of the
+// NameSpace like above, Stat("/") will return a "not found" error which could
+// break typical directory traversal routines. In such cases, use NewNameSpace()
+// to get a NameSpace pre-initialized with an emulated empty directory at root.
+//
+// Given this name space, a ReadDir of /src/pkg/code will check each prefix
+// of the path for a mount point (first /src/pkg/code, then /src/pkg, then /src,
+// then /), stopping when it finds one.  For the above example, /src/pkg/code
+// will find the mount point at /src/pkg:
+//
+//	{old: "/src/pkg", fs: OS(`c:\Go`), new: "/src/pkg"},
+//	{old: "/src/pkg", fs: OS(`d:\Work1`), new: "/src"},
+//	{old: "/src/pkg", fs: OS(`d:\Work2`), new: "/src"},
+//
+// ReadDir will when execute these three calls and merge the results:
+//
+//	OS(`c:\Go`).ReadDir("/src/pkg/code")
+//	OS(`d:\Work1').ReadDir("/src/code")
+//	OS(`d:\Work2').ReadDir("/src/code")
+//
+// Note that the "/src/pkg" in "/src/pkg/code" has been replaced by
+// just "/src" in the final two calls.
+//
+// OS is itself an implementation of a file system: it implements
+// OS(`c:\Go`).ReadDir("/src/pkg/code") as ioutil.ReadDir(`c:\Go\src\pkg\code`).
+//
+// Because the new path is evaluated by fs (here OS(root)), another way
+// to read the mount table is to mentally combine fs+new, so that this table:
+//
+//	{old: "/src/pkg", fs: OS(`c:\Go`), new: "/src/pkg"},
+//	{old: "/src/pkg", fs: OS(`d:\Work1`), new: "/src"},
+//	{old: "/src/pkg", fs: OS(`d:\Work2`), new: "/src"},
+//
+// reads as:
+//
+//	"/src/pkg" -> c:\Go\src\pkg
+//	"/src/pkg" -> d:\Work1\src
+//	"/src/pkg" -> d:\Work2\src
+//
+// An invariant (a redundancy) of the name space representation is that
+// ns[mtpt][i].old is always equal to mtpt (in the example, ns["/src/pkg"]'s
+// mount table entries always have old == "/src/pkg").  The 'old' field is
+// useful to callers, because they receive just a []mountedFS and not any
+// other indication of which mount point was found.
+type NameSpace map[string][]mountedFS
+
+// A mountedFS handles requests for path by replacing
+// a prefix 'old' with 'new' and then calling the fs methods.
+type mountedFS struct {
+	old string
+	fs  FileSystem
+	new string
+}
+
+// hasPathPrefix reports whether x == y or x == y + "/" + more.
+func hasPathPrefix(x, y string) bool {
+	return x == y || strings.HasPrefix(x, y) && (strings.HasSuffix(y, "/") || strings.HasPrefix(x[len(y):], "/"))
+}
+
+// translate translates path for use in m, replacing old with new.
+//
+// mountedFS{"/src/pkg", fs, "/src"}.translate("/src/pkg/code") == "/src/code".
+func (m mountedFS) translate(path string) string {
+	path = pathpkg.Clean("/" + path)
+	if !hasPathPrefix(path, m.old) {
+		panic("translate " + path + " but old=" + m.old)
+	}
+	return pathpkg.Join(m.new, path[len(m.old):])
+}
+
+func (NameSpace) String() string {
+	return "ns"
+}
+
+// Fprint writes a text representation of the name space to w.
+func (ns NameSpace) Fprint(w io.Writer) {
+	fmt.Fprint(w, "name space {\n")
+	var all []string
+	for mtpt := range ns {
+		all = append(all, mtpt)
+	}
+	sort.Strings(all)
+	for _, mtpt := range all {
+		fmt.Fprintf(w, "\t%s:\n", mtpt)
+		for _, m := range ns[mtpt] {
+			fmt.Fprintf(w, "\t\t%s %s\n", m.fs, m.new)
+		}
+	}
+	fmt.Fprint(w, "}\n")
+}
+
+// clean returns a cleaned, rooted path for evaluation.
+// It canonicalizes the path so that we can use string operations
+// to analyze it.
+func (NameSpace) clean(path string) string {
+	return pathpkg.Clean("/" + path)
+}
+
+type BindMode int
+
+const (
+	BindReplace BindMode = iota
+	BindBefore
+	BindAfter
+)
+
+// Bind causes references to old to redirect to the path new in newfs.
+// If mode is BindReplace, old redirections are discarded.
+// If mode is BindBefore, this redirection takes priority over existing ones,
+// but earlier ones are still consulted for paths that do not exist in newfs.
+// If mode is BindAfter, this redirection happens only after existing ones
+// have been tried and failed.
+func (ns NameSpace) Bind(old string, newfs FileSystem, new string, mode BindMode) {
+	old = ns.clean(old)
+	new = ns.clean(new)
+	m := mountedFS{old, newfs, new}
+	var mtpt []mountedFS
+	switch mode {
+	case BindReplace:
+		mtpt = append(mtpt, m)
+	case BindAfter:
+		mtpt = append(mtpt, ns.resolve(old)...)
+		mtpt = append(mtpt, m)
+	case BindBefore:
+		mtpt = append(mtpt, m)
+		mtpt = append(mtpt, ns.resolve(old)...)
+	}
+
+	// Extend m.old, m.new in inherited mount point entries.
+	for i := range mtpt {
+		m := &mtpt[i]
+		if m.old != old {
+			if !hasPathPrefix(old, m.old) {
+				// This should not happen.  If it does, panic so
+				// that we can see the call trace that led to it.
+				panic(fmt.Sprintf("invalid Bind: old=%q m={%q, %s, %q}", old, m.old, m.fs.String(), m.new))
+			}
+			suffix := old[len(m.old):]
+			m.old = pathpkg.Join(m.old, suffix)
+			m.new = pathpkg.Join(m.new, suffix)
+		}
+	}
+
+	ns[old] = mtpt
+}
+
+// resolve resolves a path to the list of mountedFS to use for path.
+func (ns NameSpace) resolve(path string) []mountedFS {
+	path = ns.clean(path)
+	for {
+		if m := ns[path]; m != nil {
+			if debugNS {
+				fmt.Printf("resolve %s: %v\n", path, m)
+			}
+			return m
+		}
+		if path == "/" {
+			break
+		}
+		path = pathpkg.Dir(path)
+	}
+	return nil
+}
+
+// Open implements the FileSystem Open method.
+func (ns NameSpace) Open(path string) (ReadSeekCloser, error) {
+	var err error
+	for _, m := range ns.resolve(path) {
+		if debugNS {
+			fmt.Printf("tx %s: %v\n", path, m.translate(path))
+		}
+		tp := m.translate(path)
+		r, err1 := m.fs.Open(tp)
+		if err1 == nil {
+			return r, nil
+		}
+		// IsNotExist errors in overlay FSes can mask real errors in
+		// the underlying FS, so ignore them if there is another error.
+		if err == nil || os.IsNotExist(err) {
+			err = err1
+		}
+	}
+	if err == nil {
+		err = &os.PathError{Op: "open", Path: path, Err: os.ErrNotExist}
+	}
+	return nil, err
+}
+
+// stat implements the FileSystem Stat and Lstat methods.
+func (ns NameSpace) stat(path string, f func(FileSystem, string) (os.FileInfo, error)) (os.FileInfo, error) {
+	var err error
+	for _, m := range ns.resolve(path) {
+		fi, err1 := f(m.fs, m.translate(path))
+		if err1 == nil {
+			return fi, nil
+		}
+		if err == nil {
+			err = err1
+		}
+	}
+	if err == nil {
+		err = &os.PathError{Op: "stat", Path: path, Err: os.ErrNotExist}
+	}
+	return nil, err
+}
+
+func (ns NameSpace) Stat(path string) (os.FileInfo, error) {
+	return ns.stat(path, FileSystem.Stat)
+}
+
+func (ns NameSpace) Lstat(path string) (os.FileInfo, error) {
+	return ns.stat(path, FileSystem.Lstat)
+}
+
+// dirInfo is a trivial implementation of os.FileInfo for a directory.
+type dirInfo string
+
+func (d dirInfo) Name() string       { return string(d) }
+func (d dirInfo) Size() int64        { return 0 }
+func (d dirInfo) Mode() os.FileMode  { return os.ModeDir | 0555 }
+func (d dirInfo) ModTime() time.Time { return startTime }
+func (d dirInfo) IsDir() bool        { return true }
+func (d dirInfo) Sys() interface{}   { return nil }
+
+var startTime = time.Now()
+
+// ReadDir implements the FileSystem ReadDir method.  It's where most of the magic is.
+// (The rest is in resolve.)
+//
+// Logically, ReadDir must return the union of all the directories that are named
+// by path.  In order to avoid misinterpreting Go packages, of all the directories
+// that contain Go source code, we only include the files from the first,
+// but we include subdirectories from all.
+//
+// ReadDir must also return directory entries needed to reach mount points.
+// If the name space looks like the example in the type NameSpace comment,
+// but c:\Go does not have a src/pkg subdirectory, we still want to be able
+// to find that subdirectory, because we've mounted d:\Work1 and d:\Work2
+// there.  So if we don't see "src" in the directory listing for c:\Go, we add an
+// entry for it before returning.
+func (ns NameSpace) ReadDir(path string) ([]os.FileInfo, error) {
+	path = ns.clean(path)
+
+	// List matching directories and determine whether any of them contain
+	// Go files.
+	var (
+		dirs       [][]os.FileInfo
+		goDirIndex = -1
+		readDirErr error
+	)
+
+	for _, m := range ns.resolve(path) {
+		dir, err := m.fs.ReadDir(m.translate(path))
+		if err != nil {
+			if readDirErr == nil {
+				readDirErr = err
+			}
+			continue
+		}
+
+		dirs = append(dirs, dir)
+
+		if goDirIndex < 0 {
+			for _, f := range dir {
+				if !f.IsDir() && strings.HasSuffix(f.Name(), ".go") {
+					goDirIndex = len(dirs) - 1
+					break
+				}
+			}
+		}
+	}
+
+	// Build a list of files and subdirectories. If a directory contains Go files,
+	// only include files from that directory. Otherwise, include files from
+	// all directories. Include subdirectories from all directories regardless
+	// of whether Go files are present.
+	haveName := make(map[string]bool)
+	var all []os.FileInfo
+	for i, dir := range dirs {
+		for _, f := range dir {
+			name := f.Name()
+			if !haveName[name] && (f.IsDir() || goDirIndex < 0 || goDirIndex == i) {
+				all = append(all, f)
+				haveName[name] = true
+			}
+		}
+	}
+
+	// Add any missing directories needed to reach mount points.
+	for old := range ns {
+		if hasPathPrefix(old, path) && old != path {
+			// Find next element after path in old.
+			elem := old[len(path):]
+			elem = strings.TrimPrefix(elem, "/")
+			if i := strings.Index(elem, "/"); i >= 0 {
+				elem = elem[:i]
+			}
+			if !haveName[elem] {
+				haveName[elem] = true
+				all = append(all, dirInfo(elem))
+			}
+		}
+	}
+
+	if len(all) == 0 {
+		return nil, readDirErr
+	}
+
+	sort.Sort(byName(all))
+	return all, nil
+}
+
+// RootType returns the RootType for the given path in the namespace.
+func (ns NameSpace) RootType(path string) RootType {
+	// We resolve the given path to a list of mountedFS and then return
+	// the root type for the filesystem which contains the path.
+	for _, m := range ns.resolve(path) {
+		_, err := m.fs.ReadDir(m.translate(path))
+		// Found a match, return the filesystem's root type
+		if err == nil {
+			return m.fs.RootType(path)
+		}
+	}
+	return ""
+}
+
+// byName implements sort.Interface.
+type byName []os.FileInfo
+
+func (f byName) Len() int           { return len(f) }
+func (f byName) Less(i, j int) bool { return f[i].Name() < f[j].Name() }
+func (f byName) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }

--- a/vendor/golang.org/x/tools/godoc/vfs/os.go
+++ b/vendor/golang.org/x/tools/godoc/vfs/os.go
@@ -1,0 +1,105 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vfs
+
+import (
+	"fmt"
+	"go/build"
+	"io/ioutil"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"runtime"
+)
+
+// We expose a new variable because otherwise we need to copy the findGOROOT logic again
+// from cmd/godoc which is already copied twice from the standard library.
+
+// GOROOT is the GOROOT path under which the godoc binary is running.
+// It is needed to check whether a filesystem root is under GOROOT or not.
+// This is set from cmd/godoc/main.go.
+var GOROOT = runtime.GOROOT()
+
+// OS returns an implementation of FileSystem reading from the
+// tree rooted at root.  Recording a root is convenient everywhere
+// but necessary on Windows, because the slash-separated path
+// passed to Open has no way to specify a drive letter.  Using a root
+// lets code refer to OS(`c:\`), OS(`d:\`) and so on.
+func OS(root string) FileSystem {
+	var t RootType
+	switch {
+	case root == GOROOT:
+		t = RootTypeGoRoot
+	case isGoPath(root):
+		t = RootTypeGoPath
+	}
+	return osFS{rootPath: root, rootType: t}
+}
+
+type osFS struct {
+	rootPath string
+	rootType RootType
+}
+
+func isGoPath(path string) bool {
+	for _, bp := range filepath.SplitList(build.Default.GOPATH) {
+		for _, gp := range filepath.SplitList(path) {
+			if bp == gp {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (root osFS) String() string { return "os(" + root.rootPath + ")" }
+
+// RootType returns the root type for the filesystem.
+//
+// Note that we ignore the path argument because roottype is a property of
+// this filesystem. But for other filesystems, the roottype might need to be
+// dynamically deduced at call time.
+func (root osFS) RootType(path string) RootType {
+	return root.rootType
+}
+
+func (root osFS) resolve(path string) string {
+	// Clean the path so that it cannot possibly begin with ../.
+	// If it did, the result of filepath.Join would be outside the
+	// tree rooted at root.  We probably won't ever see a path
+	// with .. in it, but be safe anyway.
+	path = pathpkg.Clean("/" + path)
+
+	return filepath.Join(root.rootPath, path)
+}
+
+func (root osFS) Open(path string) (ReadSeekCloser, error) {
+	f, err := os.Open(root.resolve(path))
+	if err != nil {
+		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if fi.IsDir() {
+		f.Close()
+		return nil, fmt.Errorf("Open: %s is a directory", path)
+	}
+	return f, nil
+}
+
+func (root osFS) Lstat(path string) (os.FileInfo, error) {
+	return os.Lstat(root.resolve(path))
+}
+
+func (root osFS) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(root.resolve(path))
+}
+
+func (root osFS) ReadDir(path string) ([]os.FileInfo, error) {
+	return ioutil.ReadDir(root.resolve(path)) // is sorted
+}

--- a/vendor/golang.org/x/tools/godoc/vfs/vfs.go
+++ b/vendor/golang.org/x/tools/godoc/vfs/vfs.go
@@ -1,0 +1,58 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package vfs defines types for abstract file system access and provides an
+// implementation accessing the file system of the underlying OS.
+package vfs // import "golang.org/x/tools/godoc/vfs"
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// RootType indicates the type of files contained within a directory.
+//
+// It is used to indicate whether a directory is the root
+// of a GOROOT, a GOPATH, or neither.
+// An empty string represents the case when a directory is neither.
+type RootType string
+
+const (
+	RootTypeGoRoot RootType = "GOROOT"
+	RootTypeGoPath RootType = "GOPATH"
+)
+
+// The FileSystem interface specifies the methods godoc is using
+// to access the file system for which it serves documentation.
+type FileSystem interface {
+	Opener
+	Lstat(path string) (os.FileInfo, error)
+	Stat(path string) (os.FileInfo, error)
+	ReadDir(path string) ([]os.FileInfo, error)
+	RootType(path string) RootType
+	String() string
+}
+
+// Opener is a minimal virtual filesystem that can only open regular files.
+type Opener interface {
+	Open(name string) (ReadSeekCloser, error)
+}
+
+// A ReadSeekCloser can Read, Seek, and Close.
+type ReadSeekCloser interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
+
+// ReadFile reads the file named by path from fs and returns the contents.
+func ReadFile(fs Opener, path string) ([]byte, error) {
+	rc, err := fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return ioutil.ReadAll(rc)
+}

--- a/vendor/golang.org/x/tools/godoc/vfs/zipfs/BUILD.bazel
+++ b/vendor/golang.org/x/tools/godoc/vfs/zipfs/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["zipfs.go"],
+    importmap = "kubevirt.io/kubevirt/vendor/golang.org/x/tools/godoc/vfs/zipfs",
+    importpath = "golang.org/x/tools/godoc/vfs/zipfs",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/golang.org/x/tools/godoc/vfs:go_default_library"],
+)

--- a/vendor/golang.org/x/tools/godoc/vfs/zipfs/zipfs.go
+++ b/vendor/golang.org/x/tools/godoc/vfs/zipfs/zipfs.go
@@ -1,0 +1,291 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package zipfs file provides an implementation of the FileSystem
+// interface based on the contents of a .zip file.
+//
+// Assumptions:
+//
+//   - The file paths stored in the zip file must use a slash ('/') as path
+//     separator; and they must be relative (i.e., they must not start with
+//     a '/' - this is usually the case if the file was created w/o special
+//     options).
+//   - The zip file system treats the file paths found in the zip internally
+//     like absolute paths w/o a leading '/'; i.e., the paths are considered
+//     relative to the root of the file system.
+//   - All path arguments to file system methods must be absolute paths.
+package zipfs // import "golang.org/x/tools/godoc/vfs/zipfs"
+
+import (
+	"archive/zip"
+	"fmt"
+	"go/build"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/tools/godoc/vfs"
+)
+
+// zipFI is the zip-file based implementation of FileInfo
+type zipFI struct {
+	name string    // directory-local name
+	file *zip.File // nil for a directory
+}
+
+func (fi zipFI) Name() string {
+	return fi.name
+}
+
+func (fi zipFI) Size() int64 {
+	if f := fi.file; f != nil {
+		return int64(f.UncompressedSize)
+	}
+	return 0 // directory
+}
+
+func (fi zipFI) ModTime() time.Time {
+	if f := fi.file; f != nil {
+		return f.ModTime()
+	}
+	return time.Time{} // directory has no modified time entry
+}
+
+func (fi zipFI) Mode() os.FileMode {
+	if fi.file == nil {
+		// Unix directories typically are executable, hence 555.
+		return os.ModeDir | 0555
+	}
+	return 0444
+}
+
+func (fi zipFI) IsDir() bool {
+	return fi.file == nil
+}
+
+func (fi zipFI) Sys() interface{} {
+	return nil
+}
+
+// zipFS is the zip-file based implementation of FileSystem
+type zipFS struct {
+	*zip.ReadCloser
+	list zipList
+	name string
+}
+
+func (fs *zipFS) String() string {
+	return "zip(" + fs.name + ")"
+}
+
+func (fs *zipFS) RootType(abspath string) vfs.RootType {
+	var t vfs.RootType
+	switch {
+	case exists(path.Join(vfs.GOROOT, abspath)):
+		t = vfs.RootTypeGoRoot
+	case isGoPath(abspath):
+		t = vfs.RootTypeGoPath
+	}
+	return t
+}
+
+func isGoPath(abspath string) bool {
+	for _, p := range filepath.SplitList(build.Default.GOPATH) {
+		if exists(path.Join(p, abspath)) {
+			return true
+		}
+	}
+	return false
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func (fs *zipFS) Close() error {
+	fs.list = nil
+	return fs.ReadCloser.Close()
+}
+
+func zipPath(name string) (string, error) {
+	name = path.Clean(name)
+	if !path.IsAbs(name) {
+		return "", fmt.Errorf("stat: not an absolute path: %s", name)
+	}
+	return name[1:], nil // strip leading '/'
+}
+
+func isRoot(abspath string) bool {
+	return path.Clean(abspath) == "/"
+}
+
+func (fs *zipFS) stat(abspath string) (int, zipFI, error) {
+	if isRoot(abspath) {
+		return 0, zipFI{
+			name: "",
+			file: nil,
+		}, nil
+	}
+	zippath, err := zipPath(abspath)
+	if err != nil {
+		return 0, zipFI{}, err
+	}
+	i, exact := fs.list.lookup(zippath)
+	if i < 0 {
+		// zippath has leading '/' stripped - print it explicitly
+		return -1, zipFI{}, &os.PathError{Path: "/" + zippath, Err: os.ErrNotExist}
+	}
+	_, name := path.Split(zippath)
+	var file *zip.File
+	if exact {
+		file = fs.list[i] // exact match found - must be a file
+	}
+	return i, zipFI{name, file}, nil
+}
+
+func (fs *zipFS) Open(abspath string) (vfs.ReadSeekCloser, error) {
+	_, fi, err := fs.stat(abspath)
+	if err != nil {
+		return nil, err
+	}
+	if fi.IsDir() {
+		return nil, fmt.Errorf("Open: %s is a directory", abspath)
+	}
+	r, err := fi.file.Open()
+	if err != nil {
+		return nil, err
+	}
+	return &zipSeek{fi.file, r}, nil
+}
+
+type zipSeek struct {
+	file *zip.File
+	io.ReadCloser
+}
+
+func (f *zipSeek) Seek(offset int64, whence int) (int64, error) {
+	if whence == 0 && offset == 0 {
+		r, err := f.file.Open()
+		if err != nil {
+			return 0, err
+		}
+		f.Close()
+		f.ReadCloser = r
+		return 0, nil
+	}
+	return 0, fmt.Errorf("unsupported Seek in %s", f.file.Name)
+}
+
+func (fs *zipFS) Lstat(abspath string) (os.FileInfo, error) {
+	_, fi, err := fs.stat(abspath)
+	return fi, err
+}
+
+func (fs *zipFS) Stat(abspath string) (os.FileInfo, error) {
+	_, fi, err := fs.stat(abspath)
+	return fi, err
+}
+
+func (fs *zipFS) ReadDir(abspath string) ([]os.FileInfo, error) {
+	i, fi, err := fs.stat(abspath)
+	if err != nil {
+		return nil, err
+	}
+	if !fi.IsDir() {
+		return nil, fmt.Errorf("ReadDir: %s is not a directory", abspath)
+	}
+
+	var list []os.FileInfo
+
+	// make dirname the prefix that file names must start with to be considered
+	// in this directory. we must special case the root directory because, per
+	// the spec of this package, zip file entries MUST NOT start with /, so we
+	// should not append /, as we would in every other case.
+	var dirname string
+	if isRoot(abspath) {
+		dirname = ""
+	} else {
+		zippath, err := zipPath(abspath)
+		if err != nil {
+			return nil, err
+		}
+		dirname = zippath + "/"
+	}
+	prevname := ""
+	for _, e := range fs.list[i:] {
+		if !strings.HasPrefix(e.Name, dirname) {
+			break // not in the same directory anymore
+		}
+		name := e.Name[len(dirname):] // local name
+		file := e
+		if i := strings.IndexRune(name, '/'); i >= 0 {
+			// We infer directories from files in subdirectories.
+			// If we have x/y, return a directory entry for x.
+			name = name[0:i] // keep local directory name only
+			file = nil
+		}
+		// If we have x/y and x/z, don't return two directory entries for x.
+		// TODO(gri): It should be possible to do this more efficiently
+		// by determining the (fs.list) range of local directory entries
+		// (via two binary searches).
+		if name != prevname {
+			list = append(list, zipFI{name, file})
+			prevname = name
+		}
+	}
+
+	return list, nil
+}
+
+func New(rc *zip.ReadCloser, name string) vfs.FileSystem {
+	list := make(zipList, len(rc.File))
+	copy(list, rc.File) // sort a copy of rc.File
+	sort.Sort(list)
+	return &zipFS{rc, list, name}
+}
+
+type zipList []*zip.File
+
+// zipList implements sort.Interface
+func (z zipList) Len() int           { return len(z) }
+func (z zipList) Less(i, j int) bool { return z[i].Name < z[j].Name }
+func (z zipList) Swap(i, j int)      { z[i], z[j] = z[j], z[i] }
+
+// lookup returns the smallest index of an entry with an exact match
+// for name, or an inexact match starting with name/. If there is no
+// such entry, the result is -1, false.
+func (z zipList) lookup(name string) (index int, exact bool) {
+	// look for exact match first (name comes before name/ in z)
+	i := sort.Search(len(z), func(i int) bool {
+		return name <= z[i].Name
+	})
+	if i >= len(z) {
+		return -1, false
+	}
+	// 0 <= i < len(z)
+	if z[i].Name == name {
+		return i, true
+	}
+
+	// look for inexact match (must be in z[i:], if present)
+	z = z[i:]
+	name += "/"
+	j := sort.Search(len(z), func(i int) bool {
+		return name <= z[i].Name
+	})
+	if j >= len(z) {
+		return -1, false
+	}
+	// 0 <= j < len(z)
+	if strings.HasPrefix(z[j].Name, name) {
+		return i + j, false
+	}
+
+	return -1, false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,6 +31,9 @@ github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/btf
 github.com/cilium/ebpf/internal/unix
 github.com/cilium/ebpf/link
+# github.com/cli/browser v1.2.0
+## explicit; go 1.14
+github.com/cli/browser
 # github.com/containernetworking/plugins v1.1.1
 ## explicit; go 1.17
 github.com/containernetworking/plugins/pkg/ns

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -542,6 +542,8 @@ golang.org/x/tools/go/ast/inspector
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/packagesdriver
 golang.org/x/tools/go/packages
+golang.org/x/tools/godoc/vfs
+golang.org/x/tools/godoc/vfs/zipfs
 golang.org/x/tools/internal/event
 golang.org/x/tools/internal/event/core
 golang.org/x/tools/internal/event/keys


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:


To start an embedded novnc instance where automatically a browser page will be opened, run:

```
$ virtctl novnc myvm
```



To only start the embedded novnc instance and connect via other means than the local browser (e.g. remote browser), run:

```
$ virtctl novnc --serve-only myvm
Open http://127.0.0.1:38467?autoconnect=true to connect to the virtual machine.
```

It will not open a browser automatically. By clicking on the provided link a browser window opens and the presented NOVNC client connects right away to the VM.

The NOVNC instance is embedded as a zip file in virtctl and served directly by reading from the zip archive with the helpf of the `zipfs` package. As such no temporary space is needed and the binary size is still kept relatively small since the client is embedded as a zip file.

This helps in two scenarios:
 * when users don't have a VNC client, or no compatible VNC client installed on the node.
 * when in addition users have to port-forward the connection. In that case directly hitting the port-forward address in the browser opens a terminal, instead of having to point a local VNC client to a TCP forward.
 
Especially in the case of port-forwarding this is helpful, and it can replace the need to:
 * either install a VNC client locally, where `virtctl vnc` is the sole driver why one has to touch the system
 * or trying to make X11 forwarding work

Both cases happen in various debug scenarios pretty often, and this PR can help reducing the friction on initial engagements.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

* An `includenovnc` build flag is added to let vendors deliberately decide if they want to embed and ship novnc.
* By default only the OSS bazel build will include the command.

Potential improvements:

* In the case of local invocation, it would be possible to also directly hit the webbrowser and seamlessly open a browser tab. That would remove the need to click on the link.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `virtctl novnc` which embedds a novnc instance to increase the VNC invocation success rate
```
