### PR TITLE
Macvtap deprecation

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17506,6 +17506,7 @@
       "type": "string"
      },
      "macvtap": {
+      "description": "Deprecated, please refer to Kubevirt user guide for alternatives.",
       "$ref": "#/definitions/v1.InterfaceMacvtap"
      },
      "masquerade": {

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -178,7 +178,7 @@ func fuzzKubeVirtConfig(seed int64) *virtconfig.ClusterConfig {
 				virtconfig.HotplugVolumesGate,
 				virtconfig.HostDiskGate,
 				virtconfig.VirtIOFSGate,
-				virtconfig.MacvtapGate,
+				deprecation.MacvtapGate,
 				deprecation.PasstGate,
 				virtconfig.DownwardMetricsFeatureGate,
 				deprecation.NonRoot,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1772,7 +1772,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			enableFeatureGate(virtconfig.MacvtapGate)
+			enableFeatureGate(deprecation.MacvtapGate)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
@@ -1815,7 +1815,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			enableFeatureGate(virtconfig.MacvtapGate)
+			enableFeatureGate(deprecation.MacvtapGate)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
 			Expect(causes).To(BeEmpty())
 		})

--- a/pkg/virt-config/deprecation/BUILD.bazel
+++ b/pkg/virt-config/deprecation/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "feature-gates.go",
+        "macvtap.go",
         "passt.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-config/deprecation",

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -40,6 +40,7 @@ const (
 	PasstGate              = "Passt"              // Deprecated
 	NonRoot                = "NonRoot"            // Deprecated
 	PSA                    = "PSA"                // Deprecated
+	MacvtapGate            = "Macvtap"            // Deprecated
 )
 
 type FeatureGate struct {
@@ -56,6 +57,7 @@ var featureGates = [...]FeatureGate{
 	{Name: PSA, State: GA},
 	{Name: CPUNodeDiscoveryGate, State: GA},
 	{Name: PasstGate, State: Deprecated, Message: passtDeprecationMessage, VmiSpecUsed: passtApiUsed},
+	{Name: MacvtapGate, State: Deprecated, Message: macvtapDeprecationMessage, VmiSpecUsed: macvtapApiUsed},
 }
 
 func init() {

--- a/pkg/virt-config/deprecation/macvtap.go
+++ b/pkg/virt-config/deprecation/macvtap.go
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package deprecation
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
+
+const macvtapDeprecationMessage = "Macvtap network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives."
+
+func macvtapApiUsed(spec *v1.VirtualMachineInstanceSpec) bool {
+	for _, net := range spec.Domain.Devices.Interfaces {
+		if net.Macvtap != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -39,7 +39,6 @@ const (
 	HotplugVolumesGate    = "HotplugVolumes"
 	HostDiskGate          = "HostDisk"
 	VirtIOFSGate          = "ExperimentalVirtiofsSupport"
-	MacvtapGate           = "Macvtap"
 
 	DownwardMetricsFeatureGate = "DownwardMetrics"
 	Root                       = "Root"
@@ -165,7 +164,7 @@ func (config *ClusterConfig) VirtiofsEnabled() bool {
 }
 
 func (config *ClusterConfig) MacvtapEnabled() bool {
-	return config.isFeatureGateEnabled(MacvtapGate)
+	return config.isFeatureGateEnabled(deprecation.MacvtapGate)
 }
 
 func (config *ClusterConfig) PasstEnabled() bool {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5958,9 +5958,8 @@ var CRDsValidation map[string]string = map[string]string{
                                   de:ad:00:00:be:af or DE-AD-00-00-BE-AF.'
                                 type: string
                               macvtap:
-                                description: InterfaceMacvtap connects to a given
-                                  network by extending the Kubernetes node's L2 networks
-                                  via a macvtap interface.
+                                description: Deprecated, please refer to Kubevirt
+                                  user guide for alternatives.
                                 type: object
                               masquerade:
                                 description: InterfaceMasquerade connects to a given
@@ -10541,9 +10540,8 @@ var CRDsValidation map[string]string = map[string]string{
                           or DE-AD-00-00-BE-AF.'
                         type: string
                       macvtap:
-                        description: InterfaceMacvtap connects to a given network
-                          by extending the Kubernetes node's L2 networks via a macvtap
-                          interface.
+                        description: Deprecated, please refer to Kubevirt user guide
+                          for alternatives.
                         type: object
                       masquerade:
                         description: InterfaceMasquerade connects to a given network
@@ -13321,9 +13319,8 @@ var CRDsValidation map[string]string = map[string]string{
                           or DE-AD-00-00-BE-AF.'
                         type: string
                       macvtap:
-                        description: InterfaceMacvtap connects to a given network
-                          by extending the Kubernetes node's L2 networks via a macvtap
-                          interface.
+                        description: Deprecated, please refer to Kubevirt user guide
+                          for alternatives.
                         type: object
                       masquerade:
                         description: InterfaceMasquerade connects to a given network
@@ -15514,9 +15511,8 @@ var CRDsValidation map[string]string = map[string]string{
                                   de:ad:00:00:be:af or DE-AD-00-00-BE-AF.'
                                 type: string
                               macvtap:
-                                description: InterfaceMacvtap connects to a given
-                                  network by extending the Kubernetes node's L2 networks
-                                  via a macvtap interface.
+                                description: Deprecated, please refer to Kubevirt
+                                  user guide for alternatives.
                                 type: object
                               masquerade:
                                 description: InterfaceMasquerade connects to a given
@@ -19920,9 +19916,8 @@ var CRDsValidation map[string]string = map[string]string{
                                           de:ad:00:00:be:af or DE-AD-00-00-BE-AF.'
                                         type: string
                                       macvtap:
-                                        description: InterfaceMacvtap connects to
-                                          a given network by extending the Kubernetes
-                                          node's L2 networks via a macvtap interface.
+                                        description: Deprecated, please refer to Kubevirt
+                                          user guide for alternatives.
                                         type: object
                                       masquerade:
                                         description: InterfaceMasquerade connects
@@ -25116,10 +25111,8 @@ var CRDsValidation map[string]string = map[string]string{
                                               example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.'
                                             type: string
                                           macvtap:
-                                            description: InterfaceMacvtap connects
-                                              to a given network by extending the
-                                              Kubernetes node's L2 networks via a
-                                              macvtap interface.
+                                            description: Deprecated, please refer
+                                              to Kubevirt user guide for alternatives.
                                             type: object
                                           masquerade:
                                             description: InterfaceMasquerade connects

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -1326,7 +1326,9 @@ type InterfaceBindingMethod struct {
 	Slirp      *InterfaceSlirp      `json:"slirp,omitempty"`
 	Masquerade *InterfaceMasquerade `json:"masquerade,omitempty"`
 	SRIOV      *InterfaceSRIOV      `json:"sriov,omitempty"`
-	Macvtap    *InterfaceMacvtap    `json:"macvtap,omitempty"`
+	// Deprecated, please refer to Kubevirt user guide for alternatives.
+	// +optional
+	Macvtap *InterfaceMacvtap `json:"macvtap,omitempty"`
 	// Deprecated, please refer to Kubevirt user guide for alternatives.
 	// +optional
 	Passt *InterfacePasst `json:"passt,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -694,8 +694,9 @@ func (DHCPPrivateOptions) SwaggerDoc() map[string]string {
 
 func (InterfaceBindingMethod) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":      "Represents the method which will be used to connect the interface to the guest.\nOnly one of its members may be specified.",
-		"passt": "Deprecated, please refer to Kubevirt user guide for alternatives.\n+optional",
+		"":        "Represents the method which will be used to connect the interface to the guest.\nOnly one of its members may be specified.",
+		"macvtap": "Deprecated, please refer to Kubevirt user guide for alternatives.\n+optional",
+		"passt":   "Deprecated, please refer to Kubevirt user guide for alternatives.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18553,7 +18553,8 @@ func schema_kubevirtio_api_core_v1_Interface(ref common.ReferenceCallback) commo
 					},
 					"macvtap": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/api/core/v1.InterfaceMacvtap"),
+							Description: "Deprecated, please refer to Kubevirt user guide for alternatives.",
+							Ref:         ref("kubevirt.io/api/core/v1.InterfaceMacvtap"),
 						},
 					},
 					"passt": {
@@ -18668,7 +18669,8 @@ func schema_kubevirtio_api_core_v1_InterfaceBindingMethod(ref common.ReferenceCa
 					},
 					"macvtap": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("kubevirt.io/api/core/v1.InterfaceMacvtap"),
+							Description: "Deprecated, please refer to Kubevirt user guide for alternatives.",
+							Ref:         ref("kubevirt.io/api/core/v1.InterfaceMacvtap"),
 						},
 					},
 					"passt": {

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -103,7 +103,7 @@ func AdjustKubeVirtResource() {
 		virtconfig.HotplugVolumesGate,
 		virtconfig.DownwardMetricsFeatureGate,
 		virtconfig.NUMAFeatureGate,
-		virtconfig.MacvtapGate,
+		deprecation.MacvtapGate,
 		deprecation.PasstGate,
 		virtconfig.ExpandDisksGate,
 		virtconfig.WorkloadEncryptionSEV,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following the introduction of Kubevirt Network Binding Plugin API [1] and of Macvtap network binding plugin [2], it's now possible to remove Macvtap network binding implementation from Kubevirt core.

The transition will be conducted in two phases across the next two releases:
Phase 1 (v1.2) - Kubevirt will raise a warning when the Macvtap interface is being used - this PR.
Phase 2 (v1.3) - Macvtap interface API will stop being supported by kubevirt (using the API will lead to no-op).

[1] https://kubevirt.io/user-guide/virtual_machines/network_binding_plugins
[2] https://kubevirt.io/user-guide/virtual_machines/net_binding_plugins/macvtap


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate macvtap
```
