### PR TITLE
virt-api: request/limits can now be used with CPU/Memory hotplug

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -482,14 +482,6 @@ func validateLiveUpdateFeatures(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 				}
 			}
 		}
-
-		if hasCPURequestsOrLimits(&spec.Template.Spec.Domain.Resources) {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("Configuration of CPU resource requirements is not allowed when CPU live update is enabled"),
-				Field:   field.Child("liveUpdateFeatures").String(),
-			})
-		}
 	}
 
 	// Validate Memory Hotplug
@@ -504,14 +496,6 @@ func validateLiveUpdateFeatures(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 	if spec.LiveUpdateFeatures != nil &&
 		spec.LiveUpdateFeatures.Memory != nil &&
 		spec.LiveUpdateFeatures.Memory.MaxGuest != nil {
-
-		if hasMemoryLimits(&spec.Template.Spec.Domain.Resources) {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("Configuration of Memory limits is not allowed when Memory live update is enabled"),
-				Field:   field.Child("liveUpdateFeatures").String(),
-			})
-		}
 
 		if spec.Template.Spec.Domain.CPU != nil &&
 			spec.Template.Spec.Domain.CPU.Realtime != nil {
@@ -950,20 +934,4 @@ func (admitter *VMsAdmitter) isMigrationInProgress(vmi *v1.VirtualMachineInstanc
 		return fmt.Errorf("cannot update while VMI migration is in progress: %v", err)
 	}
 	return nil
-}
-
-func hasCPURequestsOrLimits(rr *v1.ResourceRequirements) bool {
-	if _, ok := rr.Requests[corev1.ResourceCPU]; ok {
-		return true
-	}
-	if _, ok := rr.Limits[corev1.ResourceCPU]; ok {
-		return true
-	}
-
-	return false
-}
-
-func hasMemoryLimits(rr *v1.ResourceRequirements) bool {
-	_, ok := rr.Limits[corev1.ResourceMemory]
-	return ok
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1895,26 +1895,6 @@ var _ = Describe("Validating VM Admitter", func() {
 				Expect(response.Result.Details.Causes[0].Message).To(ContainSubstring("Number of sockets in CPU topology is greater than the maximum sockets allowed"))
 			})
 
-			It("should reject VM creation when resource requests are configured", func() {
-				vm.Spec.Template.Spec.Domain.Resources.Requests = make(k8sv1.ResourceList)
-				vm.Spec.Template.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("400m")
-
-				response := admitVm(vmsAdmitter, vm)
-				Expect(response.Allowed).To(BeFalse())
-				Expect(response.Result.Details.Causes[0].Field).To(Equal("spec.liveUpdateFeatures"))
-				Expect(response.Result.Details.Causes[0].Message).To(ContainSubstring("Configuration of CPU resource requirements is not allowed when CPU live update is enabled"))
-			})
-
-			It("should reject VM creation when resource limits are configured", func() {
-				vm.Spec.Template.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-				vm.Spec.Template.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("400m")
-
-				response := admitVm(vmsAdmitter, vm)
-				Expect(response.Allowed).To(BeFalse())
-				Expect(response.Result.Details.Causes[0].Field).To(Equal("spec.liveUpdateFeatures"))
-				Expect(response.Result.Details.Causes[0].Message).To(ContainSubstring("Configuration of CPU resource requirements is not allowed when CPU live update is enabled"))
-			})
-
 			When("Hot CPU change is in progress", func() {
 				BeforeEach(func() {
 					vm.Status.Ready = true
@@ -2174,8 +2154,6 @@ var _ = Describe("Validating VM Admitter", func() {
 					Guest: &guest,
 				}
 				vm.Spec.Template.Spec.Architecture = rt.GOARCH
-				vm.Spec.Template.Spec.Domain.Resources.Limits = nil
-				vm.Spec.Template.Spec.Domain.Resources.Requests = nil
 				vm.Status.Ready = true
 			})
 
@@ -2192,14 +2170,6 @@ var _ = Describe("Validating VM Admitter", func() {
 					Type:    metav1.CauseTypeFieldValueNotSupported,
 					Field:   "spec.template.spec.domain.memory.maxGuest",
 					Message: "Memory maxGuest cannot be set directy in VM template",
-				}),
-				Entry("resource limits are configured", func(vm *v1.VirtualMachine) {
-					vm.Spec.Template.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-					vm.Spec.Template.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-				}, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Field:   "spec.liveUpdateFeatures",
-					Message: "Configuration of Memory limits is not allowed when Memory live update is enabled",
 				}),
 				Entry("hugepages is configured", func(vm *v1.VirtualMachine) {
 					vm.Spec.Template.Spec.Domain.Memory.Hugepages = &v1.Hugepages{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The limitation in configuring requests/limits when using CPU/Memory hotplug has no real technical roadblock and as such can be removed to have more freedom when defining a VM.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Requests/Limits can now be configured when using CPU/Memory hotplug
```
