### PR TITLE
[release-1.0] Stop considering nodes without `kubevirt.io/schedulable` label when finding lowest TSC frequency on the cluster

### DIFF
--- a/pkg/virt-controller/watch/topology/filter.go
+++ b/pkg/virt-controller/watch/topology/filter.go
@@ -3,6 +3,8 @@ package topology
 import (
 	"math"
 
+	"k8s.io/client-go/tools/cache"
+
 	v1 "k8s.io/api/core/v1"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -75,6 +77,17 @@ func Not(f FilterPredicateFunc) FilterPredicateFunc {
 	}
 }
 
+func Or(predicates ...FilterPredicateFunc) FilterPredicateFunc {
+	return func(node *v1.Node) bool {
+		for _, p := range predicates {
+			if p(node) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 func FilterNodesFromCache(objs []interface{}, predicates ...FilterPredicateFunc) []*v1.Node {
 	match := []*v1.Node{}
 	for _, obj := range objs {
@@ -91,6 +104,22 @@ func FilterNodesFromCache(objs []interface{}, predicates ...FilterPredicateFunc)
 		}
 	}
 	return match
+}
+
+func IsNodeRunningVmis(vmiStore cache.Store) FilterPredicateFunc {
+	return func(node *v1.Node) bool {
+		if node == nil {
+			return false
+		}
+
+		for _, vmi := range vmiStore.List() {
+			vmi := vmi.(*virtv1.VirtualMachineInstance)
+			if vmi.Status.NodeName == node.Name {
+				return true
+			}
+		}
+		return false
+	}
 }
 
 // ToleranceForFrequency returns TSCTolerancePPM parts per million of freq, rounded down to the nearest Hz

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -56,6 +56,7 @@ func (t *topologyHinter) LowestTSCFrequencyOnCluster() (int64, error) {
 	}
 	nodes := FilterNodesFromCache(t.nodeStore.List(),
 		HasInvTSCFrequency,
+		IsSchedulable,
 	)
 	freq := LowestTSCFrequency(nodes)
 	return freq, nil

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -56,7 +56,10 @@ func (t *topologyHinter) LowestTSCFrequencyOnCluster() (int64, error) {
 	}
 	nodes := FilterNodesFromCache(t.nodeStore.List(),
 		HasInvTSCFrequency,
-		IsSchedulable,
+		Or(
+			IsSchedulable,
+			IsNodeRunningVmis(t.vmiStore),
+		),
 	)
 	freq := LowestTSCFrequency(nodes)
 	return freq, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of https://github.com/kubevirt/kubevirt/pull/10182 (which is a follow-up to https://github.com/kubevirt/kubevirt/pull/10169).

Fixes https://github.com/kubevirt/kubevirt/issues/10181

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop considering nodes without `kubevirt.io/schedulable` label when finding lowest TSC frequency on the cluster
```
