### PR TITLE
Restore default hotplug attachment pod request to original values

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -650,11 +650,11 @@ func hotplugContainerLimits(config *virtconfig.ClusterConfig) k8sv1.ResourceList
 }
 
 func hotplugContainerRequests(config *virtconfig.ClusterConfig) k8sv1.ResourceList {
-	cpuQuantity := resource.MustParse("100m")
+	cpuQuantity := resource.MustParse("10m")
 	if cpu := config.GetSupportContainerRequest(v1.HotplugAttachment, k8sv1.ResourceCPU); cpu != nil {
 		cpuQuantity = *cpu
 	}
-	memQuantity := resource.MustParse("80M")
+	memQuantity := resource.MustParse("2M")
 	if mem := config.GetSupportContainerRequest(v1.HotplugAttachment, k8sv1.ResourceMemory); mem != nil {
 		memQuantity = *mem
 	}

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -328,6 +328,13 @@ var _ = Describe("Resource pod spec renderer", func() {
 
 	defaultRequest := func() kubev1.ResourceList {
 		return kubev1.ResourceList{
+			kubev1.ResourceCPU:    resource.MustParse("10m"),
+			kubev1.ResourceMemory: resource.MustParse("2M"),
+		}
+	}
+
+	defaultLimit := func() kubev1.ResourceList {
+		return kubev1.ResourceList{
 			kubev1.ResourceCPU:    resource.MustParse("100m"),
 			kubev1.ResourceMemory: resource.MustParse("80M"),
 		}
@@ -355,7 +362,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 		Expect(res.Requests).To(BeEquivalentTo(expectedReq))
 		Expect(res.Limits).To(BeEquivalentTo(expectedLim))
 	},
-		Entry("empty request/limit", kubev1.ResourceList{}, kubev1.ResourceList{}, defaultRequest(), defaultRequest()),
+		Entry("empty request/limit", kubev1.ResourceList{}, kubev1.ResourceList{}, defaultRequest(), defaultLimit()),
 		Entry("empty request, set limit", kubev1.ResourceList{}, kubev1.ResourceList{
 			kubev1.ResourceCPU:    resource.MustParse("25m"),
 			kubev1.ResourceMemory: resource.MustParse("32M"),
@@ -369,7 +376,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 		}, kubev1.ResourceList{}, kubev1.ResourceList{
 			kubev1.ResourceCPU:    resource.MustParse("140m"),
 			kubev1.ResourceMemory: resource.MustParse("1024M"),
-		}, defaultRequest()),
+		}, defaultLimit()),
 		Entry("set request, set limit", kubev1.ResourceList{
 			kubev1.ResourceCPU:    resource.MustParse("25m"),
 			kubev1.ResourceMemory: resource.MustParse("32M"),
@@ -389,7 +396,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 			kubev1.ResourceCPU:    resource.MustParse("140m"),
 			kubev1.ResourceMemory: resource.MustParse("1024M"),
 		}, kubev1.ResourceList{
-			kubev1.ResourceCPU:    resource.MustParse("100m"),
+			kubev1.ResourceCPU:    resource.MustParse("10m"),
 			kubev1.ResourceMemory: resource.MustParse("32M"),
 		}, kubev1.ResourceList{
 			kubev1.ResourceCPU:    resource.MustParse("140m"),
@@ -402,7 +409,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 			kubev1.ResourceMemory: resource.MustParse("1024M"),
 		}, kubev1.ResourceList{
 			kubev1.ResourceCPU:    resource.MustParse("25m"),
-			kubev1.ResourceMemory: resource.MustParse("80M"),
+			kubev1.ResourceMemory: resource.MustParse("2M"),
 		}, kubev1.ResourceList{
 			kubev1.ResourceCPU:    resource.MustParse("140m"),
 			kubev1.ResourceMemory: resource.MustParse("1024M"),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4059,17 +4059,17 @@ var _ = Describe("Template", func() {
 			Entry("when volume is a filesystem", false),
 		)
 
-		verifyPodRequestLimits1to1Ratio := func(pod *k8sv1.Pod) {
-			cpuLimit := pod.Spec.Containers[0].Resources.Limits.Cpu().Value()
+		verifyPodRequestLimits := func(pod *k8sv1.Pod) {
+			cpuLimit := pod.Spec.Containers[0].Resources.Limits.Cpu().MilliValue()
 			memLimit := pod.Spec.Containers[0].Resources.Limits.Memory().Value()
-			cpuReq := pod.Spec.Containers[0].Resources.Requests.Cpu().Value()
+			cpuReq := pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 			memReq := pod.Spec.Containers[0].Resources.Requests.Memory().Value()
 			expCpuLimitQ := resource.MustParse("100m")
-			Expect(cpuLimit).To(Equal(expCpuLimitQ.Value()))
+			Expect(cpuLimit).To(Equal(expCpuLimitQ.MilliValue()))
 			expMemLimitQ := resource.MustParse("80M")
 			Expect(memLimit).To(Equal(expMemLimitQ.Value()))
-			expCpuReqQ := resource.MustParse("100m")
-			Expect(cpuReq).To(Equal(expCpuReqQ.Value()))
+			expCpuReqQ := resource.MustParse("10m")
+			Expect(cpuReq).To(Equal(expCpuReqQ.MilliValue()))
 			expMemReqQ := resource.MustParse("2M")
 			Expect(memReq).To(Equal(expMemReqQ.Value()))
 		}
@@ -4093,7 +4093,7 @@ var _ = Describe("Template", func() {
 			claimMap := map[string]*k8sv1.PersistentVolumeClaim{}
 			pod, err := svc.RenderHotplugAttachmentPodTemplate([]*v1.Volume{}, ownerPod, vmi, claimMap, false)
 			Expect(err).ToNot(HaveOccurred())
-			verifyPodRequestLimits1to1Ratio(pod)
+			verifyPodRequestLimits(pod)
 		})
 
 		DescribeTable("hould compute the correct resource req according to desired QoS when rendering hotplug trigger pods", func(isBlock bool) {
@@ -4114,7 +4114,7 @@ var _ = Describe("Template", func() {
 			}
 			pod, err := svc.RenderHotplugAttachmentTriggerPodTemplate(&v1.Volume{}, ownerPod, vmi, "test", isBlock, false)
 			Expect(err).ToNot(HaveOccurred())
-			verifyPodRequestLimits1to1Ratio(pod)
+			verifyPodRequestLimits(pod)
 		},
 			Entry("when volume is a block device", true),
 			Entry("when volume is a filesystem", false),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4070,7 +4070,7 @@ var _ = Describe("Template", func() {
 			Expect(memLimit).To(Equal(expMemLimitQ.Value()))
 			expCpuReqQ := resource.MustParse("100m")
 			Expect(cpuReq).To(Equal(expCpuReqQ.Value()))
-			expMemReqQ := resource.MustParse("80M")
+			expMemReqQ := resource.MustParse("2M")
 			Expect(memReq).To(Equal(expMemReqQ.Value()))
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As a quick fix we modified the requests and limit ratio to be 1. However this is not ideal since it reserves a lot of cpu and memory for that container that doesn't really do anything at all. Its purpose is to attach a volume to the node.

We added the ability to set the requests and limits for all the supporting containers in (#9422). At this point anyone can set the ratio to what they want. So lets restore the defaults to the original values, so that people that don't care don't end up using a lot of memory for no reason.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Restored hotplug attachment pod request/limit to original value
```
