### PR TITLE
Support specify one node to migrate

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16713,6 +16713,10 @@
    "v1.VirtualMachineInstanceMigrationSpec": {
     "type": "object",
     "properties": {
+     "nodeName": {
+      "description": "The name of the destination node to perform the migration on. NodeName does not need to exist in the migration objects namespace",
+      "type": "string"
+     },
      "vmiName": {
       "description": "The name of the VMI to perform the migration on. VMI must exist in the migration objects namespace",
       "type": "string"

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -303,7 +303,8 @@ func (app *SubresourceAPIApp) MigrateVMRequestHandler(request *restful.Request, 
 				GenerateName: "kubevirt-migrate-vm-",
 			},
 			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: name,
+				VMIName:  name,
+				NodeName: bodyStruct.NodeName,
 			},
 		}, k8smetav1.CreateOptions{DryRun: bodyStruct.DryRun})
 		if err != nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -118,6 +118,18 @@ func (admitter *MigrationCreateAdmitter) Admit(ar *admissionv1.AdmissionReview) 
 		return webhookutils.ToAdmissionResponseError(err)
 	}
 
+	nodeName := migration.Spec.NodeName
+	if nodeName != "" {
+		_, err = admitter.VirtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return webhookutils.ToAdmissionResponseError(err)
+		}
+
+		if nodeName == vmi.Status.NodeName {
+			return webhookutils.ToAdmissionResponseError(fmt.Errorf("the same source and destination node, so there is no need to migrate"))
+		}
+	}
+
 	reviewResponse := admissionv1.AdmissionResponse{}
 	reviewResponse.Allowed = true
 	return &reviewResponse

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -678,6 +678,7 @@ func (c *MigrationController) createTargetPod(migration *virtv1.VirtualMachineIn
 
 	templatePod.ObjectMeta.Labels[virtv1.MigrationJobLabel] = string(migration.UID)
 	templatePod.ObjectMeta.Annotations[virtv1.MigrationJobNameAnnotation] = migration.Name
+	templatePod.Spec.NodeName = migration.Spec.NodeName
 
 	// If cpu model is "host model" allow migration only to nodes that supports this cpu model
 	if cpu := vmi.Spec.Domain.CPU; cpu != nil && cpu.Model == virtv1.CPUModeHostModel {

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -330,6 +330,8 @@ func NewVirtualMachineInstanceMigrationCrd() (*extv1.CustomResourceDefinition, e
 				Description: "The current phase of VM instance migration"},
 			{Name: "VMI", Type: "string", JSONPath: ".spec.vmiName",
 				Description: "The name of the VMI to perform the migration on"},
+			{Name: "NodeName", Type: "string", JSONPath: ".spec.nodeName",
+				Description: "The name of the the destination node to perform the migration on"},
 		}, &extv1.CustomResourceSubresources{
 			Status: &extv1.CustomResourceSubresourceStatus{},
 		})

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -13717,6 +13717,10 @@ var CRDsValidation map[string]string = map[string]string{
       type: object
     spec:
       properties:
+        nodeName:
+          description: The name of the destination node to perform the migration on.
+            NodeName does not need to exist in the migration objects namespace
+          type: string
         vmiName:
           description: The name of the VMI to perform the migration on. VMI must exist
             in the migration objects namespace

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -67,6 +67,18 @@ func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
 	}
 }
 
+// ExactMoreArgs validate minimum, maximum number of input parameters
+func ExactMoreArgs(nameOfCommand string, min, max int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) > max || len(args) < min {
+			fmt.Fprintf(os.Stderr, "fatal: Number of input parameters is incorrect, %s accepts mininum %d maximum %d arg(s), received %d\n\n", nameOfCommand, min, max, len(args))
+			cmd.Help()
+			return errors.New("argument validation failed")
+		}
+		return nil
+	}
+}
+
 // PrintWarningForPausedVMI prints warning message if VMI is paused
 func PrintWarningForPausedVMI(virtCli kubecli.KubevirtClient, vmiName string, namespace string) {
 	vmi, err := virtCli.VirtualMachineInstance(namespace).Get(context.Background(), vmiName, k8smetav1.GetOptions{})

--- a/pkg/virtctl/vm/common.go
+++ b/pkg/virtctl/vm/common.go
@@ -61,6 +61,10 @@ func usage(cmd string) string {
 		return fmt.Sprintf("  # %s a virtual machine instance called 'myvm':\n  {{ProgramName}} %s myvm", strings.Title(cmd), cmd)
 	}
 
+	if cmd == COMMAND_MIGRATE {
+		return fmt.Sprintf("  # %s a virtual machine called 'myvm':\n  {{ProgramName}} %s myvm\n  # %s a virtual machine called 'myvm' to node called 'worker1':\n  {{ProgramName}} %s myvm worker1", strings.Title(cmd), cmd, strings.Title(cmd), cmd)
+	}
+
 	return fmt.Sprintf("  # %s a virtual machine called 'myvm':\n  {{ProgramName}} %s myvm", strings.Title(cmd), cmd)
 }
 

--- a/pkg/virtctl/vm/migrate.go
+++ b/pkg/virtctl/vm/migrate.go
@@ -34,10 +34,10 @@ const COMMAND_MIGRATE = "migrate"
 
 func NewMigrateCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "migrate (VM)",
-		Short:   "Migrate a virtual machine.",
+		Use:     "migrate (VM) [Node]",
+		Short:   "Migrate a virtual machine can specify node migration or random migration.",
 		Example: usage(COMMAND_MIGRATE),
-		Args:    templates.ExactArgs("migrate", 1),
+		Args:    templates.ExactMoreArgs("migrate", 1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_MIGRATE, clientConfig: clientConfig}
 			return c.migrateRun(args)
@@ -50,6 +50,10 @@ func NewMigrateCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 func (o *Command) migrateRun(args []string) error {
 	vmiName := args[0]
+	nodeName := ""
+	if len(args) == 2 {
+		nodeName = args[1]
+	}
 
 	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
 	if err != nil {
@@ -58,7 +62,7 @@ func (o *Command) migrateRun(args []string) error {
 
 	dryRunOption := setDryRunOption(dryRun)
 
-	err = virtClient.VirtualMachine(namespace).Migrate(context.Background(), vmiName, &v1.MigrateOptions{DryRun: dryRunOption})
+	err = virtClient.VirtualMachine(namespace).Migrate(context.Background(), vmiName, &v1.MigrateOptions{DryRun: dryRunOption, NodeName: nodeName})
 	if err != nil {
 		return fmt.Errorf("Error migrating VirtualMachine %v", err)
 	}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1351,6 +1351,8 @@ type VirtualMachineInstanceMigrationList struct {
 type VirtualMachineInstanceMigrationSpec struct {
 	// The name of the VMI to perform the migration on. VMI must exist in the migration objects namespace
 	VMIName string `json:"vmiName,omitempty" valid:"required"`
+	// The name of the destination node to perform the migration on. NodeName does not need to exist in the migration objects namespace
+	NodeName string `json:"nodeName,omitempty"`
 }
 
 // VirtualMachineInstanceMigrationPhaseTransitionTimestamp gives a timestamp in relation to when a phase is set on a vmi
@@ -2226,6 +2228,8 @@ type MigrateOptions struct {
 	// +optional
 	// +listType=atomic
 	DryRun []string `json:"dryRun,omitempty" protobuf:"bytes,1,rep,name=dryRun"`
+	// The name of the destination node to perform the migration on. NodeName does not need to exist in the migration objects namespace
+	NodeName string `json:"nodeName,omitempty"`
 }
 
 // VirtualMachineInstanceGuestAgentInfo represents information from the installed guest agent

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -313,7 +313,8 @@ func (VirtualMachineInstanceMigrationList) SwaggerDoc() map[string]string {
 
 func (VirtualMachineInstanceMigrationSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"vmiName": "The name of the VMI to perform the migration on. VMI must exist in the migration objects namespace",
+		"vmiName":  "The name of the VMI to perform the migration on. VMI must exist in the migration objects namespace",
+		"nodeName": "The name of the destination node to perform the migration on. NodeName does not need to exist in the migration objects namespace",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -24831,6 +24831,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationSpec(ref commo
 							Format:      "",
 						},
 					},
+					"nodeName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the destination node to perform the migration on. NodeName does not need to exist in the migration objects namespace",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The current migration of virtual machines involves setting node affinity or node selectors, but cannot be done by specifying a fixed node. Now there are currently two ways to migrate:
- Migrate to the specified node through the `virtctl migrate vm node` command.
- Migrate to the selected node by scheduler through the `virtctl migrate vm` command.

kubectl get vmim
```
NAME                                       PHASE               VMI                NODENAME
kubevirt-migrate-vm-2snmc      Succeeded         vm-test           worker1
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
