### PR TITLE
tests, reporter: If the suite fails, execute the reporter

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -88,7 +88,7 @@ func NewKubernetesReporter(artifactsDir string, maxFailures int) *KubernetesRepo
 	}
 }
 
-func (r *KubernetesReporter) JustAfterEach(specReport types.SpecReport) {
+func (r *KubernetesReporter) ReportSpec(specReport types.SpecReport) {
 	fmt.Fprintf(GinkgoWriter, "On failure, artifacts will be collected in %s/%d_*\n", r.artifactsDir, r.failureCount+1)
 
 	if r.failureCount > r.maxFails {

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -88,6 +88,20 @@ func NewKubernetesReporter(artifactsDir string, maxFailures int) *KubernetesRepo
 	}
 }
 
+func (r *KubernetesReporter) Report(report types.Report) {
+	if report.SuiteSucceeded {
+		return
+	}
+
+	if r.artifactsDir == "" {
+		return
+	}
+
+	fmt.Fprintf(GinkgoWriter, "Test suite failed, collect artifacts in %s\n", r.artifactsDir)
+
+	r.dumpNamespaces(report.RunTime, testsuite.TestNamespaces)
+}
+
 func (r *KubernetesReporter) ReportSpec(specReport types.SpecReport) {
 	fmt.Fprintf(GinkgoWriter, "On failure, artifacts will be collected in %s/%d_*\n", r.artifactsDir, r.failureCount+1)
 

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1092,13 +1092,6 @@ func (r *KubernetesReporter) dumpK8sEntityToFile(virtCli kubecli.KubevirtClient,
 	fmt.Fprintln(f, prettyJson.String())
 }
 
-func (r *KubernetesReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
-	if setupSummary.State.Is(types.SpecStateFailureStates) {
-		r.failureCount++
-		r.DumpTestNamespaces(setupSummary.RunTime)
-	}
-}
-
 func (r *KubernetesReporter) logClusterOverview() {
 	binary := ""
 	if flags.KubeVirtKubectlPath != "" {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -123,6 +123,14 @@ func getMaxFailsFromEnv() int {
 	return maxFails
 }
 
+var _ = ReportAfterSuite("Collect cluster data", func(report Report) {
+	artifactPath := filepath.Join(flags.ArtifactsDir, "k8s-reporter", "suite")
+	kvReport := reporter.NewKubernetesReporter(artifactPath, 1)
+	kvReport.Cleanup()
+
+	kvReport.Report(report)
+})
+
 var _ = ReportAfterSuite("TestTests", func(report Report) {
 	for _, reporter := range afterSuiteReporters {
 		ginkgo_reporters.ReportViaDeprecatedReporter(reporter, report)

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -130,5 +130,5 @@ var _ = ReportAfterSuite("TestTests", func(report Report) {
 })
 
 var _ = JustAfterEach(func() {
-	k8sReporter.JustAfterEach(CurrentSpecReport())
+	k8sReporter.ReportSpec(CurrentSpecReport())
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

After all tests finished and all teardown fixtures executed, report
the state of the cluster.
    
This is useful for cases where all tests pass but the suite fails, due
to one of its teardown cleanups (e.g. waiting for all test namespaces to
be deleted).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
