### PR TITLE
Experiment with shared PROC namespace

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -534,6 +534,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			},
 		},
 		Spec: k8sv1.PodSpec{
+			ShareProcessNamespace:         pointer.Bool(true),
 			Hostname:                      hostName,
 			Subdomain:                     vmi.Spec.Subdomain,
 			SecurityContext:               computePodSecurityContext(vmi, podSeccompProfile),


### PR DESCRIPTION
**What this PR does / why we need it**:


This has the potential to make virt-handler mount magic for containerdisks obsolete.

This commit just tests if anything else would be affected if we enable proc sharing and does not alter any logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
