### PR TITLE
seccomp: Use 'Names' field to define the syscall

### DIFF
--- a/pkg/virt-handler/seccomp/seccomp.go
+++ b/pkg/virt-handler/seccomp/seccomp.go
@@ -70,7 +70,7 @@ func defaultProfile() *seccomp.Seccomp {
 	}
 
 	profile.Syscalls = append(profile.Syscalls, &seccomp.Syscall{
-		Name:   "userfaultfd",
+		Names:  []string{"userfaultfd"},
 		Action: seccomp.ActAllow,
 		Args:   []*seccomp.Arg{},
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Apparently, `Name` has been deprecated in favour of `Names`. Some container runtimes do not handle `Name` and thus fail to correctly set the profile for seccomp.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Refs:
- https://github.com/moby/moby/blob/bd70d66a6289305c9ea4b040dc0281296bd40567/profiles/seccomp/seccomp.go#L54-L66
- https://github.com/opencontainers/runtime-spec/blob/68346ed538d50d73869d48edb009fb0c2d1dd66e/specs-go/config.go#L794-L800

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
