### PR TITLE
Add required and preferred annotations

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -22807,6 +22807,14 @@
      "memory"
     ],
     "properties": {
+     "annotations": {
+      "description": "Optionally defines the required Annotations to be used by the instance type and applied to the VirtualMachineInstance",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string",
+       "default": ""
+      }
+     },
      "cpu": {
       "description": "Required CPU related attributes of the instancetype.",
       "default": {},
@@ -22916,6 +22924,14 @@
     "description": "VirtualMachinePreferenceSpec is a description of the VirtualMachinePreference or VirtualMachineClusterPreference.",
     "type": "object",
     "properties": {
+     "annotations": {
+      "description": "Optionally defines preferred Annotations to be applied to the VirtualMachineInstance",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string",
+       "default": ""
+      }
+     },
      "clock": {
       "description": "Clock optionally defines preferences associated with the Clock attribute of a VirtualMachineInstance DomainSpec",
       "$ref": "#/definitions/v1beta1.ClockPreferences"

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -936,7 +936,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					NodeSelector: map[string]string{"key": "value"},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 				Expect(vmi.Spec.NodeSelector).To(Equal(instancetypeSpec.NodeSelector))
 			})
@@ -945,7 +945,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{}
 				vmi.Spec.NodeSelector = map[string]string{"key": "value"}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 				Expect(vmi.Spec.NodeSelector).To(Equal(map[string]string{"key": "value"}))
 			})
@@ -956,7 +956,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 				vmi.Spec.NodeSelector = map[string]string{"key": "value"}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.nodeSelector"))
 			})
@@ -968,7 +968,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					SchedulerName: "ultra-scheduler",
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 				Expect(vmi.Spec.SchedulerName).To(Equal(instancetypeSpec.SchedulerName))
 			})
@@ -977,7 +977,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{}
 				vmi.Spec.SchedulerName = "super-fast-scheduler"
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 				Expect(vmi.Spec.SchedulerName).To(Equal("super-fast-scheduler"))
 			})
@@ -988,7 +988,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 				vmi.Spec.SchedulerName = "slow-scheduler"
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.schedulerName"))
 			})
@@ -1017,7 +1017,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 
 			It("should default to PreferSockets", func() {
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(instancetypeSpec.CPU.Guest))
@@ -1035,7 +1035,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				preferredCPUTopology := instancetypev1beta1.PreferCores
 				preferenceSpec.CPU.PreferredCPUTopology = &preferredCPUTopology
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(uint32(1)))
@@ -1052,7 +1052,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				preferredCPUTopology := instancetypev1beta1.PreferThreads
 				preferenceSpec.CPU.PreferredCPUTopology = &preferredCPUTopology
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(uint32(1)))
@@ -1069,7 +1069,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				preferredCPUTopology := instancetypev1beta1.PreferSockets
 				preferenceSpec.CPU.PreferredCPUTopology = &preferredCPUTopology
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(instancetypeSpec.CPU.Guest))
@@ -1095,7 +1095,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					Threads: 1,
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(3))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.cpu.sockets"))
 				Expect(conflicts[1].String()).To(Equal("spec.template.spec.domain.cpu.cores"))
@@ -1115,7 +1115,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.resources.requests.cpu"))
 			})
@@ -1133,7 +1133,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.resources.limits.cpu"))
 			})
@@ -1161,7 +1161,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 						},
 					},
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(vmi.Spec.Domain.CPU.Features).To(HaveLen(2))
 				Expect(vmi.Spec.Domain.CPU.Features).To(ContainElements([]v1.CPUFeature{
 					{
@@ -1189,7 +1189,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 
 			It("should apply to VMI", func() {
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Memory.Guest).To(Equal(instancetypeSpec.Memory.Guest))
@@ -1203,7 +1203,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				expectedOverhead := int64(float32(instancetypeSpec.Memory.Guest.Value()) * (1 - float32(instancetypeSpec.Memory.OvercommitPercent)/100))
 				Expect(expectedOverhead).ToNot(Equal(instancetypeSpec.Memory.Guest.Value()))
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 				memRequest := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
 				Expect(memRequest.Value()).To(Equal(expectedOverhead))
@@ -1215,7 +1215,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					Guest: &vmiMemGuest,
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.memory"))
 			})
@@ -1233,7 +1233,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.resources.requests.memory"))
 			})
@@ -1251,7 +1251,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.resources.limits.memory"))
 			})
@@ -1268,7 +1268,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 
 			It("should apply to VMI", func() {
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.IOThreadsPolicy).To(Equal(*instancetypeSpec.IOThreadsPolicy))
@@ -1277,7 +1277,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should detect IOThreadsPolicy conflict", func() {
 				vmi.Spec.Domain.IOThreadsPolicy = &instancetypePolicy
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.ioThreadsPolicy"))
 			})
@@ -1294,7 +1294,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 
 			It("should apply to VMI", func() {
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.LaunchSecurity).To(Equal(*instancetypeSpec.LaunchSecurity))
@@ -1305,7 +1305,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					SEV: &v1.SEV{},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.launchSecurity"))
 			})
@@ -1325,7 +1325,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 
 			It("should apply to VMI", func() {
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.GPUs).To(Equal(instancetypeSpec.GPUs))
@@ -1339,7 +1339,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.devices.gpus"))
 			})
@@ -1359,7 +1359,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 
 			It("should apply to VMI", func() {
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.HostDevices).To(Equal(instancetypeSpec.HostDevices))
@@ -1373,9 +1373,92 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(HaveLen(1))
 				Expect(conflicts[0].String()).To(Equal("spec.template.spec.domain.devices.hostDevices"))
+			})
+		})
+
+		Context("Instancetype.Spec.Annotations", func() {
+
+			var multipleAnnotations map[string]string
+
+			BeforeEach(func() {
+				multipleAnnotations = map[string]string{
+					"annotation-1": "1",
+					"annotation-2": "2",
+				}
+
+				instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{
+					Annotations: make(map[string]string),
+				}
+			})
+
+			It("should apply to VMI", func() {
+				instancetypeSpec.Annotations = multipleAnnotations
+
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, nil, &vmi.Spec, &vmi.ObjectMeta)
+				Expect(conflicts).To(BeEmpty())
+				Expect(vmi.Annotations).To(Equal(instancetypeSpec.Annotations))
+			})
+
+			It("should not detect conflict when annotation with the same value already exists", func() {
+				instancetypeSpec.Annotations = multipleAnnotations
+				vmi.Annotations = multipleAnnotations
+
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, nil, &vmi.Spec, &vmi.ObjectMeta)
+				Expect(conflicts).To(BeEmpty())
+				Expect(vmi.Annotations).To(Equal(instancetypeSpec.Annotations))
+			})
+
+			It("should detect conflict when annotation with different value already exists", func() {
+				instancetypeSpec.Annotations = multipleAnnotations
+				vmi.Annotations = map[string]string{
+					"annotation-1": "conflict",
+				}
+
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, nil, &vmi.Spec, &vmi.ObjectMeta)
+				Expect(conflicts).To(HaveLen(1))
+				Expect(conflicts[0].String()).To(Equal("annotations.annotation-1"))
+			})
+		})
+
+		Context("Preference.Spec.Annotations", func() {
+
+			var multipleAnnotations map[string]string
+
+			BeforeEach(func() {
+				multipleAnnotations = map[string]string{
+					"annotation-1": "1",
+					"annotation-2": "2",
+				}
+
+				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
+					Annotations: make(map[string]string),
+				}
+			})
+
+			It("should apply to VMI", func() {
+				preferenceSpec.Annotations = multipleAnnotations
+
+				conflicts := instancetypeMethods.ApplyToVmi(field, nil, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
+				Expect(conflicts).To(BeEmpty())
+				Expect(vmi.Annotations).To(Equal(preferenceSpec.Annotations))
+			})
+
+			It("should not overwrite already existing values", func() {
+				preferenceSpec.Annotations = multipleAnnotations
+				vmiAnnotations := map[string]string{
+					"annotation-1": "dont-overwrite",
+					"annotation-2": "dont-overwrite",
+					"annotation-3": "dont-overwrite",
+				}
+				vmi.Annotations = vmiAnnotations
+
+				conflicts := instancetypeMethods.ApplyToVmi(field, nil, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
+				Expect(conflicts).To(BeEmpty())
+				Expect(vmi.Annotations).To(HaveLen(3))
+				Expect(vmi.Annotations).To(Equal(vmiAnnotations))
 			})
 		})
 
@@ -1495,13 +1578,13 @@ var _ = Describe("Instancetype and Preferences", func() {
 							Pod: &v1.PodNetwork{},
 						},
 					}}
-					Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeNil())
+					Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeNil())
 					Expect(vmi.Spec.Domain.Devices.Interfaces[0].Masquerade).ToNot(BeNil())
 					Expect(vmi.Spec.Domain.Devices.Interfaces[1].Masquerade).To(BeNil())
 				})
 				It("should not be applied on interface that has another binding set", func() {
 					vmi.Spec.Domain.Devices.Interfaces[0].SRIOV = &v1.InterfaceSRIOV{}
-					Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeNil())
+					Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeNil())
 					Expect(vmi.Spec.Domain.Devices.Interfaces[0].Masquerade).To(BeNil())
 					Expect(vmi.Spec.Domain.Devices.Interfaces[0].SRIOV).ToNot(BeNil())
 				})
@@ -1509,13 +1592,13 @@ var _ = Describe("Instancetype and Preferences", func() {
 					vmi.Spec.Networks = []v1.Network{{
 						Name: vmi.Spec.Domain.Devices.Interfaces[0].Name,
 					}}
-					Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeNil())
+					Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeNil())
 					Expect(vmi.Spec.Domain.Devices.Interfaces[0].Masquerade).To(BeNil())
 				})
 			})
 
 			It("should apply to VMI", func() {
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeFalse())
@@ -1557,7 +1640,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("Should apply when a VMI disk doesn't have a DiskDevice target defined", func() {
 				vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk = nil
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(preferenceSpec.Devices.PreferredDiskBus))
@@ -1567,7 +1650,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				diskTypeForTest := v1.DiskBusSCSI
 
 				vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus = diskTypeForTest
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(diskTypeForTest))
@@ -1620,7 +1703,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 
 			It("should apply to VMI", func() {
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Features.ACPI).To(Equal(*preferenceSpec.Features.PreferredAcpi))
@@ -1640,7 +1723,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Features.Hyperv.EVMCS.Enabled).To(BeFalse())
@@ -1659,7 +1742,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.BIOS.UseSerial).To(Equal(*preferenceSpec.Firmware.PreferredUseBiosSerial))
@@ -1675,7 +1758,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).To(Equal(*preferenceSpec.Firmware.PreferredUseSecureBoot))
@@ -1695,7 +1778,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 						},
 					},
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(vmi.Spec.Domain.Firmware.Bootloader.EFI).To(BeNil())
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.BIOS.UseSerial).To(BeFalse())
 			})
@@ -1714,7 +1797,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 						},
 					},
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.BIOS.UseSerial).To(BeFalse())
 			})
 
@@ -1732,7 +1815,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 						},
 					},
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(vmi.Spec.Domain.Firmware.Bootloader.BIOS).To(BeNil())
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).To(BeFalse())
 			})
@@ -1751,7 +1834,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 						},
 					},
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).To(BeFalse())
 			})
 		})
@@ -1765,7 +1848,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Machine.Type).To(Equal(preferenceSpec.Machine.PreferredMachineType))
@@ -1787,7 +1870,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					},
 				}
 
-				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
+				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Clock.ClockOffset).To(Equal(*preferenceSpec.Clock.PreferredClockOffset))
@@ -1800,7 +1883,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					PreferredSubdomain: pointer.String("kubevirt.io"),
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(vmi.Spec.Subdomain).To(Equal(*preferenceSpec.PreferredSubdomain))
 			})
 
@@ -1810,7 +1893,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					PreferredSubdomain: pointer.String("kubevirt.io"),
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(vmi.Spec.Subdomain).To(Equal(userDefinedValue))
 			})
 		})
@@ -1820,7 +1903,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					PreferredTerminationGracePeriodSeconds: pointer.Int64(180),
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(*vmi.Spec.TerminationGracePeriodSeconds).To(Equal(*preferenceSpec.PreferredTerminationGracePeriodSeconds))
 			})
 
@@ -1830,7 +1913,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					PreferredTerminationGracePeriodSeconds: pointer.Int64(180),
 				}
-				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)).To(BeEmpty())
+				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(*vmi.Spec.TerminationGracePeriodSeconds).To(Equal(userDefinedValue))
 			})
 		})

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -1328,7 +1328,7 @@ func (ctrl *VMExportController) expandVirtualMachine(vm *virtv1.VirtualMachine) 
 		return vm, nil
 	}
 
-	conflicts := ctrl.instancetypeMethods.ApplyToVmi(field.NewPath("spec", "template", "spec"), instancetypeSpec, preferenceSpec, &vm.Spec.Template.Spec)
+	conflicts := ctrl.instancetypeMethods.ApplyToVmi(field.NewPath("spec", "template", "spec"), instancetypeSpec, preferenceSpec, &vm.Spec.Template.Spec, &vm.Spec.Template.ObjectMeta)
 	if len(conflicts) > 0 {
 		return nil, fmt.Errorf("cannot expand instancetype to VM, due to %d conflicts", len(conflicts))
 	}

--- a/pkg/testutils/mock_instancetype.go
+++ b/pkg/testutils/mock_instancetype.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -11,7 +12,7 @@ import (
 
 type MockInstancetypeMethods struct {
 	FindInstancetypeSpecFunc        func(vm *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachineInstancetypeSpec, error)
-	ApplyToVmiFunc                  func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) instancetype.Conflicts
+	ApplyToVmiFunc                  func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts
 	FindPreferenceSpecFunc          func(vm *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error)
 	StoreControllerRevisionsFunc    func(vm *v1.VirtualMachine) error
 	InferDefaultInstancetypeFunc    func(vm *v1.VirtualMachine) (*v1.InstancetypeMatcher, error)
@@ -25,8 +26,8 @@ func (m *MockInstancetypeMethods) FindInstancetypeSpec(vm *v1.VirtualMachine) (*
 	return m.FindInstancetypeSpecFunc(vm)
 }
 
-func (m *MockInstancetypeMethods) ApplyToVmi(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) instancetype.Conflicts {
-	return m.ApplyToVmiFunc(field, instancetypespec, preferenceSpec, vmiSpec)
+func (m *MockInstancetypeMethods) ApplyToVmi(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts {
+	return m.ApplyToVmiFunc(field, instancetypespec, preferenceSpec, vmiSpec, vmiMetadata)
 }
 
 func (m *MockInstancetypeMethods) FindPreferenceSpec(vm *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error) {
@@ -54,7 +55,7 @@ func NewMockInstancetypeMethods() *MockInstancetypeMethods {
 		FindInstancetypeSpecFunc: func(_ *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachineInstancetypeSpec, error) {
 			return nil, nil
 		},
-		ApplyToVmiFunc: func(_ *k8sfield.Path, _ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, _ *v1.VirtualMachineInstanceSpec) instancetype.Conflicts {
+		ApplyToVmiFunc: func(_ *k8sfield.Path, _ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, _ *v1.VirtualMachineInstanceSpec, _ *metav1.ObjectMeta) instancetype.Conflicts {
 			return nil
 		},
 		FindPreferenceSpecFunc: func(_ *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error) {

--- a/pkg/virt-api/rest/expand.go
+++ b/pkg/virt-api/rest/expand.go
@@ -101,7 +101,7 @@ func expandSpecResponse(vm *v1.VirtualMachine, instancetypeMethods instancetype.
 		return
 	}
 
-	conflicts := instancetypeMethods.ApplyToVmi(field.NewPath("spec", "template", "spec"), instancetypeSpec, preferenceSpec, &vm.Spec.Template.Spec)
+	conflicts := instancetypeMethods.ApplyToVmi(field.NewPath("spec", "template", "spec"), instancetypeSpec, preferenceSpec, &vm.Spec.Template.Spec, &vm.Spec.Template.ObjectMeta)
 	if len(conflicts) > 0 {
 		writeError(errorFunc(fmt.Errorf("cannot expand instancetype to VM")), response)
 		return

--- a/pkg/virt-api/rest/expand_test.go
+++ b/pkg/virt-api/rest/expand_test.go
@@ -127,9 +127,14 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			}
 
 			cpu := &v1.CPU{Cores: 2}
+			annotations := map[string]string{
+				"annotations-1": "1",
+				"annotations-2": "2",
+			}
 
-			instancetypeMethods.ApplyToVmiFunc = func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) instancetype.Conflicts {
+			instancetypeMethods.ApplyToVmiFunc = func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts {
 				vmiSpec.Domain.CPU = cpu
+				vmiMetadata.Annotations = annotations
 				return nil
 			}
 
@@ -139,11 +144,13 @@ var _ = Describe("Instancetype expansion subresources", func() {
 
 			expectedVm := vm.DeepCopy()
 			expectedVm.Spec.Template.Spec.Domain.CPU = cpu
+			expectedVm.Spec.Template.ObjectMeta.Annotations = annotations
 
 			recorder := callExpandSpecApi(vm)
 			responseVm := &v1.VirtualMachine{}
 			Expect(json.NewDecoder(recorder.Body).Decode(responseVm)).To(Succeed())
 
+			Expect(responseVm.Spec.Template.ObjectMeta.Annotations).To(Equal(expectedVm.Spec.Template.ObjectMeta.Annotations))
 			Expect(responseVm.Spec.Template.Spec).To(Equal(expectedVm.Spec.Template.Spec))
 		})
 
@@ -153,7 +160,7 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			}
 
 			machineType := "test-machine"
-			instancetypeMethods.ApplyToVmiFunc = func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) instancetype.Conflicts {
+			instancetypeMethods.ApplyToVmiFunc = func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts {
 				vmiSpec.Domain.Machine = &v1.Machine{Type: machineType}
 				return nil
 			}
@@ -177,7 +184,7 @@ var _ = Describe("Instancetype expansion subresources", func() {
 				return &instancetypev1beta1.VirtualMachineInstancetypeSpec{}, nil
 			}
 
-			instancetypeMethods.ApplyToVmiFunc = func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) instancetype.Conflicts {
+			instancetypeMethods.ApplyToVmiFunc = func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts {
 				return instancetype.Conflicts{k8sfield.NewPath("spec", "template", "spec", "example", "path")}
 			}
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -262,7 +262,7 @@ func (admitter *VMsAdmitter) applyInstancetypeToVm(vm *v1.VirtualMachine) (*inst
 		return nil, nil, nil
 	}
 
-	conflicts := admitter.InstancetypeMethods.ApplyToVmi(k8sfield.NewPath("spec", "template", "spec"), instancetypeSpec, preferenceSpec, &vm.Spec.Template.Spec)
+	conflicts := admitter.InstancetypeMethods.ApplyToVmi(k8sfield.NewPath("spec", "template", "spec"), instancetypeSpec, preferenceSpec, &vm.Spec.Template.Spec, &vm.Spec.Template.ObjectMeta)
 
 	if len(conflicts) == 0 {
 		return instancetypeSpec, preferenceSpec, nil

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1642,7 +1642,7 @@ var _ = Describe("Validating VM Admitter", func() {
 			instancetypeMethods.FindPreferenceSpecFunc = func(_ *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error) {
 				return &instancetypev1beta1.VirtualMachinePreferenceSpec{}, nil
 			}
-			instancetypeMethods.ApplyToVmiFunc = func(_ *k8sfield.Path, _ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, _ *v1.VirtualMachineInstanceSpec) instancetype.Conflicts {
+			instancetypeMethods.ApplyToVmiFunc = func(_ *k8sfield.Path, _ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, _ *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts {
 				return instancetype.Conflicts{path1, path2}
 			}
 
@@ -1664,7 +1664,7 @@ var _ = Describe("Validating VM Admitter", func() {
 			instancetypeMethods.FindInstancetypeSpecFunc = func(_ *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachineInstancetypeSpec, error) {
 				return &instancetypev1beta1.VirtualMachineInstancetypeSpec{}, nil
 			}
-			instancetypeMethods.ApplyToVmiFunc = func(_ *k8sfield.Path, _ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) instancetype.Conflicts {
+			instancetypeMethods.ApplyToVmiFunc = func(_ *k8sfield.Path, _ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts {
 				vmiSpec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("-1Mi")
 				return nil
 			}
@@ -1684,7 +1684,7 @@ var _ = Describe("Validating VM Admitter", func() {
 			}
 
 			// Mock out ApplyToVmiFunc so that it applies some changes to the CPU of the provided VMISpec
-			instancetypeMethods.ApplyToVmiFunc = func(_ *k8sfield.Path, _ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) instancetype.Conflicts {
+			instancetypeMethods.ApplyToVmiFunc = func(_ *k8sfield.Path, _ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts {
 				vmiSpec.Domain.CPU = &v1.CPU{Cores: 1, Threads: 1, Sockets: 1}
 				return nil
 			}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1607,8 +1607,7 @@ func (c *VMController) applyInstancetypeToVmi(vm *virtv1.VirtualMachine, vmi *vi
 	instancetype.AddInstancetypeNameAnnotations(vm, vmi)
 	instancetype.AddPreferenceNameAnnotations(vm, vmi)
 
-	conflicts := c.instancetypeMethods.ApplyToVmi(k8sfield.NewPath("spec"), instancetypeSpec, preferenceSpec, &vmi.Spec)
-	if len(conflicts) > 0 {
+	if conflicts := c.instancetypeMethods.ApplyToVmi(k8sfield.NewPath("spec"), instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta); len(conflicts) > 0 {
 		return fmt.Errorf("VMI conflicts with instancetype spec in fields: [%s]", conflicts.String())
 	}
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7892,6 +7892,12 @@ var CRDsValidation map[string]string = map[string]string{
     spec:
       description: Required spec describing the instancetype
       properties:
+        annotations:
+          additionalProperties:
+            type: string
+          description: Optionally defines the required Annotations to be used by the
+            instance type and applied to the VirtualMachineInstance
+          type: object
         cpu:
           description: Required CPU related attributes of the instancetype.
           properties:
@@ -8101,6 +8107,12 @@ var CRDsValidation map[string]string = map[string]string{
     spec:
       description: Required spec describing the preferences
       properties:
+        annotations:
+          additionalProperties:
+            type: string
+          description: Optionally defines preferred Annotations to be applied to the
+            VirtualMachineInstance
+          type: object
         clock:
           description: Clock optionally defines preferences associated with the Clock
             attribute of a VirtualMachineInstance DomainSpec
@@ -16780,6 +16792,12 @@ var CRDsValidation map[string]string = map[string]string{
     spec:
       description: Required spec describing the instancetype
       properties:
+        annotations:
+          additionalProperties:
+            type: string
+          description: Optionally defines the required Annotations to be used by the
+            instance type and applied to the VirtualMachineInstance
+          type: object
         cpu:
           description: Required CPU related attributes of the instancetype.
           properties:
@@ -21203,6 +21221,12 @@ var CRDsValidation map[string]string = map[string]string{
     spec:
       description: Required spec describing the preferences
       properties:
+        annotations:
+          additionalProperties:
+            type: string
+          description: Optionally defines preferred Annotations to be applied to the
+            VirtualMachineInstance
+          type: object
         clock:
           description: Clock optionally defines preferences associated with the Clock
             attribute of a VirtualMachineInstance DomainSpec

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha1/conversion_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha1/conversion_generated.go
@@ -667,6 +667,7 @@ func autoConvert_v1beta1_VirtualMachineInstancetypeSpec_To_v1alpha1_VirtualMachi
 	out.HostDevices = *(*[]corev1.HostDevice)(unsafe.Pointer(&in.HostDevices))
 	out.IOThreadsPolicy = (*corev1.IOThreadsPolicy)(unsafe.Pointer(in.IOThreadsPolicy))
 	out.LaunchSecurity = (*corev1.LaunchSecurity)(unsafe.Pointer(in.LaunchSecurity))
+	// WARNING: in.Annotations requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -784,6 +785,7 @@ func autoConvert_v1beta1_VirtualMachinePreferenceSpec_To_v1alpha1_VirtualMachine
 	// WARNING: in.PreferredSubdomain requires manual conversion: does not exist in peer-type
 	// WARNING: in.PreferredTerminationGracePeriodSeconds requires manual conversion: does not exist in peer-type
 	// WARNING: in.Requirements requires manual conversion: does not exist in peer-type
+	// WARNING: in.Annotations requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha2/conversion_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha2/conversion_generated.go
@@ -677,6 +677,7 @@ func autoConvert_v1beta1_VirtualMachineInstancetypeSpec_To_v1alpha2_VirtualMachi
 	out.HostDevices = *(*[]corev1.HostDevice)(unsafe.Pointer(&in.HostDevices))
 	out.IOThreadsPolicy = (*corev1.IOThreadsPolicy)(unsafe.Pointer(in.IOThreadsPolicy))
 	out.LaunchSecurity = (*corev1.LaunchSecurity)(unsafe.Pointer(in.LaunchSecurity))
+	// WARNING: in.Annotations requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -794,6 +795,7 @@ func autoConvert_v1beta1_VirtualMachinePreferenceSpec_To_v1alpha2_VirtualMachine
 	// WARNING: in.PreferredSubdomain requires manual conversion: does not exist in peer-type
 	// WARNING: in.PreferredTerminationGracePeriodSeconds requires manual conversion: does not exist in peer-type
 	// WARNING: in.Requirements requires manual conversion: does not exist in peer-type
+	// WARNING: in.Annotations requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
@@ -603,6 +603,13 @@ func (in *VirtualMachineInstancetypeSpec) DeepCopyInto(out *VirtualMachineInstan
 		*out = new(v1.LaunchSecurity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -728,6 +735,13 @@ func (in *VirtualMachinePreferenceSpec) DeepCopyInto(out *VirtualMachinePreferen
 		in, out := &in.Requirements, &out.Requirements
 		*out = new(PreferenceRequirements)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -116,6 +116,11 @@ type VirtualMachineInstancetypeSpec struct {
 	//
 	// +optional
 	LaunchSecurity *v1.LaunchSecurity `json:"launchSecurity,omitempty"`
+
+	// Optionally defines the required Annotations to be used by the instance type and applied to the VirtualMachineInstance
+	//
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // CPUInstancetype contains the CPU related configuration of a given VirtualMachineInstancetypeSpec.
@@ -274,6 +279,11 @@ type VirtualMachinePreferenceSpec struct {
 	//
 	//+optional
 	Requirements *PreferenceRequirements `json:"requirements,omitempty"`
+
+	// Optionally defines preferred Annotations to be applied to the VirtualMachineInstance
+	//
+	//+optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 type VolumePreferences struct {

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -39,6 +39,7 @@ func (VirtualMachineInstancetypeSpec) SwaggerDoc() map[string]string {
 		"hostDevices":     "Optionally defines any HostDevices associated with the instancetype.\n\n+optional\n+listType=atomic",
 		"ioThreadsPolicy": "Optionally defines the IOThreadsPolicy to be used by the instancetype.\n\n+optional",
 		"launchSecurity":  "Optionally defines the LaunchSecurity to be used by the instancetype.\n\n+optional",
+		"annotations":     "Optionally defines the required Annotations to be used by the instance type and applied to the VirtualMachineInstance\n\n+optional",
 	}
 }
 
@@ -104,6 +105,7 @@ func (VirtualMachinePreferenceSpec) SwaggerDoc() map[string]string {
 		"preferredSubdomain":                     "Subdomain of the VirtualMachineInstance\n\n+optional",
 		"preferredTerminationGracePeriodSeconds": "Grace period observed after signalling a VirtualMachineInstance to stop after which the VirtualMachineInstance is force terminated.\n\n+optional",
 		"requirements":                           "Requirements defines the minium amount of instance type defined resources required by a set of preferences\n\n+optional",
+		"annotations":                            "Optionally defines preferred Annotations to be applied to the VirtualMachineInstance\n\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -28289,6 +28289,22 @@ func schema_kubevirtio_api_instancetype_v1beta1_VirtualMachineInstancetypeSpec(r
 							Ref:         ref("kubevirt.io/api/core/v1.LaunchSecurity"),
 						},
 					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optionally defines the required Annotations to be used by the instance type and applied to the VirtualMachineInstance",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"cpu", "memory"},
 			},
@@ -28462,6 +28478,22 @@ func schema_kubevirtio_api_instancetype_v1beta1_VirtualMachinePreferenceSpec(ref
 						SchemaProps: spec.SchemaProps{
 							Description: "Requirements defines the minium amount of instance type defined resources required by a set of preferences",
 							Ref:         ref("kubevirt.io/api/instancetype/v1beta1.PreferenceRequirements"),
+						},
+					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optionally defines preferred Annotations to be applied to the VirtualMachineInstance",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
 						},
 					},
 				},

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -293,6 +293,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vmi := libvmi.NewCirros()
 
 			instancetype := newVirtualMachineInstancetype(vmi)
+			instancetype.Spec.Annotations = map[string]string{
+				"required-annotation-1": "1",
+				"required-annotation-2": "2",
+			}
 			instancetype, err := virtClient.VirtualMachineInstancetype(testsuite.GetTestNamespace(instancetype)).
 				Create(context.Background(), instancetype, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -320,6 +324,11 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			}
 			preference.Spec.PreferredTerminationGracePeriodSeconds = pointer.Int64(15)
 			preference.Spec.PreferredSubdomain = pointer.String("non-existent-subdomain")
+			preference.Spec.Annotations = map[string]string{
+				"preferred-annotation-1": "1",
+				"preferred-annotation-2": "use-vm-value",
+				"required-annotation-1":  "use-instancetype-value",
+			}
 
 			preference, err = virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(preference)).
 				Create(context.Background(), preference, metav1.CreateOptions{})
@@ -329,6 +338,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			removeResourcesAndPreferencesFromVMI(vmi)
 
 			vm := tests.NewRandomVirtualMachine(vmi, false)
+
+			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{
+				"preferred-annotation-2": "2",
+			}
 
 			// Add the instancetype and preference matchers to the VM spec
 			vm.Spec.Instancetype = &v1.InstancetypeMatcher{
@@ -376,6 +389,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(vmi.Annotations[v1.ClusterInstancetypeAnnotation]).To(Equal(""))
 			Expect(vmi.Annotations[v1.PreferenceAnnotation]).To(Equal(preference.Name))
 			Expect(vmi.Annotations[v1.ClusterPreferenceAnnotation]).To(Equal(""))
+			Expect(vmi.Annotations).To(HaveKeyWithValue("required-annotation-1", "1"))
+			Expect(vmi.Annotations).To(HaveKeyWithValue("required-annotation-2", "2"))
+			Expect(vmi.Annotations).To(HaveKeyWithValue("preferred-annotation-1", "1"))
+			Expect(vmi.Annotations).To(HaveKeyWithValue("preferred-annotation-2", "2"))
 		})
 		It("should apply memory overcommit instancetype to VMI", func() {
 			vmi := libvmi.NewCirros()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds preferred and required annotations to preferences and instance types. It also renames ApplyToVmi function to Apply.

**Release note**:
```
None
```
