### PR TITLE
[hotplug tests]: Use /mnt instead of /tmp for separate device tests

### DIFF
--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -50,18 +50,18 @@ ls -al /local-storage/hp_file.img
 LOOP_DEVICE_HP=$(chroot /host losetup --verbose --find --show /mnt/local-storage/hp_file.img)
 echo LOOP_DEVICE_HP=${LOOP_DEVICE_HP} >>/etc/bashrc
 chroot /host mkfs.ext4 $LOOP_DEVICE_HP
-mkdir -p /hostImages/mount_hp
+mkdir -p /local-storage/mount_hp
 ls -al /host${LOOP_DEVICE_HP}
-chroot /host mount ${LOOP_DEVICE_HP} /tmp/hostImages/mount_hp
-mkdir -p /host/tmp/hostImages/mount_hp/test
+chroot /host mount ${LOOP_DEVICE_HP} /mnt/local-storage/mount_hp
+mkdir -p /host/mnt/local-storage/mount_hp/test
 # When the host is ubuntu, by default, selinux is not used, so chcon is not necessary.
 # If selinux tag is set, use chcon to change /hostImages privileges.
 if [ ${SELINUX_TAG:0:1} != "?" ]; then
     chcon -Rt svirt_sandbox_file_t /host/tmp/hostImages
     chcon -R unconfined_u:object_r:svirt_sandbox_file_t:s0 /host/mnt/local-storage/
 fi
-chmod 777 /host/tmp/hostImages/mount_hp
-chmod 777 /host/tmp/hostImages/mount_hp/test
+chmod 777 /host/mnt/local-storage/mount_hp
+chmod 777 /host/mnt/local-storage/mount_hp/test
 
 cat /etc/bashrc
 

--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -266,7 +266,7 @@ func createSeparateDeviceHostPathPv(osName, namespace, nodeName string) {
 			PersistentVolumeReclaimPolicy: k8sv1.PersistentVolumeReclaimRetain,
 			PersistentVolumeSource: k8sv1.PersistentVolumeSource{
 				HostPath: &k8sv1.HostPathVolumeSource{
-					Path: "/tmp/hostImages/mount_hp/test",
+					Path: "/mnt/local-storage/mount_hp/test",
 				},
 			},
 			StorageClassName: StorageClassHostPathSeparateDevice,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On some systems mounts on /tmp get reverted at some point, resulting in hotplug separate device test failures.
Somewhat similar to https://github.com/kubevirt/kubevirt/pull/7200


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
