### PR TITLE
test: tweak some time based test values

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -907,10 +907,10 @@ var _ = Describe("Migration watcher", func() {
 			Entry("in pending state", virtv1.MigrationPending, true, defaultUnschedulablePendingTimeoutSeconds, ""),
 			Entry("in scheduling state", virtv1.MigrationScheduling, true, defaultUnschedulablePendingTimeoutSeconds, ""),
 			Entry("in scheduled state", virtv1.MigrationScheduled, false, defaultUnschedulablePendingTimeoutSeconds, ""),
-			Entry("in pending state but timeout not hit", virtv1.MigrationPending, false, defaultUnschedulablePendingTimeoutSeconds-1, ""),
+			Entry("in pending state but timeout not hit", virtv1.MigrationPending, false, defaultUnschedulablePendingTimeoutSeconds-10, ""),
 			Entry("in pending state with custom timeout", virtv1.MigrationPending, true, int64(10), "10"),
-			Entry("in pending state with custom timeout not hit", virtv1.MigrationPending, false, int64(10), "11"),
-			Entry("in scheduling state but timeout not hit", virtv1.MigrationScheduling, false, defaultUnschedulablePendingTimeoutSeconds-1, ""),
+			Entry("in pending state with custom timeout not hit", virtv1.MigrationPending, false, int64(8), "11"),
+			Entry("in scheduling state but timeout not hit", virtv1.MigrationScheduling, false, defaultUnschedulablePendingTimeoutSeconds-10, ""),
 		)
 
 		DescribeTable("should handle pod stuck in pending phase for extended period of time", func(phase virtv1.VirtualMachineInstanceMigrationPhase, shouldTimeout bool, timeLapse int64, annotationVal string) {
@@ -945,10 +945,10 @@ var _ = Describe("Migration watcher", func() {
 			Entry("in pending state", virtv1.MigrationPending, true, defaultCatchAllPendingTimeoutSeconds, ""),
 			Entry("in scheduling state", virtv1.MigrationScheduling, true, defaultCatchAllPendingTimeoutSeconds, ""),
 			Entry("in scheduled state", virtv1.MigrationScheduled, false, defaultCatchAllPendingTimeoutSeconds, ""),
-			Entry("in pending state but timeout not hit", virtv1.MigrationPending, false, defaultCatchAllPendingTimeoutSeconds-1, ""),
+			Entry("in pending state but timeout not hit", virtv1.MigrationPending, false, defaultCatchAllPendingTimeoutSeconds-10, ""),
 			Entry("in pending state with custom timeout", virtv1.MigrationPending, true, int64(10), "10"),
-			Entry("in pending state with custom timeout not hit", virtv1.MigrationPending, false, int64(10), "11"),
-			Entry("in scheduling state but timeout not hit", virtv1.MigrationScheduling, false, defaultCatchAllPendingTimeoutSeconds-1, ""),
+			Entry("in pending state with custom timeout not hit", virtv1.MigrationPending, false, int64(8), "11"),
+			Entry("in scheduling state but timeout not hit", virtv1.MigrationScheduling, false, defaultCatchAllPendingTimeoutSeconds-10, ""),
 		)
 	})
 

--- a/pkg/virt-handler/retry_manager_test.go
+++ b/pkg/virt-handler/retry_manager_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 var _ = Describe("virt-handler retry manager", func() {
-	const initialWait, maxWait, maxFailResponseTime = 200 * time.Millisecond, 5 * time.Second, 1 * time.Second
-	const buffer = 10 * time.Millisecond
+	const initialWait, maxWait, maxFailResponseTime = 500 * time.Millisecond, 5 * time.Second, 1 * time.Second
+	const buffer = 100 * time.Millisecond
 	var retryManager *FailRetryManager
 	const key = "c4ab4ae0-db63-45d8-aa0f-fc53dc84bdab"
 


### PR DESCRIPTION
Some unit tests require some time alignment
to test the right behavior.
This could cause some failures if there isn't
a reasonable tolerance on the margin of error.

Let's reduce the flakiness, increasing the
tolerance.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/10670

**Special notes for your reviewer**:
- Retry manager flakyness:
https://search.ci.kubevirt.io/?search=Should+do+exponential+backoff+on+failure+retries&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=%5Epull-kubevirt-unit-test%24&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

- Migration test flakyness:
https://search.ci.kubevirt.io/?search=state+in+scheduling+state+but+timeout+not+hit&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=%5Epull-kubevirt-unit-test%24&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/kind flake
/cc @dhiller @xpivarc