### PR TITLE
fix(vmclone): delete snapshot and restore after pvc bound

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -744,6 +744,19 @@ func GetVirtualMachineCloneInformerIndexers() cache.Indexers {
 
 			return nil, nil
 		},
+		// Gets: restore key. Returns: clones in phase Succeeded
+		string(clonev1alpha1.Succeeded): func(obj interface{}) ([]string, error) {
+			vmClone, ok := obj.(*clonev1alpha1.VirtualMachineClone)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			if vmClone.Status.Phase == clonev1alpha1.Succeeded && vmClone.Status.RestoreName != nil {
+				return []string{getkey(vmClone, *vmClone.Status.RestoreName)}, nil
+			}
+
+			return nil, nil
+		},
 	}
 }
 

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	restoreNameAnnotation = "restore.kubevirt.io/name"
+	RestoreNameAnnotation = "restore.kubevirt.io/name"
 
 	populatedForPVCAnnotation = "cdi.kubevirt.io/storage.populatedFor"
 
@@ -755,7 +755,7 @@ func (t *vmRestoreTarget) createDataVolume(dvt kubevirtv1.DataVolumeTemplateSpec
 	if newDataVolume.Annotations == nil {
 		newDataVolume.Annotations = make(map[string]string)
 	}
-	newDataVolume.Annotations[restoreNameAnnotation] = t.vmRestore.Name
+	newDataVolume.Annotations[RestoreNameAnnotation] = t.vmRestore.Name
 
 	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(t.vm.Namespace).Create(context.Background(), newDataVolume, v1.CreateOptions{}); err != nil {
 		t.controller.Recorder.Eventf(t.vm, corev1.EventTypeWarning, restoreDataVolumeCreateErrorEvent, "Error creating restore DataVolume %s: %v", newDataVolume.Name, err)
@@ -1065,7 +1065,7 @@ func CreateRestorePVCDefFromVMRestore(vmRestoreName, restorePVCName string, volu
 	}
 	pvc.Labels[restoreSourceNameLabel] = sourceVmName
 	pvc.Labels[restoreSourceNamespaceLabel] = sourceVmNamespace
-	pvc.Annotations[restoreNameAnnotation] = vmRestoreName
+	pvc.Annotations[RestoreNameAnnotation] = vmRestoreName
 	return pvc
 }
 

--- a/pkg/storage/snapshot/restore_base.go
+++ b/pkg/storage/snapshot/restore_base.go
@@ -189,7 +189,7 @@ func (ctrl *VMRestoreController) handleDataVolume(obj interface{}) {
 	}
 
 	if dv, ok := obj.(*v1beta1.DataVolume); ok {
-		restoreName, ok := dv.Annotations[restoreNameAnnotation]
+		restoreName, ok := dv.Annotations[RestoreNameAnnotation]
 		if !ok {
 			return
 		}
@@ -207,7 +207,7 @@ func (ctrl *VMRestoreController) handlePVC(obj interface{}) {
 	}
 
 	if pvc, ok := obj.(*corev1.PersistentVolumeClaim); ok {
-		restoreName, ok := pvc.Annotations[restoreNameAnnotation]
+		restoreName, ok := pvc.Annotations[RestoreNameAnnotation]
 		if !ok {
 			return
 		}

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -851,7 +851,7 @@ func (vca *VirtControllerApp) initCloneController() {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "clone-controller")
 	vca.vmCloneController, err = clone.NewVmCloneController(
-		vca.clientSet, vca.vmCloneInformer, vca.vmSnapshotInformer, vca.vmRestoreInformer, vca.vmInformer, vca.vmSnapshotContentInformer, recorder,
+		vca.clientSet, vca.vmCloneInformer, vca.vmSnapshotInformer, vca.vmRestoreInformer, vca.vmInformer, vca.vmSnapshotContentInformer, vca.persistentVolumeClaimInformer, recorder,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -229,6 +229,7 @@ var _ = Describe("Application", func() {
 			vmRestoreInformer,
 			vmInformer,
 			vmSnapshotContentInformer,
+			pvcInformer,
 			recorder,
 		)
 

--- a/pkg/virt-controller/watch/clone/clone_base.go
+++ b/pkg/virt-controller/watch/clone/clone_base.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"time"
 
+	k8scorev1 "k8s.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/storage/snapshot"
+
 	"kubevirt.io/api/clone"
 	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 
@@ -32,6 +36,7 @@ const (
 	RestoreCreationFailed Event = "RestoreCreationFailed"
 	RestoreReady          Event = "RestoreReady"
 	TargetVMCreated       Event = "TargetVMCreated"
+	PVCBound              Event = "PVCBound"
 
 	SnapshotDeleted    Event = "SnapshotDeleted"
 	SourceDoesNotExist Event = "SourceDoesNotExist"
@@ -44,6 +49,7 @@ type VMCloneController struct {
 	restoreInformer         cache.SharedIndexInformer
 	vmInformer              cache.SharedIndexInformer
 	snapshotContentInformer cache.SharedIndexInformer
+	pvcInformer             cache.SharedIndexInformer
 	recorder                record.EventRecorder
 
 	vmCloneQueue       workqueue.RateLimitingInterface
@@ -51,7 +57,7 @@ type VMCloneController struct {
 	cloneStatusUpdater *status.CloneStatusUpdater
 }
 
-func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapshotInformer, restoreInformer, vmInformer, snapshotContentInformer cache.SharedIndexInformer, recorder record.EventRecorder) (*VMCloneController, error) {
+func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapshotInformer, restoreInformer, vmInformer, snapshotContentInformer, pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder) (*VMCloneController, error) {
 	ctrl := VMCloneController{
 		client:                  client,
 		vmCloneInformer:         vmCloneInformer,
@@ -59,6 +65,7 @@ func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapsh
 		restoreInformer:         restoreInformer,
 		vmInformer:              vmInformer,
 		snapshotContentInformer: snapshotContentInformer,
+		pvcInformer:             pvcInformer,
 		recorder:                recorder,
 		vmCloneQueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-vmclone"),
 		vmStatusUpdater:         status.NewVMStatusUpdater(client),
@@ -94,6 +101,18 @@ func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapsh
 			AddFunc:    ctrl.handleRestore,
 			UpdateFunc: func(oldObj, newObj interface{}) { ctrl.handleRestore(newObj) },
 			DeleteFunc: ctrl.handleRestore,
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = ctrl.pvcInformer.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    ctrl.handlePVC,
+			UpdateFunc: func(oldObj, newObj interface{}) { ctrl.handlePVC(newObj) },
+			DeleteFunc: ctrl.handlePVC,
 		},
 	)
 
@@ -190,6 +209,43 @@ func (ctrl *VMCloneController) handleRestore(obj interface{}) {
 	}
 
 	for _, key := range restoreWaitingKeys {
+		ctrl.vmCloneQueue.AddRateLimited(key)
+	}
+}
+
+func (ctrl *VMCloneController) handlePVC(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+
+	pvc, ok := obj.(*k8scorev1.PersistentVolumeClaim)
+	if !ok {
+		log.Log.Errorf(unknownTypeErrFmt, "persistentvolumeclaim")
+		return
+	}
+
+	var (
+		restoreName string
+		exists      bool
+	)
+
+	if restoreName, exists = pvc.Annotations[snapshot.RestoreNameAnnotation]; !exists {
+		return
+	}
+
+	if pvc.Status.Phase != k8scorev1.ClaimBound {
+		return
+	}
+
+	restoreKey := getKey(restoreName, pvc.Namespace)
+
+	succeededWaitingKeys, err := ctrl.vmCloneInformer.GetIndexer().IndexKeys(string(clonev1alpha1.Succeeded), restoreKey)
+	if err != nil {
+		log.Log.Object(pvc).Reason(err).Error("cannot get clone succeededWaitingKeys from " + string(clonev1alpha1.Succeeded) + " indexer")
+		return
+	}
+
+	for _, key := range succeededWaitingKeys {
 		ctrl.vmCloneQueue.AddRateLimited(key)
 	}
 }

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -68,6 +68,7 @@ var _ = Describe("Clone", func() {
 	var snapshotInformer cache.SharedIndexInformer
 	var restoreInformer cache.SharedIndexInformer
 	var snapshotContentInformer cache.SharedIndexInformer
+	var pvcInformer cache.SharedIndexInformer
 
 	var cloneInformer cache.SharedIndexInformer
 	var cloneSource *framework.FakeControllerSource
@@ -111,6 +112,11 @@ var _ = Describe("Clone", func() {
 
 	addRestore := func(restore *snapshotv1alpha1.VirtualMachineRestore) {
 		err := restoreInformer.GetStore().Add(restore)
+		Expect(err).ShouldNot(HaveOccurred())
+	}
+
+	addPVC := func(pvc *k8sv1.PersistentVolumeClaim) {
+		err := pvcInformer.GetStore().Add(pvc)
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -265,6 +271,7 @@ var _ = Describe("Clone", func() {
 		restoreInformer, _ = testutils.NewFakeInformerFor(&snapshotv1alpha1.VirtualMachineRestore{})
 		cloneInformer, cloneSource = testutils.NewFakeInformerFor(&clonev1alpha1.VirtualMachineClone{})
 		snapshotContentInformer, _ = testutils.NewFakeInformerFor(&snapshotv1alpha1.VirtualMachineSnapshotContent{})
+		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
@@ -276,6 +283,7 @@ var _ = Describe("Clone", func() {
 			restoreInformer,
 			vmInformer,
 			snapshotContentInformer,
+			pvcInformer,
 			recorder)
 		mockQueue = testutils.NewMockWorkQueue(controller.vmCloneQueue)
 		controller.vmCloneQueue = mockQueue
@@ -470,6 +478,60 @@ var _ = Describe("Clone", func() {
 
 				controller.Execute()
 				expectEvent(TargetVMCreated)
+			})
+
+			When("the clone process is finished and involves one or more PVCs", func() {
+				var (
+					pvc      *k8sv1.PersistentVolumeClaim
+					snapshot *snapshotv1alpha1.VirtualMachineSnapshot
+					restore  *snapshotv1alpha1.VirtualMachineRestore
+				)
+
+				BeforeEach(func() {
+					snapshot = createVirtualMachineSnapshot(sourceVM)
+					snapshot.Status.ReadyToUse = pointer.Bool(true)
+
+					pvc = createPVC(sourceVM.Namespace, k8sv1.ClaimPending)
+					restore = createVirtualMachineRestore(sourceVM, snapshot.Name)
+					restore.Status.Complete = pointer.Bool(true)
+					restore.Status.Restores = []snapshotv1alpha1.VolumeRestore{
+						{PersistentVolumeClaimName: pvc.Name},
+					}
+
+					vmClone.Status.SnapshotName = pointer.String(snapshot.Name)
+					vmClone.Status.RestoreName = pointer.String(restore.Name)
+					vmClone.Status.Phase = clonev1alpha1.CreatingTargetVM
+
+					targetVM := sourceVM.DeepCopy()
+					targetVM.Name = vmClone.Spec.Target.Name
+
+					addVM(sourceVM)
+					addVM(targetVM)
+					addClone(vmClone)
+					addSnapshot(snapshot)
+					addRestore(restore)
+					addPVC(pvc)
+
+					expectCloneUpdate(clonev1alpha1.Succeeded)
+					controller.Execute()
+					expectEvent(TargetVMCreated)
+				})
+
+				It("if not all the PVCs are bound, nothing should happen", func() {
+					addClone(vmClone)
+					controller.Execute()
+				})
+
+				It("if all the pvc are bound, snapshot and restore should be deleted", func() {
+					pvc = createPVC(sourceVM.Namespace, k8sv1.ClaimBound)
+					addPVC(pvc)
+					expectSnapshotDelete(snapshot.Name)
+					expectRestoreDelete(restore.Name)
+
+					addClone(vmClone)
+					controller.Execute()
+					testutils.ExpectEvents(recorder, string(TargetVMCreated), string(PVCBound))
+				})
 			})
 
 			It("when snapshot is deleted before restore is ready - should fail", func() {
@@ -959,6 +1021,19 @@ func createVirtualMachineRestore(vm *virtv1.VirtualMachine, snapshotName string)
 			VirtualMachineSnapshotName: snapshotName,
 		},
 		Status: &snapshotv1alpha1.VirtualMachineRestoreStatus{},
+	}
+}
+
+func createPVC(namespace string, phase k8sv1.PersistentVolumeClaimPhase) *k8sv1.PersistentVolumeClaim {
+	return &k8sv1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-pvc",
+			Namespace: namespace,
+			UID:       "pvc-UID",
+		},
+		Status: k8sv1.PersistentVolumeClaimStatus{
+			Phase: phase,
+		},
 	}
 }
 


### PR DESCRIPTION
The clone process involves `vmsnapshot` and `vmrestore`.
Currently, these are both deleted as soon as the restore is finished. If the source vm has a pvc the `vmrestore` process creates another pvc, pointing to the volumesnapshot previously created by the `vmsnapshot`.
With `Immediate` binding mode the pvc(s) created are immediately bound.
When `WaitForFirstConsumer` binding mode is used the pvc will stay in "Pending" state until a pod is created(the virt-launcher pod).
In the latter case, when the cloned vm is started, it is stuck in "WaitingForVolumeBinding" becuse the related PVC binding is failing, due to the snapshot source has being deleted. In other words, we cannot delete the snapshot resources until all the pvc are Bound.

This patch aim to delay the snapshot and the restore deletion until we are sure that all the pvc are bound.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/10832
jira-ticket: https://issues.redhat.com/browse/CNV-32667
**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bugfix] Clone VM with WaitForFirstConsumer binding mode PVC now works.
```
