### PR TITLE
Keep RerunOnFailure VM runStrategy across stop/start

### DIFF
--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -605,10 +605,10 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 }
 
 func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, response *restful.Response) {
-	// RunStrategyHalted         -> force stop if graceperiod in request is shorter than before, otherwise doesn't make sense
+	// RunStrategyHalted         -> force stop if grace period in request is shorter than before, otherwise doesn't make sense
 	// RunStrategyManual         -> send stop request
 	// RunStrategyAlways         -> spec.running = false
-	// RunStrategyRerunOnFailure -> spec.running = false
+	// RunStrategyRerunOnFailure -> send stop request
 	// RunStrategyOnce           -> spec.running = false
 
 	name := request.PathParameter("name")

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -680,7 +680,7 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 		if err != nil {
 			return
 		}
-	case v1.RunStrategyManual:
+	case v1.RunStrategyRerunOnFailure, v1.RunStrategyManual:
 		if !hasVMI || vmi.IsFinal() {
 			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf(vmNotRunning)), response)
 			return
@@ -691,7 +691,7 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 		if err != nil {
 			return
 		}
-	case v1.RunStrategyRerunOnFailure, v1.RunStrategyAlways, v1.RunStrategyOnce:
+	case v1.RunStrategyAlways, v1.RunStrategyOnce:
 		bodyString := getRunningJson(vm, false)
 		log.Log.Object(vm).V(4).Infof(patchingVMFmt, bodyString)
 		_, patchErr = app.virtCli.VirtualMachine(namespace).Patch(context.Background(), vm.GetName(), patchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1577,13 +1577,13 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 		},
 			Entry("RunStrategyAlways", v1.RunStrategyAlways, "", false, &v1.StopOptions{}),
 			Entry("RunStrategyOnce", v1.RunStrategyOnce, "", false, &v1.StopOptions{}),
-			Entry("RunStrategyRerunOnFailure", v1.RunStrategyRerunOnFailure, "", false, &v1.StopOptions{}),
+			Entry("RunStrategyRerunOnFailure", v1.RunStrategyRerunOnFailure, "", true, &v1.StopOptions{}),
 			Entry("RunStrategyManual", v1.RunStrategyManual, "VM is not running", true, &v1.StopOptions{}),
 			Entry("RunStrategyHalted", v1.RunStrategyHalted, "VM is not running", true, &v1.StopOptions{}),
 
 			Entry("RunStrategyAlways with dry-run option", v1.RunStrategyAlways, "", false, &v1.StopOptions{DryRun: getDryRunOption()}),
 			Entry("RunStrategyOnce with dry-run option", v1.RunStrategyOnce, "", false, &v1.StopOptions{DryRun: getDryRunOption()}),
-			Entry("RunStrategyRerunOnFailure with dry-run option", v1.RunStrategyRerunOnFailure, "", false, &v1.StopOptions{DryRun: getDryRunOption()}),
+			Entry("RunStrategyRerunOnFailure with dry-run option", v1.RunStrategyRerunOnFailure, "", true, &v1.StopOptions{DryRun: getDryRunOption()}),
 			Entry("RunStrategyManual with dry-run option", v1.RunStrategyManual, "VM is not running", true, &v1.StopOptions{DryRun: getDryRunOption()}),
 			Entry("RunStrategyHalted with dry-run option", v1.RunStrategyHalted, "VM is not running", true, &v1.StopOptions{DryRun: getDryRunOption()}),
 		)
@@ -1653,7 +1653,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmClient.EXPECT().Get(context.Background(), vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil)
 			vmiClient.EXPECT().Get(context.Background(), vm.Name, &k8smetav1.GetOptions{}).Return(vmi, nil)
 
-			if runStrategy == v1.RunStrategyManual {
+			if runStrategy == v1.RunStrategyManual || runStrategy == v1.RunStrategyRerunOnFailure {
 				vmClient.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), &k8smetav1.PatchOptions{}).Return(vm, nil)
 			} else {
 				vmClient.EXPECT().Patch(context.Background(), vm.Name, types.MergePatchType, gomock.Any(), &k8smetav1.PatchOptions{}).Return(vm, nil)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -916,14 +916,14 @@ func (c *VMController) startStop(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualM
 	case virtv1.RunStrategyRerunOnFailure:
 		// For this RunStrategy, a VMI should only be restarted if it failed.
 		// If a VMI enters the Succeeded phase, it should not be restarted.
+		var forceStop, vmiFailed bool
 		if vmi != nil {
-			var forceStop bool
 			if forceStop = hasStopRequestForVMI(vm, vmi); forceStop {
 				log.Log.Object(vm).Infof("processing stop request for VMI with phase %s and VM runStrategy: %s", vmi.Status.Phase, runStrategy)
-
 			}
+			vmiFailed = vmi.Status.Phase == virtv1.Failed
 
-			if forceStop || vmi.Status.Phase == virtv1.Failed {
+			if vmi.DeletionTimestamp == nil && (forceStop || vmiFailed) {
 				// For RerunOnFailure, this controller should only restart the VirtualMachineInstance
 				// if it failed.
 				log.Log.Object(vm).Infof("%s with VMI in phase %s and VM runStrategy: %s", stoppingVmMsg, vmi.Status.Phase, runStrategy)
@@ -932,9 +932,25 @@ func (c *VMController) startStop(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualM
 					log.Log.Object(vm).Errorf(failureDeletingVmiErrFormat, err)
 					return &syncErrorImpl{fmt.Errorf(failureDeletingVmiErrFormat, err), VMIFailedDeleteReason}
 				}
-				// return to let the controller pick up the expected deletion
+
+				if vmiFailed {
+					addRequest := []virtv1.VirtualMachineStateChangeRequest{{Action: virtv1.StartRequest}}
+					req, err := json.Marshal(addRequest)
+					if err != nil {
+						return &syncErrorImpl{fmt.Errorf("failed to patch VM with start action: %v", err), VMIFailedDeleteReason}
+					}
+					patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/stateChangeRequests", "value": %s}]`, string(req))
+					err = c.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &v1.PatchOptions{})
+					if err != nil {
+						return &syncErrorImpl{fmt.Errorf("failed to patch VM with start action: %v", err), VMIFailedDeleteReason}
+					}
+				}
 			}
-			// VirtualMachineInstance is OK no need to do anything
+			// return to let the controller pick up the expected deletion
+			return nil
+		}
+
+		if !hasStartRequest(vm) {
 			return nil
 		}
 
@@ -2593,7 +2609,7 @@ func (c *VMController) isTrimFirstChangeRequestNeeded(vm *virtv1.VirtualMachine,
 		}
 	case virtv1.StartRequest:
 		// If the current VMI is running, then it has been started.
-		if vmi != nil {
+		if vmi != nil && vmi.DeletionTimestamp == nil {
 			log.Log.Object(vm).V(4).Infof("VMI exists. clearing start request")
 			return true
 		}
@@ -2738,6 +2754,22 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 
 	if !c.needsSync(key) {
 		return vm, nil, nil
+	}
+
+	// Using the empty printableStatus as an indication that the VM was just created.
+	if vm.Status.PrintableStatus == "" && vm.Spec.RunStrategy != nil && *vm.Spec.RunStrategy == virtv1.RunStrategyRerunOnFailure {
+		// VM just got created a RerunOnFailure VM, it needs to auto-start
+		addRequest := []virtv1.VirtualMachineStateChangeRequest{{Action: virtv1.StartRequest}}
+		req, err := json.Marshal(addRequest)
+		if err != nil {
+			return vm, nil, err
+		}
+		patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/stateChangeRequests", "value": %s}]`, string(req))
+		err = c.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &v1.PatchOptions{})
+		if err != nil {
+			return vm, nil, err
+		}
+		vm.Status.StateChangeRequests = append(vm.Status.StateChangeRequests, addRequest[0])
 	}
 
 	if vm.DeletionTimestamp != nil {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -859,6 +859,22 @@ func (c *VMController) handleVolumeRequests(vm *virtv1.VirtualMachine, vmi *virt
 	return nil
 }
 
+func (c *VMController) addStartRequest(vm *virtv1.VirtualMachine) error {
+	addRequest := []virtv1.VirtualMachineStateChangeRequest{{Action: virtv1.StartRequest}}
+	req, err := json.Marshal(addRequest)
+	if err != nil {
+		return err
+	}
+	patch := fmt.Sprintf(`{ "status":{ "stateChangeRequests":%s } }`, string(req))
+	err = c.statusUpdater.PatchStatus(vm, types.MergePatchType, []byte(patch), &v1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	vm.Status.StateChangeRequests = append(vm.Status.StateChangeRequests, addRequest[0])
+
+	return nil
+}
+
 func (c *VMController) startStop(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) syncError {
 	runStrategy, err := vm.RunStrategy()
 	if err != nil {
@@ -916,16 +932,16 @@ func (c *VMController) startStop(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualM
 	case virtv1.RunStrategyRerunOnFailure:
 		// For this RunStrategy, a VMI should only be restarted if it failed.
 		// If a VMI enters the Succeeded phase, it should not be restarted.
-		var forceStop, vmiFailed bool
 		if vmi != nil {
-			if forceStop = hasStopRequestForVMI(vm, vmi); forceStop {
+			forceStop := hasStopRequestForVMI(vm, vmi)
+			if forceStop {
 				log.Log.Object(vm).Infof("processing stop request for VMI with phase %s and VM runStrategy: %s", vmi.Status.Phase, runStrategy)
 			}
-			vmiFailed = vmi.Status.Phase == virtv1.Failed
+			vmiFailed := vmi.Status.Phase == virtv1.Failed
+			vmiSucceeded := vmi.Status.Phase == virtv1.Succeeded
 
-			if vmi.DeletionTimestamp == nil && (forceStop || vmiFailed) {
-				// For RerunOnFailure, this controller should only restart the VirtualMachineInstance
-				// if it failed.
+			if vmi.DeletionTimestamp == nil && (forceStop || vmiFailed || vmiSucceeded) {
+				// For RerunOnFailure, this controller should only restart the VirtualMachineInstance if it failed.
 				log.Log.Object(vm).Infof("%s with VMI in phase %s and VM runStrategy: %s", stoppingVmMsg, vmi.Status.Phase, runStrategy)
 				err := c.stopVMI(vm, vmi)
 				if err != nil {
@@ -934,13 +950,7 @@ func (c *VMController) startStop(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualM
 				}
 
 				if vmiFailed {
-					addRequest := []virtv1.VirtualMachineStateChangeRequest{{Action: virtv1.StartRequest}}
-					req, err := json.Marshal(addRequest)
-					if err != nil {
-						return &syncErrorImpl{fmt.Errorf("failed to patch VM with start action: %v", err), VMIFailedDeleteReason}
-					}
-					patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/stateChangeRequests", "value": %s}]`, string(req))
-					err = c.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &v1.PatchOptions{})
+					err = c.addStartRequest(vm)
 					if err != nil {
 						return &syncErrorImpl{fmt.Errorf("failed to patch VM with start action: %v", err), VMIFailedDeleteReason}
 					}
@@ -2515,8 +2525,9 @@ func (c *VMController) syncConditions(vm *virtv1.VirtualMachine, vmi *virtv1.Vir
 
 	// sync VMI conditions, ignore list represents conditions that are not synced generically
 	syncIgnoreMap := map[string]interface{}{
-		string(virtv1.VirtualMachineReady):   nil,
-		string(virtv1.VirtualMachineFailure): nil,
+		string(virtv1.VirtualMachineReady):       nil,
+		string(virtv1.VirtualMachineFailure):     nil,
+		string(virtv1.VirtualMachineInitialized): nil,
 	}
 	vmiCondMap := make(map[string]interface{})
 
@@ -2756,20 +2767,23 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		return vm, nil, nil
 	}
 
-	// Using the empty printableStatus as an indication that the VM was just created.
-	if vm.Status.PrintableStatus == "" && vm.Spec.RunStrategy != nil && *vm.Spec.RunStrategy == virtv1.RunStrategyRerunOnFailure {
-		// VM just got created a RerunOnFailure VM, it needs to auto-start
-		addRequest := []virtv1.VirtualMachineStateChangeRequest{{Action: virtv1.StartRequest}}
-		req, err := json.Marshal(addRequest)
+	conditionManager := controller.NewVirtualMachineConditionManager()
+	if !conditionManager.HasCondition(vm, virtv1.VirtualMachineInitialized) {
+		runStrategy, err := vm.RunStrategy()
 		if err != nil {
 			return vm, nil, err
 		}
-		patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/stateChangeRequests", "value": %s}]`, string(req))
-		err = c.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &v1.PatchOptions{})
-		if err != nil {
-			return vm, nil, err
+		if runStrategy == virtv1.RunStrategyRerunOnFailure {
+			// VM just got created with RerunOnFailure runStrategy, it needs to auto-start
+			err = c.addStartRequest(vm)
+			if err != nil {
+				return vm, nil, err
+			}
 		}
-		vm.Status.StateChangeRequests = append(vm.Status.StateChangeRequests, addRequest[0])
+		vm.Status.Conditions = append(vm.Status.Conditions, virtv1.VirtualMachineCondition{
+			Type:   virtv1.VirtualMachineInitialized,
+			Status: k8score.ConditionTrue,
+		})
 	}
 
 	if vm.DeletionTimestamp != nil {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -1022,7 +1022,7 @@ var _ = Describe("VirtualMachine", func() {
 				}).Return(nil, nil)
 
 				if runStrategy == virtv1.RunStrategyRerunOnFailure {
-					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Do(
+					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.MergePatchType, gomock.Any(), gomock.Any()).Do(
 						func(ctx context.Context, name string, patchType types.PatchType, body []byte, opts *metav1.PatchOptions) {
 							Expect(string(body)).To(ContainSubstring(`"action":"Start"`))
 						}).Return(vm, nil).Times(2)
@@ -1383,7 +1383,7 @@ var _ = Describe("VirtualMachine", func() {
 				}).Return(nil, nil)
 
 				if runStrategy == virtv1.RunStrategyRerunOnFailure {
-					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Do(
+					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.MergePatchType, gomock.Any(), gomock.Any()).Do(
 						func(ctx context.Context, name string, patchType types.PatchType, body []byte, opts *metav1.PatchOptions) {
 							Expect(string(body)).To(ContainSubstring(`"action":"Start"`))
 						}).Return(vm, nil).Times(1)
@@ -1907,6 +1907,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vm.Spec.Running = nil
 			vm.Spec.RunStrategy = &runStrategy
+
 			addVirtualMachine(vm)
 
 			// expect creation called
@@ -1921,7 +1922,7 @@ var _ = Describe("VirtualMachine", func() {
 			}).Return(nil, nil)
 
 			if runStrategy == virtv1.RunStrategyRerunOnFailure {
-				vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Do(
+				vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.MergePatchType, gomock.Any(), gomock.Any()).Do(
 					func(ctx context.Context, name string, patchType types.PatchType, body []byte, opts *metav1.PatchOptions) {
 						Expect(string(body)).To(ContainSubstring(`"action":"Start"`))
 					}).Return(vm, nil).Times(1)
@@ -2941,7 +2942,7 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				if runStrategy == virtv1.RunStrategyRerunOnFailure {
-					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Do(
+					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.MergePatchType, gomock.Any(), gomock.Any()).Do(
 						func(ctx context.Context, name string, patchType types.PatchType, body []byte, opts *metav1.PatchOptions) {
 							Expect(string(body)).To(ContainSubstring(`"action":"Start"`))
 						}).Return(vm, nil).Times(1)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -1021,9 +1021,14 @@ var _ = Describe("VirtualMachine", func() {
 					}
 				}).Return(nil, nil)
 
-				//	if runStrategy != v1.RunStrategyManual {
+				if runStrategy == virtv1.RunStrategyRerunOnFailure {
+					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Do(
+						func(ctx context.Context, name string, patchType types.PatchType, body []byte, opts *metav1.PatchOptions) {
+							Expect(string(body)).To(ContainSubstring(`"action":"Start"`))
+						}).Return(vm, nil).Times(2)
+				}
+
 				shouldExpectVMIFinalizerRemoval(vmi)
-				//	}
 
 				controller.Execute()
 
@@ -1376,6 +1381,13 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
 					Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 				}).Return(nil, nil)
+
+				if runStrategy == virtv1.RunStrategyRerunOnFailure {
+					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Do(
+						func(ctx context.Context, name string, patchType types.PatchType, body []byte, opts *metav1.PatchOptions) {
+							Expect(string(body)).To(ContainSubstring(`"action":"Start"`))
+						}).Return(vm, nil).Times(1)
+				}
 
 				controller.Execute()
 
@@ -1907,6 +1919,13 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
+
+			if runStrategy == virtv1.RunStrategyRerunOnFailure {
+				vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Do(
+					func(ctx context.Context, name string, patchType types.PatchType, body []byte, opts *metav1.PatchOptions) {
+						Expect(string(body)).To(ContainSubstring(`"action":"Start"`))
+					}).Return(vm, nil).Times(1)
+			}
 
 			controller.Execute()
 
@@ -2920,6 +2939,13 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).ToNot(Equal(virtv1.VirtualMachineStatusCrashLoopBackOff))
 					}
 				})
+
+				if runStrategy == virtv1.RunStrategyRerunOnFailure {
+					vmInterface.EXPECT().PatchStatus(context.Background(), vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).Do(
+						func(ctx context.Context, name string, patchType types.PatchType, body []byte, opts *metav1.PatchOptions) {
+							Expect(string(body)).To(ContainSubstring(`"action":"Start"`))
+						}).Return(vm, nil).Times(1)
+				}
 
 				controller.Execute()
 			},

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1654,6 +1654,9 @@ const (
 	// VirtualMachinePaused is added in a virtual machine when its vmi
 	// signals with its own condition that it is paused.
 	VirtualMachinePaused VirtualMachineConditionType = "Paused"
+
+	// VirtualMachineInitialized means the virtual machine object has been seen by the VM controller
+	VirtualMachineInitialized VirtualMachineConditionType = "Initialized"
 )
 
 type HostDiskType string

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -946,7 +947,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(vm.Spec.RunStrategy).ToNot(BeNil())
-					Expect(*vm.Spec.RunStrategy).To(Equal(v1.RunStrategyHalted))
+					Expect(*vm.Spec.RunStrategy).To(Equal(v1.RunStrategyRerunOnFailure))
 					By("Ensuring stateChangeRequests list is cleared")
 					Expect(vm.Status.StateChangeRequests).To(BeEmpty())
 				})
@@ -980,12 +981,12 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Eventually(ThisVM(vm), 240*time.Second, 1*time.Second).Should(Not(haveStateChangeRequests()))
 				})
 
-				It("[test_id:2188] should not remove a succeeded VMI", func() {
+				It("[test_id:2188] should remove a succeeded VMI", func() {
 					By("creating a VM with RunStrategyRerunOnFailure")
 					vm := newVirtualMachineWithRunStrategy(v1.RunStrategyRerunOnFailure)
 
 					By("Waiting for VMI to be ready")
-					Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(beReady())
+					Eventually(ThisVM(vm), time.Minute, time.Second).Should(beReady())
 
 					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -998,20 +999,49 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						&expect.BExp{R: console.PromptExpression},
 					}, 10)).To(Succeed())
 
-					By("Ensuring the VirtualMachineInstance enters Succeeded phase")
-					Eventually(ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(HaveSucceeded())
+					By("Waiting for the VMI to disappear")
+					Eventually(func() bool {
+						_, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
+						return errors.IsNotFound(err)
+					}, time.Minute, time.Second).Should(BeTrue())
+				})
 
-					// At this point, explicitly test that a start command will delete an existing
-					// VMI in the Succeeded phase.
-					By("Invoking virtctl start")
-					restartCommand := clientcmd.NewRepeatableVirtctlCommand(virtctl.COMMAND_START, "--namespace", vm.Namespace, vm.Name)
-					Expect(restartCommand()).To(Succeed())
+				It("should restart a failed VMI", func() {
+					By("creating a VM with RunStrategyRerunOnFailure")
+					vm := newVirtualMachineWithRunStrategy(v1.RunStrategyRerunOnFailure)
 
-					By("Waiting for StartRequest to be cleared")
-					Eventually(ThisVM(vm), 240*time.Second, 1*time.Second).Should(Not(haveStateChangeRequests()))
+					By("Waiting for VM to exist")
+					Eventually(ThisVM(vm), time.Minute, time.Second).Should(beReady())
 
-					By("Waiting for VM to be ready")
-					Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(beReady())
+					By("Waiting for VM to start")
+					Eventually(func() v1.VirtualMachinePrintableStatus {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						return vm.Status.PrintableStatus
+					}, time.Minute, time.Second).Should(Equal(v1.VirtualMachineStatusRunning))
+
+					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Triggering a segfault in qemu")
+					emulator, err := tests.GetRunningVMIEmulator(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					emulator = filepath.Base(emulator)
+					tests.RunCommandOnVmiPod(vmi, []string{"killall", "-11", emulator})
+
+					By("Ensuring the VM stops")
+					Eventually(func() v1.VirtualMachinePrintableStatus {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						return vm.Status.PrintableStatus
+					}, time.Minute, time.Second).Should(Equal(v1.VirtualMachineStatusStopped))
+
+					By("Waiting for VM to start again")
+					Eventually(func() v1.VirtualMachinePrintableStatus {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						return vm.Status.PrintableStatus
+					}, time.Minute, time.Second).Should(Equal(v1.VirtualMachineStatusRunning))
 				})
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Shutting down a RerunOnFailure changes its runStrategy to Halted.
This PR is an attempt to preserve RerunOnFailure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
