### PR TITLE
Fix #10471 Add snapshotExpectations and vmCloneExpectations for clone controller

### DIFF
--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/clone",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/controller:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/util/status:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",

--- a/pkg/virt-controller/watch/clone/util.go
+++ b/pkg/virt-controller/watch/clone/util.go
@@ -17,6 +17,7 @@ import (
 
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	v1 "kubevirt.io/api/core/v1"
+	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 
 const (
@@ -32,6 +33,14 @@ var currentTime = func() *metav1.Time {
 
 func getKey(name, namespace string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+func getSnapshotKey(snapshot *snapshotv1alpha1.VirtualMachineSnapshot) string {
+	return fmt.Sprintf("%s/%s", snapshot.ObjectMeta.Namespace, snapshot.ObjectMeta.Name)
+}
+
+func getVirtualMachineCloneKey(vmclone *clonev1alpha1.VirtualMachineClone) string {
+	return fmt.Sprintf("%s/%s", vmclone.ObjectMeta.Namespace, vmclone.ObjectMeta.Name)
 }
 
 func generateNameWithRandomSuffix(names ...string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix #10471
In my opinion, snapshot double create because snapshot create for vmclone is quicker than vmclone update. The snapshot create action add a vmclone key enqueue. The vmclone reconcile with `vmClone.Status.SnapshotName == nil` because vmclone haven't update in updateStatus method. 
We can add Expectations for snapshot and vmclone to avoid it.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10471

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
