### PR TITLE
Fix networking doc

### DIFF
--- a/docs/devel/networking.md
+++ b/docs/devel/networking.md
@@ -133,7 +133,7 @@ Let's refer to the image below to get a better understanding of how this
 
 Bridge binding mechanism diagram
 
-![alt text](https://github.com/kubevirt/kubevirt.github.io/blob/source/assets/images/diagram.png)
+![alt text](https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/main/assets/images/diagram.png)
 
 As can be seen in the diagram above, there are three actors at play: CNI,
 libvirt, and DHCP. For completeness sake, let's add one more actor that is
@@ -309,9 +309,7 @@ chain postrouting {
 
 In the `KUBEVIRT_POSTINBOUND` chain, in case the source address is localhost, SNAT is
 performed: the source IP address of the outbound packet is modified to the IP address of
-the gateway -
--
-`10.11.12.1`.
+the gateway - `10.11.12.1`.
 
 ```
 chain KUBEVIRT_POSTINBOUND {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR improve two things in [networking](https://github.com/kubevirt/kubevirt/blob/main/docs/devel/networking.md).

1)change url for "Bridge binding mechanism diagram" 
2)Fix formatting errors in text

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
 