### PR TITLE
e2e: Introduce QUARANTINE label

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -195,7 +195,7 @@ export KUBEVIRT_DEPLOY_PROMETHEUS=true
 
 export KUBEVIRT_PROVIDER="${TEST_LANE}"
 
-ginko_params="$ginko_params -no-color -succinct -skip=QUARANTINE -randomize-all"
+ginko_params="$ginko_params -no-color -succinct --label-filter=!QUARANTINE -randomize-all"
 for test_file in $(echo "${NEW_TESTS}" | tr '|' '\n'); do
     ginko_params+=" -focus-file=${test_file}"
 done

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -450,11 +450,7 @@ fi
 # If KUBEVIRT_QUARANTINE is not set, do not run quarantined tests. When it is
 # set the whole suite (quarantined and stable) will be run.
 if [ -z "$KUBEVIRT_QUARANTINE" ]; then
-    if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
-        export KUBEVIRT_E2E_SKIP="${KUBEVIRT_E2E_SKIP}|QUARANTINE"
-    else
-        export KUBEVIRT_E2E_SKIP="QUARANTINE"
-    fi
+  add_to_label_filter '(!QUARANTINE)' '&&'
 fi
 
 # Prepare RHEL PV for Template testing

--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -55,9 +55,10 @@ A test must be put in quarantine when any of these conditions is met:
 
 A PR will be proposed on Mondays every two weeks with a batch of the tests that
 met the first condition. A PR can be proposed at any time for the tests that meet
-the second condition. In both cases the PR will add the text `[QUARANTINE]` to
-each test's description in the code. An email will be sent to the owners of the
-suspected tests.
+the second condition. In both cases the PR will add the text `[QUARANTINE]` and
+the `decorators.Quarantine` [labelDecorator](https://github.com/kubevirt/kubevirt/blob/9a3799f7a0b97b70033e119c0b401778c51dee14/tests/decorators/decorators.go#L5)
+to each test's description in the code.
+An email will be sent to the owners of the suspected tests.
 
 After the PR with the quarantine candidates is proposed there is a grace period
 of 2 days to prepare and land a fix for a test in the batch. If at least 5
@@ -66,7 +67,8 @@ consecutive executions with the fix pass the test can be removed from the batch.
 #### Quarantined test owners
 
 Each quarantined test must have a team owner. The PR will add the text
-`[sig-{compute,network,storage,operator}]` to each test's description.
+`[sig-{compute,network,storage,operator}]` to each test's description and
+the proper label decorator.
 
 #### Quarantining release blockers
 
@@ -92,9 +94,9 @@ indicated by the team assigned to bring the test back to the stable suite.
 
 After two weeks with successful executions has passed, a quarantined tests will
 be ready to join the stable suite again. A member of the team assigned to each
-quarantined tests will propose a PR to remove the text `[QUARANTINE]` from the
-test description in the code. After merging this PR the test will be out of
-quarantine.
+quarantined tests will propose a PR to remove the text `[QUARANTINE]` and the
+label decorator from the test description in the code.
+After merging this PR the test will be out of quarantine.
 
 [1]: https://martinfowler.com/articles/nonDeterminism.html#Quarantine
 [2]: https://www.thoughtworks.com/en-us/insights/blog/no-more-flaky-tests-go-team

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -3,6 +3,9 @@ package decorators
 import . "github.com/onsi/ginkgo/v2"
 
 var (
+	//
+	Quarantine = []interface{}{Label("QUARANTINE")}
+
 	// SIGs
 	SigCompute           = []interface{}{Label("sig-compute")}
 	SigOperator          = []interface{}{Label("sig-operator")}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2428,7 +2428,7 @@ spec:
 			}
 		})
 
-		It("[test_id:3153][QUARANTINE] Ensure infra can handle dynamically detecting DataVolume Support", func() {
+		It("[test_id:3153][QUARANTINE] Ensure infra can handle dynamically detecting DataVolume Support", decorators.Quarantine, func() {
 			if !libstorage.HasDataVolumeCRD() {
 				Skip("Can't test DataVolume support when DataVolume CRD isn't present")
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In https://github.com/kubevirt/kubevirt/pull/8881 we switch using label based filtering instead of
name based filtering.
We introduced several labels and adjusted the script to consume them.

The Quarantine process is still using name based filtering, and we want to align the two behaviors.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @brianmcarey @dhiller