### PR TITLE
Improve conformance of subresources.kubvirt.io openapi spec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11254,6 +11254,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1vmi-addvolume",
      "parameters": [
       {
@@ -11375,6 +11378,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/freeze": {
     "put": {
      "description": "Freeze a VirtualMachineInstance object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1Freeze",
      "parameters": [
       {
@@ -11467,6 +11473,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/pause": {
     "put": {
      "description": "Pause a VirtualMachineInstance object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1Pause",
      "parameters": [
       {
@@ -11606,6 +11615,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine Instance",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1vmi-removevolume",
      "parameters": [
       {
@@ -11698,6 +11710,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/sev/injectlaunchsecret": {
     "put": {
      "description": "Inject SEV launch secret into a Virtual Machine",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1SEVInjectLaunchSecret",
      "parameters": [
       {
@@ -11790,6 +11805,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/sev/setupsession": {
     "put": {
      "description": "Setup SEV session parameters for a Virtual Machine",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1SEVSetupSession",
      "parameters": [
       {
@@ -11923,6 +11941,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/unpause": {
     "put": {
      "description": "Unpause a VirtualMachineInstance object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1Unpause",
      "parameters": [
       {
@@ -12159,6 +12180,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1vm-addvolume",
      "parameters": [
       {
@@ -12260,6 +12284,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/memorydump": {
     "put": {
      "description": "Dumps a VirtualMachineInstance memory.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1MemoryDump",
      "parameters": [
       {
@@ -12311,6 +12338,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/migrate": {
     "put": {
      "description": "Migrate a running VirtualMachine to another node.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1Migrate",
      "parameters": [
       {
@@ -12491,6 +12521,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1vm-removevolume",
      "parameters": [
       {
@@ -12542,6 +12575,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/restart": {
     "put": {
      "description": "Restart a VirtualMachine object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1Restart",
      "parameters": [
       {
@@ -12598,6 +12634,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/start": {
     "put": {
      "description": "Start a VirtualMachine object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1Start",
      "parameters": [
       {
@@ -12655,6 +12694,9 @@
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/stop": {
     "put": {
      "description": "Stop a VirtualMachine object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1Stop",
      "parameters": [
       {
@@ -12888,6 +12930,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3vmi-addvolume",
      "parameters": [
       {
@@ -13009,6 +13054,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/freeze": {
     "put": {
      "description": "Freeze a VirtualMachineInstance object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3Freeze",
      "parameters": [
       {
@@ -13101,6 +13149,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/pause": {
     "put": {
      "description": "Pause a VirtualMachineInstance object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3Pause",
      "parameters": [
       {
@@ -13240,6 +13291,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine Instance",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3vmi-removevolume",
      "parameters": [
       {
@@ -13332,6 +13386,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/sev/injectlaunchsecret": {
     "put": {
      "description": "Inject SEV launch secret into a Virtual Machine",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3SEVInjectLaunchSecret",
      "parameters": [
       {
@@ -13424,6 +13481,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/sev/setupsession": {
     "put": {
      "description": "Setup SEV session parameters for a Virtual Machine",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3SEVSetupSession",
      "parameters": [
       {
@@ -13557,6 +13617,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/unpause": {
     "put": {
      "description": "Unpause a VirtualMachineInstance object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3Unpause",
      "parameters": [
       {
@@ -13793,6 +13856,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3vm-addvolume",
      "parameters": [
       {
@@ -13894,6 +13960,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/memorydump": {
     "put": {
      "description": "Dumps a VirtualMachineInstance memory.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3MemoryDump",
      "parameters": [
       {
@@ -13945,6 +14014,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/migrate": {
     "put": {
      "description": "Migrate a running VirtualMachine to another node.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3Migrate",
      "parameters": [
       {
@@ -14125,6 +14197,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3vm-removevolume",
      "parameters": [
       {
@@ -14176,6 +14251,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/restart": {
     "put": {
      "description": "Restart a VirtualMachine object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3Restart",
      "parameters": [
       {
@@ -14232,6 +14310,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/start": {
     "put": {
      "description": "Start a VirtualMachine object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3Start",
      "parameters": [
       {
@@ -14289,6 +14370,9 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/stop": {
     "put": {
      "description": "Stop a VirtualMachine object.",
+     "consumes": [
+      "*/*"
+     ],
      "operationId": "v1alpha3Stop",
      "parameters": [
       {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11239,7 +11239,17 @@
        }
       }
      }
-    }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
    },
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/addvolume": {
     "put": {
@@ -11342,7 +11352,25 @@
        "description": "Unauthorized"
       }
      }
-    }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
    },
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/freeze": {
     "put": {
@@ -11999,7 +12027,25 @@
        "description": "Unauthorized"
       }
      }
-    }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
    },
    "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/vnc": {
     "get": {
@@ -12827,7 +12873,17 @@
        }
       }
      }
-    }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
    },
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/addvolume": {
     "put": {
@@ -12930,7 +12986,25 @@
        "description": "Unauthorized"
       }
      }
-    }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
    },
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/freeze": {
     "put": {
@@ -13587,7 +13661,25 @@
        "description": "Unauthorized"
       }
      }
-    }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
    },
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/vnc": {
     "get": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -329,7 +329,7 @@
      }
     }
    },
-   "/apis/clone.kubevirt.io/v1alpha1/virtualmachineclones/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/clone.kubevirt.io/v1alpha1/virtualmachineclones/{name}": {
     "get": {
      "description": "Get a VirtualMachineClone object.",
      "produces": [
@@ -647,7 +647,7 @@
      }
     }
    },
-   "/apis/export.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineexports": {
+   "/apis/export.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachineexports": {
     "get": {
      "description": "Get a list of VirtualMachineExport objects.",
      "produces": [
@@ -874,7 +874,7 @@
      }
     }
    },
-   "/apis/export.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineexports/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/export.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachineexports/{name}": {
     "get": {
      "description": "Get a VirtualMachineExport object.",
      "produces": [
@@ -1150,7 +1150,7 @@
      }
     ]
    },
-   "/apis/export.kubevirt.io/v1alpha1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineexports": {
+   "/apis/export.kubevirt.io/v1alpha1/watch/namespaces/{namespace}/virtualmachineexports": {
     "get": {
      "description": "Watch a VirtualMachineExport object.",
      "produces": [
@@ -1372,7 +1372,7 @@
      }
     }
    },
-   "/apis/instancetype.kubevirt.io/v1beta1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancetypes": {
+   "/apis/instancetype.kubevirt.io/v1beta1/namespaces/{namespace}/virtualmachineinstancetypes": {
     "get": {
      "description": "Get a list of VirtualMachineInstancetype objects.",
      "produces": [
@@ -1599,7 +1599,7 @@
      }
     }
    },
-   "/apis/instancetype.kubevirt.io/v1beta1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancetypes/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/instancetype.kubevirt.io/v1beta1/namespaces/{namespace}/virtualmachineinstancetypes/{name}": {
     "get": {
      "description": "Get a VirtualMachineInstancetype object.",
      "produces": [
@@ -1792,7 +1792,7 @@
      }
     ]
    },
-   "/apis/instancetype.kubevirt.io/v1beta1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinepreferences": {
+   "/apis/instancetype.kubevirt.io/v1beta1/namespaces/{namespace}/virtualmachinepreferences": {
     "get": {
      "description": "Get a list of VirtualMachinePreference objects.",
      "produces": [
@@ -2019,7 +2019,7 @@
      }
     }
    },
-   "/apis/instancetype.kubevirt.io/v1beta1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinepreferences/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/instancetype.kubevirt.io/v1beta1/namespaces/{namespace}/virtualmachinepreferences/{name}": {
     "get": {
      "description": "Get a VirtualMachinePreference object.",
      "produces": [
@@ -2423,7 +2423,7 @@
      }
     }
    },
-   "/apis/instancetype.kubevirt.io/v1beta1/virtualmachineclusterinstancetypes/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/instancetype.kubevirt.io/v1beta1/virtualmachineclusterinstancetypes/{name}": {
     "get": {
      "description": "Get a VirtualMachineClusterInstancetype object.",
      "produces": [
@@ -2819,7 +2819,7 @@
      }
     }
    },
-   "/apis/instancetype.kubevirt.io/v1beta1/virtualmachineclusterpreferences/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/instancetype.kubevirt.io/v1beta1/virtualmachineclusterpreferences/{name}": {
     "get": {
      "description": "Get a VirtualMachineClusterPreference object.",
      "produces": [
@@ -3170,7 +3170,7 @@
      }
     ]
    },
-   "/apis/instancetype.kubevirt.io/v1beta1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancetypes": {
+   "/apis/instancetype.kubevirt.io/v1beta1/watch/namespaces/{namespace}/virtualmachineinstancetypes": {
     "get": {
      "description": "Watch a VirtualMachineInstancetype object.",
      "produces": [
@@ -3259,7 +3259,7 @@
      }
     ]
    },
-   "/apis/instancetype.kubevirt.io/v1beta1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinepreferences": {
+   "/apis/instancetype.kubevirt.io/v1beta1/watch/namespaces/{namespace}/virtualmachinepreferences": {
     "get": {
      "description": "Watch a VirtualMachinePreference object.",
      "produces": [
@@ -3807,7 +3807,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/kubevirt": {
     "get": {
      "description": "Get a list of KubeVirt objects.",
      "produces": [
@@ -4034,7 +4034,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/kubevirt/{name}": {
     "get": {
      "description": "Get a KubeVirt object.",
      "produces": [
@@ -4227,7 +4227,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstancemigrations": {
     "get": {
      "description": "Get a list of VirtualMachineInstanceMigration objects.",
      "produces": [
@@ -4454,7 +4454,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstancemigrations/{name}": {
     "get": {
      "description": "Get a VirtualMachineInstanceMigration object.",
      "produces": [
@@ -4647,7 +4647,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstancepresets": {
     "get": {
      "description": "Get a list of VirtualMachineInstancePreset objects.",
      "produces": [
@@ -4874,7 +4874,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstancepresets/{name}": {
     "get": {
      "description": "Get a VirtualMachineInstancePreset object.",
      "produces": [
@@ -5067,7 +5067,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstancereplicasets": {
     "get": {
      "description": "Get a list of VirtualMachineInstanceReplicaSet objects.",
      "produces": [
@@ -5294,7 +5294,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstancereplicasets/{name}": {
     "get": {
      "description": "Get a VirtualMachineInstanceReplicaSet object.",
      "produces": [
@@ -5487,7 +5487,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances": {
     "get": {
      "description": "Get a list of VirtualMachineInstance objects.",
      "produces": [
@@ -5714,7 +5714,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}": {
     "get": {
      "description": "Get a VirtualMachineInstance object.",
      "produces": [
@@ -5907,7 +5907,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachines": {
     "get": {
      "description": "Get a list of VirtualMachine objects.",
      "produces": [
@@ -6134,7 +6134,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}": {
     "get": {
      "description": "Get a VirtualMachine object.",
      "produces": [
@@ -6823,7 +6823,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace}/kubevirt": {
     "get": {
      "description": "Watch a KubeVirt object.",
      "produces": [
@@ -6912,7 +6912,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace}/virtualmachineinstancemigrations": {
     "get": {
      "description": "Watch a VirtualMachineInstanceMigration object.",
      "produces": [
@@ -7001,7 +7001,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace}/virtualmachineinstancepresets": {
     "get": {
      "description": "Watch a VirtualMachineInstancePreset object.",
      "produces": [
@@ -7090,7 +7090,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace}/virtualmachineinstancereplicasets": {
     "get": {
      "description": "Watch a VirtualMachineInstanceReplicaSet object.",
      "produces": [
@@ -7179,7 +7179,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace}/virtualmachineinstances": {
     "get": {
      "description": "Watch a VirtualMachineInstance object.",
      "produces": [
@@ -7268,7 +7268,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace}/virtualmachines": {
     "get": {
      "description": "Watch a VirtualMachine object.",
      "produces": [
@@ -8025,7 +8025,7 @@
      }
     }
    },
-   "/apis/migrations.kubevirt.io/v1alpha1/migrationpolicies/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/migrations.kubevirt.io/v1alpha1/migrationpolicies/{name}": {
     "get": {
      "description": "Get a MigrationPolicy object.",
      "produces": [
@@ -8343,7 +8343,7 @@
      }
     }
    },
-   "/apis/pool.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinepools": {
+   "/apis/pool.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachinepools": {
     "get": {
      "description": "Get a list of VirtualMachinePool objects.",
      "produces": [
@@ -8570,7 +8570,7 @@
      }
     }
    },
-   "/apis/pool.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinepools/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/pool.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachinepools/{name}": {
     "get": {
      "description": "Get a VirtualMachinePool object.",
      "produces": [
@@ -8846,7 +8846,7 @@
      }
     ]
    },
-   "/apis/pool.kubevirt.io/v1alpha1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinepools": {
+   "/apis/pool.kubevirt.io/v1alpha1/watch/namespaces/{namespace}/virtualmachinepools": {
     "get": {
      "description": "Watch a VirtualMachinePool object.",
      "produces": [
@@ -9068,7 +9068,7 @@
      }
     }
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinerestores": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachinerestores": {
     "get": {
      "description": "Get a list of VirtualMachineRestore objects.",
      "produces": [
@@ -9295,7 +9295,7 @@
      }
     }
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinerestores/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachinerestores/{name}": {
     "get": {
      "description": "Get a VirtualMachineRestore object.",
      "produces": [
@@ -9488,7 +9488,7 @@
      }
     ]
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinesnapshotcontents": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachinesnapshotcontents": {
     "get": {
      "description": "Get a list of VirtualMachineSnapshotContent objects.",
      "produces": [
@@ -9715,7 +9715,7 @@
      }
     }
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinesnapshotcontents/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachinesnapshotcontents/{name}": {
     "get": {
      "description": "Get a VirtualMachineSnapshotContent object.",
      "produces": [
@@ -9908,7 +9908,7 @@
      }
     ]
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinesnapshots": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachinesnapshots": {
     "get": {
      "description": "Get a list of VirtualMachineSnapshot objects.",
      "produces": [
@@ -10135,7 +10135,7 @@
      }
     }
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinesnapshots/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/namespaces/{namespace}/virtualmachinesnapshots/{name}": {
     "get": {
      "description": "Get a VirtualMachineSnapshot object.",
      "produces": [
@@ -10577,7 +10577,7 @@
      }
     ]
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinerestores": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/watch/namespaces/{namespace}/virtualmachinerestores": {
     "get": {
      "description": "Watch a VirtualMachineRestore object.",
      "produces": [
@@ -10666,7 +10666,7 @@
      }
     ]
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinesnapshotcontents": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/watch/namespaces/{namespace}/virtualmachinesnapshotcontents": {
     "get": {
      "description": "Watch a VirtualMachineSnapshotContent object.",
      "produces": [
@@ -10755,7 +10755,7 @@
      }
     ]
    },
-   "/apis/snapshot.kubevirt.io/v1alpha1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachinesnapshots": {
+   "/apis/snapshot.kubevirt.io/v1alpha1/watch/namespaces/{namespace}/virtualmachinesnapshots": {
     "get": {
      "description": "Watch a VirtualMachineSnapshot object.",
      "produces": [
@@ -11206,7 +11206,7 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/expand-vm-spec": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/expand-vm-spec": {
     "put": {
      "description": "Expands instancetype and preference into the passed VirtualMachine object.",
      "consumes": [
@@ -11241,7 +11241,7 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
      "operationId": "v1vmi-addvolume",
@@ -11292,7 +11292,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/console": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/console": {
     "get": {
      "description": "Open a websocket connection to a serial console on the specified VirtualMachineInstance.",
      "operationId": "v1Console",
@@ -11321,7 +11321,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/filesystemlist": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/filesystemlist": {
     "get": {
      "description": "Get list of active filesystems on guest machine via guest agent",
      "consumes": [
@@ -11344,7 +11344,7 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/freeze": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/freeze": {
     "put": {
      "description": "Freeze a VirtualMachineInstance object.",
      "operationId": "v1Freeze",
@@ -11395,7 +11395,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/guestosinfo": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/guestosinfo": {
     "get": {
      "description": "Get guest agent os information",
      "consumes": [
@@ -11436,7 +11436,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/pause": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/pause": {
     "put": {
      "description": "Pause a VirtualMachineInstance object.",
      "operationId": "v1Pause",
@@ -11493,7 +11493,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/portforward/{port:[0-9]+}": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/portforward/{port}": {
     "get": {
      "description": "Open a websocket connection forwarding traffic to the specified VirtualMachineInstance and port.",
      "operationId": "v1vmi-PortForward",
@@ -11530,7 +11530,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/portforward/{port:[0-9]+}/{protocol:tcp|udp}": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/portforward/{port}/{protocol}": {
     "get": {
      "description": "Open a websocket connection forwarding traffic of the specified protocol (either tcp or udp) to the specified VirtualMachineInstance and port.",
      "operationId": "v1vmi-PortForwardWithProtocol",
@@ -11575,7 +11575,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/removevolume": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine Instance",
      "operationId": "v1vmi-removevolume",
@@ -11626,7 +11626,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/sev/fetchcertchain": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/sev/fetchcertchain": {
     "get": {
      "description": "Fetch SEV certificate chain from the node where Virtual Machine is scheduled",
      "consumes": [
@@ -11667,7 +11667,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/sev/injectlaunchsecret": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/sev/injectlaunchsecret": {
     "put": {
      "description": "Inject SEV launch secret into a Virtual Machine",
      "operationId": "v1SEVInjectLaunchSecret",
@@ -11718,7 +11718,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/sev/querylaunchmeasurement": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/sev/querylaunchmeasurement": {
     "get": {
      "description": "Query SEV launch measurement from a Virtual Machine",
      "consumes": [
@@ -11759,7 +11759,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/sev/setupsession": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/sev/setupsession": {
     "put": {
      "description": "Setup SEV session parameters for a Virtual Machine",
      "operationId": "v1SEVSetupSession",
@@ -11810,7 +11810,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/softreboot": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/softreboot": {
     "put": {
      "description": "Soft reboot a VirtualMachineInstance object.",
      "operationId": "v1SoftReboot",
@@ -11851,7 +11851,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/unfreeze": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/unfreeze": {
     "put": {
      "description": "Unfreeze a VirtualMachineInstance object.",
      "operationId": "v1Unfreeze",
@@ -11892,7 +11892,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/unpause": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/unpause": {
     "put": {
      "description": "Unpause a VirtualMachineInstance object.",
      "operationId": "v1Unpause",
@@ -11949,7 +11949,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/usbredir": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/usbredir": {
     "get": {
      "description": "Open a websocket connection to connect to USB device on the specified VirtualMachineInstance.",
      "operationId": "v1usbredir",
@@ -11978,7 +11978,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/userlist": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/userlist": {
     "get": {
      "description": "Get list of active users via guest agent",
      "consumes": [
@@ -12001,7 +12001,7 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/vnc": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/vnc": {
     "get": {
      "description": "Open a websocket connection to connect to VNC on the specified VirtualMachineInstance.",
      "operationId": "v1VNC",
@@ -12030,7 +12030,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/vnc/screenshot": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/vnc/screenshot": {
     "get": {
      "description": "Get a PNG VNC screenshot of the specified VirtualMachineInstance.",
      "operationId": "v1VNCScreenshot",
@@ -12066,7 +12066,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/vsock": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachineinstances/{name}/vsock": {
     "get": {
      "description": "Open a websocket connection forwarding traffic to the specified VirtualMachineInstance and port via VSOCK.",
      "operationId": "v1VSOCK",
@@ -12110,7 +12110,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine.",
      "operationId": "v1vm-addvolume",
@@ -12161,7 +12161,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/expand-spec": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/expand-spec": {
     "get": {
      "description": "Get VirtualMachine object with expanded instancetype and preference.",
      "produces": [
@@ -12211,7 +12211,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/memorydump": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/memorydump": {
     "put": {
      "description": "Dumps a VirtualMachineInstance memory.",
      "operationId": "v1MemoryDump",
@@ -12262,7 +12262,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/migrate": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/migrate": {
     "put": {
      "description": "Migrate a running VirtualMachine to another node.",
      "operationId": "v1Migrate",
@@ -12319,7 +12319,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/portforward/{port:[0-9]+}": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/portforward/{port}": {
     "get": {
      "description": "Open a websocket connection forwarding traffic to the running VMI for the specified VirtualMachine and port.",
      "operationId": "v1vm-PortForward",
@@ -12356,7 +12356,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/portforward/{port:[0-9]+}/{protocol:tcp|udp}": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/portforward/{port}/{protocol}": {
     "get": {
      "description": "Open a websocket connection forwarding traffic of the specified protocol (either tcp or udp) to the specified VirtualMachine and port.",
      "operationId": "v1vm-PortForwardWithProtocol",
@@ -12401,7 +12401,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/removememorydump": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/removememorydump": {
     "put": {
      "description": "Remove memory dump association.",
      "operationId": "v1RemoveMemoryDump",
@@ -12442,7 +12442,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/removevolume": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine.",
      "operationId": "v1vm-removevolume",
@@ -12493,7 +12493,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/restart": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/restart": {
     "put": {
      "description": "Restart a VirtualMachine object.",
      "operationId": "v1Restart",
@@ -12549,7 +12549,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/start": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/start": {
     "put": {
      "description": "Start a VirtualMachine object.",
      "operationId": "v1Start",
@@ -12606,7 +12606,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/stop": {
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace}/virtualmachines/{name}/stop": {
     "put": {
      "description": "Stop a VirtualMachine object.",
      "operationId": "v1Stop",
@@ -12794,7 +12794,7 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/expand-vm-spec": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/expand-vm-spec": {
     "put": {
      "description": "Expands instancetype and preference into the passed VirtualMachine object.",
      "consumes": [
@@ -12829,7 +12829,7 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
      "operationId": "v1alpha3vmi-addvolume",
@@ -12880,7 +12880,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/console": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/console": {
     "get": {
      "description": "Open a websocket connection to a serial console on the specified VirtualMachineInstance.",
      "operationId": "v1alpha3Console",
@@ -12909,7 +12909,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/filesystemlist": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/filesystemlist": {
     "get": {
      "description": "Get list of active filesystems on guest machine via guest agent",
      "consumes": [
@@ -12932,7 +12932,7 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/freeze": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/freeze": {
     "put": {
      "description": "Freeze a VirtualMachineInstance object.",
      "operationId": "v1alpha3Freeze",
@@ -12983,7 +12983,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/guestosinfo": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/guestosinfo": {
     "get": {
      "description": "Get guest agent os information",
      "consumes": [
@@ -13024,7 +13024,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/pause": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/pause": {
     "put": {
      "description": "Pause a VirtualMachineInstance object.",
      "operationId": "v1alpha3Pause",
@@ -13081,7 +13081,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/portforward/{port:[0-9]+}": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/portforward/{port}": {
     "get": {
      "description": "Open a websocket connection forwarding traffic to the specified VirtualMachineInstance and port.",
      "operationId": "v1alpha3vmi-PortForward",
@@ -13118,7 +13118,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/portforward/{port:[0-9]+}/{protocol:tcp|udp}": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/portforward/{port}/{protocol}": {
     "get": {
      "description": "Open a websocket connection forwarding traffic of the specified protocol (either tcp or udp) to the specified VirtualMachineInstance and port.",
      "operationId": "v1alpha3vmi-PortForwardWithProtocol",
@@ -13163,7 +13163,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/removevolume": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine Instance",
      "operationId": "v1alpha3vmi-removevolume",
@@ -13214,7 +13214,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/sev/fetchcertchain": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/sev/fetchcertchain": {
     "get": {
      "description": "Fetch SEV certificate chain from the node where Virtual Machine is scheduled",
      "consumes": [
@@ -13255,7 +13255,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/sev/injectlaunchsecret": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/sev/injectlaunchsecret": {
     "put": {
      "description": "Inject SEV launch secret into a Virtual Machine",
      "operationId": "v1alpha3SEVInjectLaunchSecret",
@@ -13306,7 +13306,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/sev/querylaunchmeasurement": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/sev/querylaunchmeasurement": {
     "get": {
      "description": "Query SEV launch measurement from a Virtual Machine",
      "consumes": [
@@ -13347,7 +13347,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/sev/setupsession": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/sev/setupsession": {
     "put": {
      "description": "Setup SEV session parameters for a Virtual Machine",
      "operationId": "v1alpha3SEVSetupSession",
@@ -13398,7 +13398,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/softreboot": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/softreboot": {
     "put": {
      "description": "Soft reboot a VirtualMachineInstance object.",
      "operationId": "v1alpha3SoftReboot",
@@ -13439,7 +13439,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/unfreeze": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/unfreeze": {
     "put": {
      "description": "Unfreeze a VirtualMachineInstance object.",
      "operationId": "v1alpha3Unfreeze",
@@ -13480,7 +13480,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/unpause": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/unpause": {
     "put": {
      "description": "Unpause a VirtualMachineInstance object.",
      "operationId": "v1alpha3Unpause",
@@ -13537,7 +13537,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/usbredir": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/usbredir": {
     "get": {
      "description": "Open a websocket connection to connect to USB device on the specified VirtualMachineInstance.",
      "operationId": "v1alpha3usbredir",
@@ -13566,7 +13566,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/userlist": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/userlist": {
     "get": {
      "description": "Get list of active users via guest agent",
      "consumes": [
@@ -13589,7 +13589,7 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/vnc": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/vnc": {
     "get": {
      "description": "Open a websocket connection to connect to VNC on the specified VirtualMachineInstance.",
      "operationId": "v1alpha3VNC",
@@ -13618,7 +13618,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/vnc/screenshot": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/vnc/screenshot": {
     "get": {
      "description": "Get a PNG VNC screenshot of the specified VirtualMachineInstance.",
      "operationId": "v1alpha3VNCScreenshot",
@@ -13654,7 +13654,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/vsock": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/vsock": {
     "get": {
      "description": "Open a websocket connection forwarding traffic to the specified VirtualMachineInstance and port via VSOCK.",
      "operationId": "v1alpha3VSOCK",
@@ -13698,7 +13698,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine.",
      "operationId": "v1alpha3vm-addvolume",
@@ -13749,7 +13749,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/expand-spec": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/expand-spec": {
     "get": {
      "description": "Get VirtualMachine object with expanded instancetype and preference.",
      "produces": [
@@ -13799,7 +13799,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/memorydump": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/memorydump": {
     "put": {
      "description": "Dumps a VirtualMachineInstance memory.",
      "operationId": "v1alpha3MemoryDump",
@@ -13850,7 +13850,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/migrate": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/migrate": {
     "put": {
      "description": "Migrate a running VirtualMachine to another node.",
      "operationId": "v1alpha3Migrate",
@@ -13907,7 +13907,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/portforward/{port:[0-9]+}": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/portforward/{port}": {
     "get": {
      "description": "Open a websocket connection forwarding traffic to the running VMI for the specified VirtualMachine and port.",
      "operationId": "v1alpha3vm-PortForward",
@@ -13944,7 +13944,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/portforward/{port:[0-9]+}/{protocol:tcp|udp}": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/portforward/{port}/{protocol}": {
     "get": {
      "description": "Open a websocket connection forwarding traffic of the specified protocol (either tcp or udp) to the specified VirtualMachine and port.",
      "operationId": "v1alpha3vm-PortForwardWithProtocol",
@@ -13989,7 +13989,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/removememorydump": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/removememorydump": {
     "put": {
      "description": "Remove memory dump association.",
      "operationId": "v1alpha3RemoveMemoryDump",
@@ -14030,7 +14030,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/removevolume": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine.",
      "operationId": "v1alpha3vm-removevolume",
@@ -14081,7 +14081,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/restart": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/restart": {
     "put": {
      "description": "Restart a VirtualMachine object.",
      "operationId": "v1alpha3Restart",
@@ -14137,7 +14137,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/start": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/start": {
     "put": {
      "description": "Start a VirtualMachine object.",
      "operationId": "v1alpha3Start",
@@ -14194,7 +14194,7 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/stop": {
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/stop": {
     "put": {
      "description": "Stop a VirtualMachine object.",
      "operationId": "v1alpha3Stop",

--- a/pkg/rest/mime.go
+++ b/pkg/rest/mime.go
@@ -20,6 +20,7 @@
 package rest
 
 const (
+	MIME_ANY         string = "*/*"
 	MIME_JSON        string = "application/json"
 	MIME_JSON_PATCH  string = "application/json-patch+json"
 	MIME_JSON_STREAM string = "application/json;stream=watch"

--- a/pkg/virt-api/BUILD.bazel
+++ b/pkg/virt-api/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
         "//pkg/monitoring/profiler:go_default_library",
+        "//pkg/rest:go_default_library",
         "//pkg/rest/filter:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/util:go_default_library",

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -61,6 +61,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/healthz"
 	"kubevirt.io/kubevirt/pkg/monitoring/profiler"
+	mime "kubevirt.io/kubevirt/pkg/rest"
 	"kubevirt.io/kubevirt/pkg/rest/filter"
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -229,6 +230,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		restartRouteBuilder := subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("restart")).
 			To(subresourceApp.RestartVMRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.RestartOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Restart").
@@ -241,6 +243,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("migrate")).
 			To(subresourceApp.MigrateVMRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.MigrateOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Migrate").
@@ -251,6 +254,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("start")).
 			To(subresourceApp.StartVMRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.StartOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Start").
@@ -261,6 +265,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		stopRouteBuilder := subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("stop")).
 			To(subresourceApp.StopVMRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.StopOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Stop").
@@ -283,6 +288,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("freeze")).
 			To(subresourceApp.FreezeVMIRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.FreezeUnfreezeTimeout{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Freeze").
@@ -308,6 +314,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("pause")).
 			To(subresourceApp.PauseVMIRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.PauseOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Pause").
@@ -318,6 +325,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("unpause")).
 			To(subresourceApp.UnpauseVMIRequestHandler). // handles VMIs as well
+			Consumes(mime.MIME_ANY).
 			Reads(v1.UnpauseOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Unpause").
@@ -457,6 +465,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("addvolume")).
 			To(subresourceApp.VMIAddVolumeRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.AddVolumeOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"vmi-addvolume").
@@ -466,6 +475,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("removevolume")).
 			To(subresourceApp.VMIRemoveVolumeRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.RemoveVolumeOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"vmi-removevolume").
@@ -475,6 +485,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("addvolume")).
 			To(subresourceApp.VMAddVolumeRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.AddVolumeOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"vm-addvolume").
@@ -484,6 +495,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("removevolume")).
 			To(subresourceApp.VMRemoveVolumeRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.RemoveVolumeOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"vm-removevolume").
@@ -493,6 +505,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("memorydump")).
 			To(subresourceApp.MemoryDumpVMRequestHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.VirtualMachineMemoryDumpRequest{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"MemoryDump").
@@ -531,6 +544,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("sev/setupsession")).
 			To(subresourceApp.SEVSetupSessionHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.SEVSessionOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"SEVSetupSession").
@@ -540,6 +554,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourcePath(subresourcesvmiGVR)+definitions.SubResourcePath("sev/injectlaunchsecret")).
 			To(subresourceApp.SEVInjectLaunchSecretHandler).
+			Consumes(mime.MIME_ANY).
 			Reads(v1.SEVSecretOptions{}).
 			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"SEVInjectLaunchSecret").

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -386,6 +386,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(definitions.NamespacedResourceBasePath(expandvmspecGVR)).
 			To(subresourceApp.ExpandSpecRequestHandler).
+			Param(definitions.NamespaceParam(subws)).
 			Operation(version.Version+"ExpandSpec").
 			Consumes(restful.MIME_JSON).
 			Produces(restful.MIME_JSON).
@@ -438,6 +439,7 @@ func (app *virtAPIApp) composeSubresources() {
 			To(subresourceApp.UserList).
 			Consumes(restful.MIME_JSON).
 			Produces(restful.MIME_JSON).
+			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Userlist").
 			Doc("Get list of active users via guest agent").
 			Writes(v1.VirtualMachineInstanceGuestOSUserList{}).
@@ -447,6 +449,7 @@ func (app *virtAPIApp) composeSubresources() {
 			To(subresourceApp.FilesystemList).
 			Consumes(restful.MIME_JSON).
 			Produces(restful.MIME_JSON).
+			Param(definitions.NamespaceParam(subws)).Param(definitions.NameParam(subws)).
 			Operation(version.Version+"Filesystemlist").
 			Doc("Get list of active filesystems on guest machine via guest agent").
 			Writes(v1.VirtualMachineInstanceFileSystemList{}).

--- a/pkg/virt-api/definitions/definitions.go
+++ b/pkg/virt-api/definitions/definitions.go
@@ -643,11 +643,11 @@ func GroupVersionBasePath(gvr schema.GroupVersion) string {
 }
 
 func NamespacedResourceBasePath(gvr schema.GroupVersionResource) string {
-	return fmt.Sprintf("/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/%s", gvr.Resource)
+	return fmt.Sprintf("/namespaces/{namespace}/%s", gvr.Resource)
 }
 
 func NamespacedResourcePath(gvr schema.GroupVersionResource) string {
-	return fmt.Sprintf("/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/%s/{name:[a-z0-9][a-z0-9\\-]*}", gvr.Resource)
+	return fmt.Sprintf("/namespaces/{namespace}/%s/{name}", gvr.Resource)
 }
 
 func ClusterResourceBasePath(gvr schema.GroupVersionResource) string {
@@ -655,7 +655,7 @@ func ClusterResourceBasePath(gvr schema.GroupVersionResource) string {
 }
 
 func ClusterResourcePath(gvr schema.GroupVersionResource) string {
-	return fmt.Sprintf("%s/{name:[a-z0-9][a-z0-9\\-]*}", gvr.Resource)
+	return fmt.Sprintf("%s/{name}", gvr.Resource)
 }
 
 func SubResourcePath(subResource string) string {
@@ -665,9 +665,9 @@ func SubResourcePath(subResource string) string {
 const (
 	PortParamName     = "port"
 	TLSParamName      = "tls"
-	PortPath          = "/{port:[0-9]+}"
+	PortPath          = "/{port}"
 	ProtocolParamName = "protocol"
-	ProtocolPath      = "/{protocol:tcp|udp}"
+	ProtocolPath      = "/{protocol}"
 )
 
 func PortForwardPortParameter(ws *restful.WebService) *restful.Parameter {

--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -48,6 +48,9 @@ var noAuthEndpoints = map[string]struct{}{
 	"/apis":       {},
 	"/healthz":    {},
 	"/openapi/v2": {},
+	// Although KubeVirt does not publish v3, Kubernetes aggregator controller will
+	// handle v2 to v3 (lossy) conversion if KubeVirt returns 404 on this endpoint
+	"/openapi/v3": {},
 	// The endpoints with just the version are needed for api aggregation discovery
 	// Test with e.g. kubectl get --raw /apis/subresources.kubevirt.io/v1
 	"/apis/subresources.kubevirt.io/v1":               {},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Due to non conformant OpenAPI definition, [ZAP](https://www.zaproxy.org/) scanner aborts when trying to discover the KubeVirt subresources API.

This patch series fixes the issues reported by ZAP so that the security scan can proceed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-34685

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
