### PR TITLE
Improve image-upload condition to know if population succeeded

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -817,15 +817,16 @@ func validateUploadDataVolume(client kubecli.KubevirtClient, pvc *v1.PersistentV
 		}
 		return nil, err
 	}
+
 	// When using populators, the upload happens on the PVC Prime. We need to check it instead.
 	if dv.Annotations[UsePopulatorAnnotation] == "true" {
+		// We can assume the PVC is populated once it's bound
+		if pvc.Status.Phase == v1.ClaimBound {
+			return nil, fmt.Errorf("PVC %s already successfully populated", name)
+		}
+		// Get the PVC Prime since the upload is happening there
 		pvcPrimeName, ok := pvc.Annotations[PVCPrimeNameAnnotation]
 		if !ok {
-			// The PVC Prime name annotation is removed once the population succeeds.
-			// If the annotation is not there AND the pod is succeeded, we can safely assume the PVC was populated.
-			if pvc.Annotations[PodPhaseAnnotation] == string(v1.PodSucceeded) {
-				return nil, fmt.Errorf("PVC %s already successfully populated", name)
-			}
 			return nil, fmt.Errorf("Unable to get PVC Prime name from PVC %s/%s", pvc.Namespace, name)
 		}
 		pvc, err = client.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), pvcPrimeName, metav1.GetOptions{})
@@ -833,6 +834,7 @@ func validateUploadDataVolume(client kubecli.KubevirtClient, pvc *v1.PersistentV
 			return nil, fmt.Errorf("Unable to get PVC Prime %s/%s", dv.Namespace, name)
 		}
 	}
+
 	return pvc, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This pull request aims to act as a minor correction/follow-up for this PR: https://github.com/kubevirt/kubevirt/pull/10534.

Instead of checking both the pod phase and the pvcPrime annotation, it's more straightforward to check the target PVC phase: When using populators, a bound target PVC will always mean that the population has succeeded. This will help us address some corner cases in https://bugzilla.redhat.com/show_bug.cgi?id=2241658.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Partial fix of https://bugzilla.redhat.com/show_bug.cgi?id=2241658

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
