### PR TITLE
virt-launcher, converter: Remove redundent check for '/dev/vhost-net' presense

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -2139,20 +2139,6 @@ func GracePeriodSeconds(vmi *v1.VirtualMachineInstance) int64 {
 	return gracePeriodSeconds
 }
 
-func (c *ConverterContext) IsVirtIONetProhibited() (bool, error) {
-	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(vhostNetPath, c.AllowEmulation); err != nil {
-		return false, err
-	} else if softwareEmulation {
-		logger := log.DefaultLogger()
-		logger.Infof("In-kernel virtio-net device emulation '%s' not present. Falling back to QEMU userland emulation.", vhostNetPath)
-	} else if _, err := os.Stat(vhostNetPath); errors.Is(err, os.ErrNotExist) {
-		return true, nil
-	} else if err != nil {
-		return false, err
-	}
-	return false, nil
-}
-
 func InterpretTransitionalModelType(useVirtioTransitional *bool) string {
 	if useVirtioTransitional != nil && *useVirtioTransitional {
 		return "virtio-transitional"

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -37,11 +37,6 @@ import (
 )
 
 func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext) ([]api.Interface, error) {
-	isVirtioNetProhibited, err := c.IsVirtIONetProhibited()
-	if err != nil {
-		return nil, err
-	}
-
 	var domainInterfaces []api.Interface
 
 	nonAbsentIfaces := netvmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
@@ -67,12 +62,6 @@ func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 				Type: translateModel(vmi.Spec.Domain.Devices.UseVirtioTransitional, ifaceType),
 			},
 			Alias: api.NewUserDefinedAlias(iface.Name),
-		}
-
-		// if AllowEmulation unset and at least one NIC model is virtio,
-		// /dev/vhost-net must be present as we should have asked for it.
-		if ifaceType == v1.VirtIO && isVirtioNetProhibited {
-			return nil, fmt.Errorf("In-kernel virtio-net device emulation '/dev/vhost-net' not present")
 		}
 
 		if queueCount := uint(CalculateNetworkQueues(vmi, ifaceType)); queueCount != 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In case a VM requires virtio network, when at least one interface model is set to virtio explicitly or empty (implicitly), virt-controller template code will add mount /dev/vhost-net to virt-launcher pod.

The virt-launcher converter code (VM spec to domain XML) checks if /dev/vhost-net exist, if not and Kubevirt is not set to allow software emulation, it will fail syncVMI routine and cause re-enqueues.

In Kubernetes, if a pod spec specifies a resource that doesn't exist the pod hang on scheduling phase and wont start.
In our case, when '/dev/vhost-net' is not present in any node virt-launcher pod wont start.

Failing in case a VM has virito interface(s) but '/dev/vhost-net' is not present is redundant, because when virt-launcher converter code runs it means the pod has started and '/dev/vhost-net' exist.

Also, virt-handler claims ownership of `/dev/vhost-net` [1] just before network setup starts.
If `/dev/vhost-net` is not present, the network setup code will fail and cause the virt-launcher pod to fail.

[1] https://github.com/kubevirt/kubevirt/blob/aa6bdd0b7d6e9c279009efa6f497fee101a13040/pkg/virt-handler/vm.go#L571-L570

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Unfortunately its not possible to unit-test this because a need k8s API server is necessary to decide if pod spec is valid
and schedule successfully.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
