### PR TITLE
Improve error handling when attempting to upload an already succeeded DataVolume

### DIFF
--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -736,6 +736,24 @@ var _ = Describe("ImageUpload", func() {
 			Expect(err.Error()).Should(ContainSubstring("Unable to get PVC Prime name from PVC"))
 		})
 
+		It("DV is using populators but PVC has no PVC Prime annotation and pod is succeeded", func() {
+			dv := dvSpecWithPhase(cdiv1.UploadReady)
+			dv.Annotations = map[string]string{UsePopulatorAnnotation: "true"}
+			pvc := pvcSpecWithUploadAnnotation()
+			pvc.Annotations = map[string]string{podPhaseAnnotation: string(v1.PodSucceeded)}
+			testInitAsyncWithCdiObjects(
+				http.StatusOK,
+				true,
+				[]runtime.Object{pvc},
+				[]runtime.Object{dv},
+			)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--uploadproxy-url", server.URL, "--insecure", "--archive-path", archiveFilePath)
+			err := cmd()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("already successfully populated"))
+		})
+
 		It("DV is using populators but PVC Prime doesn't exist", func() {
 			dv := dvSpecWithPhase(cdiv1.UploadReady)
 			dv.Annotations = map[string]string{UsePopulatorAnnotation: "true"}


### PR DESCRIPTION
**What this PR does / why we need it**:

We had to adjust some of the image-upload behavior with the addition of populators and the PVC Prime logic. This PR improves the handling of a specific error case to better report the status of the PVC.

When searching for the PVC Prime name annotation, if there's a pod succeeded annotation in the target PVC, we can safely assume it was successfully populated, so now we return a `PVC already successfully populated` message instead of the previous, more generic `Unable to get PVC Prime name`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2241658

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
