### PR TITLE
Drop certain keys from clone annotation filters

### DIFF
--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -615,7 +615,8 @@ var _ = Describe("Clone", func() {
 				Expect(restore.Spec.VirtualMachineSnapshotName).To(Equal(snapshotName))
 
 				patchedVM, err := offlinePatchVM(sourceVM, restore.Spec.Patches)
-				Expect(patchedVM.Spec).To(Equal(patchedVM.Spec))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(patchedVM.Spec).To(Equal(expectedVM.Spec))
 
 				return true, create.GetObject(), nil
 			})
@@ -694,8 +695,11 @@ var _ = Describe("Clone", func() {
 					if i%2 == 0 {
 						iface.MacAddress = generateNewMacAddress()
 						newMacAddresses[iface.Name] = iface.MacAddress
-						expectedInterfaces[i] = iface
+					} else {
+						// empty MAC for others
+						iface.MacAddress = ""
 					}
+					expectedInterfaces[i] = iface
 				}
 
 				sourceVM.Spec.Template.Spec.Domain.Devices.Interfaces = originalInterfaces
@@ -804,6 +808,35 @@ var _ = Describe("Clone", func() {
 				Entry("with labels", labels),
 				Entry("with annotations", annotations),
 			)
+
+			It("should not strip lastRestoreUID annotation from newly created VM", func() {
+				if sourceVM.Annotations == nil {
+					sourceVM.Annotations = make(map[string]string)
+				}
+				sourceVM.Annotations["restore.kubevirt.io/lastRestoreUID"] = "bar"
+				// controller mutates original ptrs annotations
+				sourceVMCpy := sourceVM.DeepCopy()
+				vmClone.Spec.AnnotationFilters = []string{"somekey/*"}
+				addVM(sourceVM)
+				addClone(vmClone)
+
+				client.Fake.PrependReactor("create", restoreResource, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					create, ok := action.(testing.CreateAction)
+					Expect(ok).To(BeTrue())
+
+					restore := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+					Expect(restore.Spec.VirtualMachineSnapshotName).To(Equal(snapshotName))
+
+					expectedPatches := []string{`{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": ""}`}
+					Expect(restore.Spec.Patches).To(Equal(expectedPatches))
+					patchedVM, err := offlinePatchVM(sourceVMCpy, restore.Spec.Patches)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(patchedVM.Annotations).To(HaveKey("restore.kubevirt.io/lastRestoreUID"))
+
+					return true, create.GetObject(), nil
+				})
+				controller.Execute()
+			})
 
 		})
 

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -251,7 +251,6 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 		}
 		expectEqualTemplateAnnotations := func(targetVM, sourceVM *virtv1.VirtualMachine, keysToExclude ...string) {
 			expectEqualStrMap(targetVM.Spec.Template.ObjectMeta.Annotations, sourceVM.Spec.Template.ObjectMeta.Annotations, fmt.Sprintf(cloneShouldEqualSourceMsgPattern, "template.annotations"), keysToExclude...)
-
 		}
 
 		expectSpecsToEqualExceptForMacAddress := func(vm1, vm2 *virtv1.VirtualMachine) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some annotations are needed for functionality, and we cannot get rid of them easily;
This causes new target VMs to be created without lastRestoreAnnotation.
One of the impacts of this is that we keep reconciling the target VM back to pre-patched state
(duplicate mac err loop on ocp virt)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Double cloning with filter fails
```
