### PR TITLE
[bug-fix] Reference changed without changing the definition

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -45,7 +45,7 @@ The number of VMs in the cluster by namespace. Type: Gauge.
 ### kubevirt_virt_api_up
 The number of virt-api pods that are up. Type: Gauge.
 
-### kubevirt_virt_controller_leading
+### kubevirt_virt_controller_leading_status
 Indication for an operating virt-controller. Type: Gauge.
 
 ### kubevirt_virt_controller_ready

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -121,7 +121,7 @@ var (
 
 	leaderGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "kubevirt_virt_controller_leading",
+			Name: "kubevirt_virt_controller_leading_status",
 			Help: "Indication for an operating virt-controller.",
 		},
 	)


### PR DESCRIPTION
a metric name changed only in the test files and not in the metric definition, see https://github.com/kubevirt/kubevirt/pull/9821 and see the bug here:https://github.com/kubevirt/kubevirt/pull/9821/files#diff-9ad6a6110d7d4105a50147793d748edfaa2237b821bd4e5a6f512b5cb3030ef7R352

**Special notes for your reviewer**:
Blocking https://github.com/kubevirt/kubevirt/pull/10323

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Deprecation notice for the metric listed in the PR. Please update your systems to use the new metrics names:
kubevirt_virt_controller_leading | kubevirt_virt_controller_leading_status

```
