### PR TITLE
Add rate limit for creating attachment pods

### DIFF
--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -41,7 +41,7 @@ const (
 const (
 	FedoraVolumeSize = "6Gi"
 	CirrosVolumeSize = "512Mi"
-	BlankVolumeSize  = "64Mi"
+	BlankVolumeSize  = "16Mi"
 )
 
 // ContainerDiskFor takes the name of an image and returns the full


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When hotplug a large number of volumes at once the number of created and deleted attachment pods is quite large and puts a strain on the api server. This commit puts a rate limit on how fast attachment pods can be created.

This is especially important for when kubevirt is used to host another kubernetes cluster, and that cluster deploys an application that creates a lot of volumes at once. This can potentially overwhelm the API server with attachment pods. This can manifest itself in one of two ways.
1. Too many attachment pods being created at once (and deleted). This mainly happens when there are not a lot of volumes attached to a VM.
2. When there are a lot of volumes attached to a VM (100+) creating a new attachment pod takes some time, especially if these are filesystem volumes (it has to chown files and things of that nature). So if a lot of volumes are added in a short period of time, then creating a lot of pods will take a lot of time, and won't be useful since it will be replaced immediately with a new pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Based on https://github.com/kubevirt/kubevirt/pull/10841

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Attachment pod creation is now rate limited
```
