### PR TITLE
Add external resource provider to USB Host Pass through device

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19206,6 +19206,10 @@
      "resourceName"
     ],
     "properties": {
+     "externalResourceProvider": {
+      "description": "If true, KubeVirt will leave the allocation and monitoring to an external device plugin",
+      "type": "boolean"
+     },
      "resourceName": {
       "description": "Identifies the list of USB host devices. e.g: kubevirt.io/storage, kubevirt.io/bootable-usb, etc",
       "type": "string",

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -693,6 +693,10 @@ spec:
                       usb:
                         items:
                           properties:
+                            externalResourceProvider:
+                              description: If true, KubeVirt will leave the allocation
+                                and monitoring to an external device plugin
+                              type: boolean
                             resourceName:
                               description: 'Identifies the list of USB host devices.
                                 e.g: kubevirt.io/storage, kubevirt.io/bootable-usb,
@@ -3751,6 +3755,10 @@ spec:
                       usb:
                         items:
                           properties:
+                            externalResourceProvider:
+                              description: If true, KubeVirt will leave the allocation
+                                and monitoring to an external device plugin
+                              type: boolean
                             resourceName:
                               description: 'Identifies the list of USB host devices.
                                 e.g: kubevirt.io/storage, kubevirt.io/bootable-usb,

--- a/pkg/virt-handler/device-manager/usb_device.go
+++ b/pkg/virt-handler/device-manager/usb_device.go
@@ -605,6 +605,11 @@ func discoverAllowedUSBDevices(usbs []v1.USBHostDevice) map[string][]*PluginDevi
 	localDevices := discoverLocalUSBDevicesFunc()
 	for _, usbConfig := range usbs {
 		resourceName := usbConfig.ResourceName
+		if usbConfig.ExternalResourceProvider {
+			log.Log.V(6).Infof("Skipping discovery of %s. To be handled by external device-plugin",
+				resourceName)
+			continue
+		}
 		index := 0
 		usbdevs, foundAll := localDevices.fetch(usbConfig.Selectors)
 		for foundAll {

--- a/pkg/virt-handler/device-manager/usb_device_test.go
+++ b/pkg/virt-handler/device-manager/usb_device_test.go
@@ -156,6 +156,34 @@ var _ = Describe("USB Device", func() {
 				},
 			},
 		),
+		Entry("1 resource external-provider, 1 resource matching 1 USB device total",
+			[]v1.USBHostDevice{
+				{
+					ResourceName: resourceName1,
+					Selectors: []v1.USBSelector{
+						{
+							Vendor:  fmt.Sprintf("%x", usbs[0].Vendor),
+							Product: fmt.Sprintf("%x", usbs[0].Product),
+						},
+					},
+				},
+				{
+					ResourceName:             resourceName2,
+					ExternalResourceProvider: true,
+					Selectors: []v1.USBSelector{
+						{
+							Vendor:  fmt.Sprintf("%x", usbs[1].Vendor),
+							Product: fmt.Sprintf("%x", usbs[1].Product),
+						},
+					},
+				},
+			},
+			map[string][]*PluginDevices{
+				resourceName1: []*PluginDevices{
+					newPluginDevices(resourceName1, 0, []*USBDevice{usbs[0]}),
+				},
+			},
+		),
 		Entry("Should ignore a config with same USB selector",
 			[]v1.USBHostDevice{
 				{

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1291,6 +1291,10 @@ var CRDsValidation map[string]string = map[string]string{
                 usb:
                   items:
                     properties:
+                      externalResourceProvider:
+                        description: If true, KubeVirt will leave the allocation and
+                          monitoring to an external device plugin
+                        type: boolean
                       resourceName:
                         description: 'Identifies the list of USB host devices. e.g:
                           kubevirt.io/storage, kubevirt.io/bootable-usb, etc'

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2596,6 +2596,9 @@ type USBHostDevice struct {
 	ResourceName string `json:"resourceName"`
 	// +listType=atomic
 	Selectors []USBSelector `json:"selectors,omitempty"`
+	// If true, KubeVirt will leave the allocation and monitoring to an
+	// external device plugin
+	ExternalResourceProvider bool `json:"externalResourceProvider,omitempty"`
 }
 
 type USBSelector struct {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -821,8 +821,9 @@ func (PermittedHostDevices) SwaggerDoc() map[string]string {
 
 func (USBHostDevice) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"resourceName": "Identifies the list of USB host devices.\ne.g: kubevirt.io/storage, kubevirt.io/bootable-usb, etc",
-		"selectors":    "+listType=atomic",
+		"resourceName":             "Identifies the list of USB host devices.\ne.g: kubevirt.io/storage, kubevirt.io/bootable-usb, etc",
+		"selectors":                "+listType=atomic",
+		"externalResourceProvider": "If true, KubeVirt will leave the allocation and monitoring to an\nexternal device plugin",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -22135,6 +22135,13 @@ func schema_kubevirtio_api_core_v1_USBHostDevice(ref common.ReferenceCallback) c
 							},
 						},
 					},
+					"externalResourceProvider": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If true, KubeVirt will leave the allocation and monitoring to an external device plugin",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"resourceName"},
 			},

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -59,13 +59,6 @@ var _ = Describe("[Serial][sig-compute][USB] host USB Passthrough", Serial, deco
 		err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
 		libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
-
-		kv := util.GetCurrentKv(virtClient)
-		// Reinitialized the DeveloperConfiguration to avoid to influence the next test
-		config = kv.Spec.Configuration
-		config.DeveloperConfiguration = &v1.DeveloperConfiguration{}
-		config.PermittedHostDevices = &v1.PermittedHostDevices{}
-		tests.UpdateKubeVirtConfigValueAndWait(config)
 	})
 
 	Context("with usb storage", func() {

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -30,11 +30,9 @@ const (
 )
 
 var _ = Describe("[Serial][sig-compute][USB] host USB Passthrough", Serial, decorators.SigCompute, decorators.USB, func() {
-	var (
-		virtClient kubecli.KubevirtClient
-		config     v1.KubeVirtConfiguration
-		vmi        *v1.VirtualMachineInstance
-	)
+	var virtClient kubecli.KubevirtClient
+	var config v1.KubeVirtConfiguration
+	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a follow up from https://github.com/kubevirt/kubevirt/pull/10015
It does minor fixes suggested by @xpivarc and adds support to `external resource provider`, similar to PCI and Mediated devices.

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
