### PR TITLE
Add PreferAny option to CPU preferences

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -394,6 +394,11 @@ func checkCPUPreferenceRequirements(instancetypeSpec *instancetypev1beta1.Virtua
 		if cpuResources < preferenceSpec.Requirements.CPU.Guest {
 			return Conflicts{cpuField.Child("cores"), cpuField.Child("sockets")}, fmt.Errorf(InsufficientVMCPUResourcesErrorFmt, cpuResources, preferenceSpec.Requirements.CPU.Guest, "cores and sockets")
 		}
+	case instancetypev1beta1.PreferAny:
+		cpuResources := vmiSpec.Domain.CPU.Cores * vmiSpec.Domain.CPU.Sockets * vmiSpec.Domain.CPU.Threads
+		if cpuResources < preferenceSpec.Requirements.CPU.Guest {
+			return Conflicts{cpuField.Child("cores"), cpuField.Child("sockets"), cpuField.Child("threads")}, fmt.Errorf(InsufficientVMCPUResourcesErrorFmt, cpuResources, preferenceSpec.Requirements.CPU.Guest, "cores, sockets and threads")
+		}
 	}
 
 	return nil, nil
@@ -964,7 +969,7 @@ func applyCPU(field *k8sfield.Path, instancetypeSpec *instancetypev1beta1.Virtua
 	switch GetPreferredTopology(preferenceSpec) {
 	case instancetypev1beta1.PreferCores:
 		vmiSpec.Domain.CPU.Cores = instancetypeSpec.CPU.Guest
-	case instancetypev1beta1.PreferSockets:
+	case instancetypev1beta1.PreferSockets, instancetypev1beta1.PreferAny:
 		vmiSpec.Domain.CPU.Sockets = instancetypeSpec.CPU.Guest
 	case instancetypev1beta1.PreferThreads:
 		vmiSpec.Domain.CPU.Threads = instancetypeSpec.CPU.Guest

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -315,6 +315,11 @@ const (
 
 	// Prefer vCPUs to be spread evenly between cores and sockets with any remaining vCPUs being presented as cores
 	PreferSpread PreferredCPUTopology = "preferSpread"
+
+	// Prefer vCPUs to be spread according to VirtualMachineInstanceTemplateSpec
+	//
+	// If used with VirtualMachineInstanceType it will use sockets as default
+	PreferAny PreferredCPUTopology = "preferAny"
 )
 
 // CPUPreferences contains various optional CPU preferences.

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -1766,6 +1766,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		var (
 			preferCores   = instancetypev1beta1.PreferCores
 			preferThreads = instancetypev1beta1.PreferThreads
+			preferAny     = instancetypev1beta1.PreferAny
 		)
 
 		DescribeTable("should be accepted when", func(instancetype *instancetypev1beta1.VirtualMachineInstancetype, preference *instancetypev1beta1.VirtualMachinePreference, vm *v1.VirtualMachine) {
@@ -2009,6 +2010,46 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 										Cores:   uint32(1),
 										Threads: uint32(2),
 										Sockets: uint32(1),
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			Entry("VirtualMachine meets CPU (preferAny) requirements",
+				nil,
+				&instancetypev1beta1.VirtualMachinePreference{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "preference-",
+					},
+					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+						CPU: &instancetypev1beta1.CPUPreferences{
+							PreferredCPUTopology: &preferAny,
+						},
+						Requirements: &instancetypev1beta1.PreferenceRequirements{
+							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
+								Guest: uint32(4),
+							},
+						},
+					},
+				},
+				&v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "vm-",
+					},
+					Spec: v1.VirtualMachineSpec{
+						Running: pointer.Bool(false),
+						Preference: &v1.PreferenceMatcher{
+							Kind: "VirtualMachinePreference",
+						},
+						Template: &v1.VirtualMachineInstanceTemplateSpec{
+							Spec: v1.VirtualMachineInstanceSpec{
+								Domain: v1.DomainSpec{
+									CPU: &v1.CPU{
+										Cores:   uint32(2),
+										Threads: uint32(1),
+										Sockets: uint32(2),
 									},
 								},
 							},
@@ -2267,6 +2308,47 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 								Domain: v1.DomainSpec{
 									CPU: &v1.CPU{
 										Cores:   uint32(1),
+										Threads: uint32(1),
+										Sockets: uint32(1),
+									},
+								},
+							},
+						},
+					},
+				},
+				"insufficient CPU resources",
+			),
+			Entry("VirtualMachine does not meet CPU (preferAny) requirements",
+				nil,
+				&instancetypev1beta1.VirtualMachinePreference{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "preference-",
+					},
+					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+						CPU: &instancetypev1beta1.CPUPreferences{
+							PreferredCPUTopology: &preferAny,
+						},
+						Requirements: &instancetypev1beta1.PreferenceRequirements{
+							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
+								Guest: uint32(4),
+							},
+						},
+					},
+				},
+				&v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "vm-",
+					},
+					Spec: v1.VirtualMachineSpec{
+						Running: pointer.Bool(false),
+						Preference: &v1.PreferenceMatcher{
+							Kind: "VirtualMachinePreference",
+						},
+						Template: &v1.VirtualMachineInstanceTemplateSpec{
+							Spec: v1.VirtualMachineInstanceSpec{
+								Domain: v1.DomainSpec{
+									CPU: &v1.CPU{
+										Cores:   uint32(2),
 										Threads: uint32(1),
 										Sockets: uint32(1),
 									},


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds PreferAny option to CPU preferences that should allow a user to accept any topology when there are required number of vCPUs provided.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
None
```
