### PR TITLE
Fix host usb permissions

### DIFF
--- a/pkg/virt-handler/device-manager/usb_device.go
+++ b/pkg/virt-handler/device-manager/usb_device.go
@@ -391,7 +391,7 @@ func (plugin *USBDevicePlugin) Allocate(_ context.Context, allocRequest *plugina
 
 			deviceSpecs := []*pluginapi.DeviceSpec{}
 			for _, dev := range pluginDevices.Devices {
-				spath, err := safepath.JoinAndResolveWithRelativeRoot(dev.DevicePath)
+				spath, err := safepath.JoinAndResolveWithRelativeRoot(util.HostRootMount, dev.DevicePath)
 				if err != nil {
 					return nil, fmt.Errorf("error opening the socket %s: %v", dev.DevicePath, err)
 				}

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -99,6 +99,7 @@ const (
 
 	HostDevicePCI  = "pci"
 	HostDeviceMDev = "mdev"
+	HostDeviceUSB  = "usb"
 	AddressPCI     = "pci"
 )
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -160,7 +160,7 @@ func createUSBHostDevice(device HostDeviceMetaData, usbAddress string) (*api.Hos
 	bus, deviceNumber := strs[0], strs[1]
 
 	return &api.HostDevice{
-		Type:  "usb",
+		Type:  api.HostDeviceUSB,
 		Mode:  "subsystem",
 		Alias: api.NewUserDefinedAlias("usb-host-" + device.Name),
 		Source: api.HostDeviceSource{

--- a/tests/usb/BUILD.bazel
+++ b/tests/usb/BUILD.bazel
@@ -6,7 +6,9 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/usb",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The device plugin for USB host pass though is not properly configuring device permissions prior to allocate the USB device to VMI. This PR fixes it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10727 

**Special notes for your reviewer**:
The fix is a one liner, by prefixing the path with `/proc/1/root`
I've added an extra check to the functional test to verify the emulated USB device has the right permission _after_ the VMI is created.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes device permission when using USB host passthrough
```
