### PR TITLE
tests: avoid a global constant

### DIFF
--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -261,13 +261,14 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 			})
 
 			It("should keep connectivity after a migration", func() {
+				const containerCompletionWaitTime = 60
 				migration := tests.NewRandomMigration(serverVMI.Name, serverVMI.GetNamespace())
 				_ = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 				// In case of clientVMI and serverVMI running on the same node before migration, the serverVMI
 				// will be reachable only when the original launcher pod terminates.
 				Eventually(func() error {
 					return waitForPodCompleted(serverVMI.Namespace, serverVMIPodName)
-				}, tests.ContainerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod: %s", serverVMIPodName))
+				}, containerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod: %s", serverVMIPodName))
 				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed(), "connectivity is expected *after* migrating the VMI")
 			})
 		})

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -197,9 +197,10 @@ var istioTests = func(vmType VmType) {
 				libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 			})
 			It("All containers should complete in source virt-launcher pod after migration", func() {
+				const containerCompletionWaitTime = 60
 				Eventually(func() error {
 					return allContainersCompleted(sourcePodName)
-				}, tests.ContainerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod"))
+				}, containerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod"))
 			})
 		})
 		Describe("SSH traffic", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -102,16 +102,15 @@ import (
 )
 
 const (
-	BinBash                     = "/bin/bash"
-	StartingVMInstance          = "Starting a VirtualMachineInstance"
-	WaitingVMInstanceStart      = "Waiting until the VirtualMachineInstance will start"
-	EchoLastReturnValue         = "echo $?\n"
-	CustomHostPath              = "custom-host-path"
-	DiskAlpineHostPath          = "disk-alpine-host-path"
-	DiskWindowsSysprep          = "disk-windows-sysprep"
-	DiskCustomHostPath          = "disk-custom-host-path"
-	defaultDiskSize             = "1Gi"
-	ContainerCompletionWaitTime = 60
+	BinBash                = "/bin/bash"
+	StartingVMInstance     = "Starting a VirtualMachineInstance"
+	WaitingVMInstanceStart = "Waiting until the VirtualMachineInstance will start"
+	EchoLastReturnValue    = "echo $?\n"
+	CustomHostPath         = "custom-host-path"
+	DiskAlpineHostPath     = "disk-alpine-host-path"
+	DiskWindowsSysprep     = "disk-windows-sysprep"
+	DiskCustomHostPath     = "disk-custom-host-path"
+	defaultDiskSize        = "1Gi"
 )
 
 func TestCleanup() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -103,7 +103,6 @@ import (
 
 const (
 	BinBash                = "/bin/bash"
-	StartingVMInstance     = "Starting a VirtualMachineInstance"
 	waitingVMInstanceStart = "Waiting until the VirtualMachineInstance will start"
 	EchoLastReturnValue    = "echo $?\n"
 	CustomHostPath         = "custom-host-path"
@@ -244,7 +243,7 @@ func DeleteSecret(name, namespace string) {
 	}
 }
 func RunVMI(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
-	By(StartingVMInstance)
+	By("Starting a VirtualMachineInstance")
 	virtCli := kubevirt.Client()
 
 	var obj *v1.VirtualMachineInstance

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -104,7 +104,7 @@ import (
 const (
 	BinBash                = "/bin/bash"
 	StartingVMInstance     = "Starting a VirtualMachineInstance"
-	WaitingVMInstanceStart = "Waiting until the VirtualMachineInstance will start"
+	waitingVMInstanceStart = "Waiting until the VirtualMachineInstance will start"
 	EchoLastReturnValue    = "echo $?\n"
 	CustomHostPath         = "custom-host-path"
 	DiskAlpineHostPath     = "disk-alpine-host-path"
@@ -258,7 +258,7 @@ func RunVMI(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInsta
 
 func RunVMIAndExpectLaunch(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
 	vmi = RunVMI(vmi, timeout)
-	By(WaitingVMInstanceStart)
+	By(waitingVMInstanceStart)
 	return libwait.WaitForVMIPhase(vmi,
 		[]v1.VirtualMachineInstancePhase{v1.Running},
 		libwait.WithTimeout(timeout),
@@ -269,7 +269,7 @@ func RunVMIAndExpectLaunchWithDataVolume(vmi *v1.VirtualMachineInstance, dv *cdi
 	vmi = RunVMI(vmi, timeout)
 	By("Waiting until the DataVolume is ready")
 	libstorage.EventuallyDV(dv, timeout, HaveSucceeded())
-	By(WaitingVMInstanceStart)
+	By(waitingVMInstanceStart)
 	warningsIgnoreList := []string{"didn't find PVC", "unable to find datavolume"}
 	return libwait.WaitForVMIPhase(vmi,
 		[]v1.VirtualMachineInstancePhase{v1.Running},
@@ -280,7 +280,7 @@ func RunVMIAndExpectLaunchWithDataVolume(vmi *v1.VirtualMachineInstance, dv *cdi
 
 func RunVMIAndExpectLaunchIgnoreWarnings(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
 	obj := RunVMI(vmi, timeout)
-	By(WaitingVMInstanceStart)
+	By(waitingVMInstanceStart)
 	return libwait.WaitForSuccessfulVMIStart(obj,
 		libwait.WithFailOnWarnings(false),
 		libwait.WithTimeout(timeout),


### PR DESCRIPTION
tests/utils.go is way too long and too many things depend on it. Let's have one less.

```release-note
NONE
```
