### PR TITLE
Prevent creation of another Kubevirt

### DIFF
--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -408,6 +408,9 @@ func (app *VirtOperatorApp) Run() {
 	mux.HandleFunc(components.KubeVirtUpdateValidatePath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		validating_webhooks.Serve(w, r, operator_webhooks.NewKubeVirtUpdateAdmitter(app.clientSet, app.clusterConfig))
 	}))
+	mux.HandleFunc(components.KubeVirtCreateValidatePath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		validating_webhooks.Serve(w, r, operator_webhooks.NewKubeVirtCreateAdmitter(app.clientSet))
+	}))
 	webhookServer.Handler = &mux
 	go func() {
 		err := webhookServer.ListenAndServeTLS("", "")

--- a/pkg/virt-operator/resource/generate/components/webhooks.go
+++ b/pkg/virt-operator/resource/generate/components/webhooks.go
@@ -137,6 +137,30 @@ func NewOpertorValidatingWebhookConfiguration(operatorNamespace string) *admissi
 					},
 				},
 			},
+			{
+				Name:                    "kubevirt-create-validator.kubevirt.io",
+				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
+				SideEffects:             &sideEffectNone,
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{
+						admissionregistrationv1.Create,
+					},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{core.GroupName},
+						APIVersions: virtv1.ApiSupportedWebhookVersions,
+						Resources:   []string{"kubevirts"},
+					},
+				}},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: operatorNamespace,
+						Name:      VirtOperatorServiceName,
+						Path:      pointer.String(KubeVirtCreateValidatePath),
+					},
+				},
+			},
 		},
 	}
 }
@@ -802,6 +826,8 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 }
 
 const KubeVirtUpdateValidatePath = "/kubevirt-validate-update"
+
+const KubeVirtCreateValidatePath = "/kubevirt-validate-create"
 
 const VMICreateValidatePath = "/virtualmachineinstances-validate-create"
 

--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "kubevirt-create-admitter.go",
         "kubevirt-update-admitter.go",
         "webhook.go",
     ],
@@ -30,6 +31,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "kubevirt-create-admitter_test.go",
         "kubevirt-update-admitter_test.go",
         "webhook_test.go",
         "webhooks_suite_test.go",

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package webhooks
+
+import (
+	"fmt"
+
+	"kubevirt.io/client-go/log"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	webhooks "kubevirt.io/kubevirt/pkg/util/webhooks"
+	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
+)
+
+func NewKubeVirtCreateAdmitter(client kubecli.KubevirtClient) *kubeVirtCreateAdmitter {
+	return &kubeVirtCreateAdmitter{
+		client: client,
+	}
+}
+
+type kubeVirtCreateAdmitter struct {
+	client kubecli.KubevirtClient
+}
+
+// This validating webhook actually starts running AFTER the KubeVirt CR has been created
+// as it gets installed by virt-operator in its sync-loop, this means that this will only
+// check for creation of a new KubeVirt CR (rejecting it), no validation can be done here
+// as that is done in the 'kubevirt-update-validator.kubevirt.io' webhook
+
+func (k *kubeVirtCreateAdmitter) Admit(review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	log.Log.Info("Trying to create KV")
+	if resp := webhooks.ValidateSchema(v1.KubeVirtGroupVersionKind, review.Request.Object.Raw); resp != nil {
+		return resp
+	}
+	//TODO: Do we want semantic validation
+
+	// Best effort
+	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(&metav1.ListOptions{})
+	if err != nil {
+		return webhooks.ToAdmissionResponseError(err)
+	}
+	if len(list.Items) == 0 {
+		fmt.Println("Allowed to create KV")
+		return webhookutils.NewPassingAdmissionResponse()
+	}
+	return webhooks.ToAdmissionResponseError(fmt.Errorf("Kubevirt is already created"))
+}

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter_test.go
@@ -1,0 +1,86 @@
+package webhooks
+
+import (
+	"encoding/json"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+var _ = Describe("Validating KubeVirtCreate Admitter", func() {
+	var admitter *kubeVirtCreateAdmitter
+	var kvInterface *kubecli.MockKubeVirtInterface
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		kubevirtClient := kubecli.NewMockKubevirtClient(ctrl)
+		kvInterface = kubecli.NewMockKubeVirtInterface(ctrl)
+		kubevirtClient.EXPECT().KubeVirt(gomock.Any()).Return(kvInterface).AnyTimes()
+
+		admitter = NewKubeVirtCreateAdmitter(kubevirtClient)
+	})
+
+	It("should prevent creating another Kubevirt resource", func() {
+		alreadyExistingKv := v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "Different",
+				Name:      "Existing",
+			},
+		}
+		kvInterface.EXPECT().List(gomock.Any()).
+			Return(&v1.KubeVirtList{Items: []v1.KubeVirt{alreadyExistingKv}}, nil).AnyTimes()
+
+		newKv := v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "New",
+			},
+		}
+
+		b, err := json.Marshal(newKv)
+		Expect(err).ToNot(HaveOccurred())
+		review := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Namespace: "test",
+				Name:      "kubevirt",
+				Object: runtime.RawExtension{
+					Raw: b,
+				},
+			},
+		}
+
+		response := admitter.Admit(review)
+		Expect(response.Allowed).To(BeFalse(), "Additional attempts to create Kubevirt should fail")
+	})
+
+	It("should allow creating new Kubevirt resource", func() {
+		kvInterface.EXPECT().List(gomock.Any()).
+			Return(&v1.KubeVirtList{Items: []v1.KubeVirt{}}, nil).AnyTimes()
+
+		newKv := v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "New",
+			},
+		}
+
+		b, err := json.Marshal(newKv)
+		Expect(err).ToNot(HaveOccurred())
+		review := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Namespace: "test",
+				Name:      "kubevirt",
+				Object: runtime.RawExtension{
+					Raw: b,
+				},
+			},
+		}
+
+		response := admitter.Admit(review)
+		Expect(response.Allowed).To(BeTrue(), "Create Kubevirt should be allowed")
+	})
+})

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -473,27 +473,6 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			kv = util.GetCurrentKv(virtClient)
 		})
 
-		copyKV := func(kv *v1.KubeVirt) *v1.KubeVirt {
-			var kvCopy v1.KubeVirt
-
-			kvCopy.ObjectMeta = *kv.ObjectMeta.DeepCopy()
-			kvCopy.Spec = *kv.Spec.DeepCopy()
-			return &kvCopy
-		}
-
-		It("[test_id:7647]create a KubeVirt CR", func() {
-			kvCopy := copyKV(kv)
-			kvCopy.Name = "test-kubevirt-cr"
-
-			By("Make a Dry-Run request to create a KubeVirt CR")
-			err = tests.DryRunCreate(restClient, resource, kvCopy.Namespace, kvCopy, nil)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Check that no KubeVirt CR was actually created")
-			_, err = virtClient.KubeVirt(kvCopy.Namespace).Get(kvCopy.Name, &metav1.GetOptions{})
-			Expect(errors.IsNotFound(err)).To(BeTrue())
-		})
-
 		It("[Serial][test_id:7648]delete a KubeVirt CR", Serial, func() {
 			By("Make a Dry-Run request to delete a KubeVirt CR")
 			deletePolicy := metav1.DeletePropagationForeground


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is https://github.com/kubevirt/kubevirt/pull/10499 plus removing an e2e test that is now unnecessary.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
