### PR TITLE
[guest-console-log] initialize log file if rootful

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -377,6 +377,13 @@ func main() {
 	// Initialize local and shared directories
 	initializeDirs(*ephemeralDiskDir, *containerDiskDir, *hotplugDiskDir, *uid)
 
+	if !*runWithNonRoot {
+		err := virtlauncher.InitializeConsoleLogFile(filepath.Join("/var/run/kubevirt-private", *uid))
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	if *simulateCrash {
 		panic(fmt.Errorf("Simulated virt-launcher crash"))
 	}

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -20,6 +20,7 @@
 package virtlauncher
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,6 +62,27 @@ func InitializePrivateDirectories(baseDir string) error {
 		return err
 	}
 	if err := diskutils.DefaultOwnershipManager.UnsafeSetFileOwnership(baseDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func InitializeConsoleLogFile(baseDir string) error {
+	logPath := filepath.Join(baseDir, "virt-serial0-log")
+
+	_, err := os.Stat(logPath)
+	if errors.Is(err, os.ErrNotExist) {
+		file, err := os.Create(logPath)
+		if err != nil {
+			return err
+		}
+		if err = file.Close(); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	if err = diskutils.DefaultOwnershipManager.UnsafeSetFileOwnership(logPath); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
libvirt initializes the log file for the
serial console device as owned by its user
and with 600 permissions.
So when executing in rootful mode (deprecated)
virt-tail, running rootless by design, is not
able to read it.
Fix pre-creating the log file with the
expected ownership when in rootful mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://issues.redhat.com/browse/CNV-33763
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2242849

**Special notes for your reviewer**:
It can be reproduced only in rootful mode, rootful CI lanes are not executed by default as part of pre-submit jobs

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
