### PR TITLE
Network plugin binding API: Support CNI plugins

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17343,6 +17343,10 @@
    "v1.InterfaceBindingPlugin": {
     "type": "object",
     "properties": {
+     "networkAttachmentDefinition": {
+      "description": "NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object. Format: \u003cname\u003e, \u003cnamespace\u003e/\u003cname\u003e. If namespace is not specified, VMI namespace is assumed. version: 1alphav1",
+      "type": "string"
+     },
      "sidecarImage": {
       "description": "SidecarImage references a container image that runs in the virt-launcher pod. The sidecar handles (libvirt) domain configuration and optional services. version: 1alphav1",
       "type": "string"

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -624,6 +624,12 @@ spec:
                       binding:
                         additionalProperties:
                           properties:
+                            networkAttachmentDefinition:
+                              description: 'NetworkAttachmentDefinition references
+                                to a NetworkAttachmentDefinition CR object. Format:
+                                <name>, <namespace>/<name>. If namespace is not specified,
+                                VMI namespace is assumed. version: 1alphav1'
+                              type: string
                             sidecarImage:
                               description: 'SidecarImage references a container image
                                 that runs in the virt-launcher pod. The sidecar handles
@@ -3682,6 +3688,12 @@ spec:
                       binding:
                         additionalProperties:
                           properties:
+                            networkAttachmentDefinition:
+                              description: 'NetworkAttachmentDefinition references
+                                to a NetworkAttachmentDefinition CR object. Format:
+                                <name>, <namespace>/<name>. If namespace is not specified,
+                                VMI namespace is assumed. version: 1alphav1'
+                              type: string
                             sidecarImage:
                               description: 'SidecarImage references a container image
                                 that runs in the virt-launcher pod. The sidecar handles

--- a/pkg/network/netbinding/netbinding.go
+++ b/pkg/network/netbinding/netbinding.go
@@ -96,7 +96,7 @@ func slirpNetBindingPluginSidecar(vmi *v1.VirtualMachineInstance, kvConfig *v1.K
 	}
 
 	var slirpSidecarImage string
-	if plugin := readNetBindingPluginConfiguration(kvConfig, SlirpNetworkBindingPluginName); plugin == nil {
+	if plugin := ReadNetBindingPluginConfiguration(kvConfig, SlirpNetworkBindingPluginName); plugin == nil {
 		// In case no Slirp network binding plugin is registered (i.e.: specified in in Kubevirt config) use default image
 		// to prevent newly created Slirp VMs from hanging, and reduce friction for users who didn't register an image yet.
 		// TODO: remove this workaround by next Kubevirt release v1.2.0.
@@ -114,7 +114,7 @@ func slirpNetBindingPluginSidecar(vmi *v1.VirtualMachineInstance, kvConfig *v1.K
 	}
 }
 
-func readNetBindingPluginConfiguration(kvConfig *v1.KubeVirtConfiguration, pluginName string) *v1.InterfaceBindingPlugin {
+func ReadNetBindingPluginConfiguration(kvConfig *v1.KubeVirtConfiguration, pluginName string) *v1.InterfaceBindingPlugin {
 	if kvConfig != nil && kvConfig.NetworkConfiguration != nil && kvConfig.NetworkConfiguration.Binding != nil {
 		if plugin, exist := kvConfig.NetworkConfiguration.Binding[pluginName]; exist {
 			return &plugin

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/host-disk:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/namescheme:go_default_library",
+        "//pkg/network/netbinding:go_default_library",
         "//pkg/network/sriov:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",

--- a/pkg/virt-controller/services/multus_annotations_test.go
+++ b/pkg/virt-controller/services/multus_annotations_test.go
@@ -28,6 +28,9 @@ import (
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 var _ = Describe("Multus annotations", func() {
@@ -86,4 +89,81 @@ var _ = Describe("Multus annotations", func() {
 			Expect(multusAnnotationPool.toString()).To(BeIdenticalTo(expectedString))
 		})
 	})
+
+	Context("Generate Multus network selection annotation", func() {
+		When("NetworkBindingPlugins feature enabled", func() {
+			It("should fail if the specified network binding plugin is not registered (specified in Kubevirt config)", func() {
+				vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"}}
+				vmi.Spec.Networks = []v1.Network{
+					{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+					{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}}}
+
+				config := testsClusterConfig(map[string]v1.InterfaceBindingPlugin{
+					"another-test-binding": {NetworkAttachmentDefinition: "another-test-binding-net"},
+				})
+
+				_, err := GenerateMultusCNIAnnotation(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, config)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should add network binding plugin net-attach-def to multus annotation", func() {
+				vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"}}
+				vmi.Spec.Networks = []v1.Network{
+					{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+					{Name: "blue", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test1"}}},
+					{Name: "red", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "other-namespace/test1"}}},
+				}
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+					{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}},
+					{Name: "blue"}, {Name: "red"}}
+
+				config := testsClusterConfig(map[string]v1.InterfaceBindingPlugin{
+					"test-binding": {NetworkAttachmentDefinition: "test-binding-net"},
+				})
+
+				Expect(GenerateMultusCNIAnnotation(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, config)).To(MatchJSON(
+					`[
+						{"name": "test-binding-net","namespace": "default", "cni-args": {"logic-network-name": "default"}},						
+						{"name": "test1","namespace": "default","interface": "pod16477688c0e"},
+						{"name": "test1","namespace": "other-namespace","interface": "podb1f51a511f1"}
+					]`,
+				))
+			})
+
+			DescribeTable("should parse NetworkAttachmentDefinition name and namespace correctly, given",
+				func(netAttachDefRawName, expectedAnnot string) {
+					vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"}}
+					vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+					vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+						{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}}}
+
+					config := testsClusterConfig(map[string]v1.InterfaceBindingPlugin{
+						"test-binding": {NetworkAttachmentDefinition: netAttachDefRawName},
+					})
+
+					Expect(GenerateMultusCNIAnnotation(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, config)).To(MatchJSON(expectedAnnot))
+				},
+				Entry("name with no namespace", "my-binding",
+					`[{"namespace": "default", "name": "my-binding", "cni-args": {"logic-network-name": "default"}}]`),
+				Entry("name with namespace", "namespace1/my-binding",
+					`[{"namespace": "namespace1", "name": "my-binding", "cni-args": {"logic-network-name": "default"}}]`),
+			)
+		})
+	})
 })
+
+func testsClusterConfig(plugins map[string]v1.InterfaceBindingPlugin) *virtconfig.ClusterConfig {
+	kvConfig := &v1.KubeVirtConfiguration{
+		DeveloperConfiguration: &v1.DeveloperConfiguration{
+			FeatureGates: []string{"NetworkBindingPlugins"},
+		},
+		NetworkConfiguration: &v1.NetworkConfiguration{
+			Binding: plugins,
+		},
+	}
+	config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kvConfig)
+
+	return config
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -272,7 +272,7 @@ func (t *templateService) RenderMigrationManifest(vmi *v1.VirtualMachineInstance
 	if namescheme.PodHasOrdinalInterfaceName(NonDefaultMultusNetworksIndexedByIfaceName(pod)) {
 		ordinalNameScheme := namescheme.CreateOrdinalNetworkNameScheme(vmi.Spec.Networks)
 		multusNetworksAnnotation, err := GenerateMultusCNIAnnotationFromNameScheme(
-			vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, ordinalNameScheme)
+			vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, ordinalNameScheme, t.clusterConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -484,7 +484,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 				sidecarContainerName(i), vmi, sidecarResources(vmi, t.clusterConfig), requestedHookSidecar, userId).Render(requestedHookSidecar.Command))
 	}
 
-	podAnnotations, err := generatePodAnnotations(vmi)
+	podAnnotations, err := generatePodAnnotations(vmi, t.clusterConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -1269,7 +1269,7 @@ func generateContainerSecurityContext(selinuxType string, container *k8sv1.Conta
 	container.SecurityContext.SELinuxOptions.Level = "s0"
 }
 
-func generatePodAnnotations(vmi *v1.VirtualMachineInstance) (map[string]string, error) {
+func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.ClusterConfig) (map[string]string, error) {
 	annotationsSet := map[string]string{
 		v1.DomainAnnotation: vmi.GetObjectMeta().GetName(),
 	}
@@ -1283,7 +1283,7 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance) (map[string]string, 
 		return iface.State != v1.InterfaceStateAbsent
 	})
 	nonAbsentNets := vmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, nonAbsentIfaces)
-	multusAnnotation, err := GenerateMultusCNIAnnotation(vmi.Namespace, nonAbsentIfaces, nonAbsentNets)
+	multusAnnotation, err := GenerateMultusCNIAnnotation(vmi.Namespace, nonAbsentIfaces, nonAbsentNets, config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2292,7 +2292,7 @@ func (c *VMIController) updateMultusAnnotation(namespace string, interfaces []vi
 
 	indexedMultusStatusIfaces := services.NonDefaultMultusNetworksIndexedByIfaceName(pod)
 	networkToPodIfaceMap := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, indexedMultusStatusIfaces)
-	multusAnnotations, err := services.GenerateMultusCNIAnnotationFromNameScheme(namespace, interfaces, networks, networkToPodIfaceMap)
+	multusAnnotations, err := services.GenerateMultusCNIAnnotationFromNameScheme(namespace, interfaces, networks, networkToPodIfaceMap, c.clusterConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1224,6 +1224,12 @@ var CRDsValidation map[string]string = map[string]string{
                 binding:
                   additionalProperties:
                     properties:
+                      networkAttachmentDefinition:
+                        description: 'NetworkAttachmentDefinition references to a
+                          NetworkAttachmentDefinition CR object. Format: <name>, <namespace>/<name>.
+                          If namespace is not specified, VMI namespace is assumed.
+                          version: 1alphav1'
+                        type: string
                       sidecarImage:
                         description: 'SidecarImage references a container image that
                           runs in the virt-launcher pod. The sidecar handles (libvirt)

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2675,6 +2675,11 @@ type InterfaceBindingPlugin struct {
 	// The sidecar handles (libvirt) domain configuration and optional services.
 	// version: 1alphav1
 	SidecarImage string `json:"sidecarImage,omitempty"`
+	// NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object.
+	// Format: <name>, <namespace>/<name>.
+	// If namespace is not specified, VMI namespace is assumed.
+	// version: 1alphav1
+	NetworkAttachmentDefinition string `json:"networkAttachmentDefinition,omitempty"`
 }
 
 // GuestAgentPing configures the guest-agent based ping probe

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -878,7 +878,8 @@ func (NetworkConfiguration) SwaggerDoc() map[string]string {
 
 func (InterfaceBindingPlugin) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"sidecarImage": "SidecarImage references a container image that runs in the virt-launcher pod.\nThe sidecar handles (libvirt) domain configuration and optional services.\nversion: 1alphav1",
+		"sidecarImage":                "SidecarImage references a container image that runs in the virt-launcher pod.\nThe sidecar handles (libvirt) domain configuration and optional services.\nversion: 1alphav1",
+		"networkAttachmentDefinition": "NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object.\nFormat: <name>, <namespace>/<name>.\nIf namespace is not specified, VMI namespace is assumed.\nversion: 1alphav1",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18566,6 +18566,13 @@ func schema_kubevirtio_api_core_v1_InterfaceBindingPlugin(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"networkAttachmentDefinition": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object. Format: <name>, <namespace>/<name>. If namespace is not specified, VMI namespace is assumed. version: 1alphav1",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR implement the Network binding plugin API's Pod Creation & Definition integration point  [[1]](https://docs.google.com/document/d/13fLaqZuM8El_CT5XzxPv-1epKsB1-Spv_jtXveEkkdQ#heading=h.qcw5usdbc0nx), enable invoking CNIs  to configure virt-launcher pod network namespace.

How it works:
Similar to secondary networks, the binding plugin CNI is invoked by Multus, its necessary to define a `NetworkAttachmentDefiniton` for the bidning plugin.
Kubevirt will add the requested binding plugin `NetworkAttachmentDefiniton` to virt-launcher pod's Multus network selection annotation.
When the pod is created, its CNI chain will be invoked including the required binding plugin CNI.

How to use:
Given a network binding plugin 'dummy' that require invoking CNI.

Create `NetworkAttachmentDefinition` with the CNI(s) config for the binding plugin:
```
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: network-binding-dummy
spec:
  config: |
    {
      "cniVersion":"0.3.1",
      "name": "network-binding-dummy",
      "plugins": [
          {   
              "type": "templatecni"
          }
      ]
    }
```
`templatecni` source [[2]](https://github.com/EdDev/template-cni)

Enable network binding plugins feature and register the plugin and its `NetwrokAttachmentDefinition` in Kubevirt config:
```
  apiVersion: kubevirt.io/v1
  kind: KubeVirt
  metadata:
    name: kubevirt
    namespace: kubevirt
  spec:
    configuration:
      developerConfiguration:
        featureGates:
        - NetworkBindingPlugins
      network:
        binding:
          dummy:
            networkAttachmentDefinition: dummy-net-binding
. . .
```

Specify the binding in the VM spec:
```
apiVersion: kubevirt.io/v1
kind: VirtualMachineInstance
metadata:
  name: vmi-dummy-cni
spec:
  domain:
    devices:
      interfaces:
        - name: mgmt
          binding:
            name: dummy
. . .
```

virt-launcher pod's Multus network selection annotation include the required binding `NetworkAttachmentDefinition` : 
```
apiVersion: v1
kind: Pod
metadata:
  name: virt-launcher-vmi-dummy-cni-jjphk
  annotations:
    kubectl.kubernetes.io/default-container: compute
    kubevirt.io/domain: vmi-dummy-cni
    k8s.v1.cni.cncf.io/networks: '[
       . . . 
       {"name":"network-binding-dummy","namespace":"default","interface":"pod4ccb1906e14"},
    ]'
. . .
```


[1]  Network binding plugin API design: https://docs.google.com/document/d/13fLaqZuM8El_CT5XzxPv-1epKsB1-Spv_jtXveEkkdQ#heading=h.qcw5usdbc0nx
[2] `templatecni` source: https://github.com/EdDev/template-cni

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Last commit fixes virt-controller vmi_test.go unit tests, it required some more changes thus moved to new commit.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network binding plugin API support CNIs, new integration point on virt-launcher pod creation.
```
