### PR TITLE
Slirp hook sidecar

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -192,6 +192,7 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)example-hook-sidecar:$(container_tag)": "//cmd/example-hook-sidecar:example-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)example-disk-mutation-hook-sidecar:$(container_tag)": "//cmd/example-disk-mutation-hook-sidecar:example-disk-mutation-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)example-cloudinit-hook-sidecar:$(container_tag)": "//cmd/example-cloudinit-hook-sidecar:example-cloudinit-hook-sidecar-image",
+        "$(container_prefix)/$(image_prefix)network-slirp-binding:$(container_tag)": "//cmd/network-slirp-binding:network-slirp-binding-image",
         # container-disk images
         "$(container_prefix)/$(image_prefix)alpine-container-disk-demo:$(container_tag)": "//containerimages:alpine-container-disk-image",
         "$(container_prefix)/$(image_prefix)cirros-container-disk-demo:$(container_tag)": "//containerimages:cirros-container-disk-image",
@@ -326,6 +327,15 @@ container_push(
     image = "//cmd/sidecars:sidecar-shim-image",
     registry = "$(container_prefix)",
     repository = "$(image_prefix)sidecar-shim",
+    tag = "$(container_tag)",
+)
+
+container_push(
+    name = "push-network-slirp-binding",
+    format = "Docker",
+    image = "//cmd/network-slirp-binding:network-slirp-binding-image",
+    registry = "$(container_prefix)",
+    repository = "$(image_prefix)network-slirp-binding",
     tag = "$(container_tag)",
 )
 

--- a/cmd/network-slirp-binding/BUILD.bazel
+++ b/cmd/network-slirp-binding/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/network-slirp-binding",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//cmd/network-slirp-binding/server:go_default_library",
+        "//pkg/hooks:go_default_library",
+        "//pkg/hooks/info:go_default_library",
+        "//pkg/hooks/v1alpha2:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "network-slirp-binding",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+)
+
+container_image(
+    name = "version-container",
+    base = "//:passwd-image",
+    directory = "/",
+    files = ["//:get-version"],
+)
+
+container_image(
+    name = "network-slirp-binding-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    base = ":version-container",
+    directory = "/",
+    entrypoint = ["/network-slirp-binding"],
+    files = [":network-slirp-binding"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/network-slirp-binding/BUILD.bazel
+++ b/cmd/network-slirp-binding/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/cmd/network-slirp-binding",
     visibility = ["//visibility:private"],
     deps = [
+        "//cmd/network-slirp-binding/dns:go_default_library",
         "//cmd/network-slirp-binding/server:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/hooks/info:go_default_library",

--- a/cmd/network-slirp-binding/README.md
+++ b/cmd/network-slirp-binding/README.md
@@ -1,0 +1,10 @@
+# KubeVirt Network Slirp Binding Plugin
+
+## Summary
+
+Slirp network binding plugin configures VMs Slirp interface using Kubevirts hook sidecar interface.
+
+It will be used by Kubevirt to offload slirp networking configuration.
+
+> _NOTE_:
+> Slirp network binding is supported for pod network interfaces only.

--- a/cmd/network-slirp-binding/README.md
+++ b/cmd/network-slirp-binding/README.md
@@ -8,3 +8,43 @@ It will be used by Kubevirt to offload slirp networking configuration.
 
 > _NOTE_:
 > Slirp network binding is supported for pod network interfaces only.
+
+# How to use
+
+Register the `slirp` binding plugin with its sidecar image:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  configuration:
+    network:
+      binding:
+        slirp:
+          sidecarImage: registry:5000/kubevirt/network-slirp-binding:devel
+  ...
+```
+
+In the VM spec, set interface to use `slirp` binding plugin:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  name: vmi-slirp
+spec:
+  domain:
+    devices:
+      interfaces:
+      - name: slirp
+        binding:
+          name: slirp
+  ...
+  networks:
+  - name: slirp-net
+    pod: {}
+  ...
+```

--- a/cmd/network-slirp-binding/callback/BUILD.bazel
+++ b/cmd/network-slirp-binding/callback/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["callback.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/network-slirp-binding/callback",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/virt-launcher/virtwrap/api:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "callback_suite_test.go",
+        "callback_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/cmd/network-slirp-binding/callback/callback.go
+++ b/cmd/network-slirp-binding/callback/callback.go
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package callback
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+// TODO: move to Kubevirt domain API package
+const libvirtDomainQemuSchema = "http://libvirt.org/schemas/domain/qemu/1.0"
+
+type DomainSpecMutator interface {
+	Mutate(*domainschema.DomainSpec) (*domainschema.DomainSpec, error)
+}
+
+func OnDefineDomain(domainXML []byte, domSpecMutator DomainSpecMutator) ([]byte, error) {
+	domainSpec := &domainschema.DomainSpec{
+		// Unmarshalling domain spec makes the XML namespace attribute empty.
+		// Some domain parameters requires namespace to be defined.
+		// e.g: https://libvirt.org/drvqemu.html#pass-through-of-arbitrary-qemu-commands
+		XmlNS: libvirtDomainQemuSchema,
+	}
+	if err := xml.Unmarshal(domainXML, domainSpec); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal given domain spec: %v", err)
+	}
+
+	updatedDomainSpec, err := domSpecMutator.Mutate(domainSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedDomainSpecXML, err := xml.Marshal(updatedDomainSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal updated domain spec: %v", err)
+	}
+
+	return updatedDomainSpecXML, nil
+}

--- a/cmd/network-slirp-binding/callback/callback_suite_test.go
+++ b/cmd/network-slirp-binding/callback/callback_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package callback_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestCallback(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/cmd/network-slirp-binding/callback/callback_test.go
+++ b/cmd/network-slirp-binding/callback/callback_test.go
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package callback_test
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
+	"kubevirt.io/kubevirt/cmd/network-slirp-binding/callback"
+)
+
+var _ = Describe("hook callback handler", func() {
+	Context("on define domain", func() {
+		It("should fail given empty byte slice stream", func() {
+			_, err := callback.OnDefineDomain([]byte{}, mutatorStub{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail given invalid domain XML", func() {
+			_, err := callback.OnDefineDomain([]byte("invalid-domain-xml"), mutatorStub{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail when domain spec mutator fails", func() {
+			domain := domainschema.NewMinimalDomain("test")
+			originalDomainSpecXML, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedErr := fmt.Errorf("test error")
+			domSpecMutator := mutatorStub{failMutate: expectedErr}
+
+			_, err = callback.OnDefineDomain(originalDomainSpecXML, domSpecMutator)
+			Expect(err).To(Equal(expectedErr))
+		})
+
+		It("given no-op mutator, domain spec should not change", func() {
+			domain := domainschema.NewMinimalDomain("test")
+			domainSpecXML, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+			domSpecMutator := mutatorStub{domSpec: &domain.Spec}
+
+			Expect(callback.OnDefineDomain(domainSpecXML, domSpecMutator)).To(Equal(domainSpecXML))
+		})
+
+		It("domain spec should mutate successfully", func() {
+			domain := domainschema.NewMinimalDomain("test")
+			domainSpecXML, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			mutatedDomainSpec := domain.Spec.DeepCopy()
+			mutatedDomainSpec.Devices.Interfaces = append(mutatedDomainSpec.Devices.Interfaces,
+				domainschema.Interface{Alias: domainschema.NewUserDefinedAlias("test")})
+			domSpecMutator := mutatorStub{domSpec: mutatedDomainSpec}
+
+			mutatedDomainSpecXML, err := xml.Marshal(mutatedDomainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(callback.OnDefineDomain(domainSpecXML, domSpecMutator)).To(Equal(mutatedDomainSpecXML))
+		})
+	})
+})
+
+type mutatorStub struct {
+	domSpec    *domainschema.DomainSpec
+	failMutate error
+}
+
+func (s mutatorStub) Mutate(_ *domainschema.DomainSpec) (*domainschema.DomainSpec, error) {
+	return s.domSpec, s.failMutate
+}

--- a/cmd/network-slirp-binding/dns/BUILD.bazel
+++ b/cmd/network-slirp-binding/dns/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["resolvconf.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/network-slirp-binding/dns",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/network/dns:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+    ],
+)

--- a/cmd/network-slirp-binding/dns/resolvconf.go
+++ b/cmd/network-slirp-binding/dns/resolvconf.go
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package dns
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/network/dns"
+)
+
+const resolvConf = "/etc/resolv.conf"
+
+func ReadResolvConfSearchDomains() ([]string, error) {
+
+	// #nosec No risk for path injection. resolvConf is static "/etc/resolve.conf"
+	resolvConfRaw, err := os.ReadFile(resolvConf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read resolv.conf at %q: %v", resolvConf, err)
+	}
+
+	searchDomains, err := dns.ParseSearchDomains(string(resolvConfRaw))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse search domains out of %q: %v", resolvConf, err)
+	}
+
+	log.Log.Infof("Found search domains in %s: %s", resolvConf, strings.Join(searchDomains, " "))
+
+	return searchDomains, nil
+}

--- a/cmd/network-slirp-binding/domain/BUILD.bazel
+++ b/cmd/network-slirp-binding/domain/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["domain.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/network-slirp-binding/domain",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/network/vmispec:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "domain_suite_test.go",
+        "domain_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/cmd/network-slirp-binding/domain/domain.go
+++ b/cmd/network-slirp-binding/domain/domain.go
@@ -1,0 +1,169 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package domain
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	vmschema "kubevirt.io/api/core/v1"
+
+	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+)
+
+type SlirpNetworkConfigurator struct {
+	vmiSpecIface   *vmschema.Interface
+	vmiSpecNetwork *vmschema.Network
+	searchDomains  []string
+}
+
+func NewSlirpNetworkConfigurator(ifaces []vmschema.Interface, networks []vmschema.Network, searchDomains []string) (*SlirpNetworkConfigurator, error) {
+	network := vmispec.LookupPodNetwork(networks)
+	if network == nil {
+		return nil, fmt.Errorf("pod network not found")
+	}
+	iface := vmispec.LookupInterfaceByName(ifaces, network.Name)
+	if iface == nil || iface.Slirp == nil {
+		return nil, fmt.Errorf("no slirp iface found")
+	}
+
+	return &SlirpNetworkConfigurator{
+		vmiSpecIface:   iface,
+		vmiSpecNetwork: network,
+		searchDomains:  searchDomains,
+	}, nil
+}
+
+func (s SlirpNetworkConfigurator) Mutate(domainSpec *domainschema.DomainSpec) (*domainschema.DomainSpec, error) {
+	slirpQemuCmdArgs, err := generateSlirpNetworkQemuCmdArgs(s.vmiSpecIface, s.vmiSpecNetwork, s.searchDomains)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(slirpQemuCmdArgs) == 0 {
+		log.Log.Warning("no qemu cmd args configured, domain spec did not change")
+		return domainSpec, nil
+	}
+
+	domainSpecCopy := domainSpec.DeepCopy()
+	if domainSpecCopy.QEMUCmd == nil {
+		domainSpecCopy.QEMUCmd = &domainschema.Commandline{}
+	}
+	domainSpecCopy.QEMUCmd.QEMUArg = append(domainSpecCopy.QEMUCmd.QEMUArg, slirpQemuCmdArgs...)
+
+	return domainSpecCopy, nil
+}
+
+func generateSlirpNetworkQemuCmdArgs(iface *vmschema.Interface, network *vmschema.Network, searchDomains []string) ([]domainschema.Arg, error) {
+	backendDeviceQemuArgs, err := generateBackendDeviceQemuArg(iface, network, searchDomains)
+	if err != nil {
+		return nil, err
+	}
+
+	var qemuArgs []domainschema.Arg
+	qemuArgs = append(qemuArgs, backendDeviceQemuArgs...)
+	qemuArgs = append(qemuArgs, generateNetDeviceQemuArg(iface)...)
+
+	return qemuArgs, nil
+}
+
+func generateBackendDeviceQemuArg(iface *vmschema.Interface, network *vmschema.Network, dnsDomains []string) ([]domainschema.Arg, error) {
+	backendDeviceConf := domainschema.Arg{Value: fmt.Sprintf("user,id=%s", iface.Name)}
+
+	cidr, err := networkCIDR(network)
+	if err != nil {
+		return nil, err
+	}
+	backendDeviceConf.Value += fmt.Sprintf(",net=%s", cidr)
+
+	for _, dnsDomain := range dnsDomains {
+		backendDeviceConf.Value += fmt.Sprintf(",dnssearch=%s", dnsDomain)
+	}
+
+	ports, err := ifacePorts(iface)
+	if err != nil {
+		return nil, err
+	}
+	for _, port := range ports {
+		backendDeviceConf.Value += fmt.Sprintf(",hostfwd=%[1]s::%[2]d-:%[2]d", strings.ToLower(port.Protocol), port.Port)
+	}
+
+	return []domainschema.Arg{{Value: "-netdev"}, backendDeviceConf}, nil
+}
+
+func networkCIDR(network *vmschema.Network) (string, error) {
+	if network.Pod.VMNetworkCIDR != "" {
+		if _, _, err := net.ParseCIDR(network.Pod.VMNetworkCIDR); err != nil {
+			return "", fmt.Errorf("invalid network CIDR %q: %v", network.Pod.VMNetworkCIDR, err)
+		}
+		return network.Pod.VMNetworkCIDR, nil
+	}
+
+	return domainschema.DefaultVMCIDR, nil
+}
+
+func ifacePorts(iface *vmschema.Interface) ([]vmschema.Port, error) {
+	if len(iface.Ports) == 0 {
+		return nil, nil
+	}
+
+	var ports []vmschema.Port
+	configuredPorts := make(map[string]struct{}, 0)
+	for _, ifacePort := range iface.Ports {
+		if ifacePort.Port <= 0 {
+			return nil, fmt.Errorf("invalid port %q", ifacePort.Port)
+		}
+
+		if ifacePort.Protocol == "" {
+			ifacePort.Protocol = domainschema.DefaultProtocol
+		}
+
+		// each port should be set once otherwise QEMU process crash
+		portConfig := fmt.Sprintf("%s-%d", ifacePort.Protocol, ifacePort.Port)
+		if _, ok := configuredPorts[portConfig]; !ok {
+			ports = append(ports, ifacePort)
+			configuredPorts[portConfig] = struct{}{}
+		}
+	}
+
+	return ports, nil
+}
+
+func generateNetDeviceQemuArg(iface *vmschema.Interface) []domainschema.Arg {
+	// slirp configuration works only with 'e1000' or 'rtl8139'
+	ifaceModel := iface.Model
+	if ifaceModel != "e1000" && ifaceModel != "rtl8139" {
+		log.Log.Infof("interface (%q) model type (%q) is not supported by QEMU slirp Network, using 'e1000' model type instead",
+			iface.Name, iface.Model)
+		ifaceModel = "e1000"
+	}
+	netDeviceConf := fmt.Sprintf(`"driver":%[1]q,"netdev":%[2]q,"id":%[2]q`, ifaceModel, iface.Name)
+	if iface.MacAddress != "" {
+		// We assume address was already validated in API layer so just pass it to libvirt as-is.
+		netDeviceConf += fmt.Sprintf(`,"mac":%q`, iface.MacAddress)
+	}
+
+	return []domainschema.Arg{{Value: "-device"}, {Value: fmt.Sprintf(`{%s}`, netDeviceConf)}}
+}

--- a/cmd/network-slirp-binding/domain/domain_suite_test.go
+++ b/cmd/network-slirp-binding/domain/domain_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package domain_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestDomain(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/cmd/network-slirp-binding/domain/domain_test.go
+++ b/cmd/network-slirp-binding/domain/domain_test.go
@@ -1,0 +1,180 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package domain_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vmschema "kubevirt.io/api/core/v1"
+
+	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
+	"kubevirt.io/kubevirt/cmd/network-slirp-binding/domain"
+)
+
+var _ = Describe("QEMU slirp networking", func() {
+	Context("configure domain spec slirp interface QMEU command line", func() {
+		var testSearchDomain = []string{"dns.com"}
+
+		It("should fail given no pod network", func() {
+			network := vmschema.Network{Name: "secondary", NetworkSource: vmschema.NetworkSource{Multus: &vmschema.MultusNetwork{}}}
+
+			_, err := domain.NewSlirpNetworkConfigurator(nil, []vmschema.Network{network}, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail given no slirp iface", func() {
+			network := vmschema.Network{Name: "secondary", NetworkSource: vmschema.NetworkSource{Multus: &vmschema.MultusNetwork{}}}
+			iface := vmschema.Interface{Name: "secondary", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Bridge: &vmschema.InterfaceBridge{}}}
+
+			_, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		DescribeTable("should succeed, given",
+			func(iface vmschema.Interface, network vmschema.Network, expectedQEMUCmdArgs []domainschema.Arg) {
+				testDomainSpec := &domainschema.NewMinimalDomain("test").Spec
+
+				expectedDomainSpec := &domainschema.NewMinimalDomain("test").Spec
+				expectedDomainSpec.QEMUCmd = &domainschema.Commandline{QEMUArg: expectedQEMUCmdArgs}
+
+				testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testMutator.Mutate(testDomainSpec)).To(Equal(expectedDomainSpec))
+			},
+			Entry("default slirp interface",
+				*vmschema.DefaultSlirpNetworkInterface(),
+				*vmschema.DefaultPodNetwork(),
+				[]domainschema.Arg{
+					{Value: `-netdev`},
+					{Value: `user,id=default,net=10.0.2.0/24,dnssearch=dns.com`},
+					{Value: `-device`},
+					{Value: `{"driver":"e1000","netdev":"default","id":"default"}`},
+				},
+			),
+			Entry("custom CIDR",
+				vmschema.Interface{Name: "slirpTest", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Slirp: &vmschema.InterfaceSlirp{}}},
+				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{
+					VMNetworkCIDR: "192.168.100.0/24",
+				}}},
+				[]domainschema.Arg{
+					{Value: `-netdev`}, {Value: `user,id=slirpTest,net=192.168.100.0/24,dnssearch=dns.com`},
+					{Value: `-device`}, {Value: `{"driver":"e1000","netdev":"slirpTest","id":"slirpTest"}`},
+				},
+			),
+			Entry("ports",
+				vmschema.Interface{Name: "slirpTest", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Slirp: &vmschema.InterfaceSlirp{}},
+					Ports: []vmschema.Port{
+						{Name: "http", Protocol: "TCP", Port: 80},
+						{Port: 8080},
+					},
+				},
+				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}},
+				[]domainschema.Arg{
+					{Value: `-netdev`}, {Value: `user,id=slirpTest,net=10.0.2.0/24,dnssearch=dns.com,hostfwd=tcp::80-:80,hostfwd=tcp::8080-:8080`},
+					{Value: `-device`}, {Value: `{"driver":"e1000","netdev":"slirpTest","id":"slirpTest"}`},
+				},
+			),
+			Entry("slirp interface with virtio model type - should be changed to e1000",
+				vmschema.Interface{Name: "slirpTest", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Slirp: &vmschema.InterfaceSlirp{}},
+					Model: "virtio",
+				},
+				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}},
+				[]domainschema.Arg{
+					{Value: `-netdev`}, {Value: `user,id=slirpTest,net=10.0.2.0/24,dnssearch=dns.com`},
+					{Value: `-device`}, {Value: `{"driver":"e1000","netdev":"slirpTest","id":"slirpTest"}`},
+				},
+			),
+			Entry("custom MAC address",
+				vmschema.Interface{Name: "slirpTest", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Slirp: &vmschema.InterfaceSlirp{}},
+					MacAddress: "02:02:02:02:02:02",
+				},
+				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}},
+				[]domainschema.Arg{
+					{Value: `-netdev`}, {Value: `user,id=slirpTest,net=10.0.2.0/24,dnssearch=dns.com`},
+					{Value: `-device`}, {Value: `{"driver":"e1000","netdev":"slirpTest","id":"slirpTest","mac":"02:02:02:02:02:02"}`},
+				},
+			),
+			Entry("iface model 'rtl8139'",
+				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: domain.SlirpPluginName},
+					Model: "rtl8139",
+				},
+				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}},
+				[]domainschema.Arg{
+					{Value: `-netdev`}, {Value: `user,id=slirpTest,net=10.0.2.0/24,dnssearch=dns.com`},
+					{Value: `-device`}, {Value: `{"driver":"rtl8139","netdev":"slirpTest","id":"slirpTest"}`},
+				},
+			),
+		)
+
+		It("should not override other QEMU CMD args", func() {
+			network := vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}}
+			iface := vmschema.Interface{Name: "slirpTest", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Slirp: &vmschema.InterfaceSlirp{}}}
+
+			testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedArg := "abc"
+			domSpec := &domainschema.DomainSpec{
+				QEMUCmd: &domainschema.Commandline{QEMUArg: []domainschema.Arg{{Value: expectedArg}}},
+			}
+
+			mutatedDomSpec, err := testMutator.Mutate(domSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(mutatedDomSpec.QEMUCmd.QEMUArg).To(Equal(
+				[]domainschema.Arg{
+					{Value: expectedArg},
+					{Value: `-netdev`}, {Value: `user,id=slirpTest,net=10.0.2.0/24,dnssearch=dns.com`},
+					{Value: `-device`}, {Value: `{"driver":"e1000","netdev":"slirpTest","id":"slirpTest"}`},
+				},
+			))
+		})
+
+		It("should fail given invalid custom CIDR", func() {
+			network := vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{
+				VMNetworkCIDR: "592.468.300.0/24",
+			}}}
+			iface := vmschema.Interface{Name: "slirpTest", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Slirp: &vmschema.InterfaceSlirp{}}}
+
+			testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = testMutator.Mutate(&domainschema.DomainSpec{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		DescribeTable("should fail given invalid port",
+			func(port int32) {
+				iface := vmschema.Interface{Name: "slirpTest", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Slirp: &vmschema.InterfaceSlirp{}},
+					Ports: []vmschema.Port{{Port: port}},
+				}
+				network := vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}}
+
+				testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+				Expect(err).ToNot(HaveOccurred())
+				_, err = testMutator.Mutate(&domainschema.DomainSpec{})
+				Expect(err).To(HaveOccurred())
+			},
+			Entry("invalid port: -1", int32(-1)),
+			Entry("out off range port: 0", int32(0)),
+		)
+	})
+})

--- a/cmd/network-slirp-binding/main.go
+++ b/cmd/network-slirp-binding/main.go
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+
+	"google.golang.org/grpc"
+
+	"kubevirt.io/kubevirt/pkg/hooks"
+	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
+	hooksV1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
+
+	"kubevirt.io/client-go/log"
+
+	srv "kubevirt.io/kubevirt/cmd/network-slirp-binding/server"
+)
+
+func main() {
+	socketPath := filepath.Join(hooks.HookSocketsSharedDirectory, "slirp.sock")
+	socket, err := net.Listen("unix", socketPath)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Failed to initialized socket on path: %s", socket)
+		log.Log.Error("Check whether given directory exists and socket name is not already taken by other file")
+		os.Exit(1)
+	}
+	defer os.Remove(socketPath)
+
+	server := grpc.NewServer([]grpc.ServerOption{}...)
+	hooksInfo.RegisterInfoServer(server, srv.InfoServer{Version: "v1alpha2"})
+	hooksV1alpha2.RegisterCallbacksServer(server, srv.V1alpha2Server{})
+
+	log.Log.Infof("Starting hook server exposing 'info' and '%s' services on socket %q", socketPath, "v1alpha2")
+	server.Serve(socket)
+}

--- a/cmd/network-slirp-binding/server/BUILD.bazel
+++ b/cmd/network-slirp-binding/server/BUILD.bazel
@@ -7,8 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/network-slirp-binding/callback:go_default_library",
+        "//cmd/network-slirp-binding/domain:go_default_library",
         "//pkg/hooks/info:go_default_library",
         "//pkg/hooks/v1alpha2:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )

--- a/cmd/network-slirp-binding/server/BUILD.bazel
+++ b/cmd/network-slirp-binding/server/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["server.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/network-slirp-binding/server",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/network-slirp-binding/callback:go_default_library",
+        "//pkg/hooks/info:go_default_library",
+        "//pkg/hooks/v1alpha2:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+    ],
+)

--- a/cmd/network-slirp-binding/server/server.go
+++ b/cmd/network-slirp-binding/server/server.go
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package server
+
+import (
+	"context"
+
+	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
+	hooksV1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
+
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/cmd/network-slirp-binding/callback"
+)
+
+type InfoServer struct {
+	Version string
+}
+
+func (s InfoServer) Info(_ context.Context, _ *hooksInfo.InfoParams) (*hooksInfo.InfoResult, error) {
+	log.Log.Infof("Info method has been called")
+
+	return &hooksInfo.InfoResult{
+		Name: "network-slirp-binding",
+		Versions: []string{
+			s.Version,
+		},
+		HookPoints: []*hooksInfo.HookPoint{
+			{
+				Name:     hooksInfo.OnDefineDomainHookPointName,
+				Priority: 0,
+			},
+		},
+	}, nil
+}
+
+type V1alpha2Server struct{}
+
+func (s V1alpha2Server) OnDefineDomain(_ context.Context, params *hooksV1alpha2.OnDefineDomainParams) (*hooksV1alpha2.OnDefineDomainResult, error) {
+	log.Log.Info("OnDefineDomain callback method has been called")
+
+	newDomainXML, err := callback.OnDefineDomain(params.GetDomainXML(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &hooksV1alpha2.OnDefineDomainResult{
+		DomainXML: newDomainXML,
+	}, nil
+}
+
+func (s V1alpha2Server) PreCloudInitIso(_ context.Context, params *hooksV1alpha2.PreCloudInitIsoParams) (*hooksV1alpha2.PreCloudInitIsoResult, error) {
+	log.Log.Info("PreCloudInitIso method has been called")
+
+	return &hooksV1alpha2.PreCloudInitIsoResult{
+		CloudInitData: params.GetCloudInitData(),
+	}, nil
+}

--- a/cmd/network-slirp-binding/server/server.go
+++ b/cmd/network-slirp-binding/server/server.go
@@ -51,7 +51,9 @@ func (s InfoServer) Info(_ context.Context, _ *hooksInfo.InfoParams) (*hooksInfo
 	}, nil
 }
 
-type V1alpha2Server struct{}
+type V1alpha2Server struct {
+	SearchDomains []string
+}
 
 func (s V1alpha2Server) OnDefineDomain(_ context.Context, params *hooksV1alpha2.OnDefineDomainParams) (*hooksV1alpha2.OnDefineDomainResult, error) {
 	log.Log.Info("OnDefineDomain callback method has been called")

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -23,7 +23,7 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
-PUSH_TARGETS=(${PUSH_TARGETS:-virt-operator virt-api virt-controller virt-handler virt-launcher virt-exportserver virt-exportproxy conformance libguestfs-tools pr-helper example-hook-sidecar example-disk-mutation-hook-sidecar example-cloudinit-hook-sidecar alpine-container-disk-demo cirros-container-disk-demo cirros-custom-container-disk-demo virtio-container-disk alpine-ext-kernel-boot-demo fedora-with-test-tooling-container-disk alpine-with-test-tooling-container-disk fedora-realtime-container-disk disks-images-provider nfs-server vm-killer winrmcli sidecar-shim})
+PUSH_TARGETS=(${PUSH_TARGETS:-virt-operator virt-api virt-controller virt-handler virt-launcher virt-exportserver virt-exportproxy conformance libguestfs-tools pr-helper example-hook-sidecar example-disk-mutation-hook-sidecar example-cloudinit-hook-sidecar alpine-container-disk-demo cirros-container-disk-demo cirros-custom-container-disk-demo virtio-container-disk alpine-ext-kernel-boot-demo fedora-with-test-tooling-container-disk alpine-with-test-tooling-container-disk fedora-realtime-container-disk disks-images-provider nfs-server vm-killer winrmcli sidecar-shim network-slirp-binding})
 
 for tag in ${docker_tag} ${docker_tag_alt}; do
     for target in ${PUSH_TARGETS[@]}; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR introduce Slirp hook sidecar, its a new hook sidecar for configuring Slirp network interfaces in Kubevirt.

Currently Slirp interfaces configure by Kubevirt, internally. 
With the new sidecar hook, its possible to delegate Slirp interfces configuration outside Kubevirt
and enable reducing code maintenance.

Unlike other hook sidecar examples, Slirp hook-sidcar is set automatically by Kubevirt for VMs who has Slirp interface.
No need to add Kubeviet hook-sidecar annotation or any other configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Commits 4-7 are for testing slirp hook sidecar e2e, integrating the new hook-sidecar will be done in a follow up PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce network binding plugin for Slirp networking, interfacing with Kubevirt new network binding plugin API.
```
