### PR TITLE
Replacing kubevirt logo from cncf branding with kubevirt community

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KubeVirt
 
 <p align="center">
-<img src="https://cncf-branding.netlify.app/img/projects/kubevirt/icon/color/kubevirt-icon-color.png" width="100">
+<img src="https://github.com/kubevirt/community/blob/main/logo/KubeVirt_icon.png" width="100">
 </p>
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

KubeVirt logo isn't loading on the kubevirt/kubevirt README. Not sure why but the src is pointing to cncf/cncf-branding repo and it hasn't changed in years. Replacing it with the KubeVirt logo from our community repo. 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
