### PR TITLE
Add PreferredInterfaceSRIOV

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -22578,6 +22578,10 @@
       "description": "PreferredInterfaceModel optionally defines the preferred model to be used by Interface devices.",
       "type": "string"
      },
+     "preferredInterfaceSRIOV": {
+      "description": "PreferredInterfaceSRIOV optionally defines the preferred SRIOV configuration to use with each network interface.",
+      "$ref": "#/definitions/v1.InterfaceSRIOV"
+     },
      "preferredLunBus": {
       "description": "PreferredLunBus optionally defines the preferred bus for Lun Disk devices.",
       "type": "string"

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8445,6 +8445,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: PreferredInterfaceModel optionally defines the preferred
                 model to be used by Interface devices.
               type: string
+            preferredInterfaceSRIOV:
+              description: PreferredInterfaceSRIOV optionally defines the preferred
+                SRIOV configuration to use with each network interface.
+              type: object
             preferredLunBus:
               description: PreferredLunBus optionally defines the preferred bus for
                 Lun Disk devices.
@@ -21701,6 +21705,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: PreferredInterfaceModel optionally defines the preferred
                 model to be used by Interface devices.
               type: string
+            preferredInterfaceSRIOV:
+              description: PreferredInterfaceSRIOV optionally defines the preferred
+                SRIOV configuration to use with each network interface.
+              type: object
             preferredLunBus:
               description: PreferredLunBus optionally defines the preferred bus for
                 Lun Disk devices.

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha1/conversion_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha1/conversion_generated.go
@@ -321,6 +321,7 @@ func autoConvert_v1beta1_DevicePreferences_To_v1alpha1_DevicePreferences(in *v1b
 	out.PreferredNetworkInterfaceMultiQueue = (*bool)(unsafe.Pointer(in.PreferredNetworkInterfaceMultiQueue))
 	out.PreferredTPM = (*corev1.TPMDevice)(unsafe.Pointer(in.PreferredTPM))
 	// WARNING: in.PreferredInterfaceMasquerade requires manual conversion: does not exist in peer-type
+	// WARNING: in.PreferredInterfaceSRIOV requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha2/conversion_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha2/conversion_generated.go
@@ -331,6 +331,7 @@ func autoConvert_v1beta1_DevicePreferences_To_v1alpha2_DevicePreferences(in *v1b
 	out.PreferredNetworkInterfaceMultiQueue = (*bool)(unsafe.Pointer(in.PreferredNetworkInterfaceMultiQueue))
 	out.PreferredTPM = (*corev1.TPMDevice)(unsafe.Pointer(in.PreferredTPM))
 	// WARNING: in.PreferredInterfaceMasquerade requires manual conversion: does not exist in peer-type
+	// WARNING: in.PreferredInterfaceSRIOV requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
@@ -213,6 +213,11 @@ func (in *DevicePreferences) DeepCopyInto(out *DevicePreferences) {
 		*out = new(v1.InterfaceMasquerade)
 		**out = **in
 	}
+	if in.PreferredInterfaceSRIOV != nil {
+		in, out := &in.PreferredInterfaceSRIOV, &out.PreferredInterfaceSRIOV
+		*out = new(v1.InterfaceSRIOV)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -458,6 +458,11 @@ type DevicePreferences struct {
 	//
 	// +optional
 	PreferredInterfaceMasquerade *v1.InterfaceMasquerade `json:"preferredInterfaceMasquerade,omitempty"`
+
+	// PreferredInterfaceSRIOV optionally defines the preferred SRIOV configuration to use with each network interface.
+	//
+	// +optional
+	PreferredInterfaceSRIOV *v1.InterfaceSRIOV `json:"preferredInterfaceSRIOV,omitempty"`
 }
 
 // FeaturePreferences contains various optional defaults for Features.

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -151,6 +151,7 @@ func (DevicePreferences) SwaggerDoc() map[string]string {
 		"preferredNetworkInterfaceMultiQueue": "PreferredNetworkInterfaceMultiQueue optionally enables the vhost multiqueue feature for virtio interfaces.\n\n+optional",
 		"preferredTPM":                        "PreferredTPM optionally defines the preferred TPM device to be used.\n\n+optional",
 		"preferredInterfaceMasquerade":        "PreferredInterfaceMasquerade optionally defines the preferred masquerade configuration to use with each network interface.\n\n+optional",
+		"preferredInterfaceSRIOV":             "PreferredInterfaceSRIOV optionally defines the preferred SRIOV configuration to use with each network interface.\n\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -27956,11 +27956,17 @@ func schema_kubevirtio_api_instancetype_v1beta1_DevicePreferences(ref common.Ref
 							Ref:         ref("kubevirt.io/api/core/v1.InterfaceMasquerade"),
 						},
 					},
+					"preferredInterfaceSRIOV": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PreferredInterfaceSRIOV optionally defines the preferred SRIOV configuration to use with each network interface.",
+							Ref:         ref("kubevirt.io/api/core/v1.InterfaceSRIOV"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"kubevirt.io/api/core/v1.BlockSize", "kubevirt.io/api/core/v1.InterfaceMasquerade", "kubevirt.io/api/core/v1.Rng", "kubevirt.io/api/core/v1.TPMDevice", "kubevirt.io/api/core/v1.VGPUOptions"},
+			"kubevirt.io/api/core/v1.BlockSize", "kubevirt.io/api/core/v1.InterfaceMasquerade", "kubevirt.io/api/core/v1.InterfaceSRIOV", "kubevirt.io/api/core/v1.Rng", "kubevirt.io/api/core/v1.TPMDevice", "kubevirt.io/api/core/v1.VGPUOptions"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `PreferredInterfaceSRIOV ` to `VirtualMachinePreference` , allowing the definition of the preferred SRIOV configuration to use with network interface.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```
None
```
