### PR TITLE
virt-controller, vmi: Update the multus annotation only if it changed and fix an unplug bug

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2296,13 +2296,15 @@ func (c *VMIController) updateMultusAnnotation(namespace string, interfaces []vi
 	if err != nil {
 		return err
 	}
+
+	currentMultusAnnotation := podAnnotations[networkv1.NetworkAttachmentAnnot]
 	log.Log.Object(pod).V(4).Infof(
 		"current multus annotation for pod: %s; updated multus annotation for pod with: %s",
-		podAnnotations[networkv1.NetworkAttachmentAnnot],
+		currentMultusAnnotation,
 		multusAnnotations,
 	)
 
-	if multusAnnotations != "" {
+	if multusAnnotations != currentMultusAnnotation {
 		newAnnotations := map[string]string{networkv1.NetworkAttachmentAnnot: multusAnnotations}
 		patchedPod, err := c.syncPodAnnotations(pod, newAnnotations)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

If the calculated multus annotation is identical to the existing, there
is no need to execute a patch on the VMI object.

This change also resolves a bug that occurs when unplugging the last
secondary network.
Before this fix, when the last network got unplugged, no secondary
network got left, therefore there was no multus annotation generated.
And this led to not patching the VMI object, although it should have.

The relevant e2e test has been updated to cover the last unplug interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The problem has been detected with an initial fix on https://github.com/kubevirt/kubevirt/pull/10043 .

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
