### PR TITLE
Make builder image and registry name configurable

### DIFF
--- a/hack/builder/arch.sh
+++ b/hack/builder/arch.sh
@@ -1,2 +1,0 @@
-# TODO: reenable ppc64le when new builds are available
-ARCHITECTURES="amd64 arm64"

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -19,8 +19,8 @@ if ! grep -q -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; t
     ${KUBEVIRT_CRI} >&2 run --rm --privileged multiarch/qemu-user-static --reset -p yes
 fi
 
-# shellcheck source=hack/builder/arch.sh
-. "${SCRIPT_DIR}/arch.sh"
+# shellcheck source=hack/builder/common.sh
+. "${SCRIPT_DIR}/common.sh"
 # shellcheck source=hack/builder/version.sh
 . "${SCRIPT_DIR}/version.sh"
 
@@ -36,7 +36,7 @@ for ARCH in ${ARCHITECTURES}; do
         ;;
     esac
     ${KUBEVIRT_CRI} >&2 pull --platform="linux/${ARCH}" quay.io/centos/centos:stream9
-    ${KUBEVIRT_CRI} >&2 build --platform="linux/${ARCH}" -t "quay.io/kubevirt/builder:${VERSION}-${ARCH}" --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
+    ${KUBEVIRT_CRI} >&2 build --platform="linux/${ARCH}" -t "${DOCKER_PREFIX}/${DOCKER_IMAGE}:${VERSION}-${ARCH}" --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
 done
 
 # Print the version for use by other callers such as publish.sh

--- a/hack/builder/common.sh
+++ b/hack/builder/common.sh
@@ -1,0 +1,5 @@
+DOCKER_PREFIX=${DOCKER_PREFIX:-"quay.io/kubevirt"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"builder"}
+
+# TODO: reenable ppc64le when new builds are available
+ARCHITECTURES="amd64 arm64"

--- a/hack/builder/publish.sh
+++ b/hack/builder/publish.sh
@@ -18,22 +18,16 @@ cleanup() {
 
 cleanup
 
-# shellcheck source=hack/builder/arch.sh
-. "${SCRIPT_DIR}/arch.sh"
+# shellcheck source=hack/builder/common.sh
+. "${SCRIPT_DIR}/common.sh"
 # Use the value of VERSION returned from build.sh instead of version.sh to ensure the correct image is published
 VERSION=$($(dirname "$0")/build.sh)
 
 for ARCH in ${ARCHITECTURES}; do
-    ${KUBEVIRT_CRI} push quay.io/kubevirt/builder:${VERSION}-${ARCH}
-    TMP_IMAGES="${TMP_IMAGES} quay.io/kubevirt/builder:${VERSION}-${ARCH}"
+    ${KUBEVIRT_CRI} push ${DOCKER_PREFIX}/${DOCKER_IMAGE}:${VERSION}-${ARCH}
+    TMP_IMAGES="${TMP_IMAGES} ${DOCKER_PREFIX}/${DOCKER_IMAGE}:${VERSION}-${ARCH}"
 done
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
-${KUBEVIRT_CRI} manifest create --amend quay.io/kubevirt/builder:${VERSION} ${TMP_IMAGES}
-
-if [ "${KUBEVIRT_CRI}" = "podman" ]; then
-    # FIXME: Workaround https://github.com/containers/podman/issues/18360 and remove once https://github.com/containers/podman/commit/bab4217cd16be609ac35ccf3061d1e34f787856f is released
-    ${KUBEVIRT_CRI} manifest push quay.io/kubevirt/builder:${VERSION} quay.io/kubevirt/builder:${VERSION}
-else
-    ${KUBEVIRT_CRI} manifest push quay.io/kubevirt/builder:${VERSION}
-fi
+${KUBEVIRT_CRI} manifest create --amend ${DOCKER_PREFIX}/${DOCKER_IMAGE}:${VERSION} ${TMP_IMAGES}
+${KUBEVIRT_CRI} manifest push ${DOCKER_PREFIX}/${DOCKER_IMAGE}:${VERSION}

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,7 +12,7 @@ fi
 
 fail_if_cri_bin_missing
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2306271234-e00d9fcf9"
+KUBEVIRT_BUILDER_IMAGE=${KUBEVIRT_BUILDER_IMAGE:-"quay.io/kubevirt/builder:2306271234-e00d9fcf9"}
 
 SYNC_OUT=${SYNC_OUT:-true}
 


### PR DESCRIPTION
**What this PR does / why we need it**: This MR allows to build custom builder image easily by configuring `DOCKER_PREFIX` and `DOCKER_IMAGE` (as well as `KUBEVIRT_BUILDER_IMAGE`) env variables instead of using hardcoded `quay.io/kubevirt/builder`. Also in the future it will be much easier to destination (either registry or image) whenever needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: None

**Special notes for your reviewer**: Note that by default we will be still using `quay.io/kubevirt/builder` so nothing changes here.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
