### PR TITLE
Rename VMI migration metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -21,21 +21,6 @@ The total number of requests to deprecated KubeVirt APIs. Type: Counter.
 ### kubevirt_configuration_emulation_enabled
 Indicates whether the Software Emulation is enabled in the configuration. Type: Gauge.
 
-### kubevirt_migrate_vmi_data_processed_bytes
-The total Guest OS data processed and migrated to the new VM. Type: Gauge.
-
-### kubevirt_migrate_vmi_data_remaining_bytes
-The remaining guest OS data to be migrated to the new VM. Type: Gauge.
-
-### kubevirt_migrate_vmi_dirty_memory_rate_bytes
-The rate of memory being dirty in the Guest OS. Type: Gauge.
-
-### kubevirt_migrate_vmi_disk_transfer_rate_bytes
-The rate at which the disk is being transferred. Type: Gauge.
-
-### kubevirt_migrate_vmi_memory_transfer_rate_bytes
-The rate at which the memory is being transferred. Type: Gauge.
-
 ### kubevirt_nodes_with_kvm
 The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. Type: Gauge.
 
@@ -147,23 +132,38 @@ The amount of memory which can be reclaimed by balloon without pushing the guest
 ### kubevirt_vmi_memory_used_bytes
 Amount of `used` memory as seen by the domain. Type: Gauge.
 
+### kubevirt_vmi_migration_data_processed_bytes
+The total Guest OS data processed and migrated to the new VM. Type: Gauge.
+
+### kubevirt_vmi_migration_data_remaining_bytes
+The remaining guest OS data to be migrated to the new VM. Type: Gauge.
+
+### kubevirt_vmi_migration_dirty_memory_rate_bytes
+The rate of memory being dirty in the Guest OS. Type: Gauge.
+
+### kubevirt_vmi_migration_disk_transfer_rate_bytes
+The rate at which the memory is being transferred. Type: Gauge.
+
+### kubevirt_vmi_migration_failed
+Indicates if the VMI migration failed. Type: Gauge.
+
+### kubevirt_vmi_migration_memory_transfer_rate_bytes
+The rate at which the disk is being transferred. Type: Gauge.
+
 ### kubevirt_vmi_migration_phase_transition_time_from_creation_seconds
 Histogram of VM migration phase transitions duration from creation time in seconds. Type: Histogram.
 
-### kubevirt_vmi_migrations_failed
-Number of failed migrations. Type: Gauge.
+### kubevirt_vmi_migration_succeeded
+Indicates if the VMI migration succeeded. Type: Gauge.
 
-### kubevirt_vmi_migrations_pending
+### kubevirt_vmi_migrations_in_pending_phase
 Number of current pending migrations. Type: Gauge.
 
-### kubevirt_vmi_migrations_running
+### kubevirt_vmi_migrations_in_running_phase
 Number of current running migrations. Type: Gauge.
 
-### kubevirt_vmi_migrations_scheduling
+### kubevirt_vmi_migrations_in_scheduling_phase
 Number of current scheduling migrations. Type: Gauge.
-
-### kubevirt_vmi_migrations_succeeded
-Number of migrations successfully executed. Type: Gauge.
 
 ### kubevirt_vmi_network_receive_bytes_total
 Total network traffic received in bytes. Type: Counter.

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -725,7 +725,7 @@ tests:
   # Excessive VMI Migrations in a period of time
   - interval: 1h
     input_series:
-      - series: 'kubevirt_vmi_migrations_succeeded{vmi="vmi-example-1"}'
+      - series: 'kubevirt_vmi_migration_succeeded{vmi="vmi-example-1"}'
         # time:  0 1 2 3 4 5
         values: "_ _ _ 1 7 13"
 

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -43,11 +43,11 @@ import (
 
 const (
 	PrometheusCollectionTimeout            = vms.CollectionTimeout
-	MigrateVmiDataRemainingMetricName      = "kubevirt_migrate_vmi_data_remaining_bytes"
-	MigrateVmiDataProcessedMetricName      = "kubevirt_migrate_vmi_data_processed_bytes"
-	MigrateVmiDirtyMemoryRateMetricName    = "kubevirt_migrate_vmi_dirty_memory_rate_bytes"
-	MigrateVmiMemoryTransferRateMetricName = "kubevirt_migrate_vmi_memory_transfer_rate_bytes"
-	MigrateVmiDiskTransferRateMetricName   = "kubevirt_migrate_vmi_disk_transfer_rate_bytes"
+	MigrateVmiDataRemainingMetricName      = "kubevirt_vmi_migration_data_remaining_bytes"
+	MigrateVmiDataProcessedMetricName      = "kubevirt_vmi_migration_data_processed_bytes"
+	MigrateVmiDirtyMemoryRateMetricName    = "kubevirt_vmi_migration_dirty_memory_rate_bytes"
+	MigrateVmiMemoryTransferRateMetricName = "kubevirt_vmi_migration_disk_transfer_rate_bytes"
+	MigrateVmiDiskTransferRateMetricName   = "kubevirt_vmi_migration_memory_transfer_rate_bytes"
 )
 
 var (

--- a/pkg/monitoring/migrationstats/collector.go
+++ b/pkg/monitoring/migrationstats/collector.go
@@ -28,11 +28,11 @@ import (
 )
 
 const (
-	PendingMigrations    = "kubevirt_vmi_migrations_pending"
-	SchedulingMigrations = "kubevirt_vmi_migrations_scheduling"
-	RunningMigrations    = "kubevirt_vmi_migrations_running"
-	SucceededMigrations  = "kubevirt_vmi_migrations_succeeded"
-	FailedMigrations     = "kubevirt_vmi_migrations_failed"
+	PendingMigrations    = "kubevirt_vmi_migrations_in_pending_phase"
+	SchedulingMigrations = "kubevirt_vmi_migrations_in_scheduling_phase"
+	RunningMigrations    = "kubevirt_vmi_migrations_in_running_phase"
+	SucceededMigration   = "kubevirt_vmi_migration_succeeded"
+	FailedMigration      = "kubevirt_vmi_migration_failed"
 )
 
 var (
@@ -55,15 +55,15 @@ var (
 			nil,
 			nil,
 		),
-		SucceededMigrations: prometheus.NewDesc(
-			SucceededMigrations,
-			"Number of migrations successfully executed.",
+		SucceededMigration: prometheus.NewDesc(
+			SucceededMigration,
+			"Indicates if the VMI migration succeeded.",
 			[]string{"vmi", "vmim"},
 			nil,
 		),
-		FailedMigrations: prometheus.NewDesc(
-			FailedMigrations,
-			"Number of failed migrations.",
+		FailedMigration: prometheus.NewDesc(
+			FailedMigration,
+			"Indicates if the VMI migration failed.",
 			[]string{"vmi", "vmim"},
 			nil,
 		),
@@ -125,9 +125,9 @@ func (ps *prometheusScraper) Report(vmims []*k6tv1.VirtualMachineInstanceMigrati
 		case k6tv1.MigrationRunning, k6tv1.MigrationScheduled, k6tv1.MigrationPreparingTarget, k6tv1.MigrationTargetReady:
 			runningCount++
 		case k6tv1.MigrationSucceeded:
-			ps.pushMetric(migrationMetrics[SucceededMigrations], 1, vmim.Spec.VMIName, vmim.Name)
+			ps.pushMetric(migrationMetrics[SucceededMigration], 1, vmim.Spec.VMIName, vmim.Name)
 		default:
-			ps.pushMetric(migrationMetrics[FailedMigrations], 1, vmim.Spec.VMIName, vmim.Name)
+			ps.pushMetric(migrationMetrics[FailedMigration], 1, vmim.Spec.VMIName, vmim.Name)
 		}
 	}
 

--- a/pkg/monitoring/migrationstats/collector_test.go
+++ b/pkg/monitoring/migrationstats/collector_test.go
@@ -84,11 +84,11 @@ var _ = Describe("Migration Stats Collector", func() {
 
 		Expect(containsMetric).To(BeTrue())
 	},
-		Entry("Failed migration", k6tv1.MigrationFailed, FailedMigrations),
+		Entry("Failed migration", k6tv1.MigrationFailed, FailedMigration),
 		Entry("Pending migration", k6tv1.MigrationPending, PendingMigrations),
 		Entry("Running migration", k6tv1.MigrationRunning, RunningMigrations),
 		Entry("Scheduling migration", k6tv1.MigrationScheduling, SchedulingMigrations),
-		Entry("Succeeded migration", k6tv1.MigrationSucceeded, SucceededMigrations),
+		Entry("Succeeded migration", k6tv1.MigrationSucceeded, SucceededMigration),
 	)
 
 	It("should set succeeded and pending to 1 and others to 0 with 1 successful and 1 pending", func() {

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -457,7 +457,7 @@ func NewPrometheusRuleSpec(ns string) *v1.PrometheusRuleSpec {
 		},
 		{
 			Alert: "KubeVirtVMIExcessiveMigrations",
-			Expr:  intstr.FromString("sum by (vmi) (max_over_time(kubevirt_vmi_migrations_succeeded[1d])) >= 12"),
+			Expr:  intstr.FromString("sum by (vmi) (max_over_time(kubevirt_vmi_migration_succeeded[1d])) >= 12"),
 			Annotations: map[string]string{
 				"description": "VirtualMachineInstance {{ $labels.vmi }} has been migrated more than 12 times during the last 24 hours",
 				"summary":     "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours.",

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -161,14 +161,14 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 			libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 
-			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_pending", 0)
-			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_scheduling", 0)
-			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_running", 0)
+			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_pending_phase", 0)
+			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_scheduling_phase", 0)
+			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_running_phase", 0)
 
 			labels := map[string]string{
 				"vmi": vmi.Name,
 			}
-			waitForMetricValueWithLabels(virtClient, "kubevirt_vmi_migrations_succeeded", 1, labels)
+			waitForMetricValueWithLabels(virtClient, "kubevirt_vmi_migration_succeeded", 1, labels)
 
 			By("Delete VMIs")
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
@@ -192,12 +192,12 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 			migration.Annotations = map[string]string{v1.MigrationUnschedulablePodTimeoutSecondsAnnotation: "60"}
 			migration = libmigration.RunMigration(virtClient, migration)
 
-			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_scheduling", 1)
+			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_scheduling_phase", 1)
 
 			Eventually(matcher.ThisMigration(migration), 2*time.Minute, 5*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed), "migration creation should fail")
 
-			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_scheduling", 0)
-			waitForMetricValueWithLabels(virtClient, "kubevirt_vmi_migrations_failed", 1, labels)
+			waitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_scheduling_phase", 0)
+			waitForMetricValueWithLabels(virtClient, "kubevirt_vmi_migration_failed", 1, labels)
 
 			By("Deleting the VMI")
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
VMI Migration metrics names are inconsistent. Some of them have a `kubevirt_vmi_` prefix (as expected), and some `kubevirt_migrate` prefix. In addition, some of the migration metrics names don't represent properly what the metrics do. For example, `kubevirt_vmi_migrations_succeeded` metric is actually a boolean metric per VMI and migration, and thus this PR changes its name to `kubevirt_vmi_migration_succeeded` (same issue with `kubevirt_vmi_migrations_failed` metric). 

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/CNV-33042, https://bugzilla.redhat.com/show_bug.cgi?id=2239648

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecation notice for the metrics listed in the PR. Please update your systems to use the new metrics names.
|kubevirt_migrate_vmi_data_processed_bytes | kubevirt_vmi_migration_data_processed_bytes|
|kubevirt_migrate_vmi_data_remaining_bytes | kubevirt_vmi_migration_data_remaining_bytes|
|kubevirt_migrate_vmi_dirty_memory_rate_bytes | kubevirt_vmi_migration_dirty_memory_rate_bytes|
|kubevirt_migrate_vmi_disk_transfer_rate_bytes | kubevirt_vmi_migration_disk_transfer_rate_bytes|
|kubevirt_migrate_vmi_memory_transfer_rate_bytes | kubevirt_vmi_migration_memory_transfer_rate_bytes|
|kubevirt_vmi_migrations_failed | kubevirt_vmi_migration_failed|
|kubevirt_vmi_migrations_succeeded | kubevirt_vmi_migration_succeeded|
|kubevirt_vmi_migrations_pending | kubevirt_vmi_migrations_in_pending_phase|
|kubevirt_vmi_migrations_running | kubevirt_vmi_migrations_in_running_phase|
|kubevirt_vmi_migrations_scheduling | kubevirt_vmi_migrations_in_scheduling_phase|


```
