### PR TITLE
instancetypes: Clear VM guest memory when ignoring inference failures

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -46,8 +46,8 @@ type Methods interface {
 	ApplyToVmi(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) Conflicts
 	FindPreferenceSpec(vm *virtv1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error)
 	StoreControllerRevisions(vm *virtv1.VirtualMachine) error
-	InferDefaultInstancetype(vm *virtv1.VirtualMachine) (*virtv1.InstancetypeMatcher, error)
-	InferDefaultPreference(vm *virtv1.VirtualMachine) (*virtv1.PreferenceMatcher, error)
+	InferDefaultInstancetype(vm *virtv1.VirtualMachine) error
+	InferDefaultPreference(vm *virtv1.VirtualMachine) error
 	CheckPreferenceRequirements(instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) (Conflicts, error)
 }
 
@@ -726,13 +726,13 @@ func (m *InstancetypeMethods) findClusterInstancetypeByClient(resourceName strin
 	return instancetype, nil
 }
 
-func (m *InstancetypeMethods) InferDefaultInstancetype(vm *virtv1.VirtualMachine) (*virtv1.InstancetypeMatcher, error) {
+func (m *InstancetypeMethods) InferDefaultInstancetype(vm *virtv1.VirtualMachine) error {
 	if vm.Spec.Instancetype == nil {
-		return nil, nil
+		return nil
 	}
-	// Return unchanged matcher when inference is disabled
+	// Leave matcher unchanged when inference is disabled
 	if vm.Spec.Instancetype.InferFromVolume == "" {
-		return vm.Spec.Instancetype, nil
+		return nil
 	}
 
 	defaultName, defaultKind, err := m.inferDefaultsFromVolumes(vm, vm.Spec.Instancetype.InferFromVolume, apiinstancetype.DefaultInstancetypeLabel, apiinstancetype.DefaultInstancetypeKindLabel)
@@ -744,25 +744,27 @@ func (m *InstancetypeMethods) InferDefaultInstancetype(vm *virtv1.VirtualMachine
 		if errors.As(err, &ignoreableInferenceErr) && ignoreFailure {
 			//nolint:gomnd
 			log.Log.Object(vm).V(3).Info("Ignored error during inference of instancetype, clearing matcher.")
-			return nil, nil
+			vm.Spec.Instancetype = nil
+			return nil
 		}
 
-		return nil, err
+		return err
 	}
 
-	return &virtv1.InstancetypeMatcher{
+	vm.Spec.Instancetype = &virtv1.InstancetypeMatcher{
 		Name: defaultName,
 		Kind: defaultKind,
-	}, nil
+	}
+	return nil
 }
 
-func (m *InstancetypeMethods) InferDefaultPreference(vm *virtv1.VirtualMachine) (*virtv1.PreferenceMatcher, error) {
+func (m *InstancetypeMethods) InferDefaultPreference(vm *virtv1.VirtualMachine) error {
 	if vm.Spec.Preference == nil {
-		return nil, nil
+		return nil
 	}
-	// Return unchanged matcher when inference is disabled
+	// Leave matcher unchanged when inference is disabled
 	if vm.Spec.Preference.InferFromVolume == "" {
-		return vm.Spec.Preference, nil
+		return nil
 	}
 
 	defaultName, defaultKind, err := m.inferDefaultsFromVolumes(vm, vm.Spec.Preference.InferFromVolume, apiinstancetype.DefaultPreferenceLabel, apiinstancetype.DefaultPreferenceKindLabel)
@@ -774,16 +776,18 @@ func (m *InstancetypeMethods) InferDefaultPreference(vm *virtv1.VirtualMachine) 
 		if errors.As(err, &ignoreableInferenceErr) && ignoreFailure {
 			//nolint:gomnd
 			log.Log.Object(vm).V(3).Info("Ignored error during inference of preference, clearing matcher.")
-			return nil, nil
+			vm.Spec.Preference = nil
+			return nil
 		}
 
-		return nil, err
+		return err
 	}
 
-	return &virtv1.PreferenceMatcher{
+	vm.Spec.Preference = &virtv1.PreferenceMatcher{
 		Name: defaultName,
 		Kind: defaultKind,
-	}, nil
+	}
+	return nil
 }
 
 /*

--- a/pkg/testutils/mock_instancetype.go
+++ b/pkg/testutils/mock_instancetype.go
@@ -15,8 +15,8 @@ type MockInstancetypeMethods struct {
 	ApplyToVmiFunc                  func(field *k8sfield.Path, instancetypespec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec, vmiMetadata *metav1.ObjectMeta) instancetype.Conflicts
 	FindPreferenceSpecFunc          func(vm *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error)
 	StoreControllerRevisionsFunc    func(vm *v1.VirtualMachine) error
-	InferDefaultInstancetypeFunc    func(vm *v1.VirtualMachine) (*v1.InstancetypeMatcher, error)
-	InferDefaultPreferenceFunc      func(vm *v1.VirtualMachine) (*v1.PreferenceMatcher, error)
+	InferDefaultInstancetypeFunc    func(vm *v1.VirtualMachine) error
+	InferDefaultPreferenceFunc      func(vm *v1.VirtualMachine) error
 	CheckPreferenceRequirementsFunc func(instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) (instancetype.Conflicts, error)
 }
 
@@ -38,11 +38,11 @@ func (m *MockInstancetypeMethods) StoreControllerRevisions(vm *v1.VirtualMachine
 	return m.StoreControllerRevisionsFunc(vm)
 }
 
-func (m *MockInstancetypeMethods) InferDefaultInstancetype(vm *v1.VirtualMachine) (*v1.InstancetypeMatcher, error) {
+func (m *MockInstancetypeMethods) InferDefaultInstancetype(vm *v1.VirtualMachine) error {
 	return m.InferDefaultInstancetypeFunc(vm)
 }
 
-func (m *MockInstancetypeMethods) InferDefaultPreference(vm *v1.VirtualMachine) (*v1.PreferenceMatcher, error) {
+func (m *MockInstancetypeMethods) InferDefaultPreference(vm *v1.VirtualMachine) error {
 	return m.InferDefaultPreferenceFunc(vm)
 }
 
@@ -64,11 +64,11 @@ func NewMockInstancetypeMethods() *MockInstancetypeMethods {
 		StoreControllerRevisionsFunc: func(_ *v1.VirtualMachine) error {
 			return nil
 		},
-		InferDefaultInstancetypeFunc: func(_ *v1.VirtualMachine) (*v1.InstancetypeMatcher, error) {
-			return nil, nil
+		InferDefaultInstancetypeFunc: func(_ *v1.VirtualMachine) error {
+			return nil
 		},
-		InferDefaultPreferenceFunc: func(_ *v1.VirtualMachine) (*v1.PreferenceMatcher, error) {
-			return nil, nil
+		InferDefaultPreferenceFunc: func(_ *v1.VirtualMachine) error {
+			return nil
 		},
 		CheckPreferenceRequirementsFunc: func(_ *instancetypev1beta1.VirtualMachineInstancetypeSpec, _ *instancetypev1beta1.VirtualMachinePreferenceSpec, _ *v1.VirtualMachineInstanceSpec) (instancetype.Conflicts, error) {
 			return nil, nil

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -97,7 +97,7 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	// Set VM defaults
 	log.Log.Object(&vm).V(4).Info("Apply defaults")
 
-	if err = mutator.inferDefaultInstancetype(&vm); err != nil {
+	if err = mutator.InstancetypeMethods.InferDefaultInstancetype(&vm); err != nil {
 		log.Log.Reason(err).Error("admission failed, unable to set default instancetype")
 		return &admissionv1.AdmissionResponse{
 			Result: &metav1.Status{
@@ -107,7 +107,7 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 		}
 	}
 
-	if err = mutator.inferDefaultPreference(&vm); err != nil {
+	if err = mutator.InstancetypeMethods.InferDefaultPreference(&vm); err != nil {
 		log.Log.Reason(err).Error("admission failed, unable to set default preference")
 		return &admissionv1.AdmissionResponse{
 			Result: &metav1.Status{
@@ -206,24 +206,6 @@ func (mutator *VMsMutator) setPreferenceStorageClassName(vm *v1.VirtualMachine, 
 			}
 		}
 	}
-}
-
-func (mutator *VMsMutator) inferDefaultInstancetype(vm *v1.VirtualMachine) error {
-	instancetypeMatcher, err := mutator.InstancetypeMethods.InferDefaultInstancetype(vm)
-	if err != nil {
-		return err
-	}
-	vm.Spec.Instancetype = instancetypeMatcher
-	return nil
-}
-
-func (mutator *VMsMutator) inferDefaultPreference(vm *v1.VirtualMachine) error {
-	preferenceMatcher, err := mutator.InstancetypeMethods.InferDefaultPreference(vm)
-	if err != nil {
-		return err
-	}
-	vm.Spec.Preference = preferenceMatcher
-	return nil
 }
 
 func (mutator *VMsMutator) setDefaultInstancetypeKind(vm *v1.VirtualMachine) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With this change the guest memory of VMs is cleared when inference of an instancetype was successful and the IgnoreInferFromVolumeFailure policy was set in the instancetype matcher. This allows to enable inference of instancetypes in virtctl by default without breaking the previous behavior by allowing virtctl to provide a fallback amount of memory to be used when inference fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Required to keep previous behavior before #10450 and #10463 were introduced.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Clear VM guest memory when ignoring inference failures
```
