### PR TITLE
virt-controller set TerminationGracePeriod of VMI to DeletionGracePeriod of VM when deleting VM with kubectl

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1419,6 +1419,16 @@ func (c *VMController) stopVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMac
 	}
 
 	// stop it
+	// if for some reason the VM has been requested to be deleted, we want to use the
+	// deletion grace period specified to the VM as the TerminationGracePeriodSeconds
+	// for the VMI.
+	if vm.DeletionTimestamp != nil {
+		err = c.patchVMITerminationGracePeriod(vm.GetDeletionGracePeriodSeconds(), vmi)
+		if err != nil {
+			log.Log.Object(vmi).Errorf("unable to patch vmi termination grace period: %v", err)
+			return err
+		}
+	}
 	c.expectations.ExpectDeletions(vmKey, []string{controller.VirtualMachineInstanceKey(vmi)})
 	err = c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Delete(context.Background(), vmi.ObjectMeta.Name, &v1.DeleteOptions{})
 
@@ -3026,4 +3036,11 @@ func (c *VMController) setupLiveFeatures(
 
 	c.setupCPUHotplug(vm, vmi, VMIDefaults, maxRatio)
 	c.setupMemoryHotplug(vm, vmi, maxRatio)
+}
+
+func (c *VMController) patchVMITerminationGracePeriod(gracePeriod *int64, vmi *virtv1.VirtualMachineInstance) error {
+
+	patch := fmt.Sprintf(`{"spec":{"terminationGracePeriodSeconds": %d }}`, *gracePeriod)
+	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.MergePatchType, []byte(patch), &v1.PatchOptions{})
+	return err
 }

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3039,7 +3039,9 @@ func (c *VMController) setupLiveFeatures(
 }
 
 func (c *VMController) patchVMITerminationGracePeriod(gracePeriod *int64, vmi *virtv1.VirtualMachineInstance) error {
-
+	if gracePeriod == nil {
+		return nil
+	}
 	patch := fmt.Sprintf(`{"spec":{"terminationGracePeriodSeconds": %d }}`, *gracePeriod)
 	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.MergePatchType, []byte(patch), &v1.PatchOptions{})
 	return err

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -183,8 +183,8 @@ var _ = Describe("VirtualMachine", func() {
 			virtClient.EXPECT().AuthorizationV1().Return(k8sClient.AuthorizationV1()).AnyTimes()
 		})
 
-		shouldExpectGracePeriodPatched := func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) {
-			patch := fmt.Sprintf(`{"spec":{"terminationGracePeriodSeconds": %d }}`, *vm.DeletionGracePeriodSeconds)
+		shouldExpectGracePeriodPatched := func(expectedGracePeriod int64, vmi *virtv1.VirtualMachineInstance) {
+			patch := fmt.Sprintf(`{"spec":{"terminationGracePeriodSeconds": %d }}`, expectedGracePeriod)
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.MergePatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 		}
 
@@ -2040,8 +2040,7 @@ var _ = Describe("VirtualMachine", func() {
 		It("should delete VirtualMachineInstance when VirtualMachine marked for deletion", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 			vm.DeletionTimestamp = now()
-			vmGracePeriod := v1.DefaultGracePeriodSeconds
-			vm.DeletionGracePeriodSeconds = &vmGracePeriod
+			vm.DeletionGracePeriodSeconds = kvpointer.P(v1.DefaultGracePeriodSeconds)
 
 			addVirtualMachine(vm)
 			vmiFeeder.Add(vmi)
@@ -2049,7 +2048,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
-			shouldExpectGracePeriodPatched(vm, vmi)
+			shouldExpectGracePeriodPatched(v1.DefaultGracePeriodSeconds, vmi)
 
 			controller.Execute()
 
@@ -3300,8 +3299,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, vmi := DefaultVirtualMachine(true)
 
 					vm.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-					vmGracePeriod := v1.DefaultGracePeriodSeconds
-					vm.DeletionGracePeriodSeconds = &vmGracePeriod
+					vm.DeletionGracePeriodSeconds = kvpointer.P(v1.DefaultGracePeriodSeconds)
 					vmi.Status.Phase = phase
 
 					if condType != "" {
@@ -3313,7 +3311,7 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 					vmiFeeder.Add(vmi)
 
-					shouldExpectGracePeriodPatched(vm, vmi)
+					shouldExpectGracePeriodPatched(v1.DefaultGracePeriodSeconds, vmi)
 					vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).AnyTimes()
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
 						objVM := obj.(*virtv1.VirtualMachine)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -183,6 +183,11 @@ var _ = Describe("VirtualMachine", func() {
 			virtClient.EXPECT().AuthorizationV1().Return(k8sClient.AuthorizationV1()).AnyTimes()
 		})
 
+		shouldExpectGracePeriodPatched := func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) {
+			patch := fmt.Sprintf(`{"spec":{"terminationGracePeriodSeconds": %d }}`, *vm.DeletionGracePeriodSeconds)
+			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.MergePatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
+		}
+
 		shouldExpectVMIFinalizerRemoval := func(vmi *virtv1.VirtualMachineInstance) {
 			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": ["%s"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`, virtv1.VirtualMachineControllerFinalizer)
 
@@ -2035,6 +2040,8 @@ var _ = Describe("VirtualMachine", func() {
 		It("should delete VirtualMachineInstance when VirtualMachine marked for deletion", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 			vm.DeletionTimestamp = now()
+			vmGracePeriod := v1.DefaultGracePeriodSeconds
+			vm.DeletionGracePeriodSeconds = &vmGracePeriod
 
 			addVirtualMachine(vm)
 			vmiFeeder.Add(vmi)
@@ -2042,6 +2049,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
+			shouldExpectGracePeriodPatched(vm, vmi)
 
 			controller.Execute()
 
@@ -3292,6 +3300,8 @@ var _ = Describe("VirtualMachine", func() {
 					vm, vmi := DefaultVirtualMachine(true)
 
 					vm.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+					vmGracePeriod := v1.DefaultGracePeriodSeconds
+					vm.DeletionGracePeriodSeconds = &vmGracePeriod
 					vmi.Status.Phase = phase
 
 					if condType != "" {
@@ -3303,6 +3313,7 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 					vmiFeeder.Add(vmi)
 
+					shouldExpectGracePeriodPatched(vm, vmi)
 					vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).AnyTimes()
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
 						objVM := obj.(*virtv1.VirtualMachine)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1496,6 +1496,49 @@ status:
 			waitForResourceDeletion(k8sClient, "pods", expectedPodName)
 		})
 
+		Context("Deleting a running VM with high TerminationGracePeriod via command line", func() {
+			DescribeTable("should force delete the VM", func(deleteFlags []string) {
+				By("getting a VM with a high TerminationGracePeriod")
+				vmi := libvmi.New(
+					libvmi.WithResourceMemory("128Mi"),
+					libvmi.WithTerminationGracePeriod(1600),
+				)
+				vm := tests.NewRandomVirtualMachine(vmi, true)
+				vm.Namespace = testsuite.GetTestNamespace(vm)
+
+				vmJson, err := tests.GenerateVMJson(vm, workDir)
+				Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
+
+				By("Creating VM using k8s client binary")
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for VMI to start")
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 240*time.Second, 1*time.Second).Should(BeRunning())
+
+				By("Checking that VM is running")
+				stdout, _, err := clientcmd.RunCommand(k8sClient, "describe", "vmis", vm.GetName())
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(vmRunningRe.FindString(stdout)).ToNot(Equal(""), "VMI is not Running")
+
+				By("Sending a force delete VM request using k8s client binary")
+				deleteCmd := append([]string{"delete", "vm", vm.GetName()}, deleteFlags...)
+				_, _, err = clientcmd.RunCommand(k8sClient, deleteCmd...)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying the VM gets deleted")
+				waitForResourceDeletion(k8sClient, "vms", vm.GetName())
+
+				By("Verifying pod gets deleted")
+				expectedPodName := getExpectedPodName(vm)
+				waitForResourceDeletion(k8sClient, "pods", expectedPodName)
+			},
+				Entry("when --force and --grace-period=0 are provided", []string{"--force", "--grace-period=0"}),
+				Entry("when --now is provided", []string{"--now"}),
+			)
+		})
+
 		Context("should not change anything if dry-run option is passed", func() {
 			It("[test_id:7530]in start command", func() {
 				vm, vmJson := createVMAndGenerateJson(false)


### PR DESCRIPTION
This PR deals with issues faced when a user tries to force delete a running VM directly (in this case, if the VMI is stuck in `Terminating` and block the VMI and VM both from being deleted) using `kubectl delete vm [vmName] --force --grace-period=0`, the VM continues to be stuck and the VMI and VM don't get deleted until the VMI's `Spec.TerminationGracePeriodSeconds` expires. This becomes an issues for VMs that have high termination grace periods (for example, Windows VM templates in [kubevirt/common-templates](https://github.com/kubevirt/common-templates/blob/master/templates/windows11.tpl.yaml) by default have a termination grace period of 3600 seconds), when the user expects the VM to be deleted immediately when using a force deletion.

When force stopping a VM using `virtctl stop [vmName] --force --grace-period=0`, `virt-api` takes the grace period given (for now only grace-period of 0 is supported), and updates the VMI's `Spec.TerminationGracePeriodSeconds`. Then, when `virt-controller` later sends the `Delete` API request for the VMI, with no grace period in the `DeleteOptions` specified, the value in the VMI's `TerminationGracePeriodSeconds` will be used by default. `virt-launcher`'s libvirt domain manager also uses the grace period from `Spec.TerminationGracePeriodSeconds`, storing this value in its metadata cache when syncing the VMI.

Ultimately, the problem here is that when calling `kubectl` on the running/stuck VM directly without explicitly stopping the VM first, the VMI's `Spec.TerminationGracePeriodSeconds` is never updated, so its default value is used instead (hence the force deletion hanging for an hour in the above example). Instead, the grace-period passed through the `kubectl delete` command gets put in the VM's `ObjectMeta.DeletionGracePeriodSeconds`; this is only set once a deletion has been requested and the `ObjectMeta.DeletionTimestamp` also gets set.

This PR makes it so that any time `virt-controller` needs to stop the VMI, it will now first check to see if the VM has been requested to be deleted as well (check if `ObjectMeta.DeletionTimestamp` has been set). If so, it will patch the value from the VM's `ObjectMeta.DeletionGracePeriodSeconds` to the VMI's `Spec.TerminationGracePeriodSeconds` before sending the Delete request.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: The [Boy Scout Rule](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) was considered and applied if needed
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to the [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
