### PR TITLE
Fix e2e tests when using CRIO 1.28

### DIFF
--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -405,6 +405,18 @@ func (m *mounter) ContainerDisksReady(vmi *v1.VirtualMachineInstance, notInitial
 			}
 		}
 	}
+
+	if util.HasKernelBootContainerImage(vmi) {
+		_, err := m.kernelBootSocketPathGetter(vmi)
+		if err != nil {
+			log.DefaultLogger().Object(vmi).Reason(err).Info("kernelboot container not yet ready")
+			if time.Now().After(notInitializedSince.Add(m.suppressWarningTimeout)) {
+				return false, fmt.Errorf("kernelboot container still not ready after one minute")
+			}
+			return false, nil
+		}
+	}
+
 	log.DefaultLogger().Object(vmi).V(4).Info("all containerdisks are ready")
 	return true, nil
 }

--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -81,38 +81,43 @@ var _ = Describe("ContainerDisk", func() {
 	})
 
 	Context("checking if containerDisks are ready", func() {
-		It("should return false and no error if we are still within the tolerated retry period", func() {
-			m.socketPathGetter = func(vmi *v1.VirtualMachineInstance, volumeIndex int) (string, error) {
-				return "", fmt.Errorf("not found")
-			}
-			ready, err := m.ContainerDisksReady(vmi, time.Now())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ready).To(BeFalse())
-		})
-		It("should return false and an error if we are outside the tolerated retry period", func() {
-			m.socketPathGetter = func(vmi *v1.VirtualMachineInstance, volumeIndex int) (string, error) {
-				return "", fmt.Errorf("not found")
-			}
-			ready, err := m.ContainerDisksReady(vmi, time.Now().Add(-2*time.Minute))
-			Expect(err).To(HaveOccurred())
-			Expect(ready).To(BeFalse())
-		})
-		It("should return true and no error once everything is ready and we are within the tolerated retry period", func() {
-			m.socketPathGetter = func(vmi *v1.VirtualMachineInstance, volumeIndex int) (string, error) {
-				return "someting", nil
-			}
-			ready, err := m.ContainerDisksReady(vmi, time.Now())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ready).To(BeTrue())
-		})
-		It("should return true and no error once everything is ready when we are outside of the tolerated retry period", func() {
-			m.socketPathGetter = func(vmi *v1.VirtualMachineInstance, volumeIndex int) (string, error) {
-				return "someting", nil
-			}
-			ready, err := m.ContainerDisksReady(vmi, time.Now().Add(-2*time.Minute))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ready).To(BeTrue())
-		})
+
+		DescribeTable("should", func(
+			pathGetter containerdisk.SocketPathGetter,
+			addedDelay time.Duration,
+			errorMatcher gomega_types.GomegaMatcher,
+			shouldBeReady bool,
+		) {
+			m.socketPathGetter = pathGetter
+			ready, err := m.ContainerDisksReady(vmi, time.Now().Add(addedDelay))
+			Expect(err).To(errorMatcher)
+			Expect(ready).To(Equal(shouldBeReady))
+		},
+			Entry("return false and no error if we are still within the tolerated retry period",
+				func(*v1.VirtualMachineInstance, int) (string, error) { return "", fmt.Errorf("not found") },
+				time.Duration(0),
+				Succeed(),
+				false,
+			),
+			Entry("return false and an error if we are outside the tolerated retry period",
+				func(*v1.VirtualMachineInstance, int) (string, error) { return "", fmt.Errorf("not found") },
+				time.Duration(-2*time.Minute),
+				HaveOccurred(),
+				false,
+			),
+			Entry("return true and no error once everything is ready and we are within the tolerated retry period",
+				func(*v1.VirtualMachineInstance, int) (string, error) { return "someting", nil },
+				time.Duration(0),
+				Succeed(),
+				true,
+			),
+			Entry("return true and no error once everything is ready when we are outside of the tolerated retry period",
+				func(*v1.VirtualMachineInstance, int) (string, error) { return "someting", nil },
+				time.Duration(-2*time.Minute),
+				Succeed(),
+				true,
+			),
+		)
 
 		Context("with kernelBoot container", func() {
 

--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -113,6 +113,59 @@ var _ = Describe("ContainerDisk", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ready).To(BeTrue())
 		})
+
+		Context("with kernelBoot container", func() {
+
+			BeforeEach(func() {
+				vmi.Spec.Volumes = []v1.Volume{}
+
+				vmi.Spec.Domain.Firmware = &v1.Firmware{
+					KernelBoot: &v1.KernelBoot{
+						Container: &v1.KernelBootContainer{
+							KernelPath: "/fake-kernel",
+							InitrdPath: "/fake-initrd",
+						},
+					},
+				}
+			})
+
+			DescribeTable("should", func(
+				pathGetter containerdisk.KernelBootSocketPathGetter,
+				addedDelay time.Duration,
+				errorMatcher gomega_types.GomegaMatcher,
+				shouldBeReady bool,
+			) {
+				m.kernelBootSocketPathGetter = pathGetter
+				ready, err := m.ContainerDisksReady(vmi, time.Now().Add(addedDelay))
+				Expect(err).To(errorMatcher)
+				Expect(ready).To(Equal(shouldBeReady))
+			},
+				Entry("return false and no error if we are still within the tolerated retry period",
+					func(*v1.VirtualMachineInstance) (string, error) { return "", fmt.Errorf("not found") },
+					time.Duration(0),
+					Succeed(),
+					false,
+				),
+				Entry("return false and an error if we are outside the tolerated retry period",
+					func(*v1.VirtualMachineInstance) (string, error) { return "", fmt.Errorf("not found") },
+					time.Duration(-2*time.Minute),
+					HaveOccurred(),
+					false,
+				),
+				Entry("return true and no error once everything is ready and we are within the tolerated retry period",
+					func(*v1.VirtualMachineInstance) (string, error) { return "someting", nil },
+					time.Duration(0),
+					Succeed(),
+					true,
+				),
+				Entry("return true and no error once everything is ready when we are outside of the tolerated retry period",
+					func(*v1.VirtualMachineInstance) (string, error) { return "someting", nil },
+					time.Duration(-2*time.Minute),
+					Succeed(),
+					true,
+				),
+			)
+		})
 	})
 
 	Context("verify mount target recording for vmi", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
1. Fixes this flake https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/10884/pull-kubevirt-e2e-k8s-1.28-sig-compute/1737261845598703616 by making sure kernelboot containers are ready before trying to mount kernel artifacts into virt-launcher.
2. Removes a useless e2e test which will always fail when run with CRIO 1.28.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
