### PR TITLE
tests: Delete VMI prior to NFS server pod

### DIFF
--- a/images/nfs-server/BUILD.bazel
+++ b/images/nfs-server/BUILD.bazel
@@ -2,6 +2,14 @@ load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
 )
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "entrypoint",
+    srcs = [":entrypoint.sh"],
+    mode = "0775",
+    package_dir = "/",
+)
 
 container_image(
     name = "nfs-server-image",
@@ -13,6 +21,7 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_arm64": "@nfs-server_aarch64//image",
         "//conditions:default": "@nfs-server//image",
     }),
+    cmd = ["/entrypoint.sh"],
     ports = [
         "111/udp",
         "2049/udp",
@@ -24,6 +33,9 @@ container_image(
         "32765/tcp",
         "32766/tcp",
         "32767/tcp",
+    ],
+    tars = [
+        ":entrypoint",
     ],
     visibility = ["//visibility:public"],
 )

--- a/images/nfs-server/entrypoint.sh
+++ b/images/nfs-server/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# The NFS grace period is set to 90 seconds and it stalls the clients
+# trying to access the share right after the server start. This may affect
+# the tests and lead to timeouts so disable the setting.
+sed -i"" \
+    -e "s#Grace_Period = 90#Graceless = true#g" \
+    /opt/start_nfs.sh
+
+exec /opt/start_nfs.sh

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -253,6 +253,11 @@ var _ = SIGDescribe("Storage", func() {
 				var pvName string
 				var nfsPod *k8sv1.Pod
 				AfterEach(func() {
+					// Ensure VMI is deleted before bringing down the NFS server
+					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
+					libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+
 					if targetImagePath != testsuite.HostPathAlpine {
 						tests.DeleteAlpineWithNonQEMUPermissions()
 					}

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -268,11 +268,10 @@ var _ = SIGDescribe("Storage", func() {
 					var nodeName string
 					// Start the VirtualMachineInstance with the PVC attached
 					if storageEngine == "nfs" {
-						targetImage := targetImagePath
 						if !imageOwnedByQEMU {
-							targetImage, nodeName = tests.CopyAlpineWithNonQEMUPermissions()
+							targetImagePath, nodeName = tests.CopyAlpineWithNonQEMUPermissions()
 						}
-						nfsPod = storageframework.InitNFS(targetImage, nodeName)
+						nfsPod = storageframework.InitNFS(targetImagePath, nodeName)
 						pvName = createNFSPvAndPvc(family, nfsPod)
 					} else {
 						pvName = tests.DiskAlpineHostPath


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Kubelet fails to umount the NFS volume and gets stuck when performing pod cleanup if the server has already gone. Ensure that the VMI is deleted first, and the corresponding volume is released (current global tests cleanup hook does not guarantee deletion order).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I observe the issue after running nightly tests. I see the nodes in `NotReady` state with stale NFS mount points:

```
# mount | grep nfs
10.42.1.220:/ on /var/lib/kubelet/pods/0747bcc2-9f8d-473d-acfc-21393679e9d0/volumes/kubernetes.io~nfs/test-nfsfb92r6g7cvw57rghvh25q7j99wj7vws9tbbqwhkp58v222mq type nfs4 (rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.132,local_lock=none,addr=10.42.1.220)
10.42.1.225:/ on /var/lib/kubelet/pods/16b805f0-0e86-469d-8bf8-7d8685830a3e/volumes/kubernetes.io~nfs/test-nfsfb92r6g7cvw57rghvh25q7j99wj7vws9tbbqwhkp58v222mq type nfs4 (rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.132,local_lock=none,addr=10.42.1.225)
10.42.1.240:/ on /var/lib/kubelet/pods/d6ccc012-5529-438b-b3fc-f3d35df04ab1/volumes/kubernetes.io~nfs/test-nfsfb92r6g7cvw57rghvh25q7j99wj7vws9tbbqwhkp58v222mq type nfs4 (rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.132,local_lock=none,addr=10.42.1.240)
```

The nodes become non-operational and the subsequent tests fail. This can only be fixed by either manually running `umount -lf ...` or by rebooting the affected nodes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
