### PR TITLE
Allow setting of requests/limits on VMExport pod

### DIFF
--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -38,7 +38,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -909,11 +908,11 @@ var _ = Describe("Export controller", func() {
 		Expect(pod.Spec.Containers[0].Resources.Requests.Cpu()).ToNot(BeNil())
 		Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()).To(Equal(int64(100)))
 		Expect(pod.Spec.Containers[0].Resources.Requests.Memory()).ToNot(BeNil())
-		Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ScaledValue(resource.Mega)).To(Equal(int64(200)))
+		Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(int64(209715200)))
 		Expect(pod.Spec.Containers[0].Resources.Limits.Cpu()).ToNot(BeNil())
 		Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().MilliValue()).To(Equal(int64(1000)))
 		Expect(pod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
-		Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ScaledValue(resource.Mega)).To(Equal(int64(1024)))
+		Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1073741824)))
 	},
 		Entry("PVC", createPVCVMExport, 3),
 		Entry("VM", populateVmExportVM, 4),

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -38,6 +38,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -905,6 +906,14 @@ var _ = Describe("Export controller", func() {
 		}))
 		Expect(pod.Annotations[annCertParams]).To(Equal("{\"Duration\":7200000000000,\"RenewBefore\":3600000000000}"))
 		Expect(pod.Spec.Containers[0].Env).To(ContainElements(expectedPodEnvVars))
+		Expect(pod.Spec.Containers[0].Resources.Requests.Cpu()).ToNot(BeNil())
+		Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()).To(Equal(int64(100)))
+		Expect(pod.Spec.Containers[0].Resources.Requests.Memory()).ToNot(BeNil())
+		Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ScaledValue(resource.Mega)).To(Equal(int64(200)))
+		Expect(pod.Spec.Containers[0].Resources.Limits.Cpu()).ToNot(BeNil())
+		Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().MilliValue()).To(Equal(int64(1000)))
+		Expect(pod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
+		Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ScaledValue(resource.Mega)).To(Equal(int64(1024)))
 	},
 		Entry("PVC", createPVCVMExport, 3),
 		Entry("VM", populateVmExportVM, 4),

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -646,6 +646,43 @@ func hotplugContainerRequests(config *virtconfig.ClusterConfig) k8sv1.ResourceLi
 	}
 }
 
+func vmExportContainerResourceRequirements(config *virtconfig.ClusterConfig) k8sv1.ResourceRequirements {
+	return k8sv1.ResourceRequirements{
+		Limits:   vmExportContainerLimits(config),
+		Requests: vmExportContainerRequests(config),
+	}
+}
+
+func vmExportContainerLimits(config *virtconfig.ClusterConfig) k8sv1.ResourceList {
+	cpuQuantity := resource.MustParse("1")
+	if cpu := config.GetSupportContainerLimit(v1.VMExport, k8sv1.ResourceCPU); cpu != nil {
+		cpuQuantity = *cpu
+	}
+	memQuantity := resource.MustParse("1024M")
+	if mem := config.GetSupportContainerLimit(v1.VMExport, k8sv1.ResourceMemory); mem != nil {
+		memQuantity = *mem
+	}
+	return k8sv1.ResourceList{
+		k8sv1.ResourceCPU:    cpuQuantity,
+		k8sv1.ResourceMemory: memQuantity,
+	}
+}
+
+func vmExportContainerRequests(config *virtconfig.ClusterConfig) k8sv1.ResourceList {
+	cpuQuantity := resource.MustParse("100m")
+	if cpu := config.GetSupportContainerRequest(v1.VMExport, k8sv1.ResourceCPU); cpu != nil {
+		cpuQuantity = *cpu
+	}
+	memQuantity := resource.MustParse("200M")
+	if mem := config.GetSupportContainerRequest(v1.VMExport, k8sv1.ResourceMemory); mem != nil {
+		memQuantity = *mem
+	}
+	return k8sv1.ResourceList{
+		k8sv1.ResourceCPU:    cpuQuantity,
+		k8sv1.ResourceMemory: memQuantity,
+	}
+}
+
 func multiplyMemory(mem resource.Quantity, multiplication float64) resource.Quantity {
 	overheadAddition := float64(mem.ScaledValue(resource.Kilo)) * (multiplication - 1.0)
 	additionalOverhead := resource.NewScaledQuantity(int64(overheadAddition), resource.Kilo)

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -658,7 +658,7 @@ func vmExportContainerLimits(config *virtconfig.ClusterConfig) k8sv1.ResourceLis
 	if cpu := config.GetSupportContainerLimit(v1.VMExport, k8sv1.ResourceCPU); cpu != nil {
 		cpuQuantity = *cpu
 	}
-	memQuantity := resource.MustParse("1024M")
+	memQuantity := resource.MustParse("1024Mi")
 	if mem := config.GetSupportContainerLimit(v1.VMExport, k8sv1.ResourceMemory); mem != nil {
 		memQuantity = *mem
 	}
@@ -673,7 +673,7 @@ func vmExportContainerRequests(config *virtconfig.ClusterConfig) k8sv1.ResourceL
 	if cpu := config.GetSupportContainerRequest(v1.VMExport, k8sv1.ResourceCPU); cpu != nil {
 		cpuQuantity = *cpu
 	}
-	memQuantity := resource.MustParse("200M")
+	memQuantity := resource.MustParse("200Mi")
 	if mem := config.GetSupportContainerRequest(v1.VMExport, k8sv1.ResourceMemory); mem != nil {
 		memQuantity = *mem
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1060,6 +1060,7 @@ func (t *templateService) RenderExporterManifest(vmExport *exportv1.VirtualMachi
 						AllowPrivilegeEscalation: pointer.Bool(false),
 						Capabilities:             &k8sv1.Capabilities{Drop: []k8sv1.Capability{"ALL"}},
 					},
+					Resources: vmExportContainerResourceRequirements(t.clusterConfig),
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2371,6 +2371,8 @@ const (
 	VirtioFS SupportContainerType = "virtiofs"
 	// SideCar is the container resources for a side car
 	SideCar SupportContainerType = "sidecar"
+	// VMExport is the container resources for a vm exporter pod
+	VMExport SupportContainerType = "vmexport"
 )
 
 // SupportContainerResources are used to specify the cpu/memory request and limits for the containers that support various features of Virtual Machines. These containers are usually idle and don't require a lot of memory or cpu.

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -484,9 +484,9 @@ var _ = SIGDescribe("Export", func() {
 		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu()).ToNot(BeNil())
 		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu().Value()).To(Equal(int64(1)))
 		Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory()).ToNot(BeNil())
-		Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(int64(200000000)))
+		Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(int64(200 * 1024 * 1024)))
 		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
-		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1024000000)))
+		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1024 * 1024 * 1024)))
 	}
 
 	type populateFunction func(string, k8sv1.PersistentVolumeMode) (*k8sv1.PersistentVolumeClaim, string)
@@ -1556,8 +1556,8 @@ var _ = SIGDescribe("Export", func() {
 			if !exists {
 				Skip("Skip test when Filesystem storage is not present")
 			}
-			cpu := resource.MustParse("1")
-			mem := resource.MustParse("1024Mi")
+			cpu := resource.MustParse("500m")
+			mem := resource.MustParse("1240Mi")
 			updateKubeVirtExportRequestLimit(&cpu, &cpu, &mem, &mem)
 			dataVolume := libdv.NewDataVolume(
 				libdv.WithNamespace(testsuite.GetTestNamespace(nil)),
@@ -1599,13 +1599,13 @@ var _ = SIGDescribe("Export", func() {
 			By("Verifying the ratio is proper for the exporter pod")
 			exporterPod := getExporterPod(export)
 			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Cpu()).ToNot(BeNil())
-			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Cpu().Value()).To(Equal(int64(1)))
+			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()).To(Equal(int64(500)))
 			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu()).ToNot(BeNil())
-			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu().Value()).To(Equal(int64(1)))
+			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu().MilliValue()).To(Equal(int64(500)))
 			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory()).ToNot(BeNil())
-			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(int64(1073741824)))
+			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(int64(1240 * 1024 * 1024)))
 			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
-			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1073741824)))
+			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1240 * 1024 * 1024)))
 			// Remove limit range to avoid having to configure proper VMI ratio for VMI.
 			removeLimitRangeFromNamespace()
 			By("Starting VMI, the export should return to pending")

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -476,6 +476,19 @@ var _ = SIGDescribe("Export", func() {
 		Expect(*vmExport.Status.TokenSecretRef).ToNot(BeEmpty())
 	}
 
+	verifyDefaultRequestLimits := func(export *exportv1.VirtualMachineExport) {
+		By("Verifying the exporter pod has default request/limits")
+		exporterPod := getExporterPod(export)
+		Expect(exporterPod.Spec.Containers[0].Resources.Requests.Cpu()).ToNot(BeNil())
+		Expect(exporterPod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()).To(Equal(int64(100)))
+		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu()).ToNot(BeNil())
+		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu().Value()).To(Equal(int64(1)))
+		Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory()).ToNot(BeNil())
+		Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(int64(200000000)))
+		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
+		Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1024000000)))
+	}
+
 	type populateFunction func(string, k8sv1.PersistentVolumeMode) (*k8sv1.PersistentVolumeClaim, string)
 	type verifyFunction func(string, string, *k8sv1.Pod, k8sv1.PersistentVolumeMode)
 	type storageClassFunction func() (string, bool)
@@ -514,6 +527,7 @@ var _ = SIGDescribe("Export", func() {
 		export = waitForReadyExport(export)
 		checkExportSecretRef(export)
 		Expect(*export.Status.TokenSecretRef).To(Equal(token.Name))
+		verifyDefaultRequestLimits(export)
 
 		By("Creating download pod, so we can download image")
 		targetPvc := &k8sv1.PersistentVolumeClaim{
@@ -1455,52 +1469,151 @@ var _ = SIGDescribe("Export", func() {
 		waitForExportCondition(export, expectedVMRunningCondition(vm.Name, vm.Namespace), "export should report VM running")
 	})
 
-	It("should report export pending if PVC is in use because of VMI using it, and start the VM export if the PVC is not in use, then stop again once pvc in use again", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
-		dataVolume := libdv.NewDataVolume(
-			libdv.WithNamespace(testsuite.GetTestNamespace(nil)),
-			libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
-			libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
+	Context("with limit range", func() {
+		var (
+			lr             *k8sv1.LimitRange
+			originalConfig virtv1.KubeVirtConfiguration
 		)
-		dataVolume = createDataVolume(dataVolume)
-		vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-		vmi = createVMI(vmi)
-		Eventually(func() virtv1.VirtualMachineInstancePhase {
-			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-			if errors.IsNotFound(err) {
-				return ""
-			}
-			Expect(err).ToNot(HaveOccurred())
-			return vmi.Status.Phase
-		}, 180*time.Second, time.Second).Should(Equal(virtv1.Running))
-		// For testing the token is the name of the source VM.
-		token := createExportTokenSecret(vmi.Name, vmi.Namespace)
-		pvcName := ""
-		for _, volume := range vmi.Spec.Volumes {
-			if volume.DataVolume != nil {
-				pvcName = volume.DataVolume.Name
-			}
-		}
-		Expect(pvcName).ToNot(BeEmpty())
-		export := createPVCExportObject(pvcName, vmi.Namespace, token)
-		Expect(export).ToNot(BeNil())
-		waitForExportPhase(export, exportv1.Pending)
-		waitForExportCondition(export, expectedPVCInUseCondition(dataVolume.Name, dataVolume.Namespace), "export should report pvc in use")
 
-		By("Deleting VMI, we should get the export ready eventually")
-		deleteVMI(vmi)
-		export = waitForReadyExport(export)
-		checkExportSecretRef(export)
-		Expect(*export.Status.TokenSecretRef).To(Equal(token.Name))
-		verifyKubevirtInternal(export, export.Name, export.Namespace, vmi.Spec.Volumes[0].DataVolume.Name)
-		By("Starting VMI, the export should return to pending")
-		vmi = tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-		vmi = createVMI(vmi)
-		waitForExportPhase(export, exportv1.Pending)
-		waitForExportCondition(export, expectedPVCInUseCondition(dataVolume.Name, dataVolume.Namespace), "export should report pvc in use")
+		updateKubeVirtExportRequestLimit := func(cpuRequest, cpuLimit, memRequest, memLimit *resource.Quantity) {
+			By("Updating hotplug and container disks ratio to the specified ratio")
+			resources := k8sv1.ResourceRequirements{
+				Requests: k8sv1.ResourceList{
+					k8sv1.ResourceCPU:    *cpuRequest,
+					k8sv1.ResourceMemory: *memRequest,
+				},
+				Limits: k8sv1.ResourceList{
+					k8sv1.ResourceCPU:    *cpuLimit,
+					k8sv1.ResourceMemory: *memLimit,
+				},
+			}
+			config := originalConfig.DeepCopy()
+			config.SupportContainerResources = []virtv1.SupportContainerResources{
+				{
+					Type:      virtv1.VMExport,
+					Resources: resources,
+				},
+			}
+			tests.UpdateKubeVirtConfigValueAndWait(*config)
+		}
+
+		createLimitRangeInNamespace := func(namespace string, memRatio, cpuRatio float64) {
+			lr = &k8sv1.LimitRange{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      fmt.Sprintf("%s-lr", namespace),
+				},
+				Spec: k8sv1.LimitRangeSpec{
+					Limits: []k8sv1.LimitRangeItem{
+						{
+							Type: k8sv1.LimitTypeContainer,
+							MaxLimitRequestRatio: k8sv1.ResourceList{
+								k8sv1.ResourceMemory: resource.MustParse(fmt.Sprintf("%f", memRatio)),
+								k8sv1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%f", cpuRatio)),
+							},
+							Max: k8sv1.ResourceList{
+								k8sv1.ResourceMemory: resource.MustParse("2Gi"),
+								k8sv1.ResourceCPU:    resource.MustParse("2"),
+							},
+							Min: k8sv1.ResourceList{
+								k8sv1.ResourceMemory: resource.MustParse("1Mi"),
+								k8sv1.ResourceCPU:    resource.MustParse("1m"),
+							},
+						},
+					},
+				},
+			}
+			lr, err = virtClient.CoreV1().LimitRanges(namespace).Create(context.Background(), lr, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			By("Ensuring LimitRange exists")
+			Eventually(func() error {
+				lr, err = virtClient.CoreV1().LimitRanges(namespace).Get(context.Background(), lr.Name, metav1.GetOptions{})
+				return err
+			}, 30*time.Second, 1*time.Second).Should(BeNil())
+		}
+
+		removeLimitRangeFromNamespace := func() {
+			if lr != nil {
+				err = virtClient.CoreV1().LimitRanges(lr.Namespace).Delete(context.Background(), lr.Name, metav1.DeleteOptions{})
+				if !errors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				lr = nil
+			}
+			tests.UpdateKubeVirtConfigValueAndWait(originalConfig)
+		}
+
+		BeforeEach(func() {
+			originalConfig = *util.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
+		})
+
+		AfterEach(func() {
+			removeLimitRangeFromNamespace()
+		})
+
+		It("[Serial] should report export pending if PVC is in use because of VMI using it, and start the VM export if the PVC is not in use, then stop again once pvc in use again", Serial, func() {
+			sc, exists := libstorage.GetRWOFileSystemStorageClass()
+			if !exists {
+				Skip("Skip test when Filesystem storage is not present")
+			}
+			cpu := resource.MustParse("1")
+			mem := resource.MustParse("1024Mi")
+			updateKubeVirtExportRequestLimit(&cpu, &cpu, &mem, &mem)
+			dataVolume := libdv.NewDataVolume(
+				libdv.WithNamespace(testsuite.GetTestNamespace(nil)),
+				libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
+			)
+			dataVolume = createDataVolume(dataVolume)
+			vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+			vmi = createVMI(vmi)
+			Eventually(func() virtv1.VirtualMachineInstancePhase {
+				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return ""
+				}
+				Expect(err).ToNot(HaveOccurred())
+				return vmi.Status.Phase
+			}, 180*time.Second, time.Second).Should(Equal(virtv1.Running))
+			createLimitRangeInNamespace(testsuite.GetTestNamespace(nil), float64(1), float64(1))
+			// For testing the token is the name of the source VM.
+			token := createExportTokenSecret(vmi.Name, vmi.Namespace)
+			pvcName := ""
+			for _, volume := range vmi.Spec.Volumes {
+				if volume.DataVolume != nil {
+					pvcName = volume.DataVolume.Name
+				}
+			}
+			Expect(pvcName).ToNot(BeEmpty())
+			export := createPVCExportObject(pvcName, vmi.Namespace, token)
+			Expect(export).ToNot(BeNil())
+			waitForExportPhase(export, exportv1.Pending)
+			waitForExportCondition(export, expectedPVCInUseCondition(dataVolume.Name, dataVolume.Namespace), "export should report pvc in use")
+
+			By("Deleting VMI, we should get the export ready eventually")
+			deleteVMI(vmi)
+			export = waitForReadyExport(export)
+			checkExportSecretRef(export)
+			Expect(*export.Status.TokenSecretRef).To(Equal(token.Name))
+			verifyKubevirtInternal(export, export.Name, export.Namespace, vmi.Spec.Volumes[0].DataVolume.Name)
+			By("Verifying the ratio is proper for the exporter pod")
+			exporterPod := getExporterPod(export)
+			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Cpu()).ToNot(BeNil())
+			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Cpu().Value()).To(Equal(int64(1)))
+			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu()).ToNot(BeNil())
+			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Cpu().Value()).To(Equal(int64(1)))
+			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory()).ToNot(BeNil())
+			Expect(exporterPod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(int64(1073741824)))
+			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
+			Expect(exporterPod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1073741824)))
+			// Remove limit range to avoid having to configure proper VMI ratio for VMI.
+			removeLimitRangeFromNamespace()
+			By("Starting VMI, the export should return to pending")
+			vmi = tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+			vmi = createVMI(vmi)
+			waitForExportPhase(export, exportv1.Pending)
+			waitForExportCondition(export, expectedPVCInUseCondition(dataVolume.Name, dataVolume.Namespace), "export should report pvc in use")
+		})
 	})
 
 	getManifestUrl := func(manifests []exportv1.VirtualMachineExportManifest, manifestType exportv1.ExportManifestType) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently the VMExport pod won't start inside a namespace with a quota. It will also not work inside a namespace with a specific limit range ratio. This commit allows one to specify the requests and limits of the VMExport pod, and it adds some defaults so it will work inside a namespace with a quota.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [RHBZ 2236422](https://bugzilla.redhat.com/show_bug.cgi?id=2236422) 

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: VMExport now works in a namespace with quotas defined.
```
