### PR TITLE
net, e2e: Skip SR-IOV hotplug if FG is disabled

### DIFF
--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -49,7 +49,9 @@ var _ = SIGDescribe("[Serial] SRIOV nic-hotplug", Serial, decorators.SRIOV, func
 	sriovResourceName := readSRIOVResourceName()
 
 	BeforeEach(func() {
-		Expect(checks.HasFeature(virtconfig.HotplugNetworkIfacesGate)).To(BeTrue())
+		if !checks.HasFeature(virtconfig.HotplugNetworkIfacesGate) {
+			Skip("HotplugNICs feature gate is disabled.")
+		}
 	})
 
 	BeforeEach(func() {


### PR DESCRIPTION
PR #10185 introduced the SR-IOV migration-based hotplug with an E2E test that fails [1] in case the `HotplugNICs` feature gate is disabled.

The CI system of kubevirt/kubevirtci, has an SR-IOV lane that deploys a cluster and runs the conformance test mechanism with a focus on SR-IOV tests[2] without enabling the `HotplugNICs` feature gate.

This causes the pre-submit jobs in kubevirt/kubevirtci to fail[3], and requires a maintainer override in order to merge PRs.

As an immediate fix, skip the SR-IOV migration based hotplug tests if the `HotplugNICs` feature gate is disabled.

The kubevirt/kubevirt tests will not be affected by this change. A more permanent fix will follow.

[1] https://github.com/kubevirt/kubevirt/blob/cb29e9f87d41deae0d9e1efa6b0cde53ecd8c28a/tests/network/hotplug_sriov.go#L52
[2] https://github.com/kubevirt/project-infra/blob/88e8dbd315a7bc908f637ebe3168f1fe7da97839/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml#L53
[3] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/1070/check-up-kind-1.27-sriov/1691706923780411392

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
