### PR TITLE
[release-1.0] cgroupsv2: reconstruct device allowlist/drop internal device allow list state

### DIFF
--- a/pkg/hotplug-disk/hotplug-disk.go
+++ b/pkg/hotplug-disk/hotplug-disk.go
@@ -53,21 +53,18 @@ type HotplugDiskManagerInterface interface {
 
 func NewHotplugDiskManager(kubeletPodsDir string) *hotplugDiskManager {
 	return &hotplugDiskManager{
-		podsBaseDir:       filepath.Join(util.HostRootMount, kubeletPodsDir),
-		targetPodBasePath: TargetPodBasePath,
+		podsBaseDir: filepath.Join(util.HostRootMount, kubeletPodsDir),
 	}
 }
 
 func NewHotplugDiskWithOptions(podsBaseDir string) *hotplugDiskManager {
 	return &hotplugDiskManager{
-		podsBaseDir:       podsBaseDir,
-		targetPodBasePath: TargetPodBasePath,
+		podsBaseDir: podsBaseDir,
 	}
 }
 
 type hotplugDiskManager struct {
-	podsBaseDir       string
-	targetPodBasePath func(podBaseDir string, podUID types.UID) string
+	podsBaseDir string
 }
 
 // GetHotplugTargetPodPathOnHost retrieves the target pod (virt-launcher) path on the host.

--- a/pkg/hotplug-disk/hotplug-disk_test.go
+++ b/pkg/hotplug-disk/hotplug-disk_test.go
@@ -41,22 +41,14 @@ var _ = Describe("HotplugDisk", func() {
 
 	BeforeEach(func() {
 		// Create some directories and files in temporary location.
-		tempDir, err = os.MkdirTemp("/tmp", "hp-disk-test")
-		Expect(err).ToNot(HaveOccurred())
+		tempDir = GinkgoT().TempDir()
 		podsBaseDir = filepath.Join(tempDir, "podsBaseDir")
 		err = os.MkdirAll(filepath.Join(podsBaseDir), os.FileMode(0755))
 		hotplug = &hotplugDiskManager{
-			podsBaseDir:       podsBaseDir,
-			targetPodBasePath: nil,
+			podsBaseDir: podsBaseDir,
 		}
 
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		if tempDir != "" {
-			Expect(os.RemoveAll(tempDir)).To(Succeed())
-		}
 	})
 
 	It("GetHotplugTargetPodPathOnHost should return the correct path", func() {

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -96,6 +96,7 @@ go_test(
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",
+        "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/container-disk:go_default_library",
         "//pkg/virt-handler/hotplug-disk:go_default_library",

--- a/pkg/virt-handler/cgroup/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/cgroup",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/safepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -23,6 +24,7 @@ go_library(
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/devices:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/cgroup/cgroup_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_test.go
@@ -43,7 +43,7 @@ var _ = Describe("cgroup manager", func() {
 		if version == V1 {
 			return newCustomizedV1Manager(mockRuncCgroupManager, false, execVirtChrootFunc, getCurrentlyDefinedRulesFunc)
 		} else {
-			return newCustomizedV2Manager(mockRuncCgroupManager, false, execVirtChrootFunc)
+			return newCustomizedV2Manager(mockRuncCgroupManager, false, nil, execVirtChrootFunc)
 		}
 	}
 
@@ -85,10 +85,11 @@ var _ = Describe("cgroup manager", func() {
 
 		Expect(rulesDefined).To(ContainElement(fakeRule), "defined rule is expected to exist")
 
-		for _, defaultRule := range GenerateDefaultDeviceRules() {
+		defaultDeviceRules := GenerateDefaultDeviceRules()
+		for _, defaultRule := range defaultDeviceRules {
 			Expect(rulesDefined).To(ContainElement(defaultRule), "default rules are expected to be defined")
 		}
-
+		Expect(rulesDefined).To(HaveLen(len(defaultDeviceRules) + 1))
 	},
 		Entry("for v1", V1),
 		Entry("for v2", V2),

--- a/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
+++ b/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
@@ -7,6 +7,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 	v1 "kubevirt.io/api/core/v1"
+
+	cgroup "kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 )
 
 // Mock of VolumeMounter interface
@@ -30,44 +32,44 @@ func (_m *MockVolumeMounter) EXPECT() *_MockVolumeMounterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockVolumeMounter) Mount(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "Mount", vmi)
+func (_m *MockVolumeMounter) Mount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "Mount", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) Mount(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Mount", arg0)
+func (_mr *_MockVolumeMounterRecorder) Mount(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Mount", arg0, arg1)
 }
 
-func (_m *MockVolumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID) error {
-	ret := _m.ctrl.Call(_m, "MountFromPod", vmi, sourceUID)
+func (_m *MockVolumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "MountFromPod", vmi, sourceUID, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) MountFromPod(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountFromPod", arg0, arg1)
+func (_mr *_MockVolumeMounterRecorder) MountFromPod(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountFromPod", arg0, arg1, arg2)
 }
 
-func (_m *MockVolumeMounter) Unmount(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "Unmount", vmi)
+func (_m *MockVolumeMounter) Unmount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "Unmount", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) Unmount(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unmount", arg0)
+func (_mr *_MockVolumeMounterRecorder) Unmount(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unmount", arg0, arg1)
 }
 
-func (_m *MockVolumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "UnmountAll", vmi)
+func (_m *MockVolumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "UnmountAll", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) UnmountAll(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmountAll", arg0)
+func (_mr *_MockVolumeMounterRecorder) UnmountAll(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmountAll", arg0, arg1)
 }
 
 func (_m *MockVolumeMounter) IsMounted(vmi *v1.VirtualMachineInstance, volume string, sourceUID types.UID) (bool, error) {

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -46,10 +46,6 @@ var (
 		return safepath.JoinAndResolveWithRelativeRoot("/proc/1/root", fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~empty-dir/hotplug-disks", string(podUID)))
 	}
 
-	sourcePodBasePath = func(podUID types.UID) (*safepath.Path, error) {
-		return safepath.JoinAndResolveWithRelativeRoot("/proc/1/root", fmt.Sprintf("root/var/lib/kubelet/pods/%s/volumes", string(podUID)))
-	}
-
 	socketPath = func(podUID types.UID) string {
 		return fmt.Sprintf("pods/%s/volumes/kubernetes.io~empty-dir/hotplug-disks/hp.sock", string(podUID))
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -173,6 +173,10 @@ var PasswordRelatedGuestAgentCommands = []string{
 	"guest-set-user-password",
 }
 
+var getCgroupManager = func(vmi *v1.VirtualMachineInstance) (cgroup.Manager, error) {
+	return cgroup.NewManagerFromVM(vmi)
+}
+
 func NewController(
 	recorder record.EventRecorder,
 	clientset kubecli.KubevirtClient,
@@ -2035,7 +2039,11 @@ func (d *VirtualMachineController) processVmCleanup(vmi *v1.VirtualMachineInstan
 	if err := d.containerDiskMounter.Unmount(vmi); err != nil {
 		return err
 	}
-	if err := d.hotplugVolumeMounter.UnmountAll(vmi); err != nil {
+
+	// UnmountAll does the cleanup on the "best effort" basis: it is
+	// safe to pass a nil cgroupManager.
+	cgroupManager, _ := getCgroupManager(vmi)
+	if err := d.hotplugVolumeMounter.UnmountAll(vmi, cgroupManager); err != nil {
 		return err
 	}
 
@@ -2652,7 +2660,11 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 
 	// Mount hotplug disks
 	if attachmentPodUID := vmi.Status.MigrationState.TargetAttachmentPodUID; attachmentPodUID != types.UID("") {
-		if err := d.hotplugVolumeMounter.MountFromPod(vmi, attachmentPodUID); err != nil {
+		cgroupManager, err := getCgroupManager(vmi)
+		if err != nil {
+			return err
+		}
+		if err := d.hotplugVolumeMounter.MountFromPod(vmi, attachmentPodUID, cgroupManager); err != nil {
 			return fmt.Errorf("failed to mount hotplug volumes: %v", err)
 		}
 	}
@@ -2762,14 +2774,8 @@ func (d *VirtualMachineController) affinePitThread(vmi *v1.VirtualMachineInstanc
 	return unix.SchedSetaffinity(pitpid, &Mask)
 }
 
-func (d *VirtualMachineController) configureHousekeepingCgroup(vmi *v1.VirtualMachineInstance) error {
-	cgroupManager, err := cgroup.NewManagerFromVM(vmi)
-	if err != nil {
-		return err
-	}
-
-	err = cgroupManager.CreateChildCgroup("housekeeping", "cpuset")
-	if err != nil {
+func (d *VirtualMachineController) configureHousekeepingCgroup(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	if err := cgroupManager.CreateChildCgroup("housekeeping", "cpuset"); err != nil {
 		log.Log.Reason(err).Error("CreateChildCgroup ")
 		return err
 	}
@@ -2851,6 +2857,10 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		return err
 	}
 
+	cgroupManager, err := getCgroupManager(vmi)
+	if err != nil {
+		return err
+	}
 	var errorTolerantFeaturesError []error
 	disksInfo := map[string]*containerdisk.DiskInfo{}
 	if !vmi.IsRunning() && !vmi.IsFinal() {
@@ -2870,7 +2880,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		}
 
 		// Try to mount hotplug volume if there is any during startup.
-		if err := d.hotplugVolumeMounter.Mount(vmi); err != nil {
+		if err := d.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
 			return err
 		}
 
@@ -2947,7 +2957,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 			log.Log.Object(vmi).Error(err.Error())
 		}
 
-		if err := d.hotplugVolumeMounter.Mount(vmi); err != nil {
+		if err := d.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
 			return err
 		}
 
@@ -2991,7 +3001,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 	}
 
 	if vmi.IsCPUDedicated() && vmi.Spec.Domain.CPU.IsolateEmulatorThread {
-		err = d.configureHousekeepingCgroup(vmi)
+		err = d.configureHousekeepingCgroup(vmi, cgroupManager)
 		if err != nil {
 			return err
 		}
@@ -3014,7 +3024,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 
 	if vmi.IsRunning() {
 		// Umount any disks no longer mounted
-		if err := d.hotplugVolumeMounter.Unmount(vmi); err != nil {
+		if err := d.hotplugVolumeMounter.Unmount(vmi, cgroupManager); err != nil {
 			return err
 		}
 	}
@@ -3308,7 +3318,7 @@ func (d *VirtualMachineController) claimDeviceOwnership(virtLauncherRootMount *s
 }
 
 func (d *VirtualMachineController) reportDedicatedCPUSetForMigratingVMI(vmi *v1.VirtualMachineInstance) error {
-	cgroupManager, err := cgroup.NewManagerFromVM(vmi)
+	cgroupManager, err := getCgroupManager(vmi)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual cherrypick of https://github.com/kubevirt/kubevirt/pull/10689.
Include cleanup from https://github.com/kubevirt/kubevirt/pull/10216 as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: cgroupsv2 device allowlist is bound to virt-handler internal state/block disk device overwritten on hotplug
```
