### PR TITLE
misc fixes: go:embed (2), docs (1) and minor refactor

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18323,7 +18323,7 @@
       "default": ""
      },
      "resourceName": {
-      "description": "The name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_nameThe name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_name",
+      "description": "The name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_name",
       "type": "string",
       "default": ""
      }

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -665,10 +665,7 @@ spec:
                             resourceName:
                               description: The name of the resource that is representing
                                 the device. Exposed by a device plugin and requested
-                                by VMs. Typically of the form vendor.com/product_nameThe
-                                name of the resource that is representing the device.
-                                Exposed by a device plugin and requested by VMs. Typically
-                                of the form vendor.com/product_name
+                                by VMs. Typically of the form vendor.com/product_name
                               type: string
                           required:
                           - pciVendorSelector
@@ -3675,10 +3672,7 @@ spec:
                             resourceName:
                               description: The name of the resource that is representing
                                 the device. Exposed by a device plugin and requested
-                                by VMs. Typically of the form vendor.com/product_nameThe
-                                name of the resource that is representing the device.
-                                Exposed by a device plugin and requested by VMs. Typically
-                                of the form vendor.com/product_name
+                                by VMs. Typically of the form vendor.com/product_name
                               type: string
                           required:
                           - pciVendorSelector

--- a/pkg/virt-launcher/virtwrap/api/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/api/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "testdata/domain_x86_64.xml.tmpl",
         "testdata/domain_ppc64le.xml.tmpl",
         "testdata/domain_arm64.xml.tmpl",
+        "testdata/domain_numa_topology.xml",
     ],
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/api/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "testdata/domain_ppc64le.xml.tmpl",
         "testdata/domain_arm64.xml.tmpl",
         "testdata/domain_numa_topology.xml",
+        "testdata/cpu_pinning.xml",
     ],
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -48,6 +48,9 @@ var (
 
 	//go:embed testdata/domain_numa_topology.xml
 	domainNumaTopology []byte
+
+	//go:embed testdata/cpu_pinning.xml
+	cpuPinningXML []byte
 )
 
 const (
@@ -292,13 +295,6 @@ var _ = ginkgo.Describe("Schema", func() {
 	})
 
 	ginkgo.Context("With cpu pinning", func() {
-		var testXML = `<cputune>
-<vcpupin vcpu="0" cpuset="1"/>
-<vcpupin vcpu="1" cpuset="5"/>
-<iothreadpin iothread="0" cpuset="1"/>
-<iothreadpin iothread="1" cpuset="5"/>
-<emulatorpin cpuset="6"/>
-</cputune>`
 		var exampleCpuTune = CPUTune{
 			VCPUPin: []CPUTuneVCPUPin{
 				{
@@ -327,7 +323,7 @@ var _ = ginkgo.Describe("Schema", func() {
 
 		ginkgo.It("Unmarshal into struct", func() {
 			newCpuTune := CPUTune{}
-			Expect(xml.Unmarshal([]byte(testXML), &newCpuTune)).To(Succeed())
+			Expect(xml.Unmarshal(cpuPinningXML, &newCpuTune)).To(Succeed())
 			Expect(newCpuTune).To(Equal(exampleCpuTune))
 		})
 	})

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -45,6 +45,9 @@ var (
 	//go:embed testdata/domain_arm64.xml.tmpl
 	exampleXMLarm64                   string
 	exampleXMLarm64withNoneMemballoon string
+
+	//go:embed testdata/domain_numa_topology.xml
+	domainNumaTopology []byte
 )
 
 const (
@@ -255,27 +258,6 @@ var _ = ginkgo.Describe("Schema", func() {
 
 	ginkgo.Context("With numa topology", func() {
 		ginkgo.It("should marshal and unmarshal the values", func() {
-			var testXML = `
-<domain>
-<cputune>
-	<vcpupin vcpu="0" cpuset="1"/>
-	<vcpupin vcpu="1" cpuset="5"/>
-	<vcpupin vcpu="2" cpuset="2"/>
-	<vcpupin vcpu="3" cpuset="6"/>
-</cputune>
-<numatune>
-  <memory mode="strict" nodeset="1-2"/> 
-  <memnode cellid="0" mode="strict" nodeset="1"/>
-  <memnode cellid="2" mode="preferred" nodeset="2"/>
-</numatune>
-<cpu>
-	<numa>
-		<cell id="0" cpus="0-1" memory="3" unit="GiB"/>
-		<cell id="1" cpus="2-3" memory="3" unit="GiB"/>
-	</numa>
-</cpu>
-</domain>
-`
 			spec := &DomainSpec{}
 			expectedSpec := &DomainSpec{
 				CPU: CPU{NUMA: &NUMA{Cells: []NUMACell{
@@ -301,7 +283,7 @@ var _ = ginkgo.Describe("Schema", func() {
 					},
 				},
 			}
-			Expect(xml.Unmarshal([]byte(testXML), spec)).To(Succeed())
+			Expect(xml.Unmarshal(domainNumaTopology, spec)).To(Succeed())
 			Expect(spec.NUMATune).To(Equal(expectedSpec.NUMATune))
 			Expect(spec.CPUTune).To(Equal(expectedSpec.CPUTune))
 			Expect(spec.CPU).To(Equal(expectedSpec.CPU))

--- a/pkg/virt-launcher/virtwrap/api/testdata/cpu_pinning.xml
+++ b/pkg/virt-launcher/virtwrap/api/testdata/cpu_pinning.xml
@@ -1,0 +1,7 @@
+<cputune>
+  <vcpupin vcpu="0" cpuset="1"/>
+  <vcpupin vcpu="1" cpuset="5"/>
+  <iothreadpin iothread="0" cpuset="1"/>
+  <iothreadpin iothread="1" cpuset="5"/>
+  <emulatorpin cpuset="6"/>
+</cputune>`

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_numa_topology.xml
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_numa_topology.xml
@@ -1,0 +1,20 @@
+<domain>
+<cputune>
+	<vcpupin vcpu="0" cpuset="1"/>
+	<vcpupin vcpu="1" cpuset="5"/>
+	<vcpupin vcpu="2" cpuset="2"/>
+	<vcpupin vcpu="3" cpuset="6"/>
+</cputune>
+<numatune>
+  <memory mode="strict" nodeset="1-2"/> 
+  <memnode cellid="0" mode="strict" nodeset="1"/>
+  <memnode cellid="2" mode="preferred" nodeset="2"/>
+</numatune>
+<cpu>
+	<numa>
+		<cell id="0" cpus="0-1" memory="3" unit="GiB"/>
+		<cell id="1" cpus="2-3" memory="3" unit="GiB"/>
+	</numa>
+</cpu>
+</domain>
+`

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1861,15 +1861,18 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 	}
 
-	if virtLauncherLogVerbosity, err := strconv.Atoi(os.Getenv(services.ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY)); err == nil && (virtLauncherLogVerbosity > services.EXT_LOG_VERBOSITY_THRESHOLD) && isAMD64(c.Architecture) {
-		// isa-debugcon device is only for x86_64
-		initializeQEMUCmdAndQEMUArg(domain)
+	if isAMD64(c.Architecture) {
+		virtLauncherLogVerbosity, err := strconv.Atoi(os.Getenv(services.ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY))
+		if err == nil && virtLauncherLogVerbosity > services.EXT_LOG_VERBOSITY_THRESHOLD {
+			// isa-debugcon device is only for x86_64
+			initializeQEMUCmdAndQEMUArg(domain)
 
-		domain.Spec.QEMUCmd.QEMUArg = append(domain.Spec.QEMUCmd.QEMUArg,
-			api.Arg{Value: "-chardev"},
-			api.Arg{Value: fmt.Sprintf("file,id=firmwarelog,path=%s", QEMUSeaBiosDebugPipe)},
-			api.Arg{Value: "-device"},
-			api.Arg{Value: "isa-debugcon,iobase=0x402,chardev=firmwarelog"})
+			domain.Spec.QEMUCmd.QEMUArg = append(domain.Spec.QEMUCmd.QEMUArg,
+				api.Arg{Value: "-chardev"},
+				api.Arg{Value: fmt.Sprintf("file,id=firmwarelog,path=%s", QEMUSeaBiosDebugPipe)},
+				api.Arg{Value: "-device"},
+				api.Arg{Value: "isa-debugcon,iobase=0x402,chardev=firmwarelog"})
+		}
 	}
 
 	if vmi.Spec.Domain.Devices.TPM != nil {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1263,10 +1263,7 @@ var CRDsValidation map[string]string = map[string]string{
                       resourceName:
                         description: The name of the resource that is representing
                           the device. Exposed by a device plugin and requested by
-                          VMs. Typically of the form vendor.com/product_nameThe name
-                          of the resource that is representing the device. Exposed
-                          by a device plugin and requested by VMs. Typically of the
-                          form vendor.com/product_name
+                          VMs. Typically of the form vendor.com/product_name
                         type: string
                     required:
                     - pciVendorSelector

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2555,9 +2555,7 @@ type PciHostDevice struct {
 	PCIVendorSelector string `json:"pciVendorSelector"`
 	// The name of the resource that is representing the device. Exposed by
 	// a device plugin and requested by VMs. Typically of the form
-	// vendor.com/product_nameThe name of the resource that is representing
-	// the device. Exposed by a device plugin and requested by VMs.
-	// Typically of the form vendor.com/product_name
+	// vendor.com/product_name
 	ResourceName string `json:"resourceName"`
 	// If true, KubeVirt will leave the allocation and monitoring to an
 	// external device plugin

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -816,7 +816,7 @@ func (PciHostDevice) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                         "PciHostDevice represents a host PCI device allowed for passthrough",
 		"pciVendorSelector":        "The vendor_id:product_id tuple of the PCI device",
-		"resourceName":             "The name of the resource that is representing the device. Exposed by\na device plugin and requested by VMs. Typically of the form\nvendor.com/product_nameThe name of the resource that is representing\nthe device. Exposed by a device plugin and requested by VMs.\nTypically of the form vendor.com/product_name",
+		"resourceName":             "The name of the resource that is representing the device. Exposed by\na device plugin and requested by VMs. Typically of the form\nvendor.com/product_name",
 		"externalResourceProvider": "If true, KubeVirt will leave the allocation and monitoring to an\nexternal device plugin",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20365,7 +20365,7 @@ func schema_kubevirtio_api_core_v1_PciHostDevice(ref common.ReferenceCallback) c
 					},
 					"resourceName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_nameThe name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_name",
+							Description: "The name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_name",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",


### PR DESCRIPTION
**What this PR does / why we need it**:
This is minor/misc fixes.

**Special notes for your reviewer**:

To not create PR with single/trivial fixes, I put some of those in a side branch, to let it grow. 5 changes seems like okay to have a PR :)

* Yesterday found 2 more possible moves to go:embed under virtwrap/schema. Follow up of https://github.com/kubevirt/kubevirt/pull/10263
* The doc change is about removing duplication (probably a copy-paste error?)
* The converter refactor was related to some work I was doing with logs. I think it should be considered good practice to make code blocks that are architecture depended, just my opinion.

**Release note**:
```release-note
NONE
```
