### PR TITLE
vmclone admitter: Replace string literals with consts

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -250,8 +250,8 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			vmClone.Spec.Source.Kind = kind
 			admitter.admitAndExpect(vmClone, true)
 		},
-			Entry("VM", "VirtualMachine"),
-			Entry("Snapshot", "VirtualMachineSnapshot"),
+			Entry("VM", virtualMachineKind),
+			Entry("Snapshot", virtualMachineSnapshotKind),
 		)
 
 		It("Should reject unknown source type", func() {
@@ -272,8 +272,8 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 
 	When("Both source and target kinds are VirtualMachine", func() {
 		It("Should reject a target with the same name as the source", func() {
-			vmClone.Spec.Source.Kind = "VirtualMachine"
-			vmClone.Spec.Target.Kind = "VirtualMachine"
+			vmClone.Spec.Source.Kind = virtualMachineKind
+			vmClone.Spec.Target.Kind = virtualMachineKind
 
 			vmClone.Spec.Target.Name = vmClone.Spec.Source.Name
 			admitter.admitAndExpect(vmClone, false)
@@ -282,8 +282,8 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 
 	When("Source kind is a VirtualMachineSnapshot and target kind is VirtualMachine", func() {
 		It("Should allow the target to have the same name as the source", func() {
-			vmClone.Spec.Source.Kind = "VirtualMachineSnapshot"
-			vmClone.Spec.Target.Kind = "VirtualMachine"
+			vmClone.Spec.Source.Kind = virtualMachineSnapshotKind
+			vmClone.Spec.Target.Kind = virtualMachineKind
 
 			vmClone.Spec.Target.Name = vmClone.Spec.Source.Name
 			admitter.admitAndExpect(vmClone, true)
@@ -330,7 +330,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		})
 
 		It("should reject if vmsnapshot contents don't include a volume's backup", func() {
-			vmClone.Spec.Source.Kind = "VirtualMachineSnapshot"
+			vmClone.Spec.Source.Kind = virtualMachineSnapshotKind
 
 			kubevirtClient.Fake.PrependReactor("get", "virtualmachinesnapshotcontents", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				contents := &v1alpha1.VirtualMachineSnapshotContent{
@@ -444,7 +444,7 @@ func newValidClone() *clonev1lpha1.VirtualMachineClone {
 func newValidObjReference() *k8sv1.TypedLocalObjectReference {
 	return &k8sv1.TypedLocalObjectReference{
 		APIGroup: pointer.String(core.GroupName),
-		Kind:     "VirtualMachine",
+		Kind:     virtualMachineKind,
 		Name:     "clone-source-vm",
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, there are multiple occurrences of the following string literals:
- "VirtualMachine"
- "VirtualMachineSnapshot"

Replace them with constants.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
