### PR TITLE
Fix flaky test in k8s-1.26-sig-storage

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1273,15 +1273,11 @@ var _ = SIGDescribe("Storage", func() {
 			)
 
 			It("should run the VMI created with a DataVolume source and use the LUN disk", func() {
-				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
-				if !foundSC {
-					Skip("Unable to find valid storage class")
-				}
-				pv, err = tests.CreatePVwithSCSIDisk(sc, "scsipv", nodeName, device)
+				pv, err = tests.CreatePVwithSCSIDisk("scsi-disks", "scsipv", nodeName, device)
 				Expect(err).ToNot(HaveOccurred())
 				dv := libdv.NewDataVolume(
 					libdv.WithBlankImageSource(),
-					libdv.WithPVC(libdv.PVCWithStorageClass(sc),
+					libdv.WithPVC(libdv.PVCWithStorageClass(pv.Spec.StorageClassName),
 						libdv.PVCWithBlockVolumeMode(),
 						libdv.PVCWithAccessMode(k8sv1.ReadWriteOnce),
 						libdv.PVCWithVolumeSize("8Mi"),
@@ -1302,15 +1298,28 @@ var _ = SIGDescribe("Storage", func() {
 				)
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
-				By(fmt.Sprintf("Checking that %s has a capacity of 8Mi", device))
+				lunDisk := "/dev/"
+				Eventually(func() bool {
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for _, volStatus := range vmi.Status.VolumeStatus {
+						if volStatus.Name == "lun0" {
+							lunDisk += volStatus.Target
+							return true
+						}
+					}
+					return false
+				}, 30*time.Second, time.Second).Should(BeTrue())
+
+				By(fmt.Sprintf("Checking that %s has a capacity of 8Mi", lunDisk))
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("sudo blockdev --getsize64 %s\n", device)},
+					&expect.BSnd{S: fmt.Sprintf("sudo blockdev --getsize64 %s\n", lunDisk)},
 					&expect.BExp{R: "8388608"}, // 8Mi in bytes
 				}, 30)).To(Succeed())
 
-				By(fmt.Sprintf("Checking if we can write to %s", device))
+				By(fmt.Sprintf("Checking if we can write to %s", lunDisk))
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 -F %s\n", device)},
+					&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 -F %s\n", lunDisk)},
 					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: tests.EchoLastReturnValue},
 					&expect.BExp{R: console.RetValue("0")},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This pull request aims to fix a test that's been consistently failing on k8s-1.26-sig-storage during these last days, as tested in https://github.com/kubevirt/kubevirt/pull/10449.

Introduces two fixes:
- Uses a fake storage class to force static provisioning. Using an existing SC was flaky behavior.
- Builds the name of the VM device with more precision, instead of relying on the disk name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
