### PR TITLE
virtctl: cloneAPI add template filters

### DIFF
--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -37,31 +37,35 @@ import (
 const (
 	Clone = "clone"
 
-	NameFlag             = "name"
-	SourceNameFlag       = "source-name"
-	TargetNameFlag       = "target-name"
-	SourceTypeFlag       = "source-type"
-	TargetTypeFlag       = "target-type"
-	LabelFilterFlag      = "label-filter"
-	AnnotationFilterFlag = "annotation-filter"
-	NewMacAddressesFlag  = "new-mac-address"
-	NewSMBiosSerialFlag  = "new-smbios-serial"
+	NameFlag                     = "name"
+	SourceNameFlag               = "source-name"
+	TargetNameFlag               = "target-name"
+	SourceTypeFlag               = "source-type"
+	TargetTypeFlag               = "target-type"
+	LabelFilterFlag              = "label-filter"
+	AnnotationFilterFlag         = "annotation-filter"
+	TemplateLabelFilterFlag      = "template-label-filter"
+	TemplateAnnotationFilterFlag = "template-annotation-filter"
+	NewMacAddressesFlag          = "new-mac-address"
+	NewSMBiosSerialFlag          = "new-smbios-serial"
 
 	supportedSourceTypes = "vm, vmsnapshot"
 	supportedTargetTypes = "vm"
 )
 
 type createClone struct {
-	namespace         string
-	name              string
-	sourceName        string
-	targetName        string
-	sourceType        string
-	targetType        string
-	labelFilters      []string
-	annotationFilters []string
-	newMacAddresses   []string
-	newSmbiosSerial   string
+	namespace                 string
+	name                      string
+	sourceName                string
+	targetName                string
+	sourceType                string
+	targetType                string
+	labelFilters              []string
+	annotationFilters         []string
+	templateLabelFilters      []string
+	templateAnnotationFilters []string
+	newMacAddresses           []string
+	newSmbiosSerial           string
 
 	clientConfig clientcmd.ClientConfig
 }
@@ -97,6 +101,8 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&c.targetType, TargetTypeFlag, emptyValue, "Specify the clone's target type. Default type is VM. Supported types: "+supportedTargetTypes)
 	cmd.Flags().StringArrayVar(&c.labelFilters, LabelFilterFlag, nil, "Specify clone's label filters. "+supportsMultipleFlags)
 	cmd.Flags().StringArrayVar(&c.annotationFilters, AnnotationFilterFlag, nil, "Specify clone's annotation filters. "+supportsMultipleFlags)
+	cmd.Flags().StringArrayVar(&c.templateLabelFilters, TemplateLabelFilterFlag, nil, "Specify clone's template label filters. "+supportsMultipleFlags)
+	cmd.Flags().StringArrayVar(&c.templateAnnotationFilters, TemplateAnnotationFilterFlag, nil, "Specify clone's template annotation filters. "+supportsMultipleFlags)
 	cmd.Flags().StringArrayVar(&c.newMacAddresses, NewMacAddressesFlag, nil, "Specify clone's new mac addresses. For example: 'interfaceName0:newAddress0'")
 	cmd.Flags().StringVar(&c.newSmbiosSerial, NewSMBiosSerialFlag, emptyValue, "Specify the clone's new smbios serial")
 
@@ -157,6 +163,12 @@ func (c *createClone) usage() string {
   # Create a manifest for a clone with annotation filters:
   {{ProgramName}} create clone --source-name sourceVM --annotation-filter '*' --annotation-filter '!some/key'
 
+  # Create a manifest for a clone with template label filters:
+  {{ProgramName}} create clone --source-name sourceVM --template-label-filter '*' --template-label-filter '!some/key'
+
+  # Create a manifest for a clone with template annotation filters:
+  {{ProgramName}} create clone --source-name sourceVM --template-annotation-filter '*' --template-annotation-filter '!some/key'
+
   # Create a manifest for a clone with new MAC addresses:
   {{ProgramName}} create clone --source-name sourceVM --new-mac-address interface1:00-11-22 --new-mac-address interface2:00-11-33
 
@@ -188,6 +200,10 @@ func (c *createClone) newClone() (*clonev1alpha1.VirtualMachineClone, error) {
 		Target:            target,
 		AnnotationFilters: c.annotationFilters,
 		LabelFilters:      c.labelFilters,
+		Template: clonev1alpha1.VirtualMachineCloneTemplateFilters{
+			AnnotationFilters: c.templateAnnotationFilters,
+			LabelFilters:      c.templateLabelFilters,
+		},
 	}
 
 	if c.newSmbiosSerial != "" {

--- a/pkg/virtctl/create/clone/clone_test.go
+++ b/pkg/virtctl/create/clone/clone_test.go
@@ -38,12 +38,12 @@ const (
 	snapshotKind, snapshotApiGroup = "VirtualMachineSnapshot", "snapshot.kubevirt.io"
 )
 const (
-	LabelFilters = iota
-	AnnotationsFilters
-	LabelAndAnnotationsFilters
-	TemplateLabelFilters
-	TemplateAnnotationsFilters
-	TemplateLabelAndAnnotationsFilters
+	labelFilters = iota
+	annotationsFilters
+	labelAndAnnotationsFilters
+	templateLabelFilters
+	templateAnnotationsFilters
+	templateLabelAndAnnotationsFilters
 )
 
 var _ = Describe("create clone", func() {
@@ -134,24 +134,24 @@ var _ = Describe("create clone", func() {
 			flags := getSourceNameFlags()
 
 			switch filterType {
-			case LabelFilters:
+			case labelFilters:
 				flags = addFlag(flags, clone.LabelFilterFlag, "*")
 				flags = addFlag(flags, clone.LabelFilterFlag, `"!some/key"`)
-			case AnnotationsFilters:
+			case annotationsFilters:
 				flags = addFlag(flags, clone.AnnotationFilterFlag, "*")
 				flags = addFlag(flags, clone.AnnotationFilterFlag, `"!some/key"`)
-			case LabelAndAnnotationsFilters:
+			case labelAndAnnotationsFilters:
 				flags = addFlag(flags, clone.LabelFilterFlag, "*")
 				flags = addFlag(flags, clone.LabelFilterFlag, `"!some/key"`)
 				flags = addFlag(flags, clone.AnnotationFilterFlag, "*")
 				flags = addFlag(flags, clone.AnnotationFilterFlag, `"!some/key"`)
-			case TemplateLabelFilters:
+			case templateLabelFilters:
 				flags = addFlag(flags, clone.TemplateLabelFilterFlag, "*")
 				flags = addFlag(flags, clone.TemplateLabelFilterFlag, `"!some/key"`)
-			case TemplateAnnotationsFilters:
+			case templateAnnotationsFilters:
 				flags = addFlag(flags, clone.TemplateAnnotationFilterFlag, "*")
 				flags = addFlag(flags, clone.TemplateAnnotationFilterFlag, `"!some/key"`)
-			case TemplateLabelAndAnnotationsFilters:
+			case templateLabelAndAnnotationsFilters:
 				flags = addFlag(flags, clone.TemplateLabelFilterFlag, "*")
 				flags = addFlag(flags, clone.TemplateLabelFilterFlag, `"!some/key"`)
 				flags = addFlag(flags, clone.TemplateAnnotationFilterFlag, "*")
@@ -163,29 +163,29 @@ var _ = Describe("create clone", func() {
 			const expectedLen = 2
 
 			switch filterType {
-			case LabelFilters:
+			case labelFilters:
 				Expect(cloneObj.Spec.LabelFilters).To(HaveLen(expectedLen))
-			case AnnotationsFilters:
+			case annotationsFilters:
 				Expect(cloneObj.Spec.AnnotationFilters).To(HaveLen(expectedLen))
-			case LabelAndAnnotationsFilters:
+			case labelAndAnnotationsFilters:
 				Expect(cloneObj.Spec.LabelFilters).To(HaveLen(expectedLen))
 				Expect(cloneObj.Spec.AnnotationFilters).To(HaveLen(expectedLen))
-			case TemplateLabelFilters:
+			case templateLabelFilters:
 				Expect(cloneObj.Spec.Template.LabelFilters).To(HaveLen(expectedLen))
-			case TemplateAnnotationsFilters:
+			case templateAnnotationsFilters:
 				Expect(cloneObj.Spec.Template.AnnotationFilters).To(HaveLen(expectedLen))
-			case TemplateLabelAndAnnotationsFilters:
+			case templateLabelAndAnnotationsFilters:
 				Expect(cloneObj.Spec.Template.LabelFilters).To(HaveLen(expectedLen))
 				Expect(cloneObj.Spec.Template.AnnotationFilters).To(HaveLen(expectedLen))
 			}
 
 		},
-			Entry("label filters", LabelFilters),
-			Entry("annotation filters", AnnotationsFilters),
-			Entry("label and annotation filters", LabelAndAnnotationsFilters),
-			Entry("template-label filters", TemplateLabelFilters),
-			Entry("template-annotation filters", TemplateAnnotationsFilters),
-			Entry("template-label and template-annotation filters", TemplateLabelAndAnnotationsFilters),
+			Entry("label filters", labelFilters),
+			Entry("annotation filters", annotationsFilters),
+			Entry("label and annotation filters", labelAndAnnotationsFilters),
+			Entry("template-label filters", templateLabelFilters),
+			Entry("template-annotation filters", templateAnnotationsFilters),
+			Entry("template-label and template-annotation filters", templateLabelAndAnnotationsFilters),
 		)
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
virtctl support to add template label and annotation filters
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10374 

**Special notes for your reviewer**:
https://github.com/kubevirt/kubevirt/pull/10658
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
  # Create a manifest for a clone with template label filters:
  virtctl create clone --source-name sourceVM --template-label-filter '*' --template-label-filter '!some/key'

  # Create a manifest for a clone with template annotation filters:
  virtctl create clone --source-name sourceVM --template-annotation-filter '*' --template-annotation-filter '!some/key'

```
