### PR TITLE
set user-defined kubelet dir to  handler with operator

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -365,6 +365,7 @@ func (app *virtHandlerApp) Run() {
 		app.VirtShareDir,
 		app.VirtPrivateDir,
 		app.KubeletPodsDir,
+		app.KubeletRoot,
 		vmiSourceInformer,
 		vmiTargetInformer,
 		domainSharedInformer,

--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,14 +34,14 @@ type HeartBeat struct {
 	devicePluginWaitTimeout   time.Duration
 }
 
-func NewHeartBeat(clientset k8scli.CoreV1Interface, deviceManager device_manager.DeviceControllerInterface, clusterConfig *virtconfig.ClusterConfig, host string) *HeartBeat {
+func NewHeartBeat(clientset k8scli.CoreV1Interface, deviceManager device_manager.DeviceControllerInterface, clusterConfig *virtconfig.ClusterConfig, host, kubeletRoot string) *HeartBeat {
 	return &HeartBeat{
 		clientset:               clientset,
 		deviceManagerController: deviceManager,
 		clusterConfig:           clusterConfig,
 		host:                    host,
 		// This is a temporary workaround until k8s bug #66525 is resolved
-		cpuManagerPaths:           []string{virtutil.CPUManagerPath, virtutil.CPUManagerOS3Path},
+		cpuManagerPaths:           []string{path.Join(virtutil.HostRootMount, kubeletRoot, "cpu_manager_state"), virtutil.CPUManagerPath, virtutil.CPUManagerOS3Path},
 		devicePluginPollIntervall: 1 * time.Second,
 		devicePluginWaitTimeout:   10 * time.Second,
 	}

--- a/pkg/virt-handler/heartbeat/heartbeat_test.go
+++ b/pkg/virt-handler/heartbeat/heartbeat_test.go
@@ -14,6 +14,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 )
@@ -38,7 +39,7 @@ var _ = Describe("Heartbeat", func() {
 	})
 	Context("upon finishing", func() {
 		It("should set the node to not schedulable", func() {
-			heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController(true), config(), "mynode")
+			heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController(true), config(), "mynode", util.KubeletRoot)
 			stopChan := make(chan struct{})
 			done := heartbeat.Run(30*time.Second, stopChan)
 			Eventually(func() map[string]string {
@@ -57,7 +58,7 @@ var _ = Describe("Heartbeat", func() {
 	})
 
 	DescribeTable("with cpumanager featuregate should set the node to", func(deviceController device_manager.DeviceControllerInterface, cpuManagerPaths []string, schedulable string, cpumanager string) {
-		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(virtconfig.CPUManager), "mynode")
+		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(virtconfig.CPUManager), "mynode", util.KubeletRoot)
 		heartbeat.cpuManagerPaths = cpuManagerPaths
 		heartbeat.do()
 		node, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "mynode", metav1.GetOptions{})
@@ -92,7 +93,7 @@ var _ = Describe("Heartbeat", func() {
 	)
 
 	DescribeTable("without cpumanager featuregate should set the node to", func(deviceController device_manager.DeviceControllerInterface, schedulable string) {
-		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode")
+		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode", util.KubeletRoot)
 		heartbeat.do()
 		node, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "mynode", metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -110,7 +111,7 @@ var _ = Describe("Heartbeat", func() {
 	)
 
 	DescribeTable("without deviceplugin and", func(deviceController device_manager.DeviceControllerInterface, initiallySchedulable string, finallySchedulable string) {
-		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode")
+		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode", util.KubeletRoot)
 		heartbeat.devicePluginWaitTimeout = 2 * time.Second
 		heartbeat.devicePluginPollIntervall = 10 * time.Millisecond
 		stopChan := make(chan struct{})

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -283,7 +283,7 @@ var _ = Describe("HotplugVolume", func() {
 				ownershipManager:   ownershipManager,
 			}
 
-			deviceBasePath = func(sourceUID types.UID) (*safepath.Path, error) {
+			deviceBasePath = func(sourceUID types.UID, podsBaseDir string) (*safepath.Path, error) {
 				return newDir(tempDir, string(sourceUID), "volumes")
 			}
 			statSourceDevice = func(fileName *safepath.Path) (os.FileInfo, error) {
@@ -546,7 +546,7 @@ var _ = Describe("HotplugVolume", func() {
 				ownershipManager:   ownershipManager,
 			}
 
-			deviceBasePath = func(podUID types.UID) (*safepath.Path, error) {
+			deviceBasePath = func(podUID types.UID, podsBaseDir string) (*safepath.Path, error) {
 				return volumeDir, nil
 			}
 			isolationDetector = func(path string) isolation.PodIsolationDetector {
@@ -734,7 +734,7 @@ var _ = Describe("HotplugVolume", func() {
 				ownershipManager:   ownershipManager,
 			}
 
-			deviceBasePath = func(podUID types.UID) (*safepath.Path, error) {
+			deviceBasePath = func(podUID types.UID, podsBaseDir string) (*safepath.Path, error) {
 				return newDir(tempDir, string(podUID), "volumes")
 			}
 			statSourceDevice = func(fileName *safepath.Path) (os.FileInfo, error) {
@@ -793,7 +793,7 @@ var _ = Describe("HotplugVolume", func() {
 				},
 			})
 			vmi.Status.VolumeStatus = volumeStatuses
-			deviceBasePath = func(podUID types.UID) (*safepath.Path, error) {
+			deviceBasePath = func(podUID types.UID, podsBaseDir string) (*safepath.Path, error) {
 				return newDir(tempDir, string(podUID), "volumeDevices")
 			}
 			blockDevicePath, err := newDir(tempDir, string(sourcePodUID), "volumeDevices", "blockvolume")
@@ -917,7 +917,7 @@ var _ = Describe("HotplugVolume", func() {
 				},
 			})
 			vmi.Status.VolumeStatus = volumeStatuses
-			deviceBasePath = func(podUID types.UID) (*safepath.Path, error) {
+			deviceBasePath = func(podUID types.UID, podsBaseDir string) (*safepath.Path, error) {
 				return newDir(tempDir, string(podUID), "volumeDevices")
 			}
 			blockDevicePath, err := newDir(tempDir, string(sourcePodUID), "volumeDevices", "blockvolume")

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -181,6 +181,7 @@ func NewController(
 	virtShareDir string,
 	virtPrivateDir string,
 	kubeletPodsDir string,
+	kubeletRoot string,
 	vmiSourceInformer cache.SharedIndexInformer,
 	vmiTargetInformer cache.SharedIndexInformer,
 	domainInformer cache.SharedInformer,
@@ -284,7 +285,7 @@ func NewController(
 		device_manager.PermanentHostDevicePlugins(maxDevices, permissions),
 		clusterConfig,
 		clientset.CoreV1())
-	c.heartBeat = heartbeat.NewHeartBeat(clientset.CoreV1(), c.deviceManagerController, clusterConfig, host)
+	c.heartBeat = heartbeat.NewHeartBeat(clientset.CoreV1(), c.deviceManagerController, clusterConfig, host, kubeletRoot)
 
 	return c, nil
 }

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -205,13 +205,15 @@ var _ = Describe("VirtualMachineInstance", func() {
 		mockHotplugVolumeMounter = hotplug_volume.NewMockVolumeMounter(ctrl)
 
 		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, config)
-		controller, _ = NewController(recorder,
+		controller, _ = NewController(
+			recorder,
 			virtClient,
 			host,
 			podIpAddress,
 			shareDir,
 			privateDir,
 			podsDir,
+			util.KubeletRoot,
 			vmiSourceInformer,
 			vmiTargetInformer,
 			domainInformer,


### PR DESCRIPTION
What this PR does / why we need it:
The purpose of the PR is on operator working with user-defined kubelet data dir - to set correct kubelet data dir for virt components and vms if kubelet-pods-dir or kubelet-root is user-defined.
The path under proc/1/root should be the actual path of kubelet on device.If the kubelet data dir is user-defined,the path under proc/1/root which be used should also be set.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #8998

**Release note**:
```release-note
The parameters kubelet-pods-dir and kubelet-root have different priorities. If both are set, kubelet-pods-dir has a higher priority.
```
