### PR TITLE
tests/utils: replace a long-named function with libvmi.NewFedora

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -633,13 +633,6 @@ func NewRandomVMWithDataVolumeAndUserDataInStorageClass(imageUrl, namespace, use
 	return NewRandomVMWithDataVolumeAndUserData(dataVolume, userData)
 }
 
-func NewRandomVMIWithEphemeralDiskHighMemory(containerImage string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
-
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-	return vmi
-}
-
 func NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(containerImage string, userData string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, userData)
 
@@ -773,11 +766,6 @@ func NewRandomFedoraVMIWithBlacklistGuestAgent(commands string) *v1.VirtualMachi
 		libvmi.WithCloudInitNoCloudUserData(GetFedoraToolsGuestAgentBlacklistUserData(commands), false),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData),
 	)
-}
-
-func NewRandomFedoraVMIWithEphemeralDiskHighMemory() *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling))
-	return vmi
 }
 
 func GetFedoraToolsGuestAgentBlacklistUserData(commands string) string {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -944,10 +944,6 @@ func NewRandomVMIWithHostDisk(diskPath string, diskType v1.HostDiskType, nodeNam
 }
 
 func AddConfigMapDisk(vmi *v1.VirtualMachineInstance, configMapName string, volumeName string) {
-	AddConfigMapDiskWithCustomLabel(vmi, configMapName, volumeName, "")
-
-}
-func AddConfigMapDiskWithCustomLabel(vmi *v1.VirtualMachineInstance, configMapName string, volumeName string, volumeLabel string) {
 	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 		Name: volumeName,
 		VolumeSource: v1.VolumeSource{
@@ -955,7 +951,7 @@ func AddConfigMapDiskWithCustomLabel(vmi *v1.VirtualMachineInstance, configMapNa
 				LocalObjectReference: k8sv1.LocalObjectReference{
 					Name: configMapName,
 				},
-				VolumeLabel: volumeLabel,
+				VolumeLabel: "",
 			},
 		},
 	})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2939,7 +2939,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 	Context("[rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check Chassis value", func() {
 
 		It("[Serial][test_id:2927]Test Chassis value in a newly created VM", Serial, func() {
-			vmi := tests.NewRandomFedoraVMIWithEphemeralDiskHighMemory()
+			vmi := libvmi.NewFedora()
 			vmi.Spec.Domain.Chassis = &v1.Chassis{
 				Asset: "Test-123",
 			}
@@ -2971,7 +2971,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			vmi = tests.NewRandomFedoraVMIWithEphemeralDiskHighMemory()
+			vmi = libvmi.NewFedora()
 		})
 
 		It("[test_id:2751]test default SMBios", func() {
@@ -3053,7 +3053,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		var DiskBusIDE v1.DiskBus = "ide"
 
 		BeforeEach(func() {
-			vmi = tests.NewRandomFedoraVMIWithEphemeralDiskHighMemory()
+			vmi = libvmi.NewFedora()
 		})
 
 		DescribeTable("For various bus types", func(bus v1.DiskBus, errMsg string) {
@@ -3164,7 +3164,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		BeforeEach(func() {
 			checks.SkipIfRunningOnKindInfra("Skip KVM MSR prescence test on kind")
 
-			vmi = tests.NewRandomFedoraVMIWithEphemeralDiskHighMemory()
+			vmi = libvmi.NewFedora()
 		})
 
 		It("[test_id:5271]test cpuid hidden", func() {


### PR DESCRIPTION

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
