### PR TITLE
net, netstat: Prioritize pod IP info over GA data

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -99,14 +99,14 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				})
 
-				It("should report PodIP/s IPv4 as its own on interface status", func() {
+				It("should report PodIP/s on interface status", func() {
 					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Eventually(vmiIP, 2*time.Minute, 5*time.Second).Should(Equal(vmiPod.Status.PodIP), "should contain VMI Status IP as Pod status ip")
-					Eventually(vmiIPs, 2*time.Minute, 5*time.Second).Should(ContainElement(vmiPod.Status.PodIP), "should contain IPv4 reported by guest agent")
-				})
-
-				It("should report VMIs static IPv6 at interface status", func() {
-					Eventually(vmiIPs, 2*time.Minute, 5*time.Second).Should(ContainElement(libnet.DefaultIPv6Address), "should contain IPv6 address set by cloud-init and reported by guest agent")
+					var podIPs []string
+					for _, ip := range vmiPod.Status.PodIPs {
+						podIPs = append(podIPs, ip.IP)
+					}
+					Eventually(vmiIPs, 2*time.Minute, 5*time.Second).Should(Equal(podIPs), "should contain VMI Status IP as Pod status IPs")
 				})
 			})
 			When("no Guest Agent exists", func() {

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -146,7 +146,7 @@ var _ = SIGDescribe("Infosource", func() {
 
 			networkInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceMac)
 			Expect(networkInterface).NotTo(BeNil(), "interface not found")
-			Expect(networkInterface.IP).To(BeEmpty())
+			Expect(networkInterface.IP).NotTo(BeEmpty())
 
 			guestInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceNewMac)
 			Expect(guestInterface).NotTo(BeNil(), "interface not found")


### PR DESCRIPTION
**What this PR does / why we need it**:

Up until this change, for interfaces that used masquerade-like binding, the guest-agent data has not overridden the pod IPs. But it did override any pod information for other bindings (e.g. bridge).

In order to generalize the logic and avoid the dependency on specific bindings, the following logic is now used:
- VMI interface status will reflect the pod IPs unless GA data for the specific interface is showing no IP (i.e. the guest has no IP set).
- In case GA reports no IP, it will clear any IP from the interface status. The logic behind this is: If there is no IP in the guest, the VM is not reachable and therefore we can reflect that through the VMI interface status by not reporting the IP.
- In case there is no IP data from the pod, GA IP data will be used.

This logic will allow to correctly reflect IPs from custom network binding plugins.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
