### PR TITLE
Add rest timeout to migration controller

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -104,6 +104,8 @@ const (
 	exporterImage       = "virt-exportserver"
 	launcherQemuTimeout = 240
 
+	migrationControllerRestTimeout = 30 * time.Second
+
 	imagePullSecret = ""
 
 	virtShareDir = "/var/run/kubevirt"
@@ -634,6 +636,11 @@ func (vca *VirtControllerApp) initCommon() {
 	if err != nil {
 		panic(err)
 	}
+	// Adding a timeout to the clientSet of the migration controller, to avoid potential deadlocks
+	clientSet, err := vca.clientSet.SetRestTimeout(migrationControllerRestTimeout)
+	if err != nil {
+		panic(err)
+	}
 	vca.migrationController, err = NewMigrationController(
 		vca.templateService,
 		vca.vmiInformer,
@@ -645,7 +652,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.migrationPolicyInformer,
 		vca.resourceQuotaInformer,
 		vca.vmiRecorder,
-		vca.clientSet,
+		clientSet,
 		vca.clusterConfig,
 	)
 	if err != nil {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -955,6 +955,17 @@ func (_mr *_MockKubevirtClientRecorder) Config() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Config")
 }
 
+func (_m *MockKubevirtClient) SetRestTimeout(timeout time.Duration) (KubevirtClient, error) {
+	ret := _m.ctrl.Call(_m, "SetRestTimeout", timeout)
+	ret0, _ := ret[0].(KubevirtClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubevirtClientRecorder) SetRestTimeout(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRestTimeout", arg0)
+}
+
 // Mock of StreamInterface interface
 type MockStreamInterface struct {
 	ctrl     *gomock.Controller

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -96,6 +96,7 @@ type KubevirtClient interface {
 	MigrationPolicyClient() *migrationsv1.MigrationsV1alpha1Client
 	kubernetes.Interface
 	Config() *rest.Config
+	SetRestTimeout(timeout time.Duration) (KubevirtClient, error)
 }
 
 type kubevirt struct {
@@ -116,6 +117,20 @@ type kubevirt struct {
 	migrationsClient        *migrationsv1.MigrationsV1alpha1Client
 	cloneClient             *clonev1alpha1.CloneV1alpha1Client
 	*kubernetes.Clientset
+}
+
+func (k kubevirt) SetRestTimeout(timeout time.Duration) (KubevirtClient, error) {
+	config := rest.CopyConfig(k.config)
+	config.Timeout = timeout
+	k.config = config
+
+	restClient, err := rest.RESTClientFor(k.config)
+	if err != nil {
+		return &k, err
+	}
+	k.restClient = restClient
+
+	return &k, nil
 }
 
 func (k kubevirt) Config() *rest.Config {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets a timeout on the REST client used by the migration controller.
That avoids a potential deadlock if an API call never receives a reply.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-30386

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
