### PR TITLE
test/utils: drop two public functions

### DIFF
--- a/tests/compute/credentials_test.go
+++ b/tests/compute/credentials_test.go
@@ -228,7 +228,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			})
 
 			vmi := libvmi.NewFedora(
-				libvmi.WithCloudInitConfigDriveData(userData),
+				libvmi.WithCloudInitConfigDriveUserData(userData),
 				withSSHPK(secretID, propagationMethod))
 			vmi = tests.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
 			verifySSHKeys(vmi)

--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -60,8 +60,8 @@ func WithCloudInitNoCloudNetworkData(data string) Option {
 	}
 }
 
-// WithCloudInitConfigDriveData adds cloud-init config-drive user data.
-func WithCloudInitConfigDriveData(data string) Option {
+// WithCloudInitConfigDriveUserData adds cloud-init config-drive user data.
+func WithCloudInitConfigDriveUserData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -583,16 +583,6 @@ func NewRandomVMWithDataVolumeAndUserDataInStorageClass(imageUrl, namespace, use
 	return NewRandomVMWithDataVolumeAndUserData(dataVolume, userData)
 }
 
-// NewRandomVMIWithEphemeralDiskAndUserdataHighMemory
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(containerImage string, userData string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, userData)
-
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-	return vmi
-}
-
 // NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataHighMemory
 //
 // Deprecated: Use libvmi directly

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -559,18 +559,6 @@ func NewRandomVMWithDataVolume(imageUrl string, namespace string) (*v1.VirtualMa
 	return vm, true
 }
 
-// NewRandomVMWithDataVolumeAndUserData
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMWithDataVolumeAndUserData(dataVolume *cdiv1.DataVolume, userData string) *v1.VirtualMachine {
-	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
-	AddUserData(vmi, "cloud-init", userData)
-	vm := libvmi.NewVirtualMachine(vmi)
-
-	libstorage.AddDataVolumeTemplate(vm, dataVolume)
-	return vm
-}
-
 // NewRandomVMWithDataVolumeAndUserDataInStorageClass
 //
 // Deprecated: Use libvmi directly
@@ -579,8 +567,12 @@ func NewRandomVMWithDataVolumeAndUserDataInStorageClass(imageUrl, namespace, use
 		libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullNode),
 		libdv.WithPVC(libdv.PVCWithStorageClass(storageClass), libdv.PVCWithVolumeSize(dvSizeBySourceURL(imageUrl))),
 	)
+	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
+	AddUserData(vmi, "cloud-init", userData)
+	vm := libvmi.NewVirtualMachine(vmi)
 
-	return NewRandomVMWithDataVolumeAndUserData(dataVolume, userData)
+	libstorage.AddDataVolumeTemplate(vm, dataVolume)
+	return vm
 }
 
 // NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataHighMemory

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -220,7 +220,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					"#cloud-config\npassword: %s\nchpasswd: { expire: False }",
 					fedoraPassword,
 				)
-				vmi := libvmi.NewFedora(libvmi.WithCloudInitConfigDriveData(userData))
+				vmi := libvmi.NewFedora(libvmi.WithCloudInitConfigDriveUserData(userData))
 				// runStrategy := v1.RunStrategyManual
 				vm := &v1.VirtualMachine{
 					ObjectMeta: vmi.ObjectMeta,

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -152,9 +152,9 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						fedoraPassword,
 						sshAuthorizedKey,
 					)
-					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling), userData)
+					vmi := libvmi.NewFedora(libvmi.WithCloudInitNoCloudUserData(userData))
 
-					LaunchVMI(vmi)
+					vmi = LaunchVMI(vmi)
 					CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
 					VerifyUserDataVMI(vmi, []expect.Batcher{


### PR DESCRIPTION
Make tests/utils.go slightly shorter by moving two functions away from it.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```