### PR TITLE
Quarantine flaky test of migration over dedicated network

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -3255,7 +3255,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 		})
 	})
 
-	Context("[Serial] with a dedicated migration network", Serial, func() {
+	Context("[Serial][QUARANTINE] with a dedicated migration network", Serial, func() {
 		BeforeEach(func() {
 			virtClient = kubevirt.Client()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This test has flaked 6% of the time over the past 14 days[1] which means that it qualifies for quarantine[2].

It is also one of the top tests in the recent flakefinder report[3]

[1] https://search.ci.kubevirt.io/?search=dedicated+migration+network&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
[2] https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md#putting-tests-in-quarantine
[3] https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2023-11-13-168h.html#row3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @xpivarc 
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- ~[ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- ~[ ] PR: The PR description is expressive enough and will help future contributors~
- ~[ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)~
- ~[ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)~
- ~[ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- ~[ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- ~[ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- ~[ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

**Release note**:
```release-note
NONE
```
