### PR TITLE
cgroupsv2: reconstruct device allowlist/drop internal device allow list state

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -99,6 +99,7 @@ go_test(
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",
+        "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/container-disk:go_default_library",
         "//pkg/virt-handler/hotplug-disk:go_default_library",

--- a/pkg/virt-handler/cgroup/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/cgroup",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/safepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -23,6 +24,7 @@ go_library(
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/devices:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/cgroup/cgroup_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_test.go
@@ -43,7 +43,7 @@ var _ = Describe("cgroup manager", func() {
 		if version == V1 {
 			return newCustomizedV1Manager(mockRuncCgroupManager, false, execVirtChrootFunc, getCurrentlyDefinedRulesFunc)
 		} else {
-			return newCustomizedV2Manager(mockRuncCgroupManager, false, execVirtChrootFunc)
+			return newCustomizedV2Manager(mockRuncCgroupManager, false, nil, execVirtChrootFunc)
 		}
 	}
 
@@ -85,10 +85,11 @@ var _ = Describe("cgroup manager", func() {
 
 		Expect(rulesDefined).To(ContainElement(fakeRule), "defined rule is expected to exist")
 
-		for _, defaultRule := range GenerateDefaultDeviceRules() {
+		defaultDeviceRules := GenerateDefaultDeviceRules()
+		for _, defaultRule := range defaultDeviceRules {
 			Expect(rulesDefined).To(ContainElement(defaultRule), "default rules are expected to be defined")
 		}
-
+		Expect(rulesDefined).To(HaveLen(len(defaultDeviceRules) + 1))
 	},
 		Entry("for v1", V1),
 		Entry("for v2", V2),

--- a/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
+++ b/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
@@ -7,6 +7,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 	v1 "kubevirt.io/api/core/v1"
+
+	cgroup "kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 )
 
 // Mock of VolumeMounter interface
@@ -30,44 +32,44 @@ func (_m *MockVolumeMounter) EXPECT() *_MockVolumeMounterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockVolumeMounter) Mount(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "Mount", vmi)
+func (_m *MockVolumeMounter) Mount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "Mount", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) Mount(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Mount", arg0)
+func (_mr *_MockVolumeMounterRecorder) Mount(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Mount", arg0, arg1)
 }
 
-func (_m *MockVolumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID) error {
-	ret := _m.ctrl.Call(_m, "MountFromPod", vmi, sourceUID)
+func (_m *MockVolumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "MountFromPod", vmi, sourceUID, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) MountFromPod(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountFromPod", arg0, arg1)
+func (_mr *_MockVolumeMounterRecorder) MountFromPod(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountFromPod", arg0, arg1, arg2)
 }
 
-func (_m *MockVolumeMounter) Unmount(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "Unmount", vmi)
+func (_m *MockVolumeMounter) Unmount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "Unmount", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) Unmount(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unmount", arg0)
+func (_mr *_MockVolumeMounterRecorder) Unmount(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unmount", arg0, arg1)
 }
 
-func (_m *MockVolumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "UnmountAll", vmi)
+func (_m *MockVolumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "UnmountAll", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) UnmountAll(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmountAll", arg0)
+func (_mr *_MockVolumeMounterRecorder) UnmountAll(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmountAll", arg0, arg1)
 }
 
 func (_m *MockVolumeMounter) IsMounted(vmi *v1.VirtualMachineInstance, volume string, sourceUID types.UID) (bool, error) {

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -572,6 +572,119 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 	})
 
+	Context("Offline VM with a block volume", func() {
+		var (
+			vm *v1.VirtualMachine
+			sc string
+		)
+
+		BeforeEach(func() {
+			var exists bool
+
+			sc, exists = libstorage.GetRWXBlockStorageClass()
+			if !exists {
+				Skip("Skip test when RWXBlock storage class is not present")
+			}
+
+			vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(
+				cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
+				testsuite.GetTestNamespace(nil),
+				corev1.ReadWriteMany,
+			)
+			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+
+			By("Creating VirtualMachine")
+			vm, err = virtClient.VirtualMachine(vmi.Namespace).Create(context.Background(), tests.NewRandomVirtualMachine(vmi, false))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		DescribeTable("Should start with a hotplug block", func(addVolumeFunc addVolumeFunction) {
+			dv := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
+
+			By("Adding a hotplug block volume")
+			addVolumeFunc(vm.Name, vm.Namespace, dv.Name, dv.Name, v1.DiskBusSCSI, false, "")
+
+			By("Verifying the volume has been added to the template spec")
+			verifyVolumeAndDiskVMAdded(virtClient, vm, dv.Name)
+
+			By("Starting the VM")
+			vm = tests.StartVirtualMachine(vm)
+			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying the volume is attached and usable")
+			verifyVolumeAndDiskVMIAdded(virtClient, vmi, dv.Name)
+			verifyVolumeStatus(vmi, v1.VolumeReady, "", dv.Name)
+			getVmiConsoleAndLogin(vmi)
+			targets := verifyHotplugAttachedAndUseable(vmi, []string{dv.Name})
+			Expect(targets).To(HaveLen(1))
+		},
+			Entry("DataVolume", addDVVolumeVM),
+			Entry("PersistentVolume", addPVCVolumeVM),
+		)
+
+		It("[Serial]Should preserve access to block devices if virt-handler crashes", Serial, func() {
+			blockDevices := []string{"/dev/disk0"}
+
+			By("Adding a hotplug block volume")
+			dv := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
+			blockDevices = append(blockDevices, fmt.Sprintf("/var/run/kubevirt/hotplug-disks/%s", dv.Name))
+			addDVVolumeVM(vm.Name, vm.Namespace, dv.Name, dv.Name, v1.DiskBusSCSI, false, "")
+
+			By("Verifying the volume has been added to the template spec")
+			verifyVolumeAndDiskVMAdded(virtClient, vm, dv.Name)
+
+			By("Starting the VM")
+			vm = tests.StartVirtualMachine(vm)
+			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying the volume is attached and usable")
+			verifyVolumeAndDiskVMIAdded(virtClient, vmi, dv.Name)
+			verifyVolumeStatus(vmi, v1.VolumeReady, "", dv.Name)
+			getVmiConsoleAndLogin(vmi)
+			targets := verifyHotplugAttachedAndUseable(vmi, []string{dv.Name})
+			Expect(targets).To(HaveLen(1))
+
+			By("Deleting virt-handler pod")
+			virtHandlerPod, err := libnode.GetVirtHandlerPod(virtClient, vmi.Status.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() bool {
+				err := virtClient.CoreV1().
+					Pods(virtHandlerPod.GetObjectMeta().GetNamespace()).
+					Delete(context.Background(), virtHandlerPod.GetObjectMeta().GetName(), metav1.DeleteOptions{})
+				return errors.IsNotFound(err)
+			}, 60*time.Second, 1*time.Second).Should(BeTrue(), "virt-handler pod is expected to be deleted")
+
+			By("Waiting for virt-handler pod to restart")
+			Eventually(func() bool {
+				virtHandlerPod, err = libnode.GetVirtHandlerPod(virtClient, vmi.Status.NodeName)
+				return err == nil && virtHandlerPod.Status.Phase == corev1.PodRunning
+			}, 60*time.Second, 1*time.Second).Should(BeTrue(), "virt-handler pod is expected to be restarted")
+
+			By("Adding another hotplug block volume")
+			dv = createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
+			blockDevices = append(blockDevices, fmt.Sprintf("/var/run/kubevirt/hotplug-disks/%s", dv.Name))
+			addDVVolumeVM(vm.Name, vm.Namespace, dv.Name, dv.Name, v1.DiskBusSCSI, false, "")
+
+			By("Verifying the volume is attached and usable")
+			verifyVolumeAndDiskVMIAdded(virtClient, vmi, dv.Name)
+			verifyVolumeStatus(vmi, v1.VolumeReady, "", dv.Name)
+			getVmiConsoleAndLogin(vmi)
+			targets = verifyHotplugAttachedAndUseable(vmi, []string{dv.Name})
+			Expect(targets).To(HaveLen(1))
+
+			By("Verifying the block devices are still accessible")
+			for _, dev := range blockDevices {
+				By(fmt.Sprintf("Verifying %s", dev))
+				output := tests.RunCommandOnVmiPod(vmi, []string{
+					"dd", fmt.Sprintf("if=%s", dev), "of=/dev/null", "bs=1", "count=1", "status=none",
+				})
+				Expect(output).To(BeEmpty())
+			}
+		})
+	})
+
 	Context("WFFC storage", func() {
 		var (
 			vm *v1.VirtualMachine
@@ -982,14 +1095,31 @@ var _ = SIGDescribe("Hotplug", func() {
 				sc  string
 
 				numberOfMigrations int
+				hotplugLabelKey    string
 				sourceNode         string
 				targetNode         string
 			)
 
 			const (
-				hotplugLabelKey   = "kubevirt-test-migration-with-hotplug-disks"
 				hotplugLabelValue = "true"
 			)
+
+			containerDiskVMIFunc := func() *v1.VirtualMachineInstance {
+				return libvmi.NewCirros(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+			}
+			persistentDiskVMIFunc := func() *v1.VirtualMachineInstance {
+				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(
+					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
+					testsuite.GetTestNamespace(nil),
+					corev1.ReadWriteMany,
+				)
+				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+
+				return vmi
+			}
 
 			BeforeEach(func() {
 				exists := false
@@ -1023,14 +1153,8 @@ var _ = SIGDescribe("Hotplug", func() {
 				}
 				// Ensure the virt-launcher pod is scheduled on the chosen source node and then
 				// migrated to the proper target.
+				hotplugLabelKey = fmt.Sprintf("%s-hotplug-disk-migration", testsuite.GetTestNamespace(nil))
 				libnode.AddLabelToNode(sourceNode, hotplugLabelKey, hotplugLabelValue)
-				vmi = libvmi.NewCirros(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				)
-				vmi.Spec.NodeSelector = map[string]string{hotplugLabelKey: hotplugLabelValue}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
-				libnode.AddLabelToNode(targetNode, hotplugLabelKey, hotplugLabelValue)
 			})
 
 			AfterEach(func() {
@@ -1039,7 +1163,11 @@ var _ = SIGDescribe("Hotplug", func() {
 				libnode.RemoveLabelFromNode(targetNode, hotplugLabelKey)
 			})
 
-			It("should allow live migration with attached hotplug volumes", func() {
+			DescribeTable("should allow live migration with attached hotplug volumes", func(vmiFunc func() *v1.VirtualMachineInstance) {
+				vmi = vmiFunc()
+				vmi.Spec.NodeSelector = map[string]string{hotplugLabelKey: hotplugLabelValue}
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				libnode.AddLabelToNode(targetNode, hotplugLabelKey, hotplugLabelValue)
 				volumeName := "testvolume"
 				volumeMode := corev1.PersistentVolumeBlock
 				addVolumeFunc := addDVVolumeVMI
@@ -1104,7 +1232,10 @@ var _ = SIGDescribe("Hotplug", func() {
 				Expect(err).ToNot(HaveOccurred())
 				verifyVolumeAndDiskVMIAdded(virtClient, vmi, volumeName)
 				verifyVolumeStatus(vmi, v1.VolumeReady, "", volumeName)
-			})
+			},
+				Entry("containerDisk VMI", containerDiskVMIFunc),
+				Entry("persistent disk VMI", persistentDiskVMIFunc),
+			)
 		})
 
 		Context("disk mutating sidecar", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is just a resurrection of https://github.com/kubevirt/kubevirt/pull/8865 that unites the tests commits and adds some new ones.
Credit goes to @vasiliy-ul, @awels, @iholder101 

When a block volume is non-hotpluggable (i.e. it is specified explicitly in the VMI spec), the device cgroup permissions are managed purely by Kubernetes and CRI. For v2, a BPF program is assigned to the pod's cgroup.
However, today, when we attach hotplug volumes, we overwrite the BPF program to allow access to the new block device
since there is no way to append a single device to the allow list (https://github.com/opencontainers/runc/issues/3196).

With the current path, we also "forget" to populate the new allow list with the existing non hotpluggable disks.
This breaks, for instance, live migration, since the main disk needs to `open()` again, and that is not allowed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7710 
Fixes #8699 
https://issues.redhat.com/browse/CNV-34724

**Special notes for your reviewer**:
Following this PR, we are able to reconstruct the entire VM device allow list.
However, in the future, when we support things like https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/, we may need to also be able to reconstruct more VM-related devices.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: cgroupsv2 device allowlist is bound to virt-handler internal state/block disk device overwritten on hotplug
```
