### PR TITLE
Provide way to customize generated Multus pod annotation

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -931,6 +931,9 @@ func (app *virtAPIApp) registerMutatingWebhook(informers *webhooks.Informers) {
 	http.HandleFunc(components.VMIMutatePath, func(w http.ResponseWriter, r *http.Request) {
 		mutating_webhook.ServeVMIs(w, r, app.clusterConfig, informers)
 	})
+	http.HandleFunc(components.VirtLauncherPodMutatePath, func(w http.ResponseWriter, r *http.Request) {
+		mutating_webhook.ServeVirtLauncherPods(w, r, app.clusterConfig, informers)
+	})
 	http.HandleFunc(components.MigrationMutatePath, func(w http.ResponseWriter, r *http.Request) {
 		mutating_webhook.ServeMigrationCreate(w, r)
 	})
@@ -1069,6 +1072,7 @@ func (app *virtAPIApp) Run() {
 	vmiPresetInformer := kubeInformerFactory.VirtualMachinePreset()
 	vmRestoreInformer := kubeInformerFactory.VirtualMachineRestore()
 	namespaceInformer := kubeInformerFactory.Namespace()
+	virtLauncherPodInformer := kubeInformerFactory.VirtLauncherPod()
 
 	stopChan := make(chan struct{}, 1)
 	defer close(stopChan)
@@ -1103,10 +1107,11 @@ func (app *virtAPIApp) Run() {
 	kubeInformerFactory.WaitForCacheSync(stopChan)
 
 	webhookInformers := &webhooks.Informers{
-		VMIPresetInformer:  vmiPresetInformer,
-		VMRestoreInformer:  vmRestoreInformer,
-		DataSourceInformer: dataSourceInformer,
-		NamespaceInformer:  namespaceInformer,
+		VirtLauncherPodInformer: virtLauncherPodInformer,
+		VMIPresetInformer:       vmiPresetInformer,
+		VMRestoreInformer:       vmRestoreInformer,
+		DataSourceInformer:      dataSourceInformer,
+		NamespaceInformer:       namespaceInformer,
 	}
 
 	// Build webhook subresources

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -84,6 +84,10 @@ func ServeVMIs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtc
 	serve(resp, req, &mutators.VMIsMutator{ClusterConfig: clusterConfig, VMIPresetInformer: informers.VMIPresetInformer})
 }
 
+func ServeVirtLauncherPods(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, informers *webhooks.Informers) {
+	serve(resp, req, &mutators.VirtLauncherPodsMutator{ClusterConfig: clusterConfig, VirtLauncherPodInformer: informers.VirtLauncherPodInformer})
+}
+
 func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request) {
 	serve(resp, req, &mutators.MigrationCreateMutator{})
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/virt-launcher-pod-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/virt-launcher-pod-mutator.go
@@ -1,0 +1,190 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package mutators
+
+import (
+	"encoding/json"
+	"fmt"
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"net"
+	"slices"
+)
+
+const MultusCustomizationAnnotation = "k8s.v1.cni.cncf.io/networks-customization"
+
+type VirtLauncherPodsMutator struct {
+	ClusterConfig           *virtconfig.ClusterConfig
+	VirtLauncherPodInformer cache.SharedIndexInformer
+}
+
+func (mutator *VirtLauncherPodsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	if !webhookutils.ValidateRequestResource(ar.Request.Resource, "", "pods") {
+		err := fmt.Errorf("expect resource to be '%s'", "pods")
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	raw := ar.Request.Object.Raw
+	pod := corev1.Pod{}
+
+	err := json.Unmarshal(raw, &pod)
+	if err != nil {
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	if value, exists := pod.Labels[kubevirtv1.AppLabel]; !exists || value != "virt-launcher" {
+		err := fmt.Errorf("admission failed, pod '%s' is not a virt-launcher instance", pod.Name)
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	rawKubevirtMultusAnnotation := pod.Annotations[networkv1.NetworkAttachmentAnnot]
+	if rawKubevirtMultusAnnotation == "" {
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+	kubevirtMultusAnnotation, err := deserializeMultusAnnotation(rawKubevirtMultusAnnotation)
+	if err != nil {
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	rawUserMultusAnnotation := pod.Annotations[MultusCustomizationAnnotation]
+	if rawUserMultusAnnotation == "" {
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+	userMultusAnnotation, err := deserializeMultusAnnotation(rawUserMultusAnnotation)
+	if err != nil {
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	newMultusAnnotation, err := enrichMultusAnnotation(kubevirtMultusAnnotation, userMultusAnnotation)
+	if err != nil {
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	serializedMultusAnnotation, err := json.Marshal(newMultusAnnotation)
+	if err != nil {
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	patchType := admissionv1.PatchTypeJSONPatch
+	patchBytes, err := patch.GeneratePatchPayload(
+		patch.PatchOperation{
+			Op:    patch.PatchReplaceOp,
+			Path:  "/metadata/annotations/k8s.v1.cni.cncf.io~1networks",
+			Value: string(serializedMultusAnnotation),
+		},
+	)
+	if err != nil {
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	return &admissionv1.AdmissionResponse{
+		Allowed:   true,
+		Patch:     patchBytes,
+		PatchType: &patchType,
+	}
+}
+
+func enrichMultusAnnotation(kubevirtNetworks, userNetworks []networkv1.NetworkSelectionElement) ([]networkv1.NetworkSelectionElement, error) {
+	networks := make([]networkv1.NetworkSelectionElement, 0)
+
+	for _, kubevirtNetwork := range kubevirtNetworks {
+		kubevirtNetworkKey := networkKey(kubevirtNetwork)
+		userIndex := slices.IndexFunc(userNetworks, func(userNetwork networkv1.NetworkSelectionElement) bool {
+			return kubevirtNetworkKey == networkKey(userNetwork)
+		})
+
+		if userIndex == -1 {
+			networks = append(networks, kubevirtNetwork)
+			continue
+		}
+
+		userNetwork := userNetworks[userIndex]
+		mergedNetwork, err := mergeNetworks(kubevirtNetwork, userNetwork)
+		if err != nil {
+			return nil, err
+		}
+		networks = append(networks, *mergedNetwork)
+	}
+
+	return networks, nil
+}
+
+func mergeNetworks(kubevirtNetwork, userNetwork networkv1.NetworkSelectionElement) (*networkv1.NetworkSelectionElement, error) {
+	if userNetwork.InterfaceRequest != "" {
+		return nil, fmt.Errorf("interface name can't be modified for '%s' - value is managed by virt-controller", kubevirtNetwork.Name)
+	}
+	if userNetwork.MacRequest != "" {
+		return nil, fmt.Errorf("mac address should be set for '%s' through the interface definition in the VMI spec", kubevirtNetwork.Name)
+	}
+	if len(userNetwork.IPRequest) > 0 {
+		if kubevirtNetwork.IPRequest == nil {
+			kubevirtNetwork.IPRequest = []string{}
+		}
+		kubevirtNetwork.IPRequest = append(kubevirtNetwork.IPRequest, userNetwork.IPRequest...)
+	}
+	if len(userNetwork.GatewayRequest) > 0 {
+		if kubevirtNetwork.GatewayRequest == nil {
+			kubevirtNetwork.GatewayRequest = []net.IP{}
+		}
+		kubevirtNetwork.GatewayRequest = append(kubevirtNetwork.GatewayRequest, userNetwork.GatewayRequest...)
+	}
+	if len(userNetwork.PortMappingsRequest) > 0 {
+		if kubevirtNetwork.PortMappingsRequest == nil {
+			kubevirtNetwork.PortMappingsRequest = []*networkv1.PortMapEntry{}
+		}
+		kubevirtNetwork.PortMappingsRequest = append(kubevirtNetwork.PortMappingsRequest, userNetwork.PortMappingsRequest...)
+	}
+	if userNetwork.BandwidthRequest != nil {
+		kubevirtNetwork.BandwidthRequest = userNetwork.BandwidthRequest
+	}
+	if userNetwork.InfinibandGUIDRequest != "" {
+		kubevirtNetwork.InfinibandGUIDRequest = userNetwork.InfinibandGUIDRequest
+	}
+	if userNetwork.CNIArgs != nil && len(*userNetwork.CNIArgs) > 0 {
+		kubevirtNetwork.CNIArgs = userNetwork.CNIArgs
+	}
+
+	return &kubevirtNetwork, nil
+}
+
+func networkKey(element networkv1.NetworkSelectionElement) string {
+	if element.Namespace != "" {
+		return element.Namespace + "/" + element.Name
+	}
+	return element.Name
+}
+
+func deserializeMultusAnnotation(payload string) ([]networkv1.NetworkSelectionElement, error) {
+	var multusAnnotation []networkv1.NetworkSelectionElement
+	if err := json.Unmarshal([]byte(payload), &multusAnnotation); err != nil {
+		return nil, fmt.Errorf("failed to deserialize multus annotation: %v", err)
+	}
+
+	return multusAnnotation, nil
+}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/virt-launcher-pod-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/virt-launcher-pod-mutator_test.go
@@ -1,0 +1,215 @@
+// ginkgo --focus "Virt Launcher Pod Mutator"
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ */
+
+package mutators
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/testutils"
+	"net"
+)
+
+const (
+	networkName          = "name"
+	networkNamespace     = "namespace"
+	networkInterfaceName = "eth0"
+	networkMacAddress    = "00:00:00:00:00:01"
+	networkIp            = "192.168.0.1"
+)
+
+var _ = Describe("Virt Launcher Pod Mutator", func() {
+
+	DescribeTable("should build valid network key", func(network networkv1.NetworkSelectionElement, expected string) {
+		result := networkKey(network)
+		Expect(result).To(Equal(expected))
+	},
+		Entry("with network only", networkv1.NetworkSelectionElement{
+			Name: networkName,
+		}, networkName),
+		Entry("with network and namespace", networkv1.NetworkSelectionElement{
+			Name:      networkName,
+			Namespace: networkNamespace,
+		}, networkNamespace+"/"+networkName),
+	)
+
+	It("should deserialize Multus networks", func() {
+		payload := `[
+			{
+				"name":"name1",
+				"namespace":"namespace1",
+				"ips":["10.10.0.110/24"],
+				"mac":"00:00:00:00:00:01",
+				"interface":"pod890360ec7a1"
+			},
+			{
+				"name":"name2",
+				"namespace":"namespace2",
+				"ips":["10.100.2.101/24"],
+				"mac":"00:00:00:00:00:02",
+				"interface":"pod0b696b333de"
+			}
+		]`
+		_, err := deserializeMultusAnnotation(payload)
+		Expect(err).To(BeNil())
+	})
+
+	It("should merge networks", func() {
+		infinibandGuid := uuid.New().String()
+		portMappings := []*networkv1.PortMapEntry{{HostPort: 56000, ContainerPort: 8080, Protocol: "TCP", HostIP: "192.168.0.1"}}
+		bandwithEntries := networkv1.BandwidthEntry{IngressRate: 1, IngressBurst: 10, EgressRate: 1, EgressBurst: 10}
+		CNIArgs := map[string]interface{}{"key": "value"}
+		gateways := []net.IP{net.ParseIP("192.168.0.1"), net.ParseIP("192.168.0.2")}
+
+		network1 := networkv1.NetworkSelectionElement{
+			Name:             networkName,
+			Namespace:        networkNamespace,
+			InterfaceRequest: networkInterfaceName,
+			MacRequest:       networkMacAddress,
+		}
+		network2 := networkv1.NetworkSelectionElement{
+			Name:                  networkName,
+			Namespace:             networkNamespace,
+			IPRequest:             []string{networkIp},
+			InfinibandGUIDRequest: infinibandGuid,
+			PortMappingsRequest:   portMappings,
+			BandwidthRequest:      &bandwithEntries,
+			CNIArgs:               &CNIArgs,
+			GatewayRequest:        gateways,
+		}
+
+		result, err := mergeNetworks(network1, network2)
+
+		Expect(err).To(BeNil())
+		Expect(result.InterfaceRequest).To(Equal(networkInterfaceName))
+		Expect(result.IPRequest).To(Equal([]string{networkIp}))
+		Expect(result.MacRequest).To(Equal(networkMacAddress))
+		Expect(result.InfinibandGUIDRequest).To(Equal(infinibandGuid))
+		Expect(result.PortMappingsRequest).To(Equal(portMappings))
+		Expect(result.BandwidthRequest).To(Equal(&bandwithEntries))
+		Expect(result.CNIArgs).To(Equal(&CNIArgs))
+		Expect(result.GatewayRequest).To(Equal(gateways))
+	})
+
+	It("should fail on networks merge with interface name not customizable", func() {
+		network1 := networkv1.NetworkSelectionElement{
+			Name:             networkName,
+			Namespace:        networkNamespace,
+			InterfaceRequest: networkInterfaceName,
+			MacRequest:       networkMacAddress,
+		}
+		network2 := networkv1.NetworkSelectionElement{
+			Name:             networkName,
+			Namespace:        networkNamespace,
+			InterfaceRequest: networkInterfaceName,
+		}
+		_, err := mergeNetworks(network1, network2)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal(fmt.Sprintf("interface name can't be modified for '%s' - value is managed by virt-controller", networkName)))
+	})
+
+	It("should fail on networks merge with mac address not customizable", func() {
+		network1 := networkv1.NetworkSelectionElement{
+			Name:             networkName,
+			Namespace:        networkNamespace,
+			InterfaceRequest: networkInterfaceName,
+			MacRequest:       networkMacAddress,
+		}
+		network2 := networkv1.NetworkSelectionElement{
+			Name:       networkName,
+			Namespace:  networkNamespace,
+			MacRequest: networkMacAddress,
+		}
+		_, err := mergeNetworks(network1, network2)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal(fmt.Sprintf("mac address should be set for '%s' through the interface definition in the VMI spec", networkName)))
+	})
+
+	It("should match networks by key and merge network elements", func() {
+		extraNetwork := "extraNetwork"
+		networkIps := []string{networkIp}
+		networks1 := []networkv1.NetworkSelectionElement{
+			{Name: extraNetwork},
+			{Name: networkName, Namespace: networkNamespace},
+		}
+		networks2 := []networkv1.NetworkSelectionElement{
+			{Name: networkName, Namespace: networkNamespace, IPRequest: []string{networkIp}},
+		}
+
+		result, err := enrichMultusAnnotation(networks1, networks2)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(2))
+		Expect(result[0].Name).To(Equal(extraNetwork))
+		Expect(result[0].IPRequest).To(BeNil())
+		Expect(result[1].Name).To(Equal(networkName))
+		Expect(result[1].IPRequest).To(Equal(networkIps))
+	})
+
+	It("should mutate Multus pod annotation", func() {
+		mutator := &VirtLauncherPodsMutator{}
+		var kvInformer cache.SharedIndexInformer
+		mutator.ClusterConfig, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+		mutator.VirtLauncherPodInformer = kvInformer
+
+		pod := corev1.Pod{}
+		pod.Labels = map[string]string{
+			v1.AppLabel: "virt-launcher",
+		}
+		pod.Annotations = map[string]string{
+			networkv1.NetworkAttachmentAnnot: `[{
+				"name": "name",
+				"namespace": "namespace",
+				"mac": "00:00:00:00:00:01",
+				"interface":"pod890360ec7a1"
+			}]`,
+			MultusCustomizationAnnotation: `[{
+				"name": "name",
+				"namespace": "namespace",
+				"ips": ["10.10.0.110/24"]
+			}]`,
+		}
+
+		podBytes, _ := json.Marshal(pod)
+		admissionReview := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Resource: k8smetav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+				Object: runtime.RawExtension{
+					Raw: podBytes,
+				},
+			},
+		}
+
+		admissionResponse := mutator.Mutate(admissionReview)
+
+		Expect(admissionResponse).ToNot(BeNil())
+		Expect(admissionResponse.Allowed).To(BeTrue())
+		expected := []uint8(`[{"op":"replace","path":"/metadata/annotations/k8s.v1.cni.cncf.io~1networks","value":"[{\"name\":\"name\",\"namespace\":\"namespace\",\"ips\":[\"10.10.0.110/24\"],\"mac\":\"00:00:00:00:00:01\",\"interface\":\"pod890360ec7a1\"}]"}]`)
+		Expect(admissionResponse.Patch).To(Equal(expected))
+	})
+})

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -74,10 +74,11 @@ var MigrationGroupVersionResource = metav1.GroupVersionResource{
 }
 
 type Informers struct {
-	VMIPresetInformer  cache.SharedIndexInformer
-	VMRestoreInformer  cache.SharedIndexInformer
-	DataSourceInformer cache.SharedIndexInformer
-	NamespaceInformer  cache.SharedIndexInformer
+	VirtLauncherPodInformer cache.SharedIndexInformer
+	VMIPresetInformer       cache.SharedIndexInformer
+	VMRestoreInformer       cache.SharedIndexInformer
+	DataSourceInformer      cache.SharedIndexInformer
+	NamespaceInformer       cache.SharedIndexInformer
 }
 
 func IsKubeVirtServiceAccount(serviceAccount string) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
When virt-controller is generating the Multus pod annotation, several properties can be set:
- `name`
- `namespace`
- `interface`
- `mac` _(optional)_

This proposal enables the customization of the Multus annotation.

**Which issue(s) this PR fixes**:
Fixes #4564

**Checklist**
- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or **not required**
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (https://github.com/kubevirt/user-guide/pull/749).
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) ([Slack Message](https://kubernetes.slack.com/archives/C0163DT0R8X/p1703382239665979))

**Release note**:
```release-note
Add a way to customize generated Multus pod annotation using mutating webhook
```