### PR TITLE
Adding backup mechanism to report vulnerabilities in security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,7 @@ supported by security teams of involved vendors.
 List of involved vendor security teams:
 - Red Hat <secalert@redhat.com>
 - SUSE <security@suse.de>
+
+## Alternate Reporting Mechanism
+
+If you are unable to report the vulnerability to the dedicated email address, you can use the [GitHub vulnerability report mechanism](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have a dedicated mailing list for reporting vulnerabilities, however we had a situation earlier where this was not possible. 

The CNCF recommends the use of the (GitHub vulnerability reporting mechanism)[https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability] for projects, however this would make it not visible to the vendor security teams that help us with vulnerabilities. As a result we would like to have the mechanism available to people, but only as an alternative for when the mailing list cannot be used. 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @stu-gott 