### PR TITLE
Delegate Slirp network configuration to hook sidecar using Slirp network binding plugin

### DIFF
--- a/pkg/network/domainspec/domainspec_suite_test.go
+++ b/pkg/network/domainspec/domainspec_suite_test.go
@@ -20,41 +20,11 @@ func newVMI(namespace, name string) *v1.VirtualMachineInstance {
 	return vmi
 }
 
-func newVMISlirpInterface(namespace string, name string) *v1.VirtualMachineInstance {
-	vmi := newVMI(namespace, name)
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultSlirpNetworkInterface()}
-	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-	return vmi
-}
-
 func newVMIMacvtapInterface(namespace string, vmiName string, ifaceName string) *v1.VirtualMachineInstance {
 	vmi := newVMI(namespace, vmiName)
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMacvtapNetworkInterface(ifaceName)}
 	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 	return vmi
-}
-
-func NewDomainWithSlirpInterface() *api.Domain {
-	domain := &api.Domain{}
-	domain.Spec.Devices.Interfaces = []api.Interface{{
-		Model: &api.Model{
-			Type: "e1000",
-		},
-		Type:  "user",
-		Alias: api.NewUserDefinedAlias("default"),
-	},
-	}
-
-	// Create network interface
-	if domain.Spec.QEMUCmd == nil {
-		domain.Spec.QEMUCmd = &api.Commandline{}
-	}
-
-	if domain.Spec.QEMUCmd.QEMUArg == nil {
-		domain.Spec.QEMUCmd.QEMUArg = make([]api.Arg, 0)
-	}
-
-	return domain
 }
 
 func NewDomainWithMacvtapInterface(macvtapName string) *api.Domain {

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -107,8 +107,8 @@ func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain, networks []v1.N
 			return nil, fmt.Errorf("no iface matching with network %s", networks[i].Name)
 		}
 
-		// Binding plugin and SR-IOV devices are not part of the phases
-		if iface.Binding != nil || iface.SRIOV != nil {
+		// Binding plugin, SR-IOV and Slirp devices are not part of the phases
+		if iface.Binding != nil || iface.SRIOV != nil || iface.Slirp != nil {
 			continue
 		}
 

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -268,9 +268,6 @@ func (l *podNIC) newLibvirtSpecGenerator(domain *api.Domain) domainspec.LibvirtS
 	if l.vmiSpecIface.Masquerade != nil {
 		return domainspec.NewMasqueradeLibvirtSpecGenerator(l.vmiSpecIface, l.vmiSpecNetwork, domain, l.podInterfaceName, l.handler)
 	}
-	if l.vmiSpecIface.Slirp != nil {
-		return domainspec.NewSlirpLibvirtSpecGenerator(l.vmiSpecIface, domain)
-	}
 	if l.vmiSpecIface.Macvtap != nil {
 		return domainspec.NewMacvtapLibvirtSpecGenerator(l.vmiSpecIface, domain, l.podInterfaceName, l.handler)
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -365,6 +365,21 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 	requestedHookSidecarList = append(requestedHookSidecarList, bindingSidecars...)
 
+	// Read requested hookSidecars from VMI spec
+	slirpIfaces := vmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(i v1.Interface) bool {
+		return i.Slirp != nil
+	})
+	if len(slirpIfaces) > 0 {
+		if plugin := ReadNetBindingPluginConfiguration(t.clusterConfig.GetConfig(), SlirpNetworkBindingPluginName); plugin == nil {
+			return nil, fmt.Errorf("couldn't find %s network binding plugin configuration, make sure its specified in Kubevirt config", SlirpNetworkBindingPluginName)
+		} else {
+			requestedHookSidecarList = append(requestedHookSidecarList, hooks.HookSidecar{
+				Image:           plugin.SidecarImage,
+				ImagePullPolicy: t.clusterConfig.GetImagePullPolicy(),
+			})
+		}
+	}
+
 	var command []string
 	if tempPod {
 		logger := log.DefaultLogger()

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1324,85 +1324,6 @@ var _ = Describe("Converter", func() {
 			}
 		})
 
-		It("should add tcp if protocol not exist", func() {
-			iface := v1.Interface{Name: "test", InterfaceBindingMethod: v1.InterfaceBindingMethod{}, Ports: []v1.Port{{Port: 80}}}
-			iface.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
-			qemuArg := api.Arg{Value: fmt.Sprintf("user,id=%s", iface.Name)}
-
-			Expect(configPortForward(&qemuArg, iface)).To(Succeed())
-			Expect(qemuArg.Value).To(Equal(fmt.Sprintf("user,id=%s,hostfwd=tcp::80-:80", iface.Name)))
-		})
-		It("should not fail for duplicate port with different protocol configuration", func() {
-			iface := v1.Interface{Name: "test", InterfaceBindingMethod: v1.InterfaceBindingMethod{}, Ports: []v1.Port{{Port: 80}, {Port: 80, Protocol: "UDP"}}}
-			iface.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
-			qemuArg := api.Arg{Value: fmt.Sprintf("user,id=%s", iface.Name)}
-
-			Expect(configPortForward(&qemuArg, iface)).To(Succeed())
-			Expect(qemuArg.Value).To(Equal(fmt.Sprintf("user,id=%s,hostfwd=tcp::80-:80,hostfwd=udp::80-:80", iface.Name)))
-		})
-		It("Should create network configuration for slirp device", func() {
-			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			name := "otherName"
-			iface := v1.Interface{Name: name, InterfaceBindingMethod: v1.InterfaceBindingMethod{}, Ports: []v1.Port{{Port: 80}, {Port: 80, Protocol: "UDP"}}}
-			iface.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
-			net := v1.DefaultPodNetwork()
-			net.Name = name
-			vmi.Spec.Networks = []v1.Network{*net}
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface}
-
-			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(BeNil())
-			Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(2))
-		})
-		It("Should create two network configuration for slirp device", func() {
-			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			name1 := "Name"
-
-			iface1 := v1.Interface{Name: name1, InterfaceBindingMethod: v1.InterfaceBindingMethod{}, Ports: []v1.Port{{Port: 80}, {Port: 80, Protocol: "UDP"}}}
-			iface1.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
-			net1 := v1.DefaultPodNetwork()
-			net1.Name = name1
-
-			name2 := "otherName"
-			iface2 := v1.Interface{Name: name2, InterfaceBindingMethod: v1.InterfaceBindingMethod{}, Ports: []v1.Port{{Port: 90}}}
-			iface2.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
-			net2 := v1.DefaultPodNetwork()
-			net2.Name = name2
-
-			vmi.Spec.Networks = []v1.Network{*net1, *net2}
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface1, iface2}
-
-			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(BeNil())
-			Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(4))
-		})
-		It("Should create two network configuration one for slirp device and one for bridge device", func() {
-			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			name1 := "Name"
-
-			iface1 := v1.DefaultBridgeNetworkInterface()
-			iface1.Name = name1
-			net1 := v1.DefaultPodNetwork()
-			net1.Name = name1
-
-			name2 := "otherName"
-			iface2 := v1.Interface{Name: name2, InterfaceBindingMethod: v1.InterfaceBindingMethod{}, Ports: []v1.Port{{Port: 90}}}
-			iface2.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
-			net2 := v1.DefaultPodNetwork()
-			net2.Name = name2
-
-			vmi.Spec.Networks = []v1.Network{*net1, *net2}
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*iface1, iface2}
-
-			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(BeNil())
-			Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(2))
-			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(2))
-			Expect(domain.Spec.Devices.Interfaces[0].Type).To(Equal("ethernet"))
-			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("virtio-non-transitional"))
-			Expect(domain.Spec.Devices.Interfaces[1].Type).To(Equal("user"))
-			Expect(domain.Spec.Devices.Interfaces[1].Model.Type).To(Equal("e1000"))
-		})
 		It("Should set domain interface source correctly for multus", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
@@ -1498,7 +1419,6 @@ var _ = Describe("Converter", func() {
 			name1 := "Name"
 
 			iface1 := v1.Interface{Name: name1, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}
-			iface1.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
 			net1 := v1.DefaultPodNetwork()
 			net1.Name = name1
 
@@ -1515,7 +1435,6 @@ var _ = Describe("Converter", func() {
 			name1 := "Name"
 
 			iface1 := v1.Interface{Name: name1, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}
-			iface1.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
 			net1 := v1.DefaultPodNetwork()
 			net1.Name = name1
 
@@ -2515,11 +2434,13 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			vmi.Spec.Domain.Devices.AutoattachMemBalloon = pointer.BoolPtr(true)
+			nonVirtioIface := v1.Interface{Name: "red", Model: "e1000"}
+			secondaryNetwork := v1.Network{Name: "red"}
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				*v1.DefaultBridgeNetworkInterface(), *v1.DefaultSlirpNetworkInterface(),
+				*v1.DefaultBridgeNetworkInterface(), nonVirtioIface,
 			}
 			vmi.Spec.Networks = []v1.Network{
-				*v1.DefaultPodNetwork(), *v1.DefaultPodNetwork(),
+				*v1.DefaultPodNetwork(), secondaryNetwork,
 			}
 			vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{
 				SEV: &v1.SEV{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR changes Kubevirt network setup logic to delegate Slirp networking configuration to sidecar 
using Slirp network binding plugin (introduced by #10272).

From the user perspective there is no change, configuring VM with Slirp remains.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
In case no Slirp network binding plugin is registered (i.e.: spesified in Kubevirt config), the following default image will be used: 
`quay.io/kubevirt/network-slirp-binding:20230830_638c60fc8`

This is to reduce friction for users upgrading to the comming release (v1.1.0) in case no image is registered.
In the next release (v1.2.0) no default image will be set and registring an image would be mandatory.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: The [Boy Scout Rule](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) was considered and applied if needed
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to the [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubevirt now delegates Slirp networking configuration to Slirp network binding plugin.  In case you haven't registered Slirp network binding plugin image yet (i.e.: specify in Kubevirt config) the following default image would be used: `quay.io/kubevirt/network-slirp-binding:20230830_638c60fc8`. On next release (v1.2.0) no default image will be set and registering an image would be mandatory.
```
