### PR TITLE
[virt-controller] online snapshot: support CPU hotplug

### DIFF
--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -275,9 +275,18 @@ func (s *vmSnapshotSource) Spec() (snapshotv1.SourceSpec, error) {
 		if !exists {
 			return snapshotv1.SourceSpec{}, fmt.Errorf("can't get online snapshot spec, vmi doesn't exist")
 		}
+
 		vmi.Spec.Volumes = s.vm.Spec.Template.Spec.Volumes
 		vmi.Spec.Domain.Devices.Disks = s.vm.Spec.Template.Spec.Domain.Devices.Disks
 		vmCpy.Spec.Template.Spec = vmi.Spec
+
+		if vmCpy.Spec.LiveUpdateFeatures != nil &&
+			vmCpy.Spec.LiveUpdateFeatures.CPU != nil {
+			vmCpy.Spec.Template.Spec.Domain.CPU = nil
+			if s.vm.Spec.Template.Spec.Domain.CPU != nil {
+				vmCpy.Spec.Template.Spec.Domain.CPU = s.vm.Spec.Template.Spec.Domain.CPU.DeepCopy()
+			}
+		}
 	} else {
 		vmCpy.ObjectMeta = metaObj
 		vmCpy.Spec = *s.vm.Spec.DeepCopy()


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>


**What this PR does / why we need it**:
In order to support VM cloning with live-update features, the snapshot source content should be crafted
properly. In case of CPU hotplug, the CPU topology should be taken from the active VM spec rather than 
from the one in the VM revision.


**Which issue(s) this PR fixes**:
Fixes # #10481  

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
online snapshot: support CPU hotplug
```
