### PR TITLE
Support to set a specify hostName for a CloneVM

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -21467,6 +21467,10 @@
       },
       "x-kubernetes-list-type": "atomic"
      },
+     "hostname": {
+      "description": "Specifies the hostname of the clone vm.",
+      "type": "string"
+     },
      "labelFilters": {
       "description": "Example use: \"!some/key*\". For a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.",
       "type": "array",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -404,6 +404,17 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			Entry("templateFilter negation in the beginning", "!mykey/something"),
 		)
 	})
+	Context("Set a specify hostName for a CloneVM ", func() {
+		It("should accept valid hostname", func() {
+			vmClone.Spec.Hostname = pointer.String("test")
+			admitter.admitAndExpect(vmClone, true)
+		})
+
+		It("should reject invalid hostname", func() {
+			vmClone.Spec.Hostname = pointer.String("test+bad")
+			admitter.admitAndExpect(vmClone, false)
+		})
+	})
 
 })
 

--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/clone",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/util/status:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -931,6 +931,29 @@ var _ = Describe("Clone", func() {
 			})
 		})
 
+		Context("Hostname", func() {
+			const manuallySetHostName = "manually-set-hostname"
+			const emptyHostName = ""
+
+			expectHostName := func(hostname string) {
+				expectedVM := sourceVM.DeepCopy()
+				expectedVM.Spec.Template.Spec.Hostname = hostname
+				expectVMCreationFromPatches(expectedVM)
+			}
+
+			FDescribeTable("should be set", func(providedHostname *string, expectedHostname string) {
+				vmClone.Spec.Hostname = providedHostname
+				addClone(vmClone)
+
+				controller.Execute()
+				expectRestoreExists()
+				expectHostName(expectedHostname)
+			},
+				Entry("with a generated one, if not defined in clone spec", pointer.P(emptyHostName), emptyHostName),
+				Entry("with the provided one, if defined in clone spec", pointer.P(manuallySetHostName), manuallySetHostName),
+			)
+		})
+
 	})
 })
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7950,6 +7950,9 @@ var CRDsValidation map[string]string = map[string]string{
             type: string
           type: array
           x-kubernetes-list-type: atomic
+        hostname:
+          description: Specifies the hostname of the clone vm.
+          type: string
         labelFilters:
           description: |-
             Example use: "!some/key*".

--- a/staging/src/kubevirt.io/api/clone/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/clone/v1alpha1/deepcopy_generated.go
@@ -118,6 +118,11 @@ func (in *VirtualMachineCloneSpec) DeepCopyInto(out *VirtualMachineCloneSpec) {
 		*out = new(v1.TypedLocalObjectReference)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Hostname != nil {
+		in, out := &in.Hostname, &out.Hostname
+		*out = new(string)
+		**out = **in
+	}
 	if in.AnnotationFilters != nil {
 		in, out := &in.AnnotationFilters, &out.AnnotationFilters
 		*out = make([]string, len(*in))

--- a/staging/src/kubevirt.io/api/clone/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/clone/v1alpha1/types.go
@@ -65,7 +65,9 @@ type VirtualMachineCloneSpec struct {
 	// inspecting status "TargetName" field below.
 	// +optional
 	Target *corev1.TypedLocalObjectReference `json:"target,omitempty"`
-
+	// Specifies the hostname of the clone vm.
+	// +optional
+	Hostname *string `json:"hostname,omitempty"`
 	// Example use: "!some/key*".
 	// For a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.
 	// +optional

--- a/staging/src/kubevirt.io/api/clone/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/clone/v1alpha1/types_swagger_generated.go
@@ -19,6 +19,7 @@ func (VirtualMachineCloneSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"source":            "Source is the object that would be cloned. Currently supported source types are:\nVirtualMachine of kubevirt.io API group,\nVirtualMachineSnapshot of snapshot.kubevirt.io API group",
 		"target":            "Target is the outcome of the cloning process.\nCurrently supported source types are:\n- VirtualMachine of kubevirt.io API group\n- Empty (nil).\nIf the target is not provided, the target type would default to VirtualMachine and a random\nname would be generated for the target. The target's name can be viewed by\ninspecting status \"TargetName\" field below.\n+optional",
+		"hostname":          "Specifies the hostname of the clone vm.\n+optional",
 		"annotationFilters": "Example use: \"!some/key*\".\nFor a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.\n+optional\n+listType=atomic",
 		"labelFilters":      "Example use: \"!some/key*\".\nFor a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.\n+optional\n+listType=atomic",
 		"template":          "For a detailed description, please refer to https://kubevirt.io/user-guide/operations/clone_api/#label-annotation-filters.\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -15372,6 +15372,13 @@ func schema_kubevirtio_api_clone_v1alpha1_VirtualMachineCloneSpec(ref common.Ref
 							Ref:         ref("k8s.io/api/core/v1.TypedLocalObjectReference"),
 						},
 					},
+					"hostname": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies the hostname of the clone vm.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"annotationFilters": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Sometimes we want to set hostname for CloneVM just as the VM which can be set hostname.

we can realize this function based on the following

```yaml
kind: VirtualMachineClone
apiVersion: "clone.kubevirt.io/v1alpha1"
metadata:
  name: testclone
spec:
  # target definitions hostname
  hostname: vmclone
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10742

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the possibility to specify vm target hostname during clone
```
