### PR TITLE
VM with vfio devices cannot have guest memory > requested memory

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -46,8 +46,8 @@ func IsNonRootVMI(vmi *v1.VirtualMachineInstance) bool {
 	return ok || nonRoot
 }
 
-func IsSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+func IsSRIOVVmi(vmiSpec *v1.VirtualMachineInstanceSpec) bool {
+	for _, iface := range vmiSpec.Domain.Devices.Interfaces {
 		if iface.SRIOV != nil {
 			return true
 		}
@@ -56,8 +56,8 @@ func IsSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
 }
 
 // Check if a VMI spec requests GPU
-func IsGPUVMI(vmi *v1.VirtualMachineInstance) bool {
-	if vmi.Spec.Domain.Devices.GPUs != nil && len(vmi.Spec.Domain.Devices.GPUs) != 0 {
+func isGPUVMI(vmiSpec *v1.VirtualMachineInstanceSpec) bool {
+	if vmiSpec.Domain.Devices.GPUs != nil && len(vmiSpec.Domain.Devices.GPUs) != 0 {
 		return true
 	}
 	return false
@@ -76,17 +76,26 @@ func IsVMIVirtiofsEnabled(vmi *v1.VirtualMachineInstance) bool {
 }
 
 // Check if a VMI spec requests a HostDevice
-func IsHostDevVMI(vmi *v1.VirtualMachineInstance) bool {
-	if vmi.Spec.Domain.Devices.HostDevices != nil && len(vmi.Spec.Domain.Devices.HostDevices) != 0 {
+func isHostDevVMI(vmiSpec *v1.VirtualMachineInstanceSpec) bool {
+	if vmiSpec.Domain.Devices.HostDevices != nil && len(vmiSpec.Domain.Devices.HostDevices) != 0 {
 		return true
 	}
 	return false
 }
 
-// Check if a VMI spec requests a VFIO device
-func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
+// Wrapper functions used for template service VMI resource rules
+func IsHostDevVMI(vmi *v1.VirtualMachineInstance) bool {
+	return isHostDevVMI(&vmi.Spec)
+}
 
-	if IsHostDevVMI(vmi) || IsGPUVMI(vmi) || IsSRIOVVmi(vmi) {
+func IsGPUVMI(vmi *v1.VirtualMachineInstance) bool {
+	return isGPUVMI(&vmi.Spec)
+}
+
+// Check if a VMI spec requests a VFIO device
+func IsVFIOVMI(vmiSpec *v1.VirtualMachineInstanceSpec) bool {
+
+	if isHostDevVMI(vmiSpec) || isGPUVMI(vmiSpec) || IsSRIOVVmi(vmiSpec) {
 		return true
 	}
 	return false

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/webhooks:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+	"kubevirt.io/kubevirt/pkg/util"
 
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 
@@ -1383,6 +1384,7 @@ func validateGuestMemoryLimit(field *k8sfield.Path, spec *v1.VirtualMachineInsta
 	if spec.Domain.Memory != nil && spec.Domain.Memory.Guest != nil {
 		limits := spec.Domain.Resources.Limits.Memory().Value()
 		guest := spec.Domain.Memory.Guest.Value()
+		request := spec.Domain.Resources.Requests.Memory().Value()
 		if limits < guest && limits != 0 {
 			causes = append(causes, metav1.StatusCause{
 				Type: metav1.CauseTypeFieldValueInvalid,
@@ -1391,6 +1393,17 @@ func validateGuestMemoryLimit(field *k8sfield.Path, spec *v1.VirtualMachineInsta
 					spec.Domain.Memory.Guest,
 					field.Child("domain", "resources", "limits", "memory").String(),
 					spec.Domain.Resources.Limits.Memory(),
+				),
+				Field: field.Child("domain", "memory", "guest").String(),
+			})
+		} else if request < guest && util.IsVFIOVMI(spec) {
+			causes = append(causes, metav1.StatusCause{
+				Type: metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("%s '%s' must be equal to or less than the memory requested %s '%s' when VM requests VFIO device",
+					field.Child("domain", "memory", "guest").String(),
+					spec.Domain.Memory.Guest,
+					field.Child("domain", "resources", "requests", "memory").String(),
+					spec.Domain.Resources.Requests.Memory(),
 				),
 				Field: field.Child("domain", "memory", "guest").String(),
 			})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -876,35 +876,46 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.memory.guest"))
 		})
-		It("should reject guest memory greater than requested memory when VM has VFIO device", func() {
-			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.GPUGate}
-			kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{
-				PciHostDevices: []v1.PciHostDevice{
-					{
-						PCIVendorSelector: "DEAD:BEEF",
-						ResourceName:      "example.org/deadbeef",
+		Context("with guest memory greater than requested memory", func() {
+			var vmi *v1.VirtualMachineInstance
+
+			BeforeEach(func() {
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.GPUGate}
+				kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{
+					PciHostDevices: []v1.PciHostDevice{
+						{
+							PCIVendorSelector: "DEAD:BEEF",
+							ResourceName:      "example.org/deadbeef",
+						},
 					},
-				},
-			}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
+				}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
+				vmi = api.NewMinimalVMI("testvmi")
+				guestMemory := resource.MustParse("128Mi")
 
-			vmi := api.NewMinimalVMI("testvmi")
-			guestMemory := resource.MustParse("128Mi")
+				vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+					k8sv1.ResourceMemory: resource.MustParse("64Mi"),
+				}
+				vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+			})
 
-			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
-			}
-			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
-			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
-				{
-					Name:       "gpu1",
-					DeviceName: "example.org/deadbeef",
-				},
-			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.memory.guest"))
+			It("should be rejected when VM has VFIO device", func() {
+				vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
+					{
+						Name:       "gpu1",
+						DeviceName: "example.org/deadbeef",
+					},
+				}
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				Expect(causes).To(HaveLen(1))
+				Expect(causes[0].Field).To(Equal("fake.domain.memory.guest"))
+			})
+
+			It("should be allowed when VM has no VFIO device", func() {
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				Expect(causes).To(BeEmpty())
+			})
 		})
 		It("should allow guest memory which is between requests and limits when VM does not have VFIO device", func() {
 			vmi := api.NewMinimalVMI("testvmi")

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -364,7 +364,7 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 	// Additional overhead of 1G for VFIO devices. VFIO requires all guest RAM to be locked
 	// in addition to MMIO memory space to allow DMA. 1G is often the size of reserved MMIO space on x86 systems.
 	// Additial information can be found here: https://www.redhat.com/archives/libvir-list/2015-November/msg00329.html
-	if util.IsVFIOVMI(vmi) {
+	if util.IsVFIOVMI(&vmi.Spec) {
 		overhead.Add(resource.MustParse("1Gi"))
 	}
 

--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -96,7 +96,7 @@ func (s *socketBasedIsolationDetector) DetectForSocket(vm *v1.VirtualMachineInst
 
 func (s *socketBasedIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance, additionalOverheadRatio *string) error {
 	// only VFIO attached or with lock guest memory domains require MEMLOCK adjustment
-	if !util.IsVFIOVMI(vm) && !vm.IsRealtimeEnabled() && !util.IsSEVVMI(vm) {
+	if !util.IsVFIOVMI(&vm.Spec) && !vm.IsRealtimeEnabled() && !util.IsSEVVMI(vm) {
 		return nil
 	}
 
@@ -143,7 +143,7 @@ func (s *socketBasedIsolationDetector) AdjustResources(vm *v1.VirtualMachineInst
 // virt-launcher pod on the given VMI according to its spec.
 // Only VMI's with VFIO devices (e.g: SRIOV, GPU), SEV or RealTime workloads require QEMU process MEMLOCK adjustment.
 func AdjustQemuProcessMemoryLimits(podIsoDetector PodIsolationDetector, vmi *v1.VirtualMachineInstance, additionalOverheadRatio *string) error {
-	if !util.IsVFIOVMI(vmi) && !vmi.IsRealtimeEnabled() && !util.IsSEVVMI(vmi) {
+	if !util.IsVFIOVMI(&vmi.Spec) && !vmi.IsRealtimeEnabled() && !util.IsSEVVMI(vmi) {
 		return nil
 	}
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -745,6 +745,18 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			})
 		})
 
+		Context("with guest memory greater than request memory", func() {
+			It("should successfully start the VM when no VFIO device requested", func() {
+				vmi := libvmi.NewCirros(
+					libvmi.WithGuestMemory("512Mi"),
+				)
+				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+			})
+		})
+
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging memory limit from memory request and no guest memory", func() {
 			It("[test_id:3115]should show the memory request inside the VMI", func() {
 				vmi := libvmi.NewCirros(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: When creating a VM with vfio device(s), setting guest memory greater than request memory is accepted by the validator and KubeVirt attempts to create the VM. However, the VM doesn't start, instead getting stuck in `CrashLoopBackOff` with the following error:
`Message: server error. command SyncVMI failed: "LibvirtError(Code=1, Domain=10, Message='internal error: Process exited prior to exec: libvirt: error : cannot limit locked memory of process 87 to 4294967296: Operation not permitted')"
Reason: Synchronizing with the Domain failed.`

This PR prevents the VM from being created in the first place, rejecting the create VM request if the VM has vfio device(s) and its guest memory exceeds its requested memory. Additionally, if a memory overcommit would result in guest memory > requested, it will ignore the memory overcommit. 
**Note:** This only appears to be an issue specifically with VMs that have vfio device(s). Creating a VM without vfio with a guest memory greater than the requested (but still less than the limit) does not cause issues and starts the VM normally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
