### PR TITLE
[release-1.0] Set memory limits if there is a resource quota with limits

### DIFF
--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -116,6 +116,8 @@ var _ = Describe("Export controller", func() {
 		preferenceInformer          cache.SharedIndexInformer
 		clusterPreferenceInformer   cache.SharedIndexInformer
 		controllerRevisionInformer  cache.SharedIndexInformer
+		rqInformer                  cache.SharedIndexInformer
+		nsInformer                  cache.SharedIndexInformer
 		k8sClient                   *k8sfake.Clientset
 		virtClient                  *kubecli.MockKubevirtClient
 		vmExportClient              *kubevirtfake.Clientset
@@ -148,6 +150,8 @@ var _ = Describe("Export controller", func() {
 		go preferenceInformer.Run(stop)
 		go clusterPreferenceInformer.Run(stop)
 		go controllerRevisionInformer.Run(stop)
+		go rqInformer.Run(stop)
+		go nsInformer.Run(stop)
 		Expect(cache.WaitForCacheSync(
 			stop,
 			vmExportInformer.HasSynced,
@@ -168,6 +172,8 @@ var _ = Describe("Export controller", func() {
 			preferenceInformer.HasSynced,
 			clusterPreferenceInformer.HasSynced,
 			controllerRevisionInformer.HasSynced,
+			rqInformer.HasSynced,
+			nsInformer.HasSynced,
 		)).To(BeTrue())
 	}
 
@@ -203,6 +209,8 @@ var _ = Describe("Export controller", func() {
 		preferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})
 		clusterPreferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
 		controllerRevisionInformer, _ = testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
+		rqInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
+		nsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
 			volumeSnapshots: []*vsv1.VolumeSnapshot{},
 		}
@@ -226,7 +234,7 @@ var _ = Describe("Export controller", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/pvc-source_test.go
+++ b/pkg/storage/export/export/pvc-source_test.go
@@ -86,6 +86,8 @@ var _ = Describe("PVC source", func() {
 		preferenceInformer          cache.SharedIndexInformer
 		clusterPreferenceInformer   cache.SharedIndexInformer
 		controllerRevisionInformer  cache.SharedIndexInformer
+		rqInformer                  cache.SharedIndexInformer
+		nsInformer                  cache.SharedIndexInformer
 		k8sClient                   *k8sfake.Clientset
 		vmExportClient              *kubevirtfake.Clientset
 		fakeVolumeSnapshotProvider  *MockVolumeSnapshotProvider
@@ -128,6 +130,8 @@ var _ = Describe("PVC source", func() {
 		preferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})
 		clusterPreferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
 		controllerRevisionInformer, _ = testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
+		rqInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
+		nsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
 			volumeSnapshots: []*vsv1.VolumeSnapshot{},
 		}
@@ -151,7 +155,7 @@ var _ = Describe("PVC source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -84,6 +84,8 @@ var _ = Describe("PVC source", func() {
 		preferenceInformer          cache.SharedIndexInformer
 		clusterPreferenceInformer   cache.SharedIndexInformer
 		controllerRevisionInformer  cache.SharedIndexInformer
+		rqInformer                  cache.SharedIndexInformer
+		nsInformer                  cache.SharedIndexInformer
 		k8sClient                   *k8sfake.Clientset
 		vmExportClient              *kubevirtfake.Clientset
 		fakeVolumeSnapshotProvider  *MockVolumeSnapshotProvider
@@ -126,6 +128,8 @@ var _ = Describe("PVC source", func() {
 		preferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})
 		clusterPreferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
 		controllerRevisionInformer, _ = testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
+		rqInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
+		nsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
 			volumeSnapshots: []*vsv1.VolumeSnapshot{},
 		}
@@ -149,7 +153,7 @@ var _ = Describe("PVC source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -88,6 +88,8 @@ var _ = Describe("VMSnapshot source", func() {
 		preferenceInformer          cache.SharedIndexInformer
 		clusterPreferenceInformer   cache.SharedIndexInformer
 		controllerRevisionInformer  cache.SharedIndexInformer
+		rqInformer                  cache.SharedIndexInformer
+		nsInformer                  cache.SharedIndexInformer
 		k8sClient                   *k8sfake.Clientset
 		vmExportClient              *kubevirtfake.Clientset
 		fakeVolumeSnapshotProvider  *MockVolumeSnapshotProvider
@@ -130,6 +132,8 @@ var _ = Describe("VMSnapshot source", func() {
 		preferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})
 		clusterPreferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
 		controllerRevisionInformer, _ = testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
+		rqInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
+		nsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
 			volumeSnapshots: []*vsv1.VolumeSnapshot{},
 		}
@@ -153,7 +157,7 @@ var _ = Describe("VMSnapshot source", func() {
 			ServiceInformer:             serviceInformer,
 			DataVolumeInformer:          dvInformer,
 			KubevirtNamespace:           "kubevirt",
-			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			TemplateService:             services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", rqInformer.GetStore(), nsInformer.GetStore()),
 			caCertManager:               bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
 			RouteCache:                  routeCache,
 			IngressCache:                ingressCache,

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -70,6 +70,8 @@ const (
 	Multiarchitecture = "MultiArchitecture"
 	// VMLiveUpdateFeaturesGate allows updating ceratin VM fields, such as CPU sockets to enable hot-plug functionality.
 	VMLiveUpdateFeaturesGate = "VMLiveUpdateFeatures"
+	// AutoResourceLimitsGate enables automatic setting of vmi limits if there is a ResourceQuota with limits associated with the vmi namespace.
+	AutoResourceLimitsGate = "AutoResourceLimitsGate"
 )
 
 var deprecatedFeatureGates = [...]string{
@@ -229,4 +231,8 @@ func (config *ClusterConfig) MultiArchitectureEnabled() bool {
 }
 func (config *ClusterConfig) VMLiveUpdateFeaturesEnabled() bool {
 	return config.isFeatureGateEnabled(VMLiveUpdateFeaturesGate)
+}
+
+func (config *ClusterConfig) AutoResourceLimitsEnabled() bool {
+	return config.isFeatureGateEnabled(AutoResourceLimitsGate)
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -72,6 +72,8 @@ var _ = Describe("Template", func() {
 	var config *virtconfig.ClusterConfig
 	var kvInformer cache.SharedIndexInformer
 	var nonRootUser int64
+	resourceQuotaStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	namespaceStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	kv := &v1.KubeVirt{
 		ObjectMeta: metav1.ObjectMeta{
@@ -120,6 +122,8 @@ var _ = Describe("Template", func() {
 				config,
 				qemuGid,
 				"kubevirt/vmexport",
+				resourceQuotaStore,
+				namespaceStore,
 			)
 			// Set up mock clients
 			networkClient := fakenetworkclient.NewSimpleClientset()
@@ -4343,6 +4347,230 @@ var _ = Describe("Template", func() {
 			Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
 			Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().Cmp(cpuRequests)).To(BeZero())
 			Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().IsZero()).To(BeTrue())
+		})
+	})
+
+	Context("with auto Memory limits", func() {
+		const (
+			rqNamespace   = "rq-namespace"
+			noRqNamespace = "no-rq-namespace"
+		)
+		var guestMemory resource.Quantity
+
+		BeforeEach(func() {
+			config, kvInformer, svc = configFactory(defaultArch)
+			guestMemory = resource.MustParse("64M")
+
+			sampleQuantity := resource.MustParse("128M")
+			resourceQuotaWithMemoryLimits := kubev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rqNamespace,
+				},
+				Spec: kubev1.ResourceQuotaSpec{
+					Hard: kubev1.ResourceList{
+						kubev1.ResourceLimitsMemory: sampleQuantity,
+					},
+				},
+			}
+			err := resourceQuotaStore.Add(&resourceQuotaWithMemoryLimits)
+			Expect(err).ToNot(HaveOccurred())
+
+			resourceQuotaWithoutMemoryLimits := kubev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: noRqNamespace,
+				},
+				Spec: kubev1.ResourceQuotaSpec{
+					Hard: kubev1.ResourceList{
+						kubev1.ResourceMemory: sampleQuantity,
+					},
+				},
+			}
+			err = resourceQuotaStore.Add(&resourceQuotaWithoutMemoryLimits)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			for _, ns := range resourceQuotaStore.List() {
+				err := resourceQuotaStore.Delete(ns)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		When("the auto memory limits feature gate is disabled", func() {
+
+			It("should not set memory limits", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: rqNamespace,
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Resources: v1.ResourceRequirements{
+								Requests: kubev1.ResourceList{kubev1.ResourceMemory: guestMemory},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeZero())
+			})
+		})
+
+		When("the auto memory limits feature gate is enabled", func() {
+
+			BeforeEach(func() {
+				By("enabling the auto memory limits feature gate")
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.AutoResourceLimitsGate}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
+			})
+
+			Context("when the creation namespace has a resource quota with memory limits associated to it", func() {
+
+				DescribeTable("should not override limits", func(withLimits, withDedicatedCPU bool) {
+					resources := v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{kubev1.ResourceMemory: guestMemory},
+					}
+					if withLimits {
+						resources.Limits = kubev1.ResourceList{kubev1.ResourceMemory: guestMemory}
+					}
+
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testvmi",
+							Namespace: rqNamespace,
+							UID:       "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{
+							Domain: v1.DomainSpec{
+								Resources: resources,
+								CPU:       &v1.CPU{DedicatedCPUPlacement: withDedicatedCPU},
+							},
+						},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+					expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
+					expectedMemory.Add(GetMemoryOverhead(&vmi, defaultArch, config.GetConfig().AdditionalGuestMemoryOverheadRatio))
+					expectedMemory.Add(guestMemory)
+					Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeEquivalentTo(expectedMemory.Value()))
+				},
+					Entry("if they are already set in the vmi", true, false),
+					Entry("if the vmi is requesting dedicated CPU", false, true),
+				)
+
+				When("vmi does not have memory limits set", func() {
+					It("should automatically set limits using the default ratio", func() {
+						vmi := v1.VirtualMachineInstance{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "testvmi",
+								Namespace: rqNamespace,
+								UID:       "1234",
+							},
+							Spec: v1.VirtualMachineInstanceSpec{
+								Domain: v1.DomainSpec{
+									Resources: v1.ResourceRequirements{
+										Requests: kubev1.ResourceList{kubev1.ResourceMemory: guestMemory},
+									},
+								},
+							},
+						}
+
+						pod, err := svc.RenderLaunchManifest(&vmi)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+						expectedValue := int64(float64(pod.Spec.Containers[0].Resources.Requests.Memory().Value()) * DefaultMemoryLimitOverheadRatio)
+						Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeEquivalentTo(expectedValue))
+					})
+
+					When("there is the custom ratio label in the namespace", func() {
+						DescribeTable("should set limits", func(ratioLabelValue string, expectedUsedRatio float64) {
+							namespaceWithCustomMemoryRatio := kubev1.Namespace{
+								TypeMeta: metav1.TypeMeta{
+									Kind: "Namespace",
+								},
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "custom-memory-ratio-ns",
+									Labels: map[string]string{
+										v1.AutoMemoryLimitsRatioLabel: ratioLabelValue,
+									},
+								},
+							}
+							err := namespaceStore.Add(&namespaceWithCustomMemoryRatio)
+							Expect(err).ToNot(HaveOccurred())
+
+							sampleQuantity := resource.MustParse("128M")
+							resourceQuotaWithMemoryLimits := kubev1.ResourceQuota{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "custom-memory-ratio-ns",
+								},
+								Spec: kubev1.ResourceQuotaSpec{
+									Hard: kubev1.ResourceList{
+										kubev1.ResourceLimitsMemory: sampleQuantity,
+									},
+								},
+							}
+							err = resourceQuotaStore.Add(&resourceQuotaWithMemoryLimits)
+							Expect(err).ToNot(HaveOccurred())
+
+							vmi := v1.VirtualMachineInstance{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "testvmi",
+									Namespace: "custom-memory-ratio-ns",
+									UID:       "1234",
+								},
+								Spec: v1.VirtualMachineInstanceSpec{
+									Domain: v1.DomainSpec{
+										Resources: v1.ResourceRequirements{
+											Requests: kubev1.ResourceList{kubev1.ResourceMemory: guestMemory},
+										},
+									},
+								},
+							}
+
+							pod, err := svc.RenderLaunchManifest(&vmi)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+							expectedValue := int64(float64(pod.Spec.Containers[0].Resources.Requests.Memory().Value()) * expectedUsedRatio)
+							Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeEquivalentTo(expectedValue))
+						},
+							Entry("using default ratio value if the label value is not a float", "not_a_float", DefaultMemoryLimitOverheadRatio),
+							Entry("using custom ratio value if the label value is a float", "3.2", 3.2),
+						)
+					})
+				})
+			})
+
+			Context("when the creation namespace have a resource quota without memory limits associated to it", func() {
+				It("should not set memory limits", func() {
+					vmi := v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testvmi",
+							Namespace: noRqNamespace,
+							UID:       "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{
+							Domain: v1.DomainSpec{
+								Resources: v1.ResourceRequirements{
+									Requests: kubev1.ResourceList{kubev1.ResourceMemory: guestMemory},
+								},
+							},
+						},
+					}
+
+					pod, err := svc.RenderLaunchManifest(&vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+					Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeZero())
+				})
+			})
 		})
 	})
 })

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -153,7 +153,8 @@ type VirtControllerApp struct {
 	vmiInformer   cache.SharedIndexInformer
 	vmiRecorder   record.EventRecorder
 
-	namespaceStore cache.Store
+	namespaceInformer cache.SharedIndexInformer
+	namespaceStore    cache.Store
 
 	kubeVirtInformer cache.SharedIndexInformer
 
@@ -360,6 +361,7 @@ func Execute() {
 	app.kvPodInformer = app.informerFactory.KubeVirtPod()
 	app.nodeInformer = app.informerFactory.KubeVirtNode()
 	app.namespaceStore = app.informerFactory.Namespace().GetStore()
+	app.namespaceInformer = app.informerFactory.Namespace()
 	app.vmiCache = app.vmiInformer.GetStore()
 	app.vmiRecorder = app.newRecorder(k8sv1.NamespaceAll, "virtualmachine-controller")
 
@@ -567,7 +569,7 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 			}
 		}()
 
-		cache.WaitForCacheSync(stop, vca.persistentVolumeClaimInformer.HasSynced)
+		cache.WaitForCacheSync(stop, vca.persistentVolumeClaimInformer.HasSynced, vca.namespaceInformer.HasSynced, vca.resourceQuotaInformer.HasSynced)
 		close(vca.readyChan)
 		leaderGauge.Set(1)
 	}
@@ -603,6 +605,8 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.clusterConfig,
 		vca.launcherSubGid,
 		vca.exporterImage,
+		vca.resourceQuotaInformer.GetStore(),
+		vca.namespaceStore,
 	)
 
 	topologyHinter := topology.NewTopologyHinter(vca.nodeInformer.GetStore(), vca.vmiInformer.GetStore(), vca.clusterConfig)

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -83,6 +83,7 @@ var _ = Describe("Migration watcher", func() {
 	var pdbInformer cache.SharedIndexInformer
 	var migrationPolicyInformer cache.SharedIndexInformer
 	var resourceQuotaInformer cache.SharedIndexInformer
+	var namespaceInformer cache.SharedIndexInformer
 	var stop chan struct{}
 	var controller *MigrationController
 	var recorder *record.FakeRecorder
@@ -277,6 +278,7 @@ var _ = Describe("Migration watcher", func() {
 		go pdbInformer.Run(stop)
 		go migrationPolicyInformer.Run(stop)
 		go resourceQuotaInformer.Run(stop)
+		go namespaceInformer.Run(stop)
 
 		Expect(cache.WaitForCacheSync(stop,
 			vmiInformer.HasSynced,
@@ -285,6 +287,7 @@ var _ = Describe("Migration watcher", func() {
 			nodeInformer.HasSynced,
 			pdbInformer.HasSynced,
 			resourceQuotaInformer.HasSynced,
+			namespaceInformer.HasSynced,
 			migrationPolicyInformer.HasSynced)).To(BeTrue())
 
 	}
@@ -293,7 +296,7 @@ var _ = Describe("Migration watcher", func() {
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kvConfig)
 
 		controller, _ = NewMigrationController(
-			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", resourceQuotaInformer.GetStore(), namespaceInformer.GetStore()),
 			vmiInformer,
 			podInformer,
 			migrationInformer,
@@ -324,6 +327,7 @@ var _ = Describe("Migration watcher", func() {
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		pdbInformer, _ = testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
 		resourceQuotaInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
+		namespaceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		migrationPolicyInformer, _ = testutils.NewFakeInformerFor(&migrationsv1.MigrationPolicy{})
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -92,6 +92,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var kubeClient *fake.Clientset
 	var networkClient *fakenetworkclient.Clientset
 	var pvcInformer cache.SharedIndexInformer
+	var rqInformer cache.SharedIndexInformer
+	var nsInformer cache.SharedIndexInformer
 
 	var dataVolumeSource *framework.FakeControllerSource
 	var dataVolumeInformer cache.SharedIndexInformer
@@ -263,8 +265,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		cdiInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		cdiConfigInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
+		rqInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
+		nsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		controller, _ = NewVMIController(
-			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h", rqInformer.GetStore(), nsInformer.GetStore()),
 			vmiInformer,
 			vmInformer,
 			podInformer,

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -971,6 +971,10 @@ const (
 
 	// VirtualMachinePodCPULimitsLabel indicates VMI pod CPU resource limits
 	VirtualMachinePodCPULimitsLabel string = "kubevirt.io/vmi-pod-cpu-resource-limits"
+
+	// AutoMemoryLimitsRatioLabel allows to use a custom ratio for auto memory limits calculation.
+	// Must be a float >= 1.
+	AutoMemoryLimitsRatioLabel string = "alpha.kubevirt.io/auto-memory-limits-ratio"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -44,4 +44,5 @@ var (
 	RequiresTwoSchedulableNodes  = []interface{}{Label("requires-two-schedulable-nodes")}
 	VMLiveUpdateFeaturesGate     = []interface{}{Label("VMLiveUpdateFeaturesGate")}
 	RequiresRWXFilesystemStorage = []interface{}{Label("rwxfs")}
+	AutoResourceLimitsGate       = []interface{}{Label("AutoResourceLimitsGate")}
 )

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -109,6 +109,7 @@ func AdjustKubeVirtResource() {
 		virtconfig.HotplugNetworkIfacesGate,
 		virtconfig.VMPersistentState,
 		virtconfig.VMLiveUpdateFeaturesGate,
+		virtconfig.AutoResourceLimitsGate,
 	)
 	if flags.DisableCustomSELinuxPolicy {
 		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1977,7 +1977,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 	})
 
-	Context("with automatic resource limits FG enabled", func() {
+	Context("with automatic resource limits FG enabled", decorators.AutoResourceLimitsGate, func() {
 
 		When("there is no ResourceQuota with memory limits associated with the creation namespace", func() {
 			It("should not automatically set memory limits in the virt-launcher pod", func() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1977,6 +1977,76 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 	})
 
+	Context("with automatic resource limits FG enabled", func() {
+
+		When("there is no ResourceQuota with memory limits associated with the creation namespace", func() {
+			It("should not automatically set memory limits in the virt-launcher pod", func() {
+				vmi := libvmi.NewCirros()
+				By("Creating a running VMI")
+				runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
+
+				By("Ensuring no memory limit is set")
+				readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
+				Expect(err).ToNot(HaveOccurred())
+				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				_, exists := computeContainer.Resources.Limits[kubev1.ResourceMemory]
+				Expect(exists).To(BeFalse(), "Memory limits set on the compute container when none was expected")
+			})
+		})
+
+		When("a ResourceQuota with memory limits is associated to the creation namespace", func() {
+			var (
+				vmi                    *virtv1.VirtualMachineInstance
+				expectedLauncherLimits *resource.Quantity
+				vmiRequest             resource.Quantity
+			)
+
+			BeforeEach(func() {
+				vmiRequest = resource.MustParse("256Mi")
+				delta := resource.MustParse("100Mi")
+				vmi = libvmi.NewCirros(
+					libvmi.WithResourceMemory(vmiRequest.String()),
+				)
+				vmiPodRequest := services.GetMemoryOverhead(vmi, runtime.GOARCH, nil)
+				vmiPodRequest.Add(vmiRequest)
+				value := int64(float64(vmiPodRequest.Value()) * services.DefaultMemoryLimitOverheadRatio)
+
+				expectedLauncherLimits = resource.NewQuantity(value, vmiPodRequest.Format)
+
+				// Add a delta to not saturate the rq
+				rqLimit := expectedLauncherLimits.DeepCopy()
+				rqLimit.Add(delta)
+				By("Creating a Resource Quota with memory limits")
+				rq := &kubev1.ResourceQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:    testsuite.GetTestNamespace(nil),
+						GenerateName: "test-quota",
+					},
+					Spec: k8sv1.ResourceQuotaSpec{
+						Hard: kubev1.ResourceList{
+							k8sv1.ResourceLimitsMemory: resource.MustParse(rqLimit.String()),
+						},
+					},
+				}
+				_, err := virtClient.CoreV1().ResourceQuotas(testsuite.GetTestNamespace(nil)).Create(context.Background(), rq, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should set a memory limit in the virt-launcher pod", func() {
+				By("Starting the VMI")
+				runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
+
+				By("Ensuring the memory limit is set to the correct value")
+				readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
+				Expect(err).ToNot(HaveOccurred())
+				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				limits, exists := computeContainer.Resources.Limits[kubev1.ResourceMemory]
+				Expect(exists).To(BeTrue(), "expected memory limits not set on the compute container")
+				Expect(limits.Value()).To(BeEquivalentTo(expectedLauncherLimits.Value()))
+			})
+		})
+	})
+
 	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component][storage-req]with driver cache and io settings and PVC", Serial, decorators.StorageReq, func() {
 		var dataVolume *cdiv1.DataVolume
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual cherrypick of https://github.com/kubevirt/kubevirt/pull/10447 and https://github.com/kubevirt/kubevirt/pull/10497
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a Feature Gate to KV CR to automatically set memory limits when a resource quota with memory limits is associated to the creation namespace
```

/cc @acardace @jean-edouard @vladikr @fabiand 