### PR TITLE
VMClone: fix clone_test with snapshot and restore already exists  

### DIFF
--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -124,7 +124,9 @@ var _ = Describe("Clone", func() {
 			create, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
 
-			snapshot := create.GetObject().(*snapshotv1alpha1.VirtualMachineSnapshot)
+			snapshot, ok := create.GetObject().(*snapshotv1alpha1.VirtualMachineSnapshot)
+			Expect(ok).To(BeTrue())
+
 			Expect(snapshot.Name).To(Equal("tmp-snapshot-clone-uid"))
 			Expect(snapshot.Spec.Source.Kind).To(Equal("VirtualMachine"))
 			Expect(snapshot.Spec.Source.Name).To(Equal(sourceVMName))
@@ -140,7 +142,9 @@ var _ = Describe("Clone", func() {
 			create, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
 
-			snapshotcreated := create.GetObject().(*snapshotv1alpha1.VirtualMachineSnapshot)
+			snapshotcreated, ok := create.GetObject().(*snapshotv1alpha1.VirtualMachineSnapshot)
+			Expect(ok).To(BeTrue())
+
 			Expect(snapshotcreated.Spec.Source.Kind).To(Equal("VirtualMachine"))
 			Expect(snapshotcreated.Spec.Source.Name).To(Equal(sourceVMName))
 			Expect(snapshotcreated.OwnerReferences).To(HaveLen(1))
@@ -155,7 +159,9 @@ var _ = Describe("Clone", func() {
 			create, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
 
-			restore := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+			restore, ok := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+			Expect(ok).To(BeTrue())
+
 			Expect(restore.Spec.VirtualMachineSnapshotName).To(Equal(restoreName))
 			Expect(restore.OwnerReferences).To(HaveLen(1))
 			validateOwnerReference(restore.OwnerReferences[0], vmClone)
@@ -168,7 +174,9 @@ var _ = Describe("Clone", func() {
 			create, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
 
-			restorecreated := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+			restorecreated, ok := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+			Expect(ok).To(BeTrue())
+
 			Expect(restorecreated.Spec.VirtualMachineSnapshotName).To(Equal(snapshotName))
 			Expect(restorecreated.OwnerReferences).To(HaveLen(1))
 			validateOwnerReference(restorecreated.OwnerReferences[0], vmClone)
@@ -182,7 +190,9 @@ var _ = Describe("Clone", func() {
 			create, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
 
-			restorecreated := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+			restorecreated, ok := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+			Expect(ok).To(BeTrue())
+
 			Expect(restorecreated.Spec.VirtualMachineSnapshotName).To(Equal(snapshotName))
 			Expect(restorecreated.OwnerReferences).To(HaveLen(1))
 			validateOwnerReference(restorecreated.OwnerReferences[0], vmClone)
@@ -218,7 +228,9 @@ var _ = Describe("Clone", func() {
 			update, ok := action.(testing.UpdateAction)
 			Expect(ok).To(BeTrue())
 
-			vmClone := update.GetObject().(*clonev1alpha1.VirtualMachineClone)
+			vmClone, ok := update.GetObject().(*clonev1alpha1.VirtualMachineClone)
+			Expect(ok).To(BeTrue())
+
 			Expect(vmClone.Status.Phase).To(Equal(phase))
 
 			return true, update.GetObject(), nil
@@ -230,9 +242,11 @@ var _ = Describe("Clone", func() {
 			update, ok := action.(testing.UpdateAction)
 			Expect(ok).To(BeTrue())
 
-			vmClone := update.GetObject().(*clonev1alpha1.VirtualMachineClone)
+			vmClone, ok := update.GetObject().(*clonev1alpha1.VirtualMachineClone)
+			Expect(ok).To(BeTrue())
+
 			Expect(vmClone.Status.Phase).To(Equal(phase))
-			Expect(*vmClone.Status.SnapshotName).To(Equal(snapshotName))
+			Expect(vmClone.Status.SnapshotName).To(HaveValue(Equal(snapshotName)))
 
 			return true, update.GetObject(), nil
 		})
@@ -243,9 +257,11 @@ var _ = Describe("Clone", func() {
 			update, ok := action.(testing.UpdateAction)
 			Expect(ok).To(BeTrue())
 
-			vmClone := update.GetObject().(*clonev1alpha1.VirtualMachineClone)
+			vmClone, ok := update.GetObject().(*clonev1alpha1.VirtualMachineClone)
+			Expect(ok).To(BeTrue())
+
 			Expect(vmClone.Status.Phase).To(Equal(phase))
-			Expect(*vmClone.Status.RestoreName).To(Equal(restoreName))
+			Expect(vmClone.Status.RestoreName).To(HaveValue(Equal(restoreName)))
 
 			return true, update.GetObject(), nil
 		})
@@ -686,7 +702,9 @@ var _ = Describe("Clone", func() {
 				create, ok := action.(testing.CreateAction)
 				Expect(ok).To(BeTrue())
 
-				restore := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+				restore, ok := create.GetObject().(*snapshotv1alpha1.VirtualMachineRestore)
+				Expect(ok).To(BeTrue())
+
 				Expect(restore.Spec.VirtualMachineSnapshotName).To(Equal(snapshotName))
 
 				patchedVM, err := offlinePatchVM(sourceVM, restore.Spec.Patches)
@@ -1002,8 +1020,8 @@ func createVirtualMachineSnapshotSnapshotContent(vm *virtv1.VirtualMachine, snap
 	vmCpy.Spec = *vm.Spec.DeepCopy()
 	vmCpy.ResourceVersion = "1"
 	vmCpy.Status = *vm.Status.DeepCopy()
-	return &snapshotv1alpha1.VirtualMachineSnapshotContent{
 
+	return &snapshotv1alpha1.VirtualMachineSnapshotContent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vmsnapshot-content-snapshot-UID",
 			Namespace: vm.Namespace,
@@ -1015,7 +1033,6 @@ func createVirtualMachineSnapshotSnapshotContent(vm *virtv1.VirtualMachine, snap
 				VirtualMachine: vmCpy,
 			},
 		},
-
 		Status: &snapshotv1alpha1.VirtualMachineSnapshotContentStatus{},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

1）Chenge reactor functions return nil obj with AlreadyExists err
2）add snapshotcontent in clone_test

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Hi, reviewers.This pr is focuse on change what reactor functions should return with AlreadyExists err. IMO, this pr make clone_test can find the problems fixed by this https://github.com/kubevirt/kubevirt/pull/10903. 
When I dug deeper, I found that if there is no snapshotcontent in the cache, the "with source VM" test will not execute correctly, so I added snapshotcontent for clone_test.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
