### PR TITLE
instancetype: Improve admission conflict message

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -31,6 +31,7 @@ import (
 )
 
 const (
+	VMFieldConflictErrorFmt                         = "VM field %s conflicts with selected instance type"
 	InsufficientInstanceTypeCPUResourcesErrorFmt    = "insufficient CPU resources of %d vCPU provided by instance type, preference requires %d vCPU"
 	InsufficientVMCPUResourcesErrorFmt              = "insufficient CPU resources of %d vCPU provided by VirtualMachine, preference requires %d vCPU provided as %s"
 	InsufficientInstanceTypeMemoryResourcesErrorFmt = "insufficient Memory resources of %s provided by instance type, preference requires %s"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -289,7 +289,7 @@ func (admitter *VMsAdmitter) applyInstancetypeToVm(vm *v1.VirtualMachine) (*inst
 	for _, conflict := range conflicts {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "VM field conflicts with selected Instancetype",
+			Message: fmt.Sprintf(instancetype.VMFieldConflictErrorFmt, conflict.String()),
 			Field:   conflict.String(),
 		})
 	}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -160,6 +160,7 @@ go_test(
         "//pkg/hooks:go_default_library",
         "//pkg/hooks/v1alpha1:go_default_library",
         "//pkg/hooks/v1alpha2:go_default_library",
+        "//pkg/instancetype:go_default_library",
         "//pkg/network/dns:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	goerrors "errors"
+	"fmt"
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -31,6 +32,8 @@ import (
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	instancetypepkg "kubevirt.io/kubevirt/pkg/instancetype"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
@@ -468,18 +471,21 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 			cause0 := apiStatus.Status().Details.Causes[0]
 			Expect(cause0.Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(cause0.Message).To(Equal("VM field conflicts with selected Instancetype"))
-			Expect(cause0.Field).To(Equal("spec.template.spec.domain.cpu.sockets"))
+			cpuSocketsField := "spec.template.spec.domain.cpu.sockets"
+			Expect(cause0.Message).To(Equal(fmt.Sprintf(instancetypepkg.VMFieldConflictErrorFmt, cpuSocketsField)))
+			Expect(cause0.Field).To(Equal(cpuSocketsField))
 
 			cause1 := apiStatus.Status().Details.Causes[1]
 			Expect(cause1.Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(cause1.Message).To(Equal("VM field conflicts with selected Instancetype"))
-			Expect(cause1.Field).To(Equal("spec.template.spec.domain.cpu.cores"))
+			cpuCoresField := "spec.template.spec.domain.cpu.cores"
+			Expect(cause1.Message).To(Equal(fmt.Sprintf(instancetypepkg.VMFieldConflictErrorFmt, cpuCoresField)))
+			Expect(cause1.Field).To(Equal(cpuCoresField))
 
 			cause2 := apiStatus.Status().Details.Causes[2]
 			Expect(cause2.Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(cause2.Message).To(Equal("VM field conflicts with selected Instancetype"))
-			Expect(cause2.Field).To(Equal("spec.template.spec.domain.cpu.threads"))
+			cpuThreadsField := "spec.template.spec.domain.cpu.threads"
+			Expect(cause2.Message).To(Equal(fmt.Sprintf(instancetypepkg.VMFieldConflictErrorFmt, cpuThreadsField)))
+			Expect(cause2.Field).To(Equal(cpuThreadsField))
 		})
 
 		DescribeTable("[test_id:CNV-9301] should fail if the VirtualMachine has ", func(resources virtv1.ResourceRequirements, expectedField string) {
@@ -506,7 +512,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			cause := apiStatus.Status().Details.Causes[0]
 
 			Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(cause.Message).To(Equal("VM field conflicts with selected Instancetype"))
+			Expect(cause.Message).To(Equal(fmt.Sprintf(instancetypepkg.VMFieldConflictErrorFmt, expectedField)))
 			Expect(cause.Field).To(Equal(expectedField))
 		},
 			Entry("CPU resource requests", virtv1.ResourceRequirements{


### PR DESCRIPTION
/area instancetype

**What this PR does / why we need it**:

This should really contain the field causing the conflict to avoid the reader having to look around further for this information.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
