### PR TITLE
virt-launcher: fix enabled cpu num

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1243,13 +1243,16 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	if vmiCPU != nil && vmiCPU.MaxSockets != 0 {
 		// Always allow to hotplug to minimum of 1 socket
 		minEnabledCpuCount := cpuTopology.Cores * cpuTopology.Threads
+		// Total vCPU count
 		enabledCpuCount := cpuCount
 		cpuTopology.Sockets = vmiCPU.MaxSockets
 		cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
 		VCPUs := &api.VCPUs{}
 		for id := uint32(0); id < cpuCount; id++ {
+			// Enable all requestd vCPUs
 			isEnabled := id < enabledCpuCount
-			isHotpluggable := id > minEnabledCpuCount
+			// There should not be fewer vCPU than cores and threads within a single socket
+			isHotpluggable := id >= minEnabledCpuCount
 			vcpu := api.VCPUsVCPU{
 				ID:           uint32(id),
 				Enabled:      boolToYesNo(&isEnabled, true),

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1242,13 +1242,14 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	vmiCPU := vmi.Spec.Domain.CPU
 	if vmiCPU != nil && vmiCPU.MaxSockets != 0 {
 		// Always allow to hotplug to minimum of 1 socket
+		minEnabledCpuCount := cpuTopology.Cores * cpuTopology.Threads
 		enabledCpuCount := cpuCount
 		cpuTopology.Sockets = vmiCPU.MaxSockets
 		cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
 		VCPUs := &api.VCPUs{}
 		for id := uint32(0); id < cpuCount; id++ {
 			isEnabled := id < enabledCpuCount
-			isHotpluggable := !isEnabled
+			isHotpluggable := id > minEnabledCpuCount
 			vcpu := api.VCPUsVCPU{
 				ID:           uint32(id),
 				Enabled:      boolToYesNo(&isEnabled, true),

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1242,7 +1242,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	vmiCPU := vmi.Spec.Domain.CPU
 	if vmiCPU != nil && vmiCPU.MaxSockets != 0 {
 		// Always allow to hotplug to minimum of 1 socket
-		enabledCpuCount := cpuTopology.Cores * cpuTopology.Threads
+		enabledCpuCount := cpuCount
 		cpuTopology.Sockets = vmiCPU.MaxSockets
 		cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
 		VCPUs := &api.VCPUs{}

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -828,20 +828,29 @@ var _ = Describe("Converter", func() {
 			It("should define hotplugable default topology", func() {
 				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 				vmi.Spec.Domain.CPU = &v1.CPU{
-					MaxSockets: 4,
+					Cores:      2,
+					MaxSockets: 3,
 					Sockets:    2,
 				}
 				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
-				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
-				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(4)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(2)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(3)), "Expect sockets")
 				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
-				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(4)), "Expect vcpus")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(6)), "Expect vcpus")
 				Expect(domainSpec.VCPUs).ToNot(BeNil(), "Expecting topology for hotplug")
-				Expect(domainSpec.VCPUs.VCPU).To(HaveLen(4), "Expecting topology for hotplug")
-				Expect(domainSpec.VCPUs.VCPU[0].Hotpluggable).To(Equal("no"), "Expecting 1st socket to be stable")
-				Expect(domainSpec.VCPUs.VCPU[1].Hotpluggable).To(Equal("no"), "Expecting 2nd socket to be stable")
-				Expect(domainSpec.VCPUs.VCPU[2].Hotpluggable).To(Equal("yes"), "Expecting the 3rd socket to be Hotpluggable")
-				Expect(domainSpec.VCPUs.VCPU[3].Hotpluggable).To(Equal("yes"), "Expecting the 4th socket to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU).To(HaveLen(6), "Expecting topology for hotplug")
+				Expect(domainSpec.VCPUs.VCPU[0].Hotpluggable).To(Equal("no"), "Expecting the 1st vcpu to be stable")
+				Expect(domainSpec.VCPUs.VCPU[1].Hotpluggable).To(Equal("no"), "Expecting the 2nd vcpu to be stable")
+				Expect(domainSpec.VCPUs.VCPU[2].Hotpluggable).To(Equal("yes"), "Expecting the 3rd vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[3].Hotpluggable).To(Equal("yes"), "Expecting the 4th vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[4].Hotpluggable).To(Equal("yes"), "Expecting the 5th vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[5].Hotpluggable).To(Equal("yes"), "Expecting the 6th vcpu to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[0].Enabled).To(Equal("yes"), "Expecting the 1st vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[1].Enabled).To(Equal("yes"), "Expecting the 2nd vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[2].Enabled).To(Equal("yes"), "Expecting the 3rd vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[3].Enabled).To(Equal("yes"), "Expecting the 4th vcpu to be enabled")
+				Expect(domainSpec.VCPUs.VCPU[4].Enabled).To(Equal("no"), "Expecting the 5th vcpu to be disabled")
+				Expect(domainSpec.VCPUs.VCPU[5].Enabled).To(Equal("no"), "Expecting the 6th vcpu to be disabled")
 			})
 
 			DescribeTable("should convert CPU model", func(model string) {

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -839,7 +839,7 @@ var _ = Describe("Converter", func() {
 				Expect(domainSpec.VCPUs).ToNot(BeNil(), "Expecting topology for hotplug")
 				Expect(domainSpec.VCPUs.VCPU).To(HaveLen(4), "Expecting topology for hotplug")
 				Expect(domainSpec.VCPUs.VCPU[0].Hotpluggable).To(Equal("no"), "Expecting 1st socket to be stable")
-				Expect(domainSpec.VCPUs.VCPU[1].Hotpluggable).To(Equal("yes"), "Expecting the 2nd socket to be Hotpluggable")
+				Expect(domainSpec.VCPUs.VCPU[1].Hotpluggable).To(Equal("no"), "Expecting 2nd socket to be stable")
 				Expect(domainSpec.VCPUs.VCPU[2].Hotpluggable).To(Equal("yes"), "Expecting the 3rd socket to be Hotpluggable")
 				Expect(domainSpec.VCPUs.VCPU[3].Hotpluggable).To(Equal("yes"), "Expecting the 4th socket to be Hotpluggable")
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When creating a VM with `liveFeatureUpdate: { cpu: {} }`, the enabled vCpu calculation is incorrect because the number of sockets, which can be more than 1 when creating a VM, is not taken into count.

**Which issue(s) this PR fixes**  #
Fixes #10462

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
