### PR TITLE
Disallow clones with the same name for the target and source

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -275,6 +275,22 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		admitter.admitAndExpect(vmClone, false)
 	})
 
+	DescribeTable("Should reject if source and target names are equal", func(areSameKind bool) {
+		vmClone.Spec.Target.Name = vmClone.Spec.Source.Name
+
+		if areSameKind {
+			vmClone.Spec.Source.Kind = vmClone.Spec.Target.Kind
+		} else {
+			vmClone.Spec.Source.Kind = "VirtualMachineSnapshot"
+			vmClone.Spec.Target.Kind = "VirtualMachine"
+		}
+
+		admitter.admitAndExpect(vmClone, !areSameKind)
+	},
+		Entry("with same kinds", true),
+		Entry("with different kinds", false),
+	)
+
 	DescribeTable("Should reject a source volume not Snapshot-able", func(index int) {
 		vm.Status.VolumeSnapshotStatuses[index].Enabled = false
 		admitter.admitAndExpect(vmClone, false)


### PR DESCRIPTION
**What this PR does / why we need it**:
Disallow clones with the same name for the target and source if they are of the same type.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~~
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~~
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disallow clones with the same name for the target and source if they are of the same type.
```
