### PR TITLE
IsolateEmulatorThread: Add cluster-wide parity completion setting

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -97,6 +97,18 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 			addNodeSelector(newVMI, v1.SEVESLabel)
 		}
 
+		if newVMI.Spec.Domain.CPU.IsolateEmulatorThread {
+			_, emulatorThreadCompleteToEvenParityAnnotationExists := mutator.ClusterConfig.GetConfigFromKubeVirtCR().Annotations[v1.EmulatorThreadCompleteToEvenParity]
+			if emulatorThreadCompleteToEvenParityAnnotationExists &&
+				mutator.ClusterConfig.AlignCPUsEnabled() {
+				log.Log.V(4).Infof("Copy %s annotation from Kubevirt CR", v1.EmulatorThreadCompleteToEvenParity)
+				if newVMI.Annotations == nil {
+					newVMI.Annotations = map[string]string{}
+				}
+				newVMI.Annotations[v1.EmulatorThreadCompleteToEvenParity] = ""
+			}
+		}
+
 		// Add foreground finalizer
 		newVMI.Finalizers = append(newVMI.Finalizers, v1.VirtualMachineInstanceFinalizer)
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1717,15 +1717,6 @@ func ValidateVirtualMachineInstanceMetadata(field *k8sfield.Path, metadata *meta
 		}
 	}
 
-	if _, exists := annotations[v1.CPUManagerPolicyBetaOptionsAnnotation]; exists && !config.CPUManagerPolicyBetaOptionsEnabled() {
-		causes = append(causes, metav1.StatusCause{
-			Type: metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("CPUManagerPolicyBetaOptions feature gate is not enabled in kubevirt-config, invalid entry %s",
-				field.Child("annotations").Child(v1.CPUManagerPolicyBetaOptionsAnnotation).String()),
-			Field: field.Child("annotations").String(),
-		})
-	}
-
 	return causes
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -480,10 +480,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				map[string]string{hooks.HookSidecarListAnnotationName: "[{'image': 'fake-image'}]"},
 				fmt.Sprintf("invalid entry metadata.annotations.%s", hooks.HookSidecarListAnnotationName),
 			),
-			Entry("without CPUManagerPolicyBetaOptions feature gate enabled",
-				map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: string(v1.CPUManagerPolicyBetaOptionFullpCPUsOnly)},
-				fmt.Sprintf("invalid entry metadata.annotations.%s", v1.CPUManagerPolicyBetaOptionsAnnotation),
-			),
 		)
 
 		DescribeTable("should accept annotations which require feature gate enabled", func(annotations map[string]string, featureGate string) {
@@ -502,10 +498,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Entry("with sidecar feature gate enabled",
 				map[string]string{hooks.HookSidecarListAnnotationName: "[{'image': 'fake-image'}]"},
 				virtconfig.SidecarGate,
-			),
-			Entry("with CPUManagerPolicyBetaOptions feature gate enabled",
-				map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: string(v1.CPUManagerPolicyBetaOptionFullpCPUsOnly)},
-				virtconfig.CPUManagerPolicyBetaOptionsGate,
 			),
 		)
 	})

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -81,8 +81,8 @@ const (
 	//
 	// CommonInstancetypesDeploymentGate enables the deployment of common-instancetypes by virt-operator
 	CommonInstancetypesDeploymentGate = "CommonInstancetypesDeploymentGate"
-	// CPUManagerPolicyBetaOptionsGate allows conforming VM to static CPU-Manager Policies.
-	CPUManagerPolicyBetaOptionsGate = "CPUManagerPolicyBetaOptions"
+	// AlignCPUsGate allows emulator thread to assign two extra CPUs if needed to complete even parity.
+	AlignCPUsGate = "AlignCPUs"
 )
 
 var deprecatedFeatureGates = [...]string{
@@ -262,6 +262,6 @@ func (config *ClusterConfig) CommonInstancetypesDeploymentEnabled() bool {
 	return config.isFeatureGateEnabled(CommonInstancetypesDeploymentGate)
 }
 
-func (config *ClusterConfig) CPUManagerPolicyBetaOptionsEnabled() bool {
-	return config.isFeatureGateEnabled(CPUManagerPolicyBetaOptionsGate)
+func (config *ClusterConfig) AlignCPUsEnabled() bool {
+	return config.isFeatureGateEnabled(AlignCPUsGate)
 }

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -199,7 +199,7 @@ func WithAutoMemoryLimits(namespace string, namespaceStore cache.Store) Resource
 	}
 }
 
-func WithCPUPinning(cpu *v1.CPU, cpuManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions) ResourceRendererOption {
+func WithCPUPinning(cpu *v1.CPU, annotations map[string]string) ResourceRendererOption {
 	return func(renderer *ResourceRenderer) {
 		vcpus := hardware.GetNumberOfVCPUs(cpu)
 		if vcpus != 0 {
@@ -217,7 +217,8 @@ func WithCPUPinning(cpu *v1.CPU, cpuManagerPolicyBetaOption v1.CPUManagerPolicyB
 			emulatorThreadCPUs := resource.NewQuantity(1, resource.BinarySI)
 
 			limits := renderer.calculatedLimits[k8sv1.ResourceCPU]
-			if cpuManagerPolicyBetaOption == v1.CPUManagerPolicyBetaOptionFullpCPUsOnly &&
+			_, cpuManagerPolicyBetaOptionsAnnotationExists := annotations[v1.CPUManagerPolicyBetaOptionsAnnotation]
+			if cpuManagerPolicyBetaOptionsAnnotationExists &&
 				limits.Value()%2 == 0 {
 				emulatorThreadCPUs = resource.NewQuantity(2, resource.BinarySI)
 			}

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -217,8 +217,8 @@ func WithCPUPinning(cpu *v1.CPU, annotations map[string]string) ResourceRenderer
 			emulatorThreadCPUs := resource.NewQuantity(1, resource.BinarySI)
 
 			limits := renderer.calculatedLimits[k8sv1.ResourceCPU]
-			_, cpuManagerPolicyBetaOptionsAnnotationExists := annotations[v1.CPUManagerPolicyBetaOptionsAnnotation]
-			if cpuManagerPolicyBetaOptionsAnnotationExists &&
+			_, emulatorThreadCompleteToEvenParityAnnotationExists := annotations[v1.EmulatorThreadCompleteToEvenParity]
+			if emulatorThreadCompleteToEvenParityAnnotationExists &&
 				limits.Value()%2 == 0 {
 				emulatorThreadCPUs = resource.NewQuantity(2, resource.BinarySI)
 			}

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -171,22 +171,21 @@ var _ = Describe("Resource pod spec renderer", func() {
 	})
 
 	Context("WithCPUPinning option", func() {
-		const cpuManagerPolicyBetaOptionsAnnotationDisabled = ""
 		userCPURequest := resource.MustParse("200m")
 		userSpecifiedCPU := kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
 
 		It("the user requested CPU configs are *not* overriden", func() {
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{Cores: 5}, cpuManagerPolicyBetaOptionsAnnotationDisabled))
+			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{Cores: 5}, map[string]string{}))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
 		})
 
 		It("carries over the CPU limits as requests when no CPUs are requested", func() {
-			rr = NewResourceRenderer(userSpecifiedCPU, nil, WithCPUPinning(&v1.CPU{}, cpuManagerPolicyBetaOptionsAnnotationDisabled))
+			rr = NewResourceRenderer(userSpecifiedCPU, nil, WithCPUPinning(&v1.CPU{}, map[string]string{}))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
 		})
 
 		It("carries over the CPU requests as limits when no CPUs are requested", func() {
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{}, cpuManagerPolicyBetaOptionsAnnotationDisabled))
+			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{}, map[string]string{}))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
 		})
 
@@ -196,7 +195,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 				kubev1.ResourceCPU:    userCPURequest,
 				kubev1.ResourceMemory: memoryRequest,
 			}
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{Cores: 5}, cpuManagerPolicyBetaOptionsAnnotationDisabled))
+			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(&v1.CPU{Cores: 5}, map[string]string{}))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, resource.MustParse("200m")))
 			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceMemory, memoryRequest))
 		})
@@ -205,17 +204,14 @@ var _ = Describe("Resource pod spec renderer", func() {
 			userSpecifiedCPURequest := kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
 
 			DescribeTable("requires additional EmulatorThread CPUs overhead, and additional CPUs added to the limits",
-				func(fullPCPUEnabled, defineUserSpecifiedCPULimit bool, cores uint32, expectedCPUOverhead string) {
+				func(vmiAnnotations map[string]string, defineUserSpecifiedCPULimit bool, cores uint32, expectedCPUOverhead string) {
 					cpuIsolatedEmulatorThreadOverhead := resource.MustParse(expectedCPUOverhead)
 					var userSpecifiedCPULimit kubev1.ResourceList
-					var cpuManagerPolicyBetaOption v1.CPUManagerPolicyBetaOptions
 
 					if defineUserSpecifiedCPULimit {
 						userSpecifiedCPULimit = kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
 					}
-					if fullPCPUEnabled {
-						cpuManagerPolicyBetaOption = v1.CPUManagerPolicyBetaOptionFullpCPUsOnly
-					}
+
 					rr = NewResourceRenderer(
 						userSpecifiedCPULimit,
 						userSpecifiedCPURequest,
@@ -223,7 +219,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 							Cores:                 cores,
 							IsolateEmulatorThread: true,
 						},
-							cpuManagerPolicyBetaOption),
+							vmiAnnotations),
 					)
 					Expect(rr.Limits()).To(HaveKeyWithValue(
 						kubev1.ResourceCPU,
@@ -234,12 +230,12 @@ var _ = Describe("Resource pod spec renderer", func() {
 						addResources(userCPURequest, cpuIsolatedEmulatorThreadOverhead),
 					))
 				},
-				Entry("full-pcpu-only mode is disabled, only CPU requests set by the user", false, false, uint32(5), "1000m"),
-				Entry("full-pcpu-only mode is disabled, request and limits set by the user", false, true, uint32(5), "1000m"),
-				Entry("full-pcpu-only mode is enabled, only CPU requests set by the user, odd amount of cores is requested", true, false, uint32(5), "1000m"),
-				Entry("full-pcpu-only mode is enabled, only CPU requests set by the user, even amount of cores is requested", true, false, uint32(6), "2000m"),
-				Entry("full-pcpu-only mode is enabled, request and limits set by the user, odd amount of cores is requested", true, true, uint32(5), "1000m"),
-				Entry("full-pcpu-only mode is enabled, request and limits set by the user, even amount of cores is requested", true, true, uint32(6), "2000m"),
+				Entry("full-pcpu-only mode is disabled, only CPU requests set by the user", map[string]string{}, false, uint32(5), "1000m"),
+				Entry("full-pcpu-only mode is disabled, request and limits set by the user", map[string]string{}, true, uint32(5), "1000m"),
+				Entry("full-pcpu-only mode is enabled, only CPU requests set by the user, odd amount of cores is requested", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, false, uint32(5), "1000m"),
+				Entry("full-pcpu-only mode is enabled, only CPU requests set by the user, even amount of cores is requested", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, false, uint32(6), "2000m"),
+				Entry("full-pcpu-only mode is enabled, request and limits set by the user, odd amount of cores is requested", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, true, uint32(5), "1000m"),
+				Entry("full-pcpu-only mode is enabled, request and limits set by the user, even amount of cores is requested", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, true, uint32(6), "2000m"),
 			)
 		})
 	})

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -230,12 +230,12 @@ var _ = Describe("Resource pod spec renderer", func() {
 						addResources(userCPURequest, cpuIsolatedEmulatorThreadOverhead),
 					))
 				},
-				Entry("full-pcpu-only mode is disabled, only CPU requests set by the user", map[string]string{}, false, uint32(5), "1000m"),
-				Entry("full-pcpu-only mode is disabled, request and limits set by the user", map[string]string{}, true, uint32(5), "1000m"),
-				Entry("full-pcpu-only mode is enabled, only CPU requests set by the user, odd amount of cores is requested", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, false, uint32(5), "1000m"),
-				Entry("full-pcpu-only mode is enabled, only CPU requests set by the user, even amount of cores is requested", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, false, uint32(6), "2000m"),
-				Entry("full-pcpu-only mode is enabled, request and limits set by the user, odd amount of cores is requested", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, true, uint32(5), "1000m"),
-				Entry("full-pcpu-only mode is enabled, request and limits set by the user, even amount of cores is requested", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, true, uint32(6), "2000m"),
+				Entry("EmulatorThreadCompleteToEvenParity mode is disabled, only CPU requests set by the user", map[string]string{}, false, uint32(5), "1000m"),
+				Entry("EmulatorThreadCompleteToEvenParity mode is disabled, request and limits set by the user", map[string]string{}, true, uint32(5), "1000m"),
+				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, only CPU requests set by the user, odd amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, false, uint32(5), "1000m"),
+				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, only CPU requests set by the user, even amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, false, uint32(6), "2000m"),
+				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, request and limits set by the user, odd amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, true, uint32(5), "1000m"),
+				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, request and limits set by the user, even amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, true, uint32(6), "2000m"),
 			)
 		})
 	})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1464,12 +1464,10 @@ func (t *templateService) doesVMIRequireAutoCPULimits(vmi *v1.VirtualMachineInst
 func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string) VMIResourcePredicates {
 	memoryOverhead := GetMemoryOverhead(vmi, t.clusterConfig.GetClusterCPUArch(), t.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
 	withCPULimits := t.doesVMIRequireAutoCPULimits(vmi)
-	CPUManagerPolicyBetaOption := v1.CPUManagerPolicyBetaOptions(vmi.Annotations[v1.CPUManagerPolicyBetaOptionsAnnotation])
-
 	return VMIResourcePredicates{
 		vmi: vmi,
 		resourceRules: []VMIResourceRule{
-			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi.Spec.Domain.CPU, CPUManagerPolicyBetaOption)),
+			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi.Spec.Domain.CPU, vmi.Annotations)),
 			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi.Spec.Domain.CPU, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
 			NewVMIResourceRule(util.HasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),
 			NewVMIResourceRule(not(util.HasHugePages), WithMemoryOverhead(vmi.Spec.Domain.Resources, memoryOverhead)),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1725,8 +1725,8 @@ var _ = Describe("Template", func() {
 			},
 				Entry("no annotation added, odd  CPUs requested, should allocate one extra emulator CPU", map[string]string{}, uint32(3), "4"),
 				Entry("no annotation added, even CPUs requested, should allocate one extra emulator CPU", map[string]string{}, uint32(2), "3"),
-				Entry("full-pcpu-only annotation added, odd CPUs requested, should allocate one extra emulator CPU", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, uint32(3), "4"),
-				Entry("full-pcpu-only annotation added, even CPUs requested, should allocate two extra emulator CPU (to align SMT scheduling)", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, uint32(4), "6"),
+				Entry("EmulatorThreadCompleteToEvenParity annotation added, odd CPUs requested, should allocate one extra emulator CPU", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, uint32(3), "4"),
+				Entry("EmulatorThreadCompleteToEvenParity annotation added, even CPUs requested, should allocate two extra emulator CPU (to align SMT scheduling)", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, uint32(4), "6"),
 			)
 			It("should add node affinity to pod", func() {
 				config, kvInformer, svc = configFactory(defaultArch)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1725,8 +1725,8 @@ var _ = Describe("Template", func() {
 			},
 				Entry("no annotation added, odd  CPUs requested, should allocate one extra emulator CPU", map[string]string{}, uint32(3), "4"),
 				Entry("no annotation added, even CPUs requested, should allocate one extra emulator CPU", map[string]string{}, uint32(2), "3"),
-				Entry("full-pcpu-only annotation added, odd CPUs requested, should allocate one extra emulator CPU", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: string(v1.CPUManagerPolicyBetaOptionFullpCPUsOnly)}, uint32(3), "4"),
-				Entry("full-pcpu-only annotation added, even CPUs requested, should allocate two extra emulator CPU (to align SMT scheduling)", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: string(v1.CPUManagerPolicyBetaOptionFullpCPUsOnly)}, uint32(4), "6"),
+				Entry("full-pcpu-only annotation added, odd CPUs requested, should allocate one extra emulator CPU", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, uint32(3), "4"),
+				Entry("full-pcpu-only annotation added, even CPUs requested, should allocate two extra emulator CPU (to align SMT scheduling)", map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""}, uint32(4), "6"),
 			)
 			It("should add node affinity to pod", func() {
 				config, kvInformer, svc = configFactory(defaultArch)

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2058,7 +2058,7 @@ var _ = Describe("Converter", func() {
 					Expect(CPUTuneCPUs).ToNot(ContainElements(housekeepingCPUs))
 				}
 			},
-			Entry("when full-pcpu-only is disabled and there is one extra CPU assigned for emulatorThread",
+			Entry("when EmulatorThreadCompleteToEvenParity is disabled and there is one extra CPU assigned for emulatorThread",
 				v1.CPU{Sockets: 1, Cores: 2, Threads: 1},
 				&ConverterContext{CPUSet: []int{5, 6, 7},
 					Topology: &cmdv1.Topology{
@@ -2072,7 +2072,7 @@ var _ = Describe("Converter", func() {
 				},
 				map[string]string{},
 				1),
-			Entry("when full-pcpu-only is enabled and there is one extra CPU assigned for emulatorThread (odd CPUs)",
+			Entry("when EmulatorThreadCompleteToEvenParity is enabled and there is one extra CPU assigned for emulatorThread (odd CPUs)",
 				v1.CPU{Sockets: 1, Cores: 5, Threads: 1},
 				&ConverterContext{CPUSet: []int{5, 6, 7, 8, 9, 10},
 					Topology: &cmdv1.Topology{
@@ -2084,9 +2084,9 @@ var _ = Describe("Converter", func() {
 						}},
 					},
 				},
-				map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""},
+				map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""},
 				1),
-			Entry("when full-pcpu-only is enabled and there are two extra CPUs assigned for emulatorThread (even CPUs)",
+			Entry("when EmulatorThreadCompleteToEvenParity is enabled and there are two extra CPUs assigned for emulatorThread (even CPUs)",
 				v1.CPU{Sockets: 1, Cores: 6, Threads: 1},
 				&ConverterContext{CPUSet: []int{5, 6, 7, 8, 9, 10, 11, 12},
 					Topology: &cmdv1.Topology{
@@ -2098,7 +2098,7 @@ var _ = Describe("Converter", func() {
 						}},
 					},
 				},
-				map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""},
+				map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""},
 				2),
 		)
 		DescribeTable("should fail assigning CPUs to emulatorThread",
@@ -2118,7 +2118,7 @@ var _ = Describe("Converter", func() {
 				_, err = vcpu.FormatEmulatorThreadPin(cpuPool, vmiAnnotations, vCPUs)
 				Expect(err).To(MatchError(ContainSubstring(expectedErrorString)))
 			},
-			Entry("when full-pcpu-only is disabled and there are not enough CPUs to allocate emulator threads",
+			Entry("when EmulatorThreadCompleteToEvenParity is disabled and there are not enough CPUs to allocate emulator threads",
 				v1.CPU{Sockets: 1, Cores: 2, Threads: 1},
 				&ConverterContext{CPUSet: []int{5, 6},
 					Topology: &cmdv1.Topology{
@@ -2131,7 +2131,7 @@ var _ = Describe("Converter", func() {
 				},
 				map[string]string{},
 				"no CPU allocated for the emulation thread"),
-			Entry("when full-pcpu-only is enabled and there are not enough Cores to allocate emulator threads (odd CPUs)",
+			Entry("when EmulatorThreadCompleteToEvenParity is enabled and there are not enough Cores to allocate emulator threads (odd CPUs)",
 				v1.CPU{Sockets: 1, Cores: 3, Threads: 1},
 				&ConverterContext{CPUSet: []int{5, 6, 7},
 					Topology: &cmdv1.Topology{
@@ -2143,9 +2143,9 @@ var _ = Describe("Converter", func() {
 						}},
 					},
 				},
-				map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""},
+				map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""},
 				"no CPU allocated for the emulation thread"),
-			Entry("when full-pcpu-only is enabled and there are not enough Cores to allocate emulator threads (even CPUs)",
+			Entry("when EmulatorThreadCompleteToEvenParity is enabled and there are not enough Cores to allocate emulator threads (even CPUs)",
 				v1.CPU{Sockets: 1, Cores: 2, Threads: 1},
 				&ConverterContext{CPUSet: []int{5, 6, 7},
 					Topology: &cmdv1.Topology{
@@ -2157,7 +2157,7 @@ var _ = Describe("Converter", func() {
 						}},
 					},
 				},
-				map[string]string{v1.CPUManagerPolicyBetaOptionsAnnotation: ""},
+				map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""},
 				"no second CPU allocated for the emulation thread"),
 		)
 	})

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -421,8 +421,8 @@ func FormatEmulatorThreadPin(cpuPool VCPUPool, vmiAnnotations map[string]string,
 	}
 	emulatorThreads = append(emulatorThreads, availableThread)
 
-	_, fullpCPUsOnly := vmiAnnotations[v12.CPUManagerPolicyBetaOptionsAnnotation]
-	if fullpCPUsOnly &&
+	_, emulatorThreadCompleteToEvenParityEnabled := vmiAnnotations[v12.EmulatorThreadCompleteToEvenParity]
+	if emulatorThreadCompleteToEvenParityEnabled &&
 		vCPUs%2 == 0 {
 		availableThread, err = cpuPool.FitThread()
 		if err != nil {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1033,8 +1033,8 @@ const (
 	// MigrationInterfaceName is an arbitrary name used in virt-handler to connect it to a dedicated migration network
 	MigrationInterfaceName string = "migration0"
 
-	// CPUManagerPolicyBetaOptionsAnnotation indicates the CPU-Manager policy that the pod adheres to.
-	CPUManagerPolicyBetaOptionsAnnotation string = "kubevirt.io/CPUManagerPolicyBetaOptions"
+	// EmulatorThreadCompleteToEvenParity alpha annotation will cause Kubevirt to complete the VMI's CPU count to an even parity when IsolateEmulatorThread options are requested
+	EmulatorThreadCompleteToEvenParity string = "alpha.kubevirt.io/EmulatorThreadCompleteToEvenParity"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2252,13 +2252,6 @@ type VirtualMachineMemoryDumpRequest struct {
 	Message string `json:"message,omitempty"`
 }
 
-type CPUManagerPolicyBetaOptions string
-
-const (
-	// full-pcpus-only static policy allows only full physical CPUs to be scheduled to a pod
-	CPUManagerPolicyBetaOptionFullpCPUsOnly CPUManagerPolicyBetaOptions = "full-pcpus-only"
-)
-
 type MemoryDumpPhase string
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns the current implementation with the proposal suggested in PR kubevirt/community#247.
This PR is a follow up PR to #10593, #10783 and #10839.

The `kubevirt.io/CPUManagerPolicyBetaOptions` annotation and feature-gate were introduced in PR #10593 in order to change the isolateEmulatorThread CPU assignment behavior, to support SMT enabled nodes when the CPU-Manager policy is `full-pcpu-only` [0]. 

This PR is:
- removing the logic introduced to the vmi-create validating webhook on #10593.
- changing the annotation name to `alpha.kubevirt.io/EmulatorThreadCompleteToEvenParity` and feature-gate name to `AlignCPUs`. The reason is that Kubevirt should not couple itself with a beta API if not necessary, because it could and could break if CPU-Mangager ever deprecates this API.
- moving the annotation to the Kubevirt CR, thus making it a global setting. The new behavior is that when `isolateEmulatorThread` is enabled, the annotation is set and the feature gate is enabled - then the annotation will be copied to the VMI.

[0] https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-options

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [BZ#2228103](https://bugzilla.redhat.com/show_bug.cgi?id=2228103)

**Special notes for your reviewer**:
~~This PR is built on top of #10839 please skip the first commit~~

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:

```release-note
IsolateEmulatorThread: Add cluster-wide parity completion setting
```
