### PR TITLE
Housekeeping cgroup: Add full-pcpu-only support

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2829,14 +2829,14 @@ func (d *VirtualMachineController) configureHousekeepingCgroup(vmi *v1.VirtualMa
 		return nil
 	}
 
-	hkcpu, err := strconv.Atoi(domain.Spec.CPUTune.EmulatorPin.CPUSet)
+	hkcpus, err := hardware.ParseCPUSetLine(domain.Spec.CPUTune.EmulatorPin.CPUSet, 100)
 	if err != nil {
 		return err
 	}
 
-	log.Log.V(3).Object(vmi).Infof("housekeeping cpu: %v", hkcpu)
+	log.Log.V(3).Object(vmi).Infof("housekeeping cpu: %v", hkcpus)
 
-	err = cgroupManager.SetCpuSet("housekeeping", []int{hkcpu})
+	err = cgroupManager.SetCpuSet("housekeeping", hkcpus)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/util/hardware:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2028,6 +2028,7 @@ var _ = Describe("Converter", func() {
 				"expected number of queues to equal number of requested vCPUs")
 		})
 	})
+
 	Context("Correctly handle iothreads with dedicated cpus", func() {
 		var vmi *v1.VirtualMachineInstance
 
@@ -2084,7 +2085,7 @@ var _ = Describe("Converter", func() {
 			domain.Spec.IOThreads = &api.IOThreads{}
 			domain.Spec.IOThreads.IOThreads = uint(6)
 
-			Expect(vcpu.FormatDomainIOThreadPin(vmi, domain, 0, c.CPUSet)).To(Succeed())
+			Expect(vcpu.FormatDomainIOThreadPin(vmi, domain, "0", c.CPUSet)).To(Succeed())
 			expectedLayout := []api.CPUTuneIOThreadPin{
 				{IOThread: 1, CPUSet: "5,6,7"},
 				{IOThread: 2, CPUSet: "8,9,10"},
@@ -2116,7 +2117,7 @@ var _ = Describe("Converter", func() {
 			domain.Spec.IOThreads = &api.IOThreads{}
 			domain.Spec.IOThreads.IOThreads = uint(6)
 
-			Expect(vcpu.FormatDomainIOThreadPin(vmi, domain, 0, c.CPUSet)).To(Succeed())
+			Expect(vcpu.FormatDomainIOThreadPin(vmi, domain, "0", c.CPUSet)).To(Succeed())
 			expectedLayout := []api.CPUTuneIOThreadPin{
 				{IOThread: 1, CPUSet: "6"},
 				{IOThread: 2, CPUSet: "5"},

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2032,7 +2032,8 @@ var _ = Describe("Converter", func() {
 
 	Context("Correctly handle IsolateEmulatorThread with dedicated cpus", func() {
 		DescribeTable("should succeed assigning CPUs to emulatorThread",
-			func(cores uint32, converterContext *ConverterContext, expectedEmulatorThreads int) {
+			func(cores uint32, converterContext *ConverterContext, CPUManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions,
+				expectedEmulatorThreads int) {
 				var err error
 				domain := &api.Domain{}
 
@@ -2044,7 +2045,7 @@ var _ = Describe("Converter", func() {
 				domain.Spec.CPUTune, err = cpuPool.FitCores()
 				Expect(err).ToNot(HaveOccurred())
 
-				emulatorThreadsCPUSet, err := vcpu.FormatEmulatorThreadPin(cpuPool)
+				emulatorThreadsCPUSet, err := vcpu.FormatEmulatorThreadPin(cpuPool, CPUManagerPolicyBetaOption)
 				Expect(err).ToNot(HaveOccurred())
 				By("checking that the housekeeping CPUSet has the expected amount of CPUs")
 				housekeepingCPUs, err := hardware.ParseCPUSetLine(emulatorThreadsCPUSet, 100)
@@ -2057,7 +2058,7 @@ var _ = Describe("Converter", func() {
 					Expect(CPUTuneCPUs).ToNot(ContainElements(housekeepingCPUs))
 				}
 			},
-			Entry("when there is one extra CPU assigned for emulatorThread",
+			Entry("when full-pcpu-only is disabled and there is one extra CPU assigned for emulatorThread",
 				uint32(2), &ConverterContext{CPUSet: []int{5, 6, 7},
 					Topology: &cmdv1.Topology{
 						NumaCells: []*cmdv1.Cell{{
@@ -2068,10 +2069,25 @@ var _ = Describe("Converter", func() {
 						}},
 					},
 				},
+				v1.CPUManagerPolicyBetaOptions(""),
 				1),
+			Entry("when full-pcpu-only is enabled and there are two extra CPUs assigned for emulatorThread",
+				uint32(6), &ConverterContext{CPUSet: []int{5, 6, 7, 8, 9, 10, 11, 12},
+					Topology: &cmdv1.Topology{
+						NumaCells: []*cmdv1.Cell{{
+							Cpus: []*cmdv1.CPU{
+								{Id: 5}, {Id: 6}, {Id: 7}, {Id: 8}, {Id: 9}, {Id: 10},
+								{Id: 11}, {Id: 12},
+							},
+						}},
+					},
+				},
+				v1.CPUManagerPolicyBetaOptionFullpCPUsOnly,
+				2),
 		)
 		DescribeTable("should fail assigning CPUs to emulatorThread",
-			func(cores uint32, converterContext *ConverterContext, expectedErrorString string) {
+			func(cores uint32, converterContext *ConverterContext, CPUManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions,
+				expectedErrorString string) {
 				var err error
 				domain := &api.Domain{}
 
@@ -2083,10 +2099,10 @@ var _ = Describe("Converter", func() {
 				domain.Spec.CPUTune, err = cpuPool.FitCores()
 				Expect(err).ToNot(HaveOccurred())
 
-				_, err = vcpu.FormatEmulatorThreadPin(cpuPool)
+				_, err = vcpu.FormatEmulatorThreadPin(cpuPool, CPUManagerPolicyBetaOption)
 				Expect(err).To(MatchError(ContainSubstring(expectedErrorString)))
 			},
-			Entry("when there are not enough CPUs to allocate emulator threads",
+			Entry("when full-pcpu-only is disabled and there are not enough CPUs to allocate emulator threads",
 				uint32(2), &ConverterContext{CPUSet: []int{5, 6},
 					Topology: &cmdv1.Topology{
 						NumaCells: []*cmdv1.Cell{{
@@ -2096,7 +2112,21 @@ var _ = Describe("Converter", func() {
 						}},
 					},
 				},
+				v1.CPUManagerPolicyBetaOptions(""),
 				"no CPU allocated for the emulation thread"),
+			Entry("when full-pcpu-only is enabled and there are not enough Cores to allocate emulator threads",
+				uint32(2), &ConverterContext{CPUSet: []int{5, 6, 7},
+					Topology: &cmdv1.Topology{
+						NumaCells: []*cmdv1.Cell{{
+							Cpus: []*cmdv1.CPU{
+								{Id: 5}, {Id: 6},
+								{Id: 7},
+							},
+						}},
+					},
+				},
+				v1.CPUManagerPolicyBetaOptionFullpCPUsOnly,
+				"no second CPU allocated for the emulation thread"),
 		)
 	})
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 
+	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
 
 	"github.com/golang/mock/gomock"
@@ -2027,6 +2028,76 @@ var _ = Describe("Converter", func() {
 			Expect(*(domain.Spec.Devices.Disks[0].Driver.Queues)).To(Equal(expectedQueues),
 				"expected number of queues to equal number of requested vCPUs")
 		})
+	})
+
+	Context("Correctly handle IsolateEmulatorThread with dedicated cpus", func() {
+		DescribeTable("should succeed assigning CPUs to emulatorThread",
+			func(cores uint32, converterContext *ConverterContext, expectedEmulatorThreads int) {
+				var err error
+				domain := &api.Domain{}
+
+				cpuPool := vcpu.NewRelaxedCPUPool(
+					&api.CPUTopology{Sockets: 1, Cores: cores, Threads: 1},
+					converterContext.Topology,
+					converterContext.CPUSet,
+				)
+				domain.Spec.CPUTune, err = cpuPool.FitCores()
+				Expect(err).ToNot(HaveOccurred())
+
+				emulatorThreadsCPUSet, err := vcpu.FormatEmulatorThreadPin(cpuPool)
+				Expect(err).ToNot(HaveOccurred())
+				By("checking that the housekeeping CPUSet has the expected amount of CPUs")
+				housekeepingCPUs, err := hardware.ParseCPUSetLine(emulatorThreadsCPUSet, 100)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(housekeepingCPUs).To(HaveLen(expectedEmulatorThreads))
+				By("checking that the housekeeping CPUSet does not overlap with the VCPUs CPUSet")
+				for _, VCPUPin := range domain.Spec.CPUTune.VCPUPin {
+					CPUTuneCPUs, err := hardware.ParseCPUSetLine(VCPUPin.CPUSet, 100)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(CPUTuneCPUs).ToNot(ContainElements(housekeepingCPUs))
+				}
+			},
+			Entry("when there is one extra CPU assigned for emulatorThread",
+				uint32(2), &ConverterContext{CPUSet: []int{5, 6, 7},
+					Topology: &cmdv1.Topology{
+						NumaCells: []*cmdv1.Cell{{
+							Cpus: []*cmdv1.CPU{
+								{Id: 5}, {Id: 6},
+								{Id: 7},
+							},
+						}},
+					},
+				},
+				1),
+		)
+		DescribeTable("should fail assigning CPUs to emulatorThread",
+			func(cores uint32, converterContext *ConverterContext, expectedErrorString string) {
+				var err error
+				domain := &api.Domain{}
+
+				cpuPool := vcpu.NewRelaxedCPUPool(
+					&api.CPUTopology{Sockets: 1, Cores: cores, Threads: 1},
+					converterContext.Topology,
+					converterContext.CPUSet,
+				)
+				domain.Spec.CPUTune, err = cpuPool.FitCores()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = vcpu.FormatEmulatorThreadPin(cpuPool)
+				Expect(err).To(MatchError(ContainSubstring(expectedErrorString)))
+			},
+			Entry("when there are not enough CPUs to allocate emulator threads",
+				uint32(2), &ConverterContext{CPUSet: []int{5, 6},
+					Topology: &cmdv1.Topology{
+						NumaCells: []*cmdv1.Cell{{
+							Cpus: []*cmdv1.CPU{
+								{Id: 5}, {Id: 6},
+							},
+						}},
+					},
+				},
+				"no CPU allocated for the emulation thread"),
+		)
 	})
 
 	Context("Correctly handle iothreads with dedicated cpus", func() {


### PR DESCRIPTION
This PR updates the Housekeeping cgroup to support multiple CPUs.
When setting the VM to full-pcpu-only, it is possible to get a full core - containing multiple CPUs - to the emulator thread [0].
This PR assigns these CPUs to the Housekeeping cgroup, so that they can be used on the emulatorThread processes. 

Note: this PR implements the second phase of the https://github.com/kubevirt/community/pull/247.

[0] https://github.com/kubevirt/kubevirt/pull/10593

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support multiple CPUs in Housekeeping cgroup
```
