### PR TITLE
[release-1.1] virt-handler: wait up to 2 seconds for the network-status downwardAPI to appear

### DIFF
--- a/pkg/virt-handler/migration.go
+++ b/pkg/virt-handler/migration.go
@@ -22,6 +22,7 @@ package virthandler
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -29,10 +30,20 @@ import (
 // FindMigrationIP looks for dedicated migration network migration0 using the downward API and, if found, sets migration IP to it
 func FindMigrationIP(networkStatusPath string, migrationIp string) (string, error) {
 	var networkStatus []NetworkStatus
+	var dat []byte
+	var err error
 
-	dat, err := os.ReadFile(networkStatusPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read network status from downwards API")
+	for i := 0; i < 5; i++ {
+		dat, err = os.ReadFile(networkStatusPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read network status from downwards API")
+		}
+		if len(dat) != 0 {
+			break
+		}
+		if i < 4 {
+			time.Sleep(500 * time.Millisecond)
+		}
 	}
 	err = yaml.Unmarshal(dat, &networkStatus)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The network-status downward API file can take some time to get populated, and since virt-handler reads it just once on startup, the dedicated migration network can get ignored.
This is only a problem in k8s 1.27+.
This PR is a workaround, for 1.1 only (unless we decide to backport it). We are working on a proper fix in main, but it is taking longer than expected due to a potential bug in virt-operator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes the "falky" dedicated migration test (the code is flaky, not the test)

**Special notes for your reviewer**:
- The proper fix in main is https://github.com/kubevirt/kubevirt/pull/10600
- On nodes that are running without some network component (not sure which on exactly,something in CNAO), virt-handler will take an extra 2.5 seconds to start.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The dedicated migration network should now always be properly detected by virt-handler
```
