### PR TITLE
[guest-console-log] tests: Normalize newlines in guest console log

### DIFF
--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -91,12 +91,13 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 		})
 
 		Context("fetch logs", func() {
-			var cirrosLogo = strings.Replace(` ____               ____  ____
+			var cirrosLogo = `
+  ____               ____  ____
  / __/ __ ____ ____ / __ \/ __/
 / /__ / // __// __// /_/ /\ \ 
 \___//_//_/  /_/   \____/___/ 
    http://cirros-cloud.net
-`, "\n", "\r\n", 5)
+`
 
 			It("it should fetch logs for a running VM with logs API", func() {
 				vmi := tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
@@ -143,8 +144,8 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				// Expect(outputString).ToNot(ContainSubstring("Password: gocubsgo"))
 
 				By("Ensuring that logs contain the test command and its output")
-				Expect(logs).To(ContainSubstring("echo " + testString + "\r\n"))
-				Expect(logs).To(ContainSubstring("\r\n" + testString + "\r\n"))
+				Expect(logs).To(ContainSubstring("echo " + testString + "\n"))
+				Expect(logs).To(ContainSubstring("\n" + testString + "\n"))
 			})
 
 			It("it should rotate the internal log files", func() {
@@ -194,7 +195,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking that log lines are sequential with no gaps")
-				outputLines := strings.Split(logs, "\r\n")
+				outputLines := strings.Split(logs, "\n")
 				Expect(len(outputLines)).To(BeNumerically(">", 1000))
 				matchingLines := 0
 				prevSeqn := -1
@@ -249,5 +250,5 @@ func getConsoleLogs(virtClient kubecli.KubevirtClient, virtlauncherPod *k8sv1.Po
 			Container: "guest-console-log",
 		}).
 		DoRaw(context.Background())
-	return string(logsRaw), err
+	return strings.ReplaceAll(string(logsRaw), "\r\n", "\n"), err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In case the log contains `\r\n` sequence, replace it with just `\n` to allow matching against patterns with Linux-style newlines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I checked the tests with `make cluster-up` and indeed, the resulting logs contain `\r\n`. However, on my Linux environment, some of the tests fail when matching against `\r\n` pattern due to `\n` newlines in the returned output. Apparently, the newlines somehow depend on the environment (though seeing `\r\n` on Linux seems weird). Anyway, the patch modifies the tests to support both variants.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
