### PR TITLE
tests: add ignore preference disk bus test

### DIFF
--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1562,6 +1562,16 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 				Expect(vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(preferenceSpec.Devices.PreferredDiskBus))
 			})
+
+			It("[test_id:CNV-9817] Should ignore preference when a VMI disk have a DiskDevice defined", func() {
+				diskTypeForTest := v1.DiskBusSCSI
+
+				vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus = diskTypeForTest
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				Expect(conflicts).To(BeEmpty())
+
+				Expect(vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(diskTypeForTest))
+			})
 		})
 
 		Context("Preference.Features", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a test to validate that when we start a VM with disk bus defined and a preference with disk bus, the preference is ignored.

**Release note**:
```
NONE
```
