### PR TITLE
Tap generator

### DIFF
--- a/pkg/network/domainspec/domainspec_suite_test.go
+++ b/pkg/network/domainspec/domainspec_suite_test.go
@@ -20,17 +20,17 @@ func newVMI(namespace, name string) *v1.VirtualMachineInstance {
 	return vmi
 }
 
-func newVMIMacvtapInterface(namespace string, vmiName string, ifaceName string) *v1.VirtualMachineInstance {
+func newVMIMasqueradeInterface(namespace, vmiName string) *v1.VirtualMachineInstance {
 	vmi := newVMI(namespace, vmiName)
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMacvtapNetworkInterface(ifaceName)}
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
 	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 	return vmi
 }
 
-func NewDomainWithMacvtapInterface(macvtapName string) *api.Domain {
+func NewDomainInterface(name string) *api.Domain {
 	domain := &api.Domain{}
 	domain.Spec.Devices.Interfaces = []api.Interface{{
-		Alias: api.NewUserDefinedAlias(macvtapName),
+		Alias: api.NewUserDefinedAlias(name),
 		Model: &api.Model{
 			Type: v1.VirtIO,
 		},

--- a/pkg/network/domainspec/generators.go
+++ b/pkg/network/domainspec/generators.go
@@ -41,13 +41,13 @@ type LibvirtSpecGenerator interface {
 	Generate() error
 }
 
-func NewMacvtapLibvirtSpecGenerator(
+func NewTapLibvirtSpecGenerator(
 	iface *v1.Interface,
 	domain *api.Domain,
 	podInterfaceName string,
 	handler netdriver.NetworkHandler,
-) *MacvtapLibvirtSpecGenerator {
-	return &MacvtapLibvirtSpecGenerator{
+) *TapLibvirtSpecGenerator {
+	return &TapLibvirtSpecGenerator{
 		vmiSpecIface:     iface,
 		domain:           domain,
 		podInterfaceName: podInterfaceName,
@@ -200,14 +200,14 @@ func (b *MasqueradeLibvirtSpecGenerator) discoverDomainIfaceSpec() (*api.Interfa
 	return &domainIface, nil
 }
 
-type MacvtapLibvirtSpecGenerator struct {
+type TapLibvirtSpecGenerator struct {
 	vmiSpecIface     *v1.Interface
 	domain           *api.Domain
 	podInterfaceName string
 	handler          netdriver.NetworkHandler
 }
 
-func (b *MacvtapLibvirtSpecGenerator) Generate() error {
+func (b *TapLibvirtSpecGenerator) Generate() error {
 	domainIface, err := b.discoverDomainIfaceSpec()
 	if err != nil {
 		return err
@@ -224,7 +224,7 @@ func (b *MacvtapLibvirtSpecGenerator) Generate() error {
 	return nil
 }
 
-func (b *MacvtapLibvirtSpecGenerator) discoverDomainIfaceSpec() (*api.Interface, error) {
+func (b *TapLibvirtSpecGenerator) discoverDomainIfaceSpec() (*api.Interface, error) {
 	podNicLink, err := b.handler.LinkByName(b.podInterfaceName)
 	if err != nil {
 		log.Log.Reason(err).Errorf(linkIfaceFailFmt, b.podInterfaceName)

--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Pod Network", func() {
 
 			var (
 				domain        *api.Domain
-				specGenerator *MacvtapLibvirtSpecGenerator
+				specGenerator *TapLibvirtSpecGenerator
 			)
 
 			BeforeEach(func() {
@@ -84,7 +84,7 @@ var _ = Describe("Pod Network", func() {
 				vmi := newVMIMacvtapInterface("testnamespace", "testVmName", "default")
 				macvtapInterface := &netlink.GenericLink{LinkAttrs: netlink.LinkAttrs{Name: primaryPodIfaceName, MTU: mtu, HardwareAddr: fakeMac}}
 				mockNetwork.EXPECT().LinkByName(primaryPodIfaceName).Return(macvtapInterface, nil)
-				specGenerator = NewMacvtapLibvirtSpecGenerator(
+				specGenerator = NewTapLibvirtSpecGenerator(
 					&vmi.Spec.Domain.Devices.Interfaces[0], domain, primaryPodIfaceName, mockNetwork)
 			})
 

--- a/pkg/network/setup/netpod/discover.go
+++ b/pkg/network/setup/netpod/discover.go
@@ -63,6 +63,8 @@ func (n NetPod) discover(currentStatus *nmstate.Status) error {
 				return err
 			}
 
+			// This cache is no longer used by vit-launcher, the dummy interface is used instead to store the data.
+			// It is kept here for backward compatibility.
 			if err := n.storeBridgeDomainInterfaceData(podIfaceStatus, vmiSpecIface); err != nil {
 				return err
 			}

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -353,12 +353,13 @@ func (n NetPod) bridgeBindingSpec(podIfaceName string, vmiIfaceIndex int, ifaceS
 	}
 
 	dummyIface := nmstate.Interface{
-		Name:     podIfaceName,
-		TypeName: nmstate.TypeDummy,
-		MTU:      podStatusIface.MTU,
-		IPv4:     podStatusIface.IPv4,
-		IPv6:     podStatusIface.IPv6,
-		Metadata: &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
+		Name:       podIfaceName,
+		TypeName:   nmstate.TypeDummy,
+		MacAddress: podStatusIface.MacAddress,
+		MTU:        podStatusIface.MTU,
+		IPv4:       podStatusIface.IPv4,
+		IPv6:       podStatusIface.IPv6,
+		Metadata:   &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
 	}
 
 	return []nmstate.Interface{bridgeIface, podIface, tapIface, dummyIface}, nil

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -377,9 +377,10 @@ var _ = Describe("netpod", func() {
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:     "eth0",
-						TypeName: nmstate.TypeDummy,
-						MTU:      1500,
+						Name:       "eth0",
+						TypeName:   nmstate.TypeDummy,
+						MacAddress: podIfaceOrignalMAC,
+						MTU:        1500,
 						IPv4: nmstate.IP{
 							Enabled: pointer.P(true),
 							Address: []nmstate.IPAddress{{
@@ -484,10 +485,11 @@ var _ = Describe("netpod", func() {
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:     "eth0",
-						TypeName: nmstate.TypeDummy,
-						MTU:      1500,
-						IPv4:     ipDisabled,
+						Name:       "eth0",
+						TypeName:   nmstate.TypeDummy,
+						MacAddress: podIfaceOrignalMAC,
+						MTU:        1500,
+						IPv4:       ipDisabled,
 						IPv6: nmstate.IP{
 							Enabled: pointer.P(true),
 							Address: []nmstate.IPAddress{{
@@ -522,6 +524,8 @@ var _ = Describe("netpod", func() {
 			secondaryNetworkName = "secondnetwork"
 
 			hotplugEnabled = true
+
+			secondaryPodIfaceOrignalMAC = "12:34:56:78:90:cd"
 		)
 		var (
 			specNetworks   []v1.Network
@@ -561,7 +565,7 @@ var _ = Describe("netpod", func() {
 						Index:      secondaryPodInterfaceIndex,
 						TypeName:   nmstate.TypeVETH,
 						State:      nmstate.IfaceStateUp,
-						MacAddress: "12:34:56:78:90:cd",
+						MacAddress: secondaryPodIfaceOrignalMAC,
 						MTU:        1500,
 						IPv4:       ipDisabled,
 						IPv6:       ipDisabled,
@@ -689,12 +693,13 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 						{
-							Name:     secondaryPodInterfaceName,
-							TypeName: nmstate.TypeDummy,
-							MTU:      1500,
-							IPv4:     ipDisabled,
-							IPv6:     ipDisabled,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
+							Name:       secondaryPodInterfaceName,
+							TypeName:   nmstate.TypeDummy,
+							MacAddress: secondaryPodIfaceOrignalMAC,
+							MTU:        1500,
+							IPv4:       ipDisabled,
+							IPv6:       ipDisabled,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{
@@ -779,13 +784,14 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 						{
-							Name:     secondaryPodInterfaceName,
-							TypeName: nmstate.TypeDummy,
-							State:    nmstate.IfaceStateAbsent,
-							MTU:      1500,
-							IPv4:     ipDisabled,
-							IPv6:     ipDisabled,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
+							Name:       secondaryPodInterfaceName,
+							TypeName:   nmstate.TypeDummy,
+							MacAddress: secondaryPodIfaceOrignalMAC,
+							State:      nmstate.IfaceStateAbsent,
+							MTU:        1500,
+							IPv4:       ipDisabled,
+							IPv6:       ipDisabled,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{
@@ -869,12 +875,13 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 						{
-							Name:     secondaryPodInterfaceOrderedName,
-							TypeName: nmstate.TypeDummy,
-							MTU:      1500,
-							IPv4:     ipDisabled,
-							IPv6:     ipDisabled,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
+							Name:       secondaryPodInterfaceOrderedName,
+							TypeName:   nmstate.TypeDummy,
+							MacAddress: secondaryPodIfaceOrignalMAC,
+							MTU:        1500,
+							IPv4:       ipDisabled,
+							IPv6:       ipDisabled,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{
@@ -1109,11 +1116,12 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:     "pod7087ef4cd1f",
-							TypeName: nmstate.TypeDummy,
-							State:    nmstate.IfaceStateAbsent,
-							MTU:      1500,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
+							Name:       "pod7087ef4cd1f",
+							TypeName:   nmstate.TypeDummy,
+							State:      nmstate.IfaceStateAbsent,
+							MacAddress: "22:34:56:78:90:ab",
+							MTU:        1500,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						// Third network.
 						{
@@ -1142,10 +1150,11 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:     "podbc6cc93fa1e",
-							TypeName: nmstate.TypeDummy,
-							MTU:      1500,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
+							Name:       "podbc6cc93fa1e",
+							TypeName:   nmstate.TypeDummy,
+							MacAddress: "32:34:56:78:90:ab",
+							MTU:        1500,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{},
@@ -1221,11 +1230,12 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:     "pod7087ef4cd1f",
-							TypeName: nmstate.TypeDummy,
-							State:    nmstate.IfaceStateAbsent,
-							MTU:      1500,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
+							Name:       "pod7087ef4cd1f",
+							TypeName:   nmstate.TypeDummy,
+							State:      nmstate.IfaceStateAbsent,
+							MacAddress: "22:34:56:78:90:ab",
+							MTU:        1500,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						// Third network.
 						{
@@ -1245,11 +1255,12 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:     "podbc6cc93fa1e",
-							TypeName: nmstate.TypeDummy,
-							State:    nmstate.IfaceStateAbsent,
-							MTU:      1500,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
+							Name:       "podbc6cc93fa1e",
+							TypeName:   nmstate.TypeDummy,
+							State:      nmstate.IfaceStateAbsent,
+							MacAddress: "32:34:56:78:90:ab",
+							MTU:        1500,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{},
@@ -1342,10 +1353,11 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:     "pod7087ef4cd1f",
-							TypeName: nmstate.TypeDummy,
-							MTU:      1500,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
+							Name:       "pod7087ef4cd1f",
+							TypeName:   nmstate.TypeDummy,
+							MacAddress: "22:34:56:78:90:ab",
+							MTU:        1500,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						// Third network.
 						{
@@ -1365,11 +1377,12 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:     "podbc6cc93fa1e",
-							TypeName: nmstate.TypeDummy,
-							State:    nmstate.IfaceStateAbsent,
-							MTU:      1500,
-							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
+							Name:       "podbc6cc93fa1e",
+							TypeName:   nmstate.TypeDummy,
+							State:      nmstate.IfaceStateAbsent,
+							MacAddress: "32:34:56:78:90:ab",
+							MTU:        1500,
+							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{},
@@ -1538,10 +1551,11 @@ var _ = Describe("netpod", func() {
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 					},
 					{
-						Name:     "pod7087ef4cd1f",
-						TypeName: nmstate.TypeDummy,
-						MTU:      1500,
-						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
+						Name:       "pod7087ef4cd1f",
+						TypeName:   nmstate.TypeDummy,
+						MacAddress: "22:34:56:78:90:ab",
+						MTU:        1500,
+						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 					},
 					// Third network.
 					{
@@ -1561,11 +1575,12 @@ var _ = Describe("netpod", func() {
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 					},
 					{
-						Name:     "podbc6cc93fa1e",
-						TypeName: nmstate.TypeDummy,
-						State:    nmstate.IfaceStateAbsent,
-						MTU:      1500,
-						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
+						Name:       "podbc6cc93fa1e",
+						TypeName:   nmstate.TypeDummy,
+						State:      nmstate.IfaceStateAbsent,
+						MacAddress: "32:34:56:78:90:ab",
+						MTU:        1500,
+						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 					},
 				},
 				LinuxStack: nmstate.LinuxStack{},

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -136,17 +136,7 @@ func (l *podNIC) newDHCPConfigurator() dhcpconfigurator.Configurator {
 }
 
 func (l *podNIC) newLibvirtSpecGenerator(domain *api.Domain) domainspec.LibvirtSpecGenerator {
-	if l.vmiSpecIface.Bridge != nil {
-		cachedDomainIface, err := l.cachedDomainInterface()
-		if err != nil {
-			return nil
-		}
-		if cachedDomainIface == nil {
-			cachedDomainIface = &api.Interface{}
-		}
-		return domainspec.NewBridgeLibvirtSpecGenerator(l.vmiSpecIface, domain, *cachedDomainIface, l.podInterfaceName, l.handler)
-	}
-	if l.vmiSpecIface.Masquerade != nil || l.vmiSpecIface.Macvtap != nil {
+	if l.vmiSpecIface.Bridge != nil || l.vmiSpecIface.Masquerade != nil || l.vmiSpecIface.Macvtap != nil {
 		return domainspec.NewTapLibvirtSpecGenerator(l.vmiSpecIface, domain, l.podInterfaceName, l.handler)
 	}
 	if l.vmiSpecIface.Passt != nil {

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -150,7 +150,7 @@ func (l *podNIC) newLibvirtSpecGenerator(domain *api.Domain) domainspec.LibvirtS
 		return domainspec.NewMasqueradeLibvirtSpecGenerator(l.vmiSpecIface, l.vmiSpecNetwork, domain, l.podInterfaceName, l.handler)
 	}
 	if l.vmiSpecIface.Macvtap != nil {
-		return domainspec.NewMacvtapLibvirtSpecGenerator(l.vmiSpecIface, domain, l.podInterfaceName, l.handler)
+		return domainspec.NewTapLibvirtSpecGenerator(l.vmiSpecIface, domain, l.podInterfaceName, l.handler)
 	}
 	if l.vmiSpecIface.Passt != nil {
 		return domainspec.NewPasstLibvirtSpecGenerator(l.vmiSpecIface, domain, l.podInterfaceName, l.vmi)

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -146,10 +146,7 @@ func (l *podNIC) newLibvirtSpecGenerator(domain *api.Domain) domainspec.LibvirtS
 		}
 		return domainspec.NewBridgeLibvirtSpecGenerator(l.vmiSpecIface, domain, *cachedDomainIface, l.podInterfaceName, l.handler)
 	}
-	if l.vmiSpecIface.Masquerade != nil {
-		return domainspec.NewMasqueradeLibvirtSpecGenerator(l.vmiSpecIface, l.vmiSpecNetwork, domain, l.podInterfaceName, l.handler)
-	}
-	if l.vmiSpecIface.Macvtap != nil {
+	if l.vmiSpecIface.Masquerade != nil || l.vmiSpecIface.Macvtap != nil {
 		return domainspec.NewTapLibvirtSpecGenerator(l.vmiSpecIface, domain, l.podInterfaceName, l.handler)
 	}
 	if l.vmiSpecIface.Passt != nil {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -364,11 +364,12 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 
 				By("Verifying the desired custom MAC is not configured inside the pod namespace.")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, testsuite.GetTestNamespace(vmiOne))
+				podInterfaceName := "e31d7ce2712-nic"
 				out, err := exec.ExecuteCommandOnPod(
 					virtClient,
 					vmiPod,
 					"compute",
-					[]string{"sh", "-c", "ip a"},
+					[]string{"sh", "-c", fmt.Sprintf("ip a show %s", podInterfaceName)},
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
@@ -470,11 +471,12 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 
 				By("Verifying the desired custom MAC is not configured inside the pod namespace.")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, vmiOne.Namespace)
+				podInterfaceName := "72ad293a5c9-nic"
 				out, err := exec.ExecuteCommandOnPod(
 					virtClient,
 					vmiPod,
 					"compute",
-					[]string{"sh", "-c", "ip a"},
+					[]string{"sh", "-c", fmt.Sprintf("ip a show %s", podInterfaceName)},
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Masquerade, bridge and macvtap bindings are using a tap to connect to the guest.
The domain interface of all those bindings is very similar and therefore the domain interface generation was refactored to one general tap generator instead of three separate generators.
Besides the fact it made the code shorter and nicer, in a follow-up PR this tap generator will be used by the binding plugin for plugins that will use `tap` `domain-attachment`.

Changes that had to be done so it will be possible to use the general tap generator:
- bridge binding
     -  store the original pod interface MAC on the dummy interface
     - read the MAC and the MTU for the domain attachment from the dummy interface
- masquerade binding
     -  in case there is no MAC address on the spec interface, give the domain interface the pod interface MAC address (the guest is behind a NAT, so it should be ok)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
