### PR TITLE
Use libvmi.WithMasqueradeNetworking instead of an ad hoc tests/utils function

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -508,8 +508,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 		It("[test_id:1776]should configure custom Pci address", func() {
 			By("checking eth0 Pci address")
-			testVMI := libvmi.NewAlpine()
-			tests.AddExplicitPodNetworkInterface(testVMI)
+			testVMI := libvmi.NewAlpine(libvmi.WithMasqueradeNetworking()...)
 			testVMI.Spec.Domain.Devices.Interfaces[0].PciAddress = "0000:01:00.0"
 			testVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), testVMI)
 			Expect(err).ToNot(HaveOccurred())
@@ -559,10 +558,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	Context("VirtualMachineInstance with dhcp options", func() {
 		It("[test_id:1778]should offer extra dhcp options to pod iface", func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
-			dhcpVMI := libvmi.NewFedora()
-			tests.AddExplicitPodNetworkInterface(dhcpVMI)
-
-			dhcpVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
+			dhcpVMI := libvmi.NewFedora(append(libvmi.WithMasqueradeNetworking(),
+				libvmi.WithResourceMemory("1024M"))...)
 
 			// This IPv4 address tests backwards compatibility of the "DHCPOptions.NTPServers" field.
 			// The leading zero is intentional.

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -218,6 +218,14 @@ func insertProductKeyToAnswerFileTemplate(answerFileTemplate string) string {
 	return fmt.Sprintf(answerFileTemplate, productKey)
 }
 
+// addExplicitPodNetworkInterface
+//
+// Deprecated: Use libvmi
+func addExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+}
+
 var getWindowsSysprepVMISpec = func() v1.VirtualMachineInstanceSpec {
 	gracePeriod := int64(0)
 	spinlocks := uint32(8191)
@@ -310,7 +318,7 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 		windowsVMI = tests.NewRandomVMI()
 		windowsVMI.Spec = getWindowsSysprepVMISpec()
 		tests.CreateConfigMap("sysprepautounattend", windowsVMI.Namespace, map[string]string{"Autounattend.xml": answerFileWithKey, "Unattend.xml": answerFileWithKey})
-		tests.AddExplicitPodNetworkInterface(windowsVMI)
+		addExplicitPodNetworkInterface(windowsVMI)
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -226,7 +226,7 @@ func addExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 }
 
-var getWindowsSysprepVMISpec = func() v1.VirtualMachineInstanceSpec {
+func getWindowsSysprepVMISpec() v1.VirtualMachineInstanceSpec {
 	gracePeriod := int64(0)
 	spinlocks := uint32(8191)
 	firmware := types.UID(libvmi.WindowsFirmware)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1005,14 +1005,6 @@ func AddServiceAccountDisk(vmi *v1.VirtualMachineInstance, serviceAccountName st
 	})
 }
 
-// AddExplicitPodNetworkInterface
-//
-// Deprecated: Use libvmi
-func AddExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-}
-
 // AddWatchdog
 //
 // Deprecated: Use libvmi

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -71,8 +71,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, 
 		virtClient = kubevirt.Client()
 		checks.SkipIfMissingRequiredImage(virtClient, libvmi.WindowsPVCName)
 		libstorage.CreatePVC(OSWindows, testsuite.GetTestNamespace(nil), "30Gi", libstorage.Config.StorageClassWindows, true)
-		windowsVMI = libvmi.NewWindows()
-		tests.AddExplicitPodNetworkInterface(windowsVMI)
+		windowsVMI = libvmi.NewWindows(libvmi.WithMasqueradeNetworking()...)
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 


### PR DESCRIPTION
tests/utils is too long.

```release-note
NONE
```
