### PR TITLE
virtctl: Do not clear memory when implicitly inferring instancetype 

### DIFF
--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -581,14 +581,17 @@ func (c *createVM) withInferredInstancetype(vm *v1.VirtualMachine) error {
 		return err
 	}
 
-	vm.Spec.Template.Spec.Domain.Memory = nil
 	vm.Spec.Instancetype = &v1.InstancetypeMatcher{
 		InferFromVolume: c.inferInstancetypeFrom,
 	}
 
-	// If inferring implicitly possible errors during inference should be ignored
-	// on the backend because the executed command possibly still was valid.
-	if !c.explicitInstancetypeInference {
+	if c.explicitInstancetypeInference {
+		// If inferring explicitly the default guest memory should be cleared.
+		vm.Spec.Template.Spec.Domain.Memory = nil
+	} else {
+		// If inferring implicitly possible errors during inference should be ignored
+		// on the backend because the executed command possibly still was valid.
+		// The guest memory should not be cleared to provide a fallback value when inference failed.
 		failurePolicy := v1.IgnoreInferFromVolumeFailure
 		vm.Spec.Instancetype.InferFromVolumeFailurePolicy = &failurePolicy
 	}

--- a/pkg/virtctl/create/vm/vm_test.go
+++ b/pkg/virtctl/create/vm/vm_test.go
@@ -162,7 +162,13 @@ var _ = Describe("create vm", func() {
 				Expect(vm.Spec.Instancetype.InferFromVolumeFailurePolicy).ToNot(BeNil())
 				Expect(*vm.Spec.Instancetype.InferFromVolumeFailurePolicy).To(Equal(*inferFromVolumePolicy))
 			}
-			Expect(vm.Spec.Template.Spec.Domain.Memory).To(BeNil())
+			if inferFromVolumePolicy != nil && *inferFromVolumePolicy == v1.IgnoreInferFromVolumeFailure {
+				Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
+				Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).ToNot(BeNil())
+				Expect(*vm.Spec.Template.Spec.Domain.Memory.Guest).To(Equal(resource.MustParse("512Mi")))
+			} else {
+				Expect(vm.Spec.Template.Spec.Domain.Memory).To(BeNil())
+			}
 		},
 			Entry("PvcVolumeFlag and implicit inference (enabled by default)", []string{setFlag(PvcVolumeFlag, "src:my-pvc")}, "my-pvc", &ignoreInferFromVolumeFailure),
 			Entry("PvcVolumeFlag and explicit inference", []string{setFlag(PvcVolumeFlag, "src:my-pvc"), setFlag(InferInstancetypeFlag, "true")}, "my-pvc", nil),
@@ -194,7 +200,13 @@ var _ = Describe("create vm", func() {
 				Expect(vm.Spec.Instancetype.InferFromVolumeFailurePolicy).ToNot(BeNil())
 				Expect(*vm.Spec.Instancetype.InferFromVolumeFailurePolicy).To(Equal(v1.IgnoreInferFromVolumeFailure))
 			}
-			Expect(vm.Spec.Template.Spec.Domain.Memory).To(BeNil())
+			if explicit {
+				Expect(vm.Spec.Template.Spec.Domain.Memory).To(BeNil())
+			} else {
+				Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
+				Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).ToNot(BeNil())
+				Expect(*vm.Spec.Template.Spec.Domain.Memory.Guest).To(Equal(resource.MustParse("512Mi")))
+			}
 		},
 			Entry("implicit (inference enabled by default)", false),
 			Entry("explicit", true),

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -375,7 +375,9 @@ var _ = Describe("[sig-compute][virtctl]create vm", func() {
 			vm := unmarshalVM(out)
 
 			By("Asserting that implicit inference is enabled")
-			Expect(vm.Spec.Template.Spec.Domain.Memory).To(BeNil())
+			Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
+			Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).ToNot(BeNil())
+			Expect(*vm.Spec.Template.Spec.Domain.Memory.Guest).To(Equal(resource.MustParse("512Mi")))
 			Expect(vm.Spec.Instancetype).ToNot(BeNil())
 			Expect(vm.Spec.Instancetype.InferFromVolume).To(Equal(pvc.Name))
 			Expect(vm.Spec.Instancetype.InferFromVolumeFailurePolicy).ToNot(BeNil())
@@ -389,8 +391,11 @@ var _ = Describe("[sig-compute][virtctl]create vm", func() {
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Asserting that matchers were cleared")
+			By("Asserting that matchers were cleared and memory was kept")
 			Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(1))
+			Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
+			Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).ToNot(BeNil())
+			Expect(*vm.Spec.Template.Spec.Domain.Memory.Guest).To(Equal(resource.MustParse("512Mi")))
 			Expect(vm.Spec.Instancetype).To(BeNil())
 			Expect(vm.Spec.Preference).To(BeNil())
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

To keep previous behavior before inference of instancetypes by default
was enabled the guest memory is not cleared when implicitly inferring
instancetypes.

**Special notes for your reviewer**:

Based on #10543, merge after

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
