### PR TITLE
create `ExpectAtLeastTwoWorkerNodesWithCPUManager` as check and deduce number of nodes from usage inside `repeated_test.sh`

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -176,7 +176,7 @@ fi
 # for some tests we need three nodes aka two nodes with cpu manager installed, thus we grep whether the skip is present
 KUBEVIRT_NUM_NODES=2
 # shellcheck disable=SC2046
-if grep -q 'SkipTestIfNotEnoughNodesWithCPUManager' $(echo "${NEW_TESTS}" | tr '|' ' '); then
+if grep -q 'RequiresTwoWorkerNodesWithCPUManager' $(echo "${NEW_TESTS}" | tr '|' ' '); then
     KUBEVIRT_NUM_NODES=3
 fi
 
@@ -207,6 +207,8 @@ if [[ ! "$ginko_params" =~ -dry-run ]]; then
     make cluster-up
     make cluster-sync
 else
+    # Ginkgo only performs -dryRun in serial mode.
+    export KUBEVIRT_E2E_PARALLEL="false"
     NUM_TESTS=1
 fi
 

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -27,28 +27,29 @@ var (
 	KSMRequired = []interface{}{Label("KSM-required")}
 
 	// Features
-	Sysprep                      = []interface{}{Label("Sysprep")}
-	Windows                      = []interface{}{Label("Windows")}
-	Networking                   = []interface{}{Label("Networking")}
-	VMIlifecycle                 = []interface{}{Label("VMIlifecycle")}
-	Expose                       = []interface{}{Label("Expose")}
-	NativeSsh                    = []interface{}{Label("native-ssh")}
-	ExcludeNativeSsh             = []interface{}{Label("exclude-native-ssh")}
-	Reenlightenment              = []interface{}{Label("Reenlightenment")}
-	TscFrequencies               = []interface{}{Label("TscFrequencies")}
-	PasstGate                    = []interface{}{Label("PasstGate")}
-	VMX                          = []interface{}{Label("VMX")}
-	Upgrade                      = []interface{}{Label("Upgrade")}
-	CustomSELinux                = []interface{}{Label("CustomSELinux")}
-	Istio                        = []interface{}{Label("Istio")}
-	InPlaceHotplugNICs           = []interface{}{Label("in-place-hotplug-NICs")}
-	MigrationBasedHotplugNICs    = []interface{}{Label("migration-based-hotplug-NICs")}
-	NetCustomBindingPlugins      = []interface{}{Label("netCustomBindingPlugins")}
-	RequiresTwoSchedulableNodes  = []interface{}{Label("requires-two-schedulable-nodes")}
-	VMLiveUpdateFeaturesGate     = []interface{}{Label("VMLiveUpdateFeaturesGate")}
-	RequiresRWXFilesystemStorage = []interface{}{Label("rwxfs")}
-	USB                          = []interface{}{Label("USB")}
-	AutoResourceLimitsGate       = []interface{}{Label("AutoResourceLimitsGate")}
+	Sysprep                              = []interface{}{Label("Sysprep")}
+	Windows                              = []interface{}{Label("Windows")}
+	Networking                           = []interface{}{Label("Networking")}
+	VMIlifecycle                         = []interface{}{Label("VMIlifecycle")}
+	Expose                               = []interface{}{Label("Expose")}
+	NativeSsh                            = []interface{}{Label("native-ssh")}
+	ExcludeNativeSsh                     = []interface{}{Label("exclude-native-ssh")}
+	Reenlightenment                      = []interface{}{Label("Reenlightenment")}
+	TscFrequencies                       = []interface{}{Label("TscFrequencies")}
+	PasstGate                            = []interface{}{Label("PasstGate")}
+	VMX                                  = []interface{}{Label("VMX")}
+	Upgrade                              = []interface{}{Label("Upgrade")}
+	CustomSELinux                        = []interface{}{Label("CustomSELinux")}
+	Istio                                = []interface{}{Label("Istio")}
+	InPlaceHotplugNICs                   = []interface{}{Label("in-place-hotplug-NICs")}
+	MigrationBasedHotplugNICs            = []interface{}{Label("migration-based-hotplug-NICs")}
+	NetCustomBindingPlugins              = []interface{}{Label("netCustomBindingPlugins")}
+	RequiresTwoSchedulableNodes          = []interface{}{Label("requires-two-schedulable-nodes")}
+	VMLiveUpdateFeaturesGate             = []interface{}{Label("VMLiveUpdateFeaturesGate")}
+	RequiresRWXFilesystemStorage         = []interface{}{Label("rwxfs")}
+	USB                                  = []interface{}{Label("USB")}
+	AutoResourceLimitsGate               = []interface{}{Label("AutoResourceLimitsGate")}
+	RequiresTwoWorkerNodesWithCPUManager = []interface{}{Label("requires-two-worker-nodes-with-cpu-manager")}
 
 	// Storage classes
 	RequiresSnapshotStorageClass = []interface{}{Label("RequiresSnapshotStorageClass")}

--- a/tests/framework/checks/BUILD.bazel
+++ b/tests/framework/checks/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "checks.go",
+        "expects.go",
         "skips.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/framework/checks",

--- a/tests/framework/checks/expects.go
+++ b/tests/framework/checks/expects.go
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package checks
+
+import (
+	"fmt"
+
+	"kubevirt.io/kubevirt/tests/libnode"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"kubevirt.io/client-go/kubecli"
+)
+
+const (
+	DescriptionTwoWorkerNodesWCPUManagerRequired = "at least two worker nodes with cpumanager are required for migration"
+)
+
+// ExpectAtLeastTwoWorkerNodesWithCPUManager uses gomega.Expect to verify that the node list returned by
+// libnode.GetWorkerNodesWithCPUManagerEnabled contains at least two elements.
+// DescriptionTwoWorkerNodesWCPUManagerRequired is added to the default description via ginkgo.By
+func ExpectAtLeastTwoWorkerNodesWithCPUManager(virtClient kubecli.KubevirtClient) {
+	ginkgo.By(fmt.Sprintf("expect at least 2 nodes - %s", DescriptionTwoWorkerNodesWCPUManagerRequired))
+	_ = gomega.Expect(len(libnode.GetWorkerNodesWithCPUManagerEnabled(virtClient))).To(gomega.BeNumerically(">=", 2), DescriptionTwoWorkerNodesWCPUManagerRequired)
+}

--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//tests:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/flags:go_default_library",
+        "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libmigration:go_default_library",

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -171,7 +171,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			Expect(reqCpu).To(Equal(expCpu.Value()))
 		})
 
-		It("should successfully plug guaranteed vCPUs", func() {
+		It("should successfully plug guaranteed vCPUs", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
 			checks.ExpectAtLeastTwoWorkerNodesWithCPUManager(virtClient)
 			By("Creating a running VM with 1 socket and 2 max sockets")
 			const (

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/checks"
+
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	"github.com/onsi/gomega/gstruct"
@@ -20,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,8 +41,7 @@ import (
 
 var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateFeaturesGate, Serial, func() {
 	var (
-		virtClient  kubecli.KubevirtClient
-		workerLabel = "node-role.kubernetes.io/worker"
+		virtClient kubecli.KubevirtClient
 	)
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -172,17 +172,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 		})
 
 		It("should successfully plug guaranteed vCPUs", func() {
-			var nodes []k8sv1.Node
-			virtClient = kubevirt.Client()
-
-			By("getting the list of worker nodes that have cpumanager enabled")
-			nodeList, err := virtClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("%s=,%s=%s", workerLabel, "cpumanager", "true"),
-			})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nodeList).ToNot(BeNil())
-			nodes = nodeList.Items
-			Expect(len(nodes)).To(BeNumerically(">=", 2), "at least two worker nodes with cpumanager are required for migration")
+			checks.ExpectAtLeastTwoWorkerNodesWithCPUManager(virtClient)
 			By("Creating a running VM with 1 socket and 2 max sockets")
 			const (
 				maxSockets uint32 = 3
@@ -205,7 +195,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 				},
 			}
 
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
+			vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(beReady())
 			libwait.WaitForSuccessfulVMIStart(vmi)

--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//tests/framework/cleanup:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/util:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
+
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
 	"kubevirt.io/kubevirt/pkg/util/nodes"
@@ -50,6 +52,8 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
 	"kubevirt.io/kubevirt/tests/util"
 )
+
+const workerLabel = "node-role.kubernetes.io/worker"
 
 var SchedulableNode = ""
 
@@ -365,4 +369,14 @@ func GetControlPlaneNodes(virtCli kubecli.KubevirtClient) *k8sv1.NodeList {
 	Expect(controlPlaneNodes.Items).ShouldNot(BeEmpty(),
 		"There are no control-plane nodes in the cluster")
 	return controlPlaneNodes
+}
+
+func GetWorkerNodesWithCPUManagerEnabled(virtClient kubecli.KubevirtClient) []k8sv1.Node {
+	ginkgo.By("getting the list of worker nodes that have cpumanager enabled")
+	nodeList, err := virtClient.CoreV1().Nodes().List(context.TODO(), k8smetav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=,%s=%s", workerLabel, "cpumanager", "true"),
+	})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(nodeList).ToNot(BeNil())
+	return nodeList.Items
 }

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2825,7 +2825,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 		)
 	})
 
-	Context("[Serial] with CPU pinning and huge pages", Serial, func() {
+	Context("[Serial] with CPU pinning and huge pages", Serial, decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
 		It("should not make migrations fail", func() {
 			checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(2)
 			var err error
@@ -2848,7 +2848,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			migration := tests.NewRandomMigration(cpuVMI.Name, cpuVMI.Namespace)
 			libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 		})
-		Context("and NUMA passthrough", func() {
+		Context("and NUMA passthrough", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
 			It("should not make migrations fail", func() {
 				checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
 				checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(2)
@@ -3047,7 +3047,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 		})
 	})
 
-	Context("with dedicated CPUs", func() {
+	Context("with dedicated CPUs", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
 		var (
 			virtClient    kubecli.KubevirtClient
 			err           error

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -3054,7 +3054,6 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			nodes         []k8sv1.Node
 			migratableVMI *v1.VirtualMachineInstance
 			pausePod      *k8sv1.Pod
-			workerLabel   = "node-role.kubernetes.io/worker"
 			testLabel1    = "kubevirt.io/testlabel1"
 			testLabel2    = "kubevirt.io/testlabel2"
 			cgroupVersion cgroup.CgroupVersion
@@ -3142,15 +3141,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			// So let's be sig-compute and skip ourselves on sig-compute always... (they have only 1 node with CPU manager)
 			checks.SkipTestIfNotEnoughNodesWithCPUManager(2)
 			virtClient = kubevirt.Client()
-
-			By("getting the list of worker nodes that have cpumanager enabled")
-			nodeList, err := virtClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("%s=,%s=%s", workerLabel, "cpumanager", "true"),
-			})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nodeList).ToNot(BeNil())
-			nodes = nodeList.Items
-			Expect(len(nodes)).To(BeNumerically(">=", 2), "at least two worker nodes with cpumanager are required for migration")
+			nodes = libnode.GetWorkerNodesWithCPUManagerEnabled(virtClient)
 
 			By("creating a migratable VMI with 2 dedicated CPU cores")
 			migratableVMI = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
@@ -3197,8 +3188,6 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 		})
 
 		It("should successfully update a VMI's CPU set on migration", func() {
-			By("ensuring at least 2 worker nodes have cpumanager")
-			Expect(len(nodes)).To(BeNumerically(">=", 2), "at least two worker nodes with cpumanager are required for migration")
 
 			By("starting a VMI on the first node of the list")
 			libnode.AddLabelToNode(nodes[0].Name, testLabel1, "true")

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -41,7 +41,7 @@ var _ = Describe("[sig-compute][Serial]NUMA", Serial, decorators.SigCompute, fun
 		virtClient = kubevirt.Client()
 	})
 
-	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", func() {
+	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
 		checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
 		checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(1)
 		var err error

--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//tests:go_default_library",
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
+        "//tests/decorators:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libvmi:go_default_library",

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"kubevirt.io/kubevirt/tests/decorators"
+
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
 	expect "github.com/google/goexpect"
@@ -40,7 +42,7 @@ func byStartingTheVMI(vmi *v1.VirtualMachineInstance, virtClient kubecli.Kubevir
 	libwait.WaitForSuccessfulVMIStart(vmi)
 }
 
-var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", func() {
+var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
 
 	var (
 		vmi        *v1.VirtualMachineInstance


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Extracts `ExpectAtLeastTwoWorkerNodesWithCPUManager` as func and puts it into checks package. Replaces explicit node fetches with using the func where applicable.

Adds func name to grep call in `repeated_test.sh` to make sure kubevirtci instance has two cpumanager nodes if tests that require them are run.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @jean-edouard 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
