### PR TITLE
network bindings: Raise warning in case unregistered binding is used

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -606,6 +606,10 @@ func (vca *VirtControllerApp) initCommon() {
 			}),
 		services.WithSidecarCreator(
 			func(vmi *v1.VirtualMachineInstance, kvc *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
+				if err := netbinding.ValidateVMINetBindingPlugins(vmi, kvc); err != nil {
+					vca.vmiRecorder.Eventf(vmi, k8sv1.EventTypeWarning, netbinding.UnregisteredNetworkBindingPluginReason, err.Error())
+					return nil, err
+				}
 				return netbinding.NetBindingPluginSidecarList(vmi, kvc, vca.vmiRecorder)
 			}),
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In the scenario where an unregistered network binding plugin is being used the VMI wont start until the plugin is registered.
To communicate this condition better and help with troubleshooting, raise warning event in case an unregistered plugin is being used.

For example, given a VMI with the following interface spec:
```
spec:
  domain:
    devices:
      interfaces:
      - name: "mgmt"
        binding:
         name: "passt"
```
The following event will be raised:
```
$ kubectl describe vmi test-vmi
...
Events:
  Type     Reason                            Age                   From                       Message
  ----     ------                            ----                  ----                       -------
  Warning  UnregisteredNetworkBindingPlugin  44s (x17 over 6m11s)  virtualmachine-controller  network interface "mgmt" is set with unregistered network binding plugin "passt". Make sure all network binding plugins are registered in Kubevirt config.
```

This event emitting is rate limited as it being part of the reconcile loop of the VMI controller, which is managed by the controller work queue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
