### PR TITLE
SRIOV - syncVMI try to plug an SRIOV interface that is not in the pod

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -657,6 +657,11 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 				if err := c.updateVolumeStatus(vmiCopy, pod); err != nil {
 					return err
 				}
+
+				if err := c.updateInterfaceStatus(vmiCopy, pod); err != nil {
+					log.Log.Errorf("failed to update the interface status: %v", err)
+				}
+
 				// vmi is still owned by the controller but pod is already ready,
 				// so let's hand over the vmi too
 				vmiCopy.Status.Phase = virtv1.Scheduled

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//pkg/network/sriov:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice:go_default_library",

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
@@ -2173,6 +2174,12 @@ var _ = Describe("Manager", func() {
 					Multus: &v1.MultusNetwork{NetworkName: "test1"},
 				}},
 		)
+		vmi.Status = v1.VirtualMachineInstanceStatus{
+			Interfaces: []v1.VirtualMachineInstanceNetworkInterface{{
+				Name:       "test1",
+				InfoSource: vmispec.InfoSourceMultusStatus,
+			}},
+		}
 
 		domainSpec := expectedDomainFor(vmi)
 		xml, err := xml.MarshalIndent(domainSpec, "", "\t")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In case SRIOV interface/s exist, syncVMI tries to plug them to the VM.
If it fails, the whole syncVMI fails.
However, there are use cases we konw in advance it is fine to have a
SRIOV interface but not yet manage to plug it.
For example, when hotplugging a SRIOV interface. Until a migration is
done the interface/device is not plugged to the pod, therefore,
syncVM` will fail.
The PR allows ignoring SRIOV interface which are not yet plugged to
the pod and avoiding syncVMI failure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
