### PR TITLE
rbac: Add instancetype.kubevirt.io:view ClusterRole

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1236,6 +1236,15 @@ spec:
           - list
           - watch
         - apiGroups:
+          - instancetype.kubevirt.io
+          resources:
+          - virtualmachineclusterinstancetypes
+          - virtualmachineclusterpreferences
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -1176,6 +1176,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - instancetype.kubevirt.io
+  resources:
+  - virtualmachineclusterinstancetypes
+  - virtualmachineclusterpreferences
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -85,9 +85,9 @@ const (
 
 	NAMESPACE = "kubevirt-test"
 
-	resourceCount = 75
+	resourceCount = 76
 	patchCount    = 50
-	updateCount   = 26
+	updateCount   = 27
 )
 
 type KubeVirtTestData struct {
@@ -2425,7 +2425,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kvTestData.totalAdds).To(Equal(resourceCount - expectedUncreatedResources + expectedTemporaryResources))
 
 			Expect(kvTestData.controller.stores.ServiceAccountCache.List()).To(HaveLen(4))
-			Expect(kvTestData.controller.stores.ClusterRoleCache.List()).To(HaveLen(8))
+			Expect(kvTestData.controller.stores.ClusterRoleCache.List()).To(HaveLen(9))
 			Expect(kvTestData.controller.stores.ClusterRoleBindingCache.List()).To(HaveLen(6))
 			Expect(kvTestData.controller.stores.RoleCache.List()).To(HaveLen(5))
 			Expect(kvTestData.controller.stores.RoleBindingCache.List()).To(HaveLen(5))

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -55,6 +55,7 @@ func GetAllCluster() []runtime.Object {
 		newAdminClusterRole(),
 		newEditClusterRole(),
 		newViewClusterRole(),
+		newInstancetypeViewClusterRole(),
 	}
 }
 
@@ -623,6 +624,31 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					migrations.ResourceMigrationPolicies,
+				},
+				Verbs: []string{
+					"get", "list", "watch",
+				},
+			},
+		},
+	}
+}
+func newInstancetypeViewClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: VersionNamev1,
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "instancetype.kubevirt.io:view",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{
+					GroupNameInstancetype,
+				},
+				Resources: []string{
+					instancetype.ClusterPluralResourceName,
+					instancetype.ClusterPluralPreferenceResourceName,
 				},
 				Verbs: []string{
 					"get", "list", "watch",

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/api/core"
 
 	v1 "kubevirt.io/api/core/v1"
+	instancetypeapi "kubevirt.io/api/instancetype"
 	pool "kubevirt.io/api/pool"
 	"kubevirt.io/api/snapshot/v1alpha1"
 )
@@ -164,12 +165,13 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 	var k8sClient string
 	var authClient *authClientV1.AuthorizationV1Client
 
-	doSarRequest := func(group string, resource string, subresource string, namespace string, role string, verb string, expected bool) {
+	doSarRequest := func(group string, resource string, subresource string, namespace string, role string, verb string, expected, clusterWide bool) {
 		roleToUser := map[string]string{
-			"view":    testsuite.ViewServiceAccountName,
-			"edit":    testsuite.EditServiceAccountName,
-			"admin":   testsuite.AdminServiceAccountName,
-			"default": "default",
+			"view":              testsuite.ViewServiceAccountName,
+			"instancetype:view": testsuite.ViewInstancetypeServiceAccountName,
+			"edit":              testsuite.EditServiceAccountName,
+			"admin":             testsuite.AdminServiceAccountName,
+			"default":           "default",
 		}
 		userName, exists := roleToUser[role]
 		Expect(exists).To(BeTrue(), fmt.Sprintf("role %s is not defined", role))
@@ -178,7 +180,6 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		sar.Spec = authv1.SubjectAccessReviewSpec{
 			User: user,
 			ResourceAttributes: &authv1.ResourceAttributes{
-				Namespace:   namespace,
 				Verb:        verb,
 				Group:       group,
 				Version:     v1.GroupVersion.Version,
@@ -186,6 +187,10 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				Subresource: subresource,
 			},
 		}
+		if !clusterWide {
+			sar.Spec.ResourceAttributes.Namespace = namespace
+		}
+
 		result, err := authClient.SubjectAccessReviews().Create(context.Background(), sar, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.Status.Allowed).To(Equal(expected), fmt.Sprintf("access check for user '%v' on resource '%v' with subresource '%v' for verb '%v' should have returned '%v'.",
@@ -207,84 +212,142 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 	})
 
 	Describe("With default kubevirt service accounts", func() {
-		DescribeTable("should verify permissions on resources are correct for view, edit, and admin", func(group string, resource string, accessRights ...rights) {
+		DescribeTable("should verify permissions on resources are correct for view, edit, and admin", func(group string, resource string, clusterWide bool, accessRights ...rights) {
 			namespace := testsuite.GetTestNamespace(nil)
 			for _, accessRight := range accessRights {
 				for _, entry := range accessRight.list() {
 					By(fmt.Sprintf("verifying sa %s for verb %s on resource %s", entry.role, entry.verb, resource))
-					doSarRequest(group, resource, "", namespace, entry.role, entry.verb, entry.allowed)
+					doSarRequest(group, resource, "", namespace, entry.role, entry.verb, entry.allowed, clusterWide)
 				}
 			}
 		},
 			Entry("[test_id:526]given a vmi",
 				core.GroupName,
 				"virtualmachineinstances",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
 				denyAllFor("default")),
 
 			Entry("[test_id:527]given a vm",
 				core.GroupName,
 				"virtualmachines",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
 				denyAllFor("default")),
 
 			Entry("given a vmpool",
 				pool.GroupName,
 				"virtualmachinepools",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
 				denyAllFor("default")),
 
 			Entry("[test_id:528]given a vmi preset",
 				core.GroupName,
 				"virtualmachineinstancepresets",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
 				denyAllFor("default")),
 
 			Entry("[test_id:529][crit:low]given a vmi replica set",
 				core.GroupName,
 				"virtualmachineinstancereplicasets",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
 				denyAllFor("default")),
 
 			Entry("[test_id:3230]given a vmi migration",
 				core.GroupName,
 				"virtualmachineinstancemigrations",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
 				denyAllFor("default")),
 
 			Entry("[test_id:5243]given a vmsnapshot",
 				v1alpha1.SchemeGroupVersion.Group,
 				"virtualmachinesnapshots",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
 				denyAllFor("default")),
 
 			Entry("[test_id:5244]given a vmsnapshotcontent",
 				v1alpha1.SchemeGroupVersion.Group,
 				"virtualmachinesnapshotcontents",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
 				denyAllFor("default")),
 			Entry("[test_id:5245]given a vmsrestore",
 				v1alpha1.SchemeGroupVersion.Group,
 				"virtualmachinerestores",
+				false,
 				allowAllFor("admin"),
 				denyDeleteCollectionFor("edit"),
 				denyModificationsFor("view"),
+				denyAllFor("instancetype:view"),
+				denyAllFor("default")),
+			Entry("[test_id:TODO]given a virtualmachineinstancetype",
+				instancetypeapi.GroupName,
+				instancetypeapi.PluralResourceName,
+				false,
+				allowAllFor("admin"),
+				denyDeleteCollectionFor("edit"),
+				denyModificationsFor("view"),
+				// instancetype:view only provides access to the cluster-scoped resources
+				denyAllFor("instancetype:view"),
+				denyAllFor("default")),
+			Entry("[test_id:TODO]given a virtualmachinepreference",
+				instancetypeapi.GroupName,
+				instancetypeapi.PluralPreferenceResourceName,
+				false,
+				allowAllFor("admin"),
+				denyDeleteCollectionFor("edit"),
+				denyModificationsFor("view"),
+				// instancetype:view only provides access to the cluster-scoped resources
+				denyAllFor("instancetype:view"),
+				denyAllFor("default")),
+			Entry("[test_id:TODO]given a virtualmachineclusterinstancetype",
+				instancetypeapi.GroupName,
+				instancetypeapi.ClusterPluralResourceName,
+				// only ClusterRoles bound with a ClusterRoleBinding should have access
+				true,
+				denyAllFor("admin"),
+				denyAllFor("edit"),
+				denyAllFor("view"),
+				denyModificationsFor("instancetype:view"),
+				denyAllFor("default")),
+			Entry("[test_id:TODO]given a virtualmachineclusterpreference",
+				instancetypeapi.GroupName,
+				instancetypeapi.ClusterPluralResourceName,
+				// only ClusterRoles bound with a ClusterRoleBinding should have access
+				true,
+				denyAllFor("admin"),
+				denyAllFor("edit"),
+				denyAllFor("view"),
+				denyModificationsFor("instancetype:view"),
 				denyAllFor("default")),
 		)
 
@@ -293,7 +356,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			for _, accessRight := range accessRights {
 				for _, entry := range accessRight.list() {
 					By(fmt.Sprintf("verifying sa %s for verb %s on resource %s on subresource %s", entry.role, entry.verb, resource, subresource))
-					doSarRequest(v1.SubresourceGroupName, resource, subresource, namespace, entry.role, entry.verb, entry.allowed)
+					doSarRequest(v1.SubresourceGroupName, resource, subresource, namespace, entry.role, entry.verb, entry.allowed, false)
 				}
 			}
 		},

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -193,12 +193,13 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 		result, err := authClient.SubjectAccessReviews().Create(context.Background(), sar, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result.Status.Allowed).To(Equal(expected), fmt.Sprintf("access check for user '%v' on resource '%v' with subresource '%v' for verb '%v' should have returned '%v'.",
+		Expect(result.Status.Allowed).To(Equal(expected), fmt.Sprintf("access check for user '%v' on resource '%v' with subresource '%v' for verb '%v' should have returned '%v'. Gave reason %s.",
 			user,
 			resource,
 			subresource,
 			verb,
 			expected,
+			result.Status.Reason,
 		))
 	}
 

--- a/tests/testsuite/serviceaccount.go
+++ b/tests/testsuite/serviceaccount.go
@@ -21,6 +21,9 @@ package testsuite
 
 import (
 	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
@@ -36,9 +39,16 @@ const (
 	AdminServiceAccountName                   = "kubevirt-admin-test-sa"
 	EditServiceAccountName                    = "kubevirt-edit-test-sa"
 	ViewServiceAccountName                    = "kubevirt-view-test-sa"
+	ViewInstancetypeServiceAccountName        = "kubevirt-instancetype-view-test-sa"
 	SubresourceServiceAccountName             = "kubevirt-subresource-test-sa"
 	SubresourceUnprivilegedServiceAccountName = "kubevirt-subresource-test-unprivileged-sa"
 )
+
+// As our tests run in parallel we need to ensure each worker creates a
+// unique clusterRoleBinding to avoid cleaning up anothers prematurely
+func getClusterRoleBindingName(saName string) string {
+	return fmt.Sprintf("%s-%d", saName, GinkgoParallelProcess())
+}
 
 func createServiceAccounts() {
 	createServiceAccount(AdminServiceAccountName)
@@ -50,6 +60,9 @@ func createServiceAccounts() {
 	createServiceAccount(ViewServiceAccountName)
 	createRoleBinding(ViewServiceAccountName, "kubevirt.io:view")
 
+	createServiceAccount(ViewInstancetypeServiceAccountName)
+	createClusterRoleBinding(ViewInstancetypeServiceAccountName, "instancetype.kubevirt.io:view")
+
 	createServiceAccount(SubresourceServiceAccountName)
 	createSubresourceRole(SubresourceServiceAccountName)
 
@@ -60,6 +73,7 @@ func cleanupServiceAccounts() {
 	cleanupServiceAccount(AdminServiceAccountName)
 	cleanupServiceAccount(EditServiceAccountName)
 	cleanupServiceAccount(ViewServiceAccountName)
+	cleanupServiceAccount(ViewInstancetypeServiceAccountName)
 	cleanupServiceAccount(SubresourceServiceAccountName)
 	cleanupServiceAccount(SubresourceUnprivilegedServiceAccountName)
 }
@@ -91,6 +105,36 @@ func createServiceAccount(saName string) {
 	}
 
 	_, err = virtCli.CoreV1().Secrets(GetTestNamespace(nil)).Create(context.Background(), &secret, metav1.CreateOptions{})
+	if !k8serrors.IsAlreadyExists(err) {
+		util.PanicOnError(err)
+	}
+}
+
+func createClusterRoleBinding(saName string, clusterRole string) {
+	virtCli := kubevirt.Client()
+
+	clusterRoleBinding := rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getClusterRoleBindingName(saName),
+			Labels: map[string]string{
+				util.KubevirtIoTest: saName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     clusterRole,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      saName,
+				Namespace: GetTestNamespace(nil),
+			},
+		},
+	}
+
+	_, err := virtCli.RbacV1().ClusterRoleBindings().Create(context.Background(), &clusterRoleBinding, metav1.CreateOptions{})
 	if !k8serrors.IsAlreadyExists(err) {
 		util.PanicOnError(err)
 	}
@@ -196,6 +240,11 @@ func cleanupServiceAccount(saName string) {
 	}
 
 	err = virtCli.RbacV1().RoleBindings(GetTestNamespace(nil)).Delete(context.Background(), saName, metav1.DeleteOptions{})
+	if !k8serrors.IsNotFound(err) {
+		util.PanicOnError(err)
+	}
+
+	err = virtCli.RbacV1().ClusterRoleBindings().Delete(context.Background(), getClusterRoleBindingName(saName), metav1.DeleteOptions{})
 	if !k8serrors.IsNotFound(err) {
 		util.PanicOnError(err)
 	}


### PR DESCRIPTION
/area instancetype

**What this PR does / why we need it**:

This ClusterRole provides read only access to the cluster-scoped VirtualMachineCluster{Instancetype,Preference} resources within a cluster.

This is required as the existing aggregated kubevirt:view ClusterRole does not provide access to cluster-scoped resources when bound to a user using a RoleBinding.

As such we need a seperate ClusterRole to provide access to our cluster scoped resources that can be bound with a ClusterRoleBinding without providing access to all of the resources listed in the aggregated view ClusterRole.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10437

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A new `instancetype.kubevirt.io:view` `ClusterRole` has been introduced that can be bound to users via a `ClusterRoleBinding` to provide read only access to the cluster scoped `VirtualMachineCluster{Instancetype,Preference}` resources.
```
