### PR TITLE
CI: Workaround Fedora login issue

### DIFF
--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -121,7 +121,12 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
 func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 	virtClient := kubevirt.Client()
 
-	expecter, _, err := NewExpecter(virtClient, vmi, connectionTimeout)
+	// TODO: This is temporary workaround for issue seen in CI
+	// We see that 10seconds for an initial boot is not enough
+	// At the same time it seems the OS is booted within 10sec
+	// We need to have a look on Running -> Booting time
+	const double = 2
+	expecter, _, err := NewExpecter(virtClient, vmi, double*connectionTimeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR workarounds
```
{ Failure tests/infrastructure/downward-metrics.go:49
Expected success, but got an error:
    <*errors.errorString | 0xc004f1e2f0>: 
    send to spawned process command reached the timeout 9.970984101s
    {
        s: "send to spawned process command reached the timeout 9.970984101s",
    }
tests/infrastructure/downward-metrics.go:53}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
