### PR TITLE
virt-handler: do not crash when a qemu disk has no alias set

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -899,6 +899,9 @@ func (d *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.Virtua
 	if len(vmi.Status.VolumeStatus) > 0 {
 		diskDeviceMap := make(map[string]string)
 		for _, disk := range domain.Spec.Devices.Disks {
+			if disk.Alias == nil {
+				continue
+			}
 			diskDeviceMap[disk.Alias.GetName()] = disk.Target.Device
 		}
 		specVolumeMap := make(map[string]v1.Volume)


### PR DESCRIPTION
When a sidecar adds a disk to the VM's XML, it is not forced to include an alias.

**What this PR does / why we need it**:

We were seeing crashes of `virt-handler` with this log on deletion of a `VM`:

```
"component":"virt-handler","kind":"","level":"info","msg":"VMI is in phase: Running | Domain does not exist","name":"my-instance","namespace":"customer-project-priederer","pos":"vm.go:1759","timestamp":"2023-11-13T19:16:28.910982Z","uid":"ff66f4be-de79-4bb9-841a-12da78300a
ce"}
E1113 19:16:28.911054 3776784 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 571 [running]:
kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1e32500?, 0x381fd70})
        vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x99
kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc002c55d30?})
        vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1e32500, 0x381fd70})
        GOROOT/src/runtime/panic.go:884 +0x212
kubevirt.io/kubevirt/pkg/virt-handler.(*VirtualMachineController).updateVolumeStatusesFromDomain(0xc00081c540, 0xc003a31180, 0xc003a30c00)
        pkg/virt-handler/vm.go:892 +0x95b
kubevirt.io/kubevirt/pkg/virt-handler.(*VirtualMachineController).updateVMIStatus(0xc00081c540, 0xc003afc580, 0xc003a30c00, {0x0?, 0x0})
        pkg/virt-handler/vm.go:1291 +0x617
[...]
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b7c25b]
```

We are using side-cars to extend the qemu domain XML and did not always include an `alias` for a `disk` — as qemu does not need it. In our tests, even adding the alias did not always prevent this crash, possibly because of some weird caching?

**Release note**:
```release-note
NONE
```
