### PR TITLE
Raise warning when Passt interface API and feature-gate are used

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17310,6 +17310,7 @@
       "default": ""
      },
      "passt": {
+      "description": "Deprecated, please refer to Kubevirt user guide for alternatives.",
       "$ref": "#/definitions/v1.InterfacePasst"
      },
      "pciAddress": {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/webhooks:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -30,6 +30,8 @@ import (
 	"strconv"
 	"strings"
 
+	"kubevirt.io/kubevirt/pkg/util"
+
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
@@ -123,7 +125,16 @@ func (admitter *VMICreateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admis
 
 	reviewResponse := admissionv1.AdmissionResponse{}
 	reviewResponse.Allowed = true
+	reviewResponse.Warnings = append(reviewResponse.Warnings, warnDeprecatedAPIs(vmi)...)
 	return &reviewResponse
+}
+
+func warnDeprecatedAPIs(vmi *v1.VirtualMachineInstance) []string {
+	var warnings []string
+	if util.IsPasstVMI(vmi) {
+		warnings = append(warnings, "Passt interface API is deprecated. Please refer to Kubevirt user guide for alternatives.")
+	}
+	return warnings
 }
 
 func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -123,10 +123,10 @@ func (admitter *VMICreateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admis
 		return webhookutils.ToAdmissionResponse(causes)
 	}
 
-	reviewResponse := admissionv1.AdmissionResponse{}
-	reviewResponse.Allowed = true
-	reviewResponse.Warnings = append(reviewResponse.Warnings, warnDeprecatedAPIs(vmi)...)
-	return &reviewResponse
+	return &admissionv1.AdmissionResponse{
+		Allowed:  true,
+		Warnings: warnDeprecatedAPIs(vmi),
+	}
 }
 
 func warnDeprecatedAPIs(vmi *v1.VirtualMachineInstance) []string {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -30,18 +30,19 @@ const (
 	IgnitionGate      = "ExperimentalIgnitionSupport"
 	LiveMigrationGate = "LiveMigration"
 	// SRIOVLiveMigrationGate enables Live Migration for VM's with network SR-IOV interfaces.
-	SRIOVLiveMigrationGate     = "SRIOVLiveMigration"
-	CPUNodeDiscoveryGate       = "CPUNodeDiscovery"
-	HypervStrictCheckGate      = "HypervStrictCheck"
-	SidecarGate                = "Sidecar"
-	GPUGate                    = "GPU"
-	HostDevicesGate            = "HostDevices"
-	SnapshotGate               = "Snapshot"
-	VMExportGate               = "VMExport"
-	HotplugVolumesGate         = "HotplugVolumes"
-	HostDiskGate               = "HostDisk"
-	VirtIOFSGate               = "ExperimentalVirtiofsSupport"
-	MacvtapGate                = "Macvtap"
+	SRIOVLiveMigrationGate = "SRIOVLiveMigration"
+	CPUNodeDiscoveryGate   = "CPUNodeDiscovery"
+	HypervStrictCheckGate  = "HypervStrictCheck"
+	SidecarGate            = "Sidecar"
+	GPUGate                = "GPU"
+	HostDevicesGate        = "HostDevices"
+	SnapshotGate           = "Snapshot"
+	VMExportGate           = "VMExport"
+	HotplugVolumesGate     = "HotplugVolumes"
+	HostDiskGate           = "HostDisk"
+	VirtIOFSGate           = "ExperimentalVirtiofsSupport"
+	MacvtapGate            = "Macvtap"
+	// Deprecated, please refer to Kubevirt user guide for alternatives.
 	PasstGate                  = "Passt"
 	DownwardMetricsFeatureGate = "DownwardMetrics"
 	NonRoot                    = "NonRoot"
@@ -116,6 +117,14 @@ func (config *ClusterConfig) IsFeatureGateDeprecated(featureGate string) bool {
 	}
 
 	return false
+}
+
+var discontinuedFeaturesMessages = map[string]string{
+	"Passt": "Passt network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives.",
+}
+
+func (c *ClusterConfig) DiscontinuedFeatureMessage(featureGate string) string {
+	return discontinuedFeaturesMessages[featureGate]
 }
 
 func (config *ClusterConfig) ExpandDisksEnabled() bool {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5972,7 +5972,8 @@ var CRDsValidation map[string]string = map[string]string{
                                   match the Name of a Network.
                                 type: string
                               passt:
-                                description: InterfacePasst connects to a given network.
+                                description: Deprecated, please refer to Kubevirt
+                                  user guide for alternatives.
                                 type: object
                               pciAddress:
                                 description: 'If specified, the virtual network interface
@@ -10531,7 +10532,8 @@ var CRDsValidation map[string]string = map[string]string{
                           to the associated networks. Must match the Name of a Network.
                         type: string
                       passt:
-                        description: InterfacePasst connects to a given network.
+                        description: Deprecated, please refer to Kubevirt user guide
+                          for alternatives.
                         type: object
                       pciAddress:
                         description: 'If specified, the virtual network interface
@@ -13260,7 +13262,8 @@ var CRDsValidation map[string]string = map[string]string{
                           to the associated networks. Must match the Name of a Network.
                         type: string
                       passt:
-                        description: InterfacePasst connects to a given network.
+                        description: Deprecated, please refer to Kubevirt user guide
+                          for alternatives.
                         type: object
                       pciAddress:
                         description: 'If specified, the virtual network interface
@@ -15445,7 +15448,8 @@ var CRDsValidation map[string]string = map[string]string{
                                   match the Name of a Network.
                                 type: string
                               passt:
-                                description: InterfacePasst connects to a given network.
+                                description: Deprecated, please refer to Kubevirt
+                                  user guide for alternatives.
                                 type: object
                               pciAddress:
                                 description: 'If specified, the virtual network interface
@@ -19831,8 +19835,8 @@ var CRDsValidation map[string]string = map[string]string{
                                           networks. Must match the Name of a Network.
                                         type: string
                                       passt:
-                                        description: InterfacePasst connects to a
-                                          given network.
+                                        description: Deprecated, please refer to Kubevirt
+                                          user guide for alternatives.
                                         type: object
                                       pciAddress:
                                         description: 'If specified, the virtual network
@@ -25004,8 +25008,8 @@ var CRDsValidation map[string]string = map[string]string{
                                               networks. Must match the Name of a Network.
                                             type: string
                                           passt:
-                                            description: InterfacePasst connects to
-                                              a given network.
+                                            description: Deprecated, please refer
+                                              to Kubevirt user guide for alternatives.
                                             type: object
                                           pciAddress:
                                             description: 'If specified, the virtual

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -115,6 +115,7 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *
 	if featureGatesChanged(&currKV.Spec, &newKV.Spec) {
 		featureGates := newKV.Spec.Configuration.DeveloperConfiguration.FeatureGates
 		response.Warnings = append(response.Warnings, warnDeprecatedFeatureGates(featureGates, admitter.ClusterConfig)...)
+		response.Warnings = append(response.Warnings, warnDiscontinuedFeatureGate(featureGates, admitter.ClusterConfig)...)
 	}
 
 	const mdevWarningfmt = "%s is deprecated, use mediatedDeviceTypes"
@@ -457,6 +458,17 @@ func warnDeprecatedFeatureGates(featureGates []string, config *virtconfig.Cluste
 		}
 	}
 
+	return warnings
+}
+
+func warnDiscontinuedFeatureGate(featureGates []string, config *virtconfig.ClusterConfig) []string {
+	var warnings []string
+	for _, featureGate := range featureGates {
+		if msg := config.DiscontinuedFeatureMessage(featureGate); msg != "" {
+			warnings = append(warnings, msg)
+			log.Log.Warningf(msg)
+		}
+	}
 	return warnings
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -1318,7 +1318,8 @@ type InterfaceBindingMethod struct {
 	Masquerade *InterfaceMasquerade `json:"masquerade,omitempty"`
 	SRIOV      *InterfaceSRIOV      `json:"sriov,omitempty"`
 	Macvtap    *InterfaceMacvtap    `json:"macvtap,omitempty"`
-	Passt      *InterfacePasst      `json:"passt,omitempty"`
+	// Deprecated, please refer to Kubevirt user guide for alternatives.
+	Passt *InterfacePasst `json:"passt,omitempty"`
 }
 
 // InterfaceBridge connects to a given network via a linux bridge.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -687,7 +687,8 @@ func (DHCPPrivateOptions) SwaggerDoc() map[string]string {
 
 func (InterfaceBindingMethod) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"": "Represents the method which will be used to connect the interface to the guest.\nOnly one of its members may be specified.",
+		"":      "Represents the method which will be used to connect the interface to the guest.\nOnly one of its members may be specified.",
+		"passt": "Deprecated, please refer to Kubevirt user guide for alternatives.",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18488,7 +18488,8 @@ func schema_kubevirtio_api_core_v1_Interface(ref common.ReferenceCallback) commo
 					},
 					"passt": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/api/core/v1.InterfacePasst"),
+							Description: "Deprecated, please refer to Kubevirt user guide for alternatives.",
+							Ref:         ref("kubevirt.io/api/core/v1.InterfacePasst"),
 						},
 					},
 					"binding": {
@@ -18602,7 +18603,8 @@ func schema_kubevirtio_api_core_v1_InterfaceBindingMethod(ref common.ReferenceCa
 					},
 					"passt": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/api/core/v1.InterfacePasst"),
+							Description: "Deprecated, please refer to Kubevirt user guide for alternatives.",
+							Ref:         ref("kubevirt.io/api/core/v1.InterfacePasst"),
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR implements phase one of https://github.com/kubevirt/community/pull/249

Declare Passt interface API deprecated and raise warning when used and when Passt feature gate is enabled.

Enable Passt feature-gate warning:
```
$ kubectl patch kv kubevirt -n kubevirt --type=json -p='[{"op":"replace", "path":"/spec/configuration/developerConfiguration/featureGates", "value":["Passt"]}]'
Warning: Passt network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives.
kubevirt.kubevirt.io/kubevirt patched
```
Creating VMI with Passt interface warning:
```
$ kubectl create -f vmi-passt
Warning: Passt interface API is deprecated. Please refer to Kubevirt user guide for alternatives.
virtualmachineinstance.kubevirt.io/vmi-passt-no-virtio created
``` 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Passt interface API is deprecated and will be blocked in next release, please refer to Kubevirt user guide for alternatives.
```
