### PR TITLE
Remove MigrateVmiDiskTransferRateMetric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -147,9 +147,6 @@ The rate at which the memory is being transferred. Type: Gauge.
 ### kubevirt_vmi_migration_failed
 Indicates if the VMI migration failed. Type: Gauge.
 
-### kubevirt_vmi_migration_memory_transfer_rate_bytes
-The rate at which the disk is being transferred. Type: Gauge.
-
 ### kubevirt_vmi_migration_phase_transition_time_from_creation_seconds
 Histogram of VM migration phase transitions duration from creation time in seconds. Type: Histogram.
 

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -47,7 +47,6 @@ const (
 	MigrateVmiDataProcessedMetricName      = "kubevirt_vmi_migration_data_processed_bytes"
 	MigrateVmiDirtyMemoryRateMetricName    = "kubevirt_vmi_migration_dirty_memory_rate_bytes"
 	MigrateVmiMemoryTransferRateMetricName = "kubevirt_vmi_migration_disk_transfer_rate_bytes"
-	MigrateVmiDiskTransferRateMetricName   = "kubevirt_vmi_migration_memory_transfer_rate_bytes"
 )
 
 var (
@@ -109,15 +108,6 @@ func (metrics *vmiMetrics) updateMigrateInfo(jobInfo *stats.DomainJobInfo) {
 			"Network throughput used while migrating memory in Bytes per second.",
 			prometheus.GaugeValue,
 			float64(jobInfo.MemoryBps),
-		)
-	}
-
-	if jobInfo.DiskBpsSet {
-		metrics.pushCommonMetric(
-			MigrateVmiDiskTransferRateMetricName,
-			"Network throughput used while migrating disks in Bytes per second.",
-			prometheus.GaugeValue,
-			float64(jobInfo.DiskBps),
 		)
 	}
 }

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -396,12 +396,6 @@ var _ = Describe("Prometheus", func() {
 					MemoryBpsSet: true,
 					MemoryBps:    1,
 				}),
-			Entry("should handle DiskBps metrics for VMs",
-				MigrateVmiDiskTransferRateMetricName,
-				&stats.DomainJobInfo{
-					DiskBpsSet: true,
-					DiskBps:    1,
-				}),
 		)
 
 		It("should handle vcpu metrics", func() {

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -184,8 +184,6 @@ type DomainJobInfo struct {
 	DataProcessed    uint64
 	MemoryBpsSet     bool
 	MemoryBps        uint64
-	DiskBpsSet       bool
-	DiskBps          uint64
 	DataRemainingSet bool
 	DataRemaining    uint64
 	MemDirtyRateSet  bool

--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -225,8 +225,6 @@ func Convert_libvirt_DomainJobInfo_To_stats_DomainJobInfo(info *libvirt.DomainJo
 		DataProcessed:    info.DataProcessed,
 		MemoryBpsSet:     info.MemBpsSet,
 		MemoryBps:        info.MemBps,
-		DiskBpsSet:       info.DiskBpsSet,
-		DiskBps:          info.DiskBps,
 		DataRemainingSet: info.DataRemainingSet,
 		DataRemaining:    info.DataRemaining,
 		MemDirtyRateSet:  info.MemDirtyRateSet && info.MemPageSizeSet,

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -199,9 +199,7 @@ var Testdataexpected = `{
      "MemDirtyRate": 0,
      "MemDirtyRateSet": false,
      "MemoryBpsSet": false,
-     "MemoryBps": 0,
-     "DiskBpsSet": false,
-     "DiskBps": 0
+     "MemoryBps": 0
    },
    "Name": "testName", 
    "Net": [

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -499,7 +499,6 @@ func RunMigrationAndCollectMigrationMetrics(vmi *v1.VirtualMachineInstance, migr
 		"kubevirt_vmi_migration_data_processed_bytes",
 		"kubevirt_vmi_migration_dirty_memory_rate_bytes",
 		"kubevirt_vmi_migration_disk_transfer_rate_bytes",
-		"kubevirt_vmi_migration_memory_transfer_rate_bytes",
 	}
 	const family = k8sv1.IPv4Protocol
 

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -140,11 +140,6 @@ func getMetricsNotIncludeInEndpointByDefault() metricList {
 			mType:       "Gauge",
 		},
 		{
-			name:        domainstats.MigrateVmiDiskTransferRateMetricName,
-			description: "The rate at which the disk is being transferred.",
-			mType:       "Gauge",
-		},
-		{
 			name:        "kubevirt_vmi_phase_count",
 			description: "Sum of VMIs per phase and node. `phase` can be one of the following: [`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`].",
 			mType:       "Gauge",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As reported in https://bugzilla.redhat.com/show_bug.cgi?id=2117186
qemu blockjobs no longer report the actual bandwidth used.

This PR removes the related metric

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove MigrateVmiDiskTransferRateMetric
```

/cc @enp0s3 @sradco 
