### PR TITLE
access_test.go: Add expand-spec tests for OCP

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -438,6 +438,8 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			DescribeTable("should verify permissions on resources are correct for subresources", func(resource string, action string) {
 				testAction(resource, action, "no")
 			},
+				Entry("[test_id:????]given expand-vm-spec non-resource", "expand-vm-spec", "update"),
+				Entry("[test_id:????]given a vm (expand-spec)", "virtualmachines/expand-spec", "get"),
 				Entry("[test_id:2921]given a vmi (pause)", "virtualmachineinstances/pause", "update"),
 				Entry("[test_id:2921]given a vmi (unpause)", "virtualmachineinstances/unpause", "update"),
 				Entry("[test_id:2921]given a vmi (softreboot)", "virtualmachineinstances/softreboot", "update"),
@@ -480,6 +482,8 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			DescribeTable("should verify permissions on resources are correct for subresources", func(resource string, action string) {
 				testAction(resource, action, "yes")
 			},
+				Entry("[test_id:????]given expand-vm-spec non-resource", "expand-vm-spec", "update"),
+				Entry("[test_id:????]given a vm (expand-spec)", "virtualmachines/expand-spec", "get"),
 				Entry("[test_id:2921]given a vmi (pause)", "virtualmachineinstances/pause", "update"),
 				Entry("[test_id:2921]given a vmi (unpause)", "virtualmachineinstances/unpause", "update"),
 				Entry("[test_id:2921]given a vmi (softreboot)", "virtualmachineinstances/softreboot", "update"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds tests to verify that {admin,regular} users {can,cannot} access the expand-spec subresource endpoint.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
