### PR TITLE
[virt-controller] don't count pending migrations when validating the allowed migrations limit

### DIFF
--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -23,6 +23,16 @@ func ListUnfinishedMigrations(informer cache.SharedIndexInformer) []*v1.VirtualM
 	return migrations
 }
 
+func FilterRunningMigrations(migrations []*v1.VirtualMachineInstanceMigration) []*v1.VirtualMachineInstanceMigration {
+	runningMigrations := []*v1.VirtualMachineInstanceMigration{}
+	for _, migration := range migrations {
+		if migration.IsRunning() {
+			runningMigrations = append(runningMigrations, migration)
+		}
+	}
+	return runningMigrations
+}
+
 // IsMigrating returns true if a given VMI is still migrating and false otherwise.
 func IsMigrating(vmi *v1.VirtualMachineInstance) bool {
 

--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -23,16 +23,6 @@ func ListUnfinishedMigrations(informer cache.SharedIndexInformer) []*v1.VirtualM
 	return migrations
 }
 
-func FilterRunningMigrations(migrations []v1.VirtualMachineInstanceMigration) []v1.VirtualMachineInstanceMigration {
-	runningMigrations := []v1.VirtualMachineInstanceMigration{}
-	for _, migration := range migrations {
-		if migration.IsRunning() {
-			runningMigrations = append(runningMigrations, migration)
-		}
-	}
-	return runningMigrations
-}
-
 // IsMigrating returns true if a given VMI is still migrating and false otherwise.
 func IsMigrating(vmi *v1.VirtualMachineInstance) bool {
 

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -391,11 +391,12 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 		return nil
 	}
 
-	activeMigrationsFromThisSourceNode := c.numOfVMIMForThisSourceNode(vmisOnNode, activeMigrations)
+	runningMigrations := migrationutils.FilterRunningMigrations(activeMigrations)
+	activeMigrationsFromThisSourceNode := c.numOfVMIMForThisSourceNode(vmisOnNode, runningMigrations)
 	maxParallelMigrationsPerOutboundNode :=
 		int(*c.clusterConfig.GetMigrationConfiguration().ParallelOutboundMigrationsPerNode)
 	maxParallelMigrations := int(*c.clusterConfig.GetMigrationConfiguration().ParallelMigrationsPerCluster)
-	freeSpotsPerCluster := maxParallelMigrations - len(activeMigrations)
+	freeSpotsPerCluster := maxParallelMigrations - len(runningMigrations)
 	freeSpotsPerThisSourceNode := maxParallelMigrationsPerOutboundNode - activeMigrationsFromThisSourceNode
 	freeSpots := int(math.Min(float64(freeSpotsPerCluster), float64(freeSpotsPerThisSourceNode)))
 	if freeSpots <= 0 {

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -349,7 +349,8 @@ func (c *WorkloadUpdateController) getUpdateData(kv *virtv1.KubeVirt) *updateDat
 		}
 	}
 
-	data.numActiveMigrations = len(migrations)
+	runningMigrations := migrationutils.FilterRunningMigrations(migrations)
+	data.numActiveMigrations = len(runningMigrations)
 
 	objs := c.vmiInformer.GetStore().List()
 	for _, obj := range objs {

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -255,9 +255,15 @@ var _ = Describe("Workload Updater", func() {
 
 		It("should detect in-flight migrations when only migrate VMIs up to the global max migration count", func() {
 			const desiredNumberOfVMs = 50
+			const vmsPendingMigration = int(virtconfig.ParallelMigrationsPerClusterDefault)
 			kv := newKubeVirt(desiredNumberOfVMs)
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
+
+			By("populating with pending migrations that should be ignored while counting the threshold")
+			for i := 0; i < vmsPendingMigration; i++ {
+				migrationFeeder.Add(newMigration(fmt.Sprintf("vmim-pending-%d", i), fmt.Sprintf("testvm-migratable-pending-%d", i), v1.MigrationPending))
+			}
 
 			reasons := []string{}
 			for i := 0; i < desiredNumberOfVMs; i++ {

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -282,7 +282,6 @@ var _ = Describe("Workload Updater", func() {
 
 			waitForNumberOfInstancesOnVMIInformerCache(controller, desiredNumberOfVMs)
 
-			//migrationInterface.EXPECT().Create(gomock.Any()).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).AnyTimes()
 			migrationInterface.EXPECT().Create(gomock.Any(), &metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(1)
 
 			controller.Execute()

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -175,7 +175,6 @@ go_test(
         "//pkg/util:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/util/hardware:go_default_library",
-        "//pkg/util/migrations:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-api:go_default_library",
         "//pkg/virt-config:go_default_library",


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>

**What this PR does / why we need it**:
Kuebvirt has cluster-level threshold for concurrent active migrations, with per-source-node granularity.
When a controller checks whether it allowed to create more migrations, it should not count pending migrations
but only these migrations that are already scheduled and running. 

Controllers to fix: evacuation, workload-updater 

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2210070

**Release note**:
```release-note
NONE
```
