### PR TITLE
vendor: Update libvirt.org/go/libvirt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	kubevirt.io/containerized-data-importer-api v1.57.0-alpha1
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 	kubevirt.io/qe-tools v0.1.8
-	libvirt.org/go/libvirt v1.9000.0
+	libvirt.org/go/libvirt v1.9004.0
 	mvdan.cc/sh/v3 v3.1.1
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1978,8 +1978,8 @@ kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 kubevirt.io/qe-tools v0.1.8 h1:Ar7qicmzHdd+Ia+6rjHDg3D7GReIyq7QFXoC4F7TjhQ=
 kubevirt.io/qe-tools v0.1.8/go.mod h1:+Tr/WZGHIDQa/4pQgzM7+4J6YeVbUWAXESXtL2/zxqc=
-libvirt.org/go/libvirt v1.9000.0 h1:u95YEBuk85v2GO6+M3qv+WdAu2JKQSMWhCJ4R+kNDQo=
-libvirt.org/go/libvirt v1.9000.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
+libvirt.org/go/libvirt v1.9004.0 h1:u+CHhs2OhVmu0MWzBDrlbLzQ5QB3ZfWtfT+lD3EaUIs=
+libvirt.org/go/libvirt v1.9004.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
 mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157 h1:VBYz8greWWP8BDpRX0v7SDv/8rNlZVmdHdO4ZSsHj/E=
 mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157/go.mod h1:Ge4atmRUYqueGppvJ7JNrtqpqokoJEFxYbP0Z+WeKS8=
 mvdan.cc/sh/v3 v3.1.1 h1:niuYC5Ug0KzLuN6CNX3ru37v4MkVD5Wm9T4Mk2eJr9A=

--- a/vendor/libvirt.org/go/libvirt/.gitlab-ci.yml
+++ b/vendor/libvirt.org/go/libvirt/.gitlab-ci.yml
@@ -115,11 +115,6 @@ api_coverage_local_env:
     # upstream+forks: that's all folks
     - when: never
 
-# an old version without modules
-go_1_9:
-  <<: *go_build
-  image: golang:1.9
-
 # first version declared in go.mod
 go_1_11:
   <<: *go_build
@@ -131,6 +126,6 @@ go_1_16:
   image: golang:1.16
 
 # a quite new version
-go_1_19:
+go_1_20:
   <<: *go_build
-  image: golang:1.19
+  image: golang:1.20

--- a/vendor/libvirt.org/go/libvirt/README.rst
+++ b/vendor/libvirt.org/go/libvirt/README.rst
@@ -26,6 +26,8 @@ and libvirt-lxc.so. Coverage for the latter two libraries can be dropped
 from the build using build tags 'libvirt_without_qemu' or 'libvirt_without_lxc'
 respectively.
 
+The library expects to be used with Go >= 1.11 with Go modules active.
+Older versions are no longer tested, nor is usage without Go modules.
 
 Development status
 ==================

--- a/vendor/libvirt.org/go/libvirt/domain.go
+++ b/vendor/libvirt.org/go/libvirt/domain.go
@@ -292,6 +292,7 @@ const (
 	DOMAIN_PAUSED_STARTING_UP     = DomainPausedReason(C.VIR_DOMAIN_PAUSED_STARTING_UP)     /* the domainis being started */
 	DOMAIN_PAUSED_POSTCOPY        = DomainPausedReason(C.VIR_DOMAIN_PAUSED_POSTCOPY)        /* paused for post-copy migration */
 	DOMAIN_PAUSED_POSTCOPY_FAILED = DomainPausedReason(C.VIR_DOMAIN_PAUSED_POSTCOPY_FAILED) /* paused after failed post-copy */
+	DOMAIN_PAUSED_API_ERROR       = DomainPausedReason(C.VIR_DOMAIN_PAUSED_API_ERROR)       /* Some APIs (e.g., migration, snapshot) internally need to suspend a domain. This paused state reason is used when resume operation at the end of such API fails.*/
 )
 
 type DomainXMLFlags uint
@@ -2478,6 +2479,10 @@ type DomainMigrateParameters struct {
 	TLSDestination            string
 	DisksURISet               bool
 	DisksURI                  string
+	CompressionZlibLevelSet   bool
+	CompressionZlibLevel      int
+	CompressionZstdLevelSet   bool
+	CompressionZstdLevel      int
 }
 
 func getMigrateParameterFieldInfo(params *DomainMigrateParameters) map[string]typedParamsFieldInfo {
@@ -2561,6 +2566,14 @@ func getMigrateParameterFieldInfo(params *DomainMigrateParameters) map[string]ty
 		C.VIR_MIGRATE_PARAM_DISKS_URI: typedParamsFieldInfo{
 			set: &params.DisksURISet,
 			s:   &params.DisksURI,
+		},
+		C.VIR_MIGRATE_PARAM_COMPRESSION_ZLIB_LEVEL: typedParamsFieldInfo{
+			set: &params.CompressionZlibLevelSet,
+			i:   &params.CompressionZlibLevel,
+		},
+		C.VIR_MIGRATE_PARAM_COMPRESSION_ZSTD_LEVEL: typedParamsFieldInfo{
+			set: &params.CompressionZstdLevelSet,
+			i:   &params.CompressionZstdLevel,
 		},
 	}
 }

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_enums.h
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_enums.h
@@ -1648,8 +1648,11 @@
 #  if !LIBVIR_CHECK_VERSION(1, 3, 3)
 #    define VIR_DOMAIN_PAUSED_POSTCOPY_FAILED 13
 #  endif
+#  if !LIBVIR_CHECK_VERSION(9, 2, 0)
+#    define VIR_DOMAIN_PAUSED_API_ERROR 14
+#  endif
 #  if !LIBVIR_CHECK_VERSION(0, 9, 10)
-#    define VIR_DOMAIN_PAUSED_LAST 14
+#    define VIR_DOMAIN_PAUSED_LAST 15
 #  endif
 
 /* enum virDomainProcessSignal */

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_macros.h
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_macros.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #if !LIBVIR_CHECK_VERSION(0, 0, 1)
-#  define LIBVIR_VERSION_NUMBER 9000000
+#  define LIBVIR_VERSION_NUMBER 9004000
 #endif
 
 #if !LIBVIR_CHECK_VERSION(5, 8, 0)
@@ -738,6 +738,14 @@
 
 #if !LIBVIR_CHECK_VERSION(1, 3, 4)
 #  define VIR_MIGRATE_PARAM_COMPRESSION_XBZRLE_CACHE "compression.xbzrle.cache"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(9, 4, 0)
+#  define VIR_MIGRATE_PARAM_COMPRESSION_ZLIB_LEVEL "compression.zlib.level"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(9, 4, 0)
+#  define VIR_MIGRATE_PARAM_COMPRESSION_ZSTD_LEVEL "compression.zstd.level"
 #endif
 
 #if !LIBVIR_CHECK_VERSION(1, 1, 0)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1226,7 +1226,7 @@ kubevirt.io/controller-lifecycle-operator-sdk/api
 ## explicit; go 1.16
 kubevirt.io/qe-tools/pkg/ginkgo-reporters
 kubevirt.io/qe-tools/pkg/polarion-xml
-# libvirt.org/go/libvirt v1.9000.0
+# libvirt.org/go/libvirt v1.9004.0
 ## explicit; go 1.11
 libvirt.org/go/libvirt
 # mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the libvirt Go bindings to match the C library, which was recently updated as part of https://github.com/kubevirt/kubevirt/pull/10050

**Release note**:

```release-note
NONE
```