### PR TITLE
Fix recurring heartbeat error logs when no mdev devices are present

### DIFF
--- a/pkg/virt-handler/device-manager/mediated_devices_types.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types.go
@@ -272,7 +272,11 @@ func shouldRemoveMDEV(mdevUUID string, desiredTypesMap map[string]struct{}) bool
 func removeUndesiredMDEVs(desiredTypesMap map[string]struct{}) {
 	files, err := os.ReadDir(mdevBasePath)
 	if err != nil {
-		log.Log.Reason(err).Errorf("failed to remove mdev types: failed to read the content of %s directory", mdevBasePath)
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Log.Reason(err).Errorf("failed to remove mdev types: failed to read the content of %s directory", mdevBasePath)
+		} else {
+			log.Log.Reason(err).V(4).Infof("failed to remove mdev types: failed to read the content of %s directory. This most likely means that no mdev cleanup is necessary", mdevBasePath)
+		}
 		return
 	}
 	for _, file := range files {


### PR DESCRIPTION
**What this PR does / why we need it**:

When /sys/bus/mdev/devices directory exists, then no cleanup is necessary, and we don't have to log that the directory does not exist.

Fixes recurring messages like this:

```
2023-08-10T08:45:41.541322652Z {"component":"virt-handler","level":"error","msg":"failed to remove mdev types: failed to read the content of /sys/bus/mdev/devices directory","pos":"mediated_devices_types.go:263","reason":"open /sys/bus/mdev/devices: no such file or directory
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
