### PR TITLE
libvmi: avoid a boolean argument in WithCloudInitNoCloudUserData

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,7 +90,6 @@ linters:
     - stylecheck
     - typecheck
     - unconvert
-    - unparam
     - unused
     - whitespace
 

--- a/tests/compute/credentials_test.go
+++ b/tests/compute/credentials_test.go
@@ -153,7 +153,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			vmi := libvmi.NewFedora(
 				withSSHPK(secretID, withQuestAgentPropagationMethod),
 				libvmi.WithCloudInitNoCloudUserData(
-					tests.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec"), false,
+					tests.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec"),
 				),
 			)
 
@@ -175,7 +175,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			const secretID = "my-user-pass"
 			vmi := libvmi.NewFedora(
 				withPassword(secretID),
-				libvmi.WithCloudInitNoCloudUserData(tests.GetFedoraToolsGuestAgentBlacklistUserData("guest-set-user-password"), false),
+				libvmi.WithCloudInitNoCloudUserData(tests.GetFedoraToolsGuestAgentBlacklistUserData("guest-set-user-password")),
 			)
 
 			customPassword := "imadethisup"

--- a/tests/compute/credentials_test.go
+++ b/tests/compute/credentials_test.go
@@ -228,7 +228,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			})
 
 			vmi := libvmi.NewFedora(
-				libvmi.WithCloudInitConfigDriveData(userData, false),
+				libvmi.WithCloudInitConfigDriveData(userData),
 				withSSHPK(secretID, propagationMethod))
 			vmi = tests.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
 			verifySSHKeys(vmi)

--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -28,19 +28,25 @@ import (
 const cloudInitDiskName = "disk1"
 
 // WithCloudInitNoCloudUserData adds cloud-init no-cloud user data.
-func WithCloudInitNoCloudUserData(data string, b64Encoding bool) Option {
+func WithCloudInitNoCloudUserData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
-		if b64Encoding {
-			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
-			volume.CloudInitNoCloud.UserData = ""
-			volume.CloudInitNoCloud.UserDataBase64 = encodedData
-		} else {
-			volume.CloudInitNoCloud.UserData = data
-			volume.CloudInitNoCloud.UserDataBase64 = ""
-		}
+		volume.CloudInitNoCloud.UserData = data
+		volume.CloudInitNoCloud.UserDataBase64 = ""
+	}
+}
+
+// WithCloudInitNoCloudEncodedUserData adds cloud-init no-cloud base64-encoded user data
+func WithCloudInitNoCloudEncodedUserData(data string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		encodedData := base64.StdEncoding.EncodeToString([]byte(data))
+		volume.CloudInitNoCloud.UserData = ""
+		volume.CloudInitNoCloud.UserDataBase64 = encodedData
 	}
 }
 

--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -61,19 +61,13 @@ func WithCloudInitNoCloudNetworkData(data string) Option {
 }
 
 // WithCloudInitConfigDriveData adds cloud-init config-drive user data.
-func WithCloudInitConfigDriveData(data string, b64Encoding bool) Option {
+func WithCloudInitConfigDriveData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
-		if b64Encoding {
-			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
-			volume.CloudInitConfigDrive.UserData = ""
-			volume.CloudInitConfigDrive.UserDataBase64 = encodedData
-		} else {
-			volume.CloudInitConfigDrive.UserData = data
-			volume.CloudInitConfigDrive.UserDataBase64 = ""
-		}
+		volume.CloudInitConfigDrive.UserData = data
+		volume.CloudInitConfigDrive.UserDataBase64 = ""
 	}
 }
 

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -50,7 +50,7 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 // NewCirros instantiates a new CirrOS based VMI configuration
 func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	// Supplied with no user data, Cirros image takes 230s to allow login
-	withNonEmptyUserData := WithCloudInitNoCloudUserData("#!/bin/bash\necho hello\n", true)
+	withNonEmptyUserData := WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
 
 	cirrosOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
@@ -75,7 +75,7 @@ func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 
 func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	// Supplied with no user data, AlpimeWithTestTooling image takes more than 200s to allow login
-	withNonEmptyUserData := WithCloudInitNoCloudUserData("#!/bin/bash\necho hello\n", true)
+	withNonEmptyUserData := WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
 	alpineMemory := cirrosMemory
 	alpineOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -170,7 +170,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			libvmi.WithSecretDisk(secretName, secretName),
 			libvmi.WithConfigMapDisk(configMapName, configMapName),
 			libvmi.WithEmptyDisk("usb-disk", v1.DiskBusUSB, resource.MustParse("64Mi")),
-			libvmi.WithCloudInitNoCloudUserData("#!/bin/bash\necho 'hello'\n", true),
+			libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho 'hello'\n"),
 		)
 	}
 

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -85,7 +85,7 @@ var _ = SIGDescribe("Infosource", func() {
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(&secondaryLinuxBridgeInterface2, secondaryInterface2Mac)),
 				libvmi.WithNetwork(secondaryNetwork1),
 				libvmi.WithNetwork(secondaryNetwork2),
-				libvmi.WithCloudInitNoCloudUserData(manipulateGuestLinksScript(primaryInterfaceNewMac, dummyInterfaceMac), false))
+				libvmi.WithCloudInitNoCloudUserData(manipulateGuestLinksScript(primaryInterfaceNewMac, dummyInterfaceMac)))
 
 			var err error
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmiSpec)

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -497,7 +497,7 @@ func createMasqueradeVm(ports []v1.Port) *v1.VirtualMachineInstance {
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
 		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData),
-		libvmi.WithCloudInitNoCloudUserData(enablePasswordAuth(), true),
+		libvmi.WithCloudInitNoCloudEncodedUserData(enablePasswordAuth()),
 	)
 	return vmi
 }
@@ -508,7 +508,7 @@ func createPasstVm(ports []v1.Port) *v1.VirtualMachineInstance {
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
 		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
-		libvmi.WithCloudInitNoCloudUserData(enablePasswordAuth(), true),
+		libvmi.WithCloudInitNoCloudEncodedUserData(enablePasswordAuth()),
 	)
 	return vmi
 }

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -682,7 +682,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
                     ip addr add %s dev ep1
                     ip addr add %s dev ep2
                 `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6)
-				agentVMI := libvmi.NewFedora(libvmi.WithCloudInitNoCloudUserData(userdata, false))
+				agentVMI := libvmi.NewFedora(libvmi.WithCloudInitNoCloudUserData(userdata))
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
 				agentVMI.Spec.Networks = networks

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -603,7 +603,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		It("[test_id:1779]should have custom resolv.conf", func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
 			userData := "#cloud-config\n"
-			dnsVMI := libvmi.NewCirros(libvmi.WithCloudInitNoCloudUserData(userData, false))
+			dnsVMI := libvmi.NewCirros(libvmi.WithCloudInitNoCloudUserData(userData))
 
 			dnsVMI.Spec.DNSPolicy = "None"
 

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -63,7 +63,7 @@ var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", 
 		vmi = libvmi.New(
 			libvmi.WithRng(),
 			libvmi.WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime)),
-			libvmi.WithCloudInitNoCloudUserData(tuneAdminRealtimeCloudInitData, true),
+			libvmi.WithCloudInitNoCloudEncodedUserData(tuneAdminRealtimeCloudInitData),
 			libvmi.WithResourceCPU("2"),
 			libvmi.WithLimitCPU("2"),
 			libvmi.WithResourceMemory(memory),

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -44,7 +44,7 @@ func newFedoraRealtime(realtimeMask string) *v1.VirtualMachineInstance {
 	return libvmi.New(
 		libvmi.WithRng(),
 		libvmi.WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime)),
-		libvmi.WithCloudInitNoCloudUserData(tuneAdminRealtimeCloudInitData, true),
+		libvmi.WithCloudInitNoCloudEncodedUserData(tuneAdminRealtimeCloudInitData),
 		libvmi.WithLimitMemory(memory),
 		libvmi.WithLimitCPU("2"),
 		libvmi.WithResourceMemory(memory),

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -882,7 +882,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = libvmi.New(
 					libvmi.WithResourceMemory("256Mi"),
 					libvmi.WithPersistentVolumeClaim("disk0", dataVolume.Name),
-					libvmi.WithCloudInitNoCloudUserData(cirrosUserData, true),
+					libvmi.WithCloudInitNoCloudEncodedUserData(cirrosUserData),
 				)
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -773,7 +773,7 @@ func NewRandomFedoraVMIWithBlacklistGuestAgent(commands string) *v1.VirtualMachi
 	return libvmi.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithCloudInitNoCloudUserData(GetFedoraToolsGuestAgentBlacklistUserData(commands), false),
+		libvmi.WithCloudInitNoCloudUserData(GetFedoraToolsGuestAgentBlacklistUserData(commands)),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData),
 	)
 }

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -87,7 +87,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 	DescribeTable("should copy a local file back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmi.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub), false))
+			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -111,7 +111,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 	DescribeTable("should copy a local directory back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmi.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub), false))
+			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -81,7 +81,7 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 	DescribeTable("should succeed to execute a command on the VM", func(cmdFn func(string)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmi.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub), false))
+			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -107,7 +107,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 				virtiofsMountPath(pvc2), pvc2, virtiofsMountPath(pvc2), virtiofsTestFile(virtiofsMountPath(pvc2)))
 
 			vmi = libvmi.NewFedora(
-				libvmi.WithCloudInitNoCloudUserData(mountVirtiofsCommands, true),
+				libvmi.WithCloudInitNoCloudEncodedUserData(mountVirtiofsCommands),
 				libvmi.WithFilesystemPVC(pvc1),
 				libvmi.WithFilesystemPVC(pvc2),
 				libvmi.WithNamespace(namespace),
@@ -220,7 +220,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
                            `, virtiofsMountPath, pvcName, virtiofsMountPath, virtiofsTestFile)
 
 			vmi = libvmi.NewFedora(
-				libvmi.WithCloudInitNoCloudUserData(mountVirtiofsCommands, true),
+				libvmi.WithCloudInitNoCloudEncodedUserData(mountVirtiofsCommands),
 				libvmi.WithFilesystemPVC(pvcName),
 				libvmi.WithNamespace(namespace),
 			)
@@ -323,7 +323,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
                                `, virtiofsMountPath, dataVolume.Name, virtiofsMountPath, virtiofsTestFile)
 
 			vmi = libvmi.NewFedora(
-				libvmi.WithCloudInitNoCloudUserData(mountVirtiofsCommands, true),
+				libvmi.WithCloudInitNoCloudEncodedUserData(mountVirtiofsCommands),
 				libvmi.WithFilesystemDV(dataVolume.Name),
 				libvmi.WithNamespace(namespace),
 			)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -218,7 +218,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					"#cloud-config\npassword: %s\nchpasswd: { expire: False }",
 					fedoraPassword,
 				)
-				vmi := libvmi.NewFedora(libvmi.WithCloudInitConfigDriveData(userData, false))
+				vmi := libvmi.NewFedora(libvmi.WithCloudInitConfigDriveData(userData))
 				// runStrategy := v1.RunStrategyManual
 				vm := &v1.VirtualMachine{
 					ObjectMeta: vmi.ObjectMeta,

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -175,7 +175,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		vmi := libvmi.NewFedora(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			libvmi.WithCloudInitNoCloudUserData(userData, false),
+			libvmi.WithCloudInitNoCloudUserData(userData),
 		)
 		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)


### PR DESCRIPTION
A casual reader of

```
   libvmi.NewFedora(libvmi.WithCloudInitNoCloudUserData(userdata, false))
```

would find it hard to understand what is "false" about this function call. Reading deeper would reveal that it means that the userdata argument is not going to be base64-encoded before being passed to kubevirt.

As is commonly the case with functions that have a boolean argument, libvmi.WithCloudInitNoCloudUserData has actually two functions. Let us define these two functions with readable names.


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
