### PR TITLE
CHANGELOG: Import existing release notes

### DIFF
--- a/CHANGELOG/CHANGELOG-v0.0.2.md
+++ b/CHANGELOG/CHANGELOG-v0.0.2.md
@@ -1,0 +1,71 @@
+KubeVirt v0.0.2
+===============
+
+This release follows v0.0.1-alpha.5 and consists of 378 changes, contributed by
+16 people, leading to 267 files changed, 13559 insertions(+), 17180
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.0.2>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Usage of CRDs
+- Moved libvirt to a pod
+- Introduction of `virtctl`
+- Use glide instead of govendor
+- Container based ephermal disks
+- Contributing guide improvements
+- Support for Kubernetes Namespaces
+
+Contributors
+------------
+
+16 people contributed to this release:
+
+```
+       130	Roman Mohr <rmohr@redhat.com>
+        50	Stu Gott <sgott@redhat.com>
+        49	Fabian Deutsch <fabiand@redhat.com>
+        47	David Vossel <davidvossel@gmail.com>
+        31	Daniel Berrange <berrange@redhat.com>
+        30	Adam Young <ayoung@redhat.com>
+        15	Martin Polednik <mpolednik@redhat.com>
+        10	Vladik Romanovsky <vromanso@redhat.com>
+         8	Lukianov Artyom <alukiano@redhat.com>
+         2	dankenigsberg <danken@gmail.com>
+         1	Alexis Monville <alexis@monville.com>
+         1	Allon Mureinik <amureini@redhat.com>
+         1	Arik Hadas <ahadas@redhat.com>
+         1	Bohdan <cyberbond95@gmail.com>
+         1	Martin Sivak <msivak@redhat.com>
+         1	Petr Kotas <pkotas@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 31 of 31 Specs in 192.789 seconds
+> SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 0 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.0.3.md
+++ b/CHANGELOG/CHANGELOG-v0.0.3.md
@@ -1,0 +1,66 @@
+KubeVirt v0.0.3
+===============
+
+This release follows v0.0.2 and consists of 198 changes, contributed by
+9 people, leading to 165 files changed, 8321 insertions(+), 1928 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.0.3>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Containerized binary builds
+- Socket based container detection
+- cloud-init support
+- Container based ephemeral disk support
+- Basic RBAC profile
+- client-go updates
+- Rename of VM to VirtualMachine
+- Introduction of VirtualMachineReplicaSet
+- Improved migration events
+- Improved API documentation
+
+Contributors
+------------
+
+9 people contributed to this release:
+
+```
+        84	Roman Mohr <rmohr@redhat.com>
+        70	David Vossel <davidvossel@gmail.com>
+        15	Fabian Deutsch <fabiand@redhat.com>
+         9	Lukianov Artyom <alukiano@redhat.com>
+         8	Martin Polednik <mpolednik@redhat.com>
+         5	Lukas Bednar <lbednar@redhat.com>
+         3	Martin Kletzander <mkletzan@redhat.com>
+         3	Stu Gott <sgott@redhat.com>
+         1	jniederm <jniederm@users.noreply.github.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 39 of 41 Specs in 572.670 seconds
+> SUCCESS! -- 39 Passed | 0 Failed | 0 Pending | 2 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.0.4.md
+++ b/CHANGELOG/CHANGELOG-v0.0.4.md
@@ -1,0 +1,72 @@
+KubeVirt v0.0.4
+===============
+
+This release follows v0.0.3 and consists of 133 changes, contributed by
+14 people, leading to 109 files changed, 7093 insertions(+), 2437 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.0.4>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Add support for node affinity to VM.Spec
+- Add OpenAPI specification
+- Drop swagger 1.2 specification
+- virt-launcher refactoring
+- Leader election mechanism for virt-controller
+- Move from glide to dep for dependency management
+- Improve virt-handler synchronization loops
+- Add support for running the functional tests on oVirt infrastructure
+- Several tests fixes (spice, cleanup, ...)
+- Add console test tool
+- Improve libvirt event notification
+
+Contributors
+------------
+
+14 people contributed to this release:
+
+```
+        46	David Vossel <dvossel@redhat.com>
+        46	Roman Mohr <rmohr@redhat.com>
+        12	Lukas Bednar <lbednar@redhat.com>
+        11	Lukianov Artyom <alukiano@redhat.com>
+         4	Martin Sivak <msivak@redhat.com>
+         4	Petr Kotas <pkotas@redhat.com>
+         2	Fabian Deutsch <fabiand@redhat.com>
+         2	Milan Zamazal <mzamazal@redhat.com>
+         1	Artyom Lukianov <alukiano@redhat.com>
+         1	Barak Korren <bkorren@redhat.com>
+         1	Clifford Perry <coperry94@gmail.com>
+         1	Martin Polednik <mpolednik@redhat.com>
+         1	Stephen Gordon <sgordon@redhat.com>
+         1	Stu Gott <sgott@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 45 of 47 Specs in 797.286 seconds
+> SUCCESS! -- 45 Passed | 0 Failed | 0 Pending | 2 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.1.0.md
+++ b/CHANGELOG/CHANGELOG-v0.1.0.md
@@ -1,0 +1,66 @@
+KubeVirt v0.1.0
+===============
+
+This release follows v0.0.4 and consists of 115 changes, contributed by
+11 people, leading to 121 files changed, 5278 insertions(+), 1916 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.1.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Many API improvements for a proper OpenAPI reference
+- Add watchdog support
+- Drastically improve the deployment on non-vagrant setups
+  - Dropped nodeSelectors
+  - Separated inner component deployment from edge component deployment
+  - Created separate manifests for developer, test, and release deployments
+- Moved komponents to kube-system namespace
+- Improved and unified flag parsing
+
+Contributors
+------------
+
+11 people contributed to this release:
+
+```
+        42	Roman Mohr <rmohr@redhat.com>
+        20	David Vossel <dvossel@redhat.com>
+        18	Lukas Bednar <lbednar@redhat.com>
+        14	Martin Polednik <mpolednik@redhat.com>
+         7	Fabian Deutsch <fabiand@redhat.com>
+         6	Lukianov Artyom <alukiano@redhat.com>
+         3	Vladik Romanovsky <vromanso@redhat.com>
+         2	Petr Kotas <petr.kotas@gmail.com>
+         1	Barak Korren <bkorren@redhat.com>
+         1	Francois Deppierraz <francois@ctrlaltdel.ch>
+         1	Saravanan KR <skramaja@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 44 of 46 Specs in 851.185 seconds
+> SUCCESS! -- 44 Passed | 0 Failed | 0 Pending | 2 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.10.0.md
+++ b/CHANGELOG/CHANGELOG-v0.10.0.md
@@ -1,0 +1,95 @@
+KubeVirt v0.10.0
+================
+
+This release follows v0.9.0 and consists of 253 changes, contributed by
+26 people, leading to 1376 files changed, 268565 insertions(+), 9773
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.10.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Support for vhost-net
+- Support for block multi-queue
+- Support for custom PCI addresses for virtio devices
+- Support for deploying KubeVirt to a custom namespace
+- Support for ServiceAccount token disks
+- Support for multus backed networks
+- Support for genie backed networks
+- Support for kuryr backed networks
+- Support for block PVs
+- Support for configurable disk device caches
+- Support for pinned IO threads
+- Support for virtio net multi-queue
+- Support for image upload (depending on CDI)
+- Support for custom entity lists with more VM details (cusomt columns)
+- Support for IP and MAC address reporting of all vNICs
+- Basic support for guest agent status reporting
+- More structured logging
+- Better libvirt error reporting
+- Stricter CR validation
+- Better ownership references
+- Several test improvements
+
+Contributors
+------------
+
+26 people contributed to this release:
+
+```
+        54	Roman Mohr <rmohr@redhat.com>
+        50	David Vossel <dvossel@redhat.com>
+        29	Vladik Romanovsky <vromanso@redhat.com>
+        20	Stu Gott <sgott@redhat.com>
+        20	Yuval Lifshitz <ylifshit@redhat.com>
+        13	Marcin Franczyk <mfranczy@redhat.com>
+        11	Marc Sluiter <msluiter@redhat.com>
+         8	Gabriel Szasz <gszasz@redhat.com>
+         7	Artyom Lukianov <alukiano@redhat.com>
+         6	Michael Henriksen <mhenriks@redhat.com>
+         5	Petr Kotas <pkotas@redhat.com>
+         4	Koichiro Den <den@klaipeden.com>
+         4	Sebastian Scheinkman <sscheink@redhat.com>
+         3	Arik Hadas <ahadas@redhat.com>
+         3	imjoey <majunjiev@gmail.com>
+         3	steigr <me@stei.gr>
+         2	Alexander Gallego <gallego.alexx@gmail.com>
+         2	Gage Orsburn <gageorsburn@live.com>
+         2	Rich Renner <renner@osi.io>
+         1	Alexander Wels <awels@redhat.com>
+         1	Fabian Deutsch <fabiand@redhat.com>
+         1	Ihar Hrachyshka <ihar@redhat.com>
+         1	Karim Boumedhel <kboumedh@redhat.com>
+         1	Marcin Mirecki <mmirecki@redhat.com>
+         1	Shiyang Wang <shiywang@redhat.com>
+         1	renner <renner@pop-os.localdomain>
+```
+
+Test Results
+------------
+
+```
+> Ran 180 of 216 Specs in 5647.016 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.11.0.md
+++ b/CHANGELOG/CHANGELOG-v0.11.0.md
@@ -1,0 +1,82 @@
+KubeVirt v0.11.0
+================
+
+This release follows v0.10.0 and consists of 170 changes, contributed by
+25 people, leading to 349 files changed, 8497 insertions(+), 3065 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.11.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- API: registryDisk got renamed to containreDisk
+- CI: User OKD 3.11
+- Fix: Tolerate if the PVC has less capacity than expected
+- Aligned to use ownerReferences
+- Update to libvirt-4.10.0
+- Support for VNC on MAC OSX
+- Support for network SR-IOV interfaces
+- Support for custom DHCP options
+- Support for VM restarts via a custom endpoint
+- Support for liveness and readiness probes
+
+Contributors
+------------
+
+25 people contributed to this release:
+
+```
+        46	Roman Mohr <rmohr@redhat.com>
+        24	Ihar Hrachyshka <ihar@redhat.com>
+        17	Marc Sluiter <msluiter@redhat.com>
+        15	Gage Orsburn <gageorsburn@live.com>
+        10	Artyom Lukianov <alukiano@redhat.com>
+         7	Petr Kotas <pkotas@redhat.com>
+         6	Arik Hadas <ahadas@redhat.com>
+         6	Marcin Franczyk <mfranczy@redhat.com>
+         5	Quique Llorente <ellorent@redhat.com>
+         4	Fabian Deutsch <fabiand@redhat.com>
+         4	Frederik Carlier <frederik.carlier@quamotion.mobi>
+         4	Vladik Romanovsky <vromanso@redhat.com>
+         3	Dan Kenigsberg <danken@redhat.com>
+         3	Daniel Belenky <dbelenky@redhat.com>
+         3	Ihar Hrachyshka <ihrachys@redhat.com>
+         2	Karim Boumedhel <kboumedh@redhat.com>
+         2	Marcus Sorensen <mls@apple.com>
+         2	Michael Henriksen <mhenriks@redhat.com>
+         1	Adam Litke <alitke@redhat.com>
+         1	Dan Kenigsberg <danken@gmail.com>
+         1	Karel Šimon <ksimon@redhat.com>
+         1	Sebastian Scheinkman <sscheink@redhat.com>
+         1	Shiyang Wang <shiywang@redhat.com>
+         1	Stu Gott <sgott@redhat.com>
+         1	imjoey <majunjiev@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 200 of 239 Specs in 7228.750 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.11.1.md
+++ b/CHANGELOG/CHANGELOG-v0.11.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.11.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.12.0.md
+++ b/CHANGELOG/CHANGELOG-v0.12.0.md
@@ -1,0 +1,85 @@
+KubeVirt v0.12.0
+================
+
+This release follows v0.11.0 and consists of 207 changes, contributed by
+27 people, leading to 1107 files changed, 137791 insertions(+), 20497
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.12.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Introduce a KubeVirt Operator for KubeVirt life-cycle management
+- Introduce dedicated kubevirt namespace
+- Support VMI ready conditions
+- Support vCPU threads and sockets
+- Support scale and HPA for VMIRS
+- Support to pass NTP related DHCP options
+- Support guest IP address reporting via qemu guest agent
+- Support for live migration with shared storage
+- Support scheduling of VMs based on CPU family
+- Support masquerade network interface binding
+
+Contributors
+------------
+
+27 people contributed to this release:
+
+```
+        37	Marc Sluiter <msluiter@redhat.com>
+        30	Vladik Romanovsky <vromanso@redhat.com>
+        22	Roman Mohr <rmohr@redhat.com>
+        20	Artyom Lukianov <alukiano@redhat.com>
+        14	David Vossel <dvossel@redhat.com>
+        14	Lukas Bednar <lbednar@redhat.com>
+        12	Arik Hadas <ahadas@redhat.com>
+        11	Dylan Redding <dylan.redding@stackpath.com>
+         7	Sebastian Scheinkman <sscheink@redhat.com>
+         7	Yanir Quinn <yquinn@redhat.com>
+         6	Stu Gott <sgott@redhat.com>
+         5	Ihar Hrachyshka <ihar@redhat.com>
+         3	Fabian Deutsch <fabiand@redhat.com>
+         3	Quique Llorente <ellorent@redhat.com>
+         2	Justin Barrick <justin.m.barrick@gmail.com>
+         2	Marcin Franczyk <mfranczy@redhat.com>
+         2	Michael Henriksen <mhenriks@redhat.com>
+         1	Frederik Carlier <frederik.carlier@quamotion.mobi>
+         1	Ihar Hrachyshka <ihrachys@redhat.com>
+         1	Karel Šimon <ksimon@redhat.com>
+         1	Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>
+         1	Marcin Mirecki <mmirecki@redhat.com>
+         1	Petr Kotas <pkotas@redhat.com>
+         1	Richard Su <rwsu@redhat.com>
+         1	Tzvi Avni <tavni@redhat.com>
+         1	Yossi Segev <ysegev@redhat.com>
+         1	ipinto <ipinto@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 217 of 257 Specs in 6555.536 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.13.0.md
+++ b/CHANGELOG/CHANGELOG-v0.13.0.md
@@ -1,0 +1,55 @@
+KubeVirt v0.13.0
+================
+
+This release follows v0.12.0 and consists of 18 changes, contributed by
+6 people, leading to 84 files changed, 516 insertions(+), 611 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.13.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: Fix virt-api race
+- API: Remove volumeName from disks
+
+Contributors
+------------
+
+6 people contributed to this release:
+
+```
+         6	David Vossel <dvossel@redhat.com>
+         4	Stu Gott <sgott@redhat.com>
+         3	Marc Sluiter <msluiter@redhat.com>
+         3	Roman Mohr <rmohr@redhat.com>
+         1	Fabian Deutsch <fabiand@redhat.com>
+         1	Ihar Hrachyshka <ihar@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 217 of 257 Specs in 6392.444 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.13.1.md
+++ b/CHANGELOG/CHANGELOG-v0.13.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.13.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.13.2.md
+++ b/CHANGELOG/CHANGELOG-v0.13.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.13.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.13.3.md
+++ b/CHANGELOG/CHANGELOG-v0.13.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.13.3
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.13.4.md
+++ b/CHANGELOG/CHANGELOG-v0.13.4.md
@@ -1,0 +1,4 @@
+KubeVirt v0.13.4
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.13.5.md
+++ b/CHANGELOG/CHANGELOG-v0.13.5.md
@@ -1,0 +1,4 @@
+KubeVirt v0.13.5
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.13.6.md
+++ b/CHANGELOG/CHANGELOG-v0.13.6.md
@@ -1,0 +1,4 @@
+KubeVirt v0.13.6
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.13.7.md
+++ b/CHANGELOG/CHANGELOG-v0.13.7.md
@@ -1,0 +1,4 @@
+KubeVirt v0.13.7
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.14.0.md
+++ b/CHANGELOG/CHANGELOG-v0.14.0.md
@@ -1,0 +1,74 @@
+KubeVirt v0.14.0
+================
+
+This release follows v0.13.0 and consists of 115 changes, contributed by
+18 people, leading to 991 files changed, 57851 insertions(+), 44285
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.14.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: Several stabilizing fixes
+- docs: Document the KubeVirt Razor
+- build: golang update
+- Update to Kubernetes 1.12
+- Update CDI
+- Support for Ready and Created Operator conditions
+- Support (basic) EFI
+- Support for generating cloud-init network-config
+
+Contributors
+------------
+
+18 people contributed to this release:
+
+```
+        26	Artyom Lukianov <alukiano@redhat.com>
+        22	David Vossel <dvossel@redhat.com>
+        13	Marc Sluiter <msluiter@redhat.com>
+         8	Kedar Bidarkar <kbidarka@redhat.com>
+         8	Yossi Segev <ysegev@redhat.com>
+         7	Greg Bock <greg.bock@stackpath.com>
+         6	gaahrdner <github@philipgardner.com>
+         5	Stu Gott <sgott@redhat.com>
+         4	Daniel Gonzalez <daniel@gonzalez-nothnagel.de>
+         3	Fabian Deutsch <fabiand@redhat.com>
+         3	Petr Kotas <pkotas@redhat.com>
+         2	Justin Barrick <jbarrick@cloudflare.com>
+         2	Marcin Franczyk <mfranczy@redhat.com>
+         2	ipinto <ipinto@redhat.com>
+         1	Alexander Wels <awels@redhat.com>
+         1	Dan Kenigsberg <danken@redhat.com>
+         1	Yan Du <yadu@redhat.com>
+         1	yossisegev <40713576+yossisegev@users.noreply.github.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 217 of 257 Specs in 6293.783 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.15.0.md
+++ b/CHANGELOG/CHANGELOG-v0.15.0.md
@@ -1,0 +1,93 @@
+KubeVirt v0.15.0
+================
+
+This release follows v0.14.0 and consists of 273 changes, contributed by
+28 people, leading to 2300 files changed, 59757 insertions(+), 4269
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.15.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: Several fixes
+- Fix configurable number of KVM devices
+- Narrow virt-handler permissions
+- Use bazel for development builds
+- Support for live migration with shared and non-shared disks
+- Support for live migration progress tracking
+- Support for EFI boot
+- Support for libvirt 5.0
+- Support for extra DHCP options
+- Support for a hook to manipualte cloud-init metadata
+- Support setting a VM serial number
+- Support for exposing infra and VM metrics
+- Support for a tablet input device
+- Support for extra CPU flags
+- Support for ignition metadata
+- Support to set a default CPU model
+- Update to go 1.11.5
+
+Contributors
+------------
+
+28 people contributed to this release:
+
+```
+        44	Vladik Romanovsky <vromanso@redhat.com>
+        43	Artyom Lukianov <alukiano@redhat.com>
+        39	David Vossel <dvossel@redhat.com>
+        24	Francesco Romani <fromani@redhat.com>
+        24	Greg Bock <greg.bock@stackpath.com>
+        18	Roman Mohr <rmohr@redhat.com>
+         9	Karel Šimon <ksimon@redhat.com>
+         9	Tareq Alayan <talayan@redhat.com>
+         8	Marc Sluiter <msluiter@redhat.com>
+         6	Yanir Quinn <yquinn@redhat.com>
+         6	bharat <bharat@cloudflare.com>
+         5	Marcus Sorensen <marcus_sorensen@apple.com>
+         5	Yossi Segev <ysegev@redhat.com>
+         4	Meni Yakove <myakove@redhat.com>
+         4	Sebastian Scheinkman <sscheink@redhat.com>
+         4	bharatnc <bharatnc@gmail.com>
+         3	Marcus Sorensen <mls@apple.com>
+         2	Arik Hadas <ahadas@redhat.com>
+         2	Bharat Nallan Chakravarthy <bharat@cloudflare.com>
+         2	Karim Boumedhel <kboumedh@redhat.com>
+         2	Marcin Franczyk <mfranczy@redhat.com>
+         2	Nelly Credi <ncredi@redhat.com>
+         2	Vijay Bellur <vbellur@redhat.com>
+         2	yossisegev <40713576+yossisegev@users.noreply.github.com>
+         1	Michael Henriksen <mhenriks@redhat.com>
+         1	Stu Gott <sgott@redhat.com>
+         1	annastopel <astopel@redhat.com>
+         1	mlsorensen <shadowsor@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 244 of 289 Specs in 7368.455 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.16.0.md
+++ b/CHANGELOG/CHANGELOG-v0.16.0.md
@@ -1,0 +1,79 @@
+KubeVirt v0.16.0
+================
+
+This release follows v0.15.0 and consists of 228 changes, contributed by
+24 people, leading to 790 files changed, 63334 insertions(+), 2560 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.16.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Bazel fixes
+- Initial work to support upgrades (not finalized)
+- Initial support for HyperV features
+- Support propagation of MAC addresses to multus
+- Support live migration cancellation
+- Support for table input devices
+- Support for generating OLM metadata
+- Support for triggering VM live migration on node taints
+
+Contributors
+------------
+
+24 people contributed to this release:
+
+```
+        68	Roman Mohr <rmohr@redhat.com>
+        38	David Vossel <dvossel@redhat.com>
+        33	Vladik Romanovsky <vromanso@redhat.com>
+        20	Marc Sluiter <msluiter@redhat.com>
+        19	Greg Bock <greg.bock@stackpath.com>
+         9	Denis Ollier <dollierp@redhat.com>
+         7	Ihar Hrachyshka <ihar@redhat.com>
+         6	Artyom Lukianov <alukiano@redhat.com>
+         4	Arik Hadas <ahadas@redhat.com>
+         3	Francesco Romani <fromani@redhat.com>
+         3	Ihar Hrachyshka <ihrachys@redhat.com>
+         3	Marc Koderer <marc@koderer.com>
+         3	Sebastian Scheinkman <sscheink@redhat.com>
+         2	Gladkov Alexey <agladkov@redhat.com>
+         1	10240987 <ji.yuan@zte.com.cn>
+         1	Kedar Bidarkar <kbidarka@redhat.com>
+         1	Michael Henkel <michael.henkel@gmail.com>
+         1	Michael Henriksen <mhenriks@redhat.com>
+         1	Petr Kotas <pkotas@redhat.com>
+         1	Quique Llorente <ellorent@redhat.com>
+         1	Stu Gott <sgott@redhat.com>
+         1	Tareq Alayan <talayan@redhat.com>
+         1	Yossi Segev <ysegev@redhat.com>
+         1	nitkon <niteshkonkar@in.ibm.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 260 of 308 Specs in 7643.227 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.16.1.md
+++ b/CHANGELOG/CHANGELOG-v0.16.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.16.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.16.2.md
+++ b/CHANGELOG/CHANGELOG-v0.16.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.16.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.16.3.md
+++ b/CHANGELOG/CHANGELOG-v0.16.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.16.3
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.17.0.md
+++ b/CHANGELOG/CHANGELOG-v0.17.0.md
@@ -1,0 +1,73 @@
+KubeVirt v0.17.0
+================
+
+This release follows v0.16.0 and consists of 178 changes, contributed by
+16 people, leading to 439 files changed, 17189 insertions(+), 4807 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.17.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Several testcase additions
+- Improved virt-controller node distribution
+- Improved support between version migrations
+- Support for a configurable MachineType default
+- Support for live-migration of a VM on node taints
+- Support for VM swap metrics
+- Support for versioned virt-launcher / virt-handler communication
+- Support for HyperV flags
+- Support for different VM run strategies (i.e manual and rerunOnFailure)
+- Several fixes for live-migration (TLS support, protected pods)
+
+Contributors
+------------
+
+16 people contributed to this release:
+
+```
+        46	David Vossel <dvossel@redhat.com>
+        35	Roman Mohr <rmohr@redhat.com>
+        20	Vladik Romanovsky <vromanso@redhat.com>
+        18	Marc Sluiter <msluiter@redhat.com>
+        18	Stu Gott <sgott@redhat.com>
+        17	Arik Hadas <ahadas@redhat.com>
+         7	Francesco Romani <fromani@redhat.com>
+         5	Artyom Lukianov <alukiano@redhat.com>
+         2	Alexander Wels <awels@redhat.com>
+         2	Ihar Hrachyshka <ihar@redhat.com>
+         2	Karel Šimon <ksimon@redhat.com>
+         2	Marcin Franczyk <mfranczy@redhat.com>
+         1	Denis Ollier <dollierp@redhat.com>
+         1	Irit goihman <igoihman@redhat.com>
+         1	Mariusz Mazur <mmazur@redhat.com>
+         1	Petr Kotas <pkotas@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 293 of 338 Specs in 8297.680 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.17.1.md
+++ b/CHANGELOG/CHANGELOG-v0.17.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.17.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.17.2.md
+++ b/CHANGELOG/CHANGELOG-v0.17.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.17.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.17.3.md
+++ b/CHANGELOG/CHANGELOG-v0.17.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.17.3
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.17.4.md
+++ b/CHANGELOG/CHANGELOG-v0.17.4.md
@@ -1,0 +1,4 @@
+KubeVirt v0.17.4
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.18.0.md
+++ b/CHANGELOG/CHANGELOG-v0.18.0.md
@@ -1,0 +1,69 @@
+KubeVirt v0.18.0
+================
+
+This release follows v0.17.0 and consists of 167 changes, contributed by
+16 people, leading to 8712 files changed, 160209 insertions(+), 2178748
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.18.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Build: Use of go modules
+- CI: Support for Kubernetes 1.13
+- Countless testcase fixes and additions
+- Several smaller bug fixes
+- Improved upgrade documentation
+
+Contributors
+------------
+
+16 people contributed to this release:
+
+```
+        44	Stu Gott <sgott@redhat.com>
+        32	Arik Hadas <ahadas@redhat.com>
+        20	David Vossel <dvossel@redhat.com>
+        17	Artyom Lukianov <alukiano@redhat.com>
+        15	Roman Mohr <rmohr@redhat.com>
+        11	Marc Sluiter <msluiter@redhat.com>
+         6	Sebastian Scheinkman <sscheink@redhat.com>
+         5	Marcin Franczyk <mfranczy@redhat.com>
+         4	Fabian Deutsch <fabiand@redhat.com>
+         3	Denis Ollier <dollierp@redhat.com>
+         3	Petr Kotas <pkotas@redhat.com>
+         3	Vladik Romanovsky <vromanso@redhat.com>
+         1	Daniel Hiller <dhiller@redhat.com>
+         1	Ihar Hrachyshka <ihar@redhat.com>
+         1	Ihar Hrachyshka <ihrachys@redhat.com>
+         1	Keith Schincke <keith.schincke@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 311 of 359 Specs in 9209.761 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.18.1.md
+++ b/CHANGELOG/CHANGELOG-v0.18.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.18.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.19.0.md
+++ b/CHANGELOG/CHANGELOG-v0.19.0.md
@@ -1,0 +1,92 @@
+KubeVirt v0.19.0
+================
+
+This release follows v0.18.0 and consists of 216 changes, contributed by
+26 people, leading to 621 files changed, 21307 insertions(+), 11875
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.19.0-rc.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Fixes when run on kind
+- Fixes for sub-resource RBAC
+- Limit pod network interface bindings
+- Many additional bug fixes in many areas
+- Additional testcases for updates, disk types, live migration with NFS
+- Additional testcases for memory over-commit, block storage, cpu manager,
+headless mode
+- Improvements around HyperV
+- Improved error handling for runStartegies
+- Improved update procedure
+- Improved network metrics reporting (packets and errors)
+- Improved guest overhead calculation
+- Improved SR-IOV testsuite
+- Support for live migration auto-converge
+- Support for config-drive disks
+- Support for setting a pullPolicy con containerDisks
+- Support for unprivileged VMs when using SR-IOV
+- Introduction of a project security policy
+
+Contributors
+------------
+
+26 people contributed to this release:
+
+```
+        33	Marc Sluiter <msluiter@redhat.com>
+        28	Roman Mohr <rmohr@redhat.com>
+        27	Vladik Romanovsky <vromanso@redhat.com>
+        24	David Vossel <dvossel@redhat.com>
+        12	Artyom Lukianov <alukiano@redhat.com>
+        11	Arik Hadas <ahadas@redhat.com>
+        11	Francesco Romani <fromani@redhat.com>
+         9	Daniel Gonzalez <daniel@gonzalez-nothnagel.de>
+         8	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         7	Ihar Hrachyshka <ihar@redhat.com>
+         7	Marcin Franczyk <mfranczy@redhat.com>
+         6	Daniel Hiller <daniel.hiller.1972@googlemail.com>
+         5	Petr Kotas <pkotas@redhat.com>
+         5	Stu Gott <sgott@redhat.com>
+         4	Ihar Hrachyshka <ihrachys@redhat.com>
+         4	Sebastian Scheinkman <sscheink@redhat.com>
+         3	Kedar Bidarkar <kbidarka@redhat.com>
+         2	Federico Paolinelli <fpaoline@redhat.com>
+         2	Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>
+         2	j-griffith <john.griffith8@gmail.com>
+         1	Fabian Deutsch <fabiand@redhat.com>
+         1	Federico Paolinelli <fedepaol@gmail.com>
+         1	Jim Ma <ema@redhat.com>
+         1	Mark Knowles <mknowles@redhat.com>
+         1	Petr Horacek <phoracek@redhat.com>
+         1	Vatsal Parekh <vparekh@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 356 of 404 Specs in 11020.915 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.2.0.md
+++ b/CHANGELOG/CHANGELOG-v0.2.0.md
@@ -1,0 +1,58 @@
+KubeVirt v0.2.0
+===============
+
+This release follows v0.1.0 and consists of 131 changes, contributed by
+6 people, leading to 148 files changed, 9096 insertions(+), 5871 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.2.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- VM launch and shutdown flow improvements
+- VirtualMachine API redesign
+- Removal of HAProxy
+- Redesign of VNC/Console access
+- Initial support for different vagrant providers
+
+Contributors
+------------
+
+6 people contributed to this release:
+
+```
+        65	Roman Mohr <rmohr@redhat.com>
+        60	David Vossel <dvossel@redhat.com>
+         2	Fabian Deutsch <fabiand@redhat.com>
+         2	Stu Gott <sgott@redhat.com>
+         1	Marek Libra <mlibra@redhat.com>
+         1	Martin Kletzander <mkletzan@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 40 of 42 Specs in 703.532 seconds
+> SUCCESS! -- 40 Passed | 0 Failed | 0 Pending | 2 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.20.0.md
+++ b/CHANGELOG/CHANGELOG-v0.20.0.md
@@ -1,0 +1,102 @@
+KubeVirt v0.20.0
+================
+
+This release follows v0.19.0 and consists of 290 changes, contributed by
+26 people, leading to 514 files changed, 24045 insertions(+), 6666 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.20.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Containerdisks are now secure and they are not copied anymore on every start.
+Old containerdisks can still be used in the same secure way, but new
+containerdisks can't be used on older kubevirt releases
+- Create specific SecurityContextConstraints on OKD instead of using the
+privileged SCC
+- Added clone authorization check for DataVolumes with PVC source
+- The sidecar feature is feature-gated now
+- Use container image shasums instead of tags for KubeVirt deployments
+- Protect control plane components against voluntary evictions with a
+PodDisruptionBudget of MinAvailable=1
+- Replaced hardcoded `virtctl` by using the basename of the call, this enables
+nicer output when installed via krew plugin package manager
+- Added RNG device to all Fedora VMs in tests and examples (newer kernels might
+block bootimg while waiting for entropy)
+- The virtual memory is now set to match the memory limit, if memory limit is
+specified and guest memory is not
+- Support nftable for CoreOS
+- Added a block-volume flag to the virtctl image-upload command
+- Improved virtctl console/vnc data flow
+- Removed DataVolumes feature gate in favor of auto-detecting CDI support
+- Removed SR-IOV feature gate, it is enabled by default now
+- VMI-related metrics have been renamed from `kubevirt_vm_` to `kubevirt_vmi_`
+to better reflect their purpose
+- Added metric to report the VMI count
+- Improved integration with HCO by adding a CSV generator tool and modified
+KubeVirt CR conditions
+- CI Improvements:
+  - Added dedicated SR-IOV test lane
+  - Improved log gathering
+  - Reduced amount of flaky tests
+
+Contributors
+------------
+
+26 people contributed to this release:
+
+```
+70      Roman Mohr <rmohr@redhat.com>
+52      Marc Sluiter <msluiter@redhat.com>
+37      Daniel Hiller <daniel.hiller.1972@googlemail.com>
+21      Arik Hadas <ahadas@redhat.com>
+19      David Vossel <dvossel@redhat.com>
+17      Federico Paolinelli <fpaoline@redhat.com>
+12      Francesco Romani <fromani@redhat.com>
+11      Marcin Franczyk <mfranczy@redhat.com>
+8      Artyom Lukianov <alukiano@redhat.com>
+7      Gage Orsburn <gageorsburn@live.com>
+5      Ihar Hrachyshka <ihrachys@redhat.com>
+4      Michael Henriksen <mhenriks@redhat.com>
+4      Petr Kotas <pkotas@redhat.com>
+3      Ihar Hrachyshka <ihar@redhat.com>
+3      Sebastian Scheinkman <sscheink@redhat.com>
+3      Vatsal Parekh <vatsalparekh@outlook.com>
+2      Fabian Deutsch <fabiand@redhat.com>
+2      Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>
+2      Xenia Lisovskaia <polnoch@protonmail.com>
+2      kubevirt-bot <rmohr+kubebot@redhat.com>
+1      Alexander Wels <awels@redhat.com>
+1      Denys Shchedrivyi <dshchedr@redhat.com>
+1      Niels de Vos <ndevos@redhat.com>
+1      Petr Horacek <phoracek@redhat.com>
+1      Vatsal Parekh <vparekh@redhat.com>
+1      Yossi Segev <ysegev@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 363 of 415 Specs in 11596.175 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.20.1.md
+++ b/CHANGELOG/CHANGELOG-v0.20.1.md
@@ -1,0 +1,103 @@
+KubeVirt v0.20.1
+================
+
+This release follows v0.19.0 and consists of 292 changes, contributed by
+26 people, leading to 514 files changed, 24045 insertions(+), 6666 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.20.1>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Containerdisks are now secure and they are not copied anymore on every start.
+Old containerdisks can still be used in the same secure way, but new
+containerdisks can't be used on older kubevirt releases
+- Create specific SecurityContextConstraints on OKD instead of using the
+privileged SCC
+- Added clone authorization check for DataVolumes with PVC source
+- The sidecar feature is feature-gated now
+- Use container image shasums instead of tags for KubeVirt deployments
+- Protect control plane components against voluntary evictions with a
+PodDisruptionBudget of MinAvailable=1
+- Replaced hardcoded `virtctl` by using the basename of the call, this enables
+nicer output when installed via krew plugin package manager
+- Added RNG device to all Fedora VMs in tests and examples (newer kernels might
+block bootimg while waiting for entropy)
+- The virtual memory is now set to match the memory limit, if memory limit is
+specified and guest memory is not
+- Support nftable for CoreOS
+- Added a block-volume flag to the virtctl image-upload command
+- Improved virtctl console/vnc data flow
+- Removed DataVolumes feature gate in favor of auto-detecting CDI support
+- Removed SR-IOV feature gate, it is enabled by default now
+- VMI-related metrics have been renamed from `kubevirt_vm_` to `kubevirt_vmi_`
+to better reflect their purpose
+- Added metric to report the VMI count
+- Improved integration with HCO by adding a CSV generator tool and modified
+KubeVirt CR conditions
+- CI Improvements:
+  - Added dedicated SR-IOV test lane
+  - Improved log gathering
+  - Reduced amount of flaky tests
+
+Contributors
+------------
+
+26 people contributed to this release:
+
+```
+        70	Roman Mohr <rmohr@redhat.com>
+        54	Marc Sluiter <msluiter@redhat.com>
+        37	Daniel Hiller <daniel.hiller.1972@googlemail.com>
+        21	Arik Hadas <ahadas@redhat.com>
+        19	David Vossel <dvossel@redhat.com>
+        17	Federico Paolinelli <fpaoline@redhat.com>
+        12	Francesco Romani <fromani@redhat.com>
+        11	Marcin Franczyk <mfranczy@redhat.com>
+         8	Artyom Lukianov <alukiano@redhat.com>
+         7	Gage Orsburn <gageorsburn@live.com>
+         5	Ihar Hrachyshka <ihrachys@redhat.com>
+         4	Michael Henriksen <mhenriks@redhat.com>
+         4	Petr Kotas <pkotas@redhat.com>
+         3	Ihar Hrachyshka <ihar@redhat.com>
+         3	Sebastian Scheinkman <sscheink@redhat.com>
+         3	Vatsal Parekh <vatsalparekh@outlook.com>
+         2	Fabian Deutsch <fabiand@redhat.com>
+         2	Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>
+         2	Xenia Lisovskaia <polnoch@protonmail.com>
+         2	kubevirt-bot <rmohr+kubebot@redhat.com>
+         1	Alexander Wels <awels@redhat.com>
+         1	Denys Shchedrivyi <dshchedr@redhat.com>
+         1	Niels de Vos <ndevos@redhat.com>
+         1	Petr Horacek <phoracek@redhat.com>
+         1	Vatsal Parekh <vparekh@redhat.com>
+         1	Yossi Segev <ysegev@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> > Ran 363 of 415 Specs in 11596.175 seconds
+> > PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.20.2.md
+++ b/CHANGELOG/CHANGELOG-v0.20.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.20.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.20.3.md
+++ b/CHANGELOG/CHANGELOG-v0.20.3.md
@@ -1,0 +1,7 @@
+KubeVirt v0.20.3
+================
+
+Notable changes
+---------------
+
+- Fixed issue with virtctl console / vnc in case KubeVirt isn't installed in the kubevirt namespace

--- a/CHANGELOG/CHANGELOG-v0.20.4.md
+++ b/CHANGELOG/CHANGELOG-v0.20.4.md
@@ -1,0 +1,7 @@
+KubeVirt v0.20.4
+================
+
+Notable changes
+---------------
+
+- Fixed issue with memory limit of virt-launcher on OKD 4 clusters

--- a/CHANGELOG/CHANGELOG-v0.20.5.md
+++ b/CHANGELOG/CHANGELOG-v0.20.5.md
@@ -1,0 +1,7 @@
+KubeVirt v0.20.5
+================
+
+Notable changes
+---------------
+
+- Fixed issue with block mode DataVolumes

--- a/CHANGELOG/CHANGELOG-v0.20.6.md
+++ b/CHANGELOG/CHANGELOG-v0.20.6.md
@@ -1,0 +1,4 @@
+KubeVirt v0.20.6
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.20.7.md
+++ b/CHANGELOG/CHANGELOG-v0.20.7.md
@@ -1,0 +1,8 @@
+KubeVirt v0.20.7
+================
+
+Notable changes
+---------------
+
+- Fixed potential bug for migrations
+- Many bugfixes in tests

--- a/CHANGELOG/CHANGELOG-v0.20.8.md
+++ b/CHANGELOG/CHANGELOG-v0.20.8.md
@@ -1,0 +1,7 @@
+KubeVirt v0.20.8
+================
+
+Notable changes
+---------------
+
+- Added option to add a prefix to image names

--- a/CHANGELOG/CHANGELOG-v0.21.0.md
+++ b/CHANGELOG/CHANGELOG-v0.21.0.md
@@ -1,0 +1,86 @@
+KubeVirt v0.21.0
+================
+
+his release follows v0.20.0 and consists of 176 changes, contributed by
+28 people, leading to 234 files changed, 23892 insertions(+), 1616 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.21.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: Support for Kubernetes 1.14
+- Many bug fixes in several areas
+- Support for `virtctl migrate`
+- Support configurable number of controller threads
+- Support to opt-out of bridge binding for podnetwork
+- Support for OpenShift Prometheus monitoring
+- Support for setting more SMBIOS fields
+- Improved containerDisk memory usage and speed
+- Fix CRI-O memory limit
+- Drop spc_t from launcher
+- Add feature gates to security sensitive features
+
+Contributors
+------------
+
+28 people contributed to this release:
+
+```
+        40	Marc Sluiter <msluiter@redhat.com>
+        29	Arik Hadas <ahadas@redhat.com>
+        24	Stu Gott <sgott@redhat.com>
+        13	kubevirt-bot <rmohr+kubebot@redhat.com>
+        10	Vatsal Parekh <vatsalparekh@outlook.com>
+         6	Marcin Franczyk <mfranczy@redhat.com>
+         5	Federico Paolinelli <fpaoline@redhat.com>
+         5	Ihar Hrachyshka <ihrachys@redhat.com>
+         5	Petr Kotas <pkotas@redhat.com>
+         5	Vladik Romanovsky <vromanso@redhat.com>
+         3	Daniel Hiller <daniel.hiller.1972@googlemail.com>
+         3	Prashanth Buddhala <pbudds@gmail.com>
+         3	alonSadan <asadan@redhat.com>
+         3	jichenjc <jichenjc@cn.ibm.com>
+         2	Artyom Lukianov <alukiano@redhat.com>
+         2	Daniel Belenky <dbelenky@redhat.com>
+         2	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         2	Fabian Deutsch <fabiand@redhat.com>
+         2	Francesco Romani <fromani@redhat.com>
+         2	Ihar Hrachyshka <ihar@redhat.com>
+         2	Kedar Bidarkar <kbidarka@redhat.com>
+         2	Vatsal Parekh <vparekh@redhat.com>
+         1	David Vossel <dvossel@redhat.com>
+         1	Denys Shchedrivyi <dshchedr@redhat.com>
+         1	Ido Rosenzwig <irosenzw@redhat.com>
+         1	Sheng Lin <shelin@nvidia.com>
+         1	architb <architb@nvidia.com>
+         1	rnetser <rnetser@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 377 of 454 Specs in 13898.938 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.22.0.md
+++ b/CHANGELOG/CHANGELOG-v0.22.0.md
@@ -1,0 +1,82 @@
+KubeVirt v0.22.0
+================
+
+This release follows v0.21.0 and consists of 170 changes, contributed by
+28 people, leading to 753 files changed, 74964 insertions(+), 19918
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Support for Nvidia GPUs and vGPUs exposed by Nvidia Kubevirt Device Plugin.
+- VMIs now successfully start if they get a 0xfe prefixed MAC address assigned from the pod network
+- Removed dependency on host semanage in SELinux Permissive mode
+- Some changes as result of entering the CNCF sandbox (DCO check, FOSSA check, best practice badge)
+- Many bug fixes and improvements in several areas
+- CI: Introduced a OKD 4 test lane
+- CI: Many improved tests, resulting in less flakyness
+
+Contributors
+------------
+
+28 people contributed to this release:
+
+```
+        38	Roman Mohr <rmohr@redhat.com>
+        22	kubevirt-bot <rmohr+kubebot@redhat.com>
+        19	Federico Paolinelli <fpaoline@redhat.com>
+        17	Vishesh Tanksale <vtanksale@nvidia.com>
+        13	Artyom Lukianov <alukiano@redhat.com>
+         8	Marcin Franczyk <mfranczy@redhat.com>
+         7	Francesco Romani <fromani@redhat.com>
+         7	Ihar Hrachyshka <ihrachys@redhat.com>
+         6	Marc Sluiter <msluiter@redhat.com>
+         4	Arik Hadas <ahadas@redhat.com>
+         4	Ihar Hrachyshka <ihar@redhat.com>
+         4	Petr Kotas <pkotas@redhat.com>
+         3	lxs <lxs137@hotmail.com>
+         2	Kedar Bidarkar <kbidarka@redhat.com>
+         2	Vatsal Parekh <vatsalparekh@outlook.com>
+         2	Vladik Romanovsky <vromanso@redhat.com>
+         1	Alexander Wels <awels@redhat.com>
+         1	Bertrand Roussel <broussel@sierrawireless.com>
+         1	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         1	Denis Ollier <dollierp@redhat.com>
+         1	Fabian Deutsch <fabiand@redhat.com>
+         1	Pep Turró Mauri <pep@redhat.com>
+         1	Vatsal Parekh <vparekh@redhat.com>
+         1	alonSadan <asadan@redhat.com>
+         1	jichenjc <jichenjc@cn.ibm.com>
+         1	johncming <johncming@yahoo.com>
+         1	ksimon1 <ksimon@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 390 of 458 Specs in 13837.058 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.23.0.md
+++ b/CHANGELOG/CHANGELOG-v0.23.0.md
@@ -1,0 +1,67 @@
+KubeVirt v0.23.0
+================
+
+This release follows v0.22.0 and consists of 91 changes, contributed by
+15 people, leading to 216 files changed, 9040 insertions(+), 2258 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Guest OS Information is available under the VMI status now
+- Updated to Go 1.12.8 and latest bazel
+- Updated go-yaml to v2.2.4, which has a ddos vulnerability fixed
+- Cleaned up and fixed CRD scheme registration
+- Several bugfixes
+- Many CI improvements (e.g. more logs in case of test failures)
+
+Contributors
+------------
+
+15 people contributed to this release:
+
+```
+        24	Roman Mohr <rmohr@redhat.com>
+        14	ipinto <ipinto@redhat.com>
+        10	Federico Paolinelli <fpaoline@redhat.com>
+         5	Marc Sluiter <msluiter@redhat.com>
+         3	Francesco Romani <fromani@redhat.com>
+         3	Marcin Franczyk <mfranczy@redhat.com>
+         3	Petr Kotas <pkotas@redhat.com>
+         3	Prashanth Buddhala <pbudds@gmail.com>
+         2	Artyom Lukianov <alukiano@redhat.com>
+         2	Fabian Deutsch <fabiand@redhat.com>
+         2	Vladik Romanovsky <vromanso@redhat.com>
+         1	Alvaro Aleman <alv2412@googlemail.com>
+         1	Guangming Wang <guangming.wang@daocloud.io>
+         1	Kedar Bidarkar <kbidarka@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 393 of 461 Specs in 14846.610 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.23.1.md
+++ b/CHANGELOG/CHANGELOG-v0.23.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.23.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.23.2.md
+++ b/CHANGELOG/CHANGELOG-v0.23.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.23.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.23.3.md
+++ b/CHANGELOG/CHANGELOG-v0.23.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.23.3
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.24.0.md
+++ b/CHANGELOG/CHANGELOG-v0.24.0.md
@@ -1,0 +1,70 @@
+KubeVirt v0.24.0
+================
+
+This release follows v0.23.0 and consists of 73 changes, contributed by
+17 people, leading to 124 files changed, 3303 insertions(+), 617 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.24.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: Support for Kubernetes 1.15
+- CI: Support for Kubernetes 1.16
+- Add and fix a couple of test cases
+- Support for pause and unpausing VMs
+- Update of libvirt to 5.6.0
+- Fix bug related to parallel scraping of Prometheus endpoints
+- Fix to reliably test VNC
+
+Contributors
+------------
+
+17 people contributed to this release:
+
+```
+        15	Marc Sluiter <msluiter@redhat.com>
+         8	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         8	Roman Mohr <rmohr@redhat.com>
+         5	Francesco Romani <fromani@redhat.com>
+         3	Michael Henriksen <mhenriks@redhat.com>
+         2	Quique Llorente <ellorent@redhat.com>
+         2	ipinto <ipinto@redhat.com>
+         1	Andrea Bolognani <abologna@redhat.com>
+         1	Artyom Lukianov <alukiano@redhat.com>
+         1	Kedar Bidarkar <kbidarka@redhat.com>
+         1	Marcin Franczyk <marcin0franczyk@gmail.com>
+         1	Pep Turró Mauri <pep@redhat.com>
+         1	Sebastian Scheinkman <sscheink@redhat.com>
+         1	Vladik Romanovsky <vromanso@redhat.com>
+         1	alonSadan <asadan@redhat.com>
+         1	yinchengfeng <yinchengfeng@baidu.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 403 of 481 Specs in 12434.458 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.25.0.md
+++ b/CHANGELOG/CHANGELOG-v0.25.0.md
@@ -1,0 +1,61 @@
+KubeVirt v0.25.0
+================
+
+This release follows v0.24.0 and consists of 39 changes, contributed by
+11 people, leading to 82 files changed, 1989 insertions(+), 434 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.25.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: Support for Kubernetes 1.17
+- Support emulator thread pinning
+- Support virtctl restart --force
+- Support virtctl migrate to trigger live migrations from the CLI
+
+Contributors
+------------
+
+11 people contributed to this release:
+
+```
+         7	Vatsal Parekh <vparekh@redhat.com>
+         7	Vladik Romanovsky <vromanso@redhat.com>
+         3	Roman Mohr <rmohr@redhat.com>
+         2	Daniel Belenky <dbelenky@redhat.com>
+         2	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         2	Fabian Deutsch <fabiand@redhat.com>
+         1	Arik Hadas <ahadas@redhat.com>
+         1	Ihar Hrachyshka <ihrachys@redhat.com>
+         1	Michael Henriksen <mhenriks@redhat.com>
+         1	Tareq Alayan <talayan@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 407 of 485 Specs in 12424.177 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.26.0.md
+++ b/CHANGELOG/CHANGELOG-v0.26.0.md
@@ -1,0 +1,76 @@
+KubeVirt v0.26.0
+================
+
+This release follows v0.25.0 and consists of 116 changes, contributed by
+19 people, leading to 1556 files changed, 156060 insertions(+), 56779
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.26.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Fix incorrect ownerReferences to avoid VMs getting GCed
+- Fixes for several tests
+- Fix greedy permissions around Secrets by delegating them to kubelet
+- Fix OOM infra pod by increasing it's memory request
+- Clarify device support around live migrations
+- Support for an uninstall strategy to protect workloads during uninstallation
+- Support for more prometheus metrics and alert rules
+- Support for testing SRIOV connectivity in functional tests
+- Update Kubernetes client-go to 1.16.4
+- FOSSA fixes and status
+
+Contributors
+------------
+
+19 people contributed to this release:
+
+```
+        25	Roman Mohr <rmohr@redhat.com>
+        14	Vatsal Parekh <vparekh@redhat.com>
+         9	Daniel Belenky <dbelenky@redhat.com>
+         7	Omer Yahud <oyahud@oyahud.tlv.csb>
+         6	Ihar Hrachyshka <ihrachys@redhat.com>
+         4	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         3	Or Shoval <oshoval@redhat.com>
+         3	Stu Gott <sgott@redhat.com>
+         2	Federico Paolinelli <fpaoline@redhat.com>
+         2	Ihar Hrachyshka <ihar@redhat.com>
+         2	Michael Henriksen <mhenriks@redhat.com>
+         2	Petr Kotas <pkotas@redhat.com>
+         2	fossabot <badges@fossa.io>
+         1	Alberto Losada <alosadag@redhat.com>
+         1	Dan Kenigsberg <danken@redhat.com>
+         1	Igor Bezukh <ibezukh@redhat.com>
+         1	Marc Sluiter <msluiter@redhat.com>
+         1	Peter White <peter.white@metaswitch.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 417 of 498 Specs in 12827.215 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.26.1.md
+++ b/CHANGELOG/CHANGELOG-v0.26.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.26.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.26.2.md
+++ b/CHANGELOG/CHANGELOG-v0.26.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.26.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.26.3.md
+++ b/CHANGELOG/CHANGELOG-v0.26.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.26.3
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.26.4.md
+++ b/CHANGELOG/CHANGELOG-v0.26.4.md
@@ -1,0 +1,4 @@
+KubeVirt v0.26.4
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.26.5.md
+++ b/CHANGELOG/CHANGELOG-v0.26.5.md
@@ -1,0 +1,4 @@
+KubeVirt v0.26.5
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.27.0.md
+++ b/CHANGELOG/CHANGELOG-v0.27.0.md
@@ -1,0 +1,78 @@
+KubeVirt v0.27.0
+================
+
+This release follows v0.26.0 and consists of 165 changes, contributed by
+22 people, leading to 197 files changed, 7671 insertions(+), 1256 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.27.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Support for more guest agent informations in the API
+- Support setting priorityClasses on VMs
+- Support for additional control plane alerts via prometheus
+- Support for io and emulator thread pinning
+- Support setting a custom SELinux type for the launcher
+- Support to perform network configurations from handler instead of launcher
+- Support to opt-out of auto attaching the serial console
+- Support for different uninstallStaretgies for data protection
+- Fix to let qemu run in the qemu group
+- Fix guest agen connectivity check after i.e. live migrations
+
+Contributors
+------------
+
+22 people contributed to this release:
+
+```
+        58	Ihar Hrachyshka <ihrachys@redhat.com>
+        11	Stu Gott <sgott@redhat.com>
+        10	L. Pivarc <lpivarc@redhat.com>
+        10	Omer Yahud <oyahud@oyahud.tlv.csb>
+         7	Roman Mohr <rmohr@redhat.com>
+         6	Petr Kotas <pkotas@redhat.com>
+         5	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         5	Igor Bezukh <ibezukh@redhat.com>
+         4	Daniel Belenky <dbelenky@redhat.com>
+         3	Or Shoval <oshoval@redhat.com>
+         2	Alberto Losada <alosadag@redhat.com>
+         2	David Vossel <dvossel@redhat.com>
+         2	Vladik Romanovsky <vromanso@redhat.com>
+         1	Alexander Wels <awels@redhat.com>
+         1	Jed Lejosne <jed@redhat.com>
+         1	Jim Fehlig <jfehlig@suse.com>
+         1	Joowon Cheong <jwcheong0420@gmail.com>
+         1	L. Pivarc <456130@mail.muni.cz>
+         1	Murilo Fossa Vicentini <muvic@linux.ibm.com>
+         1	Sally O'Malley <somalley@redhat.com>
+         1	ipinto <ipinto@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 428 of 509 Specs in 13013.221 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.28.0.md
+++ b/CHANGELOG/CHANGELOG-v0.28.0.md
@@ -1,0 +1,82 @@
+KubeVirt v0.28.0
+================
+
+This release follows v0.27.0 and consists of 131 changes, contributed by
+20 people, leading to 172 files changed, 7960 insertions(+), 1796 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.28.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: Try to discover flaky tests before merge
+- Fix the use of priorityClasses
+- Fix guest memory overhead calculation
+- Fix SR-IOV device overhead requirements
+- Fix loading of tun module during virt-handler initialization
+- Fixes for several test cases
+- Fixes to support running with container_t
+- Support for renaming a vM
+- Support ioEmulator thread pinning
+- Support a couple of alerts for virt-handler
+- Support for filesystem listing using the guest agent
+- Support for retrieving data from the guest agent
+- Support for device role tagging
+- Support for assigning devices to the PCI root bus
+- Support for guest overhead override
+- Rewrite container-disk in C to in order to reduce it's memory footprint
+
+Contributors
+------------
+
+20 people contributed to this release:
+
+```
+        18	Vladik Romanovsky <vromanso@redhat.com>
+        16	Roman Mohr <rmohr@redhat.com>
+        13	Omer Yahud <oyahud@redhat.com>
+         7	Daniel Belenky <dbelenky@redhat.com>
+         6	Petr Kotas <pkotas@redhat.com>
+         6	Stu Gott <sgott@redhat.com>
+         5	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         4	Igor Bezukh <ibezukh@redhat.com>
+         3	Jed Lejosne <jed@redhat.com>
+         2	Andrej Krejcir <akrejcir@redhat.com>
+         2	Marcus Sorensen <marcus_sorensen@apple.com>
+         2	Petr Horacek <phoracek@redhat.com>
+         2	Quique Llorente <ellorent@redhat.com>
+         2	ipinto <ipinto@redhat.com>
+         1	Artyom Lukianov <alukiano@redhat.com>
+         1	Jim Fehlig <jfehlig@suse.com>
+         1	Miguel Duarte Barroso <mdbarroso@redhat.com>
+         1	Omer Yahud <oyahud@oyahud.tlv.csb>
+         1	ge.jin <ge.jin@woqutech.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 455 of 540 Specs in 11312.197 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.29.0.md
+++ b/CHANGELOG/CHANGELOG-v0.29.0.md
@@ -1,0 +1,85 @@
+KubeVirt v0.29.0
+================
+
+This release follows v0.28.0 and consists of 241 changes, contributed by
+28 people, leading to 302 files changed, 12931 insertions(+), 5829 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.29.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Tests: Many many test fixes
+- Tests: Many more test fixes
+- CI: Add lane with SELinux enabled
+- CI: Drop PPC64 support for now
+- Drop Genie support
+- Drop the use of hostPaths in the virt-launcher for improved security
+- Support priority classes for important componenets
+- Support IPv6 over masquerade binding
+- Support certificate rotations based on shared secrets
+- Support for VM ready condition
+- Support for advanced node labelling (supported CPU Families and machine types)
+
+Contributors
+------------
+
+28 people contributed to this release:
+
+```
+        38	David Vossel <dvossel@redhat.com>
+        25	Roman Mohr <rmohr@redhat.com>
+        21	Alona Kaplan <alkaplan@redhat.com>
+        16	Vladik Romanovsky <vromanso@redhat.com>
+        14	Stu Gott <sgott@redhat.com>
+        10	Petr Horacek <phoracek@redhat.com>
+         9	Jed Lejosne <jed@redhat.com>
+         6	Karel Simon <ksimon@redhat.com>
+         6	Miguel Duarte Barroso <mdbarroso@redhat.com>
+         6	Quique Llorente <ellorent@redhat.com>
+         4	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         4	Igor Bezukh <ibezukh@redhat.com>
+         3	Kedar Bidarkar <kbidarka@redhat.com>
+         3	Marcus Sorensen <marcus_sorensen@apple.com>
+         2	Daniel Belenky <dbelenky@redhat.com>
+         2	Edward Haas <edwardh@redhat.com>
+         2	Omer Yahud <oyahud@redhat.com>
+         2	Vatsal Parekh <vparekh@redhat.com>
+         1	Andrej Krejcir <akrejcir@redhat.com>
+         1	Fabian Deutsch <fabiand@redhat.com>
+         1	Or Shoval <oshoval@redhat.com>
+         1	Petr Kotas <pkotas@redhat.com>
+         1	Ravid Brown <>
+         1	Ravid Brown <ravid@redhat.com>
+         1	Yan Du <yadu@redhat.com>
+         1	oatakan <oatakan@gmail.com>
+         1	root <root@zeus06.eng.lab.tlv.redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 470 of 552 Specs in 11677.537 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.29.1.md
+++ b/CHANGELOG/CHANGELOG-v0.29.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.29.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.29.2.md
+++ b/CHANGELOG/CHANGELOG-v0.29.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.29.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.3.0.md
+++ b/CHANGELOG/CHANGELOG-v0.3.0.md
@@ -1,0 +1,76 @@
+KubeVirt v0.3.0
+===============
+
+This release follows v0.2.0 and consists of 469 changes, contributed by
+20 people, leading to 5408 files changed, 2170742 insertions(+), 14691
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/HEAD>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Kubernetes compatible networking
+- Kubernetes compatible PV based storage
+- VirtualMachinePresets support
+- OfflineVirtualMachine support
+- RBAC improvements
+- Switch to q35 machien type by default
+- A large number of test and CI fixes
+- Ephemeral disk support
+
+Contributors
+------------
+
+20 people contributed to this release:
+
+```
+       103	Roman Mohr <rmohr@redhat.com>
+        98	David Vossel <dvossel@redhat.com>
+        70	Petr Kotas <petr.kotas@gmail.com>
+        41	Stu Gott <sgott@redhat.com>
+        31	Lukianov Artyom <alukiano@redhat.com>
+        24	Fabian Deutsch <fabiand@redhat.com>
+        20	Lukas Bednar <lbednar@redhat.com>
+        19	Vladik Romanovsky <vromanso@redhat.com>
+        16	Martin Polednik <mpolednik@redhat.com>
+        14	Francesco Romani <fromani@redhat.com>
+        10	Travis CI <travis@travis-ci.org>
+         7	Yanir Quinn <yquinn@redhat.com>
+         6	Ryan Hallisey <rhallise@redhat.com>
+         2	Martin Kletzander <mkletzan@redhat.com>
+         2	Saravanan KR <skramaja@redhat.com>
+         2	gbenhaim <galbh2@gmail.com>
+         1	Alexander Wels <awels@redhat.com>
+         1	Suraj Narwade <surajnarwade353@gmail.com>
+         1	Vatsal Parekh <vparekh@redhat.com>
+         1	karmab <karimboumedhel@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 57 of 60 Specs in 3490.920 seconds
+> SUCCESS! -- 57 Passed | 0 Failed | 0 Pending | 3 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.30.0.md
+++ b/CHANGELOG/CHANGELOG-v0.30.0.md
@@ -1,0 +1,87 @@
+KubeVirt v0.30.0
+================
+
+This release follows v0.29.0 and consists of 168 changes, contributed by
+32 people, leading to 143 files changed, 22257 insertions(+), 6718 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.30.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Tests: Many more test fixes
+- Security: Introduce a custom SELinux policy for virt-launcher
+- More user friendly IPv6 default CIDR for IPv6 addresses
+- Fix OpenAPI compatibility issues by switching to openapi-gen
+- Improved support for EFI boot (configurable OVMF path and test fixes)
+- Improved VMI IP reporting
+- Support propagation of annotations from VMI to pods
+- Support for more fine grained (NET_RAW( capability granting to virt-launcher
+- Support for eventual consistency with DataVolumes
+
+Contributors
+------------
+
+32 people contributed to this release:
+
+```
+        14	Roman Mohr <rmohr@redhat.com>
+        12	Jed Lejosne <jed@redhat.com>
+        12	Miguel Duarte Barroso <mdbarroso@redhat.com>
+         8	Edward Haas <edwardh@redhat.com>
+         8	L. Pivarc <lpivarc@redhat.com>
+         8	Marcus Sorensen <marcus_sorensen@apple.com>
+         5	Petr Horacek <phoracek@redhat.com>
+         5	Stu Gott <sgott@redhat.com>
+         4	Daniel Belenky <dbelenky@redhat.com>
+         3	Igor Bezukh <ibezukh@redhat.com>
+         3	Karel Simon <ksimon@redhat.com>
+         3	Or Shoval <oshoval@redhat.com>
+         3	Prashanth Buddhala <pbudds@gmail.com>
+         2	Alona Kaplan <alkaplan@redhat.com>
+         2	Andrea Bolognani <abologna@redhat.com>
+         2	Dan Kenigsberg <danken@redhat.com>
+         2	David Vossel <dvossel@redhat.com>
+         2	Omer Yahud <oyahud@redhat.com>
+         2	Or Mergi <ormergi@redhat.com>
+         2	rnetser <rnetser@redhat.com>
+         1	Daniel Hiller <daniel.hiller.1972@gmail.com>
+         1	Doron Fediuck <doron-fediuck@users.noreply.github.com>
+         1	Jim Fehlig <jfehlig@suse.com>
+         1	Kunal Kushwaha <kunalkushwaha453@gmail.com>
+         1	Maya Rashish <mrashish@redhat.com>
+         1	Murilo Fossa Vicentini <muvic@linux.ibm.com>
+         1	Pedro Ibáñez <pedro@redhat.com>
+         1	Tomasz Baranski <tbaransk@redhat.com>
+         1	Vatsal Parekh <vparekh@redhat.com>
+         1	ipinto <ipinto@redhat.com>
+         1	pnavarro <pednape@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 470 of 554 Specs in 11936.748 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.30.1.md
+++ b/CHANGELOG/CHANGELOG-v0.30.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.30.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.30.2.md
+++ b/CHANGELOG/CHANGELOG-v0.30.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.30.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.30.3.md
+++ b/CHANGELOG/CHANGELOG-v0.30.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.30.3
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.30.4.md
+++ b/CHANGELOG/CHANGELOG-v0.30.4.md
@@ -1,0 +1,4 @@
+KubeVirt v0.30.4
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.30.5.md
+++ b/CHANGELOG/CHANGELOG-v0.30.5.md
@@ -1,0 +1,4 @@
+KubeVirt v0.30.5
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.30.6.md
+++ b/CHANGELOG/CHANGELOG-v0.30.6.md
@@ -1,0 +1,4 @@
+KubeVirt v0.30.6
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.30.7.md
+++ b/CHANGELOG/CHANGELOG-v0.30.7.md
@@ -1,0 +1,4 @@
+KubeVirt v0.30.7
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.31.0.md
+++ b/CHANGELOG/CHANGELOG-v0.31.0.md
@@ -1,0 +1,73 @@
+KubeVirt v0.31.0
+================
+
+This release follows v0.30.3 and consists of 209 changes, contributed by 30 people, leading to 659 files changed, 132453 insertions(+), 40469 deletions(-).
+v0.31.0 is a promotion of release candidate v0.31.0-rc.1 which was originally published 2020-07-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.31.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.31.0`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR 3690][davidvossel] Update go-grpc dependency to v1.30.0 in order to improve stability
+- [PR 3628][AlonaKaplan] Avoid virt-handler crash in case of virt-launcher network configuration error
+- [PR 3635][jean-edouard] The "HostDisk" feature gate has to be enabled to use hostDisks
+- [PR 3641][vatsalparekh] Reverts kubevirt/kubevirt#3488 because CI seems to have merged it without all tests passing
+- [PR 3488][vatsalparekh] Add a way to update VMI Status with latest Pod IP for Masquerade bindings
+- [PR 3406][tomob] If a PVC was created by a DataVolume, it cannot be used as a Volume Source for a VM. The owning DataVolume has to be used instead.
+- [PR 3566][kraxel] added: tigervnc support for linux & windows
+- [PR 3529][jean-edouard] Enabling EFI will also enable Secure Boot, which requires SMM to be enabled.
+- [PR 3455][ashleyschuett] Add KubevirtConfiguration, MigrationConfiguration, DeveloperConfiguration and NetworkConfiguration to API-types
+- [PR 3520][rmohr] Fix hot-looping on the  VMI sync-condition if errors happen during the Scheduled phase of a VMI
+- [PR 3220][mhenriks] API and controller/webhook for VirtualMachineSnapshots
+
+Contributors
+------------
+30 people contributed to this release:
+
+```
+37	Roman Mohr <rmohr@redhat.com>
+21	Michael Henriksen <mhenriks@redhat.com>
+17	Vatsal Parekh <vparekh@redhat.com>
+12	Alona Kaplan <alkaplan@redhat.com>
+11	Jed Lejosne <jed@redhat.com>
+7	David Vossel <dvossel@redhat.com>
+7	Miguel Duarte Barroso <mdbarroso@redhat.com>
+7	Or Shoval <oshoval@redhat.com>
+7	Stu Gott <sgott@redhat.com>
+6	Edward Haas <edwardh@redhat.com>
+4	Ashley Schuett <ashleyns1992@gmail.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+3	Kedar Bidarkar <kbidarka@redhat.com>
+3	Maya Rashish <mrashish@redhat.com>
+2	Daniel Belenky <dbelenky@redhat.com>
+2	Daniel Hiller <daniel.hiller.1972@gmail.com>
+2	Gerd Hoffmann <kraxel@redhat.com>
+2	Howard Zhang <howard.zhang@arm.com>
+2	Or Mergi <ormergi@redhat.com>
+2	Vladik Romanovsky <vromanso@redhat.com>
+1	Adam Litke <alitke@redhat.com>
+1	Dan Kenigsberg <danken@redhat.com>
+1	Jed Lejosne <jean-edouard@users.noreply.github.com>
+1	Jim Fehlig <jfehlig@suse.com>
+1	Joowon Cheong <jwcheong0420@gmail.com>
+1	Petr Horacek <phoracek@redhat.com>
+1	Shweta Padubidri <spadubid@localhost.localdomain>
+1	Tomasz Baranski <tbaransk@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.32.0.md
+++ b/CHANGELOG/CHANGELOG-v0.32.0.md
@@ -1,0 +1,75 @@
+KubeVirt v0.32.0
+================
+
+This release follows v0.31.0 and consists of 189 changes, contributed by 26 people, leading to 460 files changed, 17395 insertions(+), 19058 deletions(-).
+v0.32.0 is a promotion of release candidate v0.32.0-rc.2 which was originally published 2020-08-10
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.32.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.32.0`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #3921][vladikr] use correct memory units in libvirt xml
+- [PR #3893][davidvossel] Adds recurring period that resyncs virt-launcher domains with virt-handler
+- [PR #3880][sgarbour] Better error message when input parameters are not the expected number of parameters for each argument. Help menu will popup in case the number of parameters is incorrect.
+- [PR #3785][xpivarc] Vcpu wait metrics available
+- [PR #3642][vatsalparekh] Add a way to update VMI Status with latest Pod IP for Masquerade bindings
+- [PR #3636][ArthurSens] Adds kubernetes metadata.labels as VMI metrics' label
+- [PR #3825][awels] Virtctl now prints error messages from the response body on upload errors.
+- [PR #3830][davidvossel] Fixes re-establishing domain notify client connections when domain notify server restarts due to an error event.
+- [PR #3778][danielBelenky] Do not emit a SyncFailed event if we fail to sync a VMI in a final state
+- [PR #3803][andreabolognani] Not sure what to write here (see above)
+- [PR #2694][rmohr] Use native go libraries for selinux to not rely on python-selinux tools like semanage, which are not always present.
+- [PR #3692][victortoso] QEMU logs can now be fetched from outside the pod
+- [PR #3738][enp0s3] Restrict creation of VMI if it has labels that are used internally by Kubevirt components.
+- [PR #3725][danielBelenky] The tests binary is now part of the release and can be consumed from the GitHub release page.
+- [PR #3684][rmohr] Log if critical devices, like kvm, which virt-handler wants to expose are not present on the node.
+- [PR #3166][petrkotas] Introduce new virtctl commands:
+- [PR #3708][andreabolognani] Make qemu work on GCE by pulling in a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1822682
+
+Contributors
+------------
+26 people contributed to this release:
+
+```
+19	arthursens <arthursens2005@gmail.com>
+14	Igor Bezukh <ibezukh@redhat.com>
+11	Or Shoval <oshoval@redhat.com>
+11	Roman Mohr <rmohr@redhat.com>
+9	David Vossel <dvossel@redhat.com>
+8	Jed Lejosne <jed@redhat.com>
+8	Or Mergi <ormergi@redhat.com>
+7	Daniel Belenky <dbelenky@redhat.com>
+7	Edward Haas <edwardh@redhat.com>
+5	Andrea Bolognani <abologna@redhat.com>
+5	L. Pivarc <lpivarc@redhat.com>
+3	Ashley Schuett <ashleyns1992@gmail.com>
+2	Daniel Hiller <daniel.hiller.1972@gmail.com>
+2	Kedar Bidarkar <kbidarka@redhat.com>
+2	Maya Rashish <mrashish@redhat.com>
+2	Shaul Garbourg <sgarbour@redhat.com>
+2	Victor Toso <victortoso@redhat.com>
+1	Alexander Wels <awels@redhat.com>
+1	Alona Kaplan <alkaplan@redhat.com>
+1	Petr Kotas <pkotas@redhat.com>
+1	Vatsal Parekh <vparekh@redhat.com>
+1	Vladik Romanovsky <vromanso@redhat.com>
+1	alonSadan <asadan@redhat.com>
+1	rmohr <rmohr@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.33.0.md
+++ b/CHANGELOG/CHANGELOG-v0.33.0.md
@@ -1,0 +1,76 @@
+KubeVirt v0.33.0
+================
+
+This release follows v0.32.0 and consists of 239 changes, contributed by 28 people, leading to 524 files changed, 45482 insertions(+), 28415 deletions(-).
+v0.33.0 is a promotion of release candidate v0.33.0-rc.1 which was originally published 2020-09-14
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.33.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.33.0`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #3226][vatsalparekh] Added tests to verify custom pciAddress slots and function
+- [PR #4048][davidvossel] Improved reliability for failed migration retries
+- [PR #3585][mhenriks] "virtctl image-upload pvc ..." will create the PVC if it does not exist
+- [PR #3945][xpivarc] KubeVirt is now being built with Go1.13.14
+- [PR #3845][ArthurSens] action required: The domain label from VMI metrics is being removed and may break dashboards that use the domain label to identify VMIs. Use name and namespace labels instead
+- [PR #4011][dhiller] ppc64le arch has been disabled for the moment, see https://github.com/kubevirt/kubevirt/issues/4037
+- [PR #3875][stu-gott] Resources created by KubeVirt are now labelled more clearly in terms of relationship and role.
+- [PR #3791][ashleyschuett] make node as kubevirt.io/schedulable=false on virt-handler restart
+- [PR #3998][vladikr] the local provider is usable again.
+- [PR #3290][maiqueb] Have virt-handler (KubeVirt agent) create the tap devices on behalf of the virt-launchers.
+- [PR #3957][AlonaKaplan] virt-launcher support Ipv6 on dual stack cluster.
+- [PR #3952][davidvossel] Fixes rare situation where vmi may not properly terminate if failure occurs before domain starts.
+- [PR #3973][xpivarc] Fixes VMs with clock.timezone set.
+- [PR #3923][danielBelenky] Add support to configure QEMU I/O mode for VMIs
+- [PR #3889][rmohr] The status fields for our CRDs are now protected on normal PATCH and PUT operations.The /status subresource is now used where possible for status updates.
+- [PR #3568][xpivarc] Guest swap metrics available
+
+Contributors
+------------
+28 people contributed to this release:
+
+```
+23	Alona Kaplan <alkaplan@redhat.com>
+23	rmohr <rmohr@redhat.com>
+21	David Vossel <dvossel@redhat.com>
+16	Roman Mohr <rmohr@redhat.com>
+14	Miguel Duarte Barroso <mdbarroso@redhat.com>
+12	L. Pivarc <lpivarc@redhat.com>
+12	Or Mergi <ormergi@redhat.com>
+10	Edward Haas <edwardh@redhat.com>
+8	Or Shoval <oshoval@redhat.com>
+8	Stu Gott <sgott@redhat.com>
+7	Daniel Hiller <daniel.hiller.1972@gmail.com>
+5	Michael Henriksen <mhenriks@redhat.com>
+5	Petr Horacek <phoracek@redhat.com>
+4	Daniel Belenky <dbelenky@redhat.com>
+3	Ashley Schuett <ashleyns1992@gmail.com>
+2	Alexander Wels <awels@redhat.com>
+2	Kedar Bidarkar <kbidarka@redhat.com>
+2	Vladik Romanovsky <vromanso@redhat.com>
+2	arthursens <arthursens2005@gmail.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Jed Lejosne <jed@redhat.com>
+1	Quique Llorente <ellorent@redhat.com>
+1	Tomasz Baranski <tbaransk@redhat.com>
+1	Vatsal Parekh <vparekh@redhat.com>
+1	alonSadan <asadan@redhat.com>
+1	ipinto <ipinto@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.34.0.md
+++ b/CHANGELOG/CHANGELOG-v0.34.0.md
@@ -1,0 +1,95 @@
+KubeVirt v0.34.0
+================
+
+This release follows v0.33.0 and consists of 366 changes, contributed by 35 people, leading to 1042 files changed, 110966 insertions(+), 117125 deletions(-).
+v0.34.0 is a promotion of release candidate v0.34.0-rc.2 which was originally published 2020-10-07
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.34.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.34.0`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #4315][kubevirt-bot] PVCs populated by DVs are now allowed as volumes.
+- [PR #3837][jean-edouard] VM interfaces with no `bootOrder` will no longer be candidates for boot when using the BIOS bootloader, as documented
+- [PR #3879][ashleyschuett] KubeVirt should now be configured through the KubeVirt CR `configuration` key. The usage of the kubevirt-confg ConfigMap will be deprecated in the future.
+- [PR #4074][stu-gott] Fixed bug preventing non-admin users from pausing/unpausing VMs
+- [PR #4252][rhrazdil] Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1853911
+- [PR #4016][ashleyschuett] Allow for post copy VMI migrations
+- [PR #4235][davidvossel] Fixes timeout failure that occurs when pulling large containerDisk images
+- [PR #4263][rmohr] Add readiness and liveness probes to virt-handler, to clearly indicate readiness
+- [PR #4248][maiqueb] always compile KubeVirt with selinux support on pure go builds.
+- [PR #4012][danielBelenky] Added support for the eviction API for VMIs with eviction strategy. This enables VMIs to be live-migrated when the node is drained or when the descheduler wants to move a VMI to a different node.
+- [PR #4075][ArthurSens] Metric kubevirt_vmi_vcpu_seconds' state label is now exposed as a human-readable state instead of an integer
+- [PR #4162][vladikr] introduce a cpuAllocationRatio config parameter to normalize the number of CPUs requested for a pod, based on the number of vCPUs
+- [PR #4177][maiqueb] Use vishvananda/netlink instead of songgao/water to create tap devices.
+- [PR #4092][stu-gott] Allow specifying nodeSelectors, affinity and tolerations to control where KubeVirt components will run
+- [PR #3927][ArthurSens] Adds new metric kubevirt_vmi_memory_unused_bytes
+- [PR #3493][vladikr] virtIO-FS is being added as experimental, protected by a feature-gate that needs to be enabled in the kubevirt config by the administrator
+- [PR #4193][mhenriks] Add snapshot.kubevirt.io to admin/edit/view roles
+- [PR #4149][qinqon] Bump kubevirtci to k8s-1.19
+- [PR #3471][crobinso] Allow hiding that the VM is running on KVM, so that Nvidia graphics cards can be passed through
+- [PR #4115][phoracek] Add conformance automation and manifest publishing
+- [PR #3733][davidvossel] each PRs description.
+- [PR #4082][mhenriks] VirtualMachineRestore API and implementation
+- [PR #4154][davidvossel] Fixes issue with Serivce endpoints not being updated properly in place during KubeVirt updates.
+- [PR #3289][vatsalparekh] Add option to run only VNC Proxy in virtctl
+- [PR #4027][alicefr] Added memfd as default memory backend for hugepages. This introduces the new annotation kubevirt.io/memfd to disable memfd as default and fallback to the previous behavior.
+- [PR #3612][ashleyschuett] Adds `customizeComponents` to the kubevirt api
+- [PR #4029][cchengleo] Fix an issue which prevented virt-operator from installing monitoring resources in custom namespaces.
+- [PR #4031][rmohr] Initial support for sonobuoy for conformance testing
+
+Contributors
+------------
+35 people contributed to this release:
+
+```
+38	Ashley Schuett <ashleyns1992@gmail.com>
+33	Roman Mohr <rmohr@redhat.com>
+26	Michael Henriksen <mhenriks@redhat.com>
+25	Miguel Duarte Barroso <mdbarroso@redhat.com>
+21	David Vossel <dvossel@redhat.com>
+19	rmohr <rmohr@redhat.com>
+17	Stu Gott <sgott@redhat.com>
+15	Vladik Romanovsky <vromanso@redhat.com>
+11	Jed Lejosne <jed@redhat.com>
+10	Or Shoval <oshoval@redhat.com>
+8	Daniel Belenky <dbelenky@redhat.com>
+8	Quique Llorente <ellorent@redhat.com>
+7	Alice Frosi <afrosi@redhat.com>
+6	Bartosz Rybacki <brybacki@redhat.com>
+5	Cheng Cheng <cheng@ccheng.us>
+5	Edward Haas <edwardh@redhat.com>
+5	Vatsal Parekh <vparekh@redhat.com>
+4	Petr Horacek <phoracek@redhat.com>
+4	arthursens <arthursens2005@gmail.com>
+3	Cole Robinson <crobinso@redhat.com>
+2	Alexander Wels <awels@redhat.com>
+2	Cheng Cheng <ccheng@ccheng.us>
+2	Cheng Cheng <chengcheng@apple.com>
+2	Victor Toso <victortoso@redhat.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Andrea Bolognani <abologna@redhat.com>
+1	Daniel Hiller <daniel.hiller.1972@gmail.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Kedar Bidarkar <kbidarka@redhat.com>
+1	L. Pivarc <lpivarc@redhat.com>
+1	Maya Rashish <mrashish@redhat.com>
+1	Radim Hrazdil <rhrazdil@redhat.com>
+1	Ram Lavi <ralavi@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.34.1.md
+++ b/CHANGELOG/CHANGELOG-v0.34.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.34.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.34.2.md
+++ b/CHANGELOG/CHANGELOG-v0.34.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.34.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.35.0.md
+++ b/CHANGELOG/CHANGELOG-v0.35.0.md
@@ -1,0 +1,79 @@
+KubeVirt v0.35.0
+================
+
+This release follows v0.34.0 and consists of 275 changes, contributed by 31 people, leading to 254 files changed, 18061 insertions(+), 4438 deletions(-).
+v0.35.0 is a promotion of release candidate v0.35.0-rc.0 which was originally published 2020-11-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.35.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.35.0`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #4409][vladikr] Increase the static memory overhead by 10Mi
+- [PR #4272][maiqueb] Add `ip-family` to the `virtctl expose` command.
+- [PR #4398][rmohr] VMIs reflect deleted stuck virt-launcher pods with the "PodTerminating" Reason in the ready condition. The VMIRS detects this reason and immediately creates replacement VMIs.
+- [PR #4393][salanki] Disable legacy service links in `virt-launcher` Pods to speed up Pod instantiation and decrease Kubelet load in namespaces with many services.
+- [PR #2935][maiqueb] Add the macvtap BindMechanism.
+- [PR #4132][mstarostik] fixes a bug that prevented unique device name allocation when configuring both scsi and sata drives
+- [PR #3257][xpivarc] Added support of `kubectl explain` for Kubevirt resources.
+- [PR #4288][ezrasilvera] Adding DownwardAPI volumes type
+- [PR #4233][maya-r] Update base image used for pods to Fedora 31.
+- [PR #4192][xpivarc] We now run gosec in Kubevirt
+- [PR #4328][stu-gott] Version 2.x QEMU guest agents are supported.
+- [PR #4289][AlonaKaplan] Masquerade binding - set the virt-launcher pod interface MTU on the bridge.
+- [PR #4300][maiqueb] Update the NetworkInterfaceMultiqueue openAPI documentation to better specify its semantics within KubeVirt.
+- [PR #4277][awels] PVCs populated by DVs are now allowed as volumes.
+- [PR #4265][dhiller] Fix virtctl help text when running as a plugin
+- [PR #4273][dhiller] Only run Travis build for PRs against release branches
+
+Contributors
+------------
+31 people contributed to this release:
+
+```
+33	Miguel Duarte Barroso <mdbarroso@redhat.com>
+30	L. Pivarc <lpivarc@redhat.com>
+26	Roman Mohr <rmohr@redhat.com>
+12	Or Shoval <oshoval@redhat.com>
+11	Alona Kaplan <alkaplan@redhat.com>
+10	Ezra Silvera <ezra@il.ibm.com>
+9	David Vossel <dvossel@redhat.com>
+8	Edward Haas <edwardh@redhat.com>
+8	alonSadan <asadan@redhat.com>
+6	Igor Bezukh <ibezukh@redhat.com>
+6	Or Mergi <ormergi@redhat.com>
+4	Maya Rashish <mrashish@redhat.com>
+4	Vladik Romanovsky <vromanso@redhat.com>
+3	Quique Llorente <ellorent@redhat.com>
+2	Alexander Wels <awels@redhat.com>
+2	Bartosz Rybacki <brybacki@redhat.com>
+2	Cole Robinson <crobinso@redhat.com>
+2	Daniel Hiller <daniel.hiller.1972@gmail.com>
+2	Malte Starostik <github@xodtsoq.de>
+2	Michael Henriksen <mhenriks@redhat.com>
+2	Petr Horacek <phoracek@redhat.com>
+2	Stu Gott <sgott@redhat.com>
+1	Dan Kenigsberg <danken@redhat.com>
+1	Kedar Bidarkar <kbidarka@redhat.com>
+1	Nelson Mimura Gonzalez <nelson@ibm.com>
+1	Peter Salanki <peter@salanki.st>
+1	Tomasz Baranski <tbaransk@redhat.com>
+1	ipinto <ipinto@redhat.com>
+1	屈骏 <qujun@tiduyun.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.36.0.md
+++ b/CHANGELOG/CHANGELOG-v0.36.0.md
@@ -1,0 +1,84 @@
+KubeVirt v0.36.0
+================
+
+This release follows v0.35.0 and consists of 314 changes, contributed by 35 people, leading to 308 files changed, 55480 insertions(+), 4880 deletions(-).
+v0.36.0 is a promotion of release candidate v0.36.0-rc.1 which was originally published 2020-12-14
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.36.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.36.0`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #4667][kubevirt-bot] Update libvirt base container to be based of packages in rhel-av 8.3
+- [PR #4634][kubevirt-bot] Failure detection and handling for VM with EFI Insecure Boot in KubeVirt environments where EFI Insecure Boot is not supported by design.
+- [PR #4647][kubevirt-bot] Re-introduce the CAP_NET_ADMIN, to allow migration of VMs already having it.
+- [PR #4627][kubevirt-bot] Fix guest agent reporting.
+- [PR #4458][awels] It is now possible to hotplug DataVolume and PVC volumes into a running Virtual Machine.
+- [PR #4025][brybacki] Adds a special handling for DataVolumes in WaitForFirstConsumer state to support CDI's delayed binding mode.
+- [PR #4217][mfranczy] Set only an IP address for interfaces reported by qemu-guest-agent. Previously that was CIDR.
+- [PR #4195][davidvossel] AccessCredentials API for dynamic user/password and ssh public key injection
+- [PR #4335][oshoval] VMI status displays SRIOV interfaces with their network name only when they have originally
+- [PR #4408][andreabolognani] This version of KubeVirt includes upgraded virtualization technology based on libvirt 6.6.0 and QEMU 5.1.0.
+- [PR #4514][ArthurSens] `domain` label removed from metric `kubevirt_vmi_memory_unused_bytes`
+- [PR #4542][danielBelenky] Fix double migration on node evacuation
+- [PR #4506][maiqueb] Remove CAP_NET_ADMIN from the virt-launcher pod.
+- [PR #4501][AlonaKaplan] CAP_NET_RAW removed from virt-launcher.
+- [PR #4488][salanki] Disable Virtio-FS metadata cache to prevent OOM conditions on the host.
+- [PR #3937][vladikr] Generalize host devices assignment. Provides an interface between kubevirt and external device plugins. Provides a mechanism for whitelisting host devices.
+- [PR #4443][rmohr] All kubevirt webhooks support now dry-runs.
+
+Contributors
+------------
+35 people contributed to this release:
+
+```
+32	David Vossel <dvossel@redhat.com>
+32	Vladik Romanovsky <vromanso@redhat.com>
+23	Roman Mohr <rmohr@redhat.com>
+17	Alexander Wels <awels@redhat.com>
+15	Edward Haas <edwardh@redhat.com>
+15	Jed Lejosne <jed@redhat.com>
+13	Ezra Silvera <ezra@il.ibm.com>
+13	Quique Llorente <ellorent@redhat.com>
+11	Marcelo Amaral <marcelo.amaral1@ibm.com>
+11	Miguel Duarte Barroso <mdbarroso@redhat.com>
+9	Or Shoval <oshoval@redhat.com>
+8	Bartosz Rybacki <brybacki@redhat.com>
+7	Daniel Hiller <daniel.hiller.1972@gmail.com>
+5	Alona Kaplan <alkaplan@redhat.com>
+5	Andrea Bolognani <abologna@redhat.com>
+5	Stu Gott <sgott@redhat.com>
+4	Fabian Deutsch <fabiand@redhat.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+3	L. Pivarc <lpivarc@redhat.com>
+2	Daniel Belenky <dbelenky@redhat.com>
+2	alonSadan <asadan@redhat.com>
+2	屈骏 <qujun@tiduyun.com>
+1	Adam Litke <alitke@redhat.com>
+1	Christoph Stäbler <chresse1605@gmail.com>
+1	Dan Kenigsberg <danken@redhat.com>
+1	Federico Gimenez <federico.gimenez@gmail.com>
+1	Hao Yu <yuh@us.ibm.com>
+1	Marcin Franczyk <marcin0franczyk@gmail.com>
+1	Or Mergi <ormergi@redhat.com>
+1	Peter Salanki <peter@salanki.st>
+1	Tomasz Baranski <tbaransk@redhat.com>
+1	arthursens <arthursens2005@gmail.com>
+1	zouyu <zouy.fnst@cn.fujitsu.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.36.1.md
+++ b/CHANGELOG/CHANGELOG-v0.36.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.36.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.36.2.md
+++ b/CHANGELOG/CHANGELOG-v0.36.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.36.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.36.3.md
+++ b/CHANGELOG/CHANGELOG-v0.36.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.36.3
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.36.4.md
+++ b/CHANGELOG/CHANGELOG-v0.36.4.md
@@ -1,0 +1,56 @@
+KubeVirt v0.36.4
+================
+
+This release follows v0.36.3 and consists of 41 changes, contributed by 12 people, leading to 57 files changed, 1454 insertions(+), 326 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.36.4.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.36.4`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6591][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #6512][xpivarc] Fix cases where migration will not be processed if previous migration failed.
+- [PR #6400][rmohr] Fix rbac permissions for freeze/unfreeze, addvolume/removevolume, guestosinfo, filesystemlist and userlist
+- [PR #6147][rmohr] Fix rbac permissions for freeze/unfreeze, addvolume/removevolume, guestosinfo, filesystemlist and userlist
+- [PR #6269][awels] BugFix: Generate ISO images 4k aligned for node storage with 4k blocksize
+- [PR #5919][davidvossel] Fixes event recording causing a segfault in virt-controller
+- [PR #5865][xpivarc] Fix: Kubevirt build with golang 1.14+ will not fail on validation of container disk with memory allocation error
+- [PR #5851][rthallisey] Prometheus metrics scraped from virt-handler are now served from the VMI informer cache, rather than calling back to the Kubernetes API for VMI information.
+- [PR #5655][acardace] virt-launcher now populates domain's guestOS info and interfaces status according guest agent also when doing periodic resyncs.
+- [PR #5708][kubevirt-bot] Fixes null pointer dereference in migration controller
+- [PR #5705][davidvossel] Fix virt-controller clobbering in progress vmi migration state during virt handler handoff
+- [PR #5672][davidvossel] Validation/Mutation webhooks now explicitly define a 10 second timeout period
+
+Contributors
+------------
+12 people contributed to this release:
+
+```
+8	David Vossel <dvossel@redhat.com>
+4	Jed Lejosne <jed@redhat.com>
+4	Or Shoval <oshoval@redhat.com>
+3	Alexander Wels <awels@redhat.com>
+2	Marcus Sorensen <mls@apple.com>
+1	Bartosz Rybacki <brybacki@redhat.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	L. Pivarc <lpivarc@redhat.com>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+1	Vladik Romanovsky <vromanso@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.36.5.md
+++ b/CHANGELOG/CHANGELOG-v0.36.5.md
@@ -1,0 +1,60 @@
+KubeVirt v0.36.5
+================
+
+This release follows v0.36.3 and consists of 47 changes, contributed by 14 people, leading to 61 files changed, 1612 insertions(+), 359 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.36.5.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.36.5`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6837][dhiller] Backport prow release automation changes from 0.40 to 0.36
+- [PR #6291][kubevirt-bot] Fix goroutine leak in virt-handler, potentially causing issues with a high turnover of VMIs.
+- [PR #6591][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #6512][xpivarc] Fix cases where migration will not be processed if previous migration failed.
+- [PR #6400][rmohr] Fix rbac permissions for freeze/unfreeze, addvolume/removevolume, guestosinfo, filesystemlist and userlist
+- [PR #6147][rmohr] Fix rbac permissions for freeze/unfreeze, addvolume/removevolume, guestosinfo, filesystemlist and userlist
+- [PR #6269][awels] BugFix: Generate ISO images 4k aligned for node storage with 4k blocksize
+- [PR #5919][davidvossel] Fixes event recording causing a segfault in virt-controller
+- [PR #5865][xpivarc] Fix: Kubevirt build with golang 1.14+ will not fail on validation of container disk with memory allocation error
+- [PR #5851][rthallisey] Prometheus metrics scraped from virt-handler are now served from the VMI informer cache, rather than calling back to the Kubernetes API for VMI information.
+- [PR #5655][acardace] virt-launcher now populates domain's guestOS info and interfaces status according guest agent also when doing periodic resyncs.
+- [PR #5708][kubevirt-bot] Fixes null pointer dereference in migration controller
+- [PR #5705][davidvossel] Fix virt-controller clobbering in progress vmi migration state during virt handler handoff
+- [PR #5672][davidvossel] Validation/Mutation webhooks now explicitly define a 10 second timeout period
+
+Contributors
+------------
+14 people contributed to this release:
+
+```
+8	David Vossel <dvossel@redhat.com>
+5	Jed Lejosne <jed@redhat.com>
+4	Or Shoval <oshoval@redhat.com>
+3	Alexander Wels <awels@redhat.com>
+2	Marcus Sorensen <mls@apple.com>
+1	Bartosz Rybacki <brybacki@redhat.com>
+1	Daniel Hiller <dhiller@redhat.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Kevin Wiesmueller <kwiesmul@redhat.com>
+1	L. Pivarc <lpivarc@redhat.com>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+1	Vladik Romanovsky <vromanso@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.37.0.md
+++ b/CHANGELOG/CHANGELOG-v0.37.0.md
@@ -1,0 +1,71 @@
+KubeVirt v0.37.0
+================
+
+This release follows v0.36.0 and consists of 187 changes, contributed by 28 people, leading to 885 files changed, 68694 insertions(+), 10098 deletions(-).
+v0.37.0 is a promotion of release candidate v0.37.0-rc.2 which was originally published 2021-01-18
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.37.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.37.0`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #4654][AlonaKaplan] Introduce virt-launcher DHCPv6 server.
+- [PR #4669][kwiesmueller] Add nodeSelector to kubevirt components restricting them to run on linux nodes only.
+- [PR #4648][davidvossel] Update libvirt base container to be based of packages in rhel-av 8.3
+- [PR #4653][qinqon] Allow configure cloud-init with networkData only.
+- [PR #4644][ashleyschuett] Operator validation webhook will deny updates to the workloads object of the KubeVirt CR if there are running VMIs
+- [PR #3349][davidvossel] KubeVirt v1 GA api
+- [PR #4645][maiqueb] Re-introduce the CAP_NET_ADMIN, to allow migration of VMs already having it.
+- [PR #4546][yuhaohaoyu] Failure detection and handling for VM with EFI Insecure Boot in KubeVirt environments where EFI Insecure Boot is not supported by design.
+- [PR #4625][awels] virtctl upload now shows error when specifying access mode of ReadOnlyMany
+- [PR #4396][xpivarc] KubeVirt is now explainable!
+- [PR #4517][danielBelenky] Fix guest agent reporting.
+
+Contributors
+------------
+28 people contributed to this release:
+
+```
+19	Alona Kaplan <alkaplan@redhat.com>
+13	David Vossel <dvossel@redhat.com>
+12	Roman Mohr <rmohr@redhat.com>
+11	Edward Haas <edwardh@redhat.com>
+8	Dan Kenigsberg <danken@redhat.com>
+8	Vasiliy Ulyanov <vulyanov@suse.de>
+7	alonSadan <asadan@redhat.com>
+6	Miguel Duarte Barroso <mdbarroso@redhat.com>
+5	Ashley Schuett <ashleyns1992@gmail.com>
+5	Ezra Silvera <ezra@il.ibm.com>
+5	Stu Gott <sgott@redhat.com>
+4	Zhou Hao <zhouhao@cn.fujitsu.com>
+4	xiaobo <zeng.xiaobo@h3c.com>
+2	Alexander Wels <awels@redhat.com>
+2	Federico Gimenez <fgimenez@redhat.com>
+2	L. Pivarc <lpivarc@redhat.com>
+2	Quique Llorente <ellorent@redhat.com>
+1	Daniel Belenky <dbelenky@redhat.com>
+1	Daniel Hiller <dhiller@redhat.com>
+1	Hao Yu <yuh@us.ibm.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Jim Fehlig <jfehlig@suse.com>
+1	Kevin Wiesmueller <kwiesmul@redhat.com>
+1	Marcin Franczyk <marcin0franczyk@gmail.com>
+1	Or Shoval <oshoval@redhat.com>
+1	ipinto <ipinto@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.37.1.md
+++ b/CHANGELOG/CHANGELOG-v0.37.1.md
@@ -1,0 +1,37 @@
+KubeVirt v0.37.1
+================
+
+This release follows v0.37.0 and consists of 7 changes, contributed by 4 people, leading to 7 files changed, 63 insertions(+), 36 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.37.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.37.1`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #4842][kubevirt-bot] KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION env var for specifying exactly what client-go scheme version is registered
+
+Contributors
+------------
+4 people contributed to this release:
+
+```
+4	Alona Kaplan <alkaplan@redhat.com>
+1	David Vossel <dvossel@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.37.2.md
+++ b/CHANGELOG/CHANGELOG-v0.37.2.md
@@ -1,0 +1,38 @@
+KubeVirt v0.37.2
+================
+
+This release follows v0.37.1 and consists of 16 changes, contributed by 4 people, leading to 36 files changed, 804 insertions(+), 457 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.37.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.37.2`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #4872][kubevirt-bot] Add spec.domain.devices.useVirtioTransitional boolean to support virtio-transitional for old guests
+- [PR #4855][kubevirt-bot] Fix an issue where it may not be able to update the KubeVirt CR after creation for up to minutes due to certificate propagation delays
+
+Contributors
+------------
+4 people contributed to this release:
+
+```
+12	Roman Mohr <rmohr@redhat.com>
+2	David Vossel <dvossel@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.37.3.md
+++ b/CHANGELOG/CHANGELOG-v0.37.3.md
@@ -1,0 +1,39 @@
+KubeVirt v0.37.3
+================
+
+This release follows v0.37.2 and consists of 8 changes, contributed by 5 people, leading to 34 files changed, 563 insertions(+), 40 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.37.3.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.37.3`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6595][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #5852][rthallisey] Prometheus metrics scraped from virt-handler are now served from the VMI informer cache, rather than calling back to the Kubernetes API for VMI information.
+
+Contributors
+------------
+5 people contributed to this release:
+
+```
+4	Jed Lejosne <jed@redhat.com>
+1	Marcus Sorensen <mls@apple.com>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.38.0.md
+++ b/CHANGELOG/CHANGELOG-v0.38.0.md
@@ -1,0 +1,78 @@
+KubeVirt v0.38.0
+================
+
+This release follows v0.37.2 and consists of 283 changes, contributed by 34 people, leading to 1794 files changed, 110324 insertions(+), 36909 deletions(-).
+v0.38.0 is a promotion of release candidate v0.38.0-rc.0 which was originally published 2021-02-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.38.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.38.0`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #4870][qinqon] Bump k8s deps to 0.20.2
+- [PR #4571][yuvalturg] Added os, workflow and flavor labels to the kubevirt_vmi_phase_count metric
+- [PR #4659][salanki] Fixed an issue where non-root users inside a guest could not write to a Virtio-FS mount.
+- [PR #4844][xpivarc] Fixed limits/requests to accept int again
+- [PR #4850][rmohr] virtio-scsi now respects the useTransitionalVirtio flag instead of assigning a virtio version depending on the machine layout
+- [PR #4672][vladikr] allow increasing logging verbosity of infra components in KubeVirt CR
+- [PR #4838][rmohr] Fix an issue where it may not be able to update the KubeVirt CR after creation for up to minutes due to certificate propagation delays
+- [PR #4806][rmohr] Make the mutating webhooks for VMIs and VMs  required to avoid letting entities into the cluster which are not properly defaulted
+- [PR #4779][brybacki] Error messsge on virtctl image-upload to WaitForFirstConsumer DV
+- [PR #4749][davidvossel] KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION env var for specifying exactly what client-go scheme version is registered
+- [PR #4772][jean-edouard] Faster VMI phase transitions thanks to an increased number of VMI watch threads in virt-controller
+- [PR #4730][rmohr] Add spec.domain.devices.useVirtioTransitional boolean to support virtio-transitional for old guests
+
+Contributors
+------------
+34 people contributed to this release:
+
+```
+74	Roman Mohr <rmohr@redhat.com>
+31	Zhou Hao <zhouhao@cn.fujitsu.com>
+19	Dan Kenigsberg <danken@redhat.com>
+11	Vladik Romanovsky <vromanso@redhat.com>
+9	Ezra Silvera <ezra@il.ibm.com>
+8	Alona Kaplan <alkaplan@redhat.com>
+8	iholder <iholder@redhat.com>
+6	David Vossel <dvossel@redhat.com>
+6	Miguel Duarte Barroso <mdbarroso@redhat.com>
+6	Vasiliy Ulyanov <vulyanov@suse.de>
+5	Bartosz Rybacki <brybacki@redhat.com>
+5	Federico Gimenez <fgimenez@redhat.com>
+4	Andrey Odarenko <andreyo@il.ibm.com>
+3	Alexander Wels <awels@redhat.com>
+3	L. Pivarc <lpivarc@redhat.com>
+2	Andrea Bolognani <abologna@redhat.com>
+2	Edward Haas <edwardh@redhat.com>
+2	Jed Lejosne <jed@redhat.com>
+2	Quique Llorente <ellorent@redhat.com>
+1	Ashley Schuett <aschuett@redhat.com>
+1	Daniel Hiller <dhiller@redhat.com>
+1	Hu Shuai <hus.fnst@cn.fujitsu.com>
+1	Kedar Bidarkar <kbidarka@redhat.com>
+1	Or Shoval <oshoval@redhat.com>
+1	Peter Salanki <peter@salanki.st>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+1	Shaul Garbourg <sgarbour@redhat.com>
+1	Yoshiki Fujikane <ffjlabo@gmail.com>
+1	Yuval Turgeman <yturgema@redhat.com>
+1	alonSadan <asadan@redhat.com>
+1	ansijain <ansi.jain@india.nec.com>
+1	zouyu <zouy.fnst@cn.fujitsu.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.38.1.md
+++ b/CHANGELOG/CHANGELOG-v0.38.1.md
@@ -1,0 +1,78 @@
+KubeVirt v0.38.1
+================
+
+This release follows v0.37.2 and consists of 285 changes, contributed by 34 people, leading to 1794 files changed, 110347 insertions(+), 36909 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.38.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.38.1`.
+
+Pre-built containers are published on Docker Hub and can be viewed at: <https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #4870][qinqon] Bump k8s deps to 0.20.2
+- [PR #4571][yuvalturg] Added os, workflow and flavor labels to the kubevirt_vmi_phase_count metric
+- [PR #4659][salanki] Fixed an issue where non-root users inside a guest could not write to a Virtio-FS mount.
+- [PR #4844][xpivarc] Fixed limits/requests to accept int again
+- [PR #4850][rmohr] virtio-scsi now respects the useTransitionalVirtio flag instead of assigning a virtio version depending on the machine layout
+- [PR #4672][vladikr] allow increasing logging verbosity of infra components in KubeVirt CR
+- [PR #4838][rmohr] Fix an issue where it may not be able to update the KubeVirt CR after creation for up to minutes due to certificate propagation delays
+- [PR #4806][rmohr] Make the mutating webhooks for VMIs and VMs  required to avoid letting entities into the cluster which are not properly defaulted
+- [PR #4779][brybacki] Error messsge on virtctl image-upload to WaitForFirstConsumer DV
+- [PR #4749][davidvossel] KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION env var for specifying exactly what client-go scheme version is registered
+- [PR #4772][jean-edouard] Faster VMI phase transitions thanks to an increased number of VMI watch threads in virt-controller
+- [PR #4730][rmohr] Add spec.domain.devices.useVirtioTransitional boolean to support virtio-transitional for old guests
+
+Contributors
+------------
+34 people contributed to this release:
+
+```
+74	Roman Mohr <rmohr@redhat.com>
+31	Zhou Hao <zhouhao@cn.fujitsu.com>
+19	Dan Kenigsberg <danken@redhat.com>
+11	Vladik Romanovsky <vromanso@redhat.com>
+9	Ezra Silvera <ezra@il.ibm.com>
+8	Alona Kaplan <alkaplan@redhat.com>
+8	iholder <iholder@redhat.com>
+6	David Vossel <dvossel@redhat.com>
+6	Miguel Duarte Barroso <mdbarroso@redhat.com>
+6	Vasiliy Ulyanov <vulyanov@suse.de>
+5	Bartosz Rybacki <brybacki@redhat.com>
+5	Federico Gimenez <fgimenez@redhat.com>
+4	Andrey Odarenko <andreyo@il.ibm.com>
+3	Alexander Wels <awels@redhat.com>
+3	L. Pivarc <lpivarc@redhat.com>
+2	Andrea Bolognani <abologna@redhat.com>
+2	Edward Haas <edwardh@redhat.com>
+2	Jed Lejosne <jed@redhat.com>
+2	Quique Llorente <ellorent@redhat.com>
+1	Ashley Schuett <aschuett@redhat.com>
+1	Daniel Hiller <dhiller@redhat.com>
+1	Hu Shuai <hus.fnst@cn.fujitsu.com>
+1	Kedar Bidarkar <kbidarka@redhat.com>
+1	Or Shoval <oshoval@redhat.com>
+1	Peter Salanki <peter@salanki.st>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+1	Shaul Garbourg <sgarbour@redhat.com>
+1	Yoshiki Fujikane <ffjlabo@gmail.com>
+1	Yuval Turgeman <yturgema@redhat.com>
+1	alonSadan <asadan@redhat.com>
+1	ansijain <ansi.jain@india.nec.com>
+1	zouyu <zouy.fnst@cn.fujitsu.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.38.2.md
+++ b/CHANGELOG/CHANGELOG-v0.38.2.md
@@ -1,0 +1,39 @@
+KubeVirt v0.38.2
+================
+
+This release follows v0.38.1 and consists of 8 changes, contributed by 5 people, leading to 34 files changed, 565 insertions(+), 40 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.38.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.38.2`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6596][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #5853][rthallisey] Prometheus metrics scraped from virt-handler are now served from the VMI informer cache, rather than calling back to the Kubernetes API for VMI information.
+
+Contributors
+------------
+5 people contributed to this release:
+
+```
+4	Jed Lejosne <jed@redhat.com>
+1	Marcus Sorensen <mls@apple.com>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.39.0.md
+++ b/CHANGELOG/CHANGELOG-v0.39.0.md
@@ -1,0 +1,88 @@
+KubeVirt v0.39.0
+================
+
+This release follows v0.38.1 and consists of 227 changes, contributed by 38 people, leading to 480 files changed, 16457 insertions(+), 16077 deletions(-).
+v0.39.0 is a promotion of release candidate v0.39.0-rc.0 which was originally published 2021-03-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.39.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.39.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #5010][jean-edouard] Migrated VMs stay persistent and can therefore survive S3, among other things.
+- [PR #4952][ashleyschuett] Create warning NodeUnresponsive event if a node is running a VMI pod but not a virt-handler pod
+- [PR #4686][davidvossel] Automated workload updates via new KubeVirt WorkloadUpdateStrategy API
+- [PR #4886][awels] Hotplug support for WFFC datavolumes.
+- [PR #5026][AlonaKaplan] virt-launcher, masquerade binding - prefer nft over iptables.
+- [PR #4921][borod108] Added support for Sysprep in the API. A user can now add a answer file through a ConfigMap or a Secret. The User Guide is updated accordingly. /kind feature
+- [PR #4874][ormergi] Add new feature-gate SRIOVLiveMigration,
+- [PR #4917][iholder-redhat] Now it is possible to enable QEMU SeaBios debug logs setting virt-launcher log verbosity to be greater than 5.
+- [PR #4966][arnongilboa] Solve virtctl "Error when closing file ... file already closed" that shows after successful image upload
+- [PR #4489][salanki] Fix a bug where a disk.img file was created on filesystems mounted via Virtio-FS
+- [PR #4982][xpivarc] Fixing handling of transient domain
+- [PR #4984][ashleyschuett] Change customizeComponents.patches such that '*' resourceName or resourceType matches all, all fields of a patch (type, patch, resourceName, resourceType) are now required.
+- [PR #4972][vladikr] allow disabling pvspinlock to support older guest kernels
+- [PR #4927][yuhaohaoyu] Fix of XML and JSON marshalling/unmarshalling for user defined device alias names which can make migrations fail.
+- [PR #4552][rthallisey] VMs using bridged networking will survive a kubelet restart by having kubevirt create a dummy interface on the virt-launcher pods, so that some Kubernetes CNIs, that have implemented the `CHECK` RPC call, will not cause VMI pods to enter a failed state.
+- [PR #4883][iholder-redhat] Bug fixed: Enabling libvirt debug logs only if debugLogs label value is "true", disabling otherwise.
+- [PR #4840][alicefr] Generate k8s events on IO errors
+- [PR #4940][vladikr] permittedHostDevices will support both upper and lowercase letters in the device ID
+
+Contributors
+------------
+38 people contributed to this release:
+
+```
+37	David Vossel <dvossel@redhat.com>
+14	Miguel Duarte Barroso <mdbarroso@redhat.com>
+13	Roman Mohr <rmohr@redhat.com>
+10	Or Mergi <ormergi@redhat.com>
+9	Vladik Romanovsky <vromanso@redhat.com>
+8	Ashley Schuett <aschuett@redhat.com>
+7	Dan Kenigsberg <danken@redhat.com>
+7	Daniel Hiller <dhiller@redhat.com>
+7	Edward Haas <edwardh@redhat.com>
+7	iholder <iholder@redhat.com>
+6	Alexander Wels <awels@redhat.com>
+4	Jakub Guzik <jakubmguzik@gmail.com>
+4	Jed Lejosne <jed@redhat.com>
+3	Alice Frosi <afrosi@redhat.com>
+3	Itamar Holder <iholder@redhat.com>
+3	Or Shoval <oshoval@redhat.com>
+2	Federico Gimenez <fgimenez@redhat.com>
+2	Michael Henriksen <mhenriks@redhat.com>
+2	Peter Salanki <peter@salanki.st>
+2	Ryan Hallisey <rhallisey@nvidia.com>
+2	Yuval Turgeman <yturgema@redhat.com>
+1	Alona Kaplan <alkaplan@redhat.com>
+1	Andrew DeMaria <ademaria@cloudflare.com>
+1	Arnon Gilboa <agilboa@redhat.com>
+1	Cole Robinson <crobinso@redhat.com>
+1	Fabian Deutsch <fabiand@redhat.com>
+1	Hao Yu <yuh@us.ibm.com>
+1	L. Pivarc <lpivarc@redhat.com>
+1	Marcin Franczyk <marcin0franczyk@gmail.com>
+1	Petr Horacek <phoracek@redhat.com>
+1	Quique Llorente <ellorent@redhat.com>
+1	Radim Hrazdil <rhrazdil@redhat.com>
+1	Stu Gott <sgott@redhat.com>
+1	Yan Zhu <yanzhu@alauda.io>
+1	borod108 <bodnopoz@redhat.com>
+1	zouyu <zouy.fnst@cn.fujitsu.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.39.1.md
+++ b/CHANGELOG/CHANGELOG-v0.39.1.md
@@ -1,0 +1,32 @@
+KubeVirt v0.39.1
+================
+
+This release follows v0.39.0 and consists of 6 changes, contributed by 5 people, leading to 6 files changed, 322 insertions(+), 33 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.39.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.39.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Contributors
+------------
+5 people contributed to this release:
+
+```
+3	Vasiliy Ulyanov <vulyanov@suse.de>
+1	Yan Du <yadu@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.39.2.md
+++ b/CHANGELOG/CHANGELOG-v0.39.2.md
@@ -1,0 +1,41 @@
+KubeVirt v0.39.2
+================
+
+This release follows v0.39.1 and consists of 12 changes, contributed by 6 people, leading to 37 files changed, 584 insertions(+), 59 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.39.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.39.2`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6597][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #5854][rthallisey] Prometheus metrics scraped from virt-handler are now served from the VMI informer cache, rather than calling back to the Kubernetes API for VMI information.
+- [PR #5561][kubevirt-bot] Fix `docker save` issues with kubevirt images
+
+Contributors
+------------
+6 people contributed to this release:
+
+```
+4	Jed Lejosne <jed@redhat.com>
+3	Roman Mohr <rmohr@redhat.com>
+1	Marcus Sorensen <mls@apple.com>
+1	Vasiliy Ulyanov <vulyanov@suse.de>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.4.0.md
+++ b/CHANGELOG/CHANGELOG-v0.4.0.md
@@ -1,0 +1,77 @@
+KubeVirt v0.4.0
+===============
+
+This release follows v0.3.0 and consists of 180 changes, contributed by
+16 people, leading to 2272 files changed, 146578 insertions(+), 285629
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.4.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Fix several networking issues
+- Add and enable OpenShift support to CI
+- Add conditional Windows tests (if an image is present)
+- Add subresources for console access
+- virtctl config alignmnet with kubectl
+- Fix API reference generation
+- Stable UUIDs for OfflineVirtualMachines
+- Build virtctl for MacOS and Windows
+- Set default architecture to x86_64
+- Major improvement to the CI infrastructure (all containerized)
+- virtctl convenience functions for starting and stopping a VM
+
+Contributors
+------------
+
+16 people contributed to this release:
+
+```
+        53	David Vossel <dvossel@redhat.com>
+        44	Roman Mohr <rmohr@redhat.com>
+        20	Marcus Sorensen <mls@apple.com>
+        16	Stu Gott <sgott@redhat.com>
+        11	Fabian Deutsch <fabiand@redhat.com>
+         9	Lukianov Artyom <alukiano@redhat.com>
+         7	Vladik Romanovsky <vromanso@redhat.com>
+         4	Francesco Romani <fromani@redhat.com>
+         4	Lukas Bednar <lbednar@redhat.com>
+         3	Artyom Lukianov <alukiano@redhat.com>
+         3	Marek Libra <mlibra@redhat.com>
+         2	Marc Sluiter <marc@slintes.net>
+         1	Petr Kotas <petr.kotas@gmail.com>
+         1	Raghavendra Talur <rtalur@redhat.com>
+         1	Ryan Hallisey <rhallise@redhat.com>
+         1	mlsorensen <shadowsor@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 65 of 67 Specs in 2341.639 seconds
+> FAIL! -- 60 Passed | 5 Failed | 0 Pending | 2 Skipped --- FAIL: TestTests (2341.64s)
+```
+
+Note: The test failures are due to CI problems.
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.4.1.md
+++ b/CHANGELOG/CHANGELOG-v0.4.1.md
@@ -1,0 +1,61 @@
+KubeVirt v0.4.1
+===============
+
+This release follows v0.4.0 and consists of 40 changes, contributed by
+8 people, leading to 297 files changed, 42433 insertions(+), 699 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.4.1>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- VM shutdown fixes and tests
+- Functional test for CRD validation
+- Windows VM test
+- DHCP link-local change
+
+Contributors
+------------
+
+8 people contributed to this release:
+
+```
+        18	David Vossel <dvossel@redhat.com>
+         9	Roman Mohr <rmohr@redhat.com>
+         8	Artyom Lukianov <alukiano@redhat.com>
+         1	Lukas Bednar <lbednar@redhat.com>
+         1	Marcus Sorensen <mls@apple.com>
+         1	Petr Kotas <pkotas@redhat.com>
+         1	Vladik Romanovsky <vromanso@redhat.com>
+         1	karmab <karimboumedhel@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 71 of 77 Specs in 2185.664 seconds
+> SUCCESS! -- 71 Passed | 0 Failed | 0 Pending | 6 Skipped PASS
+> Ran 6 of 79 Specs in 459.489 seconds
+> SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 73 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.40.0.md
+++ b/CHANGELOG/CHANGELOG-v0.40.0.md
@@ -1,0 +1,108 @@
+KubeVirt v0.40.0
+================
+
+This release follows v0.39.0 and consists of 450 changes, contributed by 51 people, leading to 646 files changed, 42768 insertions(+), 6668 deletions(-).
+v0.40.0 is a promotion of release candidate v0.40.0-rc.2 which was originally published 2021-04-16
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.40.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.40.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #5467][rmohr] Fixes upgrades from KubeVirt v0.36
+- [PR #5350][jean-edouard] Removal of entire `permittedHostDevices` section will now remove all user-defined host device plugins.
+- [PR #5242][jean-edouard] Creating more than 1 migration at the same time for a given VMI will now fail
+- [PR #4907][vasiliy-ul] Initial cgroupv2 support
+- [PR #5324][jean-edouard] Default feature gates can now be defined in the provider configuration.
+- [PR #5006][alicefr] Add discard=unmap option
+- [PR #5022][davidvossel] Fixes race condition between operator adding service and webhooks that can result in installs/uninstalls failing
+- [PR #5310][ashleyschuett] Reconcile CRD resources
+- [PR #5102][iholder-redhat] Go version updated to 1.14.14
+- [PR #4746][ashleyschuett] Reconcile Deployments, DaemonSets, MutatingWebhookConfigurations and ValidatingWebhookConfigurations
+- [PR #5037][ormergi] Hot-plug SR-IOV VF interfaces to VM's post a successful migration.
+- [PR #5269][mlsorensen] Prometheus metrics scraped from virt-handler are now served from the VMI informer cache, rather than calling back to the Kubernetes API for VMI information.
+- [PR #5138][davidvossel] virt-handler now waits up to 5 minutes for all migrations on the node to complete before shutting down.
+- [PR #5191][yuvalturg] Added a metric for monitoring CPU affinity
+- [PR #5215][xphyr] Enable detection of Intel GVT-g vGPU.
+- [PR #4760][rmohr] Make virt-handler heartbeat more efficient and robust: Only one combined PATCH and no need to detect different cluster types anymore.
+- [PR #5091][iholder-redhat] QEMU SeaBios debug logs are being seen as part of virt-launcher log.
+- [PR #5221][rmohr] Remove  workload placement validation webhook which blocks placement updates when VMIs are running
+- [PR #5128][yuvalturg] Modified memory related metrics by adding several new metrics and splitting the swap traffic bytes metric
+- [PR #5084][ashleyschuett] Add validation to CustomizeComponents object on the KubeVirt resource
+- [PR #5182][davidvossel] New [release-blocker] functional test marker to signify tests that can never be disabled before making a release
+- [PR #5137][davidvossel] Added our policy around release branch backporting in docs/release-branch-backporting.md
+- [PR #5096][yuvalturg] Modified networking metrics by adding new metrics, splitting existing ones by rx/tx and using the device alias for the interface name when available
+- [PR #5088][awels] Hotplug works with hostpath storage.
+- [PR #4908][dhiller] Move travis tag and master builds to kubevirt prow.
+- [PR #4741][EdDev] Allow live migration for SR-IOV VM/s without preserving the VF interfaces.
+
+Contributors
+------------
+51 people contributed to this release:
+
+```
+51	Edward Haas <edwardh@redhat.com>
+48	Roman Mohr <rmohr@redhat.com>
+23	David Vossel <dvossel@redhat.com>
+21	Vasiliy Ulyanov <vulyanov@suse.de>
+12	Ashley Schuett <aschuett@redhat.com>
+12	Bartosz Rybacki <brybacki@redhat.com>
+12	Itamar Holder <iholder@redhat.com>
+12	Or Mergi <ormergi@redhat.com>
+11	Federico Gimenez <fgimenez@redhat.com>
+11	Or Shoval <oshoval@redhat.com>
+10	Dan Kenigsberg <danken@redhat.com>
+8	Antonio Cardace <acardace@redhat.com>
+7	L. Pivarc <lpivarc@redhat.com>
+6	Karel Šimon <ksimon@redhat.com>
+5	Alexander Wels <awels@redhat.com>
+5	Daniel Hiller <dhiller@redhat.com>
+5	Jed Lejosne <jed@redhat.com>
+4	Andrey Odarenko <andreyo@il.ibm.com>
+4	Hao Yu <yuh@us.ibm.com>
+4	Maya Rashish <mrashish@redhat.com>
+3	Victor Toso <victortoso@redhat.com>
+3	Yuval Turgeman <yturgema@redhat.com>
+3	alonsadan <asadan@redhat.com>
+2	Alice Frosi <afrosi@redhat.com>
+2	Andrej Krejcir <akrejcir@redhat.com>
+2	Erkan Erol <eerol@redhat.com>
+2	Mark DeNeve <markd@xphyr.net>
+2	Quique Llorente <ellorent@redhat.com>
+2	Vladik Romanovsky <vromanso@redhat.com>
+2	ansijain <ansi.jain@india.nec.com>
+2	jichenjc <jichenjc@cn.ibm.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Arnon Gilboa <agilboa@redhat.com>
+1	Ashley Schuett <ashleyns1992@gmail.com>
+1	Cole Robinson <crobinso@redhat.com>
+1	Federico Gimenez <fgimenez@users.noreply.github.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Kavya <kavya.g@ibm.com>
+1	Marcus Sorensen <mls@apple.com>
+1	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+1	Shelly Kagan <skagan@redhat.com>
+1	Shweta Padubidri <spadubid@redhat.com>
+1	Stu Gott <sgott@redhat.com>
+1	Tomas Psota <to.psota@gmail.com>
+1	Tomas Psota <tpsota@redhat.com>
+1	Vatsal Parekh <vparekh@redhat.com>
+1	Yan Du <yadu@redhat.com>
+1	alonsadan <alonsadan1@gmail.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.40.1.md
+++ b/CHANGELOG/CHANGELOG-v0.40.1.md
@@ -1,0 +1,43 @@
+KubeVirt v0.40.1
+================
+
+This release follows v0.40.0 and consists of 19 changes, contributed by 7 people, leading to 40 files changed, 1153 insertions(+), 94 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.40.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.40.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6598][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #6287][kubevirt-bot] Fix goroutine leak in virt-handler, potentially causing issues with a high turnover of VMIs.
+- [PR #5559][kubevirt-bot] Fix `docker save` issues with kubevirt images
+- [PR #5500][kubevirt-bot] Support hotplug with virtctl using addvolume and removevolume commands
+
+Contributors
+------------
+7 people contributed to this release:
+
+```
+7	Alexander Wels <awels@redhat.com>
+4	Jed Lejosne <jed@redhat.com>
+1	Kevin Wiesmueller <kwiesmul@redhat.com>
+1	Roman Mohr <rmohr@redhat.com>
+1	Vasiliy Ulyanov <vulyanov@suse.de>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.41.0.md
+++ b/CHANGELOG/CHANGELOG-v0.41.0.md
@@ -1,0 +1,108 @@
+KubeVirt v0.41.0
+================
+
+This release follows v0.40.0 and consists of 398 changes, contributed by 46 people, leading to 398 files changed, 20967 insertions(+), 6926 deletions(-).
+v0.41.0 is a promotion of release candidate v0.41.0-rc.1 which was originally published 2021-05-11
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.41.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.41.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #5586][kubevirt-bot] This version of KubeVirt includes upgraded virtualization technology based on libvirt 7.0.0 and QEMU 5.2.0.
+- [PR #5344][ashleyschuett] Reconcile PrometheusRules and ServiceMonitor resources
+- [PR #5542][andreyod] Add startStrategy field to VMI spec to allow Virtual Machine start in paused state.
+- [PR #5459][ashleyschuett] Reconcile service resource
+- [PR #5520][ashleyschuett] Reconcile required labels and annotations on ConfigMap resources
+- [PR #5533][rmohr] Fix `docker save` and `docker push` issues with released kubevirt images
+- [PR #5428][oshoval] virt-launcher now populates domain's guestOS info and interfaces status according guest agent also when doing periodic resyncs.
+- [PR #5410][ashleyschuett] Reconcile ServiceAccount resources
+- [PR #5109][Omar007] Add support for specifying a logical and physical block size for disk devices
+- [PR #5471][ashleyschuett] Reconcile APIService resources
+- [PR #5513][ashleyschuett] Reconcile Secret resources
+- [PR #5496][davidvossel] Improvements to migration proxy logging
+- [PR #5376][ashleyschuett] Reconcile CustomResourceDefinition resources
+- [PR #5435][AlonaKaplan] Support dual stack service on "virtctl expose"-
+- [PR #5425][davidvossel] Fixes VM restart during eviction when EvictionStrategy=LiveMigrate
+- [PR #5423][ashleyschuett] Add resource requests to virt-controller, virt-api, virt-operator and virt-handler
+- [PR #5343][erkanerol] Some cleanups and small additions to the storage metrics
+- [PR #4682][stu-gott] Updated Guest Agent Version compatibility check. The new approach is much more accurate.
+- [PR #5485][rmohr] Fix fallback to iptables if nftables is not used on the host on arm64
+- [PR #5426][rmohr] Fix fallback to iptables if nftables is not used on the host
+- [PR #5403][tiraboschi] Added a kubevirt_ prefix to several recording rules and metrics
+- [PR #5241][stu-gott] Introduced Duration and RenewBefore parameters for cert rotation. Previous values are now deprecated.
+- [PR #5463][acardace] Fixes upgrades from KubeVirt v0.36
+- [PR #5456][zhlhahaha] Enable arm64 cross-compilation
+- [PR #3310][davidvossel] Doc outlines our Kubernetes version compatibility commitment
+- [PR #3383][EdDev] Add `vmIPv6NetworkCIDR` under `NetworkSource.pod` to support custom IPv6 CIDR for the vm network when using masquerade binding.
+- [PR #3415][zhlhahaha] Make kubevirt code fit for arm64 support. No testing is at this stage performed against arm64 at this point.
+- [PR #5147][xpivarc] Remove CAP_NET_ADMIN from the virt-launcher pod(second take).
+- [PR #5351][awels] Support hotplug with virtctl using addvolume and removevolume commands
+- [PR #5050][ashleyschuett] Fire Prometheus Alert when a vmi is orphaned for more than an hour
+
+Contributors
+------------
+46 people contributed to this release:
+
+```
+25	David Vossel <dvossel@redhat.com>
+21	Stu Gott <sgott@redhat.com>
+20	Ashley Schuett <aschuett@redhat.com>
+18	Miguel Duarte Barroso <mdbarroso@redhat.com>
+13	Itamar Holder <iholder@redhat.com>
+11	Alexander Wels <awels@redhat.com>
+11	Or Mergi <ormergi@redhat.com>
+10	Vladik Romanovsky <vromanso@redhat.com>
+9	Alona Kaplan <alkaplan@redhat.com>
+8	Federico Gimenez <fgimenez@redhat.com>
+8	Howard Zhang <howard.zhang@arm.com>
+8	L. Pivarc <lpivarc@redhat.com>
+8	Quique Llorente <ellorent@redhat.com>
+8	Roman Mohr <rmohr@redhat.com>
+8	Shelly Kagan <skagan@redhat.com>
+7	Andrey Odarenko <andreyo@il.ibm.com>
+7	Ezra Silvera <ezra@il.ibm.com>
+7	Or Shoval <oshoval@redhat.com>
+6	Antonio Cardace <acardace@redhat.com>
+6	Edward Haas <edwardh@redhat.com>
+6	Karel Šimon <ksimon@redhat.com>
+5	Erkan Erol <eerol@redhat.com>
+4	Andrea Bolognani <abologna@redhat.com>
+3	Yuval Turgeman <yturgema@redhat.com>
+2	Alice Frosi <afrosi@redhat.com>
+2	Bartosz Rybacki <brybacki@redhat.com>
+2	Dan Kenigsberg <danken@redhat.com>
+2	Federico Gimenez <fgimenez@users.noreply.github.com>
+2	Omar Pakker <Omar007@users.noreply.github.com>
+2	Vasiliy Ulyanov <vulyanov@suse.de>
+2	Vatsal Parekh <vparekh@redhat.com>
+1	Alex <alexsimonjones@gmail.com>
+1	Andrej Krejcir <akrejcir@redhat.com>
+1	Daniel Hiller <dhiller@redhat.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Maya Rashish <mrashish@redhat.com>
+1	Michael Henriksen <mhenriks@redhat.com>
+1	Radim Hrazdil <rhrazdil@redhat.com>
+1	Ram Lavi <ralavi@redhat.com>
+1	Shirly Radco <sradco@redhat.com>
+1	Tomas Psota <tpsota@redhat.com>
+1	cchen <actor168@gmail.com>
+1	jichenjc <jichenjc@cn.ibm.com>
+1	root <root@viosd2.watson.ibm.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.41.1.md
+++ b/CHANGELOG/CHANGELOG-v0.41.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.41.1
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.41.2.md
+++ b/CHANGELOG/CHANGELOG-v0.41.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.41.2
+================
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.41.3.md
+++ b/CHANGELOG/CHANGELOG-v0.41.3.md
@@ -1,0 +1,65 @@
+KubeVirt v0.41.3
+================
+
+This release follows v0.41.0 and consists of 84 changes, contributed by 18 people, leading to 81 files changed, 2480 insertions(+), 3221 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.41.3.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.41.3`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6196][ashleyschuett] Allow multiple shutdown events to ensure the event is received by ACPI
+- [PR #6194][kubevirt-bot] Allow Failed VMs to be stopped when using `--force --gracePeriod 0`
+- [PR #6039][akalenyu] BugFix: Pending VMIs when creating concurrent bulk of VMs backed by WFFC DVs
+- [PR #5917][davidvossel] Fixes event recording causing a segfault in virt-controller
+- [PR #5886][ashleyschuett] Allow virtctl to stop VM and ignore the graceful shutdown period
+- [PR #5866][xpivarc] Fix: Kubevirt build with golang 1.14+ will not fail on validation of container disk with memory allocation error
+- [PR #5873][kubevirt-bot] Update ca-bundle if it is unable to be parsed
+- [PR #5822][kubevirt-bot] migrated references of authorization/v1beta1 to authorization/v1
+- [PR #5704][davidvossel] Fix virt-controller clobbering in progress vmi migration state during virt handler handoff
+- [PR #5707][kubevirt-bot] Fixes null pointer dereference in migration controller
+- [PR #5685][stu-gott] [bugfix] - reject VM defined with volume with no matching disk
+- [PR #5670][stu-gott] Validation/Mutation webhooks now explicitly define a 10 second timeout period
+- [PR #5653][kubevirt-bot] virt-launcher now populates domain's guestOS info and interfaces status according guest agent also when doing periodic resyncs.
+- [PR #5644][kubevirt-bot] Fix live-migration failing when VM with masquarade iface has explicitly specified any of these ports: 22222, 49152, 49153
+- [PR #5646][kubevirt-bot] virtctl rename support is dropped
+
+Contributors
+------------
+18 people contributed to this release:
+
+```
+17	Ashley Schuett <aschuett@redhat.com>
+8	David Vossel <dvossel@redhat.com>
+5	Roman Mohr <rmohr@redhat.com>
+4	L. Pivarc <lpivarc@redhat.com>
+4	Radim Hrazdil <rhrazdil@redhat.com>
+3	Antonio Cardace <acardace@redhat.com>
+2	Itamar Holder <iholder@redhat.com>
+2	Jed Lejosne <jed@redhat.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Alexander Wels <awels@redhat.com>
+1	Bartosz Rybacki <brybacki@redhat.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Karel Šimon <ksimon@redhat.com>
+1	Omer Yahud <oyahud@redhat.com>
+1	Or Shoval <oshoval@redhat.com>
+1	Petr Horáček <phoracek@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.41.4.md
+++ b/CHANGELOG/CHANGELOG-v0.41.4.md
@@ -1,0 +1,50 @@
+KubeVirt v0.41.4
+================
+
+This release follows v0.41.3 and consists of 37 changes, contributed by 11 people, leading to 70 files changed, 2270 insertions(+), 624 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.41.4.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.41.4`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6573][acardace] mutate migration PDBs instead of creating an additional one for the duration of the migration.
+- [PR #6517][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #6333][acardace] Fix virt-launcher exit pod race condition
+- [PR #6401][rmohr] Fix rbac permissions for freeze/unfreeze, addvolume/removevolume, guestosinfo, filesystemlist and userlist
+- [PR #6147][rmohr] Fix rbac permissions for freeze/unfreeze, addvolume/removevolume, guestosinfo, filesystemlist and userlist
+- [PR #5673][kubevirt-bot] Improved logging around VM/VMI shutdown and restart
+- [PR #6227][kwiesmueller] Fix goroutine leak in virt-handler, potentially causing issues with a high turnover of VMIs.
+
+Contributors
+------------
+11 people contributed to this release:
+
+```
+7	Jed Lejosne <jed@redhat.com>
+6	Antonio Cardace <acardace@redhat.com>
+3	Itamar Holder <iholder@redhat.com>
+1	David Vossel <dvossel@redhat.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Kevin Wiesmueller <kwiesmul@redhat.com>
+1	L. Pivarc <lpivarc@redhat.com>
+1	Marcus Sorensen <mls@apple.com>
+1	Shelly Kagan <skagan@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.42.0.md
+++ b/CHANGELOG/CHANGELOG-v0.42.0.md
@@ -1,0 +1,95 @@
+KubeVirt v0.42.0
+================
+
+This release follows v0.41.0 and consists of 326 changes, contributed by 36 people, leading to 699 files changed, 51909 insertions(+), 23263 deletions(-).
+v0.42.0 is a promotion of release candidate v0.42.0-rc.0 which was originally published 2021-06-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.42.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.42.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #5738][rmohr] Stop releasing jinja2 templates of our operator. Kustomize is the preferred way for customizations.
+- [PR #5691][ashleyschuett] Allow multiple shutdown events to ensure the event is received by ACPI
+- [PR #5558][ormergi] Drop virt-launcher SYS_RESOURCE capability
+- [PR #5694][davidvossel] Fixes null pointer dereference in migration controller
+- [PR #5416][iholder-redhat] [feature] support booting VMs from a custom kernel/initrd images with custom kernel arguments
+- [PR #5495][iholder-redhat] Go version updated to version 1.16.1.
+- [PR #5502][rmohr] Add downwardMetrics volume to expose a limited set of hots metrics to guests
+- [PR #5601][maya-r] Update libvirt-go to 7.3.0
+- [PR #5661][davidvossel] Validation/Mutation webhooks now explicitly define a 10 second timeout period
+- [PR #5652][rmohr] Automatically discover kube-prometheus installations and configure kubevirt monitoring
+- [PR #5631][davidvossel] Expand backport policy to include logging and debug fixes
+- [PR #5528][zcahana] Introduced a "status.printableStatus" field in the VirtualMachine CRD. This field is now displayed in the tabular output of "kubectl get vm".
+- [PR #5200][rhrazdil] Add support for Istio proxy traffic routing with masquerade interface. nftables is required for this feature.
+- [PR #5560][oshoval] virt-launcher now populates domain's guestOS info and interfaces status according guest agent also when doing periodic resyncs.
+- [PR #5514][rhrazdil] Fix live-migration failing when VM with masquarade iface has explicitly specified any of these ports: 22222, 49152, 49153
+- [PR #5583][dhiller] Reenable coverage
+- [PR #5129][davidvossel] Gracefully shutdown virt-api connections and ensure zero exit code under normal shutdown conditions
+- [PR #5582][dhiller] Fix flaky unit tests
+- [PR #5600][davidvossel] Improved logging around VM/VMI shutdown and restart
+- [PR #5564][omeryahud] virtctl rename support is dropped
+- [PR #5585][iholder-redhat] [bugfix] - reject VM defined with volume with no matching disk
+- [PR #5595][zcahana] Fixes adoption of orphan DataVolumes
+- [PR #5566][davidvossel] Release branches are now cut on the first _business day_ of the month rather than the first day.
+- [PR #5108][Omar007] Fixes handling of /proc/<pid>/mountpoint by working on the device information instead of mount information
+- [PR #5250][mlsorensen] Controller health checks will no longer actively test connectivity to the Kubernetes API. They will rely in health of their watches to determine if they have API connectivity.
+- [PR #5563][ashleyschuett] Set KubeVirt resources flags in the KubeVirt CR
+- [PR #5328][andreabolognani] This version of KubeVirt includes upgraded virtualization technology based on libvirt 7.0.0 and QEMU 5.2.0.
+
+Contributors
+------------
+36 people contributed to this release:
+
+```
+38	Roman Mohr <rmohr@redhat.com>
+32	Miguel Duarte Barroso <mdbarroso@redhat.com>
+24	Itamar Holder <iholder@redhat.com>
+15	Ashley Schuett <aschuett@redhat.com>
+14	David Vossel <dvossel@redhat.com>
+14	Zvi Cahana <zvic@il.ibm.com>
+12	Maya Rashish <mrashish@redhat.com>
+10	Andrea Bolognani <abologna@redhat.com>
+10	Daniel Hiller <dhiller@redhat.com>
+9	Radim Hrazdil <rhrazdil@redhat.com>
+7	Zhou Hao <zhouhao@fujitsu.com>
+5	Omar Pakker <Omar007@users.noreply.github.com>
+5	Or Mergi <ormergi@redhat.com>
+3	Alexander Wels <awels@redhat.com>
+3	Bartosz Rybacki <brybacki@redhat.com>
+3	Federico Gimenez <fgimenez@redhat.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+2	Kevin Wiesmueller <kwiesmul@redhat.com>
+2	Marcus Sorensen <mls@apple.com>
+2	Omer Yahud <oyahud@redhat.com>
+2	Or Shoval <oshoval@redhat.com>
+1	Antonio Cardace <acardace@redhat.com>
+1	Jed Lejosne <jed@redhat.com>
+1	Karel Šimon <ksimon@redhat.com>
+1	Krzysztof Majcher <kmajcher@redhat.com>
+1	Mark DeNeve <markd@xphyr.net>
+1	Petr Horáček <phoracek@redhat.com>
+1	Shelly Kagan <skagan@redhat.com>
+1	Stu Gott <sgott@redhat.com>
+1	Vatsal Parekh <vparekh@redhat.com>
+1	Vladik Romanovsky <vromanso@redhat.com>
+1	Zou Yu <zouy.fnst@cn.fujitsu.com>
+1	dalia-frank <dafrank@redhat.com>
+1	ipinto <ipinto@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.42.1.md
+++ b/CHANGELOG/CHANGELOG-v0.42.1.md
@@ -1,0 +1,95 @@
+KubeVirt v0.42.1
+================
+
+This release follows v0.41.0 and consists of 328 changes, contributed by 36 people, leading to 700 files changed, 51909 insertions(+), 23267 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.42.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.42.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #5738][rmohr] Stop releasing jinja2 templates of our operator. Kustomize is the preferred way for customizations.
+- [PR #5691][ashleyschuett] Allow multiple shutdown events to ensure the event is received by ACPI
+- [PR #5558][ormergi] Drop virt-launcher SYS_RESOURCE capability
+- [PR #5694][davidvossel] Fixes null pointer dereference in migration controller
+- [PR #5416][iholder-redhat] [feature] support booting VMs from a custom kernel/initrd images with custom kernel arguments
+- [PR #5495][iholder-redhat] Go version updated to version 1.16.1.
+- [PR #5502][rmohr] Add downwardMetrics volume to expose a limited set of hots metrics to guests
+- [PR #5601][maya-r] Update libvirt-go to 7.3.0
+- [PR #5661][davidvossel] Validation/Mutation webhooks now explicitly define a 10 second timeout period
+- [PR #5652][rmohr] Automatically discover kube-prometheus installations and configure kubevirt monitoring
+- [PR #5631][davidvossel] Expand backport policy to include logging and debug fixes
+- [PR #5528][zcahana] Introduced a "status.printableStatus" field in the VirtualMachine CRD. This field is now displayed in the tabular output of "kubectl get vm".
+- [PR #5200][rhrazdil] Add support for Istio proxy traffic routing with masquerade interface. nftables is required for this feature.
+- [PR #5560][oshoval] virt-launcher now populates domain's guestOS info and interfaces status according guest agent also when doing periodic resyncs.
+- [PR #5514][rhrazdil] Fix live-migration failing when VM with masquarade iface has explicitly specified any of these ports: 22222, 49152, 49153
+- [PR #5583][dhiller] Reenable coverage
+- [PR #5129][davidvossel] Gracefully shutdown virt-api connections and ensure zero exit code under normal shutdown conditions
+- [PR #5582][dhiller] Fix flaky unit tests
+- [PR #5600][davidvossel] Improved logging around VM/VMI shutdown and restart
+- [PR #5564][omeryahud] virtctl rename support is dropped
+- [PR #5585][iholder-redhat] [bugfix] - reject VM defined with volume with no matching disk
+- [PR #5595][zcahana] Fixes adoption of orphan DataVolumes
+- [PR #5566][davidvossel] Release branches are now cut on the first _business day_ of the month rather than the first day.
+- [PR #5108][Omar007] Fixes handling of /proc/<pid>/mountpoint by working on the device information instead of mount information
+- [PR #5250][mlsorensen] Controller health checks will no longer actively test connectivity to the Kubernetes API. They will rely in health of their watches to determine if they have API connectivity.
+- [PR #5563][ashleyschuett] Set KubeVirt resources flags in the KubeVirt CR
+- [PR #5328][andreabolognani] This version of KubeVirt includes upgraded virtualization technology based on libvirt 7.0.0 and QEMU 5.2.0.
+
+Contributors
+------------
+36 people contributed to this release:
+
+```
+39	Roman Mohr <rmohr@redhat.com>
+32	Miguel Duarte Barroso <mdbarroso@redhat.com>
+24	Itamar Holder <iholder@redhat.com>
+15	Ashley Schuett <aschuett@redhat.com>
+14	David Vossel <dvossel@redhat.com>
+14	Zvi Cahana <zvic@il.ibm.com>
+12	Maya Rashish <mrashish@redhat.com>
+10	Andrea Bolognani <abologna@redhat.com>
+10	Daniel Hiller <dhiller@redhat.com>
+9	Radim Hrazdil <rhrazdil@redhat.com>
+7	Zhou Hao <zhouhao@fujitsu.com>
+5	Omar Pakker <Omar007@users.noreply.github.com>
+5	Or Mergi <ormergi@redhat.com>
+3	Alexander Wels <awels@redhat.com>
+3	Bartosz Rybacki <brybacki@redhat.com>
+3	Federico Gimenez <fgimenez@redhat.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+2	Kevin Wiesmueller <kwiesmul@redhat.com>
+2	Marcus Sorensen <mls@apple.com>
+2	Omer Yahud <oyahud@redhat.com>
+2	Or Shoval <oshoval@redhat.com>
+1	Antonio Cardace <acardace@redhat.com>
+1	Jed Lejosne <jed@redhat.com>
+1	Karel Šimon <ksimon@redhat.com>
+1	Krzysztof Majcher <kmajcher@redhat.com>
+1	Mark DeNeve <markd@xphyr.net>
+1	Petr Horáček <phoracek@redhat.com>
+1	Shelly Kagan <skagan@redhat.com>
+1	Stu Gott <sgott@redhat.com>
+1	Vatsal Parekh <vparekh@redhat.com>
+1	Vladik Romanovsky <vromanso@redhat.com>
+1	Zou Yu <zouy.fnst@cn.fujitsu.com>
+1	dalia-frank <dafrank@redhat.com>
+1	ipinto <ipinto@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.42.2.md
+++ b/CHANGELOG/CHANGELOG-v0.42.2.md
@@ -1,0 +1,43 @@
+KubeVirt v0.42.2
+================
+
+This release follows v0.42.1 and consists of 27 changes, contributed by 6 people, leading to 63 files changed, 1265 insertions(+), 177 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.42.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.42.2`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6554][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #5887][ashleyschuett] Allow virtctl to stop VM and ignore the graceful shutdown period
+- [PR #5907][kubevirt-bot] Fix: ioerrors don't cause crash-looping of notify server
+- [PR #5871][maiqueb] Fix: do not override with the DHCP server advertising IP with the gateway info.
+- [PR #5875][kubevirt-bot] Update ca-bundle if it is unable to be parsed
+
+Contributors
+------------
+6 people contributed to this release:
+
+```
+10	Ashley Schuett <aschuett@redhat.com>
+7	Miguel Duarte Barroso <mdbarroso@redhat.com>
+4	Jed Lejosne <jed@redhat.com>
+1	L. Pivarc <lpivarc@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.43.0.md
+++ b/CHANGELOG/CHANGELOG-v0.43.0.md
@@ -1,0 +1,102 @@
+KubeVirt v0.43.0
+================
+
+This release follows v0.42.1 and consists of 370 changes, contributed by 41 people, leading to 569 files changed, 17418 insertions(+), 24973 deletions(-).
+v0.43.0 is a promotion of release candidate v0.43.0-rc.1 which was originally published 2021-07-08
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.43.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.43.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #5952][mhenriks] Use CDI beta API. CDI v1.20.0 is now the minimum requirement for kubevirt.
+- [PR #5846][rmohr] Add "spec.cpu.numaTopologyPassthrough" which allows emulating a host-alligned virtual numa topology for high performance
+- [PR #5894][rmohr] Add `spec.migrations.disableTLS` to the KubeVirt CR to allow disabling encrypted migrations. They stay secure by default.
+- [PR #5649][awels] Enhancement: remove one attachment pod per disk limit (behavior on upgrade with running VM with hotplugged disks is undefined)
+- [PR #5742][rmohr] VMIs which choose evictionStrategy `LifeMigrate` and request the `invtsc` cpuflag are now live-migrateable
+- [PR #5911][dhiller] Bumps kubevirtci, also suppresses kubectl.sh output to avoid confusing checks
+- [PR #5863][xpivarc] Fix: ioerrors don't cause crash-looping of notify server
+- [PR #5867][mlsorensen] New build target added to export virt-* images as a tar archive.
+- [PR #5766][davidvossel] Addition of kubevirt_vmi_phase_transition_seconds_since_creation to monitor how long it takes to transition a VMI to a specific phase from creation time.
+- [PR #5823][dhiller] Change default branch to `main` for `kubevirt/kubevirt` repository
+- [PR #5763][nunnatsa] Fix bug 1945589: Prevent migration of VMIs that uses virtiofs
+- [PR #5827][mlsorensen] Auto-provisioned disk images on empty PVCs now leave 128KiB unused to avoid edge cases that run the volume out of space.
+- [PR #5849][davidvossel] Fixes event recording causing a segfault in virt-controller
+- [PR #5797][rhrazdil] Add serviceAccountDisk automatically when Istio is enabled in VMI annotations
+- [PR #5723][ashleyschuett] Allow virtctl to stop VM and ignore the graceful shutdown period
+- [PR #5806][mlsorensen] configmap, secret, and cloud-init raw disks now work when underlying node storage has 4k blocks.
+- [PR #5623][iholder-redhat] [bugfix]: Allow migration of VMs with host-model CPU to migrate only for compatible nodes
+- [PR #5716][rhrazdil] Fix issue with virt-launcher becoming `NotReady` after migration when Istio is used.
+- [PR #5778][ashleyschuett] Update ca-bundle if it is unable to be parsed
+- [PR #5787][acardace] migrated references of authorization/v1beta1 to authorization/v1
+- [PR #5461][rhrazdil] Add support for Istio proxy when no explicit ports are specified on masquerade interface
+- [PR #5751][acardace] EFI VMIs with secureboot disabled can now be booted even when only OVMF_CODE.secboot.fd and OVMF_VARS.fd are present in the virt-launcher image
+- [PR #5629][andreyod] Support starting Virtual Machine with its guest CPU paused using `virtctl start --paused`
+- [PR #5725][dhiller] Generate REST API coverage report after functional tests
+- [PR #5758][davidvossel] Fixes kubevirt_vmi_phase_count to include all phases, even those that occur before handler hand off.
+- [PR #5745][ashleyschuett] Alert with resource usage exceeds resource requests
+- [PR #5759][mhenriks] Update CDI to 1.34.1
+- [PR #5038][kwiesmueller] Add exec command to VM liveness and readinessProbe executed through the qemu-guest-agent.
+- [PR #5431][alonSadan] Add NFT and IPTables rules to allow port-forward to non-declared ports on the VMI. Declaring ports on VMI will limit
+
+Contributors
+------------
+41 people contributed to this release:
+
+```
+47	Roman Mohr <rmohr@redhat.com>
+22	Kevin Wiesmueller <kwiesmul@redhat.com>
+20	Daniel Hiller <dhiller@redhat.com>
+18	David Vossel <dvossel@redhat.com>
+14	Miguel Duarte Barroso <mdbarroso@redhat.com>
+12	Alexander Wels <awels@redhat.com>
+12	Ashley Schuett <aschuett@redhat.com>
+10	Radim Hrazdil <rhrazdil@redhat.com>
+9	Alona Kaplan <alkaplan@redhat.com>
+9	Itamar Holder <iholder@redhat.com>
+8	Vasiliy Ulyanov <vulyanov@suse.de>
+6	Andrey Odarenko <andreyo@il.ibm.com>
+6	Marcus Sorensen <marcus_sorensen@apple.com>
+5	Zvi Cahana <zvic@il.ibm.com>
+5	alonsadan <asadan@redhat.com>
+4	Antonio Cardace <acardace@redhat.com>
+4	Federico Gimenez <fgimenez@redhat.com>
+4	L. Pivarc <lpivarc@redhat.com>
+4	Quique Llorente <ellorent@redhat.com>
+4	Shelly Kagan <skagan@redhat.com>
+3	Andrea Bolognani <abologna@redhat.com>
+3	Howard Zhang <howard.zhang@arm.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+3	Shirly Radco <sradco@redhat.com>
+2	Dan Kenigsberg <danken@redhat.com>
+2	Edward Haas <edwardh@redhat.com>
+2	Maya Rashish <mrashish@redhat.com>
+2	Michael Henriksen <mhenriks@redhat.com>
+2	Vatsal Parekh <vparekh@redhat.com>
+2	Zhou Hao <zhouhao@fujitsu.com>
+1	Andrew DeMaria <ademaria@cloudflare.com>
+1	Daniel Hiller <daniel.hiller.1972@gmail.com>
+1	Jed Lejosne <jed@redhat.com>
+1	Kedar Bidarkar <kbidarka@redhat.com>
+1	Marcin Franczyk <marcin0franczyk@gmail.com>
+1	Marcus Sorensen <mls@apple.com>
+1	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+1	Ram Lavi <ralavi@redhat.com>
+1	ansijain <ansi.jain@india.nec.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.43.1.md
+++ b/CHANGELOG/CHANGELOG-v0.43.1.md
@@ -1,0 +1,40 @@
+KubeVirt v0.43.1
+================
+
+This release follows v0.43.0 and consists of 13 changes, contributed by 6 people, leading to 45 files changed, 812 insertions(+), 87 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.43.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.43.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6555][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #6052][kubevirt-bot] make containerDisk validation memory usage limit configurable
+
+Contributors
+------------
+6 people contributed to this release:
+
+```
+4	Jed Lejosne <jed@redhat.com>
+3	Antonio Cardace <acardace@redhat.com>
+1	Peter Salanki <peter@salanki.st>
+1	Roman Mohr <rmohr@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.44.0.md
+++ b/CHANGELOG/CHANGELOG-v0.44.0.md
@@ -1,0 +1,103 @@
+KubeVirt v0.44.0
+================
+
+This release follows v0.43.0 and consists of 389 changes, contributed by 41 people, leading to 508 files changed, 28369 insertions(+), 24278 deletions(-).
+v0.44.0 is a promotion of release candidate v0.44.0-rc.0 which was originally published 2021-08-02
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.44.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.44.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6058][acardace] Fix virt-launcher exit pod race condition
+- [PR #6035][davidvossel] Addition of perfscale-audit tool for auditing performance of control plane during stress tests
+- [PR #6145][acardace] virt-launcher: disable unencrypted TCP socket for libvirtd.
+- [PR #6163][davidvossel] Handle qemu processes in defunc (zombie) state
+- [PR #6105][ashleyschuett] Add VirtualMachineInstancesPerNode to KubeVirt CR under Spec.Configuration
+- [PR #6104][zcahana] Report FailedUnschedulable VM status when scheduling errors occur
+- [PR #5905][davidvossel] VM CrashLoop detection and Exponential Backoff
+- [PR #6070][acardace] Initiate Live-Migration using a unix socket (exposed by virt-handler) instead of an additional TCP<->Unix migration proxy started by virt-launcher
+- [PR #5728][vasiliy-ul] Live migration of VMs with hotplug volumes is now enabled
+- [PR #6109][rmohr] Fix virt-controller SCC: Reflect the need for NET_BIND_SERVICE in the virt-controller SCC.
+- [PR #5942][ShellyKa13] Integrate guest agent to online VM snapshot
+- [PR #6034][ashleyschuett] Go version updated to version 1.16.6
+- [PR #6040][yuhaohaoyu] Improved debuggability by keeping the environment of a failed VMI alive.
+- [PR #6068][dhiller] Add check that not all tests have been skipped
+- [PR #6041][xpivarc] [Experimental] Virt-launcher can run as non-root user
+- [PR #6062][iholder-redhat] replace dead "stress" binary with new, maintained, "stress-ng" binary
+- [PR #6029][mhenriks] CDI to 1.36.0 with DataSource support
+- [PR #4089][victortoso] Add support to USB Redirection with usbredir
+- [PR #5946][vatsalparekh] Add guest-agent based ping probe
+- [PR #6005][acardace] make containerDisk validation memory usage limit configurable
+- [PR #5791][zcahana] Added a READY column to the tabular output of "kubectl get vm/vmi"
+- [PR #6006][awels] DataVolumes created by DataVolumeTemplates will follow the associated VMs priority class.
+- [PR #5982][davidvossel] Reduce vmi Update collisions (http code 409) during startup
+- [PR #5891][akalenyu] BugFix: Pending VMIs when creating concurrent bulk of VMs backed by WFFC DVs
+- [PR #5925][rhrazdil] Fix issue with Windows VMs not being assigned IP address configured in network-attachment-definition IPAM.
+- [PR #6007][rmohr] Fix: The bandwidth limitation on migrations is no longer ignored. Caution: The default bandwidth limitation of 64Mi is changed to "unlimited" to not break existing installations.
+- [PR #4944][kwiesmueller] Add `/portforward` subresource to `VirtualMachine` and `VirtualMachineInstance` that can tunnel TCP traffic through the API Server using a websocket stream.
+- [PR #5402][alicefr] Integration of libguestfs-tools and added new command `guestfs` to virtctl
+- [PR #5953][ashleyschuett] Allow Failed VMs to be stopped when using `--force --gracePeriod 0`
+- [PR #5876][mlsorensen] KubeVirt CR supports specifying a runtime class for virt-launcher pods via 'launcherRuntimeClass'.
+
+Contributors
+------------
+41 people contributed to this release:
+
+```
+27	David Vossel <dvossel@redhat.com>
+24	Zvi Cahana <zvic@il.ibm.com>
+22	L. Pivarc <lpivarc@redhat.com>
+16	Quique Llorente <ellorent@redhat.com>
+16	Shelly Kagan <skagan@redhat.com>
+16	Vasiliy Ulyanov <vulyanov@suse.de>
+14	Roman Mohr <rmohr@redhat.com>
+11	Antonio Cardace <acardace@redhat.com>
+10	Alice Frosi <afrosi@redhat.com>
+10	Alona Kaplan <alkaplan@redhat.com>
+9	Michael Henriksen <mhenriks@redhat.com>
+8	Marcelo Amaral <marcelo.amaral1@ibm.com>
+7	Ashley Schuett <aschuett@redhat.com>
+6	Ben Ukhanov <ben1zuk321@gmail.com>
+6	Igor Bezukh <ibezukh@redhat.com>
+6	Itamar Holder <iholder@redhat.com>
+6	Victor Toso <victortoso@redhat.com>
+5	Radim Hrazdil <rhrazdil@redhat.com>
+4	Alexander Wels <awels@redhat.com>
+4	Daniel Hiller <dhiller@redhat.com>
+4	Miguel Duarte Barroso <mdbarroso@redhat.com>
+4	Or Shoval <oshoval@redhat.com>
+3	Federico Gimenez <fgimenez@redhat.com>
+3	Marcus Sorensen <mls@apple.com>
+3	Vatsal Parekh <vparekh@redhat.com>
+3	alonsadan <asadan@redhat.com>
+2	Kevin Wiesmueller <kwiesmul@redhat.com>
+2	Marcus Sorensen <marcus_sorensen@apple.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Andrea Bolognani <abologna@redhat.com>
+1	Chris Callegari <mazzystr@gmail.com>
+1	Hao Yu <yuh@us.ibm.com>
+1	Howard Zhang <howard.zhang@arm.com>
+1	Jed Lejosne <jed@redhat.com>
+1	LiHui <andrewli@yunify.com>
+1	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+1	Simone Tiraboschi <stirabos@redhat.com>
+1	Stu Gott <sgott@redhat.com>
+1	borod108 <boris.od@gmail.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.44.1.md
+++ b/CHANGELOG/CHANGELOG-v0.44.1.md
@@ -1,0 +1,37 @@
+KubeVirt v0.44.1
+================
+
+This release follows v0.44.0 and consists of 11 changes, contributed by 4 people, leading to 16 files changed, 411 insertions(+), 38 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.44.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.44.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6219][kubevirt-bot] Add phases to the vm snapshot api, specifically a failure phase
+
+Contributors
+------------
+4 people contributed to this release:
+
+```
+6	Shelly Kagan <skagan@redhat.com>
+3	Zvi Cahana <zvic@il.ibm.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.44.2.md
+++ b/CHANGELOG/CHANGELOG-v0.44.2.md
@@ -1,0 +1,52 @@
+KubeVirt v0.44.2
+================
+
+This release follows v0.44.1 and consists of 72 changes, contributed by 12 people, leading to 140 files changed, 4706 insertions(+), 1275 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.44.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.44.2`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6479][kubevirt-bot] BugFix: Fixed hotplug race between kubelet and virt-handler when virt-launcher dies unexpectedly.
+- [PR #6392][rmohr] Better place vcpu threads on host cpus to form more efficient passthrough architectures
+- [PR #6251][rmohr] Better place vcpu threads on host cpus to form more efficient passthrough architectures
+- [PR #6344][kubevirt-bot] BugFix: hotplug was broken when using it with a hostpath volume that was on a separate device.
+- [PR #6263][rmohr] Make k8s client rate limits configurable
+- [PR #6207][kubevirt-bot] Fix goroutine leak in virt-handler, potentially causing issues with a high turnover of VMIs.
+- [PR #6101][rmohr] Make k8s client rate limits configurable
+- [PR #6249][kubevirt-bot] Fix rbac permissions for freeze/unfreeze, addvolume/removevolume, guestosinfo, filesystemlist and userlist
+
+Contributors
+------------
+12 people contributed to this release:
+
+```
+15	Roman Mohr <rmohr@redhat.com>
+14	Shelly Kagan <skagan@redhat.com>
+5	Igor Bezukh <ibezukh@redhat.com>
+4	Alexander Wels <awels@redhat.com>
+3	Israel Pinto <ipinto@redhat.com>
+2	Jed Lejosne <jed@redhat.com>
+1	Adam Litke <alitke@redhat.com>
+1	Kedar Bidarkar <kbidarka@redhat.com>
+1	Kevin Wiesmueller <kwiesmul@redhat.com>
+1	L. Pivarc <lpivarc@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.44.3.md
+++ b/CHANGELOG/CHANGELOG-v0.44.3.md
@@ -1,0 +1,41 @@
+KubeVirt v0.44.3
+================
+
+This release follows v0.44.2 and consists of 14 changes, contributed by 6 people, leading to 47 files changed, 1024 insertions(+), 147 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.44.3.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.44.3`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6518][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #6532][kubevirt-bot] mutate migration PDBs instead of creating an additional one for the duration of the migration.
+- [PR #6536][kubevirt-bot] Fix corrupted DHCP Gateway Option from local DHCP server, leading to rejected IP configuration on Windows VMs.
+
+Contributors
+------------
+6 people contributed to this release:
+
+```
+4	Antonio Cardace <acardace@redhat.com>
+4	Jed Lejosne <jed@redhat.com>
+1	Adam Litke <alitke@redhat.com>
+1	Peter Salanki <peter@salanki.st>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.45.0.md
+++ b/CHANGELOG/CHANGELOG-v0.45.0.md
@@ -1,0 +1,82 @@
+KubeVirt v0.45.0
+================
+
+This release follows v0.44.1 and consists of 290 changes, contributed by 38 people, leading to 302 files changed, 13624 insertions(+), 4851 deletions(-).
+v0.45.0 is a promotion of release candidate v0.45.0-rc.0 which was originally published 2021-09-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.45.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.45.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6191][marceloamaral] Addition of perfscale-load-generator to perform stress tests to evaluate the control plane
+- [PR #6248][VirrageS] Reduced logging in hot paths
+- [PR #6079][weihanglo] Hotplug volume can be unplugged at anytime and reattached after a VM restart.
+- [PR #6101][rmohr] Make k8s client rate limits configurable
+- [PR #6204][sradco] This PR adds to each alert the runbook url that points to a runbook that provides additional details on each alert and how to mitigate it.
+- [PR #5974][vladikr] a list of desired mdev types can now be provided in KubeVirt CR to kubevirt to configure these devices on relevant nodes
+- [PR #6147][rmohr] Fix rbac permissions for freeze/unfreeze, addvolume/removevolume, guestosinfo, filesystemlist and userlist
+- [PR #6161][ashleyschuett] Remove HostDevice validation on VMI creation
+- [PR #6078][zcahana] Report ErrImagePull/ImagePullBackOff VM status when image pull errors occur
+- [PR #6176][kwiesmueller] Fix goroutine leak in virt-handler, potentially causing issues with a high turnover of VMIs.
+- [PR #6047][ShellyKa13] Add phases to the vm snapshot api, specifically a failure phase
+- [PR #6138][ansijain] NA
+
+Contributors
+------------
+38 people contributed to this release:
+
+```
+23	Roman Mohr <rmohr@redhat.com>
+20	Shelly Kagan <skagan@redhat.com>
+15	David Vossel <dvossel@redhat.com>
+15	Vladik Romanovsky <vromanso@redhat.com>
+13	Miguel Duarte Barroso <mdbarroso@redhat.com>
+13	Or Shoval <oshoval@redhat.com>
+13	Zvi Cahana <zvic@il.ibm.com>
+11	Weihang Lo <weihang.lo@suse.com>
+8	Marcelo Amaral <marcelo.amaral1@ibm.com>
+7	L. Pivarc <lpivarc@redhat.com>
+6	Radim Hrazdil <rhrazdil@redhat.com>
+5	Edward Haas <edwardh@redhat.com>
+5	Quique Llorente <ellorent@redhat.com>
+4	Federico Gimenez <fgimenez@redhat.com>
+4	Igor Bezukh <ibezukh@redhat.com>
+3	Alexander Wels <awels@redhat.com>
+3	Ashley Schuett <aschuett@redhat.com>
+3	Israel Pinto <ipinto@redhat.com>
+3	Janusz Marcinkiewicz <januszm@nvidia.com>
+3	Jed Lejosne <jed@redhat.com>
+3	Vatsal Parekh <vparekh@redhat.com>
+2	Dan Kenigsberg <danken@redhat.com>
+2	Kedar Bidarkar <kbidarka@redhat.com>
+2	Or Mergi <ormergi@redhat.com>
+2	alonsadan <asadan@redhat.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Alona Kaplan <alkaplan@redhat.com>
+1	Hao Yu <yuh@us.ibm.com>
+1	Itamar Holder <iholder@redhat.com>
+1	Josh Berkus <josh@agliodbs.com>
+1	Kevin Wiesmueller <kwiesmul@redhat.com>
+1	Maya Rashish <mrashish@redhat.com>
+1	Shirly Radco <sradco@redhat.com>
+1	Tomasz Baranski <tbaransk@redhat.com>
+1	ansijain <ansi.jain@india.nec.com>
+1	yingbai <yingbai@cn.ibm.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.45.1.md
+++ b/CHANGELOG/CHANGELOG-v0.45.1.md
@@ -1,0 +1,42 @@
+KubeVirt v0.45.1
+================
+
+This release follows v0.45.0 and consists of 16 changes, contributed by 6 people, leading to 60 files changed, 1530 insertions(+), 239 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.45.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.45.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6537][kubevirt-bot] Fix corrupted DHCP Gateway Option from local DHCP server, leading to rejected IP configuration on Windows VMs.
+- [PR #6556][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #6480][kubevirt-bot] BugFix: Fixed hotplug race between kubelet and virt-handler when virt-launcher dies unexpectedly.
+- [PR #6384][kubevirt-bot] Better place vcpu threads on host cpus to form more efficient passthrough architectures
+
+Contributors
+------------
+6 people contributed to this release:
+
+```
+6	Roman Mohr <rmohr@redhat.com>
+4	Jed Lejosne <jed@redhat.com>
+1	Alexander Wels <awels@redhat.com>
+1	Peter Salanki <peter@salanki.st>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.46.0.md
+++ b/CHANGELOG/CHANGELOG-v0.46.0.md
@@ -1,0 +1,87 @@
+KubeVirt v0.46.0
+================
+
+This release follows v0.45.0 and consists of 256 changes, contributed by 35 people, leading to 732 files changed, 31209 insertions(+), 20471 deletions(-).
+v0.46.0 is a promotion of release candidate v0.46.0-rc.0 which was originally published 2021-10-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.46.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.46.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6425][awels] Hotplug disks are possible when iothreads are enabled.
+- [PR #6297][acardace] mutate migration PDBs instead of creating an additional one for the duration of the migration.
+- [PR #6464][awels] BugFix: Fixed hotplug race between kubelet and virt-handler when virt-launcher dies unexpectedly.
+- [PR #6465][salanki] Fix corrupted DHCP Gateway Option from local DHCP server, leading to rejected IP configuration on Windows VMs.
+- [PR #6458][vladikr] Tagged SR-IOV interfaces will now appear in the config drive metadata
+- [PR #6446][brybacki] Access mode for virtctl image upload is now optional. This version of virtctl now requires CDI v1.34 or greater
+- [PR #6391][zcahana] Cleanup obsolete permissions from virt-operator's ClusterRole
+- [PR #6419][rthallisey] Fix virt-controller panic caused by lots of deleted VMI events
+- [PR #5972][kwiesmueller] Add a `ssh` command to `virtctl` that can be used to open SSH sessions to VMs/VMIs.
+- [PR #6403][jrife] Removed go module pinning to an old version (v0.3.0) of github.com/go-kit/kit
+- [PR #6367][brybacki] virtctl imageupload now uses DataVolume.spec.storage
+- [PR #6198][iholder-redhat] Fire a Prometheus alert when a lot of REST failures are detected in virt-api
+- [PR #6211][davidvossel] cluster-profiler pprof gathering tool and corresponding "ClusterProfiler" feature gate
+- [PR #6323][vladikr] switch live migration to use unix sockets
+- [PR #6374][vladikr] Fix the default setting of CPU requests on vmipods
+- [PR #6283][rthallisey] Record the time it takes to delete a VMI and expose it as a metric
+- [PR #6251][rmohr] Better place vcpu threads on host cpus to form more efficient passthrough architectures
+- [PR #6377][rmohr] Don't fail on failed selinux relabel attempts if selinux is permissive
+- [PR #6308][awels] BugFix: hotplug was broken when using it with a hostpath volume that was on a separate device.
+- [PR #6186][davidvossel] Add resource and verb labels to rest_client_requests_total metric
+
+Contributors
+------------
+35 people contributed to this release:
+
+```
+31	David Vossel <dvossel@redhat.com>
+30	Roman Mohr <rmohr@redhat.com>
+10	Maya Rashish <mrashish@redhat.com>
+10	Vladik Romanovsky <vromanso@redhat.com>
+8	Ryan Hallisey <rhallisey@nvidia.com>
+7	Jed Lejosne <jed@redhat.com>
+7	Vasiliy Ulyanov <vulyanov@suse.de>
+6	Dan Kenigsberg <danken@redhat.com>
+5	Alexander Wels <awels@redhat.com>
+5	Bartosz Rybacki <brybacki@redhat.com>
+5	Federico Gimenez <fgimenez@redhat.com>
+5	Itamar Holder <iholder@redhat.com>
+5	L. Pivarc <lpivarc@redhat.com>
+4	Antonio Cardace <acardace@redhat.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+3	Kevin Wiesmueller <kwiesmul@redhat.com>
+3	Miguel Duarte Barroso <mdbarroso@redhat.com>
+3	Or Shoval <oshoval@redhat.com>
+2	Daniel Hiller <dhiller@redhat.com>
+1	Adam Litke <alitke@redhat.com>
+1	Alice Frosi <afrosi@redhat.com>
+1	Chris Callegari <mazzystr@gmail.com>
+1	Denis Ollier <dollierp@redhat.com>
+1	Erkan Erol <erkanerol92@gmail.com>
+1	Howard Zhang <howard.zhang@arm.com>
+1	Jordan Rife <jrife@google.com>
+1	Kedar Bidarkar <kbidarka@redhat.com>
+1	Marcelo Carneiro do Amaral <marcelo.amaral1@ibm.com>
+1	Or Mergi <ormergi@redhat.com>
+1	Peter Salanki <peter@salanki.st>
+1	Shelly Kagan <skagan@redhat.com>
+1	Vatsal Parekh <vparekh@redhat.com>
+1	Zvi Cahana <zvic@il.ibm.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.46.1.md
+++ b/CHANGELOG/CHANGELOG-v0.46.1.md
@@ -1,0 +1,36 @@
+KubeVirt v0.46.1
+================
+
+This release follows v0.46.0 and consists of 5 changes, contributed by 3 people, leading to 32 files changed, 550 insertions(+), 43 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.46.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.46.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6557][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+
+Contributors
+------------
+3 people contributed to this release:
+
+```
+4	Jed Lejosne <jed@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.47.1.md
+++ b/CHANGELOG/CHANGELOG-v0.47.1.md
@@ -1,0 +1,95 @@
+KubeVirt v0.47.1
+================
+
+This release follows v0.46.1 and consists of 311 changes, contributed by 39 people, leading to 740 files changed, 22426 insertions(+), 17615 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.47.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.47.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6775][kubevirt-bot] Bugfix: revert #6565 which prevented upgrades to v0.47.
+- [PR #6703][mhenriks] Fix BZ 2018521 - On upgrade VirtualMachineSnapshots going to Failed
+- [PR #6511][knopt] Fixed virt-api significant memory usage when using Cluster Profiler with large KubeVirt deployments. (#6478, @knopt)
+- [PR #6629][awels] BugFix: Hotplugging more than one block device would cause IO error (#6564)
+- [PR #6657][andreabolognani] This version of KubeVirt includes upgraded virtualization technology based on libvirt 7.6.0 and QEMU 6.0.0.
+- [PR #6565][Barakmor1] 'kubevirt-operator' changed to 'virt-operator' on 'managed-by' label in kubevirt's components made by virt-operator
+- [PR #6642][ShellyKa13] Include hot-plugged disks in a Online VM Snapshot
+- [PR #6513][brybacki] Adds force-bind flag to virtctl imageupload
+- [PR #6588][erkanerol] Fix recording rules based on up metrics
+- [PR #6575][davidvossel] VM controller now syncs VMI conditions to corresponding VM object
+- [PR #6661][rmohr] Make the kubevirt api compatible with client-gen to make selecting compatible k8s golang dependencies easier
+- [PR #6535][rmohr] Migrations use digests to reference containerDisks and kernel boot images to ensure disk consistency
+- [PR #6651][ormergi] Kubevirt Conformance plugin now supports passing tests images registry.
+- [PR #6589][iholder-redhat] custom kernel / initrd to boot from is now pre-pulled which improves stability
+- [PR #6199][ormergi] Kubevirt Conformance plugin now supports passing image tag or digest
+- [PR #6477][zcahana] Report DataVolumeError VM status when referenced a DataVolume indicates an error
+- [PR #6593][rhrazdil] Removed python dependencies from virt-launcher and virt-handler containers
+- [PR #6026][akrejcir] Implemented minimal VirtualMachineFlavor functionality.
+- [PR #6570][erkanerol] Use honorLabels instead of labelDrop for namespace label on metrics
+- [PR #6182][jordigilh] adds support for real time workloads
+- [PR #6177][rmohr] Switch the node base images to centos8 stream
+- [PR #6171][zcahana] Report ErrorPvcNotFound/ErrorDataVolumeNotFound VM status when PVC/DV-type volumes reference non-existent objects
+- [PR #6437][VirrageS] Fix deprecated use of watch API to prevent reporting incorrect metrics.
+- [PR #6482][jean-edouard] VMs with cloud-init data should now properly migrate from older KubeVirt versions
+- [PR #6375][dhiller] Rely on kubevirtci installing cdi during testing
+
+Contributors
+------------
+39 people contributed to this release:
+
+```
+34	Roman Mohr <rmohr@redhat.com>
+15	Andrea Bolognani <abologna@redhat.com>
+13	Jed Lejosne <jed@redhat.com>
+12	Zvi Cahana <zvic@il.ibm.com>
+12	alonsadan <asadan@redhat.com>
+10	YitzyD <yitzy.i.dier@gmail.com>
+9	Antonio Cardace <acardace@redhat.com>
+9	David Vossel <dvossel@redhat.com>
+9	Or Mergi <ormergi@redhat.com>
+8	Daniel Hiller <dhiller@redhat.com>
+8	Shelly Kagan <skagan@redhat.com>
+7	Bartosz Rybacki <brybacki@redhat.com>
+7	Or Shoval <oshoval@redhat.com>
+6	Andrej Krejcir <akrejcir@redhat.com>
+4	Alexander Wels <awels@redhat.com>
+4	Itamar Holder <iholder@redhat.com>
+4	Maya Rashish <mrashish@redhat.com>
+4	Michael Henriksen <mhenriks@redhat.com>
+4	Radim Hrazdil <rhrazdil@redhat.com>
+3	Alice Frosi <afrosi@redhat.com>
+3	Erkan Erol <eerol@redhat.com>
+3	Howard Zhang <howard.zhang@arm.com>
+3	Jordi Gil <jgil@redhat.com>
+3	L. Pivarc <lpivarc@redhat.com>
+2	Barak <bmordeha@redhat.com>
+2	Federico Gimenez <fgimenez@redhat.com>
+2	Igor Bezukh <ibezukh@redhat.com>
+1	Adam Litke <alitke@redhat.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Israel Pinto <ipinto@redhat.com>
+1	Janusz Marcinkiewicz <januszm@nvidia.com>
+1	João Vilaça <jvilaca@redhat.com>
+1	Petr Horáček <phoracek@redhat.com>
+1	Tomasz Knopik <tknopik@nvidia.com>
+1	Vasiliy Ulyanov <vulyanov@suse.de>
+1	dalia-frank <dafrank@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.48.0.md
+++ b/CHANGELOG/CHANGELOG-v0.48.0.md
@@ -1,0 +1,105 @@
+KubeVirt v0.48.0
+================
+
+This release follows v0.47.1 and consists of 282 changes, contributed by 43 people, leading to 1046 files changed, 32869 insertions(+), 12807 deletions(-).
+v0.48.0 is a promotion of release candidate v0.48.0-rc.0 which was originally published 2021-12-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.48.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.48.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6670][futuretea] Added 'virtctl soft-reboot' command to reboot the VMI.
+- [PR #6861][orelmisan] virtctl errors are written to stderr instead of stdout
+- [PR #6836][enp0s3] Added PHASE and VMI columns for the 'kubectl get vmim' CLI output
+- [PR #6784][nunnatsa] kubevirt-config configMap is no longer supported for KubeVirt configuration
+- [PR #6839][ShellyKa13] fix restore of VM with RunStrategy
+- [PR #6533][zcahana] Paused VMIs are now marked as unready even when no readinessProbe is specified
+- [PR #6858][rmohr] Fix a nil pointer in virtctl in combination with some external auth plugins
+- [PR #6780][fossedihelm] Add PatchOptions to the Patch request of the VirtualMachineInstanceInterface
+- [PR #6773][iholder-redhat] alert if migration for VMI with host-model CPU is stuck since no node is suitable
+- [PR #6714][rhrazdil] Shorten timeout for Istio proxy detection
+- [PR #6725][fossedihelm] added DryRun mode to virtcl for pause and unpause commands
+- [PR #6737][davidvossel] Pending migration target pods timeout after 5 minutes when unschedulable
+- [PR #6814][fossedihelm] Changed some terminology to be more inclusive
+- [PR #6649][Barakmor1] Designate the apps.kubevirt.io/component label for KubeVirt components.
+- [PR #6650][victortoso] Introduces support to ich9 or ac97 sound devices
+- [PR #6734][Barakmor1] replacing the command that extract libvirtd's pid  to avoid this error:
+- [PR #6802][rmohr] Maintain a separate api package which synchronizes to kubevirt.io/api for better third party integration with client-gen
+- [PR #6730][zhhray] change kubevrit cert secret type from Opaque to kubernetes.io/tls
+- [PR #6508][oshoval] Add missing domain to guest search list, in case subdomain is used.
+- [PR #6664][vladikr] enable the display and ramfb for vGPUs by default
+- [PR #6710][iholder-redhat] virt-launcher fix - stop logging successful shutdown when it isn't true
+- [PR #6162][vladikr] KVM_HINTS_REALTIME will always be set when dedicatedCpusPlacement is requested
+- [PR #6772][zcahana] Bugfix: revert #6565 which prevented upgrades to v0.47.
+- [PR #6722][zcahana] Remove obsolete scheduler.alpha.kubernetes.io/critical-pod annotation
+- [PR #6723][acardace] remove stale pdbs created by < 0.41.1 virt-controller
+- [PR #6721][iholder-redhat] Set default CPU model in VMI spec, even if not defined in KubevirtCR
+- [PR #6713][zcahana] Report WaitingForVolumeBinding VM status when PVC/DV-type volumes reference unbound PVCs
+- [PR #6681][fossedihelm] Users can use --dry-run flag
+- [PR #6663][jean-edouard] The number of virt-api and virt-controller replicas is now configurable in the CSV
+- [PR #5981][maya-r] Always resize disk.img files to the largest size at boot.
+
+Contributors
+------------
+43 people contributed to this release:
+
+```
+27	Itamar Holder <iholder@redhat.com>
+18	Zvi Cahana <zvic@il.ibm.com>
+10	Maya Rashish <mrashish@redhat.com>
+9	David Vossel <dvossel@redhat.com>
+8	Barak Mordehai <bmordeha@redhat.com>
+8	Orel Misan <omisan@redhat.com>
+7	Victor Toso <victortoso@redhat.com>
+7	Vladik Romanovsky <vromanso@redhat.com>
+7	fossedihelm <fossedihelm@gmail.com>
+7	futuretea <Hang.Yu@suse.com>
+7	hellocloudnative <200922702@qq.com>
+6	Alice Frosi <afrosi@redhat.com>
+6	Or Mergi <ormergi@redhat.com>
+5	L. Pivarc <lpivarc@redhat.com>
+4	Edward Haas <edwardh@redhat.com>
+4	Igor Bezukh <ibezukh@redhat.com>
+4	Roman Mohr <rmohr@redhat.com>
+3	Or Shoval <oshoval@redhat.com>
+3	Shelly Kagan <skagan@redhat.com>
+3	Stu Gott <sgott@redhat.com>
+3	huizhang <huizhang@alauda.io>
+2	Daniel Hiller <dhiller@redhat.com>
+2	Miguel Duarte Barroso <mdbarroso@redhat.com>
+2	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+2	Ryan Hallisey <rhallisey@nvidia.com>
+2	Vasiliy Ulyanov <vulyanov@suse.de>
+1	Antonio Cardace <acardace@redhat.com>
+1	Chris Callegari <mazzystr@gmail.com>
+1	Denys Shchedrivyi <dshchedr@redhat.com>
+1	Erkan Erol <eerol@redhat.com>
+1	Federico Gimenez <fgimenez@redhat.com>
+1	Hao Yu <yuh@us.ibm.com>
+1	Jed Lejosne <jed@redhat.com>
+1	Kedar Bidarkar <kbidarka@redhat.com>
+1	Michael Henriksen <mhenriks@redhat.com>
+1	Radim Hrazdil <rhrazdil@redhat.com>
+1	Tomas Psota <tpsota@redhat.com>
+1	Zhe Peng <zpeng@redhat.com>
+1	dalia-frank <dafrank@redhat.com>
+1	dhiller <dhiller@redhat.com>
+1	张鹏璇 <200922702@qq.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.48.1.md
+++ b/CHANGELOG/CHANGELOG-v0.48.1.md
@@ -1,0 +1,37 @@
+KubeVirt v0.48.1
+================
+
+This release follows v0.48.0 and consists of 4 changes, contributed by 3 people, leading to 4 files changed, 90 insertions(+), 62 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.48.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.48.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #6900][kubevirt-bot] Skip SSH RSA auth if no RSA key was explicitly provided and not key exists at the default location
+- [PR #6902][kubevirt-bot] Fix "Make raw terminal failed: The handle is invalid?" issue with "virtctl console" when not executed in a pty
+
+Contributors
+------------
+3 people contributed to this release:
+
+```
+2	Roman Mohr <rmohr@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.49.0.md
+++ b/CHANGELOG/CHANGELOG-v0.49.0.md
@@ -1,0 +1,92 @@
+KubeVirt v0.49.0
+================
+
+This release follows v0.48.1 and consists of 298 changes, contributed by 36 people, leading to 652 files changed, 53600 insertions(+), 8784 deletions(-).
+v0.49.0 is a promotion of release candidate v0.49.0-rc.0 which was originally published 2022-01-04
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.49.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.49.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7004][iholder-redhat] Bugfix: Avoid setting block migration for volumes used by read-only disks
+- [PR #6959][enp0s3] generate event when target pod enters unschedulable phase
+- [PR #6888][assafad] Added common labels into alert definitions
+- [PR #6166][vasiliy-ul] Experimental support of AMD SEV
+- [PR #6980][vasiliy-ul] Updated the dependencies to include the fix for CVE-2021-43565 (KubeVirt is not affected)
+- [PR #6944][iholder-redhat] Remove disabling TLS configuration from Live Migration Policies
+- [PR #6800][jean-edouard] CPU pinning doesn't require hardware-assisted virtualization anymore
+- [PR #6501][ShellyKa13] Use virtctl image-upload to upload archive content
+- [PR #6918][iholder-redhat] Bug fix: Unscheduable host-model VMI alert is now properly triggered
+- [PR #6796][Barakmor1] 'kubevirt-operator' changed to 'virt-operator' on 'managed-by' label in kubevirt's components made by virt-operator
+- [PR #6036][jean-edouard] Migrations can now be done over a dedicated multus network
+- [PR #6933][erkanerol] Add a new lane for monitoring tests
+- [PR #6949][jean-edouard] KubeVirt components should now be successfully removed on CR deletion, even when using only 1 replica for virt-api and virt-controller
+- [PR #6954][maiqueb] Update the `virtctl` exposed services `IPFamilyPolicyType` default to `IPFamilyPolicyPreferDualStack`
+- [PR #6931][fossedihelm] added DryRun to AddVolumeOptions and RemoveVolumeOptions
+- [PR #6379][nunnatsa] Fix issue https://bugzilla.redhat.com/show_bug.cgi?id=1945593
+- [PR #6399][iholder-redhat] Introduce live migration policies that allow system-admins to have fine-grained control over migration configuration for different sets of VMs.
+- [PR #6880][iholder-redhat] Add full Podman support for `make` and `make test`
+- [PR #6702][acardace] implement virt-handler canary upgrade and rollback for faster and safer rollouts
+- [PR #6717][davidvossel] Introducing the VirtualMachinePools feature for managing stateful VMs at scale
+- [PR #6698][rthallisey] Add tracing to the virt-controller work queue
+- [PR #6762][fossedihelm] added DryRun mode to virtcl to migrate command
+- [PR #6891][rmohr] Fix "Make raw terminal failed: The handle is invalid?" issue with "virtctl console" when not executed in a pty
+- [PR #6783][rmohr] Skip SSH RSA auth if no RSA key was explicitly provided and not key exists at the default location
+
+Contributors
+------------
+36 people contributed to this release:
+
+```
+55	Itamar Holder <iholder@redhat.com>
+23	Edward Haas <edwardh@redhat.com>
+21	Vasiliy Ulyanov <vulyanov@suse.de>
+19	David Vossel <dvossel@redhat.com>
+12	Jed Lejosne <jed@redhat.com>
+9	prnaraya <prnaraya@redhat.com>
+7	Barak Mordehai <bmordeha@redhat.com>
+7	Ryan Hallisey <rhallisey@nvidia.com>
+6	Antonio Cardace <acardace@redhat.com>
+6	Vladik Romanovsky <vromanso@redhat.com>
+5	fossedihelm <fossedihelm@gmail.com>
+4	Daniel Hiller <dhiller@redhat.com>
+4	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+3	Maya Rashish <mrashish@redhat.com>
+3	Or Mergi <ormergi@redhat.com>
+3	Roman Mohr <rmohr@redhat.com>
+2	Igor Bezukh <ibezukh@redhat.com>
+2	Kedar Bidarkar <kbidarka@redhat.com>
+2	Or Shoval <oshoval@redhat.com>
+2	Zhe Peng <zpeng@redhat.com>
+2	Zvi Cahana <zvic@il.ibm.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Ashley Schuett <aschuett@redhat.com>
+1	Dan Kenigsberg <danken@redhat.com>
+1	Diana Teplits <dteplits@redhat.com>
+1	Erkan Erol <eerol@redhat.com>
+1	Helene Durand <helene@kubermatic.com>
+1	L. Pivarc <lpivarc@redhat.com>
+1	Michael Henriksen <mhenriks@redhat.com>
+1	Miguel Duarte Barroso <mdbarroso@redhat.com>
+1	Orel Misan <omisan@redhat.com>
+1	Petr Horáček <phoracek@redhat.com>
+1	Shelly Kagan <skagan@redhat.com>
+1	assaf-admi <aadmi@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.49.1.md
+++ b/CHANGELOG/CHANGELOG-v0.49.1.md
@@ -1,0 +1,79 @@
+KubeVirt v0.49.1
+================
+
+This release follows v0.49.0 and consists of 200 changes, contributed by 28 people, leading to 1929 files changed, 148241 insertions(+), 56732 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.49.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.49.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #8323][jean-edouard] Improve path handling for non-root virt-launcher workloads
+- [PR #8306][kubevirt-bot] Fixed `KubeVirtComponentExceedsRequestedMemory` alert complaining about many-to-many matching not allowed.
+- [PR #8109][Barakmor1] Bump the version of emicklei/go-restful from 2.15.0 to 2.16.0
+- [PR #7984][ShellyKa13] BugFix: Fix vm restore in case of restore size bigger then PVC requested size
+- [PR #7718][akalenyu] BugFix: virtctl guestfs incorrectly assumes image name
+- [PR #7617][machadovilaca] Add Virtual Machine name label to virt-launcher pod
+- [PR #7610][acardace] Fix failed reported migrations when actually they were successful.
+- [PR #7478][orelmisan] Fixed setting custom guest pciAddress and bootOrder parameter(s) to a list of SR-IOV NICs.
+- [PR #7514][kubevirt-bot] BugFix: Fixed RBAC for admin/edit user to allow virtualmachine/addvolume and removevolume. This allows for persistent disks
+- [PR #7247][kubevirt-bot] New and resized disks are now always 1MiB-aligned
+- [PR #7179][kubevirt-bot] Improve device plugin de-registration in virt-handler and some test stabilizations
+- [PR #7166][kubevirt-bot] Garbage collect finalized migration objects only leaving the most recent 5 objects
+- [PR #7154][davidvossel] Switch from reflects.DeepEquals to equality.Semantic.DeepEquals() across the entire project
+- [PR #7146][kubevirt-bot] Updated recording rule "kubevirt_vm_container_free_memory_bytes"
+- [PR #7140][kubevirt-bot] Fixes issue associated with blocked uninstalls when VMIs exist during removal
+- [PR #7073][kubevirt-bot] When expanding disk images, take the minimum between the request and the capacity - avoid using the full underlying file system on storage like NFS, local.
+- [PR #7042][kubevirt-bot] Fix issue with ssh being unreachable on VMIs with Istio proxy
+- [PR #7034][kubevirt-bot] Add infoSource field to vmi.status.interfaces.
+- [PR #7043][kubevirt-bot] Migrating VMIs that contain dedicated CPUs will now have properly dedicated CPUs on target
+
+Contributors
+------------
+28 people contributed to this release:
+
+```
+16	Orel Misan <omisan@redhat.com>
+16	Shelly Kagan <skagan@redhat.com>
+15	Roman Mohr <rmohr@google.com>
+13	Roman Mohr <rmohr@redhat.com>
+12	Jed Lejosne <jed@redhat.com>
+12	fossedihelm <ffossemo@redhat.com>
+9	David Vossel <dvossel@redhat.com>
+6	Michael Henriksen <mhenriks@redhat.com>
+5	Daniel Hiller <dhiller@redhat.com>
+4	Alex Kalenyuk <akalenyu@redhat.com>
+4	L. Pivarc <lpivarc@redhat.com>
+4	Omer Yahud <oyahud@redhat.com>
+4	bmordeha <bmodeha@redhat.com>
+3	Alexander Wels <awels@redhat.com>
+3	Or Shoval <oshoval@redhat.com>
+2	Antonio Cardace <acardace@redhat.com>
+2	Barak Mordehai <bmordeha@redhat.com>
+2	Itamar Holder <iholder@redhat.com>
+2	João Vilaça <jvilaca@redhat.com>
+2	Radim Hrazdil <rhrazdil@redhat.com>
+2	Shirly Radco <sradco@redhat.com>
+1	Alice Frosi <afrosi@redhat.com>
+1	Erkan Erol <eerol@redhat.com>
+1	Maya Rashish <mrashish@redhat.com>
+1	Sascha Grunert <sgrunert@redhat.com>
+1	Vasiliy Ulyanov <vulyanov@suse.de>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.5.0.md
+++ b/CHANGELOG/CHANGELOG-v0.5.0.md
@@ -1,0 +1,72 @@
+KubeVirt v0.5.0
+===============
+
+This release follows v0.4.1 and consists of 151 changes, contributed by
+12 people, leading to 1415 files changed, 138035 insertions(+), 9848
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.5.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Better controller health signaling
+- Better virtctl error messages
+- Improvements to enable CRI-O support
+- Run CI on stable OpenShift
+- Add test coverage for multiple PVCs
+- Improved controller life-cycle guarantees
+- Add Webhook validation
+- Add tests coverage for node eviction
+- OfflineVirtualMachine status improvements
+- RegistryDisk API update
+
+Contributors
+------------
+
+12 people contributed to this release:
+
+```
+        71	Roman Mohr <rmohr@redhat.com>
+        53	David Vossel <dvossel@redhat.com>
+         7	Artyom Lukianov <alukiano@redhat.com>
+         6	Fabian Deutsch <fabiand@redhat.com>
+         4	Petr Kotas <pkotas@redhat.com>
+         2	Lukas Bednar <lbednar@redhat.com>
+         2	Marcus Sorensen <mls@apple.com>
+         2	Yuval Lifshitz <ylifshit@redhat.com>
+         1	Alexander Wels <awels@redhat.com>
+         1	Guohua Ouyang <gouyang@redhat.com>
+         1	Karim Boumedhel <kboumedh@redhat.com>
+         1	Travis CI <travis@travis-ci.org>
+```
+
+Test Results
+------------
+
+```
+> Ran 82 of 90 Specs in 3224.968 seconds
+> FAIL! -- 81 Passed | 1 Failed | 0 Pending | 8 Skipped --- FAIL: TestTests (3224.98s)
+```
+
+Note: The tests are a little flaky, thus not a complete pass for this release.
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.50.0.md
+++ b/CHANGELOG/CHANGELOG-v0.50.0.md
@@ -1,0 +1,91 @@
+KubeVirt v0.50.0
+================
+
+This release follows v0.49.0 and consists of 286 changes, contributed by 38 people, leading to 2776 files changed, 223758 insertions(+), 107570 deletions(-)
+warning: inexact rename detection was skipped due to too many files.
+warning: you may want to set your diff.renameLimit variable to at least 1099 and retry the command..
+v0.50.0 is a promotion of release candidate v0.50.0-rc.0 which was originally published 2022-02-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.50.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.50.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7056][fossedihelm] Update k8s dependencies to 0.23.1
+- [PR #7135][davidvossel] Switch from reflects.DeepEquals to equality.Semantic.DeepEquals() across the entire project
+- [PR #7052][sradco] Updated recording rule "kubevirt_vm_container_free_memory_bytes"
+- [PR #7000][iholder-redhat] Adds a possibility to override default libvirt log filters though VMI annotations
+- [PR #7064][davidvossel] Fixes issue associated with blocked uninstalls when VMIs exist during removal
+- [PR #7097][iholder-redhat] [Bug fix] VMI with kernel boot stuck on "Terminating" status if more disks are defined
+- [PR #6700][VirrageS] Simplify replacing `time.Ticker` in agent poller and fix default values for `qemu-*-interval` flags
+- [PR #6581][ormergi] SRIOV network interfaces are now hot-plugged when disconnected manually or due to aborted migrations.
+- [PR #6924][EdDev] Support for legacy GPU definition is removed. Please see https://kubevirt.io/user-guide/virtual_machines/host-devices on how to define host-devices.
+- [PR #6735][uril] The command `migrate_cancel` was added to virtctl. It cancels an active VM migration.
+- [PR #6883][rthallisey] Add instance-type to cloud-init metadata
+- [PR #6999][maya-r] When expanding disk images, take the minimum between the request and the capacity - avoid using the full underlying file system on storage like NFS, local.
+- [PR #6946][vladikr] Numa information of an assigned device will be presented in the devices metadata
+- [PR #6042][iholder-redhat] Fully support cgroups v2, include a new cohesive package and perform major refactoring.
+- [PR #6968][vladikr] Added Writeback disk cache support
+- [PR #6995][sradco] Alert OrphanedVirtualMachineImages name was changed to OrphanedVirtualMachineInstances.
+- [PR #6923][rhrazdil] Fix issue with ssh being unreachable on VMIs with Istio proxy
+- [PR #6821][jean-edouard] Migrating VMIs that contain dedicated CPUs will now have properly dedicated CPUs on target
+- [PR #6793][oshoval] Add infoSource field to vmi.status.interfaces.
+
+Contributors
+------------
+38 people contributed to this release:
+
+```
+37	Edward Haas <edwardh@redhat.com>
+22	Itamar Holder <iholder@redhat.com>
+14	Orel Misan <omisan@redhat.com>
+14	Shelly Kagan <skagan@redhat.com>
+10	Ryan Hallisey <rhallisey@nvidia.com>
+9	Jed Lejosne <jed@redhat.com>
+8	Dan Kenigsberg <danken@redhat.com>
+8	Vladik Romanovsky <vromanso@redhat.com>
+7	Marcelo Amaral <marcelo.amaral1@ibm.com>
+6	David Vossel <dvossel@redhat.com>
+6	L. Pivarc <lpivarc@redhat.com>
+5	Or Shoval <oshoval@redhat.com>
+5	Uri Lublin <uril@redhat.com>
+4	Alice Frosi <afrosi@redhat.com>
+4	Omer Yahud <oyahud@redhat.com>
+4	Or Mergi <ormergi@redhat.com>
+4	Roman Mohr <rmohr@redhat.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+2	Barak Mordehai <bmordeha@redhat.com>
+2	Ben Ukhanov <ben1zuk321@gmail.com>
+2	Daniel Hiller <dhiller@redhat.com>
+2	Maya Rashish <mrashish@redhat.com>
+2	Radim Hrazdil <rhrazdil@redhat.com>
+2	Shirly Radco <sradco@redhat.com>
+2	Vasiliy Ulyanov <vulyanov@suse.de>
+2	Xiaoli Ai <xlai@suse.com`>
+2	fossedihelm <fossedihelm@gmail.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Bartosz Rybacki <brybacki@redhat.com>
+1	Cedric Hauber <hauber.c@gmail.com>
+1	Denys Shchedrivyi <dshchedr@redhat.com>
+1	Erkan Erol <eerol@redhat.com>
+1	Janusz Marcinkiewicz <januszm@nvidia.com>
+1	Miguel Duarte Barroso <mdbarroso@redhat.com>
+1	Mor Cohen <mocohen@redhat.com>
+1	prnaraya <prnaraya@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.51.0.md
+++ b/CHANGELOG/CHANGELOG-v0.51.0.md
@@ -1,0 +1,72 @@
+KubeVirt v0.51.0
+================
+
+This release follows v0.50.0 and consists of 180 changes, contributed by 28 people, leading to 184 files changed, 5739 insertions(+), 4160 deletions(-).
+v0.51.0 is a promotion of release candidate v0.51.0-rc.0 which was originally published 2022-03-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.51.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.51.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7102][machadovilaca] Add Virtual Machine name label to virt-launcher pod
+- [PR #7139][davidvossel] Fixes inconsistent VirtualMachinePool VM/VMI updates by using controller revisions
+- [PR #6754][jean-edouard] New and resized disks are now always 1MiB-aligned
+- [PR #7086][acardace] Add 'EvictionStrategy' as a cluster-wide setting in the KubeVirt CR
+- [PR #7232][rmohr] Properly format the PDB scale event during migrations
+- [PR #7223][Barakmor1] Add a name label to virt-operator pods
+- [PR #7221][davidvossel] RunStrategy: Once - allows declaring a VM should run once to a finalized state
+- [PR #7091][EdDev] SR-IOV interfaces are now reported in the VMI status even without an active guest-agent.
+- [PR #7169][rmohr] Improve device plugin de-registration in virt-handler and some test stabilizations
+- [PR #6604][alicefr] Add shareable option to identify if the disk is shared with other VMs
+- [PR #7144][davidvossel] Garbage collect finalized migration objects only leaving the most recent 5 objects
+- [PR #6110][xpivarc] [Nonroot] SRIOV is now available.
+
+Contributors
+------------
+28 people contributed to this release:
+
+```
+28	Dan Kenigsberg <danken@redhat.com>
+18	Roman Mohr <rmohr@redhat.com>
+13	David Vossel <dvossel@redhat.com>
+8	Edward Haas <edwardh@redhat.com>
+7	Antonio Cardace <acardace@redhat.com>
+5	Alice Frosi <afrosi@redhat.com>
+4	Andrej Krejcir <akrejcir@redhat.com>
+4	L. Pivarc <lpivarc@redhat.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+3	Vasiliy Ulyanov <vulyanov@suse.de>
+3	Victor Toso <victortoso@redhat.com>
+3	fossedihelm <ffossemo@redhat.com>
+2	Daniel Hiller <dhiller@redhat.com>
+2	Jed Lejosne <jed@redhat.com>
+2	João Vilaça <jvilaca@redhat.com>
+2	Karel Šimon <ksimon@redhat.com>
+2	Michael Henriksen <mhenriks@redhat.com>
+2	Ryan Hallisey <rhallisey@nvidia.com>
+2	Shelly Kagan <skagan@redhat.com>
+1	Alexander Wels <awels@redhat.com>
+1	Barak Mordehai <bmordeha@redhat.com>
+1	Bartosz Rybacki <brybacki@redhat.com>
+1	Marcelo Amaral <marcelo.amaral1@ibm.com>
+1	Shirly Radco <sradco@redhat.com>
+1	Simone Tiraboschi <stirabos@redhat.com>
+1	jbpratt <jbpratt78@gmail.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.52.0.md
+++ b/CHANGELOG/CHANGELOG-v0.52.0.md
@@ -1,0 +1,89 @@
+KubeVirt v0.52.0
+================
+
+This release follows v0.51.0 and consists of 314 changes, contributed by 37 people, leading to 1006 files changed, 35687 insertions(+), 24520 deletions(-).
+v0.52.0 is a promotion of release candidate v0.52.0-rc.0 which was originally published 2022-04-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.52.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.52.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7024][fossedihelm] Add an warning message if the client and server virtctl versions are not aligned
+- [PR #7486][rmohr] Move stable.txt location to a more appropriate path
+- [PR #7372][saschagrunert] Fixed `KubeVirtComponentExceedsRequestedMemory` alert complaining about many-to-many matching not allowed.
+- [PR #7426][iholder-redhat] Add warning for manually determining core-component replica count in Kubevirt CR
+- [PR #7424][maiqueb] Provide interface binding types descriptions, which will be featured in the KubeVirt API.
+- [PR #7422][orelmisan] Fixed setting custom guest pciAddress and bootOrder parameter(s) to a list of SR-IOV NICs.
+- [PR #7421][rmohr] Fix knowhosts file corruption for virtctl ssh
+- [PR #6854][rmohr] Make virtctl ssh work with ssh-rsa+ preauthentication
+- [PR #7267][iholder-redhat] Applied migration configurations can now be found in VMI's status
+- [PR #7321][iholder-redhat] [Migration Policies]: precedence to VMI labels over Namespace labels
+- [PR #7326][oshoval] The Ginkgo dependency has been upgraded to v2.1.3 (major version upgrade)
+- [PR #7361][SeanKnight] Fixed a bug that prevents virtctl from working with clusters accessed via Rancher authentication proxy, or any other cluster where the server URL contains a path component. (#3760)
+- [PR #7255][tyleraharrison] Users are now able to specify `--address [ip_address]` when using `virtctl vnc` rather than only using 127.0.0.1
+- [PR #7275][enp0s3] Add observedGeneration to virt-operator to have a race-free way to detect KubeVirt config rollouts
+- [PR #7233][xpivarc] Bug fix: Successfully aborted migrations should be reported now
+- [PR #7158][AlonaKaplan] Add masquerade VMs support to single stack IPv6.
+- [PR #7227][rmohr] Remove VMI informer from virt-api to improve scaling characteristics of virt-api
+- [PR #7288][raspbeep] Users now don't need to specify container for `kubectl logs <vmi-pod>` and `kubectl exec <vmi-pod>`.
+- [PR #6709][xpivarc] Workloads will be migrated to nonroot implementation if NonRoot feature gate is set. (Except VirtioFS)
+- [PR #7241][lyarwood] Fixed a bug that prevents only a unattend.xml configmap or secret being provided as contents for a sysprep disk. (#7240, @lyarwood)
+
+Contributors
+------------
+37 people contributed to this release:
+
+```
+40	Itamar Holder <iholder@redhat.com>
+30	Dan Kenigsberg <danken@redhat.com>
+26	Or Shoval <oshoval@redhat.com>
+17	Roman Mohr <rmohr@redhat.com>
+13	L. Pivarc <lpivarc@redhat.com>
+9	Alona Kaplan <alkaplan@redhat.com>
+8	Edward Haas <edwardh@redhat.com>
+8	Jed Lejosne <jed@redhat.com>
+5	fossedihelm <ffossemo@redhat.com>
+4	Antonio Cardace <acardace@redhat.com>
+4	Miguel Duarte Barroso <mdbarroso@redhat.com>
+4	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+3	Ben Ukhanov <ben1zuk321@gmail.com>
+3	Karel Šimon <ksimon@redhat.com>
+3	Zhuchen Wang <zcwang@google.com>
+3	tyleraharrison <tyleraharrison@gmail.com>
+2	Daniel Hiller <dhiller@redhat.com>
+2	Igor Bezukh <ibezukh@redhat.com>
+2	Zvi Cahana <zcahana@gmail.com>
+1	Alex Kalenyuk <akalenyu@redhat.com>
+1	Bartosz Rybacki <brybacki@redhat.com>
+1	Felix Matouschek <fmatouschek@redhat.com>
+1	Frank Yang <poan.yang@suse.com>
+1	Lee Yarwood <lyarwood@redhat.com>
+1	Marcelo Amaral <marcelo.amaral1@ibm.com>
+1	Maya Rashish <mrashish@redhat.com>
+1	Orel Misan <omisan@redhat.com>
+1	Pavel Kratochvil <pakratoc@redhat.com>
+1	Radim Hrazdil <rhrazdil@redhat.com>
+1	RamLavi <ralavi@redhat.com>
+1	Sascha Grunert <sgrunert@redhat.com>
+1	Sean Knight <git@seanknight.com>
+1	Shirly Radco <sradco@redhat.com>
+1	assaf-admi <aadmi@redhat.com>
+1	fossedihelm <fossedihelm@gmail.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.53.0.md
+++ b/CHANGELOG/CHANGELOG-v0.53.0.md
@@ -1,0 +1,93 @@
+KubeVirt v0.53.0
+================
+
+This release follows v0.52.0 and consists of 293 changes, contributed by 40 people, leading to 642 files changed, 24571 insertions(+), 17591 deletions(-).
+v0.53.0 is a promotion of release candidate v0.53.0-rc.0 which was originally published 2022-05-02
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.53.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.53.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7533][akalenyu] Add several VM snapshot metrics
+- [PR #7574][rmohr] Pull in cdi dependencies with minimized transitive dependencies to ease API adoption
+- [PR #7318][iholder-redhat] Snapshot restores now support restoring to a target VM different than the source
+- [PR #7474][borod108] Added the following metrics for live migration: kubevirt_migrate_vmi_data_processed_bytes, kubevirt_migrate_vmi_data_remaining_bytes, kubevirt_migrate_vmi_dirty_memory_rate_bytes
+- [PR #7441][rmohr] Add `virtctl scp` to ease copying files from and to VMs and VMIs
+- [PR #7265][rthallisey] Support steady-state job types in the load-generator tool
+- [PR #7544][fossedihelm] Upgraded go version to 1.17.8
+- [PR #7582][acardace] Fix failed reported migrations when actually they were successful.
+- [PR #7546][0xFelix] Update virtio-container-disk to virtio-win version 0.1.217-1
+- [PR #7530][iholder-redhat] [External Kernel Boot]: Disallow kernel args without providing custom kernel
+- [PR #7493][davidvossel] Adds new EvictionStrategy "External" for blocking eviction which is handled by an external controller
+- [PR #7563][akalenyu] Switch VolumeSnapshot to v1
+- [PR #7406][acardace] Reject `LiveMigrate` as a workload-update strategy if the `LiveMigration` feature gate is not enabled.
+- [PR #7103][jean-edouard] Non-persistent vTPM now supported. Keep in mind that the state of the TPM is wiped after each shutdown. Do not enable Bitlocker!
+- [PR #7277][andreabolognani] This version of KubeVirt includes upgraded virtualization technology based on libvirt 8.0.0 and QEMU 6.2.0.
+- [PR #7130][Barakmor1] Add field to kubevirtCR to set Prometheus ServiceMonitor object's namespace
+- [PR #7401][iholder-redhat] virt-api deployment is now scalable - replicas are determined by the number of nodes in the cluster
+- [PR #7500][awels] BugFix: Fixed RBAC for admin/edit user to allow virtualmachine/addvolume and removevolume. This allows for persistent disks
+- [PR #7328][apoorvajagtap] Don't ignore --identity-file when setting --local-ssh=true on `virtctl ssh`
+- [PR #7469][xpivarc] Users can now enable the NonRoot feature gate instead of NonRootExperimental
+- [PR #7451][fossedihelm] Reduce virt-launcher memory usage by splitting monitoring and launcher processes
+
+Contributors
+------------
+40 people contributed to this release:
+
+```
+26	Edward Haas <edwardh@redhat.com>
+19	Itamar Holder <iholder@redhat.com>
+14	Alex Kalenyuk <akalenyu@redhat.com>
+11	Alona Kaplan <alkaplan@redhat.com>
+11	Jed Lejosne <jed@redhat.com>
+11	Roman Mohr <rmohr@redhat.com>
+10	Andrea Bolognani <abologna@redhat.com>
+10	Ryan Hallisey <rhallisey@nvidia.com>
+9	Miguel Duarte Barroso <mdbarroso@redhat.com>
+7	Dan Kenigsberg <danken@redhat.com>
+5	Antonio Cardace <acardace@redhat.com>
+5	L. Pivarc <lpivarc@redhat.com>
+5	Lee Yarwood <lyarwood@redhat.com>
+5	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+5	Radim Hrazdil <rhrazdil@redhat.com>
+4	Barak Mordehai <bmordeha@redhat.com>
+4	David Vossel <dvossel@redhat.com>
+4	Vasiliy Ulyanov <vulyanov@suse.de>
+3	fossedihelm <ffossemo@redhat.com>
+2	Alexander Wels <awels@redhat.com>
+2	Andrej Krejcir <akrejcir@redhat.com>
+2	Diana Teplits <dteplits@redhat.com>
+2	Felix Matouschek <fmatouschek@redhat.com>
+2	Killercoda <accounts+github@killercoda.com>
+2	Stu Gott <sgott@redhat.com>
+2	bmordeha <bmodeha@redhat.com>
+1	Andrew Burden <aburden@redhat.com>
+1	Apoorva Jagtap <apoorvajagtap4@gmail.com>
+1	Bartosz Rybacki <brybacki@redhat.com>
+1	Caleb Crane <ccrane@suse.de>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Janusz Marcinkiewicz <januszm@nvidia.com>
+1	Shirly Radco <sradco@redhat.com>
+1	Shweta Padubidri <spadubid@redhat.com>
+1	Zhe Peng <zpeng@redhat.com>
+1	assaf-admi <aadmi@redhat.com>
+1	borod108 <boris.od@gmail.com>
+1	shewensheng <shewensheng@chinatelecom.cn>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.53.1.md
+++ b/CHANGELOG/CHANGELOG-v0.53.1.md
@@ -1,0 +1,37 @@
+KubeVirt v0.53.1
+================
+
+This release follows v0.53.0 and consists of 12 changes, contributed by 4 people, leading to 7 files changed, 75 insertions(+), 14 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.53.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.53.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7749][kubevirt-bot] NoReadyVirtController and NoReadyVirtOperator should be properly fired.
+
+Contributors
+------------
+4 people contributed to this release:
+
+```
+5	L. Pivarc <lpivarc@redhat.com>
+2	akriti gupta <akrgupta@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.53.2.md
+++ b/CHANGELOG/CHANGELOG-v0.53.2.md
@@ -1,0 +1,48 @@
+KubeVirt v0.53.2
+================
+
+This release follows v0.53.1 and consists of 44 changes, contributed by 12 people, leading to 42 files changed, 522 insertions(+), 293 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.53.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.53.2`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7883][kubevirt-bot] Enable to run libguestfs-tools pod to run as noroot user
+- [PR #7794][kubevirt-bot] Allow `virtualmachines/migrate` subresource to admin/edit users
+- [PR #7866][kubevirt-bot] Adds the reason of a live-migration failure to a recorded event in case EvictionStrategy is set but live-migration is blocked due to its limitations.
+- [PR #7726][kubevirt-bot] BugFix: virtctl guestfs incorrectly assumes image name
+
+Contributors
+------------
+12 people contributed to this release:
+
+```
+16	Jed Lejosne <jed@redhat.com>
+4	Or Shoval <oshoval@redhat.com>
+2	Alex Kalenyuk <akalenyu@redhat.com>
+2	fossedihelm <ffossemo@redhat.com>
+1	Alice Frosi <afrosi@redhat.com>
+1	Daniel Hiller <dhiller@redhat.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Karel Šimon <ksimon@redhat.com>
+1	L. Pivarc <lpivarc@redhat.com>
+1	Pavel Kratochvil <pakratoc@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.54.0.md
+++ b/CHANGELOG/CHANGELOG-v0.54.0.md
@@ -1,0 +1,79 @@
+KubeVirt v0.54.0
+================
+
+This release follows v0.53.1 and consists of 223 changes, contributed by 38 people, leading to 215 files changed, 15237 insertions(+), 1800 deletions(-).
+v0.54.0 is a promotion of release candidate v0.54.0-rc.0 which was originally published 2022-06-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.54.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.54.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7757][orenc1] new alert for excessive number of VMI migrations in a period of time.
+- [PR #7517][ShellyKa13] Add virtctl Memory Dump command
+- [PR #7801][VirrageS] Empty (`nil` values) of `Address` and `Driver` fields in XML will be omitted.
+- [PR #7475][raspbeep] Adds the reason of a live-migration failure to a recorded event in case EvictionStrategy is set but live-migration is blocked due to its limitations.
+- [PR #7739][fossedihelm] Allow `virtualmachines/migrate` subresource to admin/edit users
+- [PR #7618][lyarwood] The requirement to define a `Disk` or `Filesystem` for each `Volume` associated with a `VirtualMachine` has been removed. Any `Volumes` without a `Disk` or `Filesystem` defined will have a `Disk` defined within the `VirtualMachineInstance` at runtime.
+- [PR #7529][xpivarc] NoReadyVirtController and NoReadyVirtOperator should be properly fired.
+- [PR #7465][machadovilaca] Add metrics for migrations and respective phases
+- [PR #7592][akalenyu] BugFix: virtctl guestfs incorrectly assumes image name
+
+Contributors
+------------
+38 people contributed to this release:
+
+```
+27	Lee Yarwood <lyarwood@redhat.com>
+16	Jed Lejosne <jed@redhat.com>
+15	Shelly Kagan <skagan@redhat.com>
+12	Miguel Duarte Barroso <mdbarroso@redhat.com>
+9	bmordeha <bmodeha@redhat.com>
+8	Andrea Bolognani <abologna@redhat.com>
+7	Janusz Marcinkiewicz <januszm@nvidia.com>
+6	L. Pivarc <lpivarc@redhat.com>
+5	Vasiliy Ulyanov <vulyanov@suse.de>
+4	Dan Kenigsberg <danken@redhat.com>
+4	Edward Haas <edwardh@redhat.com>
+4	Or Shoval <oshoval@redhat.com>
+3	Alex Kalenyuk <akalenyu@redhat.com>
+3	Itamar Holder <iholder@redhat.com>
+2	Alice Frosi <afrosi@redhat.com>
+2	Andrey Odarenko <andreyo@il.ibm.com>
+2	Daniel Hiller <dhiller@redhat.com>
+2	Fabian Deutsch <fabiand@redhat.com>
+2	Igor Bezukh <ibezukh@redhat.com>
+2	Marcelo Amaral <marcelo.amaral1@ibm.com>
+2	akriti gupta <akrgupta@redhat.com>
+2	fossedihelm <ffossemo@redhat.com>
+1	Andrej Krejcir <akrejcir@redhat.com>
+1	Ben Oukhanov <boukhanov@redhat.com>
+1	Diana Teplits <dteplits@redhat.com>
+1	Howard Zhang <howard.zhang@arm.com>
+1	João Vilaça <jvilaca@redhat.com>
+1	Joël Séguillon <joel.seguillon@gmail.com>
+1	Karel Šimon <ksimon@redhat.com>
+1	Nik Paushkin <63355212+NikPaushkin@users.noreply.github.com>
+1	Pavel Kratochvil <pakratoc@redhat.com>
+1	Petr Horáček <phoracek@redhat.com>
+1	Ram Lavi <ralavi@redhat.com>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+1	borod108 <boris.od@gmail.com>
+1	orenc1 <ocohen@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.55.0.md
+++ b/CHANGELOG/CHANGELOG-v0.55.0.md
@@ -1,0 +1,92 @@
+KubeVirt v0.55.0
+================
+
+This release follows v0.54.0 and consists of 391 changes, contributed by 39 people, leading to 480 files changed, 29803 insertions(+), 6373 deletions(-).
+v0.55.0 is a promotion of release candidate v0.55.0-rc.0 which was originally published 2022-07-07
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.55.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.55.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7336][iholder-redhat] Introduce clone CRD, controller and API
+- [PR #7791][iholder-redhat] Introduction of an initial deprecation policy
+- [PR #7875][lyarwood] `ControllerRevisions` of any `VirtualMachineFlavorSpec` or `VirtualMachinePreferenceSpec` are stored during the initial start of a `VirtualMachine` and used for subsequent restarts ensuring changes to the original `VirtualMachineFlavor` or `VirtualMachinePreference` do not modify the `VirtualMachine` and the `VirtualMachineInstance` it creates.
+- [PR #8011][fossedihelm] Increase virt-launcher memory overhead
+- [PR #7963][qinqon] Bump alpine_with_test_tooling
+- [PR #7881][ShellyKa13] Enable memory dump to be included in VMSnapshot
+- [PR #7926][qinqon] tests: Move main clean function to global AfterEach and create a VM per each infra_test.go Entry.
+- [PR #7845][janeczku] Fixed a bug that caused `make generate` to fail when API code comments contain backticks. (#7844, @janeczku)
+- [PR #7932][marceloamaral] Addition of kubevirt_vmi_migration_phase_transition_time_from_creation_seconds metric to monitor how long it takes to transition a VMI Migration object to a specific phase from creation time.
+- [PR #7879][marceloamaral] Faster VM phase transitions thanks to an increased virt-controller QPS/Burst
+- [PR #7807][acardace] make cloud-init 'instance-id' persistent across reboots
+- [PR #7928][iholder-redhat] bugfix: node-labeller now removes "host-model-cpu.node.kubevirt.io/" and "host-model-required-features.node.kubevirt.io/" prefixes
+- [PR #7841][jean-edouard] Non-root VMs will now migrate to root VMs after a cluster disables non-root.
+- [PR #7933][akalenyu] BugFix: Fix vm restore in case of restore size bigger then PVC requested size
+- [PR #7919][lyarwood] Device preferences are now applied to any default network interfaces or missing volume disks added to a `VirtualMachineInstance` at runtime.
+- [PR #7910][qinqon] tests: Create the expected readiness probe instead of liveness
+- [PR #7732][acardace] Prevent virt-handler from starting a migration twice
+- [PR #7594][alicefr] Enable to run libguestfs-tools pod to run as noroot user
+- [PR #7811][raspbeep] User now gets information about the type of commands which the guest agent does not support.
+- [PR #7590][awels] VMExport allows filesystem PVCs to be exported as either disks or directories.
+- [PR #7683][alicefr] Add --command and --local-ssh-opts" options to virtctl ssh to execute remote command using local ssh method
+
+Contributors
+------------
+39 people contributed to this release:
+
+```
+38	Itamar Holder <iholder@redhat.com>
+20	Alexander Wels <awels@redhat.com>
+20	Marcelo Amaral <marcelo.amaral1@ibm.com>
+19	Michael Henriksen <mhenriks@redhat.com>
+18	Miguel Duarte Barroso <mdbarroso@redhat.com>
+16	Shelly Kagan <skagan@redhat.com>
+15	Ben Oukhanov <boukhanov@redhat.com>
+14	Dan Kenigsberg <danken@redhat.com>
+13	Edward Haas <edwardh@redhat.com>
+13	Lee Yarwood <lyarwood@redhat.com>
+10	Enrique Llorente <ellorent@redhat.com>
+8	Alice Frosi <afrosi@redhat.com>
+8	Jed Lejosne <jed@redhat.com>
+8	bmordeha <bmodeha@redhat.com>
+6	Andrej Krejcir <akrejcir@redhat.com>
+6	Or Shoval <oshoval@redhat.com>
+5	Antonio Cardace <acardace@redhat.com>
+5	Janusz Marcinkiewicz <januszm@nvidia.com>
+5	Roman Mohr <rmohr@google.com>
+4	L. Pivarc <lpivarc@redhat.com>
+4	Ram Lavi <ralavi@redhat.com>
+3	Pavel Kratochvil <pakratoc@redhat.com>
+3	prnaraya <prnaraya@redhat.com>
+2	Alex Kalenyuk <akalenyu@redhat.com>
+2	Bartosz Rybacki <brybacki@redhat.com>
+2	Shirly Radco <sradco@redhat.com>
+2	fossedihelm <ffossemo@redhat.com>
+1	Arnon Gilboa <agilboa@redhat.com>
+1	Daniel Hiller <dhiller@redhat.com>
+1	Haibo Xu <haibo1.xu@intel.com>
+1	João Vilaça <jvilaca@redhat.com>
+1	Karel Šimon <ksimon@redhat.com>
+1	Or Mergi <ormergi@redhat.com>
+1	Stu Gott <sgott@redhat.com>
+1	borod108 <boris.od@gmail.com>
+1	janeczku <jabruder@gmail.com>
+1	tgfree <tgfree7@gmail.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.55.1.md
+++ b/CHANGELOG/CHANGELOG-v0.55.1.md
@@ -1,0 +1,37 @@
+KubeVirt v0.55.1
+================
+
+This release follows v0.55.0 and consists of 22 changes, contributed by 4 people, leading to 68 files changed, 2555 insertions(+), 794 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.55.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.55.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #8205][rmohr] Improve path handling for non-root virt-launcher workloads
+
+Contributors
+------------
+4 people contributed to this release:
+
+```
+19	Roman Mohr <rmohr@google.com>
+1	L. Pivarc <lpivarc@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.55.2.md
+++ b/CHANGELOG/CHANGELOG-v0.55.2.md
@@ -1,0 +1,37 @@
+KubeVirt v0.55.2
+================
+
+This release follows v0.55.1 and consists of 16 changes, contributed by 4 people, leading to 57 files changed, 1642 insertions(+), 198 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.55.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.55.2`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #8490][kubevirt-bot] Fixed migration failure of VMs with containerdisks on systems with containerd
+
+Contributors
+------------
+4 people contributed to this release:
+
+```
+11	Ram Lavi <ralavi@redhat.com>
+2	Vasiliy Ulyanov <vulyanov@suse.de>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.56.0.md
+++ b/CHANGELOG/CHANGELOG-v0.56.0.md
@@ -1,0 +1,87 @@
+KubeVirt v0.56.0
+================
+
+This release follows v0.55.1 and consists of 324 changes, contributed by 38 people, leading to 970 files changed, 18998 insertions(+), 11069 deletions(-).
+v0.56.0 is a promotion of release candidate v0.56.0-rc.1 which was originally published 2022-08-17
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.56.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.56.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #7599][iholder-redhat] Introduce a mechanism to abort non-running migrations - fixes "Unable to cancel live-migration if virt-launcher pod in pending state" bug
+- [PR #8027][alaypatel07] Wait deletion to succeed all the way till objects are finalized in perfscale tests
+- [PR #8198][rmohr] Improve path handling for non-root virt-launcher workloads
+- [PR #8136][iholder-redhat] Fix cgroups unit tests: mock out underlying runc cgroup manager
+- [PR #8047][iholder-redhat] Deprecate live migration feature gate
+- [PR #7986][iholder-redhat] [Bug-fix]: Windows VM with WSL2 guest fails to migrate
+- [PR #7814][machadovilaca] Add VMI filesystem usage metrics
+- [PR #7849][AlonaKaplan] [TECH PREVIEW] Introducing passt - a new approach to user-mode networking for virtual machines
+- [PR #7991][ShellyKa13] Virtctl memory dump with create flag to create a new pvc
+- [PR #8039][lyarwood] The flavor API and associated CRDs of `VirtualMachine{Flavor,ClusterFlavor}` are renamed to instancetype and `VirtualMachine{Instancetype,ClusterInstancetype}`.
+- [PR #8112][AlonaKaplan] Changing the default of `virtctl expose` `ip-family` parameter to be empty value instead of IPv4.
+- [PR #8073][orenc1] Bump runc to v1.1.2
+- [PR #8092][Barakmor1] Bump the version of emicklei/go-restful from 2.15.0 to 2.16.0
+- [PR #8053][alromeros] [Bug-fix]: Fix mechanism to fetch fs overhead when CDI resource has a different name
+- [PR #8035][0xFelix] Add option to wrap local scp client to scp command
+- [PR #7981][lyarwood] Conflicts will now be raised when using flavors if the `VirtualMachine` defines any `CPU` or `Memory` resource requests.
+- [PR #8068][awels] Set cache mode to match regular disks on hotplugged disks.
+
+Contributors
+------------
+38 people contributed to this release:
+
+```
+23	Itamar Holder <iholder@redhat.com>
+22	Alona Paz <alkaplan@redhat.com>
+20	Miguel Duarte Barroso <mdbarroso@redhat.com>
+19	Roman Mohr <rmohr@google.com>
+16	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+12	Dan Kenigsberg <danken@redhat.com>
+11	Edward Haas <edwardh@redhat.com>
+11	Felix Matouschek <fmatouschek@redhat.com>
+11	Michael Henriksen <mhenriks@redhat.com>
+11	Shelly Kagan <skagan@redhat.com>
+9	Igor Bezukh <ibezukh@redhat.com>
+7	Lee Yarwood <lyarwood@redhat.com>
+6	Alexander Wels <awels@redhat.com>
+5	Andrej Krejcir <akrejcir@redhat.com>
+5	L. Pivarc <lpivarc@redhat.com>
+5	bmordeha <bmodeha@redhat.com>
+4	Alay Patel <alayp@nvidia.com>
+4	Bartosz Rybacki <brybacki@redhat.com>
+3	Alvaro Romero <alromero@redhat.com>
+3	João Vilaça <jvilaca@redhat.com>
+3	Or Shoval <oshoval@redhat.com>
+3	Vasiliy Ulyanov <vulyanov@suse.de>
+2	Alice Frosi <afrosi@redhat.com>
+2	Jed Lejosne <jed@redhat.com>
+2	Maya Rashish <mrashish@redhat.com>
+2	orenc1 <ocohen@redhat.com>
+1	Alona Paz <alkaplan@alkaplan.tlv.csb>
+1	Andrei Kvapil <kvapss@gmail.com>
+1	Brian Carey <bcarey@redhat.com>
+1	Enrique Llorente <ellorent@redhat.com>
+1	Karel Šimon <ksimon@redhat.com>
+1	Radim Hrazdil <rhrazdil@redhat.com>
+1	Ram Lavi <ralavi@redhat.com>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+1	Vladimir Markelov <vmatroskin@gmail.com>
+1	fossedihelm <ffossemo@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.56.1.md
+++ b/CHANGELOG/CHANGELOG-v0.56.1.md
@@ -1,0 +1,37 @@
+KubeVirt v0.56.1
+================
+
+This release follows v0.56.0 and consists of 18 changes, contributed by 4 people, leading to 51 files changed, 1673 insertions(+), 159 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.56.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.56.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #8450][kubevirt-bot] [Bugfix]: HyperV Reenlightenment VMIs should be able to start when TSC Frequency is not exposed
+
+Contributors
+------------
+4 people contributed to this release:
+
+```
+10	Ram Lavi <ralavi@redhat.com>
+6	Itamar Holder <iholder@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.57.0.md
+++ b/CHANGELOG/CHANGELOG-v0.57.0.md
@@ -1,0 +1,101 @@
+KubeVirt v0.57.0
+================
+
+This release follows v0.56.0 and consists of 253 changes, contributed by 50 people, leading to 382 files changed, 28741 insertions(+), 4384 deletions(-).
+v0.57.0 is a promotion of release candidate v0.57.0-rc.0 which was originally published 2022-09-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.57.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.57.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #8129][mlhnono68] Fixes virtctl to support connection to clusters proxied by RANCHER or having special paths
+- [PR #8337][0xFelix] virtctl's native SSH client is now useable in the Windows console without workarounds
+- [PR #8257][awels] VirtualMachineExport now supports VM export source type.
+- [PR #8367][vladikr] fix the guest memory conversion by setting it to resources.requests.memory when guest memory is not explicitly provided
+- [PR #7990][ormergi] Deprecate SR-IOV live migration feature gate.
+- [PR #8069][lyarwood] The VirtualMachineInstancePreset resource has been deprecated ahead of removal in a future release. Users should instead use the VirtualMachineInstancetype and VirtualMachinePreference resources to encapsulate any shared resource or preferences characteristics shared by their VirtualMachines.
+- [PR #8326][0xFelix] virtctl: Do not log wrapped ssh command by default
+- [PR #8325][rhrazdil] Enable route_localnet sysctl option for masquerade binding at virt-handler
+- [PR #8159][acardace] Add support for USB disks
+- [PR #8006][lyarwood] `AutoattachInputDevice` has been added to `Devices` allowing an `Input` device to be automatically attached to a `VirtualMachine` on start up.  `PreferredAutoattachInputDevice` has also been added to `DevicePreferences` allowing users to control this behaviour with a set of preferences.
+- [PR #8134][arnongilboa] Support DataVolume garbage collection
+- [PR #8157][StefanKro] TrilioVault for Kubernetes now supports KubeVirt for backup and recovery.
+- [PR #8273][alaypatel07] add server-side validations for spec.topologySpreadConstraints during object creation
+- [PR #8049][alicefr] Set RunAsNonRoot as default for the guestfs pod
+- [PR #8107][awels] Allow VirtualMachineSnapshot as a VirtualMachineExport source
+- [PR #7846][janeczku] Added support for configuring topology spread constraints for virtual machines.
+- [PR #8215][alaypatel07] support validation for spec.affinity fields during vmi creation
+- [PR #8071][oshoval] Relax networkInterfaceMultiqueue semantics: multi queue will configure only what it can (virtio interfaces).
+- [PR #7549][akrejcir] Added new API subresources to expand instancetype and preference.
+
+Contributors
+------------
+50 people contributed to this release:
+
+```
+19	Alexander Wels <awels@redhat.com>
+16	Miguel Duarte Barroso <mdbarroso@redhat.com>
+10	Edward Haas <edwardh@redhat.com>
+10	Ram Lavi <ralavi@redhat.com>
+8	Alex Kalenyuk <akalenyu@redhat.com>
+8	Lee Yarwood <lyarwood@redhat.com>
+8	bmordeha <bmodeha@redhat.com>
+7	L. Pivarc <lpivarc@redhat.com>
+7	Shelly Kagan <skagan@redhat.com>
+5	Alay Patel <alayp@nvidia.com>
+4	Alice Frosi <afrosi@redhat.com>
+4	Andrej Krejcir <akrejcir@redhat.com>
+3	David Aghaian <16483722+daghaian@users.noreply.github.com>
+3	Igor Bezukh <ibezukh@redhat.com>
+3	Jed Lejosne <jed@redhat.com>
+3	Michael Henriksen <mhenriks@redhat.com>
+3	Or Shoval <oshoval@redhat.com>
+2	Antonio Cardace <acardace@redhat.com>
+2	Arnon Gilboa <agilboa@redhat.com>
+2	Diana Teplits <dteplits@redhat.com>
+2	Felix Matouschek <fmatouschek@redhat.com>
+2	Howard Zhang <howard.zhang@arm.com>
+2	Maya Rashish <mrashish@redhat.com>
+2	Prashanth Dintyala <vdintyala@nvidia.com>
+2	Radim Hrazdil <rhrazdil@redhat.com>
+2	Shirly Radco <sradco@redhat.com>
+2	daghaian <16483722+daghaian@users.noreply.github.com>
+1	Abirdcfly <fp544037857@gmail.com>
+1	Alona Paz <alkaplan@redhat.com>
+1	Andrea Bolognani <abologna@redhat.com>
+1	Arnaud Aubert <aaubert@magesi.com>
+1	Dan Kenigsberg <danken@redhat.com>
+1	HF <crazytaxii666@gmail.com>
+1	Itamar Holder <iholder@redhat.com>
+1	João Vilaça <jvilaca@redhat.com>
+1	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+1	Or Mergi <ormergi@redhat.com>
+1	Roman Mohr <rmohr@google.com>
+1	Roman Mohr <rmohr@redhat.com>
+1	Stefan Kroll <stefan.kroll@trilio.io>
+1	Stu Gott <sgott@redhat.com>
+1	Vasiliy Ulyanov <vulyanov@suse.de>
+1	Vladik Romanovsky <vromanso@redhat.com>
+1	Ygal Blum <ygal.blum@gmail.com>
+1	assaf-admi <aadmi@redhat.com>
+1	crazytaxii <hua.feng@99cloud.net>
+1	howard zhang <howard.zhang@arm.com>
+1	janeczku <jabruder@gmail.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.57.1.md
+++ b/CHANGELOG/CHANGELOG-v0.57.1.md
@@ -1,0 +1,37 @@
+KubeVirt v0.57.1
+================
+
+This release follows v0.57.0 and consists of 12 changes, contributed by 4 people, leading to 35 files changed, 1286 insertions(+), 93 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.57.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.57.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #8469][kubevirt-bot] [Bugfix]: HyperV Reenlightenment VMIs should be able to start when TSC Frequency is not exposed
+
+Contributors
+------------
+4 people contributed to this release:
+
+```
+6	Itamar Holder <iholder@redhat.com>
+4	Ram Lavi <ralavi@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.58.0.md
+++ b/CHANGELOG/CHANGELOG-v0.58.0.md
@@ -1,0 +1,91 @@
+KubeVirt v0.58.0
+================
+
+This release follows v0.57.1 and consists of 285 changes, contributed by 37 people, leading to 471 files changed, 26960 insertions(+), 6441 deletions(-).
+v0.58.0 is a promotion of release candidate v0.58.0-rc.0 which was originally published 2022-10-03
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.58.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.58.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #8578][rhrazdil] When using Passt binding, virl-launcher has unprivileged_port_start set to 0, so that passt may bind to all ports.
+- [PR #8463][Barakmor1] Improve metrics documentation
+- [PR #8282][akrejcir] Improves instancetype and preference controller revisions. This is a backwards incompatible change and introduces a new v1alpha2 api for instancetype and preferences.
+- [PR #8272][jean-edouard] No more empty section in the kubevirt-cr manifest
+- [PR #8536][qinqon] Don't show a failure if ConfigDrive cloud init has UserDataSecretRef and not NetworkDataSecretRef
+- [PR #8375][xpivarc] Virtiofs can be used with Nonroot feature gate
+- [PR #8465][rmohr] Add a vnc screenshot REST endpoint and a "virtctl vnc screenshot" command for UI and script integration
+- [PR #8418][alromeros] Enable automatic token generation for VirtualMachineExport objects
+- [PR #8488][0xFelix] virtctl: Be less verbose when using the local ssh client
+- [PR #8396][alicefr] Add group flag for setting the gid and fsgroup in guestfs
+- [PR #8476][iholder-redhat] Allow setting virt-operator log verbosity through Kubevirt CR
+- [PR #8366][rthallisey] Move KubeVirt to a 15 week release cadence
+- [PR #8479][arnongilboa] Enable DataVolume GC by default in cluster-deploy
+- [PR #8474][vasiliy-ul] Fixed migration failure of VMs with containerdisks on systems with containerd
+- [PR #8316][ShellyKa13] Fix possible race when deleting unready vmsnapshot and the vm remaining frozen
+- [PR #8436][xpivarc] Kubevirt is able to run with restricted Pod Security Standard enabled with an automatic escalation of namespace privileges.
+- [PR #8197][alromeros] Add vmexport command to virtctl
+- [PR #8252][fossedihelm] Add `tlsConfiguration` to Kubevirt Configuration
+- [PR #8431][rmohr] Fix shadow status updates and periodic status updates on VMs, performed by the snapshot controller
+- [PR #8359][iholder-redhat] [Bugfix]: HyperV Reenlightenment VMIs should be able to start when TSC Frequency is not exposed
+- [PR #8330][jean-edouard] Important: If you use docker with SELinux enabled, set the `DockerSELinuxMCSWorkaround` feature gate before upgrading
+- [PR #8401][machadovilaca] Rename metrics to follow the naming convention
+
+Contributors
+------------
+37 people contributed to this release:
+
+```
+20	Alvaro Romero <alromero@redhat.com>
+14	L. Pivarc <lpivarc@redhat.com>
+14	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+14	Shelly Kagan <skagan@redhat.com>
+13	Andrej Krejcir <akrejcir@redhat.com>
+13	Roman Mohr <rmohr@google.com>
+11	Lee Yarwood <lyarwood@redhat.com>
+11	Miguel Duarte Barroso <mdbarroso@redhat.com>
+10	Felix Matouschek <fmatouschek@redhat.com>
+9	Itamar Holder <iholder@redhat.com>
+8	fossedihelm <ffossemo@redhat.com>
+7	Alice Frosi <afrosi@redhat.com>
+5	Brian Carey <bcarey@redhat.com>
+5	Vasiliy Ulyanov <vulyanov@suse.de>
+4	Alex Kalenyuk <akalenyu@redhat.com>
+4	Jed Lejosne <jed@redhat.com>
+4	Ram Lavi <ralavi@redhat.com>
+3	Fabian Deutsch <fabiand@redhat.com>
+3	Radim Hrazdil <rhrazdil@redhat.com>
+2	Bartosz Rybacki <brybacki@redhat.com>
+2	Igor Bezukh <ibezukh@redhat.com>
+2	Michael Henriksen <mhenriks@redhat.com>
+2	Ryan Hallisey <rhallisey@nvidia.com>
+1	Alexander Wels <awels@redhat.com>
+1	Andrea Bolognani <abologna@redhat.com>
+1	Arnon Gilboa <agilboa@redhat.com>
+1	Christopher Desiniotis <cdesiniotis@nvidia.com>
+1	Enrique Llorente <ellorent@redhat.com>
+1	Javier Cano Cano <jcanocan@redhat.com>
+1	João Vilaça <jvilaca@redhat.com>
+1	Maya Rashish <mrashish@redhat.com>
+1	Prashanth Dintyala <vdintyala@nvidia.com>
+1	Xiaodong Ye <yeahdongcn@gmail.com>
+1	assaf-admi <aadmi@redhat.com>
+1	bmordeha <bmodeha@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.58.1.md
+++ b/CHANGELOG/CHANGELOG-v0.58.1.md
@@ -1,0 +1,77 @@
+KubeVirt v0.58.1
+================
+
+This release follows v0.58.0 and consists of 213 changes, contributed by 26 people, leading to 397 files changed, 8616 insertions(+), 3933 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.58.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.58.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #9203][jean-edouard] Most VMIs now run under the SELinux type container_t
+- [PR #9191][kubevirt-bot] Default RBAC for clone and export
+- [PR #9150][kubevirt-bot] Fix access to portforwarding on VMs/VMIs with the cluster roles kubevirt.io:admin and kubevirt.io:edit
+- [PR #9128][kubevirt-bot] Rename migration metrics removing 'total' keyword
+- [PR #9034][akalenyu] BugFix: Hotplug pods have hardcoded resource req which don't comply with LimitRange maxLimitRequestRatio of 1
+- [PR #9002][iholder101] Bugfix: virt-handler socket leak
+- [PR #8907][kubevirt-bot] Bugfix: use virt operator image if provided
+- [PR #8784][kubevirt-bot] Use exponential backoff for failing migrations
+- [PR #8816][iholder101] Expose new custom components env vars to csv-generator, manifest-templator and gs
+- [PR #8798][iholder101] Fix: Align Reenlightenment flows between converter.go and template.go
+- [PR #8731][kubevirt-bot] Allow specifying custom images for core components
+- [PR #8785][0xFelix] The expand-spec subresource endpoint was renamed to expand-vm-spec and made namespaced
+- [PR #8806][kubevirt-bot] Consider the ParallelOutboundMigrationsPerNode when evicting VMs
+- [PR #8738][machadovilaca] Use collector to set migration metrics
+- [PR #8747][kubevirt-bot] Add alerts for VMs unhealthy states
+- [PR #8685][kubevirt-bot] BugFix: Exporter pod does not comply with restricted PSA
+- [PR #8647][akalenyu] BugFix: Add an option to specify a TTL for VMExport objects
+- [PR #8609][kubevirt-bot] Fix permission denied on on selinux relabeling on some kernel versions
+- [PR #8578][rhrazdil] When using Passt binding, virl-launcher has unprivileged_port_start set to 0, so that passt may bind to all ports.
+
+Contributors
+------------
+26 people contributed to this release:
+
+```
+42	Itamar Holder <iholder@redhat.com>
+14	Felix Matouschek <fmatouschek@redhat.com>
+12	Marcelo Tosatti <mtosatti@redhat.com>
+11	bmordeha <bmodeha@redhat.com>
+10	Alex Kalenyuk <akalenyu@redhat.com>
+10	Jordi Gil <jgil@redhat.com>
+8	João Vilaça <jvilaca@redhat.com>
+7	Lee Yarwood <lyarwood@redhat.com>
+5	Alexander Wels <awels@redhat.com>
+3	Alvaro Romero <alromero@redhat.com>
+3	Antonio Cardace <acardace@redhat.com>
+3	Jed Lejosne <jed@redhat.com>
+3	Shelly Kagan <skagan@redhat.com>
+3	fossedihelm <ffossemo@redhat.com>
+3	prnaraya <prnaraya@redhat.com>
+2	L. Pivarc <lpivarc@redhat.com>
+2	Radim Hrazdil <rhrazdil@redhat.com>
+2	Ram Lavi <ralavi@redhat.com>
+2	Roman Mohr <rmohr@google.com>
+2	enp0s3 <ibezukh@redhat.com>
+1	Arnon Gilboa <agilboa@redhat.com>
+1	Brian Carey <bcarey@redhat.com>
+1	Edward Haas <edwardh@redhat.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.58.2.md
+++ b/CHANGELOG/CHANGELOG-v0.58.2.md
@@ -1,0 +1,60 @@
+KubeVirt v0.58.2
+================
+
+This release follows v0.58.1 and consists of 67 changes, contributed by 19 people, leading to 84 files changed, 2006 insertions(+), 406 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.58.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.58.2`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #9817][jcanocan] virt-controller: fix out-of-bound slice index bug in evacuation controller.
+- [PR #9699][kubevirt-bot] The install strategy job will respect the infra node placement from now on
+- [PR #9697][kubevirt-bot] fixes the requests/limits CPU number mismatch for VMs with isolatedEmulatorThread
+- [PR #9661][kubevirt-bot] TSC-enabled VMs can now migrate to a node with a non-identical (but close-enough) frequency
+- [PR #9546][xpivarc] Bug fix: DNS integration continues to work after migration
+- [PR #9522][fossedihelm] Use ECDSA instead of RSA for key generation
+- [PR #9416][kubevirt-bot] Fix vmrestore with WFFC snapshotable storage class
+- [PR #9363][iholder101] Add guest-to-request memory headroom ratio.
+- [PR #9230][ShellyKa13] Fix addvolume not rejecting adding existing volume source, fix removevolume allowing to remove non hotpluggable volume
+
+Contributors
+------------
+19 people contributed to this release:
+
+```
+6	Itamar Holder <iholder@redhat.com>
+5	Shelly Kagan <skagan@redhat.com>
+4	Jed Lejosne <jed@redhat.com>
+4	Vladik Romanovsky <vromanso@redhat.com>
+3	Vasiliy Ulyanov <vulyanov@suse.de>
+3	enp0s3 <ibezukh@redhat.com>
+3	fossedihelm <ffossemo@redhat.com>
+2	Alex Kalenyuk <akalenyu@redhat.com>
+2	L. Pivarc <lpivarc@redhat.com>
+2	Marcelo Tosatti <mtosatti@redhat.com>
+1	Alexander Wels <awels@redhat.com>
+1	Arnon Gilboa <agilboa@redhat.com>
+1	Luboslav Pivarc <lpivarc@redhat.com>
+1	Maya Rashish <mrashish@redhat.com>
+1	Orel Misan <omisan@redhat.com>
+1	Roman Mohr <rmohr@google.com>
+1	bmordeha <bmodeha@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.59.0.md
+++ b/CHANGELOG/CHANGELOG-v0.59.0.md
@@ -1,0 +1,185 @@
+KubeVirt v0.59.0
+================
+
+This release follows v0.58.1 and consists of 940 changes, contributed by 73 people, leading to 1435 files changed, 121668 insertions(+), 40676 deletions(-).
+v0.59.0 is a promotion of release candidate v0.59.0-rc.2 which was originally published 2023-03-01
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.59.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.59.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #9311][kubevirt-bot] fixes the requests/limits CPU number mismatch for VMs with isolatedEmulatorThread
+- [PR #9276][fossedihelm] Added foreground finalizer to  virtual machine
+- [PR #9295][kubevirt-bot] Fix bug of possible re-trigger of memory dump
+- [PR #9270][kubevirt-bot] BugFix: Guestfs image url not constructed correctly
+- [PR #9234][kubevirt-bot] The `dedicatedCPUPlacement` attribute is once again supported within the `VirtualMachineInstancetype` and `VirtualMachineClusterInstancetype` CRDs after a recent bugfix improved `VirtualMachine` validations, ensuring defaults are applied before any attempt to validate.
+- [PR #9267][fossedihelm] This version of KubeVirt includes upgraded virtualization technology based on libvirt 9.0.0 and QEMU 7.2.0.
+- [PR #9197][kubevirt-bot] Fix addvolume not rejecting adding existing volume source, fix removevolume allowing to remove non hotpluggable volume
+- [PR #9120][0xFelix] Fix access to portforwarding on VMs/VMIs with the cluster roles kubevirt.io:admin and kubevirt.io:edit
+- [PR #9116][EdDev] Allow the specification of the ACPI Index on a network interface.
+- [PR #8774][avlitman] Added new Virtual machines CPU metrics:
+- [PR #9087][zhuchenwang] Open `/dev/vhost-vsock` explicitly to ensure that the right vsock module is loaded
+- [PR #9020][feitnomore] Adding support for status/scale subresources so that VirtualMachinePool now supports HorizontalPodAutoscaler
+- [PR #9085][0xFelix] virtctl: Add options to infer instancetype and preference when creating a VM
+- [PR #8917][xpivarc] Kubevirt can be configured with Seccomp profile. It now ships a custom profile for the launcher.
+- [PR #9054][enp0s3] do not inject LimitRange defaults into VMI
+- [PR #7862][vladikr] Store the finalized VMI migration status in the migration objects.
+- [PR #8878][0xFelix] Add 'create vm' command to virtctl
+- [PR #9048][jean-edouard] DisableCustomSELinuxPolicy feature gate introduced to disable our custom SELinux policy
+- [PR #8953][awels] VMExport now has endpoint containing entire VM definition.
+- [PR #8976][iholder101] Fix podman CRI detection
+- [PR #9043][iholder101] Adjust operator functional tests to custom images specification
+- [PR #8875][machadovilaca] Rename migration metrics removing 'total' keyword
+- [PR #9040][lyarwood] `inferFromVolume` now uses labels instead of annotations to lookup default instance type and preference details from a referenced `Volume`. This has changed in order to provide users with a way of looking up suitably decorated resources through these labels before pointing to them within the `VirtualMachine`.
+- [PR #9039][orelmisan] client-go: Added context to additional VirtualMachineInstance's methods.
+- [PR #9018][orelmisan] client-go: Added context to additional VirtualMachineInstance's methods.
+- [PR #9025][akalenyu] BugFix: Hotplug pods have hardcoded resource req which don't comply with LimitRange maxLimitRequestRatio of 1
+- [PR #8908][orelmisan] client-go: Added context to some of VirtualMachineInstance's methods.
+- [PR #6863][rmohr] The install strategy job will respect the infra node placement from now on
+- [PR #8948][iholder101] Bugfix: virt-handler socket leak
+- [PR #8649][acardace] KubeVirt is now able to run VMs inside restricted namespaces.
+- [PR #8992][iholder101] Align with k8s fix for default limit range requirements
+- [PR #8889][rmohr] Add basic TLS encryption support for vsock websocket connections
+- [PR #8660][huyinhou] Fix remoteAddress field in virt-api log being truncated when it is an ipv6 address
+- [PR #8961][rmohr] Bump distroless base images
+- [PR #8952][rmohr] Fix read-only sata disk validation
+- [PR #8657][fossedihelm] Use an increasingly exponential backoff before retrying to start the VM, when an I/O error occurs.
+- [PR #8480][lyarwood] New `inferFromVolume` attributes have been introduced to the `{Instancetype,Preference}Matchers` of a `VirtualMachine`. When provided the `Volume` referenced by the attribute is checked for the following annotations with which to populate the `{Instancetype,Preference}Matchers`:
+- [PR #7762][VirrageS] Service `kubevirt-prometheus-metrics` now sets `ClusterIP` to `None` to make it a headless service.
+- [PR #8599][machadovilaca] Change KubevirtVmHighMemoryUsage threshold from 20MB to 50MB
+- [PR #7761][VirrageS] imagePullSecrets field has been added to KubeVirt CR to support deployments form private registries
+- [PR #8887][iholder101] Bugfix: use virt operator image if provided
+- [PR #8750][jordigilh] Fixes an issue that prevented running real time workloads in non-root configurations due to libvirt's dependency on CAP_SYS_NICE to change the vcpu's thread's scheduling and priority to FIFO and 1. The change of priority and scheduling is now executed in the virt-launcher for both root and non-root configurations, removing the dependency in libvirt.
+- [PR #8845][lyarwood] An empty `Timer` is now correctly omitted from `Clock` fixing bug #8844.
+- [PR #8842][andreabolognani] The virt-launcher pod no longer needs the SYS_PTRACE capability.
+- [PR #8734][alicefr] Change libguestfs-tools image using root appliance in qcow2 format
+- [PR #8764][ShellyKa13] Add list of included and excluded volumes in vmSnapshot
+- [PR #8811][iholder101] Custom components: support gs
+- [PR #8770][dhiller] Add Ginkgo V2 Serial decorator to serial tests as preparation to simplify parallel vs. serial test run logic
+- [PR #8808][acardace] Apply migration backoff only for evacuation migrations.
+- [PR #8525][jean-edouard] CR option mediatedDevicesTypes is deprecated in favor of mediatedDeviceTypes
+- [PR #8792][iholder101] Expose new custom components env vars to csv-generator and manifest-templator
+- [PR #8701][enp0s3] Consider the ParallelOutboundMigrationsPerNode when evicting VMs
+- [PR #8740][iholder101] Fix: Align Reenlightenment flows between converter.go and template.go
+- [PR #8530][acardace] Use exponential backoff for failing migrations
+- [PR #8720][0xFelix] The expand-spec subresource endpoint was renamed to expand-vm-spec and made namespaced
+- [PR #8458][iholder101] Introduce support for clones with a snapshot source (e.g. clone snapshot -> VM)
+- [PR #8716][rhrazdil] Add overhead of interface with Passt binding when no ports are specified
+- [PR #8619][fossedihelm] virt-launcher: use `virtqemud` daemon instead of `libvirtd`
+- [PR #8736][knopt] Added more precise rest_client_request_latency_seconds histogram buckets
+- [PR #8624][zhuchenwang] Add the REST API to be able to talk to the application in the guest VM via VSOCK.
+- [PR #8625][AlonaKaplan] iptables are no longer used by masquerade binding. Nodes with iptables only won't be able to run VMs with masquerade binding.
+- [PR #8673][iholder101] Allow specifying custom images for core components
+- [PR #8622][jean-edouard] Built with golang 1.19
+- [PR #8336][alicefr] Flag for setting the guestfs uid and gid
+- [PR #8667][huyinhou] connect VM vnc failed when virt-launcher work directory is not /
+- [PR #8368][machadovilaca] Use collector to set migration metrics
+- [PR #8558][xpivarc] Bug-fix: LimitRange integration now works when VMI is missing namespace
+- [PR #8404][andreabolognani] This version of KubeVirt includes upgraded virtualization technology based on libvirt 8.7.0, QEMU 7.1.0 and CentOS Stream 9.
+- [PR #8652][akalenyu] BugFix: Exporter pod does not comply with restricted PSA
+- [PR #8563][xpivarc] Kubevirt now runs with nonroot user by default
+- [PR #8442][kvaps] Add Deckhouse to the Adopters list
+- [PR #8546][zhuchenwang] Provides the Vsock feature for KubeVirt VMs.
+- [PR #8598][acardace] VMs configured with hugepages can now run using the default container_t SELinux type
+- [PR #8594][kylealexlane] Fix permission denied on on selinux relabeling on some kernel versions
+- [PR #8521][akalenyu] Add an option to specify a TTL for VMExport objects
+- [PR #7918][machadovilaca] Add alerts for VMs unhealthy states
+- [PR #8516][rhrazdil] When using Passt binding, virl-launcher has unprivileged_port_start set to 0, so that passt may bind to all ports.
+- [PR #7772][jean-edouard] The SELinux policy for virt-launcher is down to 4 rules, 1 for hugepages and 3 for virtiofs.
+- [PR #8402][jean-edouard] Most VMIs now run under the SELinux type container_t
+- [PR #8513][alromeros] [Bug-fix] Fix error handling in virtctl image-upload
+
+Contributors
+------------
+73 people contributed to this release:
+
+```
+62	Itamar Holder <iholder@redhat.com>
+39	L. Pivarc <lpivarc@redhat.com>
+36	Lee Yarwood <lyarwood@redhat.com>
+33	Andrea Bolognani <abologna@redhat.com>
+29	Edward Haas <edwardh@redhat.com>
+28	fossedihelm <ffossemo@redhat.com>
+25	Antonio Cardace <acardace@redhat.com>
+23	Felix Matouschek <fmatouschek@redhat.com>
+23	Jed Lejosne <jed@redhat.com>
+22	bmordeha <bmodeha@redhat.com>
+20	Roman Mohr <rmohr@google.com>
+18	Alex Kalenyuk <akalenyu@redhat.com>
+18	Orel Misan <omisan@redhat.com>
+17	Shelly Kagan <skagan@redhat.com>
+16	Alice Frosi <afrosi@redhat.com>
+14	Alexander Wels <awels@redhat.com>
+12	Marcelo Tosatti <mtosatti@redhat.com>
+11	Jordi Gil <jgil@redhat.com>
+10	Alvaro Romero <alromero@redhat.com>
+10	Andrej Krejcir <akrejcir@redhat.com>
+9	Dan Kenigsberg <danken@redhat.com>
+9	João Vilaça <jvilaca@redhat.com>
+8	Or Shoval <oshoval@redhat.com>
+8	Radim Hrazdil <rhrazdil@redhat.com>
+7	Maya Rashish <mrashish@redhat.com>
+6	Brian Carey <bcarey@redhat.com>
+6	Ram Lavi <ralavi@redhat.com>
+6	feitnomore <feitnomore@users.noreply.github.com>
+5	Bartosz Rybacki <brybacki@redhat.com>
+5	Ben Oukhanov <boukhanov@redhat.com>
+5	Janusz Marcinkiewicz <januszm@nvidia.com>
+5	Vasiliy Ulyanov <vulyanov@suse.de>
+5	Zhuchen Wang <zcwang@google.com>
+4	Alona Paz <alkaplan@redhat.com>
+4	Daniel Hiller <dhiller@redhat.com>
+4	Howard Zhang <howard.zhang@arm.com>
+4	Vladik Romanovsky <vromanso@redhat.com>
+4	enp0s3 <ibezukh@redhat.com>
+3	Javier Cano Cano <jcanocan@redhat.com>
+3	Michael Henriksen <mhenriks@redhat.com>
+3	howard zhang <howard.zhang@arm.com>
+3	huyinhou <huyinhou@bytedance.com>
+3	prnaraya <prnaraya@redhat.com>
+2	Alay Patel <alayp@nvidia.com>
+2	Arnon Gilboa <agilboa@redhat.com>
+2	Ondrej Pokorny <opokorny@redhat.com>
+2	Petr Horáček <phoracek@redhat.com>
+2	윤세준 <sjyoon@sjyoon02.local>
+1	Andrei Kvapil <kvapss@gmail.com>
+1	Arnaud Aubert <aaubert@magesi.com>
+1	Aviv Litman <alitman@redhat.com>
+1	Fabian Deutsch <fabiand@redhat.com>
+1	Geetika Kapoor <gkapoor@redhat.com>
+1	HF <crazytaxii666@gmail.com>
+1	Igor Bezukh <ibezukh@redhat.com>
+1	Miguel Duarte Barroso <mdbarroso@redhat.com>
+1	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+1	Petr Horacek <hrck@protonmail.com>
+1	PiotrProkop <pprokop@nvidia.com>
+1	Ryan Hallisey <rhallisey@nvidia.com>
+1	Shirly Radco <sradco@redhat.com>
+1	Simone Tiraboschi <stirabos@redhat.com>
+1	Stu Gott <sgott@redhat.com>
+1	Tomasz Knopik <tknopik@nvidia.com>
+1	Yan Du <yadu@redhat.com>
+1	Yufeng Duan <55268016+didovesei@users.noreply.github.com>
+1	akriti gupta <akrgupta@redhat.com>
+1	assaf-admi <aadmi@redhat.com>
+1	dalia-frank <dafrank@redhat.com>
+1	jia.dong <jia.dong@i-tudou.com>
+1	kfox1111 <Kevin.Fox@pnnl.gov>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.59.1.md
+++ b/CHANGELOG/CHANGELOG-v0.59.1.md
@@ -1,0 +1,67 @@
+KubeVirt v0.59.1
+================
+
+This release follows v0.59.0 and consists of 106 changes, contributed by 22 people, leading to 175 files changed, 5961 insertions(+), 2222 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.59.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.59.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #9825][kubevirt-bot] BugFix: allow multiple NFS disks to be used/hotplugged
+- [PR #9743][kubevirt-bot] virtctl supports retrieving vm manifest for VM export
+- [PR #9660][kubevirt-bot] TSC-enabled VMs can now migrate to a node with a non-identical (but close-enough) frequency
+- [PR #9581][kubevirt-bot] BugFix: virtualmachineclusterinstancetypes/preferences show up for get all -n <namespace>
+- [PR #9500][kubevirt-bot] Requests to update the target `Name` of a `{Instancetype,Preference}Matcher` without also updating the `RevisionName` are now rejected.
+- [PR #9507][kubevirt-bot] Bug fix: Fixes case when migration is not retried if the migration Pod gets denied.
+- [PR #9413][kubevirt-bot] Default RBAC for clone and export
+- [PR #9408][kubevirt-bot] Fix vmrestore with WFFC snapshotable storage class
+- [PR #9380][kubevirt-bot] Bug fix: DNS integration continues to work after migration
+- [PR #9362][iholder101] Add guest-to-request memory headroom ratio.
+- [PR #9145][awels] Show VirtualMachine name in the VMExport status
+- [PR #9345][kubevirt-bot] Use ECDSA instead of RSA for key generation
+- [PR #9343][kubevirt-bot] externally created mediated devices will not be deleted by virt-handler
+
+Contributors
+------------
+22 people contributed to this release:
+
+```
+7	Alexander Wels <awels@redhat.com>
+6	Itamar Holder <iholder@redhat.com>
+6	L. Pivarc <lpivarc@redhat.com>
+6	Lee Yarwood <lyarwood@redhat.com>
+6	fossedihelm <ffossemo@redhat.com>
+5	enp0s3 <ibezukh@redhat.com>
+4	Alex Kalenyuk <akalenyu@redhat.com>
+3	Alice Frosi <afrosi@redhat.com>
+3	Jed Lejosne <jed@redhat.com>
+3	Vasiliy Ulyanov <vulyanov@suse.de>
+3	Vladik Romanovsky <vromanso@redhat.com>
+2	Antonio Cardace <acardace@redhat.com>
+2	bmordeha <bmodeha@redhat.com>
+1	Alvaro Romero <alromero@redhat.com>
+1	Brian Carey <bcarey@redhat.com>
+1	Luboslav Pivarc <lpivarc@redhat.com>
+1	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+1	Orel Misan <omisan@redhat.com>
+1	Shelly Kagan <skagan@redhat.com>
+1	prnaraya <prnaraya@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.59.2.md
+++ b/CHANGELOG/CHANGELOG-v0.59.2.md
@@ -1,0 +1,44 @@
+KubeVirt v0.59.2
+================
+
+This release follows v0.59.1 and consists of 19 changes, contributed by 9 people, leading to 25 files changed, 493 insertions(+), 49 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v0.59.2.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v0.59.2`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #9910][kubevirt-bot] Bugfix: Allow lun disks to be mapped to DataVolume sources
+- [PR #9853][machadovilaca] Remove mixin query not available on all clusters
+- [PR #9826][Barakmor1] Add condition to migrations that indicates that migration was rejected by ResourceQuot
+
+Contributors
+------------
+9 people contributed to this release:
+
+```
+3	Marcelo Tosatti <mtosatti@redhat.com>
+3	bmordeha <bmodeha@redhat.com>
+1	Alexander Wels <awels@redhat.com>
+1	Alvaro Romero <alromero@redhat.com>
+1	Felix Matouschek <fmatouschek@redhat.com>
+1	João Vilaça <jvilaca@redhat.com>
+1	Maya Rashish <mrashish@redhat.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.6.0.md
+++ b/CHANGELOG/CHANGELOG-v0.6.0.md
@@ -1,0 +1,84 @@
+KubeVirt v0.6.0
+===============
+
+This release follows v0.5.0 and consists of 247 changes, contributed by
+19 people, leading to 168 files changed, 6035 insertions(+), 2389 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.6.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- A range of flakyness reducing test fixes
+- Vagrant setup got deprectated
+- Updated Docker and CentOS versions
+- Add Kubernetes 1.10.3 to test matrix
+- A couple of ginkgo concurrency fixes
+- A couple of spelling fixes
+- A range if infra updates
+
+- Use /dev/kvm if possible, otherwise fallback to emulation
+- Add default view/edit/admin RBAC Roles
+- Network MTU fixes
+- CDRom drives are now read-only
+- Secrets can now be correctly referenced on VMs
+- Add disk boot ordering
+- Add virtctl version
+- Add virtctl expose
+- Fix virtual machine memory calculations
+- Add basic virtual machine Network API
+
+Contributors
+------------
+
+19 people contributed to this release:
+
+```
+        89	Roman Mohr <rmohr@redhat.com>
+        32	Yuval Lifshitz <ylifshit@redhat.com>
+        22	Stu Gott <sgott@redhat.com>
+        16	David Vossel <dvossel@redhat.com>
+        13	Artyom Lukianov <alukiano@redhat.com>
+        13	Ihar Hrachyshka <ihar@redhat.com>
+        13	Marcus Sorensen <mls@apple.com>
+        13	Sebastian Scheinkman <sscheink@redhat.com>
+         9	Marcin Franczyk <mfranczy@redhat.com>
+         8	Vladik Romanovsky <vromanso@redhat.com>
+         5	Alexander Wels <awels@redhat.com>
+         4	Marc Sluiter <msluiter@redhat.com>
+         3	Fabian Deutsch <fabiand@redhat.com>
+         2	nmm <nmm@localhost.localdomain>
+         1	Gabriel Szasz <gszasz@redhat.com>
+         1	Jason Brooks <jbrooks@redhat.com>
+         1	Lukas Bednar <lbednar@redhat.com>
+         1	Martin Kletzander <mkletzan@redhat.com>
+         1	Phi|eas |ebada <norpol@users.noreply.github.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 105 of 115 Specs in 3638.019 seconds
+> SUCCESS! -- 105 Passed | 0 Failed | 0 Pending | 10 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.6.1.md
+++ b/CHANGELOG/CHANGELOG-v0.6.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.6.1
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.6.2.md
+++ b/CHANGELOG/CHANGELOG-v0.6.2.md
@@ -1,0 +1,55 @@
+KubeVirt v0.6.2
+===============
+
+This release follows v0.6.1 and consists of 17 changes, contributed by
+3 people, leading to 41 files changed, 343 insertions(+), 73 deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.6.2>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Binary relocation for packaging
+- QEMU Process detection
+- Role aggregation
+- CPU Model selection
+- VM Rename fix
+
+Contributors
+------------
+
+3 people contributed to this release:
+
+```
+         8	Fabian Deutsch <fabiand@redhat.com>
+         5	Artyom Lukianov <alukiano@redhat.com>
+         4	Roman Mohr <rmohr@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 117 of 128 Specs in 3774.947 seconds
+> SUCCESS! -- 117 Passed | 0 Failed | 0 Pending | 11 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.6.3.md
+++ b/CHANGELOG/CHANGELOG-v0.6.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.6.3
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.6.4.md
+++ b/CHANGELOG/CHANGELOG-v0.6.4.md
@@ -1,0 +1,4 @@
+KubeVirt v0.6.4
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.7.0.md
+++ b/CHANGELOG/CHANGELOG-v0.7.0.md
@@ -1,0 +1,94 @@
+KubeVirt v0.7.0
+===============
+
+This release follows v0.6.0 and consists of 351 changes, contributed by
+23 people, leading to 747 files changed, 395521 insertions(+), 57735
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.7.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: Move test storage to hostPath
+- CI: Add support for Kubernetes 1.10.4
+- CI: Improved network tests for multiple-interfaces
+- CI: Drop Origin 3.9 support
+- CI: Add test for testing templates on Origin
+- VM to VMI rename
+- VM affinity and anti-affinity
+- Add awareness for multiple networks
+- Add hugepage support
+- Add device-plugin based kvm
+- Add support for setting the network interface model
+- Add (basic and inital) Kubernetes compatible networking approach (SLIRP)
+- Add role aggregation for our roles
+- Add support for setting a disks serial number
+- Add support for specyfing the CPU model
+- Add support for setting an network intefraces MAC address
+- Relocate binaries for FHS conformance
+- Logging improvements
+- Template fixes
+- Fix OpenShift CRD validation
+- virtctl: Improve vnc logging improvements
+- virtctl: Add expose
+- virtctl: Use PATCH instead of PUT
+
+Contributors
+------------
+
+23 people contributed to this release:
+
+```
+        72	Roman Mohr <rmohr@redhat.com>
+        63	Artyom Lukianov <alukiano@redhat.com>
+        48	Stu Gott <sgott@redhat.com>
+        44	Ihar Hrachyshka <ihar@redhat.com>
+        36	Sebastian Scheinkman <sscheink@redhat.com>
+        19	David Vossel <dvossel@redhat.com>
+        15	Fabian Deutsch <fabiand@redhat.com>
+        12	Francesco Romani <fromani@redhat.com>
+        11	Tzvi Avni <tavni@redhat.com>
+         7	Marc Sluiter <msluiter@redhat.com>
+         4	Vladik Romanovsky <vromanso@redhat.com>
+         3	j-griffith <john.griffith8@gmail.com>
+         3	tchughesiv <tchughesiv@gmail.com>
+         2	Alexander Wels <awels@redhat.com>
+         2	Gabriel Szasz <gszasz@redhat.com>
+         2	Karim Boumedhel <kboumedh@redhat.com>
+         2	Ryan Hallisey <rhallise@redhat.com>
+         1	Adam Litke <alitke@redhat.com>
+         1	Lukas Bednar <lbednar@redhat.com>
+         1	Nelly Credi <ncredi@redhat.com>
+         1	Shiyang Wang <shiywang@redhat.com>
+         1	Thiago da Silva <thiago@redhat.com>
+         1	Yanir Quinn <yquinn@redhat.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 119 of 135 Specs in 4126.052 seconds
+> SUCCESS! -- 119 Passed | 0 Failed | 0 Pending | 16 Skipped PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.8.0.md
+++ b/CHANGELOG/CHANGELOG-v0.8.0.md
@@ -1,0 +1,102 @@
+KubeVirt v0.8.0
+===============
+
+This release follows v0.7.0 and consists of 354 changes, contributed by
+36 people, leading to 2612 files changed, 183877 insertions(+), 49008
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.8.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- Support for DataVolume
+- Support for a subprotocol for webbrowser terminals
+- Support for virtio-rng
+- Support disconnected VMs
+- Support for setting host model
+- Support for host CPU passthrough
+- Support setting a vNICs mac and PCI address
+- Support for memory over-commit
+- Support booting from network devices
+- Use less devices by default, aka disable unused ones
+- Improved VMI shutdown status
+- More logging to improve debugability
+- A lot of small fixes, including typos and documentation fixes
+- Race detection in tests
+- Hook improvements
+- Update to use Fedora 28 (includes updates of dependencies like libvirt and
+  qemu)
+- Move CI to support Kubernetes 1.11
+
+Contributors
+------------
+
+36 people contributed to this release:
+
+```
+        76	Artyom Lukianov <alukiano@redhat.com>
+        59	David Vossel <dvossel@redhat.com>
+        43	Roman Mohr <rmohr@redhat.com>
+        27	Sebastian Scheinkman <sscheink@redhat.com>
+        23	Petr Kotas <pkotas@redhat.com>
+        14	Petr Horáček <phoracek@redhat.com>
+        14	Stu Gott <sgott@redhat.com>
+        13	Marc Sluiter <msluiter@redhat.com>
+        12	Shiyang Wang <shiywang@redhat.com>
+        12	Vladik Romanovsky <vromanso@redhat.com>
+         7	Ihar Hrachyshka <ihar@redhat.com>
+         6	Ben Warren <bawarren@cisco.com>
+         5	Fabian Deutsch <fabiand@redhat.com>
+         5	dankenigsberg <danken@redhat.com>
+         4	Ihar Hrachyshka <ihrachys@redhat.com>
+         3	Arik Hadas <ahadas@redhat.com>
+         3	Michael Henriksen <mhenriks@redhat.com>
+         3	Yanir Quinn <yquinn@redhat.com>
+         3	Yuval Lifshitz <ylifshit@redhat.com>
+         3	root <root@sscheink.tlv.csb>
+         2	Daniel Belenky <dbelenky@redhat.com>
+         2	Gonzalo Rafuls <grafuls@redhat.com>
+         2	dankenigsberg <danken@gmail.com>
+         1	Alexander Wels <awels@redhat.com>
+         1	Alvaro Aleman <alv2412@googlemail.com>
+         1	Barak Korren <bkorren@redhat.com>
+         1	Boaz Shuster <boaz.shuster.github@gmail.com>
+         1	Francesco Romani <fromani@redhat.com>
+         1	Gabriel Szasz <gszasz@redhat.com>
+         1	Lukas Bednar <lbednar@redhat.com>
+         1	Ryan Hallisey <rhallise@redhat.com>
+         1	Simone Tiraboschi <stirabos@redhat.com>
+         1	William Zhang <warmchang@outlook.com>
+         1	gbenhaim <galbh2@gmail.com>
+         1	imjoey <majunjiev@gmail.com>
+         1	j-griffith <john.griffith8@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 149 of 163 Specs in 3851.878 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.9.0.md
+++ b/CHANGELOG/CHANGELOG-v0.9.0.md
@@ -1,0 +1,78 @@
+KubeVirt v0.9.0
+===============
+
+This release follows v0.8.0 and consists of 211 changes, contributed by
+20 people, leading to 1955 files changed, 112474 insertions(+), 32444
+deletions(-).
+
+The source code and selected binaries are available for download at:
+<https://github.com/kubevirt/kubevirt/releases/tag/v0.9.0>.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using [git-evtag][git-evtag].
+
+Pre-built containers are published on Docker Hub and can be viewed at:
+<https://hub.docker.com/u/kubevirt/>.
+
+Notable changes
+---------------
+
+- CI: NetworkPolicy tests
+- CI: Support for an external provider (use a preconfigured cluster for tests)
+- Fix virtctl console issues with CRI-O
+- Support to initialize empty PVs
+- Support for basic CPU pinning
+- Support for setting IO Threads
+- Support for block volumes
+- Move preset logic to mutating webhook
+- Introduce basic metrics reporting using prometheus metrics
+- Many stabilizing fixes in many places
+
+Contributors
+------------
+
+20 people contributed to this release:
+
+```
+        48	Roman Mohr <rmohr@redhat.com>
+        36	Stu Gott <sgott@redhat.com>
+        32	Vladik Romanovsky <vromanso@redhat.com>
+        22	Marc Sluiter <msluiter@redhat.com>
+        15	Artyom Lukianov <alukiano@redhat.com>
+        15	Marcin Franczyk <mfranczy@redhat.com>
+        10	David Vossel <dvossel@redhat.com>
+         8	Petr Kotas <pkotas@redhat.com>
+         5	Guohua Ouyang <gouyang@redhat.com>
+         4	Yan Du <yadu@redhat.com>
+         3	Ben Warren <bawarren@cisco.com>
+         3	Ihar Hrachyshka <ihar@redhat.com>
+         2	Gabriel Szasz <gszasz@redhat.com>
+         2	j-griffith <john.griffith8@gmail.com>
+         1	Dan Kenigsberg <danken@redhat.com>
+         1	Dylan Redding <dylan.redding@stackpath.com>
+         1	Fred Rolland <frolland@redhat.com>
+         1	Itamar Heim <iheim@localhost.localdomain>
+         1	Lukas Bednar <lbednar@redhat.com>
+         1	Piotr Kliczewski <piotr.kliczewski@gmail.com>
+```
+
+Test Results
+------------
+
+```
+> Ran 166 of 193 Specs in 4192.048 seconds
+> PASS
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- IRC: <irc://irc.freenode.net/#kubevirt>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[git-evtag]: https://github.com/cgwalters/git-evtag#using-git-evtag
+[contributing]: https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/master/LICENSE

--- a/CHANGELOG/CHANGELOG-v0.9.1.md
+++ b/CHANGELOG/CHANGELOG-v0.9.1.md
@@ -1,0 +1,4 @@
+KubeVirt v0.9.1
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.9.2.md
+++ b/CHANGELOG/CHANGELOG-v0.9.2.md
@@ -1,0 +1,4 @@
+KubeVirt v0.9.2
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.9.3.md
+++ b/CHANGELOG/CHANGELOG-v0.9.3.md
@@ -1,0 +1,4 @@
+KubeVirt v0.9.3
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.9.4.md
+++ b/CHANGELOG/CHANGELOG-v0.9.4.md
@@ -1,0 +1,4 @@
+KubeVirt v0.9.4
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.9.5.md
+++ b/CHANGELOG/CHANGELOG-v0.9.5.md
@@ -1,0 +1,4 @@
+KubeVirt v0.9.5
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v0.9.6.md
+++ b/CHANGELOG/CHANGELOG-v0.9.6.md
@@ -1,0 +1,4 @@
+KubeVirt v0.9.6
+===============
+
+No release notes.

--- a/CHANGELOG/CHANGELOG-v1.0.0.md
+++ b/CHANGELOG/CHANGELOG-v1.0.0.md
@@ -1,0 +1,201 @@
+KubeVirt v1.0.0
+===============
+
+This release follows v0.59.2 and consists of 1089 changes, contributed by 74 people, leading to 2849 files changed, 232018 insertions(+), 168449 deletions(-)
+v1.0.0 is a promotion of release candidate v1.0.0-rc.1 which was originally published 2023-06-30
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v1.0.0.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v1.0.0`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #10037][kubevirt-bot] The VM controller now replicates spec interfaces MAC addresses to the corresponding interfaces in the VMI spec.
+- [PR #9992][machadovilaca] Fix incorrect KubevirtVmHighMemoryUsage description
+- [PR #9965][kubevirt-bot] Disable network interface hotplug/unplug for VMIs. It will be supported for VMs only.
+- [PR #9931][kubevirt-bot] Fix for hotplug with WFFC SCI storage class which uses CDI populators
+- [PR #9946][kubevirt-bot] On hotunplug - remove bridge, tap and dummy interface from virt-launcher and the caches (file and volatile) from the node.
+- [PR #9757][enp0s3] Introduce CPU hotplug
+- [PR #9811][machadovilaca] Remove unnecessary marketplace tool
+- [PR #7742][Fuzzy-Math] Experimental support for AMD SEV-ES
+- [PR #9799][vladikr] Introduce an ability to set memory overcommit percentage in instanceType spec
+- [PR #8780][lyarwood] Add basic support for expressing minimum resource requirements for CPU and Memory within VirtualMachine{Preferences,ClusterPreferences}
+- [PR #9812][mhenriks] Handle DataVolume PendingPopulation phase
+- [PR #9858][fossedihelm] build virtctl for all os/architectures when `KUBEVIRT_RELEASE` env var is true
+- [PR #9765][lyarwood] Allow to define preferred cpu features in VirtualMachine{Preferences,ClusterPreferences}
+- [PR #9844][EdDev] Drop the `kubevirt.io/interface` resource name API for reserving domain resources for network interfaces.
+- [PR #9841][ormergi] Support hot-unplug of network interfaces on VirtualMachine objects
+- [PR #9851][lxs137] virt-api: portfowrad can handle IPv6 VM
+- [PR #9845][lxs137] DHCPv6 server handle request without iana option
+- [PR #9769][lyarwood] Allow to define the preferred subdomain in VirtualMachine{Preferences,ClusterPreferences}
+- [PR #9246][jean-edouard] Fixed migration issue for VMIs that have RWX disks backed by filesystem storage classes.
+- [PR #9808][jcanocan] DownwardMetrics: Rename AllocatedToVirtualServers metric to AllocatedToVirtualServers and add ResourceProcessorLimit metric
+- [PR #9832][tiraboschi] build virtctl also for arm64 for linux, darwin and windows
+- [PR #9744][lyarwood] Allow to define the preferred termination grace period in VirtualMachine{Preferences,ClusterPreferences}
+- [PR #9828][rthallisey] Publish multiarch manifests with each release
+- [PR #9761][lyarwood] Allow to define the preferred masquerade configuration in VirtualMachine{Preferences,ClusterPreferences}
+- [PR #9768][jean-edouard] New CR option to enable auto CPU limits for virt-launcher on some namespaces
+- [PR #9779][EdDev] Support hot-unplug of network interfaces on VMI objects
+- [PR #9688][xpivarc] Users are warned about the usage of deprecated fields
+- [PR #9798][rmohr] Add LiveMigrateIfPossible eviction strategy to allow admins to express a live migration preference instead of a live migration requirement for evictions.
+- [PR #9764][fossedihelm] Cluster admins can enable ksm in a set of nodes via kv configuration
+- [PR #9753][lyarwood] The following flags have been added to the `virtctl image-upload` command allowing users to associate a default instance type and/or preference with an image during upload. `--default-instancetype`,  `--default-instancetype-kind`, `--default-preference` and `--default-preference-kind`. [See the user-guide documentation](https://kubevirt.io/user-guide/virtual_machines/instancetypes/#inferfromvolume) for more details on using the uploaded image with the `inferFromVolume` feature during `VirtualMachine` creation.
+- [PR #9575][lyarwood] A new `v1beta1` version of the `instancetype.kubevirt.io` API and CRDs has been introduced.
+- [PR #9738][Barakmor1] Add condition to migrations that indicates that migration was rejected by ResourceQuota
+- [PR #9730][assafad] Add `kubevirt_vmi_memory_cached_bytes` metric
+- [PR #9674][fossedihelm] Introduce cluster configuration `VirtualMachineOptions` to specify virtual machine behavior at cluster level
+- [PR #9724][0xFelix] An alert which triggers when KubeVirt APIs marked as deprecated are used was added.
+- [PR #9623][rmohr] Bump to apimachinery 1.26
+- [PR #9747][lyarwood] action required - With the `v1.0.0` release of KubeVirt the storage version of all core `kubevirt.io` APIs will be moving to version `v1`. To accommodate the eventual removal of the `v1alpha3` version with KubeVirt >=`v1.2.0` it is recommended that operators deploy the [`kube-storage-version-migrator`](https://github.com/kubernetes-sigs/kube-storage-version-migrator) tool within their environment. This will ensure any existing `v1alpha3` stored objects are migrated to `v1` well in advance of the removal of the underlying `v1alpha3` version.
+- [PR #9268][ormergi] virt-launcher pods network interfaces name scheme is changed to hashed names (SHA256), based on the VMI spec network names.
+- [PR #9746][EdDev] Introduce the `kubevirt.io/interface` resource name to reserve domain resources for network interfaces.
+- [PR #9652][machadovilaca] Add kubevirt_number_of_vms recording rule
+- [PR #9691][fossedihelm] ksm enabled nodes will have `kubevirt.io/ksm-enabled` label
+- [PR #9628][lyarwood] * The `kubevirt.io/v1` `apiVersion` is now the default storage version for newly created objects
+- [PR #8293][daghaian] Add multi-arch support to KubeVirt. This allows a single KubeVirt installation to run VMs on different node architectures in the same cluster.
+- [PR #9686][maiqueb] Fix ownership of macvtap's char devices on non-root pods
+- [PR #9631][0xFelix] virtctl: Allow to infer instancetype or preference from specified volume when creating VMs
+- [PR #9665][rmohr] Expose the final resolved qemu machine type on the VMI on status.machine
+- [PR #9609][germag] Add support for running virtiofsd in an unprivileged container when sharing configuration volumes.
+- [PR #9651][0xFelix] virtctl: Allow to specify memory of created VMs. Default to 512Mi if no instancetype was specified or is inferred.
+- [PR #9640][jean-edouard] TSC-enabled VMs can now migrate to a node with a non-identical (but close-enough) frequency
+- [PR #9629][0xFelix] virtctl: Allow to specify the boot order of volumes when creating VMs
+- [PR #9632][toelke] * Add Genesis Cloud to the adopters list
+- [PR #9572][fossedihelm] Enable freePageReporting for new non high performance vmi
+- [PR #9435][rmohr] Ensure existence of all PVCs attached to the VMI before creating the VM target pod.
+- [PR #8156][jean-edouard] TPM VM device can now be set to persistent
+- [PR #8575][iholder101] QEMU-level migration parallelism (a.k.a. multifd) + Upgrade QEMU to 7.2.0-11.el9
+- [PR #9603][qinqon] Adapt node-labeller.sh script to work at non kvm envs with emulation.
+- [PR #9591][awels] BugFix: allow multiple NFS disks to be used/hotplugged
+- [PR #9596][iholder101] Add "virtctl create clone" command
+- [PR #9422][awels] Ability to specify cpu/mem request limit for supporting containers (hotplug/container disk/virtiofs/side car)
+- [PR #9536][akalenyu] BugFix: virtualmachineclusterinstancetypes/preferences show up for get all -n <namespace>
+- [PR #9177][alicefr] Adding SCSI persistent reservation
+- [PR #9470][machadovilaca] Enable libvirt GetDomainStats on paused VMs
+- [PR #9407][assafad] Use env `RUNBOOK_URL_TEMPLATE` for the runbooks URL template
+- [PR #9399][maiqueb] Compute the interfaces to be hotplugged based on the current domain info, rather than on the interface status.
+- [PR #9491][orelmisan] API, AddInterfaceOptions: Rename NetworkName to NetworkAttachmentDefinitionName and InterfaceName to Name
+- [PR #9327][jcanocan] DownwardMetrics: Swap KubeVirt build info with qemu version in VirtProductInfo field
+- [PR #9478][xpivarc] Bug fix: Fixes case when migration is not retried if the migration Pod gets denied.
+- [PR #9421][lyarwood] Requests to update the target `Name` of a `{Instancetype,Preference}Matcher` without also updating the `RevisionName` are now rejected.
+- [PR #9367][machadovilaca] Add VM instancetype and preference label to vmi_phase_count metric
+- [PR #9392][awels] virtctl supports retrieving vm manifest for VM export
+- [PR #9442][EdDev] Remove the VMI Status interface `podConfigDone` field in favor of a new source option in `infoSource`.
+- [PR #9376][ShellyKa13] Fix vmrestore with WFFC snapshotable storage class
+- [PR #6852][maiqueb] Dev preview: Enables network interface hotplug for VMs / VMIs
+- [PR #9300][xpivarc] Bug fix: API and virtctl invoked migration is not rejected when the VM is paused
+- [PR #9189][xpivarc] Bug fix: DNS integration continues to work after migration
+- [PR #9322][iholder101] Add guest-to-request memory headroom ratio.
+- [PR #8906][machadovilaca] Alert if there are no available nodes to run VMs
+- [PR #9320][darfux] node-labeller: Check arch on the handler side
+- [PR #9127][fossedihelm] Use ECDSA instead of RSA for key generation
+- [PR #9330][qinqon] Skip label kubevirt.io/migrationTargetNodeName from virtctl expose service selector
+- [PR #9163][vladikr] fixes the requests/limits CPU number mismatch for VMs with isolatedEmulatorThread
+- [PR #9250][vladikr] externally created mediated devices will not be deleted by virt-handler
+- [PR #9193][qinqon] Add annotation for live migration and bridged pod interface
+- [PR #9260][ShellyKa13] Fix bug of possible re-trigger of memory dump
+- [PR #9241][akalenyu] BugFix: Guestfs image url not constructed correctly
+- [PR #9220][orelmisan] client-go: Added context to VirtualMachine's methods.
+- [PR #9228][rumans] Bump virtiofs container limit
+- [PR #9169][lyarwood] The `dedicatedCPUPlacement` attribute is once again supported within the `VirtualMachineInstancetype` and `VirtualMachineClusterInstancetype` CRDs after a recent bugfix improved `VirtualMachine` validations, ensuring defaults are applied before any attempt to validate.
+- [PR #9159][andreabolognani] This version of KubeVirt includes upgraded virtualization technology based on libvirt 9.0.0 and QEMU 7.2.0.
+- [PR #8989][rthallisey] Integrate multi-architecture container manifests into the bazel make recipes
+- [PR #9188][awels] Default RBAC for clone and export
+- [PR #9145][awels] Show VirtualMachine name in the VMExport status
+- [PR #8937][fossedihelm] Added foreground finalizer to  virtual machine
+- [PR #9133][ShellyKa13] Fix addvolume not rejecting adding existing volume source, fix removevolume allowing to remove non hotpluggable volume
+- [PR #9047][machadovilaca] Deprecate VM stuck in status alerts
+
+Contributors
+------------
+74 people contributed to this release:
+
+```
+50	Edward Haas <edwardh@redhat.com>
+46	Lee Yarwood <lyarwood@redhat.com>
+39	Orel Misan <omisan@redhat.com>
+37	fossedihelm <ffossemo@redhat.com>
+36	Alice Frosi <afrosi@redhat.com>
+31	Felix Matouschek <fmatouschek@redhat.com>
+30	Miguel Duarte Barroso <mdbarroso@redhat.com>
+28	German Maglione <gmaglione@redhat.com>
+27	Or Mergi <ormergi@redhat.com>
+24	Itamar Holder <iholder@redhat.com>
+24	L. Pivarc <lpivarc@redhat.com>
+21	Alona Paz <alkaplan@redhat.com>
+20	Roman Mohr <rmohr@google.com>
+19	João Vilaça <jvilaca@redhat.com>
+18	Jed Lejosne <jed@redhat.com>
+17	Alexander Wels <awels@redhat.com>
+16	Vladik Romanovsky <vromanso@redhat.com>
+16	enp0s3 <ibezukh@redhat.com>
+14	aghaiand <david.aghaian@panasonic.aero>
+12	Ondrej Pokorny <opokorny@redhat.com>
+11	Daniel Hiller <dhiller@redhat.com>
+11	Victor Toso <victortoso@redhat.com>
+11	howard zhang <howard.zhang@arm.com>
+10	Alex Kalenyuk <akalenyu@redhat.com>
+10	Maya Rashish <mrashish@redhat.com>
+10	Shelly Kagan <skagan@redhat.com>
+9	Vasiliy Ulyanov <vulyanov@suse.de>
+8	Andrea Bolognani <abologna@redhat.com>
+7	Michael Henriksen <mhenriks@redhat.com>
+7	Ryan Hallisey <rhallisey@nvidia.com>
+7	bmordeha <bmodeha@redhat.com>
+6	David Aghaian <16483722+daghaian@users.noreply.github.com>
+6	Fabian Deutsch <fabiand@redhat.com>
+6	Nithish <nithishkarthik01@gmail.com>
+6	Or Shoval <oshoval@redhat.com>
+5	Alvaro Romero <alromero@redhat.com>
+5	Brian Carey <bcarey@redhat.com>
+4	Caleb Crane <ccrane@suse.de>
+4	Luboslav Pivarc <lpivarc@redhat.com>
+4	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+3	David Vossel <dvossel@redhat.com>
+3	Enrique Llorente <ellorent@redhat.com>
+3	Janusz Marcinkiewicz <januszm@nvidia.com>
+2	Alay Patel <alayp@nvidia.com>
+2	Andrej Krejcir <akrejcir@redhat.com>
+2	Andrew Imeson <andrew@andrewimeson.com>
+2	Antonio Cardace <acardace@redhat.com>
+2	Jan Wozniak <wozniak.jan@gmail.com>
+2	Kyle Lane <kylelane@google.com>
+2	Marcelo Tosatti <mtosatti@redhat.com>
+2	Vicente Cheng <vicente.cheng@suse.com>
+2	assaf-admi <aadmi@redhat.com>
+2	menyakun <lxs137@hotmail.com>
+1	Chris Ho <chris.he@suse.com>
+1	HF <crazytaxii666@gmail.com>
+1	Javier Cano Cano <jcanocan@redhat.com>
+1	Justin Cichra <jcichra@cloudflare.com>
+1	Li Yuxuan <liyuxuan.darfux@bytedance.com>
+1	Mark <mlavi@users.noreply.github.com>
+1	Petr Horacek <hrck@protonmail.com>
+1	Philipp Riederer <philipp@riederer.email>
+1	Pritam Saha <saha7pritam@gmail.com>
+1	Ram Lavi <ralavi@redhat.com>
+1	Romà Llorens <roma.llorens@gmail.com>
+1	Tomasz Knopik <tknopik@nvidia.com>
+1	Zhuchen Wang <zcwang@google.com>
+1	alitman <alitman@redhat.com>
+1	dalia-frank <dafrank@redhat.com>
+1	prnaraya <prnaraya@redhat.com>
+1	stirabos <stirabos@redhat.com>
+1	xpivarc <41989919+xpivarc@users.noreply.github.com>
+1	zhuanlan <zhuanlan_yewu@cmss.chinamobile.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v1.0.1.md
+++ b/CHANGELOG/CHANGELOG-v1.0.1.md
@@ -1,0 +1,84 @@
+KubeVirt v1.0.1
+===============
+
+This release follows v1.0.0 and consists of 188 changes, contributed by 31 people, leading to 226 files changed, 4540 insertions(+), 7509 deletions(-).
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v1.0.1.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is
+signed and can be verified using `git tag -v v1.0.1`.
+
+Pre-built containers are published on Quay and can be viewed at: <https://quay.io/kubevirt/>.
+
+Notable changes
+---------------
+
+- [PR #10554][kubevirt-bot] fix embed version info of virt-operator
+- [PR #10519][kubevirt-bot] A new `instancetype.kubevirt.io:view` `ClusterRole` has been introduced that can be bound to users via a `ClusterRoleBinding` to provide read only access to the cluster scoped `VirtualMachineCluster{Instancetype,Preference}` resources.
+- [PR #10493][fossedihelm] Add a Feature Gate to KV CR to automatically set memory limits when a resource quota with memory limits is associated to the creation namespace
+- [PR #10433][iholder101] Stop considering nodes without `kubevirt.io/schedulable` label when finding lowest TSC frequency on the cluster
+- [PR #10402][kubevirt-bot] BugFix: VMExport now works in a namespace with quotas defined.
+- [PR #10397][kubevirt-bot] Bugfix: Allow image-upload to recover from PendingPopulation phase
+- [PR #10273][machadovilaca] Change kubevirt_vmi_*_usage_seconds from Gauges to Counters
+- [PR #10292][kubevirt-bot] Ensure new hotplug attachment pod is ready before deleting old attachment pod
+- [PR #10266][machadovilaca] Remove affinities label from kubevirt_vmi_cpu_affinity and use sum as value
+- [PR #10205][AlonaKaplan] hotplug interface bug fix- default interface won't disappear from a hotplugged VM after restart
+- [PR #10153][kubevirt-bot] `ControllerRevisions` containing `instancetype.kubevirt.io` `CRDs` are now decorated with labels detailing specific metadata of the underlying stashed object
+- [PR #10207][kubevirt-bot] Restrict coordination/lease RBAC permissions to install namespace
+- [PR #10195][kubevirt-bot] Deprecate `spec.config.machineType` in KubeVirt CR.
+- [PR #10162][kubevirt-bot] Add boot-menu wait time when starting the VM as paused.
+- [PR #10191][kubevirt-bot] Use auth API for DataVolumes, stop importing kubevirt.io/containerized-data-importer
+- [PR #10193][kubevirt-bot] Bugfix: target virt-launcher pod hangs when migration is cancelled.
+- [PR #10176][kubevirt-bot] BugFix: deleting hotplug attachment pod will no longer detach volumes that were not removed.
+- [PR #10143][ormergi] Existing detached interfaces with 'absent' state will be cleared from VMI spec.
+- [PR #10068][kubevirt-bot] Add perf scale benchmarks for VMIs
+- [PR #10051][kubevirt-bot] Fix kubevirt_vmi_phase_count not being created
+- [PR #10037][kubevirt-bot] The VM controller now replicates spec interfaces MAC addresses to the corresponding interfaces in the VMI spec.
+
+Contributors
+------------
+31 people contributed to this release:
+
+```
+14	Vasiliy Ulyanov <vulyanov@suse.de>
+11	Or Mergi <ormergi@redhat.com>
+10	Lee Yarwood <lyarwood@redhat.com>
+10	fossedihelm <ffossemo@redhat.com>
+9	Alexander Wels <awels@redhat.com>
+7	Antonio Cardace <acardace@redhat.com>
+5	Alex Kalenyuk <akalenyu@redhat.com>
+5	Itamar Holder <iholder@redhat.com>
+4	Edward Haas <edwardh@redhat.com>
+4	João Vilaça <jvilaca@redhat.com>
+4	enp0s3 <ibezukh@redhat.com>
+3	Alay Patel <alayp@nvidia.com>
+3	Luboslav Pivarc <lpivarc@redhat.com>
+3	Pavel Tishkov <pavel.tishkov@flant.com>
+2	Alice Frosi <afrosi@redhat.com>
+2	Alona Paz <alkaplan@redhat.com>
+2	Andrej Krejcir <akrejcir@redhat.com>
+2	Arnon Gilboa <agilboa@redhat.com>
+2	Jed Lejosne <jed@redhat.com>
+2	rokkiter <101091030+rokkiter@users.noreply.github.com>
+1	Alay Patel <alay1431@gmail.com>
+1	Alvaro Romero <alromero@redhat.com>
+1	Assaf Admi <aadmi@redhat.com>
+1	Felix Matouschek <fmatouschek@redhat.com>
+1	Reficul <xuzhenglun@gmail.com>
+1	Roman Mohr <rmohr@google.com>
+1	Shelly Kagan <skagan@redhat.com>
+1	bmordeha <bmordeha@redhat.com>
+1	grass-lu <284555125@qq.com>
+```
+
+Additional Resources
+--------------------
+
+- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
+- An easy to use demo: <https://github.com/kubevirt/demo>
+- [How to contribute][contributing]
+- [License][license]
+
+[contributing]: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+[license]: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/CHANGELOG-v1.1.0.md
+++ b/CHANGELOG/CHANGELOG-v1.1.0.md
@@ -1,0 +1,184 @@
+# KubeVirt v1.1.0
+
+This release follows v1.0.1 and consists of 1071 changes, leading to 1108 files changed, 82781 insertions(+), 33012 deletions(-).
+v1.1.0 is a promotion of release candidate v1.1.0-rc.1, which was originally published on 2023-11-03.
+
+The primary release artifact of KubeVirt is the git tree. The release tag is signed and can be verified using `git tag -v v1.1.0`.
+
+The source code and selected binaries are available for download at: https://github.com/kubevirt/kubevirt/releases/tag/v1.1.0  
+Pre-built containers are published on Quay and can be viewed at: https://quay.io/kubevirt/
+
+## Notable changes
+
+- [#10669](https://github.com/kubevirt/kubevirt/pull/10669) ([@kubevirt-bot](https://github.com/kubevirt-bot)) Introduce network binding plugin for Passt networking, interfacing with Kubevirt new network binding plugin API.
+- [#10646](https://github.com/kubevirt/kubevirt/pull/10646) ([@jean-edouard](https://github.com/jean-edouard)) The dedicated migration network should now always be properly detected by virt-handler
+- [#10602](https://github.com/kubevirt/kubevirt/pull/10602) ([@kubevirt-bot](https://github.com/kubevirt-bot)) Fix LowKVMNodesCount not firing
+- [#10566](https://github.com/kubevirt/kubevirt/pull/10566) ([@fossedihelm](https://github.com/fossedihelm)) Add 100Mi of memory overhead for vmi with dedicatedCPU or that wants GuaranteedQos
+- [#10568](https://github.com/kubevirt/kubevirt/pull/10568) ([@ormergi](https://github.com/ormergi)) Network binding plugin API support CNIs, new integration point on virt-launcher pod creation.
+- [#10496](https://github.com/kubevirt/kubevirt/pull/10496) ([@fossedihelm](https://github.com/fossedihelm)) Automatically set cpu limits when a resource quota with cpu limits is associated to the creation namespace and the `AutoResourceLimits` FeatureGate is enabled
+- [#10309](https://github.com/kubevirt/kubevirt/pull/10309) ([@lyarwood](https://github.com/lyarwood)) cluster-wide [`common-instancetypes`](https://github.com/kubevirt/common-instancetypes) resources can now deployed by `virt-operator` using the `CommonInstancetypesDeploymentGate` feature gate.
+- [#10543](https://github.com/kubevirt/kubevirt/pull/10543) ([@0xFelix](https://github.com/0xFelix)) Clear VM guest memory when ignoring inference failures
+- [#9590](https://github.com/kubevirt/kubevirt/pull/9590) ([@xuzhenglun](https://github.com/xuzhenglun)) fix embed version info of virt-operator
+- [#10532](https://github.com/kubevirt/kubevirt/pull/10532) ([@alromeros](https://github.com/alromeros)) Add --volume-mode flag in image-upload
+- [#10515](https://github.com/kubevirt/kubevirt/pull/10515) ([@iholder101](https://github.com/iholder101)) Bug-fix: Stop copying VMI spec to VM during snapshots
+- [#10320](https://github.com/kubevirt/kubevirt/pull/10320) ([@victortoso](https://github.com/victortoso)) sidecar-shim implements PreCloudInitIso hook
+- [#10463](https://github.com/kubevirt/kubevirt/pull/10463) ([@0xFelix](https://github.com/0xFelix)) VirtualMachines: Introduce InferFromVolumeFailurePolicy in Instancetype- and PreferenceMatchers
+- [#10393](https://github.com/kubevirt/kubevirt/pull/10393) ([@iholder101](https://github.com/iholder101)) [Bugfix] [Clone API] Double-cloning is now working as expected.
+- [#10486](https://github.com/kubevirt/kubevirt/pull/10486) ([@assafad](https://github.com/assafad)) Deprecation notice for the metrics listed in the PR. Please update your systems to use the new metrics names.
+- [#10438](https://github.com/kubevirt/kubevirt/pull/10438) ([@lyarwood](https://github.com/lyarwood)) A new `instancetype.kubevirt.io:view` `ClusterRole` has been introduced that can be bound to users via a `ClusterRoleBinding` to provide read only access to the cluster scoped `VirtualMachineCluster{Instancetype,Preference}` resources.
+- [#10477](https://github.com/kubevirt/kubevirt/pull/10477) ([@jean-edouard](https://github.com/jean-edouard)) Dynamic KSM enabling and configuration
+- [#10110](https://github.com/kubevirt/kubevirt/pull/10110) ([@tiraboschi](https://github.com/tiraboschi)) Stream guest serial console logs from a dedicated container
+- [#10015](https://github.com/kubevirt/kubevirt/pull/10015) ([@victortoso](https://github.com/victortoso)) Implements USB host passthrough in permittedHostDevices of KubeVirt CRD
+- [#10184](https://github.com/kubevirt/kubevirt/pull/10184) ([@acardace](https://github.com/acardace)) Add memory hotplug feature
+- [#10044](https://github.com/kubevirt/kubevirt/pull/10044) ([@machadovilaca](https://github.com/machadovilaca)) Add operator-observability package
+- [#10489](https://github.com/kubevirt/kubevirt/pull/10489) ([@maiqueb](https://github.com/maiqueb)) Remove the network-attachment-definition `list` and `watch` verbs from virt-controller's RBAC
+- [#10450](https://github.com/kubevirt/kubevirt/pull/10450) ([@0xFelix](https://github.com/0xFelix)) virtctl: Enable inference in create vm subcommand by default
+- [#10447](https://github.com/kubevirt/kubevirt/pull/10447) ([@fossedihelm](https://github.com/fossedihelm)) Add a Feature Gate to KV CR to automatically set memory limits when a resource quota with memory limits is associated to the creation namespace
+- [#10253](https://github.com/kubevirt/kubevirt/pull/10253) ([@rmohr](https://github.com/rmohr)) Stop trying to create unused directory /var/run/kubevirt-ephemeral-disk in virt-controller
+- [#10231](https://github.com/kubevirt/kubevirt/pull/10231) ([@kvaps](https://github.com/kvaps)) Propogate public-keys to cloud-init NoCloud meta-data
+- [#10400](https://github.com/kubevirt/kubevirt/pull/10400) ([@alromeros](https://github.com/alromeros)) Add new vmexport flags to download raw images, either directly (--raw) or by decompressing (--decompress) them
+- [#9673](https://github.com/kubevirt/kubevirt/pull/9673) ([@germag](https://github.com/germag)) DownwardMetrics: Expose DownwardMetrics through virtio-serial channel.
+- [#10086](https://github.com/kubevirt/kubevirt/pull/10086) ([@vladikr](https://github.com/vladikr)) allow live updating VM affinity and node selector
+- [#10050](https://github.com/kubevirt/kubevirt/pull/10050) ([@victortoso](https://github.com/victortoso)) Updating the virt stack: QEMU 8.0.0, libvirt to 9.5.0, edk2 20230524,
+- [#10370](https://github.com/kubevirt/kubevirt/pull/10370) ([@benjx1990](https://github.com/benjx1990)) N/A
+- [#10391](https://github.com/kubevirt/kubevirt/pull/10391) ([@awels](https://github.com/awels)) BugFix: VMExport now works in a namespace with quotas defined.
+- [#10386](https://github.com/kubevirt/kubevirt/pull/10386) ([@liuzhen21](https://github.com/liuzhen21)) KubeSphere added to the adopter's file!
+- [#10380](https://github.com/kubevirt/kubevirt/pull/10380) ([@alromeros](https://github.com/alromeros)) Bugfix: Allow image-upload to recover from PendingPopulation phase
+- [#10366](https://github.com/kubevirt/kubevirt/pull/10366) ([@ormergi](https://github.com/ormergi)) Kubevirt now delegates Slirp networking configuration to Slirp network binding plugin.  In case you haven't registered Slirp network binding plugin image yet (i.e.: specify in Kubevirt config) the following default image would be used: `quay.io/kubevirt/network-slirp-binding:20230830_638c60fc8`. On next release (v1.2.0) no default image will be set and registering an image would be mandatory.
+- [#10167](https://github.com/kubevirt/kubevirt/pull/10167) ([@0xFelix](https://github.com/0xFelix)) virtctl: Apply namespace to created manifests
+- [#10148](https://github.com/kubevirt/kubevirt/pull/10148) ([@alromeros](https://github.com/alromeros)) Add port-forward functionalities to vmexport
+- [#9821](https://github.com/kubevirt/kubevirt/pull/9821) ([@sradco](https://github.com/sradco)) Deprecation notice for the metrics listed in the PR. Please update your systems to use the new metrics names.
+- [#10272](https://github.com/kubevirt/kubevirt/pull/10272) ([@ormergi](https://github.com/ormergi)) Introduce network binding plugin for Slirp networking, interfacing with Kubevirt new network binding plugin API.
+- [#10284](https://github.com/kubevirt/kubevirt/pull/10284) ([@AlonaKaplan](https://github.com/AlonaKaplan)) Introduce an API for network binding plugins. The feature is behind "NetworkBindingPlugins" gate.
+- [#10275](https://github.com/kubevirt/kubevirt/pull/10275) ([@awels](https://github.com/awels)) Ensure new hotplug attachment pod is ready before deleting old attachment pod
+- [#9231](https://github.com/kubevirt/kubevirt/pull/9231) ([@victortoso](https://github.com/victortoso)) Introduces sidecar-shim container image
+- [#10254](https://github.com/kubevirt/kubevirt/pull/10254) ([@rmohr](https://github.com/rmohr)) Don't mark the KubeVirt "Available" condition as false on up-to-date and ready but misscheduled virt-handler pods.
+- [#10185](https://github.com/kubevirt/kubevirt/pull/10185) ([@AlonaKaplan](https://github.com/AlonaKaplan)) Add support to migration based SRIOV hotplug.
+- [#10182](https://github.com/kubevirt/kubevirt/pull/10182) ([@iholder101](https://github.com/iholder101)) Stop considering nodes without `kubevirt.io/schedulable` label when finding lowest TSC frequency on the cluster
+- [#10138](https://github.com/kubevirt/kubevirt/pull/10138) ([@machadovilaca](https://github.com/machadovilaca)) Change kubevirt_vmi_*_usage_seconds from Gauge to Counter
+- [#10173](https://github.com/kubevirt/kubevirt/pull/10173) ([@rmohr](https://github.com/rmohr))
+- [#10101](https://github.com/kubevirt/kubevirt/pull/10101) ([@acardace](https://github.com/acardace)) Deprecate `spec.config.machineType` in KubeVirt CR.
+- [#10020](https://github.com/kubevirt/kubevirt/pull/10020) ([@akalenyu](https://github.com/akalenyu)) Use auth API for DataVolumes, stop importing kubevirt.io/containerized-data-importer
+- [#10107](https://github.com/kubevirt/kubevirt/pull/10107) ([@PiotrProkop](https://github.com/PiotrProkop)) Expose kubevirt_vmi_vcpu_delay_seconds_total reporting amount of seconds VM spent in  waiting in the queue instead of running.
+- [#10099](https://github.com/kubevirt/kubevirt/pull/10099) ([@iholder101](https://github.com/iholder101)) Bugfix: target virt-launcher pod hangs when migration is cancelled.
+- [#10056](https://github.com/kubevirt/kubevirt/pull/10056) ([@jean-edouard](https://github.com/jean-edouard)) UEFI guests now use Bochs display instead of VGA emulation
+- [#10070](https://github.com/kubevirt/kubevirt/pull/10070) ([@machadovilaca](https://github.com/machadovilaca)) Remove affinities label from kubevirt_vmi_cpu_affinity and use sum as value
+- [#10165](https://github.com/kubevirt/kubevirt/pull/10165) ([@awels](https://github.com/awels)) BugFix: deleting hotplug attachment pod will no longer detach volumes that were not removed.
+- [#9878](https://github.com/kubevirt/kubevirt/pull/9878) ([@jean-edouard](https://github.com/jean-edouard)) The EFI NVRAM can now be configured to persist across reboots
+- [#9932](https://github.com/kubevirt/kubevirt/pull/9932) ([@lyarwood](https://github.com/lyarwood)) `ControllerRevisions` containing `instancetype.kubevirt.io` `CRDs` are now decorated with labels detailing specific metadata of the underlying stashed object
+- [#10039](https://github.com/kubevirt/kubevirt/pull/10039) ([@simonyangcj](https://github.com/simonyangcj)) fix guaranteed qos of virt-launcher pod broken when use virtiofs
+- [#10116](https://github.com/kubevirt/kubevirt/pull/10116) ([@ormergi](https://github.com/ormergi)) Existing detached interfaces with 'absent' state will be cleared from VMI spec.
+- [#9982](https://github.com/kubevirt/kubevirt/pull/9982) ([@fabiand](https://github.com/fabiand)) Introduce a support lifecycle and Kubernetes target version.
+- [#10118](https://github.com/kubevirt/kubevirt/pull/10118) ([@akalenyu](https://github.com/akalenyu)) Change exportserver default UID to succeed exporting CDI standalone PVCs (not attached to VM)
+- [#10106](https://github.com/kubevirt/kubevirt/pull/10106) ([@acardace](https://github.com/acardace)) Add boot-menu wait time when starting the VM as paused.
+- [#10058](https://github.com/kubevirt/kubevirt/pull/10058) ([@alicefr](https://github.com/alicefr)) Add field errorPolicy for disks
+- [#10004](https://github.com/kubevirt/kubevirt/pull/10004) ([@AlonaKaplan](https://github.com/AlonaKaplan)) Hoyplug/unplug interfaces should be done by updating the VM spec template. virtctl and REST API endpoints were removed.
+- [#10067](https://github.com/kubevirt/kubevirt/pull/10067) ([@iholder101](https://github.com/iholder101)) Bug fix: `virtctl create clone` marshalling and replacement of `kubectl` with `kubectl virt`
+- [#9989](https://github.com/kubevirt/kubevirt/pull/9989) ([@alaypatel07](https://github.com/alaypatel07)) Add perf scale benchmarks for VMIs
+- [#10001](https://github.com/kubevirt/kubevirt/pull/10001) ([@machadovilaca](https://github.com/machadovilaca)) Fix kubevirt_vmi_phase_count not being created
+- [#9896](https://github.com/kubevirt/kubevirt/pull/9896) ([@ormergi](https://github.com/ormergi)) The VM controller now replicates spec interfaces MAC addresses to the corresponding interfaces in the VMI spec.
+- [#9840](https://github.com/kubevirt/kubevirt/pull/9840) ([@dhiller](https://github.com/dhiller)) Increase probability for flake checker script to find flakes
+- [#9988](https://github.com/kubevirt/kubevirt/pull/9988) ([@enp0s3](https://github.com/enp0s3)) always deploy the outdated VMI workload alert
+- [#7708](https://github.com/kubevirt/kubevirt/pull/7708) ([@VirrageS](https://github.com/VirrageS)) `nodeSelector` and `schedulerName` fields have been added to VirtualMachineInstancetype spec.
+- [#7197](https://github.com/kubevirt/kubevirt/pull/7197) ([@vasiliy-ul](https://github.com/vasiliy-ul)) Experimantal support of SEV attestation via the new API endpoints
+- [#9958](https://github.com/kubevirt/kubevirt/pull/9958) ([@AlonaKaplan](https://github.com/AlonaKaplan)) Disable network interface hotplug/unplug for VMIs. It will be supported for VMs only.
+- [#9882](https://github.com/kubevirt/kubevirt/pull/9882) ([@dhiller](https://github.com/dhiller)) Add some context for initial contributors about automated testing and draft pull requests.
+- [#9935](https://github.com/kubevirt/kubevirt/pull/9935) ([@xpivarc](https://github.com/xpivarc)) Bug fix - correct logging in container disk
+- [#9552](https://github.com/kubevirt/kubevirt/pull/9552) ([@phoracek](https://github.com/phoracek)) gRPC client now works correctly with non-Go gRPC servers
+- [#9918](https://github.com/kubevirt/kubevirt/pull/9918) ([@ShellyKa13](https://github.com/ShellyKa13)) Fix for hotplug with WFFC SCI storage class which uses CDI populators
+- [#9737](https://github.com/kubevirt/kubevirt/pull/9737) ([@AlonaKaplan](https://github.com/AlonaKaplan)) On hotunplug - remove bridge, tap and dummy interface from virt-launcher and the caches (file and volatile) from the node.
+- [#9861](https://github.com/kubevirt/kubevirt/pull/9861) ([@rmohr](https://github.com/rmohr)) Fix the possibility of data corruption when requestin a force-restart via "virtctl restart"
+- [#9818](https://github.com/kubevirt/kubevirt/pull/9818) ([@akrejcir](https://github.com/akrejcir)) Added "virtctl credentials" commands to dynamically change SSH keys in a VM, and to set user's password.
+- [#9872](https://github.com/kubevirt/kubevirt/pull/9872) ([@alromeros](https://github.com/alromeros)) Bugfix: Allow lun disks to be mapped to DataVolume sources
+- [#9073](https://github.com/kubevirt/kubevirt/pull/9073) ([@machadovilaca](https://github.com/machadovilaca)) Fix incorrect KubevirtVmHighMemoryUsage description
+
+## Contributors
+
+76 people contributed to this release:
+
+```
+62	Victor Toso <victortoso@redhat.com>
+55	Edward Haas <edwardh@redhat.com>
+43	Or Mergi <ormergi@redhat.com>
+42	fossedihelm <ffossemo@redhat.com>
+39	Itamar Holder <iholder@redhat.com>
+38	Alona Paz <alkaplan@redhat.com>
+36	Vasiliy Ulyanov <vulyanov@suse.de>
+27	Ondrej Pokorny <opokorny@redhat.com>
+26	Daniel Hiller <dhiller@redhat.com>
+26	Fabian Deutsch <fabiand@redhat.com>
+21	Lee Yarwood <lyarwood@redhat.com>
+19	Antonio Cardace <acardace@redhat.com>
+19	Felix Matouschek <fmatouschek@redhat.com>
+16	Luboslav Pivarc <lpivarc@redhat.com>
+15	Jed Lejosne <jed@redhat.com>
+14	Alexander Wels <awels@redhat.com>
+12	Alvaro Romero <alromero@redhat.com>
+12	João Vilaça <jvilaca@redhat.com>
+11	Roman Mohr <rmohr@google.com>
+10	enp0s3 <ibezukh@redhat.com>
+9	Varun Ramachandra Sekar <varun.sekar1994@gmail.com>
+9	prnaraya <prnaraya@redhat.com>
+9	stirabos <stirabos@redhat.com>
+8	Alex Kalenyuk <akalenyu@redhat.com>
+8	Alice Frosi <afrosi@redhat.com>
+8	Brian Carey <bcarey@redhat.com>
+7	Andrew Burden <aburden@redhat.com>
+6	L. Pivarc <lpivarc@redhat.com>
+6	Vladik Romanovsky <vromanso@redhat.com>
+5	Andrej Krejcir <akrejcir@redhat.com>
+5	German Maglione <gmaglione@redhat.com>
+4	Javier Cano Cano <jcanocan@redhat.com>
+4	Michael Henriksen <mhenriks@redhat.com>
+4	Miguel Duarte Barroso <mdbarroso@redhat.com>
+3	Alay Patel <alayp@nvidia.com>
+3	Dan Kenigsberg <danken@redhat.com>
+3	Daniel Hiller <daniel.hiller.1972@googlemail.com>
+3	Dharmit Shah <shahdharmit@gmail.com>
+3	HHHskkk <913596231@qq.com>
+3	Janusz Marcinkiewicz <januszm@nvidia.com>
+3	Or Shoval <oshoval@redhat.com>
+3	Orel Misan <omisan@redhat.com>
+3	Pavel Tishkov <pavel.tishkov@flant.com>
+3	Shelly Kagan <skagan@redhat.com>
+3	Shirly Radco <sradco@redhat.com>
+3	bmordeha <bmordeha@redhat.com>
+2	Andrei Kvapil <kvapss@gmail.com>
+2	Arnon Gilboa <agilboa@redhat.com>
+2	Assaf Admi <aadmi@redhat.com>
+2	Benjamin <72671586+benjx1990@users.noreply.github.com>
+2	Oliver Sabiniarz <o_sabiniarz@yahoo.de>
+2	PiotrProkop <pprokop@nvidia.com>
+2	howard zhang <howard.zhang@arm.com>
+2	liuzhen <liuzhen@yunify.com>
+2	rkishner <rkishner@redhat.com>
+2	rokkiter <101091030+rokkiter@users.noreply.github.com>
+2	yojay11717 <lanyujie@inspur.com>
+1	Alay Patel <alay1431@gmail.com>
+1	Andrea Bolognani <abologna@redhat.com>
+1	Aviv Litman <alitman@alitman-thinkpadp1gen4i.tlv.csb>
+1	Aviv Litman <alitman@alitman.tlv.csb>
+1	Aviv Litman <alitman@redhat.com>
+1	Eng Zer Jun <engzerjun@gmail.com>
+1	Itamar Holder <77444623+iholder101@users.noreply.github.com>
+1	Marcelo Tosatti <mtosatti@redhat.com>
+1	Maya Rashish <mrashish@redhat.com>
+1	Nahshon Unna-Tsameret <nunnatsa@redhat.com>
+1	Nijin Ashok <nashok@redhat.com>
+1	Petr Horacek <hrck@protonmail.com>
+1	Reficul <xuzhenglun@gmail.com>
+1	SIMON COTER <simon.coter@oracle.com>
+1	akrgupta <akrgupta@redhat.com>
+1	grass-lu <284555125@qq.com>
+1	rokkiter <yongen.pan@daocloud.io>
+1	wangzihao05 <wangzihao05@inspur.com>
+1	yangchenjun <yang.chenjun@99cloud.net>
+```
+
+## Additional Resources
+
+- Mailing list: https://groups.google.com/forum/#!forum/kubevirt-dev
+- Slack: https://kubernetes.slack.com/messages/virtualization
+- An easy to use demo: https://github.com/kubevirt/demo
+- How to contribute: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md
+- License: https://github.com/kubevirt/kubevirt/blob/main/LICENSE

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -1,0 +1,3 @@
+# KubeVirt release notes
+
+The most recent release is [v1.1.0](CHANGELOG-v1.1.0.md).


### PR DESCRIPTION
**What this PR does / why we need it**

Previously discussed [here](https://groups.google.com/g/kubevirt-dev/c/FvtVEAIVjo0/m/2Ekis79eAQAJ) and [here](https://groups.google.com/g/kubevirt-dev/c/lxqXb2wIqUk/m/yelXQYTUBAAJ).

The [project-infra#3056](https://github.com/kubevirt/project-infra/pull/3056) PR updates `release-tool` so that it stops embedding release notes in git tags and starts committing them to the repository instead. To prepare for that, import all existing release notes.

The tool is also updated to produce proper Markdown, and a few tweaks have been made to the structure and contents. See [`CHANGELOG/CHANGELOG-v1.1.0.md`](https://github.com/andreabolognani/kubevirt/blob/release-notes/CHANGELOG/CHANGELOG-v1.1.0.md) from this PR to get a preview.

**Release note**

```release-note
NONE
```

(ironically enough :)