### PR TITLE
flake-check: use stable kubevirtci provider, set 3 nodes if required

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -131,7 +131,7 @@ if (( $# > 0 )); then
 else
     # We only want to use stable providers for flake testing, thus we fetch the k8s version file from kubevirtci.
     # we stop at the first provider that is stable (aka doesn't have an rc or beta or alpha version)
-    for k8s_provider in $(find cluster-up/cluster -name 'k8s-[0-9].[0-9][0-9]' -print | sort -rV | grep -oE 'k8s.*'); do
+    for k8s_provider in $(cd cluster-up/cluster && ls -rd k8s-[0-9]\.[0-9][0-9]); do
         k8s_provider_version=$(curl --fail "https://raw.githubusercontent.com/kubevirt/kubevirtci/${kubevirtci_git_hash}/cluster-provision/k8s/${k8s_provider#"k8s-"}/version")
         if [[ ! "${k8s_provider_version}" =~ -(rc|alpha|beta) ]]; then
             TEST_LANES=("${k8s_provider}")

--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -190,6 +190,9 @@ fi
 
 trap '{ make cluster-down; }' EXIT SIGINT SIGTERM
 
+# Give the nodes enough memory to run tests in parallel, including tests which involve fedora
+export KUBEVIRT_MEMORY_SIZE='9216M'
+
 export KUBEVIRT_NUM_NODES
 export KUBEVIRT_WITH_CNAO="true"
 export KUBEVIRT_DEPLOY_CDI="true"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR fixes three things:

# Use a stable kubevirtci provider

We do not want to use the latest provider if it is not stable yet, since there might be regressions that are not yet fixed in an rc.

Thus we use the latest stable provider instead.

# Set 3 nodes if required

Some tests need two nodes with cpu manager installed, since the first node doesn't have it installed, they then fail.

Set nodes to 3 in that case.

# increase default node memory

The [default test script increases the node memory](https://github.com/kubevirt/kubevirt/blob/main/automation/test.sh#L109).

Since [a test was failing for this reason](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-check-tests-for-flakes) (thanks @jean-edouard) we increase the node memory to the same amount.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @jean-edouard @brianmcarey 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
