### PR TITLE
virt-launcher support monitor

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -53,6 +53,7 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )
 
 const (
@@ -1522,6 +1523,7 @@ func podLabels(vmi *v1.VirtualMachineInstance, hostName string) map[string]strin
 	labels[v1.AppLabel] = "virt-launcher"
 	labels[v1.CreatedByLabel] = string(vmi.UID)
 	labels[v1.VirtualMachineNameLabel] = hostName
+	labels[components.PROMETHUS_LABEL_KEY] = "true"
 	return labels
 }
 

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -62,13 +62,13 @@ func NewPrometheusService(namespace string) *corev1.Service {
 			Namespace: namespace,
 			Name:      "kubevirt-prometheus-metrics",
 			Labels: map[string]string{
-				virtv1.AppLabel:    "",
-				prometheusLabelKey: prometheusLabelValue,
+				virtv1.AppLabel:     "",
+				PROMETHUS_LABEL_KEY: prometheusLabelValue,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				prometheusLabelKey: prometheusLabelValue,
+				PROMETHUS_LABEL_KEY: prometheusLabelValue,
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -160,8 +160,8 @@ func newPodTemplateSpec(podName, imageName, repository, version, productName, pr
 	podTemplateSpec := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				virtv1.AppLabel:    podName,
-				prometheusLabelKey: prometheusLabelValue,
+				virtv1.AppLabel:     podName,
+				PROMETHUS_LABEL_KEY: prometheusLabelValue,
 			},
 			Name: podName,
 		},
@@ -522,9 +522,9 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						virtv1.AppLabel:    VirtOperatorName,
-						virtv1.AppName:     VirtOperatorName,
-						prometheusLabelKey: prometheusLabelValue,
+						virtv1.AppLabel:     VirtOperatorName,
+						virtv1.AppName:      VirtOperatorName,
+						PROMETHUS_LABEL_KEY: prometheusLabelValue,
 					},
 					Name: VirtOperatorName,
 				},

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	KUBEVIRT_PROMETHEUS_RULE_NAME = "prometheus-kubevirt-rules"
-	prometheusLabelKey            = "prometheus.kubevirt.io"
+	PROMETHUS_LABEL_KEY           = "prometheus.kubevirt.io"
 	prometheusLabelValue          = "true"
 	defaultRunbookURLTemplate     = "https://kubevirt.io/monitoring/runbooks/%s"
 	runbookURLTemplateEnv         = "RUNBOOK_URL_TEMPLATE"
@@ -41,14 +41,14 @@ func NewServiceMonitorCR(namespace string, monitorNamespace string, insecureSkip
 			Name:      KUBEVIRT_PROMETHEUS_RULE_NAME,
 			Labels: map[string]string{
 				"openshift.io/cluster-monitoring": "",
-				prometheusLabelKey:                prometheusLabelValue,
+				PROMETHUS_LABEL_KEY:               prometheusLabelValue,
 				"k8s-app":                         "kubevirt",
 			},
 		},
 		Spec: v1.ServiceMonitorSpec{
 			Selector: v12.LabelSelector{
 				MatchLabels: map[string]string{
-					prometheusLabelKey: prometheusLabelValue,
+					PROMETHUS_LABEL_KEY: prometheusLabelValue,
 				},
 			},
 			NamespaceSelector: v1.NamespaceSelector{
@@ -79,8 +79,8 @@ func NewPrometheusRuleCR(namespace string) *v1.PrometheusRule {
 			Name:      KUBEVIRT_PROMETHEUS_RULE_NAME,
 			Namespace: namespace,
 			Labels: map[string]string{
-				prometheusLabelKey: prometheusLabelValue,
-				"k8s-app":          "kubevirt",
+				PROMETHUS_LABEL_KEY: prometheusLabelValue,
+				"k8s-app":           "kubevirt",
 			},
 		},
 		Spec: *NewPrometheusRuleSpec(namespace),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In version 0.58, prometheus.kubevirt.io is included in the labels of virt-launcher, but not in version 1.0. I think monitoring of virt-launcher is necessary. Can I add it back?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
