### PR TITLE
network binding plugin API: Fix logic network name CNI arg format

### DIFF
--- a/pkg/virt-controller/services/multus_annotations.go
+++ b/pkg/virt-controller/services/multus_annotations.go
@@ -98,7 +98,7 @@ func newBindingPluginMultusAnnotationData(kvConfig *v1.KubeVirtConfiguration, pl
 
 	// cniArgNetworkName is the CNI arg name for the VM spec network logical name.
 	// The binding plugin CNI should read this arg and realize which logical network it should modify.
-	const cniArgNetworkName = "logic-network-name"
+	const cniArgNetworkName = "logicNetworkName"
 
 	return &networkv1.NetworkSelectionElement{
 		Namespace: netAttachDefNamespace,

--- a/pkg/virt-controller/services/multus_annotations_test.go
+++ b/pkg/virt-controller/services/multus_annotations_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Multus annotations", func() {
 
 				Expect(GenerateMultusCNIAnnotation(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, config)).To(MatchJSON(
 					`[
-						{"name": "test-binding-net","namespace": "default", "cni-args": {"logic-network-name": "default"}},						
+						{"name": "test-binding-net","namespace": "default", "cni-args": {"logicNetworkName": "default"}},						
 						{"name": "test1","namespace": "default","interface": "pod16477688c0e"},
 						{"name": "test1","namespace": "other-namespace","interface": "podb1f51a511f1"}
 					]`,
@@ -146,9 +146,9 @@ var _ = Describe("Multus annotations", func() {
 					Expect(GenerateMultusCNIAnnotation(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, config)).To(MatchJSON(expectedAnnot))
 				},
 				Entry("name with no namespace", "my-binding",
-					`[{"namespace": "default", "name": "my-binding", "cni-args": {"logic-network-name": "default"}}]`),
+					`[{"namespace": "default", "name": "my-binding", "cni-args": {"logicNetworkName": "default"}}]`),
 				Entry("name with namespace", "namespace1/my-binding",
-					`[{"namespace": "namespace1", "name": "my-binding", "cni-args": {"logic-network-name": "default"}}]`),
+					`[{"namespace": "namespace1", "name": "my-binding", "cni-args": {"logicNetworkName": "default"}}]`),
 			)
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes the network binding plugin API's logic network name CNI arg.

CNI args should be in camel case form.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
