### PR TITLE
virt-controller, net: Refactor netbinding sidecar compose

### DIFF
--- a/pkg/network/netbinding/BUILD.bazel
+++ b/pkg/network/netbinding/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["netbinding.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/network/netbinding",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/hooks:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "netbinding_suite_test.go",
+        "netbinding_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/hooks:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/libvmi:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
+    ],
+)

--- a/pkg/network/netbinding/BUILD.bazel
+++ b/pkg/network/netbinding/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/hooks:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/pkg/network/netbinding/netbinding.go
+++ b/pkg/network/netbinding/netbinding.go
@@ -35,7 +35,7 @@ import (
 func NetBindingPluginSidecarList(vmi *v1.VirtualMachineInstance, config *v1.KubeVirtConfiguration, recorder k8srecord.EventRecorder) (hooks.HookSidecarList, error) {
 	var pluginSidecars hooks.HookSidecarList
 
-	if slirpSidecar := SlirpNetBindingPluginSidecar(vmi, config, recorder); slirpSidecar != nil {
+	if slirpSidecar := slirpNetBindingPluginSidecar(vmi, config, recorder); slirpSidecar != nil {
 		pluginSidecars = append(pluginSidecars, *slirpSidecar)
 	}
 
@@ -87,7 +87,7 @@ const (
 	UnregisteredNetworkBindingPluginReason = "UnregisteredNetworkBindingPlugin"
 )
 
-func SlirpNetBindingPluginSidecar(vmi *v1.VirtualMachineInstance, kvConfig *v1.KubeVirtConfiguration, recorder k8srecord.EventRecorder) *hooks.HookSidecar {
+func slirpNetBindingPluginSidecar(vmi *v1.VirtualMachineInstance, kvConfig *v1.KubeVirtConfiguration, recorder k8srecord.EventRecorder) *hooks.HookSidecar {
 	slirpIfaces := vmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(i v1.Interface) bool {
 		return i.Slirp != nil
 	})

--- a/pkg/network/netbinding/netbinding.go
+++ b/pkg/network/netbinding/netbinding.go
@@ -22,6 +22,8 @@ package netbinding
 import (
 	"fmt"
 
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+
 	k8scorev1 "k8s.io/api/core/v1"
 	k8srecord "k8s.io/client-go/tools/record"
 
@@ -48,10 +50,8 @@ func NetBindingPluginSidecarList(vmi *v1.VirtualMachineInstance, config *v1.Kube
 		}
 	}
 
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Slirp != nil {
-			pluginSidecars = append(pluginSidecars, SlirpNetBindingPluginSidecar(vmi, config, recorder))
-		}
+	if slirpSidecar := SlirpNetBindingPluginSidecar(vmi, config, recorder); slirpSidecar != nil {
+		pluginSidecars = append(pluginSidecars, *slirpSidecar)
 	}
 
 	for _, pluginInfo := range bindingByName {
@@ -74,7 +74,14 @@ const (
 	UnregisteredNetworkBindingPluginReason = "UnregisteredNetworkBindingPlugin"
 )
 
-func SlirpNetBindingPluginSidecar(vmi *v1.VirtualMachineInstance, kvConfig *v1.KubeVirtConfiguration, recorder k8srecord.EventRecorder) hooks.HookSidecar {
+func SlirpNetBindingPluginSidecar(vmi *v1.VirtualMachineInstance, kvConfig *v1.KubeVirtConfiguration, recorder k8srecord.EventRecorder) *hooks.HookSidecar {
+	slirpIfaces := vmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(i v1.Interface) bool {
+		return i.Slirp != nil
+	})
+	if len(slirpIfaces) == 0 {
+		return nil
+	}
+
 	var slirpSidecarImage string
 	if plugin := readNetBindingPluginConfiguration(kvConfig, SlirpNetworkBindingPluginName); plugin == nil {
 		// In case no Slirp network binding plugin is registered (i.e.: specified in in Kubevirt config) use default image
@@ -88,7 +95,7 @@ func SlirpNetBindingPluginSidecar(vmi *v1.VirtualMachineInstance, kvConfig *v1.K
 		slirpSidecarImage = plugin.SidecarImage
 	}
 
-	return hooks.HookSidecar{
+	return &hooks.HookSidecar{
 		Image:           slirpSidecarImage,
 		ImagePullPolicy: kvConfig.ImagePullPolicy,
 	}

--- a/pkg/network/netbinding/netbinding.go
+++ b/pkg/network/netbinding/netbinding.go
@@ -17,7 +17,7 @@
  *
  */
 
-package services
+package netbinding
 
 import (
 	"fmt"

--- a/pkg/network/netbinding/netbinding_suite_test.go
+++ b/pkg/network/netbinding/netbinding_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package netbinding_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestNetBinding(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/network/netbinding/netbinding_test.go
+++ b/pkg/network/netbinding/netbinding_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package services_test
+package netbinding_test
 
 import (
 	"fmt"
@@ -31,7 +31,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/hooks"
-	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/pkg/network/netbinding"
+
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -44,8 +45,6 @@ var _ = Describe("Network Binding", func() {
 		testBindingName2  = "binding2"
 		testSidecarImage2 = "image2"
 		testNetworkName3  = "net1"
-
-		shouldSucceed = true
 	)
 
 	Context("binding plugin sidecar list", func() {
@@ -55,7 +54,7 @@ var _ = Describe("Network Binding", func() {
 					Binding: bindings,
 				},
 			}
-			sidecars, err := services.NetBindingPluginSidecarList(vmi, config, nil)
+			sidecars, err := netbinding.NetBindingPluginSidecarList(vmi, config, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sidecars).To(ConsistOf(expectedSidecars))
 		},
@@ -104,7 +103,7 @@ var _ = Describe("Network Binding", func() {
 			config := &v1.KubeVirtConfiguration{
 				NetworkConfiguration: &v1.NetworkConfiguration{},
 			}
-			_, err := services.NetBindingPluginSidecarList(vmi, config, record.NewFakeRecorder(1))
+			_, err := netbinding.NetBindingPluginSidecarList(vmi, config, record.NewFakeRecorder(1))
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -122,7 +121,7 @@ var _ = Describe("Network Binding", func() {
 				},
 			}
 
-			Expect(services.SlirpNetBindingPluginSidecar(vmi, config, fakeRecorder)).To(Equal(hooks.HookSidecar{
+			Expect(netbinding.SlirpNetBindingPluginSidecar(vmi, config, fakeRecorder)).To(Equal(hooks.HookSidecar{
 				ImagePullPolicy: k8scorev1.PullIfNotPresent,
 				Image:           "kubevirt/network-slirp-plugin",
 			}))
@@ -133,8 +132,8 @@ var _ = Describe("Network Binding", func() {
 				fakeRecorder := record.NewFakeRecorder(1)
 				vmi := v1.NewVMI("test", "1234")
 
-				Expect(services.SlirpNetBindingPluginSidecar(vmi, config, fakeRecorder)).To(Equal(hooks.HookSidecar{
-					Image: services.DefaultSlirpPluginImage,
+				Expect(netbinding.SlirpNetBindingPluginSidecar(vmi, config, fakeRecorder)).To(Equal(hooks.HookSidecar{
+					Image: netbinding.DefaultSlirpPluginImage,
 				}))
 			},
 			Entry("has no network configuration set", &v1.KubeVirtConfiguration{}),
@@ -165,15 +164,15 @@ var _ = Describe("Network Binding", func() {
 			fakeRecorder := record.NewFakeRecorder(1)
 			vmi := v1.NewVMI("test", "1234")
 
-			Expect(services.SlirpNetBindingPluginSidecar(vmi, &v1.KubeVirtConfiguration{}, fakeRecorder)).To(Equal(hooks.HookSidecar{
-				Image: services.DefaultSlirpPluginImage,
+			Expect(netbinding.SlirpNetBindingPluginSidecar(vmi, &v1.KubeVirtConfiguration{}, fakeRecorder)).To(Equal(hooks.HookSidecar{
+				Image: netbinding.DefaultSlirpPluginImage,
 			}))
 
 			Expect(fakeRecorder.Events).To(HaveLen(1))
 			event := <-fakeRecorder.Events
 			Expect(event).To(Equal(
 				fmt.Sprintf("Warning %s no Slirp network binding plugin image is set in Kubevirt config, using '%s' sidecar image for Slirp network binding configuration",
-					services.UnregisteredNetworkBindingPluginReason, services.DefaultSlirpPluginImage),
+					netbinding.UnregisteredNetworkBindingPluginReason, netbinding.DefaultSlirpPluginImage),
 			))
 		})
 	})

--- a/pkg/network/netbinding/netbinding_test.go
+++ b/pkg/network/netbinding/netbinding_test.go
@@ -136,6 +136,27 @@ var _ = Describe("Network Binding", func() {
 			}}))
 		})
 
+		It("should create a single slirp hook sidecar, even if multiple slirp interfaces are defined", func() {
+			fakeRecorder := record.NewFakeRecorder(1)
+			config := &v1.KubeVirtConfiguration{
+				ImagePullPolicy: k8scorev1.PullIfNotPresent,
+				NetworkConfiguration: &v1.NetworkConfiguration{
+					Binding: map[string]v1.InterfaceBindingPlugin{
+						"slirp": {SidecarImage: "kubevirt/network-slirp-plugin"},
+					},
+				},
+			}
+
+			vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, v1.Interface{
+				Name:                   testNetworkName2,
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{Slirp: &v1.InterfaceSlirp{}},
+			})
+			Expect(netbinding.NetBindingPluginSidecarList(vmi, config, fakeRecorder)).To(ConsistOf(hooks.HookSidecarList{{
+				ImagePullPolicy: k8scorev1.PullIfNotPresent,
+				Image:           "kubevirt/network-slirp-plugin",
+			}}))
+		})
+
 		DescribeTable("should create Slirp hook sidecar with default image, when Kubevirt config",
 			func(config *v1.KubeVirtConfiguration) {
 				fakeRecorder := record.NewFakeRecorder(1)

--- a/pkg/network/netbinding/netbinding_test.go
+++ b/pkg/network/netbinding/netbinding_test.go
@@ -130,20 +130,19 @@ var _ = Describe("Network Binding", func() {
 				},
 			}
 
-			Expect(netbinding.SlirpNetBindingPluginSidecar(vmi, config, fakeRecorder)).To(Equal(&hooks.HookSidecar{
+			Expect(netbinding.NetBindingPluginSidecarList(vmi, config, fakeRecorder)).To(ConsistOf(hooks.HookSidecarList{{
 				ImagePullPolicy: k8scorev1.PullIfNotPresent,
 				Image:           "kubevirt/network-slirp-plugin",
-			},
-			))
+			}}))
 		})
 
 		DescribeTable("should create Slirp hook sidecar with default image, when Kubevirt config",
 			func(config *v1.KubeVirtConfiguration) {
 				fakeRecorder := record.NewFakeRecorder(1)
 
-				Expect(netbinding.SlirpNetBindingPluginSidecar(vmi, config, fakeRecorder)).To(Equal(&hooks.HookSidecar{
+				Expect(netbinding.NetBindingPluginSidecarList(vmi, config, fakeRecorder)).To(ConsistOf(hooks.HookSidecarList{{
 					Image: netbinding.DefaultSlirpPluginImage,
-				}))
+				}}))
 			},
 			Entry("has no network configuration set", &v1.KubeVirtConfiguration{}),
 			Entry("has no network binding plugin set",
@@ -172,9 +171,9 @@ var _ = Describe("Network Binding", func() {
 		It("should raise UnregisteredNetworkBindingPlugin warning event when no slirp binding plugin image is registered (specified in Kubevirt config)", func() {
 			fakeRecorder := record.NewFakeRecorder(1)
 
-			Expect(netbinding.SlirpNetBindingPluginSidecar(vmi, &v1.KubeVirtConfiguration{}, fakeRecorder)).To(Equal(&hooks.HookSidecar{
+			Expect(netbinding.NetBindingPluginSidecarList(vmi, &v1.KubeVirtConfiguration{}, fakeRecorder)).To(ConsistOf(hooks.HookSidecarList{{
 				Image: netbinding.DefaultSlirpPluginImage,
-			}))
+			}}))
 
 			Expect(fakeRecorder.Events).To(HaveLen(1))
 			event := <-fakeRecorder.Events

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/kubectl/pkg/cmd/util/podcmd:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
@@ -97,7 +96,6 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "renderresources.go",
         "rendervolumes.go",
         "serialconsolelog.go",
+        "sidecar.go",
         "template.go",
         "virtiofs.go",
     ],

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "multus_annotations.go",
-        "net_binding.go",
         "nodeselectorrenderer.go",
         "rendercontainer.go",
         "renderresources.go",
@@ -58,7 +57,6 @@ go_test(
     name = "go_default_test",
     srcs = [
         "multus_annotations_test.go",
-        "net_binding_test.go",
         "nodeselectorrenderer_test.go",
         "rendercontainer_test.go",
         "renderresources_test.go",
@@ -81,7 +79,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-        "//tests/libvmi:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",

--- a/pkg/virt-controller/services/sidecar.go
+++ b/pkg/virt-controller/services/sidecar.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package services
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/hooks"
+)
+
+type SidecarCreatorFunc func(*v1.VirtualMachineInstance, *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error)
+
+func WithSidecarCreator(sidecarCreator SidecarCreatorFunc) templateServiceOption {
+	return func(t *templateService) {
+		t.sidecarCreators = append(t.sidecarCreators, sidecarCreator)
+	}
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -26,13 +26,11 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/record"
-
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
@@ -161,7 +159,6 @@ type templateService struct {
 	launcherSubGid             int64
 	resourceQuotaStore         cache.Store
 	namespaceStore             cache.Store
-	recorder                   record.EventRecorder
 
 	sidecarCreators []SidecarCreatorFunc
 }
@@ -1178,12 +1175,6 @@ func NewTemplateService(launcherImage string,
 	}
 
 	return &svc
-}
-
-func WithEventRecorder(recorder record.EventRecorder) templateServiceOption {
-	return func(svc *templateService) {
-		svc.recorder = recorder
-	}
 }
 
 func copyProbe(probe *v1.Probe) *k8sv1.Probe {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -26,7 +26,6 @@ import (
 
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/record"
 
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
@@ -131,7 +130,6 @@ var _ = Describe("Template", func() {
 				"kubevirt/vmexport",
 				resourceQuotaStore,
 				namespaceStore,
-				WithEventRecorder(record.NewFakeRecorder(1)),
 				WithSidecarCreator(
 					func(vmi *v1.VirtualMachineInstance, _ *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
 						return hooks.UnmarshalHookSidecarList(vmi)
@@ -2920,7 +2918,6 @@ var _ = Describe("Template", func() {
 				"kubevirt/vmexport",
 				resourceQuotaStore,
 				namespaceStore,
-				WithEventRecorder(record.NewFakeRecorder(1)),
 				WithSidecarCreator(testSidecarCreator),
 			)
 			vmi := v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2905,6 +2905,7 @@ var _ = Describe("Template", func() {
 				vmi.Spec.Networks = append(vmi.Spec.Networks, *v1.DefaultPodNetwork())
 				vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, *v1.DefaultSlirpNetworkInterface())
 
+				config, kvInformer, svc = configFactory(defaultArch)
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -2916,7 +2917,7 @@ var _ = Describe("Template", func() {
 				const slirpPluginSidecarImage = "kubevirt/network-slirp-binding:v1"
 				testBindingPluginNetConf := &v1.NetworkConfiguration{Binding: map[string]v1.InterfaceBindingPlugin{"slirp": {SidecarImage: slirpPluginSidecarImage}}}
 
-				config, kvInformer, _ = configFactory(defaultArch)
+				config, kvInformer, svc = configFactory(defaultArch)
 				kvConfig := kv.DeepCopy()
 				kvConfig.Spec.Configuration.NetworkConfiguration = testBindingPluginNetConf
 				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -136,10 +136,6 @@ var _ = Describe("Template", func() {
 					func(vmi *v1.VirtualMachineInstance, _ *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
 						return hooks.UnmarshalHookSidecarList(vmi)
 					}),
-				WithSidecarCreator(
-					func(vmi *v1.VirtualMachineInstance, kvc *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
-						return NetBindingPluginSidecarList(vmi, kvc, record.NewFakeRecorder(1))
-					}),
 			)
 			// Set up mock clients
 			networkClient := fakenetworkclient.NewSimpleClientset()
@@ -2936,48 +2932,6 @@ var _ = Describe("Template", func() {
 			Expect(pod.Spec.Containers).To(HaveLen(2))
 			Expect(pod.Spec.Containers[1].Image).To(Equal(testHookSidecar.Image))
 			Expect(pod.Spec.Containers[1].ImagePullPolicy).To(Equal(testHookSidecar.ImagePullPolicy))
-		})
-
-		Context("with slirp interface", func() {
-			It("should add slirp network binding hook sidecar container with default image when no image is registered", func() {
-				vmi := v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{
-					Name: "testvmi", Namespace: "default", UID: "1234",
-				}}
-				vmi.Spec.Networks = append(vmi.Spec.Networks, *v1.DefaultPodNetwork())
-				vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, *v1.DefaultSlirpNetworkInterface())
-
-				config, kvInformer, svc = configFactory(defaultArch)
-				pod, err := svc.RenderLaunchManifest(&vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(pod.Spec.Containers).To(HaveLen(2))
-				Expect(pod.Spec.Containers[1].Image).To(Equal("quay.io/kubevirt/network-slirp-binding:20230830_638c60fc8"))
-				Expect(pod.Spec.Containers[1].ImagePullPolicy).To(Equal(kubev1.PullPolicy("IfNotPresent")))
-			})
-			It("should add slirp network binding hook sidecar container using registered image", func() {
-				const slirpPluginSidecarImage = "kubevirt/network-slirp-binding:v1"
-				testBindingPluginNetConf := &v1.NetworkConfiguration{Binding: map[string]v1.InterfaceBindingPlugin{"slirp": {SidecarImage: slirpPluginSidecarImage}}}
-
-				config, kvInformer, svc = configFactory(defaultArch)
-				kvConfig := kv.DeepCopy()
-				kvConfig.Spec.Configuration.NetworkConfiguration = testBindingPluginNetConf
-				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
-
-				vmi := v1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testvmi", Namespace: "default", UID: "1234",
-					},
-				}
-				vmi.Spec.Networks = append(vmi.Spec.Networks, *v1.DefaultPodNetwork())
-				vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, *v1.DefaultSlirpNetworkInterface())
-
-				pod, err := svc.RenderLaunchManifest(&vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(pod.Spec.Containers).To(HaveLen(2))
-				Expect(pod.Spec.Containers[1].Image).To(Equal(slirpPluginSidecarImage))
-				Expect(pod.Spec.Containers[1].ImagePullPolicy).To(Equal(kubev1.PullPolicy("IfNotPresent")))
-			})
 		})
 
 		Context("with pod networking", func() {

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/monitoring/vmistats:go_default_library",
         "//pkg/monitoring/vmstats:go_default_library",
         "//pkg/network/namescheme:go_default_library",
+        "//pkg/network/netbinding:go_default_library",
         "//pkg/network/sriov:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/service:go_default_library",

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/container-disk:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
+        "//pkg/hooks:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/monitoring/migration:go_default_library",
         "//pkg/monitoring/migrationstats:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -604,7 +604,6 @@ func (vca *VirtControllerApp) initCommon() {
 			func(vmi *v1.VirtualMachineInstance, kvc *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
 				return netbinding.NetBindingPluginSidecarList(vmi, kvc, vca.vmiRecorder)
 			}),
-		services.WithEventRecorder(vca.vmiRecorder),
 	)
 
 	topologyHinter := topology.NewTopologyHinter(vca.nodeInformer.GetStore(), vca.vmiInformer.GetStore(), vca.clusterConfig)

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -90,6 +90,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/disruptionbudget"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation"
 	workloadupdater "kubevirt.io/kubevirt/pkg/virt-controller/watch/workload-updater"
+
+	"kubevirt.io/kubevirt/pkg/network/netbinding"
 )
 
 const (
@@ -600,7 +602,7 @@ func (vca *VirtControllerApp) initCommon() {
 			}),
 		services.WithSidecarCreator(
 			func(vmi *v1.VirtualMachineInstance, kvc *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
-				return services.NetBindingPluginSidecarList(vmi, kvc, vca.vmiRecorder)
+				return netbinding.NetBindingPluginSidecarList(vmi, kvc, vca.vmiRecorder)
 			}),
 		services.WithEventRecorder(vca.vmiRecorder),
 	)

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/cloud-init:go_default_library",
         "//pkg/network/istio:go_default_library",
+        "//pkg/network/netbinding:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -56,6 +56,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/network/netbinding"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
@@ -424,7 +425,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			libwait.WaitUntilVMIReady(deadbeafVMI, console.LoginToAlpine, libwait.WithWarningsIgnoreList(warnings))
 			checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress)
 
-			events.ExpectEvent(deadbeafVMI, k8sv1.EventTypeWarning, services.UnregisteredNetworkBindingPluginReason)
+			events.ExpectEvent(deadbeafVMI, k8sv1.EventTypeWarning, netbinding.UnregisteredNetworkBindingPluginReason)
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Decouple the net binding sidecar spec definition logic from where it is called in the flow.

The separation assists with structuring the code, reducing complexity from the existing rendering function and simplifying dependencies.
The approach is aimed to assist in adding similar sidecar creators (not limited to network bindings).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~~
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~

**Release note**:
```release-note
NONE
```
