### PR TITLE
test reporter: Fix passt log recording

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1208,7 +1208,7 @@ func (r *KubernetesReporter) executeVirtLauncherCommands(virtCli kubecli.Kubevir
 		{command: bridgeJVlanShow, fileNameSuffix: "brvlan"},
 		{command: bridgeFdb, fileNameSuffix: "brfdb"},
 		{command: "env", fileNameSuffix: "env"},
-		{command: "[ -f /var/run/kubevirt/passt.log ] && cat /var/run/kubevirt/passt.log", fileNameSuffix: "passt"},
+		{command: "cat /var/run/kubevirt/passt.log || true", fileNameSuffix: "passt"},
 	}
 
 	if tests.IsRunningOnKindInfra() {
@@ -1225,7 +1225,7 @@ func (r *KubernetesReporter) executeContainerCommands(virtCli kubecli.KubevirtCl
 	}
 
 	for _, cmd := range cmds {
-		command := strings.Split(cmd.command, " ")
+		command := []string{"sh", "-c", cmd.command}
 
 		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtCli, pod, container, command)
 		if err != nil {
@@ -1239,6 +1239,10 @@ func (r *KubernetesReporter) executeContainerCommands(virtCli kubecli.KubevirtCl
 			if errors.IsNotFound(err) || (err == nil && (pod.Status.Phase != "Running" || !isContainerReady(pod.Status.ContainerStatuses, container))) {
 				break
 			}
+			continue
+		}
+
+		if stdout == "" {
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The tests reporter raises errors regarding passt log recording failures:
```
19:49:03:   failed to execute command [[ -f /var/run/kubevirt/passt.log ] && cat /var/run/kubevirt/passt.log] on virt-launcher-testvmi-m2mf5-f5vz6, stdout: , stderr: [: missing ']'
19:49:03:   , error: command terminated with exit code 2
```
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/10432/pull-kubevirt-e2e-k8s-1.26-sig-compute/1715448253694087168#1:build-log.txt%3A3394

Since passt log recording command include the follwoing terms `[ .. ] && .. ) ` and
not running in a shell, the command is not interpreted correctly and fails.

Fix the the reporter passt logging by executing commands in pod using a shell.

To avoid creating empty log files for non passt VMs, the reporter will record
the command in file if the command stdout is empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
