### PR TITLE
[Release-1.0] Relax prometheus cr operator test

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2527,12 +2527,9 @@ spec:
 			monv1 := virtClient.PrometheusClient().MonitoringV1()
 			prometheusRule, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
-			hasWorkloadUpdates := false
-			if len(originalKv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods) > 0 {
-				hasWorkloadUpdates = true
-			}
-			expectedPromRuleSpec := components.NewPrometheusRuleSpec(flags.KubeVirtInstallNamespace, hasWorkloadUpdates)
-			Expect(prometheusRule.Spec).To(Equal(*expectedPromRuleSpec))
+			Expect(prometheusRule.Spec).ToNot(BeNil())
+			Expect(prometheusRule.Spec.Groups).ToNot(BeEmpty())
+			Expect(prometheusRule.Spec.Groups[0].Rules).ToNot(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/10238.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```