### PR TITLE
[release-1.0] Fix VMI status.GuestOSInfo

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1032,7 +1032,7 @@ func (d *VirtualMachineController) updateGuestInfoFromDomain(vmi *v1.VirtualMach
 
 	if vmi.Status.GuestOSInfo.Name != domain.Status.OSInfo.Name {
 		vmi.Status.GuestOSInfo.Name = domain.Status.OSInfo.Name
-		vmi.Status.GuestOSInfo.Version = domain.Status.OSInfo.VersionId
+		vmi.Status.GuestOSInfo.Version = domain.Status.OSInfo.Version
 		vmi.Status.GuestOSInfo.KernelRelease = domain.Status.OSInfo.KernelRelease
 		vmi.Status.GuestOSInfo.PrettyName = domain.Status.OSInfo.PrettyName
 		vmi.Status.GuestOSInfo.VersionID = domain.Status.OSInfo.VersionId

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1037,6 +1037,7 @@ func (d *VirtualMachineController) updateGuestInfoFromDomain(vmi *v1.VirtualMach
 		vmi.Status.GuestOSInfo.PrettyName = domain.Status.OSInfo.PrettyName
 		vmi.Status.GuestOSInfo.VersionID = domain.Status.OSInfo.VersionId
 		vmi.Status.GuestOSInfo.KernelVersion = domain.Status.OSInfo.KernelVersion
+		vmi.Status.GuestOSInfo.Machine = domain.Status.OSInfo.Machine
 		vmi.Status.GuestOSInfo.ID = domain.Status.OSInfo.Id
 	}
 }

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2950,23 +2950,47 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.UID = vmiTestUUID
 			vmi.ObjectMeta.ResourceVersion = "1"
 			vmi.Status.Phase = v1.Scheduled
-			guestOSName := "TestGuestOS"
 
-			vmi.Status.GuestOSInfo = v1.VirtualMachineInstanceGuestOSInfo{
-				Name: guestOSName,
-			}
+			const (
+				guestOSId            = "fedora"
+				guestOSName          = "Fedora Linux"
+				guestOSPrettyName    = "Fedora Linux 35 (Cloud Edition)"
+				guestOSVersion       = "35 (Cloud Edition)"
+				guestOSVersionId     = "35"
+				guestOSMachine       = "x86_64"
+				guestOSKernelRelease = "5.14.10-300.fc35.x86_64"
+				guestOSKernelVersion = "#1 SMP Thu Oct 7 20:48:44 UTC 2021"
+			)
+
+			vmi.Status.GuestOSInfo = v1.VirtualMachineInstanceGuestOSInfo{}
 
 			mockWatchdog.CreateFile(vmi)
 			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
 			domain.Status.Status = api.Running
 
-			domain.Status.OSInfo = api.GuestOSInfo{Name: guestOSName}
+			domain.Status.OSInfo = api.GuestOSInfo{
+				Id:            guestOSId,
+				Name:          guestOSName,
+				PrettyName:    guestOSPrettyName,
+				Version:       guestOSVersion,
+				VersionId:     guestOSVersionId,
+				Machine:       guestOSMachine,
+				KernelRelease: guestOSKernelRelease,
+				KernelVersion: guestOSKernelVersion,
+			}
 
 			vmiFeeder.Add(vmi)
 			domainFeeder.Add(domain)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.Name).To(Equal(guestOSName))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.ID).To(Equal(domain.Status.OSInfo.Id))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.Name).To(Equal(domain.Status.OSInfo.Name))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.PrettyName).To(Equal(domain.Status.OSInfo.PrettyName))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.Version).To(Equal(domain.Status.OSInfo.Version))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.VersionID).To(Equal(domain.Status.OSInfo.VersionId))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.Machine).To(Equal(domain.Status.OSInfo.Machine))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.KernelRelease).To(Equal(domain.Status.OSInfo.KernelRelease))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.GuestOSInfo.KernelVersion).To(Equal(domain.Status.OSInfo.KernelVersion))
 			}).Return(vmi, nil)
 
 			controller.Execute()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual cherry-pick of PRs #10898 and #10916.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix VMI status.GuestOSInfo Machine and Version fields
```
