### PR TITLE
Allow specifying download format in vmexport

### DIFF
--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -50,6 +50,7 @@ const (
 	storageClassArg = "storage-class"
 	accessModeArg   = "access-mode"
 	portForwardArg  = "port-forward"
+	rawArg          = "raw"
 	localPortArg    = "local-port"
 
 	configName         = "config"
@@ -64,6 +65,7 @@ var (
 	claimName    string
 	createClaim  bool
 	portForward  bool
+	rawImg       bool
 	localPort    string
 	storageClass string
 	accessMode   string
@@ -118,6 +120,7 @@ func NewMemoryDumpCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&claimName, claimNameArg, "", "pvc name to contain the memory dump")
 	cmd.Flags().BoolVar(&createClaim, createClaimArg, false, "Create the pvc that will conatin the memory dump")
 	cmd.Flags().BoolVar(&portForward, portForwardArg, false, "Configure and set port-forward in a random port to download the memory dump")
+	cmd.Flags().BoolVar(&rawImg, rawArg, false, "Downloads in raw format.")
 	cmd.Flags().StringVar(&localPort, localPortArg, "0", "Specify port for port-forward")
 	cmd.Flags().StringVar(&storageClass, storageClassArg, "", "The storage class for the PVC.")
 	cmd.Flags().StringVar(&accessMode, accessModeArg, "", "The access mode for the PVC.")
@@ -335,6 +338,7 @@ func downloadMemoryDump(namespace, vmName string, virtClient kubecli.KubevirtCli
 		ExportSource: exportSource,
 		PortForward:  portForward,
 		LocalPort:    localPort,
+		RawImg:       rawImg,
 	}
 
 	if portForward {

--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -51,6 +51,7 @@ const (
 	accessModeArg   = "access-mode"
 	portForwardArg  = "port-forward"
 	rawArg          = "raw"
+	decompressArg   = "decompress"
 	localPortArg    = "local-port"
 
 	configName         = "config"
@@ -66,6 +67,7 @@ var (
 	createClaim  bool
 	portForward  bool
 	rawImg       bool
+	decompress   bool
 	localPort    string
 	storageClass string
 	accessMode   string
@@ -121,6 +123,7 @@ func NewMemoryDumpCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.Flags().BoolVar(&createClaim, createClaimArg, false, "Create the pvc that will conatin the memory dump")
 	cmd.Flags().BoolVar(&portForward, portForwardArg, false, "Configure and set port-forward in a random port to download the memory dump")
 	cmd.Flags().BoolVar(&rawImg, rawArg, false, "Downloads in raw format.")
+	cmd.Flags().BoolVar(&decompress, decompressArg, false, "Downloads and decompress in the same step.")
 	cmd.Flags().StringVar(&localPort, localPortArg, "0", "Specify port for port-forward")
 	cmd.Flags().StringVar(&storageClass, storageClassArg, "", "The storage class for the PVC.")
 	cmd.Flags().StringVar(&accessMode, accessModeArg, "", "The access mode for the PVC.")
@@ -339,6 +342,7 @@ func downloadMemoryDump(namespace, vmName string, virtClient kubecli.KubevirtCli
 		PortForward:  portForward,
 		LocalPort:    localPort,
 		RawImg:       rawImg,
+		Decompress:   decompress,
 	}
 
 	if portForward {

--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -446,7 +446,7 @@ var _ = Describe("MemoryDump", func() {
 			utils.HandleSecretGet(coreClient, secretName)
 			utils.HandleVMExportCreate(vmExportClient, vmexport)
 
-			commandAndArgs := []string{"memory-dump", "download", "testvm", outputFileFlag, "--decompress"}
+			commandAndArgs := []string{"memory-dump", "download", "testvm", outputFileFlag, "--format", "raw"}
 			cmd := clientcmd.NewVirtctlCommand(commandAndArgs...)
 			Expect(cmd.Execute()).To(Succeed())
 		})

--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -1,6 +1,7 @@
 package memorydump_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -409,6 +410,43 @@ var _ = Describe("MemoryDump", func() {
 			utils.HandleVMExportCreate(vmExportClient, vmexport)
 
 			commandAndArgs := []string{"memory-dump", "download", "testvm", outputFileFlag}
+			cmd := clientcmd.NewVirtctlCommand(commandAndArgs...)
+			Expect(cmd.Execute()).To(Succeed())
+		})
+
+		It("should call download memory dump and decompress succesfully", func() {
+			vmexport.HandleHTTPRequest = func(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, downloadUrl string, insecure bool, exportURL string, headers map[string]string) (*http.Response, error) {
+				resp := http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(bytes.NewReader([]byte{
+						0x1f, 0x8b, 0x08, 0x08, 0xc8, 0x58, 0x13, 0x4a,
+						0x00, 0x03, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2e,
+						0x74, 0x78, 0x74, 0x00, 0xcb, 0x48, 0xcd, 0xc9,
+						0xc9, 0x57, 0x28, 0xcf, 0x2f, 0xca, 0x49, 0xe1,
+						0x02, 0x00, 0x2d, 0x3b, 0x08, 0xaf, 0x0c, 0x00,
+						0x00, 0x00,
+						0x1f, 0x8b, 0x08, 0x08, 0xc8, 0x58, 0x13, 0x4a,
+						0x00, 0x03, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2e,
+						0x74, 0x78, 0x74, 0x00, 0xcb, 0x48, 0xcd, 0xc9,
+						0xc9, 0x57, 0x28, 0xcf, 0x2f, 0xca, 0x49, 0xe1,
+						0x02, 0x00, 0x2d, 0x3b, 0x08, 0xaf, 0x0c, 0x00,
+						0x00, 0x00,
+					})),
+				}
+				return &resp, nil
+			}
+			memorydump.WaitMemoryDumpComplete = waitForMemoryDumpDefault
+			vmexport := utils.VMExportSpecPVC(vmexportName, k8smetav1.NamespaceDefault, claimName, secretName)
+			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
+				{
+					Name:    claimName,
+					Formats: utils.GetExportVolumeFormat(server.URL, exportv1.KubeVirtGz),
+				},
+			}, secretName)
+			utils.HandleSecretGet(coreClient, secretName)
+			utils.HandleVMExportCreate(vmExportClient, vmexport)
+
+			commandAndArgs := []string{"memory-dump", "download", "testvm", outputFileFlag, "--decompress"}
 			cmd := clientcmd.NewVirtctlCommand(commandAndArgs...)
 			Expect(cmd.Execute()).To(Succeed())
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR aims to add a new `--raw` flag in virtctl vmexport, so users can request downloading the raw image instead of the compressed one. It also adds a `--decompress` flag to download and decompress gzipped files.
**Usage example**:

```bash
  # Download and extract a volume from an already existing VirtualMachineExport
  {{ProgramName}} vmexport download vm1-export --volume=volume1 --output=disk.img --format=raw
```

**Special notes for your reviewer**:

Planning to add a flag to decompress the image if needed too.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new vmexport flags to download raw images, either directly (--raw) or by decompressing (--decompress) them
```
