### PR TITLE
Add 100Mi of overhead for guaranteed vmis

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
         "//pkg/config:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/network/istio:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -404,6 +404,10 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 		overhead = multiplyMemory(overhead, ratio)
 	}
 
+	if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
+		overhead.Add(resource.MustParse("100Mi"))
+	}
+
 	return overhead
 }
 

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -2,6 +2,9 @@ package services
 
 import (
 	"fmt"
+	"strconv"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -429,6 +432,304 @@ var _ = Describe("Resource pod spec renderer", func() {
 			kubev1.ResourceMemory: resource.MustParse("80M"),
 		}),
 	)
+})
+
+var _ = Describe("GetMemoryOverhead calculation", func() {
+	// VirtLauncherMonitorOverhead + VirtLauncherOverhead + VirtlogdOverhead + VirtqemudOverhead + QemuOverhead + IothreadsOverhead
+	const staticOverheadString = "218Mi"
+	var (
+		vmi                     *v1.VirtualMachineInstance
+		staticOverhead          *resource.Quantity
+		baseOverhead            *resource.Quantity
+		coresOverhead           *resource.Quantity
+		videoRAMOverhead        *resource.Quantity
+		cpuArchOverhead         *resource.Quantity
+		vfioOverhead            *resource.Quantity
+		downwardmetricsOverhead *resource.Quantity
+		sevOverhead             *resource.Quantity
+		tpmOverhead             *resource.Quantity
+		passtOverhead           *resource.Quantity
+	)
+
+	BeforeEach(func() {
+		vmi = &v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmi"},
+			Spec: v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{
+					Resources: v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+						Limits: kubev1.ResourceList{},
+					},
+				},
+			},
+		}
+		staticOverhead = pointer.P(resource.MustParse(staticOverheadString))
+		// MemoryReq / 512bit
+		baseOverhead = pointer.P(resource.MustParse("2Mi"))
+		coresOverhead = pointer.P(resource.MustParse("8Mi"))
+		videoRAMOverhead = pointer.P(resource.MustParse("16Mi"))
+		cpuArchOverhead = pointer.P(resource.MustParse("128Mi"))
+		vfioOverhead = pointer.P(resource.MustParse("1Gi"))
+		downwardmetricsOverhead = pointer.P(resource.MustParse("1Mi"))
+		sevOverhead = pointer.P(resource.MustParse("256Mi"))
+		tpmOverhead = pointer.P(resource.MustParse("53Mi"))
+		passtOverhead = pointer.P(resource.MustParse("800Mi"))
+	})
+
+	When("the vmi is not requesting any specific device or cpu or whatever", func() {
+		It("should return base overhead+static+8Mi", func() {
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			// 8Mi*1core(default)
+			expected.Add(*coresOverhead)
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+	})
+
+	When("the vmi requests the specific cpu", func() {
+		BeforeEach(func() {
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Cores:   2,
+				Threads: 2,
+				Sockets: 2,
+			}
+		})
+
+		It("should adjust overhead based on the cores/threads/sockets", func() {
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			// (2cores* 2threads *2sockets)
+			value := coresOverhead.Value() * 8
+			expected.Add(*resource.NewQuantity(value, coresOverhead.Format))
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+	})
+
+	When("the vmi requests cpu resource", func() {
+		DescribeTable("should adjust overhead", func(requests, limits string, coresMultiplier int) {
+			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceCPU] = resource.MustParse(requests)
+			if limits != "" {
+				vmi.Spec.Domain.Resources.Limits[kubev1.ResourceCPU] = resource.MustParse(limits)
+			}
+
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			value := coresOverhead.Value() * int64(coresMultiplier)
+			expected.Add(*resource.NewQuantity(value, coresOverhead.Format))
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		},
+			Entry("based on the limits if both requests and limits are provided", "3", "5", 5),
+			Entry("based on the requests if only requests are provided", "3", "", 3),
+		)
+
+	})
+
+	When("the vmi does not require auto attach graphics device", func() {
+		BeforeEach(func() {
+			vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = pointer.P(false)
+		})
+
+		It("should not add videoRAMOverhead", func() {
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*coresOverhead)
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+	})
+
+	When("the cpu arch is arm64", func() {
+		It("should add arm64 overhead", func() {
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(*cpuArchOverhead)
+			overhead := GetMemoryOverhead(vmi, "arm64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+	})
+
+	When("the vmi requests a VFIO device", func() {
+		DescribeTable("should add vfio overhead", func(devices v1.Devices) {
+			vmi.Spec.Domain.Devices = devices
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(*vfioOverhead)
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		},
+			Entry("with hostDEV", v1.Devices{HostDevices: []v1.HostDevice{{Name: "test"}}}),
+			Entry("with GPU", v1.Devices{GPUs: []v1.GPU{{Name: "test"}}}),
+			Entry("with SRIOV", v1.Devices{Interfaces: []v1.Interface{{Name: "test", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}}}),
+		)
+	})
+
+	When("the vmi has a downward metrics volume", func() {
+		BeforeEach(func() {
+			vmi.Spec.Volumes = []v1.Volume{{VolumeSource: v1.VolumeSource{DownwardMetrics: &v1.DownwardMetricsVolumeSource{}}}}
+		})
+		It("should add downwardMetrics overhead", func() {
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(*downwardmetricsOverhead)
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+	})
+
+	When("the vmi has probes fields", func() {
+		DescribeTable("should add probes overhead", func(livenessProbe, readinessProbe *v1.Probe, probeOverhead resource.Quantity) {
+			vmi.Spec.LivenessProbe = livenessProbe
+			vmi.Spec.ReadinessProbe = readinessProbe
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(probeOverhead)
+
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		},
+			Entry("with livenessProbe only", &v1.Probe{Handler: v1.Handler{Exec: &kubev1.ExecAction{}}}, nil, resource.MustParse("110Mi")),
+			Entry("with readinessProbe only", nil, &v1.Probe{Handler: v1.Handler{Exec: &kubev1.ExecAction{}}}, resource.MustParse("110Mi")),
+			Entry("with both readinessProbe adn livenessProbe", &v1.Probe{Handler: v1.Handler{Exec: &kubev1.ExecAction{}}}, &v1.Probe{Handler: v1.Handler{Exec: &kubev1.ExecAction{}}}, resource.MustParse("120Mi")),
+		)
+	})
+
+	When("the vmi requests AMD SEV", func() {
+		BeforeEach(func() {
+			vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{
+				SEV: &v1.SEV{},
+			}
+		})
+
+		It("should add SEV overhead", func() {
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(*sevOverhead)
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+	})
+
+	When("the vmi requests TPM device", func() {
+		BeforeEach(func() {
+			vmi.Spec.Domain.Devices = v1.Devices{
+				TPM: &v1.TPMDevice{},
+			}
+		})
+
+		It("should add SEV overhead", func() {
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(*tpmOverhead)
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+	})
+
+	When("the vmi requests interfaces with Passt binding", func() {
+		BeforeEach(func() {
+			vmi.Spec.Domain.Devices = v1.Devices{
+				Interfaces: []v1.Interface{
+					{Name: "passt1", InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}}},
+					{Name: "passt2", InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}}},
+					{Name: "passt3", InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}}},
+					{Name: "nonpasst", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+				},
+			}
+		})
+
+		It("should add passt overhead for each interface", func() {
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			value := passtOverhead.Value() * 3
+			expected.Add(*resource.NewQuantity(value, passtOverhead.Format))
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		})
+	})
+
+	When("the additionalOverheadRatio is provided", func() {
+		DescribeTable("should adjust the overhead using the given ratio", func(additionalOverheadRatio string, expectParseError bool) {
+			base := resource.NewScaledQuantity(0, resource.Kilo)
+			base.Add(*baseOverhead)
+			base.Add(*staticOverhead)
+			base.Add(*videoRAMOverhead)
+			base.Add(*coresOverhead)
+			var expected resource.Quantity
+			if expectParseError {
+				expected = *base
+			} else {
+				ratio, _ := strconv.ParseFloat(additionalOverheadRatio, 64)
+				expected = multiplyMemory(*base, ratio)
+			}
+
+			overhead := GetMemoryOverhead(vmi, "amd64", pointer.P(additionalOverheadRatio))
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		},
+			Entry("with the given value if the given value is a float", "3.2", false),
+			Entry("with no value if the given value is not a float", "no_float", true),
+		)
+	})
+
+	When("the vmi is requesting dedicated CPU or wants to have QOSGuaranteed", func() {
+		DescribeTable("should add 100Mi of overhead", func(requestDedicatedCPU, wantsQOSGuaranteed bool) {
+			vmi.Spec.Domain.CPU = &v1.CPU{Cores: 1}
+			if requestDedicatedCPU {
+				vmi.Spec.Domain.CPU.DedicatedCPUPlacement = true
+			}
+			if wantsQOSGuaranteed {
+				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("1Gi")
+				vmi.Spec.Domain.Resources.Limits[kubev1.ResourceMemory] = resource.MustParse("1Gi")
+				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceCPU] = resource.MustParse("4")
+				vmi.Spec.Domain.Resources.Limits[kubev1.ResourceCPU] = resource.MustParse("4")
+			}
+			expected := resource.NewScaledQuantity(0, resource.Kilo)
+			expected.Add(*baseOverhead)
+			expected.Add(*staticOverhead)
+			expected.Add(*videoRAMOverhead)
+			expected.Add(*coresOverhead)
+			expected.Add(resource.MustParse("100Mi"))
+
+			overhead := GetMemoryOverhead(vmi, "amd64", nil)
+			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
+		},
+			Entry("with DedicatedCPU", true, false),
+			Entry("when wants QOSGuaranteed", false, true),
+		)
+	})
+
 })
 
 func addResources(firstQuantity resource.Quantity, resources ...resource.Quantity) resource.Quantity {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Preliminary tests showed that the virt-overhead is underestimated by 100Mi. For guaranteed vmi this means that the limits we set are too stringent.

Also, add the full unit test coverage of the `getMemoryOverhead` function.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @xpivarc