### PR TITLE
Add --volume-mode flag in image-upload to allow specifying volume mode

### DIFF
--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -573,7 +573,7 @@ var _ = Describe("ImageUpload", func() {
 			validateDataVolume()
 		})
 
-		It("Create a VolumeMode=Block PVC", func() {
+		DescribeTable("Create a VolumeMode=Block PVC", func(flag string) {
 			testInit(http.StatusOK)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath, "--block-volume")
@@ -581,6 +581,19 @@ var _ = Describe("ImageUpload", func() {
 			Expect(dvCreateCalled.IsTrue()).To(BeTrue())
 			validateBlockPVC()
 			validateBlockDataVolume()
+		},
+			Entry("using deprecated flag", "--block-volume"),
+			Entry("using VolumeMode flag", "-volume-mode=block"),
+		)
+
+		It("Create a VolumeMode=Filesystem PVC using volume-mode flag", func() {
+			testInit(http.StatusOK)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--insecure", "--image-path", imagePath, "--volume-mode", "filesystem")
+			Expect(cmd()).To(Succeed())
+			Expect(dvCreateCalled.IsTrue()).To(BeTrue())
+			validatePVC()
+			validateDataVolume()
 		})
 
 		It("Create a non-default storage class PVC", func() {
@@ -837,6 +850,10 @@ var _ = Describe("ImageUpload", func() {
 				[]string{"dv", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null", "--archive-path", "/dev/null.tar"}),
 			Entry("Archive path and block volume true provided", "In archive upload the volume mode should always be filesystem",
 				[]string{"dv", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--archive-path", "/dev/null.tar", "--block-volume"}),
+			Entry("BlockVolume true provided with different volume-mode", "incompatible --volume-mode 'filesystem' and --block-volume",
+				[]string{"dv", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--archive-path", "/dev/null.tar", "--block-volume", "--volume-mode", "filesystem"}),
+			Entry("Invalid volume-mode specified", "Invalid volume mode 'foo'. Valid values are 'block' and 'filesystem'.",
+				[]string{"dv", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--archive-path", "/dev/null.tar", "--volume-mode", "foo"}),
 			Entry("PVC name and args", "cannot use --pvc-name and args",
 				[]string{"foo", "--pvc-name", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("Unexpected resource type", "invalid resource type foo",


### PR DESCRIPTION
**What this PR does / why we need it**:

This Pull Request aims to introduce a `volume-mode` flag to allow specifying either filesystem or block volume modes in image-upload.
    
This behavior also marks the old `block-volume` flag as deprecated, which only allows specifying block mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Unsure about the consequences of marking `block-volume` as deprecated. The flag is still usable and feels redundant since the new one allows both volume modes, but feel free to argue otherwise.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add --volume-mode flag in image-upload
```
