### PR TITLE
Clean up long functions in virt-controller migration.go

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -410,7 +410,6 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 	var pod *k8sv1.Pod = nil
 	var attachmentPod *k8sv1.Pod = nil
 	conditionManager := controller.NewVirtualMachineInstanceMigrationConditionManager()
-	vmiConditionManager := controller.NewVirtualMachineInstanceConditionManager()
 	migrationCopy := migration.DeepCopy()
 
 	podExists, attachmentPodExists := len(pods) > 0, false
@@ -499,89 +498,9 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedMigrationReason, "Migration failed because target attachment pod shutdown during migration")
 		log.Log.Object(migration).Errorf("target attachment pod %s/%s shutdown during migration", attachmentPod.Namespace, attachmentPod.Name)
 	} else {
-
-		switch migration.Status.Phase {
-		case virtv1.MigrationPhaseUnset:
-			canMigrate, err := c.canMigrateVMI(migration, vmi)
-			if err != nil {
-				return err
-			}
-
-			if canMigrate {
-				migrationCopy.Status.Phase = virtv1.MigrationPending
-			} else {
-				// can not migrate because there is an active migration already
-				// in progress for this VMI.
-				migrationCopy.Status.Phase = virtv1.MigrationFailed
-				c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedMigrationReason, "VMI is not eligible for migration because another migration job is in progress.")
-				log.Log.Object(migration).Error("Migration object ont eligible for migration because another job is in progress")
-			}
-		case virtv1.MigrationPending:
-			if podExists {
-				if controller.VMIHasHotplugVolumes(vmi) {
-					if attachmentPodExists {
-						migrationCopy.Status.Phase = virtv1.MigrationScheduling
-					}
-				} else {
-					migrationCopy.Status.Phase = virtv1.MigrationScheduling
-				}
-			} else if syncError != nil && strings.Contains(syncError.Error(), "exceeded quota") && !conditionManager.HasCondition(migration, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota) {
-				condition := virtv1.VirtualMachineInstanceMigrationCondition{
-					Type:          virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota,
-					Status:        k8sv1.ConditionTrue,
-					LastProbeTime: v1.Now(),
-				}
-				migrationCopy.Status.Conditions = append(migrationCopy.Status.Conditions, condition)
-			}
-		case virtv1.MigrationScheduling:
-			if conditionManager.HasCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota) {
-				conditionManager.RemoveCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota)
-			}
-			if isPodReady(pod) {
-				if controller.VMIHasHotplugVolumes(vmi) {
-					if attachmentPodExists && isPodReady(attachmentPod) {
-						log.Log.Object(migration).Infof("Attachment pod %s for vmi %s/%s is ready", attachmentPod.Name, vmi.Namespace, vmi.Name)
-						migrationCopy.Status.Phase = virtv1.MigrationScheduled
-					}
-				} else {
-					migrationCopy.Status.Phase = virtv1.MigrationScheduled
-				}
-			}
-		case virtv1.MigrationScheduled:
-			if vmi.Status.MigrationState != nil &&
-				vmi.Status.MigrationState.MigrationUID == migration.UID &&
-				vmi.Status.MigrationState.TargetNode != "" {
-				migrationCopy.Status.Phase = virtv1.MigrationPreparingTarget
-			}
-		case virtv1.MigrationPreparingTarget:
-			if vmi.Status.MigrationState.TargetNode != "" && vmi.Status.MigrationState.TargetNodeAddress != "" {
-				migrationCopy.Status.Phase = virtv1.MigrationTargetReady
-			}
-		case virtv1.MigrationTargetReady:
-			if vmi.Status.MigrationState.StartTimestamp != nil {
-				migrationCopy.Status.Phase = virtv1.MigrationRunning
-			}
-		case virtv1.MigrationRunning:
-			_, exists := pod.Annotations[virtv1.MigrationTargetReadyTimestamp]
-			if !exists && vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
-				key := patch.EscapeJSONPointer(virtv1.MigrationTargetReadyTimestamp)
-				patchOps := fmt.Sprintf(`[{ "op": "add", "path": "/metadata/annotations/%s", "value": "%s" }]`,
-					key,
-					vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String())
-
-				_, err := c.clientset.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name, types.JSONPatchType, []byte(patchOps), v1.PatchOptions{})
-				if err != nil {
-					return err
-				}
-			}
-
-			if vmi.Status.MigrationState.Completed &&
-				!vmiConditionManager.HasCondition(vmi, virtv1.VirtualMachineInstanceVCPUChange) &&
-				!vmiConditionManager.HasCondition(vmi, virtv1.VirtualMachineInstanceMemoryChange) {
-				migrationCopy.Status.Phase = virtv1.MigrationSucceeded
-				c.recorder.Eventf(migration, k8sv1.EventTypeNormal, SuccessfulMigrationReason, "Source node reported migration succeeded")
-				log.Log.Object(migration).Infof("VMI reported migration succeeded.")
-			}
+		err := c.processMigrationPhase(migration, migrationCopy, pod, attachmentPod, vmi, syncError)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -600,6 +519,100 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 		}
 	}
 
+	return nil
+}
+
+func (c *MigrationController) processMigrationPhase(
+	migration, migrationCopy *virtv1.VirtualMachineInstanceMigration,
+	pod, attachmentPod *k8sv1.Pod,
+	vmi *virtv1.VirtualMachineInstance,
+	syncError error,
+) error {
+	conditionManager := controller.NewVirtualMachineInstanceMigrationConditionManager()
+	vmiConditionManager := controller.NewVirtualMachineInstanceConditionManager()
+	switch migration.Status.Phase {
+	case virtv1.MigrationPhaseUnset:
+		canMigrate, err := c.canMigrateVMI(migration, vmi)
+		if err != nil {
+			return err
+		}
+
+		if canMigrate {
+			migrationCopy.Status.Phase = virtv1.MigrationPending
+		} else {
+			// can not migrate because there is an active migration already
+			// in progress for this VMI.
+			migrationCopy.Status.Phase = virtv1.MigrationFailed
+			c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedMigrationReason, "VMI is not eligible for migration because another migration job is in progress.")
+			log.Log.Object(migration).Error("Migration object ont eligible for migration because another job is in progress")
+		}
+	case virtv1.MigrationPending:
+		if pod != nil {
+			if controller.VMIHasHotplugVolumes(vmi) {
+				if attachmentPod != nil {
+					migrationCopy.Status.Phase = virtv1.MigrationScheduling
+				}
+			} else {
+				migrationCopy.Status.Phase = virtv1.MigrationScheduling
+			}
+		} else if syncError != nil && strings.Contains(syncError.Error(), "exceeded quota") && !conditionManager.HasCondition(migration, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota) {
+			condition := virtv1.VirtualMachineInstanceMigrationCondition{
+				Type:          virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota,
+				Status:        k8sv1.ConditionTrue,
+				LastProbeTime: v1.Now(),
+			}
+			migrationCopy.Status.Conditions = append(migrationCopy.Status.Conditions, condition)
+		}
+	case virtv1.MigrationScheduling:
+		if conditionManager.HasCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota) {
+			conditionManager.RemoveCondition(migrationCopy, virtv1.VirtualMachineInstanceMigrationRejectedByResourceQuota)
+		}
+		if isPodReady(pod) {
+			if controller.VMIHasHotplugVolumes(vmi) {
+				if attachmentPod != nil && isPodReady(attachmentPod) {
+					log.Log.Object(migration).Infof("Attachment pod %s for vmi %s/%s is ready", attachmentPod.Name, vmi.Namespace, vmi.Name)
+					migrationCopy.Status.Phase = virtv1.MigrationScheduled
+				}
+			} else {
+				migrationCopy.Status.Phase = virtv1.MigrationScheduled
+			}
+		}
+	case virtv1.MigrationScheduled:
+		if vmi.Status.MigrationState != nil &&
+			vmi.Status.MigrationState.MigrationUID == migration.UID &&
+			vmi.Status.MigrationState.TargetNode != "" {
+			migrationCopy.Status.Phase = virtv1.MigrationPreparingTarget
+		}
+	case virtv1.MigrationPreparingTarget:
+		if vmi.Status.MigrationState.TargetNode != "" && vmi.Status.MigrationState.TargetNodeAddress != "" {
+			migrationCopy.Status.Phase = virtv1.MigrationTargetReady
+		}
+	case virtv1.MigrationTargetReady:
+		if vmi.Status.MigrationState.StartTimestamp != nil {
+			migrationCopy.Status.Phase = virtv1.MigrationRunning
+		}
+	case virtv1.MigrationRunning:
+		_, exists := pod.Annotations[virtv1.MigrationTargetReadyTimestamp]
+		if !exists && vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
+			key := patch.EscapeJSONPointer(virtv1.MigrationTargetReadyTimestamp)
+			patchOps := fmt.Sprintf(`[{ "op": "add", "path": "/metadata/annotations/%s", "value": "%s" }]`,
+				key,
+				vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String())
+
+			_, err := c.clientset.CoreV1().Pods(pod.Namespace).Patch(context.Background(), pod.Name, types.JSONPatchType, []byte(patchOps), v1.PatchOptions{})
+			if err != nil {
+				return err
+			}
+		}
+
+		if vmi.Status.MigrationState.Completed &&
+			!vmiConditionManager.HasCondition(vmi, virtv1.VirtualMachineInstanceVCPUChange) &&
+			!vmiConditionManager.HasCondition(vmi, virtv1.VirtualMachineInstanceMemoryChange) {
+			migrationCopy.Status.Phase = virtv1.MigrationSucceeded
+			c.recorder.Eventf(migration, k8sv1.EventTypeNormal, SuccessfulMigrationReason, "Source node reported migration succeeded")
+			log.Log.Object(migration).Infof("VMI reported migration succeeded.")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: This PR cleans up two very long functions, `sync` and `updateStatus` in virt-controller `migration.go`, extracting code snippets in placing them into separate functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: The [Boy Scout Rule](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) was considered and applied if needed
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to the [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
