### PR TITLE
[release-0.58] Disable HTTP/2

### DIFF
--- a/cmd/virt-exportproxy/virt-exportproxy.go
+++ b/cmd/virt-exportproxy/virt-exportproxy.go
@@ -97,6 +97,9 @@ func (app *exportProxyApp) Run() {
 		Addr:      app.Address(),
 		Handler:   mux,
 		TLSConfig: appTLSConfig,
+		// Disable HTTP/2
+		// See CVE-2023-44487
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 	}
 
 	if err := server.ListenAndServeTLS("", ""); err != nil {

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -498,6 +498,9 @@ func (app *virtHandlerApp) runPrometheusServer(errCh chan error) {
 		Addr:      app.ServiceListen.Address(),
 		Handler:   mux,
 		TLSConfig: app.promTLSConfig,
+		// Disable HTTP/2
+		// See CVE-2023-44487
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 	}
 	errCh <- server.ListenAndServeTLS("", "")
 }

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	goflag "flag"
 	"io"
 	"io/ioutil"
@@ -150,6 +151,9 @@ func (s *exportServer) Run() {
 	srv := &http.Server{
 		Addr:    s.ListenAddr,
 		Handler: s.handler,
+		// Disable HTTP/2
+		// See CVE-2023-44487
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 	}
 
 	ch := make(chan error)

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -900,6 +900,9 @@ func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory) 
 	server := &http.Server{
 		Addr:      fmt.Sprintf("%s:%d", app.BindAddress, app.Port),
 		TLSConfig: app.tlsConfig,
+		// Disable HTTP/2
+		// See CVE-2023-44487
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 	}
 
 	// start TLS server

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -21,6 +21,7 @@ package watch
 
 import (
 	"context"
+	"crypto/tls"
 	golog "log"
 	"net/http"
 	"os"
@@ -477,6 +478,9 @@ func (vca *VirtControllerApp) Run() {
 			Addr:      vca.Address(),
 			Handler:   http.DefaultServeMux,
 			TLSConfig: promTLSConfig,
+			// Disable HTTP/2
+			// See CVE-2023-44487
+			TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		}
 		if err := server.ListenAndServeTLS("", ""); err != nil {
 			golog.Fatal(err)

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -328,6 +328,9 @@ func (app *VirtOperatorApp) Run() {
 			Addr:      app.ServiceListen.Address(),
 			Handler:   mux,
 			TLSConfig: promTLSConfig,
+			// Disable HTTP/2
+			// See CVE-2023-44487
+			TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		}
 		if err := server.ListenAndServeTLS("", ""); err != nil {
 			golog.Fatal(err)


### PR DESCRIPTION
Manual backport of #10596

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
