### PR TITLE
Slirp network binding plugin: Do not duplicate slirp iface QEMU cmd args

### DIFF
--- a/cmd/network-slirp-binding/domain/domain.go
+++ b/cmd/network-slirp-binding/domain/domain.go
@@ -81,7 +81,21 @@ func (s SlirpNetworkConfigurator) Mutate(domainSpec *domainschema.DomainSpec) (*
 	if domainSpecCopy.QEMUCmd == nil {
 		domainSpecCopy.QEMUCmd = &domainschema.Commandline{}
 	}
-	domainSpecCopy.QEMUCmd.QEMUArg = append(domainSpecCopy.QEMUCmd.QEMUArg, slirpQemuCmdArgs...)
+
+	var currentCmdArgString string
+	for _, arg := range domainSpecCopy.QEMUCmd.QEMUArg {
+		currentCmdArgString += arg.Value
+	}
+
+	var generatedCmdArgString string
+	for _, arg := range slirpQemuCmdArgs {
+		generatedCmdArgString += arg.Value
+	}
+
+	if !strings.Contains(currentCmdArgString, generatedCmdArgString) {
+		domainSpecCopy.QEMUCmd.QEMUArg = append(domainSpecCopy.QEMUCmd.QEMUArg, slirpQemuCmdArgs...)
+		return domainSpecCopy, nil
+	}
 
 	return domainSpecCopy, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR make Slirp network binding plugin to not duplicate Slirp networking QEMU cmd args  in the domain spec.
In order words make the plugin idempotent.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
