### PR TITLE
[release-1.0] Change kubevirt_vmi_*_usage_seconds from Gauges to Counters

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -105,14 +105,14 @@ Virtual Machine last transition timestamp to running status. Type: Counter.
 ### kubevirt_vm_starting_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to starting status. Type: Counter.
 
-### kubevirt_vmi_cpu_system_usage_seconds
-Total CPU time spent in system mode. Type: Gauge.
+### kubevirt_vmi_cpu_system_usage_seconds_total
+Total CPU time spent in system mode. Type: Counter.
 
-### kubevirt_vmi_cpu_usage_seconds
-Total CPU time spent in all modes (sum of both vcpu and hypervisor usage). Type: Gauge.
+### kubevirt_vmi_cpu_usage_seconds_total
+Total CPU time spent in all modes (sum of both vcpu and hypervisor usage). Type: Counter.
 
-### kubevirt_vmi_cpu_user_usage_seconds
-Total CPU time spent in user mode. Type: Gauge.
+### kubevirt_vmi_cpu_user_usage_seconds_total
+Total CPU time spent in user mode. Type: Counter.
 
 ### kubevirt_vmi_filesystem_capacity_bytes_total
 Total VM filesystem capacity in bytes. Type: Gauge.

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -242,6 +242,10 @@ func (metrics *vmiMetrics) updateCPUAffinity(cpuMap [][]bool) {
 	)
 }
 
+func nanosecondsToSeconds(ns uint64) float64 {
+	return float64(ns) / 1000000000
+}
+
 func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCPUStats *stats.DomainStatsCPU) {
 	if !domainCPUStats.TimeSet && !domainCPUStats.UserSet && !domainCPUStats.SystemSet {
 		log.Log.Warningf("No domain CPU stats is set for %s VMI.", vmi.Name)
@@ -249,28 +253,28 @@ func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCP
 
 	if domainCPUStats.TimeSet {
 		metrics.pushCommonMetric(
-			"kubevirt_vmi_cpu_usage_seconds",
+			"kubevirt_vmi_cpu_usage_seconds_total",
 			"Total CPU time spent in all modes (sum of both vcpu and hypervisor usage).",
-			prometheus.GaugeValue,
-			float64(domainCPUStats.Time/1000000000),
+			prometheus.CounterValue,
+			nanosecondsToSeconds(domainCPUStats.Time),
 		)
 	}
 
 	if domainCPUStats.UserSet {
 		metrics.pushCommonMetric(
-			"kubevirt_vmi_cpu_user_usage_seconds",
+			"kubevirt_vmi_cpu_user_usage_seconds_total",
 			"Total CPU time spent in user mode.",
-			prometheus.GaugeValue,
-			float64(domainCPUStats.User/1000000000),
+			prometheus.CounterValue,
+			nanosecondsToSeconds(domainCPUStats.User),
 		)
 	}
 
 	if domainCPUStats.SystemSet {
 		metrics.pushCommonMetric(
-			"kubevirt_vmi_cpu_system_usage_seconds",
+			"kubevirt_vmi_cpu_system_usage_seconds_total",
 			"Total CPU time spent in system mode.",
-			prometheus.GaugeValue,
-			float64(domainCPUStats.System/1000000000),
+			prometheus.CounterValue,
+			nanosecondsToSeconds(domainCPUStats.System),
 		)
 	}
 }

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -1228,18 +1228,18 @@ var _ = Describe("Prometheus", func() {
 			dto := &io_prometheus_client.Metric{}
 			result.Write(dto)
 
-			Expect(dto.GetGauge().GetValue()).To(Equal(float64(MetricValue)))
+			Expect(dto.GetCounter().GetValue()).To(Equal(float64(MetricValue)))
 
 		},
-			Entry("Total CPU time spent in all modes (sum of both vcpu and hypervisor usage)", "kubevirt_vmi_cpu_usage_seconds", 123, &stats.DomainStatsCPU{
+			Entry("Total CPU time spent in all modes (sum of both vcpu and hypervisor usage)", "kubevirt_vmi_cpu_usage_seconds_total", 123, &stats.DomainStatsCPU{
 				TimeSet: true,
 				Time:    123000000000},
 			),
-			Entry("Total CPU time spent in user mode", "kubevirt_vmi_cpu_user_usage_seconds", 456, &stats.DomainStatsCPU{
+			Entry("Total CPU time spent in user mode", "kubevirt_vmi_cpu_user_usage_seconds_total", 456, &stats.DomainStatsCPU{
 				UserSet: true,
 				User:    456000000000},
 			),
-			Entry("Total CPU time spent in system mode", "kubevirt_vmi_cpu_system_usage_seconds", 789, &stats.DomainStatsCPU{
+			Entry("Total CPU time spent in system mode", "kubevirt_vmi_cpu_system_usage_seconds_total", 789, &stats.DomainStatsCPU{
 				SystemSet: true,
 				System:    789000000000},
 			))

--- a/tests/monitoring/prometheus_utils.go
+++ b/tests/monitoring/prometheus_utils.go
@@ -66,12 +66,12 @@ func getAlerts(cli kubecli.KubevirtClient) ([]prometheusv1.Alert, error) {
 	return result.Alerts.Alerts, nil
 }
 
-func waitForMetricValue(client kubecli.KubevirtClient, metric string, expectedValue int64) {
+func waitForMetricValue(client kubecli.KubevirtClient, metric string, expectedValue float64) {
 	waitForMetricValueWithLabels(client, metric, expectedValue, nil)
 }
 
-func waitForMetricValueWithLabels(client kubecli.KubevirtClient, metric string, expectedValue int64, labels map[string]string) {
-	EventuallyWithOffset(1, func() int {
+func waitForMetricValueWithLabels(client kubecli.KubevirtClient, metric string, expectedValue float64, labels map[string]string) {
+	EventuallyWithOffset(1, func() float64 {
 		i, err := getMetricValueWithLabels(client, metric, labels)
 		if err != nil {
 			return -1
@@ -80,7 +80,7 @@ func waitForMetricValueWithLabels(client kubecli.KubevirtClient, metric string, 
 	}, 3*time.Minute, 1*time.Second).Should(BeNumerically("==", expectedValue))
 }
 
-func getMetricValueWithLabels(cli kubecli.KubevirtClient, query string, labels map[string]string) (int, error) {
+func getMetricValueWithLabels(cli kubecli.KubevirtClient, query string, labels map[string]string) (float64, error) {
 	result, err := fetchMetric(cli, query)
 	if err != nil {
 		return -1, err
@@ -99,7 +99,7 @@ func getMetricValueWithLabels(cli kubecli.KubevirtClient, query string, labels m
 		return -1, fmt.Errorf("metric value is not string")
 	}
 
-	returnVal, err := strconv.Atoi(output)
+	returnVal, err := strconv.ParseFloat(output, 64)
 	if err != nil {
 		return -1, err
 	}

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -69,7 +69,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			waitForMetricValue(virtClient, "kubevirt_number_of_vms", int64(5))
+			waitForMetricValue(virtClient, "kubevirt_number_of_vms", 5)
 		})
 	})
 
@@ -91,7 +91,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		})
 
 		checkMetricTo := func(metric string, labels map[string]string, matcher types.GomegaMatcher, description string) {
-			EventuallyWithOffset(1, func() int {
+			EventuallyWithOffset(1, func() float64 {
 				i, err := getMetricValueWithLabels(virtClient, metric, labels)
 				if err != nil {
 					return -1
@@ -230,14 +230,14 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		It("[test_id:8639]Number of disks restored and total restored bytes metric values should be correct", func() {
 			totalMetric := fmt.Sprintf("kubevirt_vmsnapshot_disks_restored_from_source_total{vm_name='simple-vm',vm_namespace='%s'}", util.NamespaceTestDefault)
 			bytesMetric := fmt.Sprintf("kubevirt_vmsnapshot_disks_restored_from_source_bytes{vm_name='simple-vm',vm_namespace='%s'}", util.NamespaceTestDefault)
-			numPVCs := 2
+			numPVCs := 2.0
 
-			for i := 1; i < numPVCs+1; i++ {
+			for i := 1.0; i < numPVCs+1; i++ {
 				// Create dummy PVC that is labelled as "restored" from VM snapshot
-				createSimplePVCWithRestoreLabels(fmt.Sprintf("vmsnapshot-restored-pvc-%d", i))
+				createSimplePVCWithRestoreLabels(fmt.Sprintf("vmsnapshot-restored-pvc-%f", i))
 				// Metric values increases per restored disk
-				waitForMetricValue(virtClient, totalMetric, int64(i))
-				waitForMetricValue(virtClient, bytesMetric, quantity.Value()*int64(i))
+				waitForMetricValue(virtClient, totalMetric, i)
+				waitForMetricValue(virtClient, bytesMetric, float64(quantity.Value())*i)
 			}
 		})
 	})

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -76,9 +76,9 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 	Context("VM status metrics", func() {
 		var vm *v1.VirtualMachine
 		var cpuMetrics = []string{
-			"kubevirt_vmi_cpu_system_usage_seconds",
-			"kubevirt_vmi_cpu_usage_seconds",
-			"kubevirt_vmi_cpu_user_usage_seconds",
+			"kubevirt_vmi_cpu_system_usage_seconds_total",
+			"kubevirt_vmi_cpu_usage_seconds_total",
+			"kubevirt_vmi_cpu_user_usage_seconds_total",
 		}
 
 		BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/10138

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change kubevirt_vmi_*_usage_seconds from Gauges to Counters
```
