### PR TITLE
Improve cpu hotplug test

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -468,17 +468,10 @@ func GetRunningPodByLabel(label string, labelType string, namespace string, node
 
 	var readyPod *k8sv1.Pod
 	for _, pod := range pods.Items {
-		ready := true
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.Name == "kubevirt-infra" {
-				ready = status.Ready
-				break
-			}
-		}
-		if ready {
-			readyPod = &pod
-			break
-		}
+		// TODO: This needs to be reworked.
+		// During migration there can be more than one pod
+		readyPod = &pod
+		break
 	}
 	if readyPod == nil {
 		return nil, fmt.Errorf("no ready pods with the label %s", label)


### PR DESCRIPTION
**What this PR does / why we need it**:
It should be more reliable to check domain xml once migration is done.

Currently, we see that the wrong Pod is picked for domain xml. There is more work to fix this behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
