### PR TITLE
Remove Pending flag from test to find leading virt-controller

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -295,7 +295,7 @@ var _ = DescribeInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][leve
 		getKubevirtVMMetrics = tests.GetKubevirtVMMetricsFunc(&virtClient, pod)
 	})
 
-	PIt("[test_id:4136][flaky] should find one leading virt-controller and two ready", func() {
+	It("[test_id:4136] should find one leading virt-controller and two ready", func() {
 		endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		foundMetrics := map[string]int{


### PR DESCRIPTION
**What this PR does / why we need it**:

This test was marked as pending and flaky over three years ago[1] - from
a number of  local runs the test seems to be stable enough. Removing the
Pending flag from the test.

If it flakes again this should be removed as it was not missed for the
last number of years.

[1] https://github.com/kubevirt/kubevirt/commit/b01540f71f2c08857ad28c221603c076fa44000e

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- ~[ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [x] PR: The PR description is expressive enough and will help future contributors
- ~[ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)~
- ~[ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)~
- ~[ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- ~[ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- ~[ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- ~[ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

**Release note**:
```release-note
NONE
```
