### PR TITLE
Set error policy to report for scsi persistent reservation

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -303,6 +303,10 @@ func setReservation(disk *api.Disk) {
 }
 
 func setErrorPolicy(diskDevice *v1.Disk, disk *api.Disk) error {
+	if diskDevice.LUN != nil && diskDevice.LUN.Reservation && diskDevice.ErrorPolicy == nil {
+		disk.Driver.ErrorPolicy = v1.DiskErrorPolicyReport
+		return nil
+	}
 	if diskDevice.ErrorPolicy == nil {
 		disk.Driver.ErrorPolicy = v1.DiskErrorPolicyStop
 		return nil

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -990,6 +990,7 @@ var _ = Describe("Converter", func() {
 			Expect(reserv.SourceReservations.Type).To(Equal("unix"))
 			Expect(reserv.SourceReservations.Path).To(Equal("/var/run/kubevirt/daemons/pr/pr-helper.sock"))
 			Expect(reserv.SourceReservations.Mode).To(Equal("client"))
+			Expect(domainSpec.Devices.Disks[0].Driver.ErrorPolicy).To(Equal(v1.DiskErrorPolicyReport))
 		})
 
 		It("should add a virtio-scsi controller if a scsci disk is present and iothreads set", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Windows Share Cluster Filesystem makes usage of SCSI reservations and it expects to handle directly IO error. Change the default error policy stop to report when the reservation is requested.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2249846

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set error policy to report when SCSI reservation is requested
```
