### PR TITLE
Quarantine flaky downward metrics test

### DIFF
--- a/tests/infrastructure/downward-metrics.go
+++ b/tests/infrastructure/downward-metrics.go
@@ -46,7 +46,7 @@ var _ = DescribeInfra("downwardMetrics", func() {
 		virtClient = kubevirt.Client()
 	})
 
-	It("[test_id:6535]should be published to a vmi and periodically updated", func() {
+	It("[test_id:6535][QUARANTINE]should be published to a vmi and periodically updated", func() {
 		vmi := libvmi.NewFedora()
 		tests.AddDownwardMetricsVolume(vmi, "vhostmd")
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 180)


### PR DESCRIPTION
**What this PR does / why we need it**:

The following test has been very flaky over the past 7 days[1]:

`Serial][sig-compute]InfrastructuredownwardMetrics [It] [test_id:6535]should be published to a vmi and periodically updated [sig-compute]`

Quarantining for now as it is causing impact across all of the sig-compute lanes.

[1] https://search.ci.kubevirt.io/?search=test_id%3A6535&maxAge=168h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @enp0s3 
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
