### PR TITLE
virt-operator: Fix AppComponent value in common-instancetypes

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1696,12 +1696,12 @@ func (k *KubeVirtTestData) getConfig(registry, version string) *util.KubeVirtDep
 		k.mockEnvVarManager)
 }
 
-func (k *KubeVirtTestData) shouldExpectInstancetypesAndPreferencesDeletions() {
+func (k *KubeVirtTestData) shouldExpectInstancetypesAndPreferencesDeletions(kv *v1.KubeVirt) {
 	expectDeleteCollection := func(action testing.Action) (bool, runtime.Object, error) {
 		deleteCollection, ok := action.(testing.DeleteCollectionAction)
 		Expect(ok).To(BeTrue())
 		ls := labels.Set{
-			v1.AppComponentLabel: v1.AppComponent,
+			v1.AppComponentLabel: apply.GetAppComponent(kv),
 			v1.ManagedByLabel:    v1.ManagedByLabelOperatorValue,
 		}
 		Expect(deleteCollection.GetListRestrictions().Labels).To(Equal(ls.AsSelector()))
@@ -1757,7 +1757,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.makeDeploymentsReady(kv)
 			kvTestData.makeHandlerReady()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 
 			// Now when the controller runs, if the namespace will be patched, the test will fail
 			// because the patch is not expected here.
@@ -1825,7 +1825,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.fakeNamespaceModificationEvent()
 			kvTestData.shouldExpectNamespacePatch()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 			kvTestData.addAll(customConfig, kv)
 			// install strategy config
 			kvTestData.addInstallStrategy(customConfig)
@@ -1879,7 +1879,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectNamespacePatch()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 
 			kvTestData.controller.Execute()
 			Expect(kvTestData.totalDeletions).To(Equal(1))
@@ -1952,7 +1952,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectNamespacePatch()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 
 			kvTestData.controller.Execute()
 			Expect(kvTestData.totalDeletions).To(Equal(1))
@@ -1994,7 +1994,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectNamespacePatch()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 
 			kvTestData.controller.Execute()
 
@@ -2041,7 +2041,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectNamespacePatch()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 
 			// invalidate all lastGeneration versions
 			numGenerations := len(kv.Status.Generations)
@@ -2104,7 +2104,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectNamespacePatch()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 
 			kvTestData.controller.Execute()
 			Expect(kvTestData.totalDeletions).To(Equal(numResources))
@@ -2753,7 +2753,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 			kvTestData.fakeNamespaceModificationEvent()
 			kvTestData.shouldExpectNamespacePatch()
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 
 			kvTestData.controller.Execute()
 
@@ -2831,7 +2831,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 			kvTestData.fakeNamespaceModificationEvent()
 			kvTestData.shouldExpectNamespacePatch()
-			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions()
+			kvTestData.shouldExpectInstancetypesAndPreferencesDeletions(kv)
 
 			kvTestData.controller.Execute()
 

--- a/pkg/virt-operator/resource/apply/instancetype_test.go
+++ b/pkg/virt-operator/resource/apply/instancetype_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Apply Instancetypes", func() {
 		)
 
 		It("should delete all instancetypes managed by virt-operator", func() {
-			deleteCollectionCalled := expectDeleteCollection(fakeClient, apiinstancetype.ClusterPluralResourceName)
+			deleteCollectionCalled := expectDeleteCollection(fakeClient, reconciler.kv, apiinstancetype.ClusterPluralResourceName)
 			Expect(reconciler.deleteInstancetypes()).To(Succeed())
 			Expect(*deleteCollectionCalled).To(BeTrue())
 		})
@@ -161,7 +161,7 @@ var _ = Describe("Apply Instancetypes", func() {
 		)
 
 		It("should delete all preferences managed by virt-operator", func() {
-			deleteCollectionCalled := expectDeleteCollection(fakeClient, apiinstancetype.ClusterPluralPreferenceResourceName)
+			deleteCollectionCalled := expectDeleteCollection(fakeClient, reconciler.kv, apiinstancetype.ClusterPluralPreferenceResourceName)
 			Expect(reconciler.deletePreferences()).To(Succeed())
 			Expect(*deleteCollectionCalled).To(BeTrue())
 		})
@@ -215,13 +215,13 @@ func expectUpdate(fakeClient *fake.Clientset, resource string, object runtime.Ob
 	return &called
 }
 
-func expectDeleteCollection(fakeClient *fake.Clientset, resource string) *bool {
+func expectDeleteCollection(fakeClient *fake.Clientset, kv *v1.KubeVirt, resource string) *bool {
 	called := false
 	fakeClient.Fake.PrependReactor("delete-collection", resource, func(action testing.Action) (bool, runtime.Object, error) {
 		deleteCollection, ok := action.(testing.DeleteCollectionAction)
 		Expect(ok).To(BeTrue())
 		ls := labels.Set{
-			v1.AppComponentLabel: v1.AppComponent,
+			v1.AppComponentLabel: GetAppComponent(kv),
 			v1.ManagedByLabel:    v1.ManagedByLabelOperatorValue,
 		}
 		Expect(deleteCollection.GetListRestrictions().Labels).To(Equal(ls.AsSelector()))

--- a/pkg/virt-operator/resource/apply/instancetypes.go
+++ b/pkg/virt-operator/resource/apply/instancetypes.go
@@ -60,7 +60,7 @@ func (r *Reconciler) createOrUpdateInstancetype(instancetype *instancetypev1beta
 
 func (r *Reconciler) deleteInstancetypes() error {
 	ls := labels.Set{
-		v1.AppComponentLabel: v1.AppComponent,
+		v1.AppComponentLabel: GetAppComponent(r.kv),
 		v1.ManagedByLabel:    v1.ManagedByLabelOperatorValue,
 	}
 
@@ -120,7 +120,7 @@ func (r *Reconciler) createOrUpdatePreference(preference *instancetypev1beta1.Vi
 
 func (r *Reconciler) deletePreferences() error {
 	ls := labels.Set{
-		v1.AppComponentLabel: v1.AppComponent,
+		v1.AppComponentLabel: GetAppComponent(r.kv),
 		v1.ManagedByLabel:    v1.ManagedByLabelOperatorValue,
 	}
 

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -96,11 +96,8 @@ func injectOperatorMetadata(kv *v1.KubeVirt, objectMeta *metav1.ObjectMeta, vers
 	if kv.Spec.ProductName != "" && util.IsValidLabel(kv.Spec.ProductName) {
 		objectMeta.Labels[v1.AppPartOfLabel] = kv.Spec.ProductName
 	}
-	objectMeta.Labels[v1.AppComponentLabel] = v1.AppComponent
 
-	if kv.Spec.ProductComponent != "" && util.IsValidLabel(kv.Spec.ProductComponent) {
-		objectMeta.Labels[v1.AppComponentLabel] = kv.Spec.ProductComponent
-	}
+	objectMeta.Labels[v1.AppComponentLabel] = GetAppComponent(kv)
 
 	objectMeta.Labels[v1.ManagedByLabel] = v1.ManagedByLabelOperatorValue
 
@@ -113,6 +110,13 @@ func injectOperatorMetadata(kv *v1.KubeVirt, objectMeta *metav1.ObjectMeta, vers
 	if injectCustomizationMetadata {
 		objectMeta.Annotations[v1.KubeVirtGenerationAnnotation] = strconv.FormatInt(kv.ObjectMeta.GetGeneration(), 10)
 	}
+}
+
+func GetAppComponent(kv *v1.KubeVirt) string {
+	if kv.Spec.ProductComponent != "" && util.IsValidLabel(kv.Spec.ProductComponent) {
+		return kv.Spec.ProductComponent
+	}
+	return v1.AppComponent
 }
 
 const (
@@ -1192,7 +1196,7 @@ func (r *Reconciler) deleteObjectsNotInInstallStrategy() error {
 	}
 
 	managedByVirtOperatorLabelSet := labels.Set{
-		v1.AppComponentLabel: v1.AppComponent,
+		v1.AppComponentLabel: GetAppComponent(r.kv),
 		v1.ManagedByLabel:    v1.ManagedByLabelOperatorValue,
 	}
 

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -3058,11 +3058,13 @@ spec:
 	})
 
 	Context("[Serial] Deployment of common-instancetypes", Serial, func() {
+		var appComponent string
 		var labelSelector string
 
 		BeforeEach(func() {
+			appComponent = apply.GetAppComponent(util2.GetCurrentKv(virtClient))
 			labelSelector = labels.Set{
-				v1.AppComponentLabel: v1.AppComponent,
+				v1.AppComponentLabel: appComponent,
 				v1.ManagedByLabel:    v1.ManagedByLabelOperatorValue,
 			}.String()
 		})
@@ -3117,8 +3119,8 @@ spec:
 		})
 
 		Context("Should take ownership", func() {
-			const appComponent = "something"
-			const managedBy = "someone"
+			const appComponentChanged = "something"
+			const managedByChanged = "someone"
 
 			It("of instancetypes", func() {
 				By("Getting instancetypes to be deployed by virt-operator")
@@ -3129,15 +3131,15 @@ spec:
 				By("Picking the first instancetype and changing its labels")
 				instancetype := instancetypes[0]
 				instancetype.Labels = map[string]string{
-					v1.AppComponentLabel: appComponent,
-					v1.ManagedByLabel:    managedBy,
+					v1.AppComponentLabel: appComponentChanged,
+					v1.ManagedByLabel:    managedByChanged,
 				}
 
 				By("Creating the instancetype")
 				instancetype, err = virtClient.VirtualMachineClusterInstancetype().Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(instancetype.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, appComponent))
-				Expect(instancetype.Labels).To(HaveKeyWithValue(v1.ManagedByLabel, managedBy))
+				Expect(instancetype.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, appComponentChanged))
+				Expect(instancetype.Labels).To(HaveKeyWithValue(v1.ManagedByLabel, managedByChanged))
 
 				By("Enabling the feature gate and waiting for KubeVirt to be ready")
 				tests.EnableFeatureGate(virtconfig.CommonInstancetypesDeploymentGate)
@@ -3146,7 +3148,7 @@ spec:
 				By("Verifying virt-operator took ownership of the instancetype")
 				instancetype, err = virtClient.VirtualMachineClusterInstancetype().Get(context.Background(), instancetype.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(instancetype.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, v1.AppComponent))
+				Expect(instancetype.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, appComponent))
 				Expect(instancetype.Labels).To(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
 			})
 
@@ -3159,15 +3161,15 @@ spec:
 				By("Picking the first preference and changing its labels")
 				preference := preferences[0]
 				preference.Labels = map[string]string{
-					v1.AppComponentLabel: appComponent,
-					v1.ManagedByLabel:    managedBy,
+					v1.AppComponentLabel: appComponentChanged,
+					v1.ManagedByLabel:    managedByChanged,
 				}
 
 				By("Creating the preference")
 				preference, err = virtClient.VirtualMachineClusterPreference().Create(context.Background(), preference, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(preference.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, appComponent))
-				Expect(preference.Labels).To(HaveKeyWithValue(v1.ManagedByLabel, managedBy))
+				Expect(preference.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, appComponentChanged))
+				Expect(preference.Labels).To(HaveKeyWithValue(v1.ManagedByLabel, managedByChanged))
 
 				By("Enabling the feature gate and waiting for KubeVirt to be ready")
 				tests.EnableFeatureGate(virtconfig.CommonInstancetypesDeploymentGate)
@@ -3176,7 +3178,7 @@ spec:
 				By("Verifying virt-operator took ownership of the preference")
 				preference, err = virtClient.VirtualMachineClusterPreference().Get(context.Background(), preference.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(preference.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, v1.AppComponent))
+				Expect(preference.Labels).To(HaveKeyWithValue(v1.AppComponentLabel, appComponent))
 				Expect(preference.Labels).To(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
 			})
 		})
@@ -3193,7 +3195,7 @@ spec:
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "clusterinstancetype-",
 						Labels: map[string]string{
-							v1.AppComponentLabel: v1.AppComponent,
+							v1.AppComponentLabel: appComponent,
 							v1.ManagedByLabel:    v1.ManagedByLabelOperatorValue,
 						},
 					},
@@ -3216,7 +3218,7 @@ spec:
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "clusterpreference-",
 						Labels: map[string]string{
-							v1.AppComponentLabel: v1.AppComponent,
+							v1.AppComponentLabel: appComponent,
 							v1.ManagedByLabel:    v1.ManagedByLabelOperatorValue,
 						},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Previously kv.Spec.ProductComponent was not honored in all places when handling resources from common-instancetypes (e.g. deleting them and in tests). This extracts the existing logic to get the correct AppComponent value into a helper function and calls it in every place where the value is needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
