### PR TITLE
Raise event in case using default Slirp binding plugin image 

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -97,6 +97,7 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/kubectl/pkg/cmd/util/podcmd:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],

--- a/pkg/virt-controller/services/net_binding_test.go
+++ b/pkg/virt-controller/services/net_binding_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Network Binding", func() {
 			}))
 
 			Expect(fakeRecorder.Events).To(HaveLen(1))
-			event := fakeRecorder.Events
+			event := <-fakeRecorder.Events
 			Expect(event).To(Equal(
 				fmt.Sprintf("Warning %s no Slirp network binding plugin image is set in Kubevirt config, using '%s' sidecar image for Slirp network binding configuration",
 					services.UnregisteredNetworkBindingPluginReason, services.DefaultSlirpPluginImage),

--- a/pkg/virt-controller/services/net_binding_test.go
+++ b/pkg/virt-controller/services/net_binding_test.go
@@ -20,8 +20,14 @@
 package services_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	k8scorev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/hooks"
@@ -49,7 +55,7 @@ var _ = Describe("Network Binding", func() {
 					Binding: bindings,
 				},
 			}
-			sidecars, err := services.NetBindingPluginSidecarList(vmi, config)
+			sidecars, err := services.NetBindingPluginSidecarList(vmi, config, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sidecars).To(ConsistOf(expectedSidecars))
 		},
@@ -98,33 +104,39 @@ var _ = Describe("Network Binding", func() {
 			config := &v1.KubeVirtConfiguration{
 				NetworkConfiguration: &v1.NetworkConfiguration{},
 			}
-			_, err := services.NetBindingPluginSidecarList(vmi, config)
+			_, err := services.NetBindingPluginSidecarList(vmi, config, record.NewFakeRecorder(1))
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
-	Context("binding plugin configuration", func() {
-		It("should read registered network binding plugins successfully", func() {
-			const testPluginName = "test"
-			testPlugin := v1.InterfaceBindingPlugin{SidecarImage: "kubevirt/network-slirp-binding"}
-
+	Context("network binding plugin configuration", func() {
+		It("should create Slirp hook sidecar with registered image (specified in Kubevirt config)", func() {
+			fakeRecorder := record.NewFakeRecorder(1)
+			vmi := v1.NewVMI("test", "1234")
 			config := &v1.KubeVirtConfiguration{
+				ImagePullPolicy: k8scorev1.PullIfNotPresent,
 				NetworkConfiguration: &v1.NetworkConfiguration{
 					Binding: map[string]v1.InterfaceBindingPlugin{
-						"plugin1":      {SidecarImage: "org1/plugin1"},
-						testPluginName: testPlugin,
-						"plugin2":      {SidecarImage: "org2/plugin2"},
+						"slirp": {SidecarImage: "kubevirt/network-slirp-plugin"},
 					},
 				},
 			}
 
-			Expect(services.ReadNetBindingPluginConfiguration(config, testPluginName)).To(Equal(&testPlugin))
+			Expect(services.SlirpNetBindingPluginSidecar(vmi, config, fakeRecorder)).To(Equal(hooks.HookSidecar{
+				ImagePullPolicy: k8scorev1.PullIfNotPresent,
+				Image:           "kubevirt/network-slirp-plugin",
+			}))
 		})
 
-		DescribeTable("should return no network binding plugins configuration, when config", func(config *v1.KubeVirtConfiguration) {
-			Expect(services.ReadNetBindingPluginConfiguration(config, "myplugin")).To(BeNil())
-		},
-			Entry("is nil", nil),
+		DescribeTable("should create Slirp hook sidecar with default image, when Kubevirt config",
+			func(config *v1.KubeVirtConfiguration) {
+				fakeRecorder := record.NewFakeRecorder(1)
+				vmi := v1.NewVMI("test", "1234")
+
+				Expect(services.SlirpNetBindingPluginSidecar(vmi, config, fakeRecorder)).To(Equal(hooks.HookSidecar{
+					Image: services.DefaultSlirpPluginImage,
+				}))
+			},
 			Entry("has no network configuration set", &v1.KubeVirtConfiguration{}),
 			Entry("has no network binding plugin set",
 				&v1.KubeVirtConfiguration{
@@ -149,9 +161,20 @@ var _ = Describe("Network Binding", func() {
 			),
 		)
 
-		It("should return default image when no Slirp network binding plugin image is registered", func() {
-			expectedIfaceBindingPlugin := &v1.InterfaceBindingPlugin{SidecarImage: "quay.io/kubevirt/network-slirp-binding:20230830_638c60fc8"}
-			Expect(services.ReadNetBindingPluginConfiguration(&v1.KubeVirtConfiguration{}, "slirp")).To(Equal(expectedIfaceBindingPlugin))
+		It("should raise UnregisteredNetworkBindingPlugin warning event when no slirp binding plugin image is registered (specified in Kubevirt config)", func() {
+			fakeRecorder := record.NewFakeRecorder(1)
+			vmi := v1.NewVMI("test", "1234")
+
+			Expect(services.SlirpNetBindingPluginSidecar(vmi, &v1.KubeVirtConfiguration{}, fakeRecorder)).To(Equal(hooks.HookSidecar{
+				Image: services.DefaultSlirpPluginImage,
+			}))
+
+			Expect(fakeRecorder.Events).To(HaveLen(1))
+			event := fakeRecorder.Events
+			Expect(event).To(Equal(
+				fmt.Sprintf("Warning %s no Slirp network binding plugin image is set in Kubevirt config, using '%s' sidecar image for Slirp network binding configuration",
+					services.UnregisteredNetworkBindingPluginReason, services.DefaultSlirpPluginImage),
+			))
 		})
 	})
 })

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -26,6 +26,7 @@ import (
 
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
@@ -124,6 +125,7 @@ var _ = Describe("Template", func() {
 				"kubevirt/vmexport",
 				resourceQuotaStore,
 				namespaceStore,
+				WithEventRecorder(record.NewFakeRecorder(1)),
 			)
 			// Set up mock clients
 			networkClient := fakenetworkclient.NewSimpleClientset()

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -605,6 +605,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.exporterImage,
 		vca.resourceQuotaInformer.GetStore(),
 		vca.namespaceStore,
+		services.WithEventRecorder(vca.vmiRecorder),
 	)
 
 	topologyHinter := topology.NewTopologyHinter(vca.nodeInformer.GetStore(), vca.vmiInformer.GetStore(), vca.clusterConfig)

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",
+        "//tests/events:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Raise verbosity of warning by rasing an event  in case no Slirp network binding plugin image is registered and Kubevirt use the default image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
It was necessary to pass the VMI event recorder to the template service.

Handling Slirp default image is moved from `ReadNetBindingPluginConfiguration` to the caller because an raising an event requires the VMI event recorder and the VMI objects.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
