### PR TITLE
tests: add meaningful logs to access failures

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -399,7 +399,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			// AS A TEST USER
 			By(fmt.Sprintf("verifying user rights for verb %s", verb))
 			result, _, _ := clientcmd.RunCommand(k8sClient, "auth", "can-i", "--as", testUser, verb, resource)
-			Expect(result).To(ContainSubstring(right))
+			Expect(result).To(ContainSubstring(right), fmt.Sprintf("unexpected permission for %s to %s a %s", testUser, verb, resource))
 		}
 
 		testRights := func(resource, right string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
`testAction()` is called *many* times by the tests in that file. Every time with different parameters.
On failure, we need to know which one failed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
