### PR TITLE
hook: add PVC option

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -38,12 +38,19 @@ type ConfigMap struct {
 	HookPath string `json:"hookPath"`
 }
 
+type PVC struct {
+	Name              string `json:"name"`
+	VolumePath        string `json:"volumePath"`
+	SharedComputePath string `json:"sharedComputePath"`
+}
+
 type HookSidecar struct {
 	Image           string           `json:"image"`
 	ImagePullPolicy k8sv1.PullPolicy `json:"imagePullPolicy"`
 	Command         []string         `json:"command,omitempty"`
 	Args            []string         `json:"args,omitempty"`
 	ConfigMap       *ConfigMap       `json:"configMap,omitempty"`
+	PVC             *PVC             `json:"pvc,omitempty"`
 }
 
 func UnmarshalHookSidecarList(vmiObject *v1.VirtualMachineInstance) (HookSidecarList, error) {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -499,6 +499,25 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			}
 			sidecarVolumes = append(sidecarVolumes, vol)
 		}
+		if requestedHookSidecar.PVC != nil {
+			volumeSource := k8sv1.VolumeSource{
+				PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+					ClaimName: requestedHookSidecar.PVC.Name,
+				},
+			}
+			vol := k8sv1.Volume{
+				Name:         requestedHookSidecar.PVC.Name,
+				VolumeSource: volumeSource,
+			}
+			sidecarVolumes = append(sidecarVolumes, vol)
+			if requestedHookSidecar.PVC.SharedComputePath != "" {
+				containers[0].VolumeMounts = append(containers[0].VolumeMounts,
+					k8sv1.VolumeMount{
+						Name:      requestedHookSidecar.PVC.Name,
+						MountPath: requestedHookSidecar.PVC.SharedComputePath,
+					})
+			}
+		}
 		containers = append(containers, sidecarContainer)
 	}
 
@@ -662,11 +681,15 @@ func newSidecarContainerRenderer(sidecarName string, vmiSpec *v1.VirtualMachineI
 		WithArgs(requestedHookSidecar.Args),
 	}
 
+	var mounts []k8sv1.VolumeMount
+	mounts = append(mounts, sidecarVolumeMount())
 	if requestedHookSidecar.ConfigMap != nil {
-		sidecarOpts = append(sidecarOpts, WithVolumeMounts(sidecarVolumeMount(), configMapVolumeMount(*requestedHookSidecar.ConfigMap)))
-	} else {
-		sidecarOpts = append(sidecarOpts, WithVolumeMounts(sidecarVolumeMount()))
+		mounts = append(mounts, configMapVolumeMount(*requestedHookSidecar.ConfigMap))
 	}
+	if requestedHookSidecar.PVC != nil {
+		mounts = append(mounts, pvcVolumeMount(*requestedHookSidecar.PVC))
+	}
+	sidecarOpts = append(sidecarOpts, WithVolumeMounts(mounts...))
 
 	if util.IsNonRootVMI(vmiSpec) {
 		sidecarOpts = append(sidecarOpts, WithNonRoot(userId))
@@ -793,6 +816,13 @@ func configMapVolumeMount(v hooks.ConfigMap) k8sv1.VolumeMount {
 		Name:      v.Name,
 		MountPath: v.HookPath,
 		SubPath:   v.Key,
+	}
+}
+
+func pvcVolumeMount(v hooks.PVC) k8sv1.VolumeMount {
+	return k8sv1.VolumeMount{
+		Name:      v.Name,
+		MountPath: v.VolumePath,
 	}
 }
 


### PR DESCRIPTION
Use a PVC for storing and sharing files between the compute and the sidecar containers.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the possibility of using a PVC with the KubeVirt hook sidecar and the compute container. 

One usage of this enhancement is for debugging purposes and a full guide with a demo is available [here](https://github.com/alicefr/kubevirt-debug/tree/main/launch-qemu-strace). This option allows to supply of additional debug tools without the need to rebuild the virt-launcher image and explain how to launch QEMU with a debug tool like strace.

A concrete example of when this can be useful is when QEMU faces some permission issues, like in [this case](https://github.com/kubevirt/kubevirt/pull/9668#issuecomment-1630331947). For those types of failures, starting QEMU with strace can save you a lot of time.


**Special notes for your reviewer**:
Please check the guide, otherwise, these changes standalone don't make much sense. I'd love also to integrate the documentation and demo somehow upstream and suggestions are welcome.

Additionally, we could provide an additional image as part of KubeVIrt release with the most used debugging tool that could be used to populate the PVC.

```release-note
Add PVC option to the hook sidecars for supplying additional debugging tools
```
