### PR TITLE
pod template, network: use network-selection-elements structs

### DIFF
--- a/pkg/virt-controller/services/multus_annotations.go
+++ b/pkg/virt-controller/services/multus_annotations.go
@@ -34,18 +34,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-type multusNetworkAnnotation struct {
-	InterfaceName string `json:"interface"`
-	Mac           string `json:"mac,omitempty"`
-	NetworkName   string `json:"name"`
-	Namespace     string `json:"namespace"`
-}
-
 type multusNetworkAnnotationPool struct {
-	pool []multusNetworkAnnotation
+	pool []networkv1.NetworkSelectionElement
 }
 
-func (mnap *multusNetworkAnnotationPool) add(multusNetworkAnnotation multusNetworkAnnotation) {
+func (mnap *multusNetworkAnnotationPool) add(multusNetworkAnnotation networkv1.NetworkSelectionElement) {
 	mnap.pool = append(mnap.pool, multusNetworkAnnotation)
 }
 
@@ -82,18 +75,18 @@ func GenerateMultusCNIAnnotationFromNameScheme(namespace string, interfaces []v1
 	return "", nil
 }
 
-func newMultusAnnotationData(namespace string, interfaces []v1.Interface, network v1.Network, podInterfaceName string) multusNetworkAnnotation {
+func newMultusAnnotationData(namespace string, interfaces []v1.Interface, network v1.Network, podInterfaceName string) networkv1.NetworkSelectionElement {
 	multusIface := vmispec.LookupInterfaceByName(interfaces, network.Name)
 	namespace, networkName := getNamespaceAndNetworkName(namespace, network.Multus.NetworkName)
 	var multusIfaceMac string
 	if multusIface != nil {
 		multusIfaceMac = multusIface.MacAddress
 	}
-	return multusNetworkAnnotation{
-		InterfaceName: podInterfaceName,
-		Mac:           multusIfaceMac,
-		Namespace:     namespace,
-		NetworkName:   networkName,
+	return networkv1.NetworkSelectionElement{
+		InterfaceRequest: podInterfaceName,
+		MacRequest:       multusIfaceMac,
+		Namespace:        namespace,
+		Name:             networkName,
 	}
 }
 

--- a/pkg/virt-controller/services/multus_annotations_test.go
+++ b/pkg/virt-controller/services/multus_annotations_test.go
@@ -25,6 +25,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
 	v1 "kubevirt.io/api/core/v1"
 )
 
@@ -69,7 +71,7 @@ var _ = Describe("Multus annotations", func() {
 	Context("a multus annotation pool with elements", func() {
 		BeforeEach(func() {
 			multusAnnotationPool = multusNetworkAnnotationPool{
-				pool: []multusNetworkAnnotation{
+				pool: []networkv1.NetworkSelectionElement{
 					newMultusAnnotationData(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, network, "net1"),
 				},
 			}
@@ -80,7 +82,7 @@ var _ = Describe("Multus annotations", func() {
 		})
 
 		It("generates a json serialized string representing the annotation", func() {
-			expectedString := `[{"interface":"net1","name":"test1","namespace":"namespace1"}]`
+			expectedString := `[{"name":"test1","namespace":"namespace1","interface":"net1"}]`
 			Expect(multusAnnotationPool.toString()).To(BeIdenticalTo(expectedString))
 		})
 	})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -984,11 +984,11 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
-				expectedIfaces := ("[" +
-					"{\"interface\":\"pod37a8eec1ce1\",\"name\":\"default\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"pod1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"pod49dba5c72f0\",\"name\":\"test1\",\"namespace\":\"other-namespace\"}" +
-					"]")
+				expectedIfaces := "[" +
+					"{\"name\":\"default\",\"namespace\":\"default\",\"interface\":\"pod37a8eec1ce1\"}," +
+					"{\"name\":\"test1\",\"namespace\":\"default\",\"interface\":\"pod1b4f0e98519\"}," +
+					"{\"name\":\"test1\",\"namespace\":\"other-namespace\",\"interface\":\"pod49dba5c72f0\"}" +
+					"]"
 				Expect(value).To(Equal(expectedIfaces))
 			})
 			It("should add default multus networks in the multus default-network annotation", func() {
@@ -1026,7 +1026,7 @@ var _ = Describe("Template", func() {
 				Expect(value).To(Equal("default"))
 				value, ok = pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
-				Expect(value).To(Equal("[{\"interface\":\"pod1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"}]"))
+				Expect(value).To(Equal("[{\"name\":\"test1\",\"namespace\":\"default\",\"interface\":\"pod1b4f0e98519\"}]"))
 			})
 			It("should add MAC address in the pod annotation", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1069,10 +1069,10 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
-				expectedIfaces := ("[" +
-					"{\"interface\":\"pod37a8eec1ce1\",\"name\":\"default\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"pod1b4f0e98519\",\"mac\":\"de:ad:00:00:be:af\",\"name\":\"test1\",\"namespace\":\"default\"}" +
-					"]")
+				expectedIfaces := "[" +
+					"{\"name\":\"default\",\"namespace\":\"default\",\"interface\":\"pod37a8eec1ce1\"}," +
+					"{\"name\":\"test1\",\"namespace\":\"default\",\"mac\":\"de:ad:00:00:be:af\",\"interface\":\"pod1b4f0e98519\"}" +
+					"]"
 				Expect(value).To(Equal(expectedIfaces))
 			})
 			DescribeTable("should add Multus networks annotation to the migration target pod with interface name scheme similar to the migration source pod",

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3247,7 +3247,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
-						`[{"interface":"pod7e0055a6880","name":"net1","namespace":"default"}]`)),
+						`[{"name":"net1","namespace":"default","interface":"pod7e0055a6880"}]`)),
 				Entry("multiple interfaces",
 					[]v1.Network{{
 						Name:          "iface1",
@@ -3265,7 +3265,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
-						`[{"interface":"pod7e0055a6880","mac":"mac1","name":"net1","namespace":"default"},{"interface":"pod48802102d24","mac":"mac2","name":"net1","namespace":"default"}]`)),
+						`[{"name":"net1","namespace":"default","mac":"mac1","interface":"pod7e0055a6880"},{"name":"net1","namespace":"default","mac":"mac2","interface":"pod48802102d24"}]`)),
 			)
 			DescribeTable("the subject interface name, in the pod networks annotation, should be in similar form as other interfaces",
 				func(testPodNetworkStatus []networkv1.NetworkStatus, expectedMultusNetworksAnnotation string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When templating the launcher pod, use network selection elements struct (from the k8snetworkplumbingwg) instead of a locally defined struct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
