### PR TITLE
[bugfix] set current CPU topology in VMI status early on VMI creation

### DIFF
--- a/pkg/virt-api/webhooks/defaults.go
+++ b/pkg/virt-api/webhooks/defaults.go
@@ -50,7 +50,16 @@ func SetDefaultVirtualMachineInstance(clusterConfig *virtconfig.ClusterConfig, v
 	setDefaultHypervFeatureDependencies(&vmi.Spec)
 	setDefaultCPUArch(clusterConfig, &vmi.Spec)
 	setGuestMemoryStatus(vmi)
+	setGuestCPUTopologyStatus(vmi)
 	return nil
+}
+
+func setGuestCPUTopologyStatus(vmi *v1.VirtualMachineInstance) {
+	vmi.Status.CurrentCPUTopology = &v1.CPUTopology{
+		Sockets: vmi.Spec.Domain.CPU.Sockets,
+		Cores:   vmi.Spec.Domain.CPU.Cores,
+		Threads: vmi.Spec.Domain.CPU.Threads,
+	}
 }
 
 func setGuestMemoryStatus(vmi *v1.VirtualMachineInstance) {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -1213,4 +1213,51 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(*status.Memory.GuestCurrent).To(Equal(memory))
 		Expect(*status.Memory.GuestRequested).To(Equal(memory))
 	})
+
+	It("should set current guest CPU topology based on Domain spec", func() {
+		cpuTopology := v1.CPU{
+			Sockets: 100,
+			Cores:   200,
+			Threads: 300,
+		}
+
+		vmi.Spec.Domain.CPU = &cpuTopology
+		_, _, status := getMetaSpecStatusFromAdmit(rt.GOARCH)
+		Expect(status.CurrentCPUTopology).ToNot(BeNil())
+		Expect(status.CurrentCPUTopology.Sockets).To(Equal(cpuTopology.Sockets))
+		Expect(status.CurrentCPUTopology.Cores).To(Equal(cpuTopology.Cores))
+		Expect(status.CurrentCPUTopology.Threads).To(Equal(cpuTopology.Threads))
+	})
+
+	It("should set current guest CPU topology based on CPU resource requests", func() {
+		const defaultCores = uint32(1)
+		const defaultThreads = uint32(1)
+		cpuRequest := resource.MustParse("2.2")
+		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
+		vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = cpuRequest
+		// Preset is configured with CPU topology
+		presetInformer.GetIndexer().Delete(preset)
+
+		_, _, status := getMetaSpecStatusFromAdmit(rt.GOARCH)
+		Expect(status.CurrentCPUTopology).ToNot(BeNil())
+		Expect(status.CurrentCPUTopology.Sockets).To(Equal(uint32(cpuRequest.Value())))
+		Expect(status.CurrentCPUTopology.Cores).To(Equal(defaultCores))
+		Expect(status.CurrentCPUTopology.Threads).To(Equal(defaultThreads))
+	})
+
+	When("VMI doesn't have any CPU requests", func() {
+		It("should set current guest CPU topology based on injected defaults", func() {
+			const defaultCores = uint32(1)
+			const defaultThreads = uint32(1)
+			const defaultSockets = uint32(1)
+			// Preset is configured with CPU topology
+			presetInformer.GetIndexer().Delete(preset)
+
+			_, _, status := getMetaSpecStatusFromAdmit(rt.GOARCH)
+			Expect(status.CurrentCPUTopology).ToNot(BeNil())
+			Expect(status.CurrentCPUTopology.Sockets).To(Equal(defaultSockets))
+			Expect(status.CurrentCPUTopology.Cores).To(Equal(defaultCores))
+			Expect(status.CurrentCPUTopology.Threads).To(Equal(defaultThreads))
+		})
+	})
 })

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5231,63 +5231,6 @@ var _ = Describe("VirtualMachine", func() {
 				})
 			})
 		})
-
-		Context("CPU topology", func() {
-			When("isn't set in VMI template", func() {
-				It("Set default CPU topology in VMI status", func() {
-					vm, vmi := DefaultVirtualMachine(true)
-					addVirtualMachine(vm)
-
-					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						Expect(arg.(*virtv1.VirtualMachineInstance).Status.CurrentCPUTopology).To(Not(BeNil()))
-					}).Return(vmi, nil)
-
-					// expect update status is called
-					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-						Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
-					}).Return(nil, nil)
-
-					controller.Execute()
-
-					testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
-				})
-			})
-			When("set in VMI template", func() {
-				It("copy CPU topology to VMI status", func() {
-					const (
-						numOfSockets uint32 = 8
-						numOfCores   uint32 = 8
-						numOfThreads uint32 = 8
-					)
-					vm, vmi := DefaultVirtualMachine(true)
-					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{
-						Sockets: numOfSockets,
-						Cores:   numOfCores,
-						Threads: numOfThreads,
-					}
-					addVirtualMachine(vm)
-
-					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						currentCPUTopology := arg.(*virtv1.VirtualMachineInstance).Status.CurrentCPUTopology
-						Expect(currentCPUTopology).To(Not(BeNil()))
-						Expect(currentCPUTopology.Sockets).To(Equal(numOfSockets))
-						Expect(currentCPUTopology.Cores).To(Equal(numOfCores))
-						Expect(currentCPUTopology.Threads).To(Equal(numOfThreads))
-					}).Return(vmi, nil)
-
-					// expect update status is called
-					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-						Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
-					}).Return(nil, nil)
-
-					controller.Execute()
-
-					testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
-				})
-			})
-		})
 	})
 })
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:

CPU current topology was set by the VM controller when it the VM was started. The bug in this approach is that when you create the VMI directly, the CPU topology is missing in the VMI status because the VM controller is not involved.

The suggested change sets the CPU topology early in the VMI creating at the mutating webhook stage.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
