### PR TITLE
isolateEmulatorThread: Add full-pcpu-only support

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1717,6 +1717,15 @@ func ValidateVirtualMachineInstanceMetadata(field *k8sfield.Path, metadata *meta
 		}
 	}
 
+	if _, exists := annotations[v1.CPUManagerPolicyBetaOptionsAnnotation]; exists && !config.CPUManagerPolicyBetaOptionsEnabled() {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("CPUManagerPolicyBetaOptions feature gate is not enabled in kubevirt-config, invalid entry %s",
+				field.Child("annotations").Child(v1.CPUManagerPolicyBetaOptionsAnnotation).String()),
+			Field: field.Child("annotations").String(),
+		})
+	}
+
 	return causes
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -480,6 +480,10 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				map[string]string{hooks.HookSidecarListAnnotationName: "[{'image': 'fake-image'}]"},
 				fmt.Sprintf("invalid entry metadata.annotations.%s", hooks.HookSidecarListAnnotationName),
 			),
+			Entry("without CPUManagerPolicyBetaOptions feature gate enabled",
+				map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: string(v1.CPUManagerPolicyBetaOptionFullpCPUsOnly)},
+				fmt.Sprintf("invalid entry metadata.annotations.%s", v1.CPUManagerPolicyBetaOptionsAnnotation),
+			),
 		)
 
 		DescribeTable("should accept annotations which require feature gate enabled", func(annotations map[string]string, featureGate string) {
@@ -498,6 +502,10 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Entry("with sidecar feature gate enabled",
 				map[string]string{hooks.HookSidecarListAnnotationName: "[{'image': 'fake-image'}]"},
 				virtconfig.SidecarGate,
+			),
+			Entry("with CPUManagerPolicyBetaOptions feature gate enabled",
+				map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: string(v1.CPUManagerPolicyBetaOptionFullpCPUsOnly)},
+				virtconfig.CPUManagerPolicyBetaOptionsGate,
 			),
 		)
 	})

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -81,6 +81,8 @@ const (
 	//
 	// CommonInstancetypesDeploymentGate enables the deployment of common-instancetypes by virt-operator
 	CommonInstancetypesDeploymentGate = "CommonInstancetypesDeploymentGate"
+	// CPUManagerPolicyBetaOptionsGate allows conforming VM to static CPU-Manager Policies.
+	CPUManagerPolicyBetaOptionsGate = "CPUManagerPolicyBetaOptions"
 )
 
 var deprecatedFeatureGates = [...]string{
@@ -258,4 +260,8 @@ func (config *ClusterConfig) AutoResourceLimitsEnabled() bool {
 
 func (config *ClusterConfig) CommonInstancetypesDeploymentEnabled() bool {
 	return config.isFeatureGateEnabled(CommonInstancetypesDeploymentGate)
+}
+
+func (config *ClusterConfig) CPUManagerPolicyBetaOptionsEnabled() bool {
+	return config.isFeatureGateEnabled(CPUManagerPolicyBetaOptionsGate)
 }

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -199,7 +199,7 @@ func WithAutoMemoryLimits(namespace string, namespaceStore cache.Store) Resource
 	}
 }
 
-func WithCPUPinning(cpu *v1.CPU) ResourceRendererOption {
+func WithCPUPinning(cpu *v1.CPU, cpuManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions) ResourceRendererOption {
 	return func(renderer *ResourceRenderer) {
 		vcpus := hardware.GetNumberOfVCPUs(cpu)
 		if vcpus != 0 {
@@ -212,14 +212,21 @@ func WithCPUPinning(cpu *v1.CPU) ResourceRendererOption {
 			}
 		}
 
-		// allocate 1 more pcpu if IsolateEmulatorThread request
+		// allocate pcpus for emulatorThread if IsolateEmulatorThread is requested
 		if cpu.IsolateEmulatorThread {
-			emulatorThreadCPU := resource.NewQuantity(1, resource.BinarySI)
+			emulatorThreadCPUs := resource.NewQuantity(1, resource.BinarySI)
+
 			limits := renderer.calculatedLimits[k8sv1.ResourceCPU]
-			limits.Add(*emulatorThreadCPU)
+			if cpuManagerPolicyBetaOption == v1.CPUManagerPolicyBetaOptionFullpCPUsOnly &&
+				limits.Value()%2 == 0 {
+				emulatorThreadCPUs = resource.NewQuantity(2, resource.BinarySI)
+			}
+
+			limits.Add(*emulatorThreadCPUs)
 			renderer.vmLimits[k8sv1.ResourceCPU] = limits
+
 			if cpuRequest, ok := renderer.vmRequests[k8sv1.ResourceCPU]; ok {
-				cpuRequest.Add(*emulatorThreadCPU)
+				cpuRequest.Add(*emulatorThreadCPUs)
 				renderer.vmRequests[k8sv1.ResourceCPU] = cpuRequest
 			}
 		}

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -171,21 +171,22 @@ var _ = Describe("Resource pod spec renderer", func() {
 	})
 
 	Context("WithCPUPinning option", func() {
+		const cpuManagerPolicyBetaOptionsAnnotationDisabled = ""
 		userCPURequest := resource.MustParse("200m")
 		userSpecifiedCPU := kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
 
 		It("the user requested CPU configs are *not* overriden", func() {
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{Cores: 5}))
+			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{Cores: 5}, cpuManagerPolicyBetaOptionsAnnotationDisabled))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
 		})
 
 		It("carries over the CPU limits as requests when no CPUs are requested", func() {
-			rr = NewResourceRenderer(userSpecifiedCPU, nil, WithCPUPinning(&v1.CPU{}))
+			rr = NewResourceRenderer(userSpecifiedCPU, nil, WithCPUPinning(&v1.CPU{}, cpuManagerPolicyBetaOptionsAnnotationDisabled))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
 		})
 
 		It("carries over the CPU requests as limits when no CPUs are requested", func() {
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{}))
+			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{}, cpuManagerPolicyBetaOptionsAnnotationDisabled))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
 		})
 
@@ -195,41 +196,50 @@ var _ = Describe("Resource pod spec renderer", func() {
 				kubev1.ResourceCPU:    userCPURequest,
 				kubev1.ResourceMemory: memoryRequest,
 			}
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{Cores: 5}))
+			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{Cores: 5}, cpuManagerPolicyBetaOptionsAnnotationDisabled))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, resource.MustParse("200m")))
 			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceMemory, memoryRequest))
 		})
 
 		When("an isolated emulator thread is requested", func() {
-			cpuIsolatedEmulatorThreadOverhead := resource.MustParse("1000m")
 			userSpecifiedCPURequest := kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
 
-			DescribeTable("requires an additional 1000m CPU, and an additional CPU is added to the limits", func(defineUserSpecifiedCPULimit bool) {
+			DescribeTable("requires additional EmulatorThread CPUs overhead, and additional CPUs added to the limits",
+				func(fullPCPUEnabled, defineUserSpecifiedCPULimit bool, cores uint32, expectedCPUOverhead string) {
+					cpuIsolatedEmulatorThreadOverhead := resource.MustParse(expectedCPUOverhead)
+					var userSpecifiedCPULimit kubev1.ResourceList
+					var cpuManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions
 
-				var userSpecifiedCPULimit kubev1.ResourceList
-
-				if defineUserSpecifiedCPULimit {
-					userSpecifiedCPULimit = kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
-				}
-				rr = NewResourceRenderer(
-					userSpecifiedCPULimit,
-					userSpecifiedCPURequest,
-					WithCPUPinning(&v1.CPU{
-						Cores:                 5,
-						IsolateEmulatorThread: true,
-					}),
-				)
-				Expect(rr.Limits()).To(HaveKeyWithValue(
-					kubev1.ResourceCPU,
-					*resource.NewQuantity(6, resource.BinarySI),
-				))
-				Expect(rr.Requests()).To(HaveKeyWithValue(
-					kubev1.ResourceCPU,
-					addResources(userCPURequest, cpuIsolatedEmulatorThreadOverhead),
-				))
-			},
-				Entry("only CPU requests set by the user", false),
-				Entry("request and limits set by the user", true),
+					if defineUserSpecifiedCPULimit {
+						userSpecifiedCPULimit = kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
+					}
+					if fullPCPUEnabled {
+						cpuManagerPolicyBetaOption = v1.CPUManagerPolicyBetaOptionFullpCPUsOnly
+					}
+					rr = NewResourceRenderer(
+						userSpecifiedCPULimit,
+						userSpecifiedCPURequest,
+						WithCPUPinning(&v1.CPU{
+							Cores:                 cores,
+							IsolateEmulatorThread: true,
+						},
+							cpuManagerPolicyBetaOption),
+					)
+					Expect(rr.Limits()).To(HaveKeyWithValue(
+						kubev1.ResourceCPU,
+						*resource.NewQuantity(cpuIsolatedEmulatorThreadOverhead.Value()+int64(cores), resource.BinarySI),
+					))
+					Expect(rr.Requests()).To(HaveKeyWithValue(
+						kubev1.ResourceCPU,
+						addResources(userCPURequest, cpuIsolatedEmulatorThreadOverhead),
+					))
+				},
+				Entry("full-pcpu-only mode is disabled, only CPU requests set by the user", false, false, uint32(5), "1000m"),
+				Entry("full-pcpu-only mode is disabled, request and limits set by the user", false, true, uint32(5), "1000m"),
+				Entry("full-pcpu-only mode is enabled, only CPU requests set by the user, odd amount of cores is requested", true, false, uint32(5), "1000m"),
+				Entry("full-pcpu-only mode is enabled, only CPU requests set by the user, even amount of cores is requested", true, false, uint32(6), "2000m"),
+				Entry("full-pcpu-only mode is enabled, request and limits set by the user, odd amount of cores is requested", true, true, uint32(5), "1000m"),
+				Entry("full-pcpu-only mode is enabled, request and limits set by the user, even amount of cores is requested", true, true, uint32(6), "2000m"),
 			)
 		})
 	})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1459,10 +1459,12 @@ func (t *templateService) doesVMIRequireAutoCPULimits(vmi *v1.VirtualMachineInst
 func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string) VMIResourcePredicates {
 	memoryOverhead := GetMemoryOverhead(vmi, t.clusterConfig.GetClusterCPUArch(), t.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
 	withCPULimits := t.doesVMIRequireAutoCPULimits(vmi)
+	CPUManagerPolicyBetaOption := v1.CPUManagerPolicyBetaOptions(vmi.Annotations[v1.CPUManagerPolicyBetaOptionsAnnotation])
+
 	return VMIResourcePredicates{
 		vmi: vmi,
 		resourceRules: []VMIResourceRule{
-			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi.Spec.Domain.CPU)),
+			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi.Spec.Domain.CPU, CPUManagerPolicyBetaOption)),
 			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi.Spec.Domain.CPU, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
 			NewVMIResourceRule(util.HasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),
 			NewVMIResourceRule(not(util.HasHugePages), WithMemoryOverhead(vmi.Spec.Domain.Resources, memoryOverhead)),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1692,13 +1692,16 @@ var _ = Describe("Template", func() {
 					}, true),
 			)
 
-			It("should allocate 1 more cpu when isolateEmulatorThread requested", func() {
+			DescribeTable("when isolateEmulatorThread requested", func(
+				annotations map[string]string, requestedCores uint32, expectedCPULimits string) {
 				config, kvInformer, svc = configFactory(defaultArch)
+
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "testvmi",
-						Namespace: "default",
-						UID:       "1234",
+						Name:        "testvmi",
+						Namespace:   "default",
+						UID:         "1234",
+						Annotations: annotations,
 					},
 					Spec: v1.VirtualMachineInstanceSpec{
 						Domain: v1.DomainSpec{
@@ -1706,7 +1709,8 @@ var _ = Describe("Template", func() {
 								DisableHotplug: true,
 							},
 							CPU: &v1.CPU{
-								Cores:                 2,
+								Cores:                 requestedCores,
+								Threads:               1,
 								DedicatedCPUPlacement: true,
 								IsolateEmulatorThread: true,
 							},
@@ -1716,9 +1720,14 @@ var _ = Describe("Template", func() {
 
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
-				cpu := resource.MustParse("3")
+				cpu := resource.MustParse(expectedCPULimits)
 				Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().Cmp(cpu)).To(BeZero())
-			})
+			},
+				Entry("no annotation added, odd  CPUs requested, should allocate one extra emulator CPU", map[string]string{}, uint32(3), "4"),
+				Entry("no annotation added, even CPUs requested, should allocate one extra emulator CPU", map[string]string{}, uint32(2), "3"),
+				Entry("full-pcpu-only annotation added, odd CPUs requested, should allocate one extra emulator CPU", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: string(v1.CPUManagerPolicyBetaOptionFullpCPUsOnly)}, uint32(3), "4"),
+				Entry("full-pcpu-only annotation added, even CPUs requested, should allocate two extra emulator CPU (to align SMT scheduling)", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: string(v1.CPUManagerPolicyBetaOptionFullpCPUsOnly)}, uint32(4), "6"),
+			)
 			It("should add node affinity to pod", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
 				nodeAffinity := k8sv1.NodeAffinity{}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -997,6 +997,9 @@ const (
 
 	// MigrationInterfaceName is an arbitrary name used in virt-handler to connect it to a dedicated migration network
 	MigrationInterfaceName string = "migration0"
+
+	// CPUManagerPolicyBetaOptionsAnnotation indicates the CPU-Manager policy that the pod adheres to.
+	CPUManagerPolicyBetaOptionsAnnotation string = "kubevirt.io/CPUManagerPolicyBetaOptions"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {
@@ -2213,6 +2216,13 @@ type VirtualMachineMemoryDumpRequest struct {
 	// +optional
 	Message string `json:"message,omitempty"`
 }
+
+type CPUManagerPolicyBetaOptions string
+
+const (
+	// full-pcpus-only static policy allows only full physical CPUs to be scheduled to a pod
+	CPUManagerPolicyBetaOptionFullpCPUsOnly CPUManagerPolicyBetaOptions = "full-pcpus-only"
+)
 
 type MemoryDumpPhase string
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add an annotation related to the `isolateEmulatorThread` feature, in order to avoid getting SMT alignment error by kubelet on the virt-launcher pod:
```
SMT Alignment Error: requested 9 cpus not multiple cpus per core = 2
```

The conditions needed in order to get this error:
- The node has hyperthreading (SMT) enabled.
- Kubelet’s CPUManager is set to static - full-pcpus-only.
- Kubevirt CR's defaultRuntimeClass is set to a high performance runtimeClass.
- VM is set with dedicatedCPUPlacement and IsolateEmulatorThread enabled.
- VM requests an even number of CPUs.

The meaning of this is that instead of IsolateEmulatorThread adding an extra CPU to the virt-launcher pod, it will add two CPUs when needed in order to get a total number of even CPUs.

Since this error is a direct result of adding the emulatorCPU by the IsolateEmulatorThread feature - the fix is currently needed on kubevirt context.

Note: this PR implements the first phase of the [design proposal](https://github.com/kubevirt/community/pull/247). 
Future PR(s) will utilize the extra CPU to the housekeeping cgroup.


**Which issue(s) this PR fixes**:
Fixes [BZ#2228103](https://bugzilla.redhat.com/show_bug.cgi?id=2228103)

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes SMT Alignment Error in virt-launcher pod by optimizing isolateEmulatorThread feature (BZ#2228103).
```
