### PR TITLE
Add a notice to virtctl console about logs

### DIFF
--- a/pkg/virtctl/console/BUILD.bazel
+++ b/pkg/virtctl/console/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/gorilla/websocket:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )

--- a/tests/virtctl/BUILD.bazel
+++ b/tests/virtctl/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "console.go",
         "create_instancetype.go",
         "create_preference.go",
         "create_vm.go",
@@ -13,6 +14,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/virtctl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//pkg/virtctl/create/instancetype:go_default_library",
         "//pkg/virtctl/create/preference:go_default_library",
         "//pkg/virtctl/create/vm:go_default_library",

--- a/tests/virtctl/console.go
+++ b/tests/virtctl/console.go
@@ -1,0 +1,61 @@
+package virtctl
+
+import (
+	"bytes"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/decorators"
+
+	"kubevirt.io/kubevirt/tests/clientcmd"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+const alpineStartupTimeout = 60
+const logWarning = "Caution: the output of this console connection can be streamed into system logs.\nIf you are inputting any screen visible sensitive information please consider using SSH unless the serial console is absolutely necessary.\n"
+const staticMessage = "console. The escape sequence is ^]\n"
+
+var _ = Describe("[sig-compute][virtctl]console", decorators.SigCompute, func() {
+	Context("virtctl caution message", func() {
+		DescribeTable("check the presence of a caution message according to LogSerialConsole configuration", func(logSerialConsole *bool, expected bool) {
+			By("Starting a VMI")
+			alpineVmi := libvmi.NewAlpine()
+			alpineVmi.Spec.Domain.Devices.AutoattachSerialConsole = pointer.P(true)
+			alpineVmi.Spec.Domain.Devices.LogSerialConsole = logSerialConsole
+			vmi := tests.RunVMIAndExpectLaunch(alpineVmi, alpineStartupTimeout)
+
+			_, cmd, err := clientcmd.CreateCommandWithNS(util.NamespaceTestDefault, "virtctl", "console", vmi.Name)
+			Expect(err).ToNot(HaveOccurred())
+			outerr := &bytes.Buffer{}
+			cmd.Stdout = outerr
+			cmd.Stderr = outerr
+			err = cmd.Start()
+			Expect(err).ToNot(HaveOccurred())
+			defer func(Process *os.Process) {
+				err := Process.Kill()
+				Expect(err).ToNot(HaveOccurred())
+			}(cmd.Process)
+
+			By("Checking for the caution message")
+			Eventually(func(g Gomega) {
+				output := string(outerr.Bytes())
+				g.Expect(output).To(ContainSubstring(staticMessage))
+				if expected {
+					g.Expect(output).To(ContainSubstring(logWarning))
+				} else {
+					g.Expect(output).ToNot(ContainSubstring(logWarning))
+				}
+			}, 5*time.Second, time.Second).Should(Succeed())
+		},
+			Entry("with true LogSerialConsole", pointer.P(true), true),
+			Entry("with false LogSerialConsole", pointer.P(false), false),
+			Entry("without LogSerialConsole", nil, true),
+		)
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Guest serial console output can now be streamed
to cluster logs. This could be eventually enabled
at cluster level being not so visible to VM owners. Those logs include the boot logs but also the output of an interactive usage of the first serial console. No access passwords for the console nor
properly handled passwords (not echoed to the screen) are going to be collected n the logs.
However, if the VM user types a password by mistake instead of a command name or if the password is visible on the screen as a clear text parameter or in the
output of any command, it could be streamed
to cluster logs along with all other screen visible text.

Let's have `virtctl console` emitting a notice
(if LogSerialConsole is not explicitly disabled) for the user suggesting to use SSH when handling sensitive informations.

Adding a test covering `virtctl console` output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-34999

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a notice to virtctl console about logs
```
