### PR TITLE
virt-controller: fix double `time.Second` multiplication in rate limiter

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -280,7 +280,7 @@ func init() {
 
 func Execute() {
 	var err error
-	var app VirtControllerApp = VirtControllerApp{}
+	var app = VirtControllerApp{}
 
 	app.LeaderElection = leaderelectionconfig.DefaultLeaderElectionConfiguration()
 
@@ -461,11 +461,11 @@ func (vca *VirtControllerApp) configModificationCallback() {
 }
 
 // Update virt-controller rate limiter
-func (app *VirtControllerApp) shouldChangeRateLimiter() {
-	config := app.clusterConfig.GetConfig()
+func (vca *VirtControllerApp) shouldChangeRateLimiter() {
+	config := vca.clusterConfig.GetConfig()
 	qps := config.ControllerConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.QPS
 	burst := config.ControllerConfiguration.RestClient.RateLimiter.TokenBucketRateLimiter.Burst
-	app.reloadableRateLimiter.Set(flowcontrol.NewTokenBucketRateLimiter(qps, burst))
+	vca.reloadableRateLimiter.Set(flowcontrol.NewTokenBucketRateLimiter(qps, burst))
 	log.Log.V(2).Infof("setting rate limiter to %v QPS and %v Burst", qps, burst)
 }
 

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -8,8 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/time/rate"
+
+	"github.com/prometheus/client_golang/prometheus"
 	k8sv1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,9 +39,9 @@ const (
 	FailedCreateVirtualMachineInstanceMigrationReason = "FailedCreate"
 	// SuccessfulCreateVirtualMachineInstanceMigrationReason is added in an event if creating a VirtualMachineInstanceMigration succeeded.
 	SuccessfulCreateVirtualMachineInstanceMigrationReason = "SuccessfulCreate"
-	// FailedEvictVirtualMachineReason is added in an event if a deletion of a VMI fails
+	// FailedEvictVirtualMachineInstanceReason is added in an event if a deletion of a VMI fails
 	FailedEvictVirtualMachineInstanceReason = "FailedEvict"
-	// SuccessfulEvictVirtualMachineReason is added in an event if a deletion of a VMI Succeeds
+	// SuccessfulEvictVirtualMachineInstanceReason is added in an event if a deletion of a VMI Succeeds
 	SuccessfulEvictVirtualMachineInstanceReason = "SuccessfulEvict"
 )
 
@@ -502,12 +503,12 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 	}
 
 	migrateCount := int(math.Min(float64(maxNewMigrations), float64(len(data.migratableOutdatedVMIs))))
-	migrationCandidates := []*virtv1.VirtualMachineInstance{}
+	var migrationCandidates []*virtv1.VirtualMachineInstance
 	if migrateCount > 0 {
 		migrationCandidates = data.migratableOutdatedVMIs[0:migrateCount]
 	}
 
-	evictionCandidates := []*virtv1.VirtualMachineInstance{}
+	var evictionCandidates []*virtv1.VirtualMachineInstance
 	if batchDeletionCount > 0 {
 		evictionCandidates = data.evictOutdatedVMIs[0:batchDeletionCount]
 	}

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -57,7 +57,7 @@ var (
 const periodicReEnqueueIntervalSeconds = 30
 
 // ensures we don't execute more than once every 5 seconds
-const defaultThrottleIntervalSeconds = 5 * time.Second
+const defaultThrottleInterval = 5 * time.Second
 
 const defaultBatchDeletionIntervalSeconds = 60
 const defaultBatchDeletionCount = 10
@@ -102,8 +102,8 @@ func NewWorkloadUpdateController(
 ) (*WorkloadUpdateController, error) {
 
 	rl := workqueue.NewMaxOfRateLimiter(
-		workqueue.NewItemExponentialFailureRateLimiter(time.Duration(defaultThrottleIntervalSeconds)*time.Second, 300*time.Second),
-		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Every(time.Duration(defaultThrottleIntervalSeconds)*time.Second), 1)},
+		workqueue.NewItemExponentialFailureRateLimiter(defaultThrottleInterval, 300*time.Second),
+		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Every(defaultThrottleInterval), 1)},
 	)
 
 	c := &WorkloadUpdateController{
@@ -181,7 +181,7 @@ func (c *WorkloadUpdateController) addMigration(obj interface{}) {
 		}
 	}
 
-	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
+	c.queue.AddAfter(key, defaultThrottleInterval)
 }
 
 func (c *WorkloadUpdateController) deleteMigration(_ interface{}) {
@@ -190,7 +190,7 @@ func (c *WorkloadUpdateController) deleteMigration(_ interface{}) {
 		return
 	}
 
-	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
+	c.queue.AddAfter(key, defaultThrottleInterval)
 }
 
 func (c *WorkloadUpdateController) updateMigration(_, _ interface{}) {
@@ -199,7 +199,7 @@ func (c *WorkloadUpdateController) updateMigration(_, _ interface{}) {
 		return
 	}
 
-	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
+	c.queue.AddAfter(key, defaultThrottleInterval)
 }
 
 func (c *WorkloadUpdateController) updateVmi(_, obj interface{}) {
@@ -222,7 +222,7 @@ func (c *WorkloadUpdateController) updateVmi(_, obj interface{}) {
 		return
 	}
 
-	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
+	c.queue.AddAfter(key, defaultThrottleInterval)
 }
 
 func (c *WorkloadUpdateController) addKubeVirt(obj interface{}) {
@@ -248,7 +248,7 @@ func (c *WorkloadUpdateController) enqueueKubeVirt(obj interface{}) {
 		logger.Object(kv).Reason(err).Error("Failed to extract key from KubeVirt.")
 		return
 	}
-	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
+	c.queue.AddAfter(key, defaultThrottleInterval)
 }
 
 // Run runs the passed in NodeController.


### PR DESCRIPTION
**What this PR does / why we need it**:
While working on metrics, I found this double multiplication which transforms a 5 second value into a ~158 year one, which seems wrong.
This PR fixes that in its first commit, and provides some nit-picky code cleanup in its second commit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The `defaultThrottleInterval` const is still used for 3 completely unrelated things, none of which seem to match its comment.
This code probably needs further cleanup.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: The [Boy Scout Rule](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) was considered and applied if needed
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to the [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
