### PR TITLE
Allow image-upload to recover from PendingPopulation phase

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -67,6 +67,8 @@ const (
 	forceImmediateBindingAnnotation = "cdi.kubevirt.io/storage.bind.immediate.requested"
 	contentTypeAnnotation           = "cdi.kubevirt.io/storage.contentType"
 	deleteAfterCompletionAnnotation = "cdi.kubevirt.io/storage.deleteAfterCompletion"
+	UsePopulatorAnnotation          = "cdi.kubevirt.io/storage.usePopulator"
+	PVCPrimeNameAnnotation          = "cdi.kubevirt.io/storage.populator.pvcPrime"
 
 	uploadReadyWaitInterval = 2 * time.Second
 
@@ -762,7 +764,7 @@ func getAndValidateUploadPVC(client kubecli.KubevirtClient, namespace, name stri
 	}
 
 	if !createPVC {
-		_, err = client.CdiClient().CdiV1beta1().DataVolumes(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		dv, err := client.CdiClient().CdiV1beta1().DataVolumes(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			// When the PVC exists but the DV doesn't, there are two possible outcomes:
 			if k8serrors.IsNotFound(err) {
@@ -775,6 +777,17 @@ func getAndValidateUploadPVC(client kubecli.KubevirtClient, namespace, name stri
 				return nil, fmt.Errorf("No DataVolume is associated with the existing PVC %s/%s", namespace, name)
 			}
 			return nil, err
+		}
+		// When using populators, the upload happens on the PVC Prime. We need to check it instead.
+		if dv.Annotations[UsePopulatorAnnotation] == "true" {
+			pvcPrimeName, ok := pvc.Annotations[PVCPrimeNameAnnotation]
+			if !ok {
+				return nil, fmt.Errorf("Unable to get PVC Prime name from PVC %s/%s", namespace, name)
+			}
+			pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Get(context.Background(), pvcPrimeName, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("Unable to get PVC Prime %s/%s", namespace, name)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR aims to fix virtctl image-upload so we allow DVs to recover from `PendingPopulation` phase, as we do with `WaitForFirstConsumer`.

This means that, if an image-upload command fails due to a DV being in `PendingPopulation` phase, we can call the command again after creating a consumer and the upload will continue as expected.

**Which issue(s) this PR fixes**:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2236060

**Special notes for your reviewer**:

We have two ways of fixing this, either in CDI by adding the missing annotations into the target PVC, or in virtctl by getting the PVC Prime and checking its annotations. We generally attempt to ignore populator logic outside CDI, but I think that adding the annotations into the target PVC is a worse idea since it can mess with the upload controller.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Allow image-upload to recover from PendingPopulation phase
```
