### PR TITLE
[release-0.59] Change kubevirt_vmi_*_usage_seconds from Gauges to Counters

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -66,14 +66,14 @@ Virtual Machine last transition timestamp to starting status. Type: Counter.
 ### kubevirt_vmi_cpu_affinity
 Details the cpu pinning map via boolean labels in the form of vcpu_X_cpu_Y. Type: Counter.
 
-### kubevirt_vmi_cpu_system_usage_seconds
-Total CPU time spent in system mode. Type: Gauge.
+### kubevirt_vmi_cpu_system_usage_seconds_total
+Total CPU time spent in system mode. Type: Counter.
 
-### kubevirt_vmi_cpu_usage_seconds
-Total CPU time spent in all modes (sum of both vcpu and hypervisor usage). Type: Gauge.
+### kubevirt_vmi_cpu_usage_seconds_total
+Total CPU time spent in all modes (sum of both vcpu and hypervisor usage). Type: Counter.
 
-### kubevirt_vmi_cpu_user_usage_seconds
-Total CPU time spent in user mode. Type: Gauge.
+### kubevirt_vmi_cpu_user_usage_seconds_total
+Total CPU time spent in user mode. Type: Counter.
 
 ### kubevirt_vmi_filesystem_capacity_bytes_total
 Total VM filesystem capacity in bytes. Type: Gauge.

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -234,6 +234,10 @@ func (metrics *vmiMetrics) updateCPUAffinity(cpuMap [][]bool) {
 	)
 }
 
+func nanosecondsToSeconds(ns uint64) float64 {
+	return float64(ns) / 1000000000
+}
+
 func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCPUStats *stats.DomainStatsCPU) {
 	if !domainCPUStats.TimeSet && !domainCPUStats.UserSet && !domainCPUStats.SystemSet {
 		log.Log.V(4).Warningf("No domain CPU stats is set for %s VMI.", vmi.Name)
@@ -241,28 +245,28 @@ func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCP
 
 	if domainCPUStats.TimeSet {
 		metrics.pushCommonMetric(
-			"kubevirt_vmi_cpu_usage_seconds",
+			"kubevirt_vmi_cpu_usage_seconds_total",
 			"Total CPU time spent in all modes (sum of both vcpu and hypervisor usage).",
-			prometheus.GaugeValue,
-			float64(domainCPUStats.Time/1000000000),
+			prometheus.CounterValue,
+			nanosecondsToSeconds(domainCPUStats.Time),
 		)
 	}
 
 	if domainCPUStats.UserSet {
 		metrics.pushCommonMetric(
-			"kubevirt_vmi_cpu_user_usage_seconds",
+			"kubevirt_vmi_cpu_user_usage_seconds_total",
 			"Total CPU time spent in user mode.",
-			prometheus.GaugeValue,
-			float64(domainCPUStats.User/1000000000),
+			prometheus.CounterValue,
+			nanosecondsToSeconds(domainCPUStats.User),
 		)
 	}
 
 	if domainCPUStats.SystemSet {
 		metrics.pushCommonMetric(
-			"kubevirt_vmi_cpu_system_usage_seconds",
+			"kubevirt_vmi_cpu_system_usage_seconds_total",
 			"Total CPU time spent in system mode.",
-			prometheus.GaugeValue,
-			float64(domainCPUStats.System/1000000000),
+			prometheus.CounterValue,
+			nanosecondsToSeconds(domainCPUStats.System),
 		)
 	}
 }

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -1211,18 +1211,18 @@ var _ = Describe("Prometheus", func() {
 			dto := &io_prometheus_client.Metric{}
 			result.Write(dto)
 
-			Expect(dto.GetGauge().GetValue()).To(Equal(float64(MetricValue)))
+			Expect(dto.GetCounter().GetValue()).To(Equal(float64(MetricValue)))
 
 		},
-			Entry("Total CPU time spent in all modes (sum of both vcpu and hypervisor usage)", "kubevirt_vmi_cpu_usage_seconds", 123, &stats.DomainStatsCPU{
+			Entry("Total CPU time spent in all modes (sum of both vcpu and hypervisor usage)", "kubevirt_vmi_cpu_usage_seconds_total", 123, &stats.DomainStatsCPU{
 				TimeSet: true,
 				Time:    123000000000},
 			),
-			Entry("Total CPU time spent in user mode", "kubevirt_vmi_cpu_user_usage_seconds", 456, &stats.DomainStatsCPU{
+			Entry("Total CPU time spent in user mode", "kubevirt_vmi_cpu_user_usage_seconds_total", 456, &stats.DomainStatsCPU{
 				UserSet: true,
 				User:    456000000000},
 			),
-			Entry("Total CPU time spent in system mode", "kubevirt_vmi_cpu_system_usage_seconds", 789, &stats.DomainStatsCPU{
+			Entry("Total CPU time spent in system mode", "kubevirt_vmi_cpu_system_usage_seconds_total", 789, &stats.DomainStatsCPU{
 				SystemSet: true,
 				System:    789000000000},
 			))

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -452,19 +452,19 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Serial, decorators
 			createVirtualMachine(vm)
 
 			metrics := []string{
-				"kubevirt_vmi_cpu_system_usage_seconds",
-				"kubevirt_vmi_cpu_usage_seconds",
-				"kubevirt_vmi_cpu_user_usage_seconds",
+				"kubevirt_vmi_cpu_system_usage_seconds_total",
+				"kubevirt_vmi_cpu_usage_seconds_total",
+				"kubevirt_vmi_cpu_user_usage_seconds_total",
 			}
 
 			for _, metric := range metrics {
-				Eventually(func() int {
+				Eventually(func() float64 {
 					v, err := getMetricValueWithLabels(virtClient, metric, nil)
 					if err != nil {
 						return -1
 					}
 
-					i, err := strconv.Atoi(v)
+					i, err := strconv.ParseFloat(v, 64)
 					if err != nil {
 						return -1
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/10273

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change kubevirt_vmi_*_usage_seconds from Gauges to Counters
```
