### PR TITLE
[release-1.1] Backport 'Drop certain keys from clone annotation filters'

### DIFF
--- a/pkg/virt-controller/watch/clone/vm-target.go
+++ b/pkg/virt-controller/watch/clone/vm-target.go
@@ -88,15 +88,17 @@ func generateLabelPatches(labels map[string]string, filters []string) (patches [
 
 func generateAnnotationPatches(annotations map[string]string, filters []string) (patches []string) {
 	const basePath = "/metadata/annotations"
+	// Some keys are needed for restore functionality
+	delete(annotations, "restore.kubevirt.io/lastRestoreUID")
 	return generateStrStrMapPatches(annotations, filters, basePath)
 }
 
-func generateStrStrMapPatches(m map[string]string, filters []string, baseJsonPath string) (patches []string) {
+func generateStrStrMapPatches(m map[string]string, filters []string, baseJSONPath string) (patches []string) {
 	appendRemovalPatch := func(key string) {
 		const patchPattern = `{"op": "remove", "path": "%s/%s"}`
 
 		key = addKeyEscapeCharacters(key)
-		patches = append(patches, fmt.Sprintf(patchPattern, baseJsonPath, key))
+		patches = append(patches, fmt.Sprintf(patchPattern, baseJSONPath, key))
 	}
 
 	if filters == nil {
@@ -130,7 +132,7 @@ func generateStrStrMapPatches(m map[string]string, filters []string, baseJsonPat
 
 	includedKeys := map[string]struct{}{}
 	// Negation filters have precedence, therefore regular filters would be applied first
-	for key, _ := range m {
+	for key := range m {
 		for _, filter := range regularFilters {
 			if matchRegex(filter, key) {
 				includedKeys[key] = struct{}{}
@@ -145,7 +147,7 @@ func generateStrStrMapPatches(m map[string]string, filters []string, baseJsonPat
 	}
 
 	// Appending removal patches
-	for originalKey, _ := range m {
+	for originalKey := range m {
 		if _, isIncluded := includedKeys[originalKey]; !isIncluded {
 			appendRemovalPatch(originalKey)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual backport of https://github.com/kubevirt/kubevirt/pull/10860

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Double cloning with filter fails
```
