### PR TITLE
[e2e] Update vmi lifecycle tests to use libvmi and simplify tests

### DIFF
--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -286,6 +286,12 @@ func WithEvictionStrategy(evictionStrategy v1.EvictionStrategy) Option {
 	}
 }
 
+func WithStartStrategy(startStrategy v1.StartStrategy) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.StartStrategy = &startStrategy
+	}
+}
+
 func baseVmi(name string) *v1.VirtualMachineInstance {
 	vmi := v1.NewVMIReferenceFromNameWithNS("", name)
 	vmi.Spec = v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -127,9 +127,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:6095]should start in paused state if start strategy set to paused", func() {
-			vmi := libvmi.NewAlpine()
-			strategy := v1.StartStrategyPaused
-			vmi.Spec.StartStrategy = &strategy
+			vmi := libvmi.NewAlpine(libvmi.WithStartStrategy(v1.StartStrategyPaused))
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -351,7 +351,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi = tests.AddBootOrderToDisk(vmi, "disk0", &alpineBootOrder)
 				vmi = tests.AddBootOrderToDisk(vmi, "disk2", &cirrosBootOrder)
 				By("starting VMI")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 
 				By("Checking console text")
 				err = console.SafeExpectBatch(vmi, []expect.Batcher{

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -151,11 +151,9 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:3195]should carry annotations to pod", func() {
-			vmi := libvmi.NewAlpine()
-			vmi.Annotations = map[string]string{
-				"testannotation": "annotation from vmi",
-			}
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+			vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(
+				libvmi.WithAnnotation("testannotation", "annotation from vmi")),
+				30)
 
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(pod).NotTo(BeNil())
@@ -164,12 +162,10 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:3196]should carry kubernetes and kubevirt annotations to pod", func() {
-			vmi := libvmi.NewAlpine()
-			vmi.Annotations = map[string]string{
-				"kubevirt.io/test":   "test",
-				"kubernetes.io/test": "test",
-			}
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+			vmi = tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(
+				libvmi.WithAnnotation("kubevirt.io/test", "test"),
+				libvmi.WithAnnotation("kubernetes.io/test", "test")),
+				30)
 
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(pod).NotTo(BeNil())

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -173,9 +173,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("Should prevent eviction when EvictionStratgy: External", func() {
-			vmi := libvmi.NewAlpine()
-			strategy := v1.EvictionStrategyExternal
-			vmi.Spec.EvictionStrategy = &strategy
+			vmi := libvmi.NewAlpine(libvmi.WithEvictionStrategy(v1.EvictionStrategyExternal))
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:

Update vmi lifecycle tests to use libvmi and simplify tests
Includes replacing repeated create and start of VMI with `RunVMIAndExpectLaunch` function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- ~[ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- ~[ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- ~[ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- ~[ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- ~[ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

**Release note**:
```release-note
NONE
```
