### PR TITLE
Specify a node to create a VM

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20544,6 +20544,10 @@
        "$ref": "#/definitions/v1.Network"
       }
      },
+     "nodeName": {
+      "description": "NodeName is a request to schedule this vm onto a specific node. If it is non-empty, the scheduler simply schedules this vm onto that node, assuming that it fits resource requirements. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+      "type": "string"
+     },
      "nodeSelector": {
       "description": "NodeSelector is a selector which must be true for the vmi to fit on a node. Selector which must match a node's labels for the vmi to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
       "type": "object",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/validate-k8s-utils.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/validate-k8s-utils.go
@@ -72,6 +72,17 @@ func validateAffinity(affinity *core.Affinity, fldPath *field.Path) field.ErrorL
 	return allErrs
 }
 
+// validateNodeName checks if given nodeName are valid
+func validateNodeName(nodeName string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for _, msg := range ValidateNodeName(nodeName, false) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeName"), nodeName, msg))
+	}
+
+	return allErrs
+}
+
 // validateNodeAffinity tests that the specified nodeAffinity fields have valid data
 func validateNodeAffinity(na *core.NodeAffinity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -588,6 +588,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			RestartPolicy:                 k8sv1.RestartPolicyNever,
 			Containers:                    containers,
 			InitContainers:                initContainers,
+			NodeName:                      vmi.Spec.NodeName,
 			NodeSelector:                  t.newNodeSelectorRenderer(vmi).Render(),
 			Volumes:                       volumeRenderer.Volumes(),
 			ImagePullSecrets:              imagePullSecrets,

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6711,6 +6711,12 @@ var CRDsValidation map[string]string = map[string]string{
                     - name
                     type: object
                   type: array
+                nodeName:
+                  description: 'NodeName is a request to schedule this vm onto a specific
+                    node. If it is non-empty, the scheduler simply schedules this
+                    vm onto that node, assuming that it fits resource requirements.
+                    More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                  type: string
                 nodeSelector:
                   additionalProperties:
                     type: string
@@ -11239,6 +11245,11 @@ var CRDsValidation map[string]string = map[string]string{
             - name
             type: object
           type: array
+        nodeName:
+          description: 'NodeName is a request to schedule this vm onto a specific
+            node. If it is non-empty, the scheduler simply schedules this vm onto
+            that node, assuming that it fits resource requirements. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+          type: string
         nodeSelector:
           additionalProperties:
             type: string
@@ -16264,6 +16275,12 @@ var CRDsValidation map[string]string = map[string]string{
                     - name
                     type: object
                   type: array
+                nodeName:
+                  description: 'NodeName is a request to schedule this vm onto a specific
+                    node. If it is non-empty, the scheduler simply schedules this
+                    vm onto that node, assuming that it fits resource requirements.
+                    More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                  type: string
                 nodeSelector:
                   additionalProperties:
                     type: string
@@ -20711,6 +20728,12 @@ var CRDsValidation map[string]string = map[string]string{
                             - name
                             type: object
                           type: array
+                        nodeName:
+                          description: 'NodeName is a request to schedule this vm
+                            onto a specific node. If it is non-empty, the scheduler
+                            simply schedules this vm onto that node, assuming that
+                            it fits resource requirements. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                          type: string
                         nodeSelector:
                           additionalProperties:
                             type: string
@@ -25933,6 +25956,12 @@ var CRDsValidation map[string]string = map[string]string{
                                 - name
                                 type: object
                               type: array
+                            nodeName:
+                              description: 'NodeName is a request to schedule this
+                                vm onto a specific node. If it is non-empty, the scheduler
+                                simply schedules this vm onto that node, assuming
+                                that it fits resource requirements. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -87,6 +87,12 @@ type VirtualMachineInstanceSpec struct {
 
 	// Specification of the desired behavior of the VirtualMachineInstance on the host.
 	Domain DomainSpec `json:"domain"`
+	//NodeName is a request to schedule this vm onto a specific node. If it is
+	//non-empty, the scheduler simply schedules this vm onto that node, assuming
+	//that it fits resource requirements.
+	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+	// +optional
+	NodeName string `json:"nodeName,omitempty"`
 	// NodeSelector is a selector which must be true for the vmi to fit on a node.
 	// Selector which must match a node's labels for the vmi to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -21,6 +21,7 @@ func (VirtualMachineInstanceSpec) SwaggerDoc() map[string]string {
 		"":                              "VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.",
 		"priorityClassName":             "If specified, indicates the pod's priority.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.\n+optional",
 		"domain":                        "Specification of the desired behavior of the VirtualMachineInstance on the host.",
+		"nodeName":                      "NodeName is a request to schedule this vm onto a specific node. If it is\nnon-empty, the scheduler simply schedules this vm onto that node, assuming\nthat it fits resource requirements.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\n+optional",
 		"nodeSelector":                  "NodeSelector is a selector which must be true for the vmi to fit on a node.\nSelector which must match a node's labels for the vmi to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\n+optional",
 		"affinity":                      "If affinity is specifies, obey all the affinity rules",
 		"schedulerName":                 "If specified, the VMI will be dispatched by specified scheduler.\nIf not specified, the VMI will be dispatched by default scheduler.\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -24150,6 +24150,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceSpec(ref common.Referen
 							Ref:         ref("kubevirt.io/api/core/v1.DomainSpec"),
 						},
 					},
+					"nodeName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeName is a request to schedule this vm onto a specific node. If it is non-empty, the scheduler simply schedules this vm onto that node, assuming that it fits resource requirements. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"nodeSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeSelector is a selector which must be true for the vmi to fit on a node. Selector which must match a node's labels for the vmi to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Though we have [Node assignment](https://kubevirt.io/user-guide/operations/node_assignment/) to chose which node to be scheduled. But in some scenarios we still need to specify an exact node to create a virtual machine and the function is the same to K8s' POD.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10937

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: vm-cirros
spec:
  template:
    spec:
      nodeName: host-0-1
```
