### PR TITLE
virt-launcher, vcpu: Fix EmulatorThreadPin assign strategy 

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2032,20 +2032,21 @@ var _ = Describe("Converter", func() {
 
 	Context("Correctly handle IsolateEmulatorThread with dedicated cpus", func() {
 		DescribeTable("should succeed assigning CPUs to emulatorThread",
-			func(cores uint32, converterContext *ConverterContext, CPUManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions,
+			func(cpu v1.CPU, converterContext *ConverterContext, CPUManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions,
 				expectedEmulatorThreads int) {
 				var err error
 				domain := &api.Domain{}
 
 				cpuPool := vcpu.NewRelaxedCPUPool(
-					&api.CPUTopology{Sockets: 1, Cores: cores, Threads: 1},
+					&api.CPUTopology{Sockets: cpu.Sockets, Cores: cpu.Cores, Threads: cpu.Threads},
 					converterContext.Topology,
 					converterContext.CPUSet,
 				)
 				domain.Spec.CPUTune, err = cpuPool.FitCores()
 				Expect(err).ToNot(HaveOccurred())
 
-				emulatorThreadsCPUSet, err := vcpu.FormatEmulatorThreadPin(cpuPool, CPUManagerPolicyBetaOption)
+				vCPUs := hardware.GetNumberOfVCPUs(&cpu)
+				emulatorThreadsCPUSet, err := vcpu.FormatEmulatorThreadPin(cpuPool, CPUManagerPolicyBetaOption, vCPUs)
 				Expect(err).ToNot(HaveOccurred())
 				By("checking that the housekeeping CPUSet has the expected amount of CPUs")
 				housekeepingCPUs, err := hardware.ParseCPUSetLine(emulatorThreadsCPUSet, 100)
@@ -2059,7 +2060,8 @@ var _ = Describe("Converter", func() {
 				}
 			},
 			Entry("when full-pcpu-only is disabled and there is one extra CPU assigned for emulatorThread",
-				uint32(2), &ConverterContext{CPUSet: []int{5, 6, 7},
+				v1.CPU{Sockets: 1, Cores: 2, Threads: 1},
+				&ConverterContext{CPUSet: []int{5, 6, 7},
 					Topology: &cmdv1.Topology{
 						NumaCells: []*cmdv1.Cell{{
 							Cpus: []*cmdv1.CPU{
@@ -2071,8 +2073,23 @@ var _ = Describe("Converter", func() {
 				},
 				v1.CPUManagerPolicyBetaOptions(""),
 				1),
-			Entry("when full-pcpu-only is enabled and there are two extra CPUs assigned for emulatorThread",
-				uint32(6), &ConverterContext{CPUSet: []int{5, 6, 7, 8, 9, 10, 11, 12},
+			Entry("when full-pcpu-only is enabled and there is one extra CPU assigned for emulatorThread (odd CPUs)",
+				v1.CPU{Sockets: 1, Cores: 5, Threads: 1},
+				&ConverterContext{CPUSet: []int{5, 6, 7, 8, 9, 10},
+					Topology: &cmdv1.Topology{
+						NumaCells: []*cmdv1.Cell{{
+							Cpus: []*cmdv1.CPU{
+								{Id: 5}, {Id: 6}, {Id: 7}, {Id: 8}, {Id: 9},
+								{Id: 10},
+							},
+						}},
+					},
+				},
+				v1.CPUManagerPolicyBetaOptionFullpCPUsOnly,
+				1),
+			Entry("when full-pcpu-only is enabled and there are two extra CPUs assigned for emulatorThread (even CPUs)",
+				v1.CPU{Sockets: 1, Cores: 6, Threads: 1},
+				&ConverterContext{CPUSet: []int{5, 6, 7, 8, 9, 10, 11, 12},
 					Topology: &cmdv1.Topology{
 						NumaCells: []*cmdv1.Cell{{
 							Cpus: []*cmdv1.CPU{
@@ -2086,24 +2103,26 @@ var _ = Describe("Converter", func() {
 				2),
 		)
 		DescribeTable("should fail assigning CPUs to emulatorThread",
-			func(cores uint32, converterContext *ConverterContext, CPUManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions,
+			func(cpu v1.CPU, converterContext *ConverterContext, CPUManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions,
 				expectedErrorString string) {
 				var err error
 				domain := &api.Domain{}
 
 				cpuPool := vcpu.NewRelaxedCPUPool(
-					&api.CPUTopology{Sockets: 1, Cores: cores, Threads: 1},
+					&api.CPUTopology{Sockets: cpu.Sockets, Cores: cpu.Cores, Threads: cpu.Threads},
 					converterContext.Topology,
 					converterContext.CPUSet,
 				)
 				domain.Spec.CPUTune, err = cpuPool.FitCores()
 				Expect(err).ToNot(HaveOccurred())
 
-				_, err = vcpu.FormatEmulatorThreadPin(cpuPool, CPUManagerPolicyBetaOption)
+				vCPUs := hardware.GetNumberOfVCPUs(&cpu)
+				_, err = vcpu.FormatEmulatorThreadPin(cpuPool, CPUManagerPolicyBetaOption, vCPUs)
 				Expect(err).To(MatchError(ContainSubstring(expectedErrorString)))
 			},
 			Entry("when full-pcpu-only is disabled and there are not enough CPUs to allocate emulator threads",
-				uint32(2), &ConverterContext{CPUSet: []int{5, 6},
+				v1.CPU{Sockets: 1, Cores: 2, Threads: 1},
+				&ConverterContext{CPUSet: []int{5, 6},
 					Topology: &cmdv1.Topology{
 						NumaCells: []*cmdv1.Cell{{
 							Cpus: []*cmdv1.CPU{
@@ -2114,8 +2133,23 @@ var _ = Describe("Converter", func() {
 				},
 				v1.CPUManagerPolicyBetaOptions(""),
 				"no CPU allocated for the emulation thread"),
-			Entry("when full-pcpu-only is enabled and there are not enough Cores to allocate emulator threads",
-				uint32(2), &ConverterContext{CPUSet: []int{5, 6, 7},
+			Entry("when full-pcpu-only is enabled and there are not enough Cores to allocate emulator threads (odd CPUs)",
+				v1.CPU{Sockets: 1, Cores: 3, Threads: 1},
+				&ConverterContext{CPUSet: []int{5, 6, 7},
+					Topology: &cmdv1.Topology{
+						NumaCells: []*cmdv1.Cell{{
+							Cpus: []*cmdv1.CPU{
+								{Id: 5}, {Id: 6},
+								{Id: 7},
+							},
+						}},
+					},
+				},
+				v1.CPUManagerPolicyBetaOptionFullpCPUsOnly,
+				"no CPU allocated for the emulation thread"),
+			Entry("when full-pcpu-only is enabled and there are not enough Cores to allocate emulator threads (even CPUs)",
+				v1.CPU{Sockets: 1, Cores: 2, Threads: 1},
+				&ConverterContext{CPUSet: []int{5, 6, 7},
 					Topology: &cmdv1.Topology{
 						NumaCells: []*cmdv1.Cell{{
 							Cpus: []*cmdv1.CPU{

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/hardware:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, when CPUManagerPolicyBetaOption annotation is set to
full-pcpus-only on the VMI, the virt-launcher pod is assigned with extra
two CPU threads meant for emulator-threads [0] - but only if the amount
of CPUs originally requested was even.
This is not aligned with the EmulatorThreadPin assignment on
virt-launcher, where 2 threads are requested regardless of the amount of
vCPUs.

Fix the EmulatorThreadPin assignment to request the second emulator
thread only if the amount of vCPUs is even.

[0] https://github.com/kubevirt/kubevirt/pull/10593

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change second emulator thread assign strategy to best-effort.
```
