### PR TITLE
Stop copying VMI spec to VM during snapshots

### DIFF
--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -268,16 +268,8 @@ func (s *vmSnapshotSource) Spec() (snapshotv1.SourceSpec, error) {
 		}
 		vmCpy.ObjectMeta = metaObj
 
-		vmi, exists, err := s.controller.getVMI(s.vm)
-		if err != nil {
-			return snapshotv1.SourceSpec{}, err
-		}
-		if !exists {
-			return snapshotv1.SourceSpec{}, fmt.Errorf("can't get online snapshot spec, vmi doesn't exist")
-		}
-		vmi.Spec.Volumes = s.vm.Spec.Template.Spec.Volumes
-		vmi.Spec.Domain.Devices.Disks = s.vm.Spec.Template.Spec.Domain.Devices.Disks
-		vmCpy.Spec.Template.Spec = vmi.Spec
+		vmCpy.Spec.Template.Spec.Volumes = s.vm.Spec.Template.Spec.Volumes
+		vmCpy.Spec.Template.Spec.Domain.Devices.Disks = s.vm.Spec.Template.Spec.Domain.Devices.Disks
 	} else {
 		vmCpy.ObjectMeta = metaObj
 		vmCpy.Spec = *s.vm.Spec.DeepCopy()

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -200,11 +200,8 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		vmi.Spec.Volumes = vm.Spec.Template.Spec.Volumes
-		vmi.Spec.Domain.Devices.Disks = vm.Spec.Template.Spec.Domain.Devices.Disks
-		vm.Spec.Template.Spec = vmi.Spec
+		vm.Spec.Template.Spec.Volumes = content.Spec.Source.VirtualMachine.Spec.Template.Spec.Volumes
+		vm.Spec.Template.Spec.Domain.Devices.Disks = content.Spec.Source.VirtualMachine.Spec.Template.Spec.Domain.Devices.Disks
 
 		Expect(*content.Spec.VirtualMachineSnapshotName).To(Equal(snapshot.Name))
 		Expect(content.Spec.Source.VirtualMachine.Spec).To(Equal(vm.Spec))

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1462,12 +1462,21 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				}
 			})
 
-			It("Bug #8435 - should create a snapshot successfully", func() {
+			DescribeTable("Bug #8435 - should create a snapshot successfully", func(toRunSourceVM bool) {
+				if toRunSourceVM {
+					By("Starting the VM and expecting it to run")
+					vm = tests.StartVMAndExpectRunning(virtClient, vm)
+				}
+
 				snapshot = newSnapshot()
 				snapshot, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
+
 				waitSnapshotReady()
-			})
+			},
+				Entry("with running source VM", true),
+				Entry("with stopped source VM", false),
+			)
 		})
 	})
 })

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -46,6 +46,8 @@ import (
 
 	v12 "k8s.io/api/apps/v1"
 
+	k6tpointer "kubevirt.io/kubevirt/pkg/pointer"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1562,11 +1564,12 @@ func NewRandomVirtualMachine(vmi *v1.VirtualMachineInstance, running bool) *v1.V
 func StopVirtualMachineWithTimeout(vm *v1.VirtualMachine, timeout time.Duration) *v1.VirtualMachine {
 	By("Stopping the VirtualMachineInstance")
 	virtClient := kubevirt.Client()
-	running := false
+
 	Eventually(func() error {
 		updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		updatedVM.Spec.Running = &running
+		updatedVM.Spec.Running = k6tpointer.P(false)
+		updatedVM.Spec.RunStrategy = nil
 		_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(context.Background(), updatedVM)
 		return err
 	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
@@ -1596,11 +1599,12 @@ func StopVirtualMachine(vm *v1.VirtualMachine) *v1.VirtualMachine {
 func StartVirtualMachine(vm *v1.VirtualMachine) *v1.VirtualMachine {
 	By("Starting the VirtualMachineInstance")
 	virtClient := kubevirt.Client()
-	running := true
+
 	Eventually(func() error {
 		updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		updatedVM.Spec.Running = &running
+		updatedVM.Spec.Running = k6tpointer.P(true)
+		updatedVM.Spec.RunStrategy = nil
 		_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(context.Background(), updatedVM)
 		return err
 	}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently a new logic was introduced to the snapshot controller which copies the VMI spec to the VM spec during snapshots. The logic was introduced [here](https://github.com/kubevirt/kubevirt/pull/6642/files#diff-7bc7197d1045e0af2ba9d29fdedb1195aadd5365362d00be0d709be10ee601f6R203-R212):
https://github.com/kubevirt/kubevirt/blob/866e725bb93a9cae87cc47c9496d8dfe6baafb8a/pkg/storage/snapshot/source.go#L271-L280

Copying the VMI spec to the VM spec is a bug. Kubevirt is designed around the principle in which the VM is a user-facing object, while the VMI is an internal object. For example, while the VM spec specifies the user's desired state, the VMI is being expanded with default values and is being patched and updated by Kubevirt's controllers.

For example, this logic interferes with cloning VMs with instance types. For example, an instance type can mandate to set certain resources to the VM, but in the VMI level the resources are expanded. Therefore, when copying the spec to the VM together with the instance type it fails in validation webhooks, since it's invalid to both use such an instance type and set resource related specs.

Another example is CPU hotplug. There, we disallow setting certain fields at the VM level, but our controllers can modify these fields at the VMI level. Copying back to the VM would create a VM with an invalid spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2227933

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~~
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~~
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug-fix: Stop copying VMI spec to VM during snapshots
```
