### PR TITLE
Fix missing migration transfer rate metric

### DIFF
--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -47,7 +47,6 @@ const (
 	MigrateVmiDataProcessedMetricName      = "kubevirt_migrate_vmi_data_processed_bytes"
 	MigrateVmiDirtyMemoryRateMetricName    = "kubevirt_migrate_vmi_dirty_memory_rate_bytes"
 	MigrateVmiMemoryTransferRateMetricName = "kubevirt_migrate_vmi_memory_transfer_rate_bytes"
-	MigrateVmiDiskTransferRateMetricName   = "kubevirt_migrate_vmi_disk_transfer_rate_bytes"
 )
 
 var (
@@ -109,15 +108,6 @@ func (metrics *vmiMetrics) updateMigrateInfo(jobInfo *stats.DomainJobInfo) {
 			"Network throughput used while migrating memory in Bytes per second.",
 			prometheus.GaugeValue,
 			float64(jobInfo.MemoryBps),
-		)
-	}
-
-	if jobInfo.DiskBpsSet {
-		metrics.pushCommonMetric(
-			MigrateVmiDiskTransferRateMetricName,
-			"Network throughput used while migrating disks in Bytes per second.",
-			prometheus.GaugeValue,
-			float64(jobInfo.DiskBps),
 		)
 	}
 }

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -396,12 +396,6 @@ var _ = Describe("Prometheus", func() {
 					MemoryBpsSet: true,
 					MemoryBps:    1,
 				}),
-			Entry("should handle DiskBps metrics for VMs",
-				MigrateVmiDiskTransferRateMetricName,
-				&stats.DomainJobInfo{
-					DiskBpsSet: true,
-					DiskBps:    1,
-				}),
 		)
 
 		It("should handle vcpu metrics", func() {

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -687,6 +687,14 @@ func GetRecordingRules(namespace string) []KubevirtRecordingRule {
 			MType:       prometheusv1.MetricTypeCounter,
 			Description: "The total number of requests to deprecated KubeVirt APIs.",
 		},
+		{
+			Rule: v1.Rule{
+				Record: "kubevirt_migrate_vmi_disk_transfer_rate_bytes",
+				Expr:   intstr.FromString("irate(kubevirt_migrate_vmi_data_processed_bytes[5m])"),
+			},
+			MType:       prometheusv1.MetricTypeGauge,
+			Description: "The rate at which the disk is being transferred.",
+		},
 	}
 }
 

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "component_monitoring.go",
+        "migration_monitoring.go",
         "monitoring.go",
         "prometheus_utils.go",
         "scaling_utils.go",
@@ -15,6 +16,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/virtctl/pause:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
         "//tests/clientcmd:go_default_library",

--- a/tests/monitoring/migration_monitoring.go
+++ b/tests/monitoring/migration_monitoring.go
@@ -1,0 +1,112 @@
+package monitoring
+
+import (
+	"context"
+	"time"
+
+	"kubevirt.io/kubevirt/tests/testsuite"
+
+	"kubevirt.io/kubevirt/tests/framework/checks"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/api/migrations/v1alpha1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libmigration"
+	"kubevirt.io/kubevirt/tests/libvmi"
+)
+
+var _ = Describe("[Serial][sig-monitoring]VM Migration Monitoring", Serial, decorators.SigMonitoring, decorators.RequiresTwoSchedulableNodes, func() {
+	var virtClient kubecli.KubevirtClient
+	var vmi *v1.VirtualMachineInstance
+
+	Context("Migration metrics", func() {
+		createVmi := func() *v1.VirtualMachineInstance {
+			By("Starting the VirtualMachineInstance")
+			opts := append(
+				libvmi.WithMasqueradeNetworking(),
+				libvmi.WithEmptyDisk("emptydisk1", v1.DiskBusUSB, resource.MustParse("2Gi")),
+			)
+
+			vmi := libvmi.NewCirros(opts...)
+			vmi.Namespace = testsuite.GetTestNamespace(nil)
+
+			return tests.RunVMIAndExpectLaunch(vmi, 240)
+		}
+
+		createMigrationPolicy := func(vmi *v1.VirtualMachineInstance, bandwidthPerMigration resource.Quantity) {
+			By("Creating a migration policy")
+			_, err := virtClient.MigrationPolicy().Create(context.TODO(), &v1alpha1.MigrationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "migration-policy-" + vmi.Name,
+				},
+				Spec: v1alpha1.MigrationPolicySpec{
+					BandwidthPerMigration: &bandwidthPerMigration,
+					Selectors: &v1alpha1.Selectors{
+						NamespaceSelector: map[string]string{
+							"kubernetes.io/metadata.name": vmi.Namespace,
+						},
+					},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		deleteMigrationPolicy := func(vmi *v1.VirtualMachineInstance) {
+			By("Deleting a migration policy")
+			err := virtClient.MigrationPolicy().Delete(context.TODO(), "migration-policy-"+vmi.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		getTransferRateMetric := func(vmi *v1.VirtualMachineInstance) float64 {
+			labels := map[string]string{
+				"name":      vmi.Name,
+				"namespace": vmi.Namespace,
+			}
+			i, err := getMetricValueWithLabels(virtClient, "kubevirt_migrate_vmi_disk_transfer_rate_bytes", labels)
+			if err != nil {
+				return -1
+			}
+			return i
+		}
+
+		BeforeEach(func() {
+			virtClient = kubevirt.Client()
+			checks.SkipIfPrometheusRuleIsNotEnabled(virtClient)
+		})
+
+		AfterEach(func() {
+			if vmi != nil {
+				deleteMigrationPolicy(vmi)
+			}
+		})
+
+		It("should show kubevirt_migrate_vmi_disk_transfer_rate_bytes", func() {
+			oneMi, err := resource.ParseQuantity("1Mi")
+			Expect(err).ToNot(HaveOccurred())
+
+			vmi = createVmi()
+			createMigrationPolicy(vmi, oneMi)
+
+			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+			migration = libmigration.RunMigration(virtClient, migration)
+
+			Eventually(func() float64 {
+				return getTransferRateMetric(vmi)
+			}, 2*time.Minute, 20*time.Second).ShouldNot(Equal(-1.0))
+			Eventually(func() float64 {
+				return getTransferRateMetric(vmi)
+			}, 3*time.Minute, 20*time.Second).Should(BeNumerically("~", oneMi.Value(), oneMi.Value()/10))
+
+			libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration)
+			libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+		})
+	})
+})

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -140,11 +140,6 @@ func getMetricsNotIncludeInEndpointByDefault() metricList {
 			mType:       "Gauge",
 		},
 		{
-			name:        domainstats.MigrateVmiDiskTransferRateMetricName,
-			description: "The rate at which the disk is being transferred.",
-			mType:       "Gauge",
-		},
-		{
 			name:        "kubevirt_vmi_phase_count",
 			description: "Sum of VMIs per phase and node. `phase` can be one of the following: [`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`].",
 			mType:       "Gauge",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

"This data was available with the old-style disk migration where disk
data was migrated over the migration stream.

As that was deprecated by qemu, libvirt switched to a new approach where
we migrate the disks by using NBD protocol and copying them via
'blockdev-mirror'.

Now the qemu blockjobs themselves do not report the actual bandwidth used,
just the progress. Since libvirt doesn't want to pointlessly poll this
data just to calculate bandwidth, the data is no longer available."

via https://listman.redhat.com/archives/libvir-list/2023-September/241935.html

This PR creates a transfer rate metric based on the absolute transfer progress data

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix missing migration transfer rate metric
```
