### PR TITLE
VMClone: Emit an event in case restore creation fails

### DIFF
--- a/pkg/virt-controller/watch/clone/clone.go
+++ b/pkg/virt-controller/watch/clone/clone.go
@@ -423,11 +423,12 @@ func (ctrl *VMCloneController) createRestoreFromVm(vmClone *clonev1alpha1.Virtua
 	createdRestore, err := ctrl.client.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, v1.CreateOptions{})
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
-			return addErrorToSyncInfo(syncInfo, fmt.Errorf("failed creating restore %s for clone %s: %v", restore.Name, vmClone.Name, err))
+			retErr := fmt.Errorf("failed creating restore %s for clone %s: %v", restore.Name, vmClone.Name, err)
+			ctrl.recorder.Event(vmClone, corev1.EventTypeWarning, string(RestoreCreationFailed), retErr.Error())
+			return addErrorToSyncInfo(syncInfo, retErr)
 		}
 		syncInfo.restoreName = restore.Name
 		return syncInfo
-
 	}
 	restore = createdRestore
 	ctrl.logAndRecord(vmClone, RestoreCreated, fmt.Sprintf("created restore %s for clone %s", restore.Name, vmClone.Name))

--- a/pkg/virt-controller/watch/clone/clone_base.go
+++ b/pkg/virt-controller/watch/clone/clone_base.go
@@ -26,11 +26,12 @@ const (
 	defaultVerbosityLevel = 2
 	unknownTypeErrFmt     = "clone controller expected object of type %s but found object of unknown type"
 
-	SnapshotCreated Event = "SnapshotCreated"
-	SnapshotReady   Event = "SnapshotReady"
-	RestoreCreated  Event = "RestoreCreated"
-	RestoreReady    Event = "RestoreReady"
-	TargetVMCreated Event = "TargetVMCreated"
+	SnapshotCreated       Event = "SnapshotCreated"
+	SnapshotReady         Event = "SnapshotReady"
+	RestoreCreated        Event = "RestoreCreated"
+	RestoreCreationFailed Event = "RestoreCreationFailed"
+	RestoreReady          Event = "RestoreReady"
+	TargetVMCreated       Event = "TargetVMCreated"
 
 	SnapshotDeleted    Event = "SnapshotDeleted"
 	SourceDoesNotExist Event = "SourceDoesNotExist"

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -173,6 +173,20 @@ var _ = Describe("Clone", func() {
 		})
 	}
 
+	expectRestoreCreationFailure := func(snapshotName string, vmClone *clonev1alpha1.VirtualMachineClone, restoreName string) {
+		client.Fake.PrependReactor("create", restoreResource, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+
+			restorecreated := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+			Expect(restorecreated.Spec.VirtualMachineSnapshotName).To(Equal(snapshotName))
+			Expect(restorecreated.OwnerReferences).To(HaveLen(1))
+			validateOwnerReference(restorecreated.OwnerReferences[0], vmClone)
+
+			return true, nil, fmt.Errorf("when shapsnot source and restore target VMs are different - target VM must not exist")
+		})
+	}
+
 	expectSnapshotDelete := func(snapshotName string) {
 		client.Fake.PrependReactor("delete", snapshotResource, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
 			create, ok := action.(testing.DeleteAction)
@@ -514,6 +528,29 @@ var _ = Describe("Clone", func() {
 						expectCloneUpdate(clonev1alpha1.RestoreInProgress)
 
 						controller.Execute()
+					})
+				})
+				When("target VM already exists", func() {
+					It("should fire an event", func() {
+						snapshot := createVirtualMachineSnapshot(sourceVM)
+						snapshot.Status.ReadyToUse = pointer.Bool(true)
+
+						restore := createVirtualMachineRestore(sourceVM, snapshot.Name)
+
+						vmClone.Status.SnapshotName = pointer.String(snapshot.Name)
+
+						vmClone.Status.Phase = clonev1alpha1.SnapshotInProgress
+
+						addVM(sourceVM)
+						addClone(vmClone)
+						addSnapshot(snapshot)
+						addRestore(restore)
+						expectRestoreCreationFailure(snapshot.Name, vmClone, restore.Name)
+						expectCloneUpdate(clonev1alpha1.RestoreInProgress)
+
+						controller.Execute()
+						expectEvent(SnapshotReady)
+						expectEvent(RestoreCreationFailed)
 					})
 				})
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When a user creates a VMClone and the target VM already exists,
the clone controller tries to create the `VirtualMachineRestore`, but is rejected by the restore validating webhook due to the fact that the target VM already exist.

The user who created the clone has no indication of what is going wrong.

There is information available about the problem in the logs of the clone controller, but we assume that it is not accessible to the user creating the VMClone.

Emit an event in case there was a failure to create the `VirtualMachineRestore` so it will be reflected on the VMClone object:

```bash
kubectl describe vmclone <name>
```

or

```bash
kubectl get events
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Based on PR #10903 please skip the first commit.~~

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMClone: Emit an event in case restore creation fails
```
