### PR TITLE
import kubevirt.io/api/core/v1 once

### DIFF
--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 
-	kubevirtv1 "kubevirt.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
@@ -1194,7 +1193,7 @@ var _ = Describe("Restore controller", func() {
 
 					expectedUpdatedCR := expectedCreatedCR.DeepCopy()
 					expectedUpdatedCR.ResourceVersion = "5"
-					expectedUpdatedCR.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(newVM, kubevirtv1.VirtualMachineGroupVersionKind)}
+					expectedUpdatedCR.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(newVM, v1.VirtualMachineGroupVersionKind)}
 					expectControllerRevisionUpdate(k8sClient, expectedUpdatedCR)
 
 					if newVM.Spec.Instancetype != nil {
@@ -1269,7 +1268,7 @@ var _ = Describe("Restore controller", func() {
 
 					expectedUpdatedCR := expectedCreatedCR.DeepCopy()
 					expectedUpdatedCR.ResourceVersion = "5"
-					expectedUpdatedCR.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(newVM, kubevirtv1.VirtualMachineGroupVersionKind)}
+					expectedUpdatedCR.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(newVM, v1.VirtualMachineGroupVersionKind)}
 					expectControllerRevisionUpdate(k8sClient, expectedUpdatedCR)
 
 					if newVM.Spec.Instancetype != nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -37,7 +36,7 @@ import (
 )
 
 var _ = Describe("Validating Pool Admitter", func() {
-	config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
+	config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 	poolAdmitter := &VMPoolAdmitter{ClusterConfig: config}
 
 	always := v1.RunStrategyAlways

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/api"
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
@@ -54,7 +53,7 @@ var _ = Describe("Pool", func() {
 
 		namespace := "test"
 		baseName := "my-pool"
-		vmInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachine{})
+		vmInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachine{})
 
 		for _, name := range existing {
 			vm, _ := DefaultVirtualMachine(true)
@@ -121,13 +120,13 @@ var _ = Describe("Pool", func() {
 			mockQueue.Wait()
 		}
 
-		addVM := func(vm *virtv1.VirtualMachine) {
+		addVM := func(vm *v1.VirtualMachine) {
 			mockQueue.ExpectAdds(1)
 			vmSource.Add(vm)
 			mockQueue.Wait()
 		}
 
-		addVMI := func(vm *virtv1.VirtualMachineInstance, expectQueue bool) {
+		addVMI := func(vm *v1.VirtualMachineInstance, expectQueue bool) {
 			if expectQueue {
 				mockQueue.ExpectAdds(1)
 			}
@@ -281,8 +280,8 @@ var _ = Describe("Pool", func() {
 			vmi.Namespace = vm.Namespace
 			vmi.Labels = vm.Spec.Template.ObjectMeta.Labels
 			vmi.OwnerReferences = []metav1.OwnerReference{{
-				APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-				Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
+				APIVersion:         v1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+				Kind:               v1.VirtualMachineGroupVersionKind.Kind,
 				Name:               vm.ObjectMeta.Name,
 				UID:                vm.ObjectMeta.UID,
 				Controller:         &t,
@@ -302,7 +301,7 @@ var _ = Describe("Pool", func() {
 			vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Times(0)
 			vmInterface.EXPECT().Update(context.Background(), gomock.Any()).MaxTimes(1).Do(func(ctx context.Context, arg interface{}) {
 				newVM := arg.(*v1.VirtualMachine)
-				revisionName := newVM.Labels[virtv1.VirtualMachinePoolRevisionName]
+				revisionName := newVM.Labels[v1.VirtualMachinePoolRevisionName]
 				Expect(revisionName).To(Equal(newPoolRevision.Name))
 			}).Return(vm, nil)
 
@@ -346,15 +345,15 @@ var _ = Describe("Pool", func() {
 			vmi.Namespace = vm.Namespace
 			vmi.Labels = mapCopy(vm.Spec.Template.ObjectMeta.Labels)
 			vmi.OwnerReferences = []metav1.OwnerReference{{
-				APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-				Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
+				APIVersion:         v1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+				Kind:               v1.VirtualMachineGroupVersionKind.Kind,
 				Name:               vm.ObjectMeta.Name,
 				UID:                vm.ObjectMeta.UID,
 				Controller:         &t,
 				BlockOwnerDeletion: &t,
 			}}
 
-			vmi.Labels[virtv1.VirtualMachinePoolRevisionName] = oldPoolRevision.Name
+			vmi.Labels[v1.VirtualMachinePoolRevisionName] = oldPoolRevision.Name
 
 			addPool(pool)
 			addVM(vm)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
 	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
@@ -109,8 +108,8 @@ var _ = Describe("VirtualMachine", func() {
 
 			dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 			dataSourceInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataSource{})
-			vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, virtcontroller.GetVMIInformerIndexers())
-			vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachine{}, virtcontroller.GetVirtualMachineInformerIndexers())
+			vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstance{}, virtcontroller.GetVMIInformerIndexers())
+			vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachine{}, virtcontroller.GetVirtualMachineInformerIndexers())
 			pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 			namespaceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 			ns1 := &k8sv1.Namespace{
@@ -183,25 +182,25 @@ var _ = Describe("VirtualMachine", func() {
 			virtClient.EXPECT().AuthorizationV1().Return(k8sClient.AuthorizationV1()).AnyTimes()
 		})
 
-		shouldExpectGracePeriodPatched := func(expectedGracePeriod int64, vmi *virtv1.VirtualMachineInstance) {
+		shouldExpectGracePeriodPatched := func(expectedGracePeriod int64, vmi *v1.VirtualMachineInstance) {
 			patch := fmt.Sprintf(`{"spec":{"terminationGracePeriodSeconds": %d }}`, expectedGracePeriod)
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.MergePatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 		}
 
-		shouldExpectVMIFinalizerRemoval := func(vmi *virtv1.VirtualMachineInstance) {
-			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": ["%s"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`, virtv1.VirtualMachineControllerFinalizer)
+		shouldExpectVMIFinalizerRemoval := func(vmi *v1.VirtualMachineInstance) {
+			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": ["%s"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`, v1.VirtualMachineControllerFinalizer)
 
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 		}
 
-		shouldExpectVMFinalizerAddition := func(vm *virtv1.VirtualMachine) {
-			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": null }, { "op": "replace", "path": "/metadata/finalizers", "value": ["%s"] }]`, virtv1.VirtualMachineControllerFinalizer)
+		shouldExpectVMFinalizerAddition := func(vm *v1.VirtualMachine) {
+			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": null }, { "op": "replace", "path": "/metadata/finalizers", "value": ["%s"] }]`, v1.VirtualMachineControllerFinalizer)
 
 			vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vm, nil)
 		}
 
-		shouldExpectVMFinalizerRemoval := func(vm *virtv1.VirtualMachine) {
-			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": ["%s"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`, virtv1.VirtualMachineControllerFinalizer)
+		shouldExpectVMFinalizerRemoval := func(vm *v1.VirtualMachine) {
+			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": ["%s"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`, v1.VirtualMachineControllerFinalizer)
 
 			vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vm, nil)
 		}
@@ -266,7 +265,7 @@ var _ = Describe("VirtualMachine", func() {
 			})
 		}
 
-		patchVMRevision := func(vm *virtv1.VirtualMachine) runtime.RawExtension {
+		patchVMRevision := func(vm *v1.VirtualMachine) runtime.RawExtension {
 			vmBytes, err := json.Marshal(vm)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -282,14 +281,14 @@ var _ = Describe("VirtualMachine", func() {
 			return runtime.RawExtension{Raw: patch}
 		}
 
-		createVMRevision := func(vm *virtv1.VirtualMachine) *appsv1.ControllerRevision {
+		createVMRevision := func(vm *v1.VirtualMachine) *appsv1.ControllerRevision {
 			return &appsv1.ControllerRevision{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      getVMRevisionName(vm.UID, vm.Generation),
 					Namespace: vm.Namespace,
 					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-						Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
+						APIVersion:         v1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+						Kind:               v1.VirtualMachineGroupVersionKind.Kind,
 						Name:               vm.ObjectMeta.Name,
 						UID:                vm.ObjectMeta.UID,
 						Controller:         &t,
@@ -301,7 +300,7 @@ var _ = Describe("VirtualMachine", func() {
 			}
 		}
 
-		addVirtualMachine := func(vm *virtv1.VirtualMachine) {
+		addVirtualMachine := func(vm *v1.VirtualMachine) {
 			syncCaches(stop)
 			mockQueue.ExpectAdds(1)
 			vmSource.Add(vm)
@@ -310,37 +309,37 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should create missing DataVolume for VirtualMachineInstance", func() {
 			vm, _ := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv2",
 					},
 				},
 			})
 
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      map[string]string{"my": "label"},
 					Annotations: map[string]string{"my": "annotation"},
 					Name:        "dv1",
 				},
 			})
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv2",
 				},
 			})
 
-			vm.Status.PrintableStatus = virtv1.VirtualMachineStatusStopped
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusStopped
 			addVirtualMachine(vm)
 
 			existingDataVolume, _ := watchutil.CreateDataVolumeManifest(virtClient, vm.Spec.DataVolumeTemplates[1], vm)
@@ -351,8 +350,8 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": string(vm.UID), "my": "label"}, map[string]string{"my": "annotation"}, &createCount)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
-				Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
+				objVM := obj.(*v1.VirtualMachine)
+				Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusProvisioning))
 			})
 
 			controller.Execute()
@@ -365,12 +364,12 @@ var _ = Describe("VirtualMachine", func() {
 			vm, vmi := DefaultVirtualMachine(isRunning)
 			vm.Status.Created = true
 			vm.Status.Ready = true
-			vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+			vm.Status.VolumeRequests = []v1.VirtualMachineVolumeRequest{
 				{
-					AddVolumeOptions: &virtv1.AddVolumeOptions{
+					AddVolumeOptions: &v1.AddVolumeOptions{
 						Name:         "vol1",
-						Disk:         &virtv1.Disk{},
-						VolumeSource: &virtv1.HotplugVolumeSource{},
+						Disk:         &v1.Disk{},
+						VolumeSource: &v1.HotplugVolumeSource{},
 					},
 				},
 			}
@@ -384,12 +383,12 @@ var _ = Describe("VirtualMachine", func() {
 			}
 
 			vmInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Spec.Template.Spec.Volumes[0].Name).To(Equal("vol1"))
+				Expect(arg.(*v1.VirtualMachine).Spec.Template.Spec.Volumes[0].Name).To(Equal("vol1"))
 			}).Return(vm, nil)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
 				// vol request shouldn't be cleared until update status observes the new volume change
-				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
+				Expect(arg.(*v1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
 			}).Return(vm, nil)
 
 			controller.Execute()
@@ -403,20 +402,20 @@ var _ = Describe("VirtualMachine", func() {
 			vm, vmi := DefaultVirtualMachine(isRunning)
 			vm.Status.Created = true
 			vm.Status.Ready = true
-			vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+			vm.Status.VolumeRequests = []v1.VirtualMachineVolumeRequest{
 				{
-					RemoveVolumeOptions: &virtv1.RemoveVolumeOptions{
+					RemoveVolumeOptions: &v1.RemoveVolumeOptions{
 						Name: "vol1",
 					},
 				},
 			}
-			vm.Spec.Template.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
+			vm.Spec.Template.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "vol1",
 			})
-			vm.Spec.Template.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name: "vol1",
-				VolumeSource: virtv1.VolumeSource{
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "testpvcdiskclaim",
 					}},
 				},
@@ -433,12 +432,12 @@ var _ = Describe("VirtualMachine", func() {
 			}
 
 			vmInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Spec.Template.Spec.Volumes).To(BeEmpty())
+				Expect(arg.(*v1.VirtualMachine).Spec.Template.Spec.Volumes).To(BeEmpty())
 			}).Return(vm, nil)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
 				// vol request shouldn't be cleared until update status observes the new volume change occured
-				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
+				Expect(arg.(*v1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
 			}).Return(vm, nil)
 
 			controller.Execute()
@@ -452,22 +451,22 @@ var _ = Describe("VirtualMachine", func() {
 			vm, vmi := DefaultVirtualMachine(isRunning)
 			vm.Status.Created = true
 			vm.Status.Ready = true
-			vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+			vm.Status.VolumeRequests = []v1.VirtualMachineVolumeRequest{
 				{
-					AddVolumeOptions: &virtv1.AddVolumeOptions{
+					AddVolumeOptions: &v1.AddVolumeOptions{
 						Name:         "vol1",
-						Disk:         &virtv1.Disk{},
-						VolumeSource: &virtv1.HotplugVolumeSource{},
+						Disk:         &v1.Disk{},
+						VolumeSource: &v1.HotplugVolumeSource{},
 					},
 				},
 			}
-			vm.Spec.Template.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
+			vm.Spec.Template.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "vol1",
 			})
-			vm.Spec.Template.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name: "vol1",
-				VolumeSource: virtv1.VolumeSource{
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "testpvcdiskclaim",
 					}},
 				},
@@ -483,7 +482,7 @@ var _ = Describe("VirtualMachine", func() {
 			}
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
+				Expect(arg.(*v1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
 			}).Return(nil, nil)
 
 			controller.Execute()
@@ -497,15 +496,15 @@ var _ = Describe("VirtualMachine", func() {
 			vm, vmi := DefaultVirtualMachine(isRunning)
 			vm.Status.Created = true
 			vm.Status.Ready = true
-			vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+			vm.Status.VolumeRequests = []v1.VirtualMachineVolumeRequest{
 				{
-					RemoveVolumeOptions: &virtv1.RemoveVolumeOptions{
+					RemoveVolumeOptions: &v1.RemoveVolumeOptions{
 						Name: "vol1",
 					},
 				},
 			}
-			vm.Spec.Template.Spec.Volumes = []virtv1.Volume{}
-			vm.Spec.Template.Spec.Domain.Devices.Disks = []virtv1.Disk{}
+			vm.Spec.Template.Spec.Volumes = []v1.Volume{}
+			vm.Spec.Template.Spec.Domain.Devices.Disks = []v1.Disk{}
 
 			addVirtualMachine(vm)
 
@@ -515,7 +514,7 @@ var _ = Describe("VirtualMachine", func() {
 			}
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
+				Expect(arg.(*v1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
 			}).Return(nil, nil)
 
 			controller.Execute()
@@ -527,29 +526,29 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should not delete failed DataVolume for VirtualMachineInstance", func() {
 			vm, _ := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv2",
 					},
 				},
 			})
 
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
 			})
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv2",
 				},
@@ -580,29 +579,29 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should not delete failed DataVolume for VirtualMachineInstance unless deletion timestamp expires ", func() {
 			vm, _ := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv2",
 					},
 				},
 			})
 
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
 			})
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv2",
 				},
@@ -629,29 +628,29 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should handle failed DataVolume without Annotations", func() {
 			vm, _ := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv2",
 					},
 				},
 			})
 
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
 			})
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv2",
 				},
@@ -682,15 +681,15 @@ var _ = Describe("VirtualMachine", func() {
 		It("should start VMI once DataVolumes are complete", func() {
 
 			vm, vmi := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
@@ -704,12 +703,12 @@ var _ = Describe("VirtualMachine", func() {
 			dataVolumeFeeder.Add(existingDataVolume)
 			// expect creation called
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
 			}).Return(vmi, nil)
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
@@ -718,15 +717,15 @@ var _ = Describe("VirtualMachine", func() {
 		It("should start VMI once DataVolumes (not templates) are complete", func() {
 
 			vm, vmi := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			dvt := virtv1.DataVolumeTemplateSpec{
+			dvt := v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
@@ -742,12 +741,12 @@ var _ = Describe("VirtualMachine", func() {
 
 			// expect creation called
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
 			}).Return(vmi, nil)
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
@@ -757,15 +756,15 @@ var _ = Describe("VirtualMachine", func() {
 			// WaitForFirstConsumer state can only be handled by VMI
 
 			vm, vmi := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
@@ -779,12 +778,12 @@ var _ = Describe("VirtualMachine", func() {
 			dataVolumeFeeder.Add(existingDataVolume)
 			// expect creation called
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
 			}).Return(vmi, nil)
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
@@ -793,15 +792,15 @@ var _ = Describe("VirtualMachine", func() {
 		It("should Not delete Datavolumes when VMI is stopped", func() {
 
 			vm, vmi := DefaultVirtualMachine(false)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
@@ -823,35 +822,35 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should create multiple DataVolumes for VirtualMachineInstance", func() {
 			vm, _ := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv2",
 					},
 				},
 			})
 
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
 			})
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv2",
 				},
 			})
 
-			vm.Status.PrintableStatus = virtv1.VirtualMachineStatusStopped
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusStopped
 			addVirtualMachine(vm)
 
 			createCount := 0
@@ -864,16 +863,16 @@ var _ = Describe("VirtualMachine", func() {
 
 		DescribeTable("should properly set priority class", func(dvPriorityClass, vmPriorityClass, expectedPriorityClass string) {
 			vm, _ := DefaultVirtualMachine(true)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
 
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
@@ -882,7 +881,7 @@ var _ = Describe("VirtualMachine", func() {
 				},
 			})
 			vm.Spec.Template.Spec.PriorityClassName = vmPriorityClass
-			vm.Status.PrintableStatus = virtv1.VirtualMachineStatusStopped
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusStopped
 			addVirtualMachine(vm)
 
 			createCount := 0
@@ -903,7 +902,7 @@ var _ = Describe("VirtualMachine", func() {
 			It("should track start failures when VMIs fail without hitting running state", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 				vmi.UID = "123"
-				vmi.Status.Phase = virtv1.Failed
+				vmi.Status.Phase = v1.Failed
 
 				addVirtualMachine(vm)
 				vmiFeeder.Add(vmi)
@@ -911,10 +910,10 @@ var _ = Describe("VirtualMachine", func() {
 				vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure).ToNot(BeNil())
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure.RetryAfterTimestamp).ToNot(BeNil())
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure.LastFailedVMIUID).To(Equal(vmi.UID))
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure.ConsecutiveFailCount).To(Equal(1))
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure).ToNot(BeNil())
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure.RetryAfterTimestamp).ToNot(BeNil())
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure.LastFailedVMIUID).To(Equal(vmi.UID))
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure.ConsecutiveFailCount).To(Equal(1))
 				}).Return(nil, nil)
 
 				shouldExpectVMIFinalizerRemoval(vmi)
@@ -927,10 +926,10 @@ var _ = Describe("VirtualMachine", func() {
 			It("should track a new start failures when a new VMI fails without hitting running state", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 				vmi.UID = "456"
-				vmi.Status.Phase = virtv1.Failed
+				vmi.Status.Phase = v1.Failed
 
 				oldRetry := time.Now().Add(-300 * time.Second)
-				vm.Status.StartFailure = &virtv1.VirtualMachineStartFailure{
+				vm.Status.StartFailure = &v1.VirtualMachineStartFailure{
 					LastFailedVMIUID:     "123",
 					ConsecutiveFailCount: 1,
 					RetryAfterTimestamp: &metav1.Time{
@@ -944,11 +943,11 @@ var _ = Describe("VirtualMachine", func() {
 				vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure).ToNot(BeNil())
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure.RetryAfterTimestamp).ToNot(BeNil())
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure.RetryAfterTimestamp.Time).ToNot(Equal(oldRetry))
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure.LastFailedVMIUID).To(Equal(vmi.UID))
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure.ConsecutiveFailCount).To(Equal(2))
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure).ToNot(BeNil())
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure.RetryAfterTimestamp).ToNot(BeNil())
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure.RetryAfterTimestamp.Time).ToNot(Equal(oldRetry))
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure.LastFailedVMIUID).To(Equal(vmi.UID))
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure.ConsecutiveFailCount).To(Equal(2))
 				}).Return(nil, nil)
 
 				shouldExpectVMIFinalizerRemoval(vmi)
@@ -961,16 +960,16 @@ var _ = Describe("VirtualMachine", func() {
 			It("should clear start failures when VMI hits running state", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 				vmi.UID = "456"
-				vmi.Status.Phase = virtv1.Running
-				vmi.Status.PhaseTransitionTimestamps = []virtv1.VirtualMachineInstancePhaseTransitionTimestamp{
+				vmi.Status.Phase = v1.Running
+				vmi.Status.PhaseTransitionTimestamps = []v1.VirtualMachineInstancePhaseTransitionTimestamp{
 					{
-						Phase:                    virtv1.Running,
+						Phase:                    v1.Running,
 						PhaseTransitionTimestamp: metav1.Now(),
 					},
 				}
 
 				oldRetry := time.Now().Add(-300 * time.Second)
-				vm.Status.StartFailure = &virtv1.VirtualMachineStartFailure{
+				vm.Status.StartFailure = &v1.VirtualMachineStartFailure{
 					LastFailedVMIUID:     "123",
 					ConsecutiveFailCount: 1,
 					RetryAfterTimestamp: &metav1.Time{
@@ -984,22 +983,22 @@ var _ = Describe("VirtualMachine", func() {
 				vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure).To(BeNil())
+					Expect(arg.(*v1.VirtualMachine).Status.StartFailure).To(BeNil())
 				}).Return(nil, nil)
 
 				controller.Execute()
 
 			})
 
-			DescribeTable("should clear existing start failures when runStrategy is halted or manual", func(runStrategy virtv1.VirtualMachineRunStrategy) {
+			DescribeTable("should clear existing start failures when runStrategy is halted or manual", func(runStrategy v1.VirtualMachineRunStrategy) {
 				vm, vmi := DefaultVirtualMachine(true)
 				vmi.UID = "456"
-				vmi.Status.Phase = virtv1.Failed
+				vmi.Status.Phase = v1.Failed
 				vm.Spec.Running = nil
 				vm.Spec.RunStrategy = &runStrategy
 
 				oldRetry := time.Now().Add(300 * time.Second)
-				vm.Status.StartFailure = &virtv1.VirtualMachineStartFailure{
+				vm.Status.StartFailure = &v1.VirtualMachineStartFailure{
 					LastFailedVMIUID:     "123",
 					ConsecutiveFailCount: 1,
 					RetryAfterTimestamp: &metav1.Time{
@@ -1013,10 +1012,10 @@ var _ = Describe("VirtualMachine", func() {
 				vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-					if runStrategy == virtv1.RunStrategyHalted || runStrategy == virtv1.RunStrategyManual {
-						Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure).To(BeNil())
+					if runStrategy == v1.RunStrategyHalted || runStrategy == v1.RunStrategyManual {
+						Expect(arg.(*v1.VirtualMachine).Status.StartFailure).To(BeNil())
 					} else {
-						Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure).ToNot(BeNil())
+						Expect(arg.(*v1.VirtualMachine).Status.StartFailure).ToNot(BeNil())
 
 					}
 				}).Return(nil, nil)
@@ -1027,16 +1026,16 @@ var _ = Describe("VirtualMachine", func() {
 
 				controller.Execute()
 
-				if runStrategy != virtv1.RunStrategyManual && runStrategy != virtv1.RunStrategyOnce {
+				if runStrategy != v1.RunStrategyManual && runStrategy != v1.RunStrategyOnce {
 					testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 				}
 			},
 
-				Entry("runStrategyHalted", virtv1.RunStrategyHalted),
-				Entry("always", virtv1.RunStrategyAlways),
-				Entry("manual", virtv1.RunStrategyManual),
-				Entry("rerunOnFailure", virtv1.RunStrategyRerunOnFailure),
-				Entry("once", virtv1.RunStrategyOnce),
+				Entry("runStrategyHalted", v1.RunStrategyHalted),
+				Entry("always", v1.RunStrategyAlways),
+				Entry("manual", v1.RunStrategyManual),
+				Entry("rerunOnFailure", v1.RunStrategyRerunOnFailure),
+				Entry("once", v1.RunStrategyOnce),
 			)
 
 			DescribeTable("should calculated expected backoff delay", func(failCount, minExpectedDelay int, maxExpectedDelay int) {
@@ -1058,7 +1057,7 @@ var _ = Describe("VirtualMachine", func() {
 				Entry("failCount 6", 6, 300, 300),
 			)
 
-			DescribeTable("has start failure backoff expired", func(vmFunc func() *virtv1.VirtualMachine, expected int64) {
+			DescribeTable("has start failure backoff expired", func(vmFunc func() *v1.VirtualMachine, expected int64) {
 				vm := vmFunc()
 				seconds := startFailureBackoffTimeLeft(vm)
 
@@ -1072,15 +1071,15 @@ var _ = Describe("VirtualMachine", func() {
 			},
 
 				Entry("no vm start failures",
-					func() *virtv1.VirtualMachine {
-						return &virtv1.VirtualMachine{}
+					func() *v1.VirtualMachine {
+						return &v1.VirtualMachine{}
 					},
 					int64(0)),
 				Entry("vm failure waiting 300 seconds",
-					func() *virtv1.VirtualMachine {
-						return &virtv1.VirtualMachine{
-							Status: virtv1.VirtualMachineStatus{
-								StartFailure: &virtv1.VirtualMachineStartFailure{
+					func() *v1.VirtualMachine {
+						return &v1.VirtualMachine{
+							Status: v1.VirtualMachineStatus{
+								StartFailure: &v1.VirtualMachineStartFailure{
 									RetryAfterTimestamp: &metav1.Time{
 										Time: time.Now().Add(300 * time.Second),
 									},
@@ -1090,10 +1089,10 @@ var _ = Describe("VirtualMachine", func() {
 					},
 					int64(300)),
 				Entry("vm failure 300 seconds past retry time",
-					func() *virtv1.VirtualMachine {
-						return &virtv1.VirtualMachine{
-							Status: virtv1.VirtualMachineStatus{
-								StartFailure: &virtv1.VirtualMachineStartFailure{
+					func() *v1.VirtualMachine {
+						return &v1.VirtualMachine{
+							Status: v1.VirtualMachineStatus{
+								StartFailure: &v1.VirtualMachineStartFailure{
 									RetryAfterTimestamp: &metav1.Time{
 										Time: time.Now().Add(-300 * time.Second),
 									},
@@ -1106,7 +1105,7 @@ var _ = Describe("VirtualMachine", func() {
 		})
 
 		Context("clone authorization tests", func() {
-			dv1 := &virtv1.DataVolumeTemplateSpec{
+			dv1 := &v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv1",
 				},
@@ -1120,7 +1119,7 @@ var _ = Describe("VirtualMachine", func() {
 				},
 			}
 
-			dv2 := &virtv1.DataVolumeTemplateSpec{
+			dv2 := &v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv2",
 				},
@@ -1148,7 +1147,7 @@ var _ = Describe("VirtualMachine", func() {
 				},
 			}
 
-			dv3 := &virtv1.DataVolumeTemplateSpec{
+			dv3 := &v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "dv3",
 				},
@@ -1161,22 +1160,22 @@ var _ = Describe("VirtualMachine", func() {
 				},
 			}
 
-			serviceAccountVol := &virtv1.Volume{
+			serviceAccountVol := &v1.Volume{
 				Name: "sa",
-				VolumeSource: virtv1.VolumeSource{
-					ServiceAccount: &virtv1.ServiceAccountVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					ServiceAccount: &v1.ServiceAccountVolumeSource{
 						ServiceAccountName: "sa",
 					},
 				},
 			}
 
-			DescribeTable("create clone DataVolume for VirtualMachineInstance", func(dv *virtv1.DataVolumeTemplateSpec, saVol *virtv1.Volume, ds *cdiv1.DataSource, fail, sourcePVC bool) {
+			DescribeTable("create clone DataVolume for VirtualMachineInstance", func(dv *v1.DataVolumeTemplateSpec, saVol *v1.Volume, ds *cdiv1.DataSource, fail, sourcePVC bool) {
 				vm, _ := DefaultVirtualMachine(true)
 				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes,
-					virtv1.Volume{
+					v1.Volume{
 						Name: "test1",
-						VolumeSource: virtv1.VolumeSource{
-							DataVolume: &virtv1.DataVolumeSource{
+						VolumeSource: v1.VolumeSource{
+							DataVolume: &v1.DataVolumeSource{
 								Name: dv.Name,
 							},
 						},
@@ -1189,7 +1188,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dv)
 
-				vm.Status.PrintableStatus = virtv1.VirtualMachineStatusStopped
+				vm.Status.PrintableStatus = v1.VirtualMachineStatusStopped
 				addVirtualMachine(vm)
 
 				createCount := 0
@@ -1301,14 +1300,14 @@ var _ = Describe("VirtualMachine", func() {
 			vmRevision := createVMRevision(vm)
 			expectControllerRevisionCreation(vmRevision)
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.VirtualMachineRevisionName).To(Equal(vmRevision.Name))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.VirtualMachineRevisionName).To(Equal(vmRevision.Name))
 			}).Return(vmi, nil)
 
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
 			controller.Execute()
@@ -1329,14 +1328,14 @@ var _ = Describe("VirtualMachine", func() {
 			expectControllerRevisionDelete(oldVMRevision)
 			expectControllerRevisionCreation(vmRevision)
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.VirtualMachineRevisionName).To(Equal(vmRevision.Name))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.VirtualMachineRevisionName).To(Equal(vmRevision.Name))
 			}).Return(vmi, nil)
 
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
 			controller.Execute()
@@ -1354,11 +1353,11 @@ var _ = Describe("VirtualMachine", func() {
 				setGenerationAnnotationOnVmi(6, vmi)
 				Expect(vmi.ObjectMeta.Annotations).To(Equal(annotations))
 			},
-				Entry("with previous annotations", map[string]string{"test": "test"}, map[string]string{"test": "test", virtv1.VirtualMachineGenerationAnnotation: "6"}),
-				Entry("without previous annotations", map[string]string{}, map[string]string{virtv1.VirtualMachineGenerationAnnotation: "6"}),
+				Entry("with previous annotations", map[string]string{"test": "test"}, map[string]string{"test": "test", v1.VirtualMachineGenerationAnnotation: "6"}),
+				Entry("without previous annotations", map[string]string{}, map[string]string{v1.VirtualMachineGenerationAnnotation: "6"}),
 			)
 
-			DescribeTable("should add generation annotation during VMI creation", func(runStrategy virtv1.VirtualMachineRunStrategy) {
+			DescribeTable("should add generation annotation during VMI creation", func(runStrategy v1.VirtualMachineRunStrategy) {
 				vm, vmi := DefaultVirtualMachine(true)
 
 				vm.Spec.Running = nil
@@ -1366,15 +1365,15 @@ var _ = Describe("VirtualMachine", func() {
 				vm.Generation = 3
 				addVirtualMachine(vm)
 
-				annotations := map[string]string{virtv1.VirtualMachineGenerationAnnotation: "3"}
+				annotations := map[string]string{v1.VirtualMachineGenerationAnnotation: "3"}
 				vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-					Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
+					Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 				}).Return(vmi, nil)
 
 				// expect update status is called
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-					Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+					Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+					Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 				}).Return(nil, nil)
 
 				controller.Execute()
@@ -1382,9 +1381,9 @@ var _ = Describe("VirtualMachine", func() {
 				testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 			},
 
-				Entry("with run strategy Always", virtv1.RunStrategyAlways),
-				Entry("with run strategy Once", virtv1.RunStrategyOnce),
-				Entry("with run strategy RerunOnFailure", virtv1.RunStrategyRerunOnFailure),
+				Entry("with run strategy Always", v1.RunStrategyAlways),
+				Entry("with run strategy Once", v1.RunStrategyOnce),
+				Entry("with run strategy RerunOnFailure", v1.RunStrategyRerunOnFailure),
 			)
 
 			It("should patch the generation annotation onto the vmi", func() {
@@ -1416,8 +1415,8 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(err).To(Equal(desiredErr))
 				}
 			},
-				Entry("with only one entry in the annotations", map[string]string{virtv1.VirtualMachineGenerationAnnotation: "6"}, asStrPtr("6"), nil),
-				Entry("with multiple entries in the annotations", map[string]string{"test": "test", virtv1.VirtualMachineGenerationAnnotation: "5"}, asStrPtr("5"), nil),
+				Entry("with only one entry in the annotations", map[string]string{v1.VirtualMachineGenerationAnnotation: "6"}, asStrPtr("6"), nil),
+				Entry("with multiple entries in the annotations", map[string]string{"test": "test", v1.VirtualMachineGenerationAnnotation: "5"}, asStrPtr("5"), nil),
 				Entry("with no generation annotation existing", map[string]string{"test": "testing"}, nil, nil),
 				Entry("with empty annotations map", map[string]string{}, nil, nil),
 			)
@@ -1446,7 +1445,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, vmi = DefaultVirtualMachine(true)
 				})
 
-				DescribeTable("should conditionally bump the generation annotation on the vmi", func(initialAnnotations map[string]string, desiredAnnotations map[string]string, revisionVmSpec virtv1.VirtualMachineSpec, newVMSpec virtv1.VirtualMachineSpec, vmGeneration int64, desiredErr error, expectPatch bool) {
+				DescribeTable("should conditionally bump the generation annotation on the vmi", func(initialAnnotations map[string]string, desiredAnnotations map[string]string, revisionVmSpec v1.VirtualMachineSpec, newVMSpec v1.VirtualMachineSpec, vmGeneration int64, desiredErr error, expectPatch bool) {
 					// Spec and generation for the vmRevision and 'old' objects
 					vmi.ObjectMeta.Annotations = initialAnnotations
 					vm.Generation = 1
@@ -1491,34 +1490,34 @@ var _ = Describe("VirtualMachine", func() {
 				},
 					Entry(
 						"with generation and template staying the same",
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						virtv1.VirtualMachineSpec{
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vm.ObjectMeta.Name,
 									Labels: vm.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 4,
 										},
 									},
 								},
 							},
 						},
-						virtv1.VirtualMachineSpec{
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vm.ObjectMeta.Name,
 									Labels: vm.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 4,
 										},
 									},
@@ -1531,34 +1530,34 @@ var _ = Describe("VirtualMachine", func() {
 					),
 					Entry(
 						"with generation increasing and a change in template",
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						virtv1.VirtualMachineSpec{
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 4,
 										},
 									},
 								},
 							},
 						},
-						virtv1.VirtualMachineSpec{
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 3,
 										},
 									},
@@ -1571,34 +1570,34 @@ var _ = Describe("VirtualMachine", func() {
 					),
 					Entry(
 						"with generation increasing and no change in template",
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "3"},
-						virtv1.VirtualMachineSpec{
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "3"},
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 4,
 										},
 									},
 								},
 							},
 						},
-						virtv1.VirtualMachineSpec{
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 4,
 										},
 									},
@@ -1611,36 +1610,36 @@ var _ = Describe("VirtualMachine", func() {
 					),
 					Entry(
 						"with generation increasing, no change in template, and run strategy changing",
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "7"},
-						virtv1.VirtualMachineSpec{
-							RunStrategy: func(rs virtv1.VirtualMachineRunStrategy) *virtv1.VirtualMachineRunStrategy { return &rs }(virtv1.RunStrategyAlways),
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "7"},
+						v1.VirtualMachineSpec{
+							RunStrategy: func(rs v1.VirtualMachineRunStrategy) *v1.VirtualMachineRunStrategy { return &rs }(v1.RunStrategyAlways),
 							Running:     func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 4,
 										},
 									},
 								},
 							},
 						},
-						virtv1.VirtualMachineSpec{
-							RunStrategy: func(rs virtv1.VirtualMachineRunStrategy) *virtv1.VirtualMachineRunStrategy { return &rs }(virtv1.RunStrategyRerunOnFailure),
+						v1.VirtualMachineSpec{
+							RunStrategy: func(rs v1.VirtualMachineRunStrategy) *v1.VirtualMachineRunStrategy { return &rs }(v1.RunStrategyRerunOnFailure),
 							Running:     func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 4,
 										},
 									},
@@ -1696,8 +1695,8 @@ var _ = Describe("VirtualMachine", func() {
 			},
 				Entry(
 					"with annotation existing - generation updates",
-					map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-					map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
+					map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+					map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
 					int64(2),
 					int64(3),
 					nil,
@@ -1707,8 +1706,8 @@ var _ = Describe("VirtualMachine", func() {
 				),
 				Entry(
 					"with annotation existing - generation does not change",
-					map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-					map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
+					map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+					map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
 					int64(2),
 					int64(2),
 					nil,
@@ -1719,8 +1718,8 @@ var _ = Describe("VirtualMachine", func() {
 				Entry(
 					// In this case the annotation should be back filled from the revision
 					"with annotation existing - ill formatted generation annotation",
-					map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2b3c"},
-					map[string]string{virtv1.VirtualMachineGenerationAnnotation: "3"},
+					map[string]string{v1.VirtualMachineGenerationAnnotation: "2b3c"},
+					map[string]string{v1.VirtualMachineGenerationAnnotation: "3"},
 					int64(3),
 					int64(3),
 					nil,
@@ -1731,7 +1730,7 @@ var _ = Describe("VirtualMachine", func() {
 				Entry(
 					"with annotation not existing - generation updates and patches vmi",
 					map[string]string{},
-					map[string]string{virtv1.VirtualMachineGenerationAnnotation: "3"},
+					map[string]string{v1.VirtualMachineGenerationAnnotation: "3"},
 					int64(3),
 					int64(4),
 					nil,
@@ -1742,7 +1741,7 @@ var _ = Describe("VirtualMachine", func() {
 				Entry(
 					"with annotation not existing - generation does not update and patches vmi",
 					map[string]string{},
-					map[string]string{virtv1.VirtualMachineGenerationAnnotation: "7"},
+					map[string]string{v1.VirtualMachineGenerationAnnotation: "7"},
 					int64(7),
 					int64(7),
 					nil,
@@ -1761,7 +1760,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, vmi = DefaultVirtualMachine(true)
 				})
 
-				DescribeTable("should update annotations and sync during Execute()", func(initialAnnotations map[string]string, desiredAnnotations map[string]string, revisionVmSpec virtv1.VirtualMachineSpec, newVMSpec virtv1.VirtualMachineSpec, revisionVmGeneration int64, vmGeneration int64, desiredErr error, expectPatch bool, desiredObservedGeneration int64, desiredDesiredGeneration int64) {
+				DescribeTable("should update annotations and sync during Execute()", func(initialAnnotations map[string]string, desiredAnnotations map[string]string, revisionVmSpec v1.VirtualMachineSpec, newVMSpec v1.VirtualMachineSpec, revisionVmGeneration int64, vmGeneration int64, desiredErr error, expectPatch bool, desiredObservedGeneration int64, desiredDesiredGeneration int64) {
 					vmi.ObjectMeta.Annotations = initialAnnotations
 					vm.Generation = revisionVmGeneration
 					vm.Spec = revisionVmSpec
@@ -1792,8 +1791,8 @@ var _ = Describe("VirtualMachine", func() {
 					}
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						Expect(arg.(*virtv1.VirtualMachine).Status.ObservedGeneration).To(Equal(desiredObservedGeneration))
-						Expect(arg.(*virtv1.VirtualMachine).Status.DesiredGeneration).To(Equal(desiredDesiredGeneration))
+						Expect(arg.(*v1.VirtualMachine).Status.ObservedGeneration).To(Equal(desiredObservedGeneration))
+						Expect(arg.(*v1.VirtualMachine).Status.DesiredGeneration).To(Equal(desiredDesiredGeneration))
 					}).Return(nil, nil)
 
 					controller.Execute()
@@ -1801,34 +1800,34 @@ var _ = Describe("VirtualMachine", func() {
 					Entry(
 						// Expect no patch on vmi annotations, and vm status to be correct
 						"with annotation existing, new changes in VM spec",
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						virtv1.VirtualMachineSpec{
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 2,
 										},
 									},
 								},
 							},
 						},
-						virtv1.VirtualMachineSpec{
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 4, // changed
 										},
 									},
@@ -1845,34 +1844,34 @@ var _ = Describe("VirtualMachine", func() {
 					Entry(
 						// Expect a patch on vmi annotations, and vm status to be correct
 						"with annotation existing, no new changes in VM spec",
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "2"},
-						map[string]string{virtv1.VirtualMachineGenerationAnnotation: "3"},
-						virtv1.VirtualMachineSpec{
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "2"},
+						map[string]string{v1.VirtualMachineGenerationAnnotation: "3"},
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 2,
 										},
 									},
 								},
 							},
 						},
-						virtv1.VirtualMachineSpec{
+						v1.VirtualMachineSpec{
 							Running: func(b bool) *bool { return &b }(true),
-							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+							Template: &v1.VirtualMachineInstanceTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:   vmi.ObjectMeta.Name,
 									Labels: vmi.ObjectMeta.Labels,
 								},
-								Spec: virtv1.VirtualMachineInstanceSpec{
+								Spec: v1.VirtualMachineInstanceSpec{
 									Domain: v1.DomainSpec{
-										CPU: &virtv1.CPU{
+										CPU: &v1.CPU{
 											Cores: 2,
 										},
 									},
@@ -1890,7 +1889,7 @@ var _ = Describe("VirtualMachine", func() {
 			})
 		})
 
-		DescribeTable("should create missing VirtualMachineInstance", func(runStrategy virtv1.VirtualMachineRunStrategy) {
+		DescribeTable("should create missing VirtualMachineInstance", func(runStrategy v1.VirtualMachineRunStrategy) {
 			vm, vmi := DefaultVirtualMachine(true)
 
 			vm.Spec.Running = nil
@@ -1899,13 +1898,13 @@ var _ = Describe("VirtualMachine", func() {
 
 			// expect creation called
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
 			}).Return(vmi, nil)
 
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
 			controller.Execute()
@@ -1913,9 +1912,9 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		},
 
-			Entry("with run strategy Always", virtv1.RunStrategyAlways),
-			Entry("with run strategy Once", virtv1.RunStrategyOnce),
-			Entry("with run strategy RerunOnFailure", virtv1.RunStrategyRerunOnFailure),
+			Entry("with run strategy Always", v1.RunStrategyAlways),
+			Entry("with run strategy Once", v1.RunStrategyOnce),
+			Entry("with run strategy RerunOnFailure", v1.RunStrategyRerunOnFailure),
 		)
 
 		It("should ignore the name of a VirtualMachineInstance templates", func() {
@@ -1925,14 +1924,14 @@ var _ = Describe("VirtualMachine", func() {
 
 			// expect creation called
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("vmname"))
-				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.GenerateName).To(Equal(""))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("vmname"))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.GenerateName).To(Equal(""))
 			}).Return(vmi, nil)
 
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
 			controller.Execute()
@@ -1942,15 +1941,15 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should update status to created if the vmi exists", func() {
 			vm, vmi := DefaultVirtualMachine(true)
-			vmi.Status.Phase = virtv1.Scheduled
+			vmi.Status.Phase = v1.Scheduled
 
 			addVirtualMachine(vm)
 			vmiFeeder.Add(vmi)
 
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeTrue())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeTrue())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
 			controller.Execute()
@@ -1965,8 +1964,8 @@ var _ = Describe("VirtualMachine", func() {
 
 			// expect update status is called
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeTrue())
-				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeTrue())
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeTrue())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeTrue())
 			}).Return(nil, nil)
 
 			controller.Execute()
@@ -1990,7 +1989,7 @@ var _ = Describe("VirtualMachine", func() {
 		It("should honour any firmware UUID present in the template", func() {
 			uid := uuid.NewRandom().String()
 			vm1, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
-			vm1.Spec.Template.Spec.Domain.Firmware = &virtv1.Firmware{UUID: types.UID(uid)}
+			vm1.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{UUID: types.UID(uid)}
 
 			vmi1 := controller.setupVMIFromVM(vm1)
 			Expect(string(vmi1.Spec.Domain.Firmware.UUID)).To(Equal(uid))
@@ -2028,7 +2027,7 @@ var _ = Describe("VirtualMachine", func() {
 			//DefaultVirtualMachine already set finalizer
 			vm, _ := DefaultVirtualMachine(false)
 			Expect(vm.Finalizers).To(HaveLen(1))
-			Expect(vm.Finalizers[0]).To(BeEquivalentTo(virtv1.VirtualMachineControllerFinalizer))
+			Expect(vm.Finalizers[0]).To(BeEquivalentTo(v1.VirtualMachineControllerFinalizer))
 			addVirtualMachine(vm)
 
 			//Expect only update status, not Patch on vmInterface
@@ -2068,13 +2067,13 @@ var _ = Describe("VirtualMachine", func() {
 			controller.Execute()
 		})
 
-		DescribeTable("should not delete VirtualMachineInstance when vmi failed", func(runStrategy virtv1.VirtualMachineRunStrategy) {
+		DescribeTable("should not delete VirtualMachineInstance when vmi failed", func(runStrategy v1.VirtualMachineRunStrategy) {
 			vm, vmi := DefaultVirtualMachine(true)
 
 			vm.Spec.Running = nil
 			vm.Spec.RunStrategy = &runStrategy
 
-			vmi.Status.Phase = virtv1.Failed
+			vmi.Status.Phase = v1.Failed
 
 			addVirtualMachine(vm)
 			vmiFeeder.Add(vmi)
@@ -2086,8 +2085,8 @@ var _ = Describe("VirtualMachine", func() {
 
 		},
 
-			Entry("with run strategy Once", virtv1.RunStrategyOnce),
-			Entry("with run strategy Manual", virtv1.RunStrategyManual),
+			Entry("with run strategy Once", v1.RunStrategyOnce),
+			Entry("with run strategy Manual", v1.RunStrategyManual),
 		)
 
 		It("should not delete the VirtualMachineInstance again if it is already marked for deletion", func() {
@@ -2137,16 +2136,16 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should detect that a DataVolume already exists and adopt it", func() {
 			vm, _ := DefaultVirtualMachine(false)
-			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "dv1",
 					},
 				},
 			})
 
-			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dv1",
 					Namespace: vm.Namespace,
@@ -2199,10 +2198,10 @@ var _ = Describe("VirtualMachine", func() {
 
 			// We should see the failed condition, replicas should stay at 0
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
-				cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+				objVM := obj.(*v1.VirtualMachine)
+				cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 				Expect(cond).To(Not(BeNil()))
-				Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+				Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 				Expect(cond.Reason).To(Equal("FailedCreate"))
 				Expect(cond.Message).To(ContainSubstring("some random failure"))
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
@@ -2222,10 +2221,10 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Delete(context.Background(), vmi.ObjectMeta.Name, gomock.Any()).Return(fmt.Errorf("some random failure"))
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
-				cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+				objVM := obj.(*v1.VirtualMachine)
+				cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 				Expect(cond).To(Not(BeNil()))
-				Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+				Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 				Expect(cond.Reason).To(Equal("FailedDelete"))
 				Expect(cond.Message).To(ContainSubstring("some random failure"))
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
@@ -2236,18 +2235,18 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvents(recorder, FailedDeleteVirtualMachineReason)
 		})
 
-		DescribeTable("should add ready condition when VMI exists", func(setup func(vmi *virtv1.VirtualMachineInstance), status k8sv1.ConditionStatus) {
+		DescribeTable("should add ready condition when VMI exists", func(setup func(vmi *v1.VirtualMachineInstance), status k8sv1.ConditionStatus) {
 			vm, vmi := DefaultVirtualMachine(true)
-			virtcontroller.NewVirtualMachineConditionManager().RemoveCondition(vm, virtv1.VirtualMachineReady)
+			virtcontroller.NewVirtualMachineConditionManager().RemoveCondition(vm, v1.VirtualMachineReady)
 			addVirtualMachine(vm)
 
 			setup(vmi)
 			vmiFeeder.Add(vmi)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
+				objVM := obj.(*v1.VirtualMachine)
 				cond := virtcontroller.NewVirtualMachineConditionManager().
-					GetCondition(objVM, virtv1.VirtualMachineReady)
+					GetCondition(objVM, v1.VirtualMachineReady)
 				Expect(cond).ToNot(BeNil())
 				Expect(cond.Status).To(Equal(status))
 			}).Return(vm, nil)
@@ -2261,30 +2260,30 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should sync VMI conditions", func() {
 			vm, vmi := DefaultVirtualMachine(true)
-			virtcontroller.NewVirtualMachineConditionManager().RemoveCondition(vm, virtv1.VirtualMachineReady)
+			virtcontroller.NewVirtualMachineConditionManager().RemoveCondition(vm, v1.VirtualMachineReady)
 
 			cm := virtcontroller.NewVirtualMachineInstanceConditionManager()
 			cmVM := virtcontroller.NewVirtualMachineConditionManager()
 
-			addCondList := []virtv1.VirtualMachineInstanceConditionType{
-				virtv1.VirtualMachineInstanceProvisioning,
-				virtv1.VirtualMachineInstanceSynchronized,
-				virtv1.VirtualMachineInstancePaused,
+			addCondList := []v1.VirtualMachineInstanceConditionType{
+				v1.VirtualMachineInstanceProvisioning,
+				v1.VirtualMachineInstanceSynchronized,
+				v1.VirtualMachineInstancePaused,
 			}
 
-			removeCondList := []virtv1.VirtualMachineInstanceConditionType{
-				virtv1.VirtualMachineInstanceAgentConnected,
-				virtv1.VirtualMachineInstanceAccessCredentialsSynchronized,
-				virtv1.VirtualMachineInstanceUnsupportedAgent,
+			removeCondList := []v1.VirtualMachineInstanceConditionType{
+				v1.VirtualMachineInstanceAgentConnected,
+				v1.VirtualMachineInstanceAccessCredentialsSynchronized,
+				v1.VirtualMachineInstanceUnsupportedAgent,
 			}
 
-			updateCondList := []virtv1.VirtualMachineInstanceConditionType{
-				virtv1.VirtualMachineInstanceIsMigratable,
+			updateCondList := []v1.VirtualMachineInstanceConditionType{
+				v1.VirtualMachineInstanceIsMigratable,
 			}
 
 			now := metav1.Now()
 			for _, condName := range addCondList {
-				cm.UpdateCondition(vmi, &virtv1.VirtualMachineInstanceCondition{
+				cm.UpdateCondition(vmi, &v1.VirtualMachineInstanceCondition{
 					Type:               condName,
 					Status:             k8score.ConditionTrue,
 					Reason:             "fakereason",
@@ -2296,7 +2295,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			for _, condName := range updateCondList {
 				// Set to true on VMI
-				cm.UpdateCondition(vmi, &virtv1.VirtualMachineInstanceCondition{
+				cm.UpdateCondition(vmi, &v1.VirtualMachineInstanceCondition{
 					Type:               condName,
 					Status:             k8score.ConditionTrue,
 					Reason:             "fakereason",
@@ -2306,8 +2305,8 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				// Set to false on VM, expect sync to update it to true
-				cmVM.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-					Type:               virtv1.VirtualMachineConditionType(condName),
+				cmVM.UpdateCondition(vm, &v1.VirtualMachineCondition{
+					Type:               v1.VirtualMachineConditionType(condName),
 					Status:             k8score.ConditionFalse,
 					Reason:             "fakereason",
 					Message:            "fakemsg",
@@ -2317,8 +2316,8 @@ var _ = Describe("VirtualMachine", func() {
 			}
 
 			for _, condName := range removeCondList {
-				cmVM.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-					Type:               virtv1.VirtualMachineConditionType(condName),
+				cmVM.UpdateCondition(vm, &v1.VirtualMachineCondition{
+					Type:               v1.VirtualMachineConditionType(condName),
 					Status:             k8score.ConditionTrue,
 					Reason:             "fakereason",
 					Message:            "fakemsg",
@@ -2331,21 +2330,21 @@ var _ = Describe("VirtualMachine", func() {
 			vmiFeeder.Add(vmi)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
+				objVM := obj.(*v1.VirtualMachine)
 				// these conditions should be added
 				for _, condName := range addCondList {
-					cond := cmVM.GetCondition(objVM, virtv1.VirtualMachineConditionType(condName))
+					cond := cmVM.GetCondition(objVM, v1.VirtualMachineConditionType(condName))
 					Expect(cond).ToNot(BeNil())
 					Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 				}
 				// these conditions shouldn't exist anymore
 				for _, condName := range removeCondList {
-					cond := cmVM.GetCondition(objVM, virtv1.VirtualMachineConditionType(condName))
+					cond := cmVM.GetCondition(objVM, v1.VirtualMachineConditionType(condName))
 					Expect(cond).To(BeNil())
 				}
 				// these conditsion should be updated
 				for _, condName := range updateCondList {
-					cond := cmVM.GetCondition(objVM, virtv1.VirtualMachineConditionType(condName))
+					cond := cmVM.GetCondition(objVM, v1.VirtualMachineConditionType(condName))
 					Expect(cond).ToNot(BeNil())
 					Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 				}
@@ -2356,13 +2355,13 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should add ready condition when VMI doesn't exists", func() {
 			vm, vmi := DefaultVirtualMachine(true)
-			virtcontroller.NewVirtualMachineConditionManager().RemoveCondition(vm, virtv1.VirtualMachineReady)
+			virtcontroller.NewVirtualMachineConditionManager().RemoveCondition(vm, v1.VirtualMachineReady)
 			addVirtualMachine(vm)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
+				objVM := obj.(*v1.VirtualMachine)
 				cond := virtcontroller.NewVirtualMachineConditionManager().
-					GetCondition(objVM, virtv1.VirtualMachineReady)
+					GetCondition(objVM, v1.VirtualMachineReady)
 				Expect(cond).ToNot(BeNil())
 				Expect(cond.Status).To(Equal(k8sv1.ConditionFalse))
 			}).Return(vm, nil)
@@ -2377,16 +2376,16 @@ var _ = Describe("VirtualMachine", func() {
 			addVirtualMachine(vm)
 
 			markAsReady(vmi)
-			vmi.Status.Conditions = append(vmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
-				Type:   virtv1.VirtualMachineInstancePaused,
+			vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
+				Type:   v1.VirtualMachineInstancePaused,
 				Status: k8sv1.ConditionTrue,
 			})
 			vmiFeeder.Add(vmi)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
+				objVM := obj.(*v1.VirtualMachine)
 				cond := virtcontroller.NewVirtualMachineConditionManager().
-					GetCondition(objVM, virtv1.VirtualMachinePaused)
+					GetCondition(objVM, v1.VirtualMachinePaused)
 				Expect(cond).ToNot(BeNil())
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			}).Return(vm, nil)
@@ -2396,8 +2395,8 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should remove paused condition", func() {
 			vm, vmi := DefaultVirtualMachine(true)
-			vm.Status.Conditions = append(vm.Status.Conditions, virtv1.VirtualMachineCondition{
-				Type:   virtv1.VirtualMachinePaused,
+			vm.Status.Conditions = append(vm.Status.Conditions, v1.VirtualMachineCondition{
+				Type:   v1.VirtualMachinePaused,
 				Status: k8sv1.ConditionTrue,
 			})
 			addVirtualMachine(vm)
@@ -2406,9 +2405,9 @@ var _ = Describe("VirtualMachine", func() {
 			vmiFeeder.Add(vmi)
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
+				objVM := obj.(*v1.VirtualMachine)
 				cond := virtcontroller.NewVirtualMachineConditionManager().
-					GetCondition(objVM, virtv1.VirtualMachinePaused)
+					GetCondition(objVM, v1.VirtualMachinePaused)
 				Expect(cond).To(BeNil())
 			}).Return(vm, nil)
 
@@ -2424,10 +2423,10 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Delete(context.Background(), vmi.ObjectMeta.Name, gomock.Any()).Return(fmt.Errorf("some random failure"))
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				objVM := obj.(*virtv1.VirtualMachine)
-				cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+				objVM := obj.(*v1.VirtualMachine)
+				cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 				Expect(cond).To(Not(BeNil()))
-				Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+				Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 				Expect(cond.Reason).To(Equal("FailedDelete"))
 				Expect(cond.Message).To(ContainSubstring("some random failure"))
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
@@ -2442,13 +2441,13 @@ var _ = Describe("VirtualMachine", func() {
 		It("should copy annotations from spec.template to vmi", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{"test": "test"}
-			annotations := map[string]string{"test": "test", virtv1.VirtualMachineGenerationAnnotation: "0"}
+			annotations := map[string]string{"test": "test", v1.VirtualMachineGenerationAnnotation: "0"}
 
-			vm.Status.PrintableStatus = virtv1.VirtualMachineStatusStarting
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusStarting
 			addVirtualMachine(vm)
 
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
+				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
 			controller.Execute()
@@ -2457,13 +2456,13 @@ var _ = Describe("VirtualMachine", func() {
 		It("should copy kubevirt ignitiondata annotation from spec.template to vmi", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{"kubevirt.io/ignitiondata": "test"}
-			annotations := map[string]string{"kubevirt.io/ignitiondata": "test", virtv1.VirtualMachineGenerationAnnotation: "0"}
+			annotations := map[string]string{"kubevirt.io/ignitiondata": "test", v1.VirtualMachineGenerationAnnotation: "0"}
 
-			vm.Status.PrintableStatus = virtv1.VirtualMachineStatusStarting
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusStarting
 			addVirtualMachine(vm)
 
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
+				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
 			controller.Execute()
@@ -2472,13 +2471,13 @@ var _ = Describe("VirtualMachine", func() {
 		It("should copy kubernetes annotations from spec.template to vmi", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"}
-			annotations := map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true", virtv1.VirtualMachineGenerationAnnotation: "0"}
+			annotations := map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true", v1.VirtualMachineGenerationAnnotation: "0"}
 
-			vm.Status.PrintableStatus = virtv1.VirtualMachineStatusStarting
+			vm.Status.PrintableStatus = v1.VirtualMachineStatusStarting
 			addVirtualMachine(vm)
 
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, obj interface{}) {
-				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
+				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
 			controller.Execute()
@@ -2490,7 +2489,7 @@ var _ = Describe("VirtualMachine", func() {
 				targetFileName = "memory.dump"
 			)
 
-			shouldExpectVMIVolumesAddPatched := func(vmi *virtv1.VirtualMachineInstance) {
+			shouldExpectVMIVolumesAddPatched := func(vmi *v1.VirtualMachineInstance) {
 				test := `{ "op": "test", "path": "/spec/volumes", "value": null}`
 				update := `{ "op": "add", "path": "/spec/volumes", "value": [{"name":"testPVC","memoryDump":{"claimName":"testPVC","hotpluggable":true}}]}`
 				patch := fmt.Sprintf("[%s, %s]", test, update)
@@ -2498,7 +2497,7 @@ var _ = Describe("VirtualMachine", func() {
 				vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 			}
 
-			shouldExpectVMIVolumesRemovePatched := func(vmi *virtv1.VirtualMachineInstance) {
+			shouldExpectVMIVolumesRemovePatched := func(vmi *v1.VirtualMachineInstance) {
 				test := `{ "op": "test", "path": "/spec/volumes", "value": [{"name":"testPVC","memoryDump":{"claimName":"testPVC","hotpluggable":true}}]}`
 				update := `{ "op": "replace", "path": "/spec/volumes", "value": []}`
 				patch := fmt.Sprintf("[%s, %s]", test, update)
@@ -2507,12 +2506,12 @@ var _ = Describe("VirtualMachine", func() {
 				vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 			}
 
-			applyVMIMemoryDumpVol := func(spec *virtv1.VirtualMachineInstanceSpec) *virtv1.VirtualMachineInstanceSpec {
-				newVolume := virtv1.Volume{
+			applyVMIMemoryDumpVol := func(spec *v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec {
+				newVolume := v1.Volume{
 					Name: testPVCName,
-					VolumeSource: virtv1.VolumeSource{
-						MemoryDump: &virtv1.MemoryDumpVolumeSource{
-							PersistentVolumeClaimVolumeSource: virtv1.PersistentVolumeClaimVolumeSource{
+					VolumeSource: v1.VolumeSource{
+						MemoryDump: &v1.MemoryDumpVolumeSource{
+							PersistentVolumeClaimVolumeSource: v1.PersistentVolumeClaimVolumeSource{
 								PersistentVolumeClaimVolumeSource: k8score.PersistentVolumeClaimVolumeSource{
 									ClaimName: testPVCName,
 								},
@@ -2536,7 +2535,7 @@ var _ = Describe("VirtualMachine", func() {
 					pvc, ok := update.GetObject().(*k8sv1.PersistentVolumeClaim)
 					Expect(ok).To(BeTrue())
 					Expect(pvc.Name).To(Equal(testPVCName))
-					Expect(pvc.Annotations[virtv1.PVCMemoryDumpAnnotation]).To(Equal(expectedAnnotation))
+					Expect(pvc.Annotations[v1.PVCMemoryDumpAnnotation]).To(Equal(expectedAnnotation))
 					pvcAnnotationUpdated <- true
 
 					return true, nil, nil
@@ -2547,9 +2546,9 @@ var _ = Describe("VirtualMachine", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 				vm.Status.Created = true
 				vm.Status.Ready = true
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
-					Phase:     virtv1.MemoryDumpAssociating,
+					Phase:     v1.MemoryDumpAssociating,
 				}
 
 				addVirtualMachine(vm)
@@ -2560,7 +2559,7 @@ var _ = Describe("VirtualMachine", func() {
 				shouldExpectVMIVolumesAddPatched(vmi)
 
 				vmInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Spec.Template.Spec.Volumes[0].Name).To(Equal(testPVCName))
+					Expect(arg.(*v1.VirtualMachine).Spec.Template.Spec.Volumes[0].Name).To(Equal(testPVCName))
 				}).Return(vm, nil)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
@@ -2571,9 +2570,9 @@ var _ = Describe("VirtualMachine", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 				vm.Status.Created = true
 				vm.Status.Ready = true
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
-					Phase:     virtv1.MemoryDumpAssociating,
+					Phase:     v1.MemoryDumpAssociating,
 				}
 
 				vm.Spec.Template.Spec = *applyVMIMemoryDumpVol(&vm.Spec.Template.Spec)
@@ -2583,13 +2582,13 @@ var _ = Describe("VirtualMachine", func() {
 				vmiFeeder.Add(vmi)
 
 				// when the memory dump volume is in the vm volume list we should change status to in progress
-				updatedMemoryDump := &virtv1.VirtualMachineMemoryDumpRequest{
+				updatedMemoryDump := &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
-					Phase:     virtv1.MemoryDumpInProgress,
+					Phase:     v1.MemoryDumpInProgress,
 				}
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
+					Expect(arg.(*v1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
 				controller.Execute()
@@ -2599,20 +2598,20 @@ var _ = Describe("VirtualMachine", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 				vm.Status.Created = true
 				vm.Status.Ready = true
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
-					Phase:     virtv1.MemoryDumpInProgress,
+					Phase:     v1.MemoryDumpInProgress,
 				}
 
 				vm.Spec.Template.Spec = *applyVMIMemoryDumpVol(&vm.Spec.Template.Spec)
 				addVirtualMachine(vm)
 				vmi.Spec = vm.Spec.Template.Spec
 				now := metav1.Now()
-				vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+				vmi.Status.VolumeStatus = []v1.VolumeStatus{
 					{
 						Name:  testPVCName,
-						Phase: virtv1.MemoryDumpVolumeCompleted,
-						MemoryDumpVolume: &virtv1.DomainMemoryDumpInfo{
+						Phase: v1.MemoryDumpVolumeCompleted,
+						MemoryDumpVolume: &v1.DomainMemoryDumpInfo{
 							StartTimestamp: &now,
 							EndTimestamp:   &now,
 							ClaimName:      testPVCName,
@@ -2623,16 +2622,16 @@ var _ = Describe("VirtualMachine", func() {
 				markAsReady(vmi)
 				vmiFeeder.Add(vmi)
 
-				updatedMemoryDump := &virtv1.VirtualMachineMemoryDumpRequest{
+				updatedMemoryDump := &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName:      testPVCName,
-					Phase:          virtv1.MemoryDumpUnmounting,
+					Phase:          v1.MemoryDumpUnmounting,
 					EndTimestamp:   &now,
 					StartTimestamp: &now,
 					FileName:       &vmi.Status.VolumeStatus[0].MemoryDumpVolume.TargetFileName,
 				}
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
+					Expect(arg.(*v1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
 				controller.Execute()
@@ -2642,21 +2641,21 @@ var _ = Describe("VirtualMachine", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 				vm.Status.Created = true
 				vm.Status.Ready = true
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
-					Phase:     virtv1.MemoryDumpInProgress,
+					Phase:     v1.MemoryDumpInProgress,
 				}
 
 				vm.Spec.Template.Spec = *applyVMIMemoryDumpVol(&vm.Spec.Template.Spec)
 				addVirtualMachine(vm)
 				vmi.Spec = vm.Spec.Template.Spec
 				now := metav1.Now()
-				vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+				vmi.Status.VolumeStatus = []v1.VolumeStatus{
 					{
 						Name:    testPVCName,
-						Phase:   virtv1.MemoryDumpVolumeFailed,
+						Phase:   v1.MemoryDumpVolumeFailed,
 						Message: "Memory dump failed",
-						MemoryDumpVolume: &virtv1.DomainMemoryDumpInfo{
+						MemoryDumpVolume: &v1.DomainMemoryDumpInfo{
 							ClaimName:    testPVCName,
 							EndTimestamp: &now,
 						},
@@ -2665,29 +2664,29 @@ var _ = Describe("VirtualMachine", func() {
 				markAsReady(vmi)
 				vmiFeeder.Add(vmi)
 
-				updatedMemoryDump := &virtv1.VirtualMachineMemoryDumpRequest{
+				updatedMemoryDump := &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName:    testPVCName,
-					Phase:        virtv1.MemoryDumpFailed,
+					Phase:        v1.MemoryDumpFailed,
 					Message:      vmi.Status.VolumeStatus[0].Message,
 					EndTimestamp: &now,
 				}
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
+					Expect(arg.(*v1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
 				controller.Execute()
 			})
 
-			DescribeTable("should remove memory dump volume from vmi volumes and update pvc annotation", func(phase virtv1.MemoryDumpPhase, expectedAnnotation string) {
+			DescribeTable("should remove memory dump volume from vmi volumes and update pvc annotation", func(phase v1.MemoryDumpPhase, expectedAnnotation string) {
 				vm, vmi := DefaultVirtualMachine(true)
 				vm.Status.Created = true
 				vm.Status.Ready = true
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
 					Phase:     phase,
 				}
-				if phase != virtv1.MemoryDumpFailed {
+				if phase != v1.MemoryDumpFailed {
 					fileName := targetFileName
 					vm.Status.MemoryDumpRequest.FileName = &fileName
 				}
@@ -2695,10 +2694,10 @@ var _ = Describe("VirtualMachine", func() {
 				vm.Spec.Template.Spec = *applyVMIMemoryDumpVol(&vm.Spec.Template.Spec)
 				addVirtualMachine(vm)
 				vmi.Spec = vm.Spec.Template.Spec
-				vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+				vmi.Status.VolumeStatus = []v1.VolumeStatus{
 					{
 						Name: testPVCName,
-						MemoryDumpVolume: &virtv1.DomainMemoryDumpInfo{
+						MemoryDumpVolume: &v1.DomainMemoryDumpInfo{
 							ClaimName: testPVCName,
 						},
 					},
@@ -2729,8 +2728,8 @@ var _ = Describe("VirtualMachine", func() {
 					return false
 				}, 10*time.Second, 2).Should(BeTrue(), "failed, pvc annotation wasn't updated")
 			},
-				Entry("when phase is Unmounting", virtv1.MemoryDumpUnmounting, targetFileName),
-				Entry("when phase is Failed", virtv1.MemoryDumpFailed, "Memory dump failed"),
+				Entry("when phase is Unmounting", v1.MemoryDumpUnmounting, targetFileName),
+				Entry("when phase is Failed", v1.MemoryDumpFailed, "Memory dump failed"),
 			)
 
 			It("should update memory dump to complete once memory dump volume unmounted", func() {
@@ -2738,9 +2737,9 @@ var _ = Describe("VirtualMachine", func() {
 				vm.Status.Created = true
 				vm.Status.Ready = true
 				now := metav1.Now()
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName:    testPVCName,
-					Phase:        virtv1.MemoryDumpUnmounting,
+					Phase:        v1.MemoryDumpUnmounting,
 					EndTimestamp: &now,
 				}
 
@@ -2750,14 +2749,14 @@ var _ = Describe("VirtualMachine", func() {
 				vmiFeeder.Add(vmi)
 
 				// in case the volume is not in vmi volume status we should update status to completed
-				updatedMemoryDump := &virtv1.VirtualMachineMemoryDumpRequest{
+				updatedMemoryDump := &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName:    testPVCName,
-					Phase:        virtv1.MemoryDumpCompleted,
+					Phase:        v1.MemoryDumpCompleted,
 					EndTimestamp: &now,
 				}
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
+					Expect(arg.(*v1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
 				controller.Execute()
@@ -2766,16 +2765,16 @@ var _ = Describe("VirtualMachine", func() {
 			It("should remove memory dump volume from vm volumes list when status is Dissociating", func() {
 				// No need to add vmi - can do this action even if vm not running
 				vm, _ := DefaultVirtualMachine(false)
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
-					Phase:     virtv1.MemoryDumpDissociating,
+					Phase:     v1.MemoryDumpDissociating,
 				}
 
 				vm.Spec.Template.Spec = *applyVMIMemoryDumpVol(&vm.Spec.Template.Spec)
 				addVirtualMachine(vm)
 
 				vmInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Spec.Template.Spec.Volumes).To(BeEmpty())
+					Expect(arg.(*v1.VirtualMachine).Spec.Template.Spec.Volumes).To(BeEmpty())
 				}).Return(vm, nil)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
@@ -2785,24 +2784,24 @@ var _ = Describe("VirtualMachine", func() {
 			It("should dissociate memory dump request when status is Dissociating and not in vm volumes", func() {
 				// No need to add vmi - can do this action even if vm not running
 				vm, _ := DefaultVirtualMachine(false)
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
-					Phase:     virtv1.MemoryDumpDissociating,
+					Phase:     v1.MemoryDumpDissociating,
 				}
 
 				addVirtualMachine(vm)
 
 				// in case the volume is not in vm volumes we should remove memory dump request
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(BeNil())
+					Expect(arg.(*v1.VirtualMachine).Status.MemoryDumpRequest).To(BeNil())
 				}).Return(nil, nil)
 
 				controller.Execute()
 			})
 
-			DescribeTable("should not setup vmi with memory dump if memory dump", func(phase virtv1.MemoryDumpPhase) {
+			DescribeTable("should not setup vmi with memory dump if memory dump", func(phase v1.MemoryDumpPhase) {
 				vm, _ := DefaultVirtualMachine(true)
-				vm.Status.MemoryDumpRequest = &virtv1.VirtualMachineMemoryDumpRequest{
+				vm.Status.MemoryDumpRequest = &v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
 					Phase:     phase,
 				}
@@ -2811,9 +2810,9 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(vmi.Spec.Volumes).To(BeEmpty())
 
 			},
-				Entry("in phase Unmounting", virtv1.MemoryDumpUnmounting),
-				Entry("in phase Completed", virtv1.MemoryDumpCompleted),
-				Entry("in phase Dissociating", virtv1.MemoryDumpDissociating),
+				Entry("in phase Unmounting", v1.MemoryDumpUnmounting),
+				Entry("in phase Completed", v1.MemoryDumpCompleted),
+				Entry("in phase Dissociating", v1.MemoryDumpDissociating),
 			)
 
 		})
@@ -2825,20 +2824,20 @@ var _ = Describe("VirtualMachine", func() {
 				addVirtualMachine(vm)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStopped))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusStopped))
 				})
 
 				controller.Execute()
 			})
 
-			DescribeTable("should set a Stopped status when VMI exists but stopped", func(phase virtv1.VirtualMachineInstancePhase, deletionTimestamp *metav1.Time) {
+			DescribeTable("should set a Stopped status when VMI exists but stopped", func(phase v1.VirtualMachineInstancePhase, deletionTimestamp *metav1.Time) {
 				vm, vmi := DefaultVirtualMachine(true)
 
 				vmi.Status.Phase = phase
-				vmi.Status.PhaseTransitionTimestamps = []virtv1.VirtualMachineInstancePhaseTransitionTimestamp{
+				vmi.Status.PhaseTransitionTimestamps = []v1.VirtualMachineInstancePhaseTransitionTimestamp{
 					{
-						Phase:                    virtv1.Running,
+						Phase:                    v1.Running,
 						PhaseTransitionTimestamp: metav1.Now(),
 					},
 				}
@@ -2849,8 +2848,8 @@ var _ = Describe("VirtualMachine", func() {
 
 				vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).AnyTimes()
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStopped))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusStopped))
 				})
 
 				shouldExpectVMIFinalizerRemoval(vmi)
@@ -2858,10 +2857,10 @@ var _ = Describe("VirtualMachine", func() {
 				controller.Execute()
 			},
 
-				Entry("in Succeeded state", virtv1.Succeeded, nil),
-				Entry("in Succeeded state with a deletionTimestamp", virtv1.Succeeded, &metav1.Time{Time: time.Now()}),
-				Entry("in Failed state", virtv1.Failed, nil),
-				Entry("in Failed state with a deletionTimestamp", virtv1.Failed, &metav1.Time{Time: time.Now()}),
+				Entry("in Succeeded state", v1.Succeeded, nil),
+				Entry("in Succeeded state with a deletionTimestamp", v1.Succeeded, &metav1.Time{Time: time.Now()}),
+				Entry("in Failed state", v1.Failed, nil),
+				Entry("in Failed state with a deletionTimestamp", v1.Failed, &metav1.Time{Time: time.Now()}),
 			)
 
 			It("Should set a Starting status when running=true and VMI doesn't exist", func() {
@@ -2871,14 +2870,14 @@ var _ = Describe("VirtualMachine", func() {
 				vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Return(vmi, nil)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStarting))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusStarting))
 				})
 
 				controller.Execute()
 			})
 
-			DescribeTable("Should set a Starting status when VMI is in a startup phase", func(phase virtv1.VirtualMachineInstancePhase) {
+			DescribeTable("Should set a Starting status when VMI is in a startup phase", func(phase v1.VirtualMachineInstancePhase) {
 				vm, vmi := DefaultVirtualMachine(true)
 
 				vmi.Status.Phase = phase
@@ -2887,20 +2886,20 @@ var _ = Describe("VirtualMachine", func() {
 				vmiFeeder.Add(vmi)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStarting))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusStarting))
 				})
 
 				controller.Execute()
 			},
 
-				Entry("VMI has no phase set", virtv1.VmPhaseUnset),
-				Entry("VMI is in Pending phase", virtv1.Pending),
-				Entry("VMI is in Scheduling phase", virtv1.Scheduling),
-				Entry("VMI is in Scheduled phase", virtv1.Scheduled),
+				Entry("VMI has no phase set", v1.VmPhaseUnset),
+				Entry("VMI is in Pending phase", v1.Pending),
+				Entry("VMI is in Scheduling phase", v1.Scheduling),
+				Entry("VMI is in Scheduled phase", v1.Scheduled),
 			)
 
-			DescribeTable("Should set a CrashLoop status when VMI is deleted and VM is in crash loop backoff", func(status virtv1.VirtualMachineStatus, runStrategy virtv1.VirtualMachineRunStrategy, hasVMI bool, expectCrashloop bool) {
+			DescribeTable("Should set a CrashLoop status when VMI is deleted and VM is in crash loop backoff", func(status v1.VirtualMachineStatus, runStrategy v1.VirtualMachineRunStrategy, hasVMI bool, expectCrashloop bool) {
 				vm, vmi := DefaultVirtualMachine(true)
 				vm.Spec.Running = nil
 				vm.Spec.RunStrategy = &runStrategy
@@ -2908,16 +2907,16 @@ var _ = Describe("VirtualMachine", func() {
 
 				addVirtualMachine(vm)
 				if hasVMI {
-					vmi.Status.Phase = virtv1.Running
+					vmi.Status.Phase = v1.Running
 					vmiFeeder.Add(vmi)
 				}
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
+					objVM := obj.(*v1.VirtualMachine)
 					if expectCrashloop {
-						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusCrashLoopBackOff))
+						Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusCrashLoopBackOff))
 					} else {
-						Expect(objVM.Status.PrintableStatus).ToNot(Equal(virtv1.VirtualMachineStatusCrashLoopBackOff))
+						Expect(objVM.Status.PrintableStatus).ToNot(Equal(v1.VirtualMachineStatusCrashLoopBackOff))
 					}
 				})
 
@@ -2925,94 +2924,94 @@ var _ = Describe("VirtualMachine", func() {
 			},
 
 				Entry("vm with runStrategy always and crash loop",
-					virtv1.VirtualMachineStatus{
-						StartFailure: &virtv1.VirtualMachineStartFailure{
+					v1.VirtualMachineStatus{
+						StartFailure: &v1.VirtualMachineStartFailure{
 							ConsecutiveFailCount: 1,
 							RetryAfterTimestamp: &metav1.Time{
 								Time: time.Now().Add(300 * time.Second),
 							},
 						},
 					},
-					virtv1.RunStrategyAlways,
+					v1.RunStrategyAlways,
 					false,
 					true),
 				Entry("vm with runStrategy rerun on failure and crash loop",
-					virtv1.VirtualMachineStatus{
-						StartFailure: &virtv1.VirtualMachineStartFailure{
+					v1.VirtualMachineStatus{
+						StartFailure: &v1.VirtualMachineStartFailure{
 							ConsecutiveFailCount: 1,
 							RetryAfterTimestamp: &metav1.Time{
 								Time: time.Now().Add(300 * time.Second),
 							},
 						},
 					},
-					virtv1.RunStrategyRerunOnFailure,
+					v1.RunStrategyRerunOnFailure,
 					false,
 					true),
 				Entry("vm with runStrategy halt should not report crash loop",
-					virtv1.VirtualMachineStatus{
-						StartFailure: &virtv1.VirtualMachineStartFailure{
+					v1.VirtualMachineStatus{
+						StartFailure: &v1.VirtualMachineStartFailure{
 							ConsecutiveFailCount: 1,
 							RetryAfterTimestamp: &metav1.Time{
 								Time: time.Now().Add(300 * time.Second),
 							},
 						},
 					},
-					virtv1.RunStrategyHalted,
+					v1.RunStrategyHalted,
 					false,
 					false),
 				Entry("vm with runStrategy manual should not report crash loop",
-					virtv1.VirtualMachineStatus{
-						StartFailure: &virtv1.VirtualMachineStartFailure{
+					v1.VirtualMachineStatus{
+						StartFailure: &v1.VirtualMachineStartFailure{
 							ConsecutiveFailCount: 1,
 							RetryAfterTimestamp: &metav1.Time{
 								Time: time.Now().Add(300 * time.Second),
 							},
 						},
 					},
-					virtv1.RunStrategyManual,
+					v1.RunStrategyManual,
 					false,
 					false),
 				Entry("vm with runStrategy once should not report crash loop",
-					virtv1.VirtualMachineStatus{
-						StartFailure: &virtv1.VirtualMachineStartFailure{
+					v1.VirtualMachineStatus{
+						StartFailure: &v1.VirtualMachineStartFailure{
 							ConsecutiveFailCount: 1,
 							RetryAfterTimestamp: &metav1.Time{
 								Time: time.Now().Add(300 * time.Second),
 							},
 						},
 					},
-					virtv1.RunStrategyOnce,
+					v1.RunStrategyOnce,
 					true,
 					false),
 				Entry("vm with runStrategy always and VMI still exists should not report crash loop",
-					virtv1.VirtualMachineStatus{
-						StartFailure: &virtv1.VirtualMachineStartFailure{
+					v1.VirtualMachineStatus{
+						StartFailure: &v1.VirtualMachineStartFailure{
 							ConsecutiveFailCount: 1,
 							RetryAfterTimestamp: &metav1.Time{
 								Time: time.Now().Add(300 * time.Second),
 							},
 						},
 					},
-					virtv1.RunStrategyAlways,
+					v1.RunStrategyAlways,
 					true,
 					false),
 			)
 			Context("VM with DataVolumes", func() {
-				var vm *virtv1.VirtualMachine
-				var vmi *virtv1.VirtualMachineInstance
+				var vm *v1.VirtualMachine
+				var vmi *v1.VirtualMachineInstance
 
 				BeforeEach(func() {
 					vm, vmi = DefaultVirtualMachine(true)
-					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 						Name: "test1",
-						VolumeSource: virtv1.VolumeSource{
-							DataVolume: &virtv1.DataVolumeSource{
+						VolumeSource: v1.VolumeSource{
+							DataVolume: &v1.DataVolumeSource{
 								Name: "dv1",
 							},
 						},
 					})
 
-					vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+					vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "dv1",
 							Namespace: vm.Namespace,
@@ -3020,7 +3019,7 @@ var _ = Describe("VirtualMachine", func() {
 					})
 				})
 
-				DescribeTable("Should set a appropriate status when DataVolume exists but not bound", func(running bool, phase cdiv1.DataVolumePhase, status virtv1.VirtualMachinePrintableStatus) {
+				DescribeTable("Should set a appropriate status when DataVolume exists but not bound", func(running bool, phase cdiv1.DataVolumePhase, status v1.VirtualMachinePrintableStatus) {
 					vm.Spec.Running = &running
 					addVirtualMachine(vm)
 
@@ -3040,7 +3039,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(pvcInformer.GetStore().Add(&pvc)).To(Succeed())
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
+						objVM := obj.(*v1.VirtualMachine)
 						Expect(objVM.Status.PrintableStatus).To(Equal(status))
 					})
 
@@ -3050,10 +3049,10 @@ var _ = Describe("VirtualMachine", func() {
 
 					controller.Execute()
 				},
-					Entry("Started VM PendingPopulation", true, cdiv1.PendingPopulation, virtv1.VirtualMachineStatusWaitingForVolumeBinding),
-					Entry("Started VM WFFC", true, cdiv1.WaitForFirstConsumer, virtv1.VirtualMachineStatusWaitingForVolumeBinding),
-					Entry("Stopped VM PendingPopulation", false, cdiv1.PendingPopulation, virtv1.VirtualMachineStatusStopped),
-					Entry("Stopped VM", false, cdiv1.WaitForFirstConsumer, virtv1.VirtualMachineStatusStopped),
+					Entry("Started VM PendingPopulation", true, cdiv1.PendingPopulation, v1.VirtualMachineStatusWaitingForVolumeBinding),
+					Entry("Started VM WFFC", true, cdiv1.WaitForFirstConsumer, v1.VirtualMachineStatusWaitingForVolumeBinding),
+					Entry("Stopped VM PendingPopulation", false, cdiv1.PendingPopulation, v1.VirtualMachineStatusStopped),
+					Entry("Stopped VM", false, cdiv1.WaitForFirstConsumer, v1.VirtualMachineStatusStopped),
 				)
 
 				DescribeTable("Should set a Provisioning status when DataVolume bound but not ready",
@@ -3072,8 +3071,8 @@ var _ = Describe("VirtualMachine", func() {
 							vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Return(vmi, nil)
 						}
 						vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-							objVM := obj.(*virtv1.VirtualMachine)
-							Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
+							objVM := obj.(*v1.VirtualMachine)
+							Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusProvisioning))
 						})
 
 						controller.Execute()
@@ -3092,8 +3091,8 @@ var _ = Describe("VirtualMachine", func() {
 					dataVolumeFeeder.Add(dv)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusDataVolumeError))
+						objVM := obj.(*v1.VirtualMachine)
+						Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusDataVolumeError))
 					})
 
 					controller.Execute()
@@ -3118,7 +3117,7 @@ var _ = Describe("VirtualMachine", func() {
 				)
 
 				It("Should clear a DataVolumeError status when the DataVolume error is gone", func() {
-					vm.Status.PrintableStatus = virtv1.VirtualMachineStatusDataVolumeError
+					vm.Status.PrintableStatus = v1.VirtualMachineStatusDataVolumeError
 					addVirtualMachine(vm)
 
 					dv, _ := watchutil.CreateDataVolumeManifest(virtClient, vm.Spec.DataVolumeTemplates[0], vm)
@@ -3130,24 +3129,24 @@ var _ = Describe("VirtualMachine", func() {
 					dataVolumeFeeder.Add(dv)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
+						objVM := obj.(*v1.VirtualMachine)
+						Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusProvisioning))
 					})
 
 					controller.Execute()
 				})
 
 				It("Should set a Provisioning status when one DataVolume is ready and another isn't", func() {
-					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 						Name: "test2",
-						VolumeSource: virtv1.VolumeSource{
-							DataVolume: &virtv1.DataVolumeSource{
+						VolumeSource: v1.VolumeSource{
+							DataVolume: &v1.DataVolumeSource{
 								Name: "dv2",
 							},
 						},
 					})
 
-					vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, virtv1.DataVolumeTemplateSpec{
+					vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "dv2",
 							Namespace: vm.Namespace,
@@ -3173,8 +3172,8 @@ var _ = Describe("VirtualMachine", func() {
 					dataVolumeFeeder.Add(dv2)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
+						objVM := obj.(*v1.VirtualMachine)
+						Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusProvisioning))
 					})
 
 					controller.Execute()
@@ -3182,15 +3181,15 @@ var _ = Describe("VirtualMachine", func() {
 			})
 
 			Context("VM with PersistentVolumeClaims", func() {
-				var vm *virtv1.VirtualMachine
-				var vmi *virtv1.VirtualMachineInstance
+				var vm *v1.VirtualMachine
+				var vmi *v1.VirtualMachineInstance
 
 				BeforeEach(func() {
 					vm, vmi = DefaultVirtualMachine(true)
-					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 						Name: "test1",
-						VolumeSource: virtv1.VolumeSource{
-							PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 								ClaimName: "pvc1",
 							}},
 						},
@@ -3214,8 +3213,8 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(pvcInformer.GetStore().Add(&pvc)).To(Succeed())
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusWaitingForVolumeBinding))
+						objVM := obj.(*v1.VirtualMachine)
+						Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusWaitingForVolumeBinding))
 					})
 
 					controller.Execute()
@@ -3230,14 +3229,14 @@ var _ = Describe("VirtualMachine", func() {
 			It("should set a Running status when VMI is running but not paused", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 
-				vmi.Status.Phase = virtv1.Running
+				vmi.Status.Phase = v1.Running
 
 				addVirtualMachine(vm)
 				vmiFeeder.Add(vmi)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusRunning))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusRunning))
 				})
 
 				controller.Execute()
@@ -3246,9 +3245,9 @@ var _ = Describe("VirtualMachine", func() {
 			It("should set a Paused status when VMI is running but is paused", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 
-				vmi.Status.Phase = virtv1.Running
-				vmi.Status.Conditions = append(vmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
-					Type:   virtv1.VirtualMachineInstancePaused,
+				vmi.Status.Phase = v1.Running
+				vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
+					Type:   v1.VirtualMachineInstancePaused,
 					Status: k8sv1.ConditionTrue,
 				})
 
@@ -3256,21 +3255,21 @@ var _ = Describe("VirtualMachine", func() {
 				vmiFeeder.Add(vmi)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusPaused))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusPaused))
 				})
 
 				controller.Execute()
 			})
 
-			DescribeTable("should set a Stopping status when VMI has a deletion timestamp set", func(phase virtv1.VirtualMachineInstancePhase, condType virtv1.VirtualMachineInstanceConditionType) {
+			DescribeTable("should set a Stopping status when VMI has a deletion timestamp set", func(phase v1.VirtualMachineInstancePhase, condType v1.VirtualMachineInstanceConditionType) {
 				vm, vmi := DefaultVirtualMachine(true)
 
 				vmi.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 				vmi.Status.Phase = phase
 
 				if condType != "" {
-					vmi.Status.Conditions = append(vmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
+					vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
 						Type:   condType,
 						Status: k8sv1.ConditionTrue,
 					})
@@ -3279,23 +3278,23 @@ var _ = Describe("VirtualMachine", func() {
 				vmiFeeder.Add(vmi)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStopping))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusStopping))
 				})
 
 				controller.Execute()
 			},
 
-				Entry("when VMI is pending", virtv1.Pending, virtv1.VirtualMachineInstanceConditionType("")),
-				Entry("when VMI is provisioning", virtv1.Pending, virtv1.VirtualMachineInstanceProvisioning),
-				Entry("when VMI is scheduling", virtv1.Scheduling, virtv1.VirtualMachineInstanceConditionType("")),
-				Entry("when VMI is scheduled", virtv1.Scheduling, virtv1.VirtualMachineInstanceConditionType("")),
-				Entry("when VMI is running", virtv1.Running, virtv1.VirtualMachineInstanceConditionType("")),
-				Entry("when VMI is paused", virtv1.Running, virtv1.VirtualMachineInstancePaused),
+				Entry("when VMI is pending", v1.Pending, v1.VirtualMachineInstanceConditionType("")),
+				Entry("when VMI is provisioning", v1.Pending, v1.VirtualMachineInstanceProvisioning),
+				Entry("when VMI is scheduling", v1.Scheduling, v1.VirtualMachineInstanceConditionType("")),
+				Entry("when VMI is scheduled", v1.Scheduling, v1.VirtualMachineInstanceConditionType("")),
+				Entry("when VMI is running", v1.Running, v1.VirtualMachineInstanceConditionType("")),
+				Entry("when VMI is paused", v1.Running, v1.VirtualMachineInstancePaused),
 			)
 
 			Context("should set a Terminating status when VM has a deletion timestamp set", func() {
-				DescribeTable("when VMI exists", func(phase virtv1.VirtualMachineInstancePhase, condType virtv1.VirtualMachineInstanceConditionType) {
+				DescribeTable("when VMI exists", func(phase v1.VirtualMachineInstancePhase, condType v1.VirtualMachineInstanceConditionType) {
 					vm, vmi := DefaultVirtualMachine(true)
 
 					vm.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
@@ -3303,7 +3302,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmi.Status.Phase = phase
 
 					if condType != "" {
-						vmi.Status.Conditions = append(vmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
+						vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
 							Type:   condType,
 							Status: k8sv1.ConditionTrue,
 						})
@@ -3314,19 +3313,19 @@ var _ = Describe("VirtualMachine", func() {
 					shouldExpectGracePeriodPatched(v1.DefaultGracePeriodSeconds, vmi)
 					vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).AnyTimes()
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
+						objVM := obj.(*v1.VirtualMachine)
+						Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusTerminating))
 					})
 
 					controller.Execute()
 				},
 
-					Entry("when VMI is pending", virtv1.Pending, virtv1.VirtualMachineInstanceConditionType("")),
-					Entry("when VMI is provisioning", virtv1.Pending, virtv1.VirtualMachineInstanceProvisioning),
-					Entry("when VMI is scheduling", virtv1.Scheduling, virtv1.VirtualMachineInstanceConditionType("")),
-					Entry("when VMI is scheduled", virtv1.Scheduling, virtv1.VirtualMachineInstanceConditionType("")),
-					Entry("when VMI is running", virtv1.Running, virtv1.VirtualMachineInstanceConditionType("")),
-					Entry("when VMI is paused", virtv1.Running, virtv1.VirtualMachineInstancePaused),
+					Entry("when VMI is pending", v1.Pending, v1.VirtualMachineInstanceConditionType("")),
+					Entry("when VMI is provisioning", v1.Pending, v1.VirtualMachineInstanceProvisioning),
+					Entry("when VMI is scheduling", v1.Scheduling, v1.VirtualMachineInstanceConditionType("")),
+					Entry("when VMI is scheduled", v1.Scheduling, v1.VirtualMachineInstanceConditionType("")),
+					Entry("when VMI is running", v1.Running, v1.VirtualMachineInstanceConditionType("")),
+					Entry("when VMI is paused", v1.Running, v1.VirtualMachineInstancePaused),
 				)
 
 				It("when VMI exists and has a deletion timestamp set", func() {
@@ -3334,14 +3333,14 @@ var _ = Describe("VirtualMachine", func() {
 
 					vm.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 					vmi.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-					vmi.Status.Phase = virtv1.Running
+					vmi.Status.Phase = v1.Running
 
 					addVirtualMachine(vm)
 					vmiFeeder.Add(vmi)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
+						objVM := obj.(*v1.VirtualMachine)
+						Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusTerminating))
 					})
 
 					controller.Execute()
@@ -3356,8 +3355,8 @@ var _ = Describe("VirtualMachine", func() {
 
 					shouldExpectVMFinalizerRemoval(vm)
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
+						objVM := obj.(*v1.VirtualMachine)
+						Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusTerminating))
 					})
 
 					controller.Execute()
@@ -3371,8 +3370,8 @@ var _ = Describe("VirtualMachine", func() {
 			It("should set a Migrating status when VMI is migrating", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 
-				vmi.Status.Phase = virtv1.Running
-				vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				vmi.Status.Phase = v1.Running
+				vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 					StartTimestamp: &metav1.Time{Time: time.Now()},
 				}
 
@@ -3380,8 +3379,8 @@ var _ = Describe("VirtualMachine", func() {
 				vmiFeeder.Add(vmi)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusMigrating))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusMigrating))
 				})
 
 				controller.Execute()
@@ -3390,47 +3389,47 @@ var _ = Describe("VirtualMachine", func() {
 			It("should set an Unknown status when VMI is in unknown phase", func() {
 				vm, vmi := DefaultVirtualMachine(true)
 
-				vmi.Status.Phase = virtv1.Unknown
+				vmi.Status.Phase = v1.Unknown
 
 				addVirtualMachine(vm)
 				vmiFeeder.Add(vmi)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusUnknown))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusUnknown))
 				})
 
 				controller.Execute()
 			})
 
 			DescribeTable("should set a failure status in accordance to VMI condition",
-				func(status virtv1.VirtualMachinePrintableStatus, cond virtv1.VirtualMachineInstanceCondition) {
+				func(status v1.VirtualMachinePrintableStatus, cond v1.VirtualMachineInstanceCondition) {
 
 					vm, vmi := DefaultVirtualMachine(true)
-					vmi.Status.Phase = virtv1.Scheduling
+					vmi.Status.Phase = v1.Scheduling
 					vmi.Status.Conditions = append(vmi.Status.Conditions, cond)
 
 					addVirtualMachine(vm)
 					vmiFeeder.Add(vmi)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
+						objVM := obj.(*v1.VirtualMachine)
 						Expect(objVM.Status.PrintableStatus).To(Equal(status))
 					})
 
 					controller.Execute()
 				},
 
-				Entry("FailedUnschedulable", virtv1.VirtualMachineStatusUnschedulable,
-					virtv1.VirtualMachineInstanceCondition{
-						Type:   virtv1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled),
+				Entry("FailedUnschedulable", v1.VirtualMachineStatusUnschedulable,
+					v1.VirtualMachineInstanceCondition{
+						Type:   v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled),
 						Status: k8sv1.ConditionFalse,
 						Reason: k8sv1.PodReasonUnschedulable,
 					},
 				),
-				Entry("FailedPvcNotFound", virtv1.VirtualMachineStatusPvcNotFound,
-					virtv1.VirtualMachineInstanceCondition{
-						Type:   virtv1.VirtualMachineInstanceSynchronized,
+				Entry("FailedPvcNotFound", v1.VirtualMachineStatusPvcNotFound,
+					v1.VirtualMachineInstanceCondition{
+						Type:   v1.VirtualMachineInstanceSynchronized,
 						Status: k8sv1.ConditionFalse,
 						Reason: FailedPvcNotFoundReason,
 					},
@@ -3439,10 +3438,10 @@ var _ = Describe("VirtualMachine", func() {
 
 			DescribeTable("should set an ImagePullBackOff/ErrPullImage statuses according to VMI Synchronized condition", func(reason string) {
 				vm, vmi := DefaultVirtualMachine(true)
-				vmi.Status.Phase = virtv1.Scheduling
-				vmi.Status.Conditions = []virtv1.VirtualMachineInstanceCondition{
+				vmi.Status.Phase = v1.Scheduling
+				vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 					{
-						Type:   virtv1.VirtualMachineInstanceSynchronized,
+						Type:   v1.VirtualMachineInstanceSynchronized,
 						Status: k8sv1.ConditionFalse,
 						Reason: reason,
 					},
@@ -3452,8 +3451,8 @@ var _ = Describe("VirtualMachine", func() {
 				vmiFeeder.Add(vmi)
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-					objVM := obj.(*virtv1.VirtualMachine)
-					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachinePrintableStatus(reason)))
+					objVM := obj.(*v1.VirtualMachine)
+					Expect(objVM.Status.PrintableStatus).To(Equal(v1.VirtualMachinePrintableStatus(reason)))
 				})
 
 				controller.Execute()
@@ -3469,8 +3468,8 @@ var _ = Describe("VirtualMachine", func() {
 			const resourceGeneration int64 = 1
 
 			var (
-				vm  *virtv1.VirtualMachine
-				vmi *virtv1.VirtualMachineInstance
+				vm  *v1.VirtualMachine
+				vmi *v1.VirtualMachineInstance
 
 				fakeInstancetypeClients       instancetypeclientset.InstancetypeV1beta1Interface
 				fakeInstancetypeClient        instancetypeclientset.VirtualMachineInstancetypeInterface
@@ -3600,7 +3599,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.CPU.Sockets).To(Equal(instancetypeObj.Spec.CPU.Guest))
 						Expect(*vmiArg.Spec.Domain.Memory.Guest).To(Equal(instancetypeObj.Spec.Memory.Guest))
 						Expect(vmiArg.Annotations).To(HaveKeyWithValue(v1.InstancetypeAnnotation, instancetypeObj.Name))
@@ -3644,7 +3643,7 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.CPU.Sockets).To(Equal(instancetypeObj.Spec.CPU.Guest))
 						Expect(*vmiArg.Spec.Domain.Memory.Guest).To(Equal(instancetypeObj.Spec.Memory.Guest))
 						Expect(vmiArg.Annotations).To(HaveKeyWithValue(v1.InstancetypeAnnotation, instancetypeObj.Name))
@@ -3777,7 +3776,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.CPU.Sockets).To(Equal(instancetypeObj.Spec.CPU.Guest))
 						Expect(*vmiArg.Spec.Domain.Memory.Guest).To(Equal(instancetypeObj.Spec.Memory.Guest))
 						Expect(vmiArg.Annotations).To(HaveKeyWithValue(v1.InstancetypeAnnotation, instancetypeObj.Name))
@@ -3812,7 +3811,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.CPU.Sockets).To(Equal(clusterInstancetypeObj.Spec.CPU.Guest))
 						Expect(*vmiArg.Spec.Domain.Memory.Guest).To(Equal(clusterInstancetypeObj.Spec.Memory.Guest))
 						Expect(vmiArg.Annotations).To(HaveKeyWithValue(v1.ClusterInstancetypeAnnotation, clusterInstancetypeObj.Name))
@@ -3850,7 +3849,7 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.CPU.Sockets).To(Equal(clusterInstancetypeObj.Spec.CPU.Guest))
 						Expect(*vmiArg.Spec.Domain.Memory.Guest).To(Equal(clusterInstancetypeObj.Spec.Memory.Guest))
 						Expect(vmiArg.Annotations).To(HaveKeyWithValue(v1.ClusterInstancetypeAnnotation, clusterInstancetypeObj.Name))
@@ -3886,7 +3885,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.CPU.Sockets).To(Equal(clusterInstancetypeObj.Spec.CPU.Guest))
 						Expect(*vmiArg.Spec.Domain.Memory.Guest).To(Equal(clusterInstancetypeObj.Spec.Memory.Guest))
 						Expect(vmiArg.Annotations).To(HaveKeyWithValue(v1.ClusterInstancetypeAnnotation, clusterInstancetypeObj.Name))
@@ -3913,10 +3912,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 						Expect(cond.Message).To(ContainSubstring("got unexpected kind in InstancetypeMatcher"))
 					}).Return(vm, nil)
@@ -3937,10 +3936,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
@@ -3960,10 +3959,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
@@ -3989,10 +3988,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 						Expect(cond.Message).To(ContainSubstring("Error encountered while storing Instancetype ControllerRevisions: VM field conflicts with selected Instancetype"))
 						Expect(cond.Message).To(ContainSubstring("spec.template.spec.domain.cpu"))
@@ -4021,10 +4020,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 						Expect(cond.Message).To(ContainSubstring("found existing ControllerRevision with unexpected data"))
 					}).Return(vm, nil)
@@ -4048,10 +4047,10 @@ var _ = Describe("VirtualMachine", func() {
 							PreferredUseEfi: pointer.Bool(true),
 						},
 						Devices: &instancetypev1beta1.DevicePreferences{
-							PreferredDiskBus:        virtv1.DiskBusVirtio,
+							PreferredDiskBus:        v1.DiskBusVirtio,
 							PreferredInterfaceModel: "virtio",
-							PreferredInputBus:       virtv1.InputBusUSB,
-							PreferredInputType:      virtv1.InputTypeTablet,
+							PreferredInputBus:       v1.InputBusUSB,
+							PreferredInputType:      v1.InputTypeTablet,
 						},
 					}
 					preference = &instancetypev1beta1.VirtualMachinePreference{
@@ -4107,7 +4106,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Firmware.Bootloader.EFI).ToNot(BeNil())
 
 						Expect(vmiArg.Annotations).ToNot(HaveKey(v1.InstancetypeAnnotation))
@@ -4150,7 +4149,7 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Firmware.Bootloader.EFI).ToNot(BeNil())
 
 						Expect(vmiArg.Annotations).ToNot(HaveKey(v1.InstancetypeAnnotation))
@@ -4170,10 +4169,10 @@ var _ = Describe("VirtualMachine", func() {
 								PreferredUseEfi: pointer.Bool(true),
 							},
 							Devices: &instancetypev1alpha1.DevicePreferences{
-								PreferredDiskBus:        virtv1.DiskBusVirtio,
+								PreferredDiskBus:        v1.DiskBusVirtio,
 								PreferredInterfaceModel: "virtio",
-								PreferredInputBus:       virtv1.InputBusUSB,
-								PreferredInputType:      virtv1.InputTypeTablet,
+								PreferredInputBus:       v1.InputBusUSB,
+								PreferredInputType:      v1.InputTypeTablet,
 							},
 						}
 
@@ -4195,10 +4194,10 @@ var _ = Describe("VirtualMachine", func() {
 								PreferredUseEfi: pointer.Bool(true),
 							},
 							Devices: &instancetypev1alpha1.DevicePreferences{
-								PreferredDiskBus:        virtv1.DiskBusVirtio,
+								PreferredDiskBus:        v1.DiskBusVirtio,
 								PreferredInterfaceModel: "virtio",
-								PreferredInputBus:       virtv1.InputBusUSB,
-								PreferredInputType:      virtv1.InputTypeTablet,
+								PreferredInputBus:       v1.InputBusUSB,
+								PreferredInputType:      v1.InputTypeTablet,
 							},
 						}
 
@@ -4228,10 +4227,10 @@ var _ = Describe("VirtualMachine", func() {
 									PreferredUseEfi: pointer.Bool(true),
 								},
 								Devices: &instancetypev1alpha1.DevicePreferences{
-									PreferredDiskBus:        virtv1.DiskBusVirtio,
+									PreferredDiskBus:        v1.DiskBusVirtio,
 									PreferredInterfaceModel: "virtio",
-									PreferredInputBus:       virtv1.InputBusUSB,
-									PreferredInputType:      virtv1.InputTypeTablet,
+									PreferredInputBus:       v1.InputBusUSB,
+									PreferredInputType:      v1.InputTypeTablet,
 								},
 							},
 						}
@@ -4254,10 +4253,10 @@ var _ = Describe("VirtualMachine", func() {
 									PreferredUseEfi: pointer.Bool(true),
 								},
 								Devices: &instancetypev1alpha2.DevicePreferences{
-									PreferredDiskBus:        virtv1.DiskBusVirtio,
+									PreferredDiskBus:        v1.DiskBusVirtio,
 									PreferredInterfaceModel: "virtio",
-									PreferredInputBus:       virtv1.InputBusUSB,
-									PreferredInputType:      virtv1.InputTypeTablet,
+									PreferredInputBus:       v1.InputBusUSB,
+									PreferredInputType:      v1.InputTypeTablet,
 								},
 							},
 						}
@@ -4295,7 +4294,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Firmware.Bootloader.EFI).ToNot(BeNil())
 
 						Expect(vmiArg.Annotations).ToNot(HaveKey(v1.InstancetypeAnnotation))
@@ -4331,7 +4330,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Firmware.Bootloader.EFI).ToNot(BeNil())
 
 						Expect(vmiArg.Annotations).ToNot(HaveKey(v1.InstancetypeAnnotation))
@@ -4369,7 +4368,7 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Firmware.Bootloader.EFI).ToNot(BeNil())
 
 						Expect(vmiArg.Annotations).ToNot(HaveKey(v1.InstancetypeAnnotation))
@@ -4405,7 +4404,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Firmware.Bootloader.EFI).ToNot(BeNil())
 
 						Expect(vmiArg.Annotations).ToNot(HaveKey(v1.InstancetypeAnnotation))
@@ -4432,10 +4431,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 						Expect(cond.Message).To(ContainSubstring("got unexpected kind in PreferenceMatcher"))
 					}).Return(vm, nil)
@@ -4456,10 +4455,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
@@ -4479,10 +4478,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
@@ -4512,10 +4511,10 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
-						objVM := obj.(*virtv1.VirtualMachine)
-						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, virtv1.VirtualMachineFailure)
+						objVM := obj.(*v1.VirtualMachine)
+						cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(objVM, v1.VirtualMachineFailure)
 						Expect(cond).To(Not(BeNil()))
-						Expect(cond.Type).To(Equal(virtv1.VirtualMachineFailure))
+						Expect(cond.Type).To(Equal(v1.VirtualMachineFailure))
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 						Expect(cond.Message).To(ContainSubstring("found existing ControllerRevision with unexpected data"))
 					}).Return(vm, nil)
@@ -4533,8 +4532,8 @@ var _ = Describe("VirtualMachine", func() {
 						Kind: instancetypeapi.SingularPreferenceResourceName,
 					}
 
-					vm.Spec.Template.Spec.Domain.Devices.Interfaces = []virtv1.Interface{}
-					vm.Spec.Template.Spec.Networks = []virtv1.Network{}
+					vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{}
+					vm.Spec.Template.Spec.Networks = []v1.Network{}
 
 					addVirtualMachine(vm)
 
@@ -4547,7 +4546,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Devices.Interfaces[0].Model).To(Equal(preference.Spec.Devices.PreferredInterfaceModel))
 						Expect(vmiArg.Spec.Networks).To(Equal([]v1.Network{*v1.DefaultPodNetwork()}))
 					}).Return(vmi, nil)
@@ -4581,8 +4580,8 @@ var _ = Describe("VirtualMachine", func() {
 						Kind: instancetypeapi.SingularPreferenceResourceName,
 					}
 
-					vm.Spec.Template.Spec.Domain.Devices.Interfaces = []virtv1.Interface{}
-					vm.Spec.Template.Spec.Networks = []virtv1.Network{}
+					vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{}
+					vm.Spec.Template.Spec.Networks = []v1.Network{}
 
 					addVirtualMachine(vm)
 
@@ -4595,7 +4594,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(*vmiArg.Spec.Domain.Devices.AutoattachPodInterface).To(BeFalse())
 						Expect(vmiArg.Spec.Domain.Devices.Interfaces).To(BeEmpty())
 						Expect(vmiArg.Spec.Networks).To(BeEmpty())
@@ -4645,7 +4644,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Devices.Disks).To(HaveLen(2))
 						Expect(vmiArg.Spec.Domain.Devices.Disks[0].Name).To(Equal(presentVolumeName))
 						// Assert that the preference hasn't overwritten anything defined by the user
@@ -4680,7 +4679,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Devices.Inputs).To(HaveLen(1))
 						Expect(vmiArg.Spec.Domain.Devices.Inputs[0].Name).To(Equal("default-0"))
 						Expect(vmiArg.Spec.Domain.Devices.Inputs[0].Type).To(Equal(preference.Spec.Devices.PreferredInputType))
@@ -4704,8 +4703,8 @@ var _ = Describe("VirtualMachine", func() {
 						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 							Devices: &instancetypev1beta1.DevicePreferences{
 								PreferredAutoattachInputDevice: pointer.Bool(true),
-								PreferredInputBus:              virtv1.InputBusVirtio,
-								PreferredInputType:             virtv1.InputTypeTablet,
+								PreferredInputBus:              v1.InputBusVirtio,
+								PreferredInputType:             v1.InputTypeTablet,
 							},
 						},
 					}
@@ -4728,7 +4727,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(vmiArg.Spec.Domain.Devices.Inputs).To(HaveLen(1))
 						Expect(vmiArg.Spec.Domain.Devices.Inputs[0].Name).To(Equal("default-0"))
 						Expect(vmiArg.Spec.Domain.Devices.Inputs[0].Type).To(Equal(autoattachInputDevicePreference.Spec.Devices.PreferredInputType))
@@ -4775,7 +4774,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().Patch(context.Background(), vm.Name, types.JSONPatchType, expectedRevisionNamePatch, &metav1.PatchOptions{})
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-						vmiArg := arg.(*virtv1.VirtualMachineInstance)
+						vmiArg := arg.(*v1.VirtualMachineInstance)
 						Expect(*vmiArg.Spec.Domain.Devices.AutoattachInputDevice).To(BeFalse())
 						Expect(vmiArg.Spec.Domain.Devices.Inputs).To(BeEmpty())
 					}).Return(vmi, nil)
@@ -4814,7 +4813,7 @@ var _ = Describe("VirtualMachine", func() {
 				addVirtualMachine(vm)
 
 				vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-					vmiArg := arg.(*virtv1.VirtualMachineInstance)
+					vmiArg := arg.(*v1.VirtualMachineInstance)
 					switch expectedIface {
 					case "bridge":
 						Expect(vmiArg.Spec.Domain.Devices.Interfaces[0].Bridge).NotTo(BeNil())
@@ -4844,7 +4843,7 @@ var _ = Describe("VirtualMachine", func() {
 			addVirtualMachine(vm)
 
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-				vmiArg := arg.(*virtv1.VirtualMachineInstance)
+				vmiArg := arg.(*v1.VirtualMachineInstance)
 				Expect(vmiArg.Spec.Domain.Devices.Interfaces).To(Equal(interfaces))
 				Expect(vmiArg.Spec.Networks).To(Equal(networks))
 			}).Return(vmi, nil)
@@ -4880,7 +4879,7 @@ var _ = Describe("VirtualMachine", func() {
 			addVirtualMachine(vm)
 
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-				vmiArg := arg.(*virtv1.VirtualMachineInstance)
+				vmiArg := arg.(*v1.VirtualMachineInstance)
 				Expect(vmiArg.Spec.Domain.Devices.Disks).To(HaveLen(2))
 				Expect(vmiArg.Spec.Domain.Devices.Disks[0].Name).To(Equal(presentVolumeName))
 				Expect(vmiArg.Spec.Domain.Devices.Disks[1].Name).To(Equal(missingVolumeName))
@@ -4900,7 +4899,7 @@ var _ = Describe("VirtualMachine", func() {
 			addVirtualMachine(vm)
 
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, arg interface{}) {
-				vmiArg := arg.(*virtv1.VirtualMachineInstance)
+				vmiArg := arg.(*v1.VirtualMachineInstance)
 
 				if expectedInputDevice != nil {
 					Expect(vmiArg.Spec.Domain.Devices.Inputs).To(HaveLen(1))
@@ -4931,8 +4930,8 @@ var _ = Describe("VirtualMachine", func() {
 			Context("CPU", func() {
 				It("should honour the maximum CPU sockets from VM spec", func() {
 					vm, _ := DefaultVirtualMachine(true)
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						CPU: &virtv1.LiveUpdateCPU{
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						CPU: &v1.LiveUpdateCPU{
 							MaxSockets: kvpointer.P(maxSocketsFromSpec),
 						},
 					}
@@ -4943,15 +4942,15 @@ var _ = Describe("VirtualMachine", func() {
 
 				It("should prefer maximum CPU sockets from VM spec rather than from cluster config", func() {
 					vm, _ := DefaultVirtualMachine(true)
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						CPU: &virtv1.LiveUpdateCPU{
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						CPU: &v1.LiveUpdateCPU{
 							MaxSockets: kvpointer.P(maxSocketsFromSpec),
 						},
 					}
 					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
-								LiveUpdateConfiguration: &virtv1.LiveUpdateConfiguration{
+								LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{
 									MaxCpuSockets: kvpointer.P(maxSocketsFromConfig),
 								},
 							},
@@ -4964,13 +4963,13 @@ var _ = Describe("VirtualMachine", func() {
 
 				It("should use maximum sockets configured in cluster config when its not set in VM spec", func() {
 					vm, _ := DefaultVirtualMachine(true)
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						CPU: &virtv1.LiveUpdateCPU{},
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						CPU: &v1.LiveUpdateCPU{},
 					}
 					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
-								LiveUpdateConfiguration: &virtv1.LiveUpdateConfiguration{
+								LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{
 									MaxCpuSockets: kvpointer.P(maxSocketsFromConfig),
 								},
 							},
@@ -4984,10 +4983,10 @@ var _ = Describe("VirtualMachine", func() {
 				It("should calculate max sockets to be 4x times the configured sockets when no max sockets defined ", func() {
 					const cpuSockets uint32 = 4
 					vm, _ := DefaultVirtualMachine(true)
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						CPU: &virtv1.LiveUpdateCPU{},
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						CPU: &v1.LiveUpdateCPU{},
 					}
-					vm.Spec.Template.Spec.Domain.CPU = &virtv1.CPU{
+					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{
 						Sockets: cpuSockets,
 					}
 
@@ -4998,8 +4997,8 @@ var _ = Describe("VirtualMachine", func() {
 				It("should calculate max sockets to be 4x times the default sockets when default CPU topology used", func() {
 					const defaultSockets uint32 = 1
 					vm, _ := DefaultVirtualMachine(true)
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						CPU: &virtv1.LiveUpdateCPU{},
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						CPU: &v1.LiveUpdateCPU{},
 					}
 
 					vmi := controller.setupVMIFromVM(vm)
@@ -5011,9 +5010,9 @@ var _ = Describe("VirtualMachine", func() {
 				It("should honour the max guest memory from VM spec", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					guestMemory := resource.MustParse("64Mi")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						Memory: &virtv1.LiveUpdateMemory{
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						Memory: &v1.LiveUpdateMemory{
 							MaxGuest: &maxGuestFromSpec,
 						},
 					}
@@ -5025,16 +5024,16 @@ var _ = Describe("VirtualMachine", func() {
 				It("should prefer maxGuest from VM spec rather than from cluster config", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					guestMemory := resource.MustParse("64Mi")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						Memory: &virtv1.LiveUpdateMemory{
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						Memory: &v1.LiveUpdateMemory{
 							MaxGuest: &maxGuestFromSpec,
 						},
 					}
 					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
-								LiveUpdateConfiguration: &virtv1.LiveUpdateConfiguration{
+								LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{
 									MaxGuest: &maxGuestFromConfig,
 								},
 							},
@@ -5048,14 +5047,14 @@ var _ = Describe("VirtualMachine", func() {
 				It("should use maxGuest configured in cluster config when its not set in VM spec", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					guestMemory := resource.MustParse("64Mi")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						Memory: &virtv1.LiveUpdateMemory{},
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						Memory: &v1.LiveUpdateMemory{},
 					}
 					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
-								LiveUpdateConfiguration: &virtv1.LiveUpdateConfiguration{
+								LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{
 									MaxGuest: &maxGuestFromConfig,
 								},
 							},
@@ -5069,14 +5068,14 @@ var _ = Describe("VirtualMachine", func() {
 				It("should opt-out from memory live-update if liveUpdateFeatures is disabled in the VM spec", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					guestMemory := resource.MustParse("0")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
 						Memory: nil,
 					}
 					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
-								LiveUpdateConfiguration: &virtv1.LiveUpdateConfiguration{
+								LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{
 									MaxGuest: &maxGuestFromConfig,
 								},
 							},
@@ -5090,9 +5089,9 @@ var _ = Describe("VirtualMachine", func() {
 				It("should calculate maxGuest to be `MaxHotplugRatio` times the configured guest memory when no maxGuest is defined", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					guestMemory := resource.MustParse("64Mi")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						Memory: &virtv1.LiveUpdateMemory{},
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						Memory: &v1.LiveUpdateMemory{},
 					}
 
 					vmi := controller.setupVMIFromVM(vm)
@@ -5102,23 +5101,23 @@ var _ = Describe("VirtualMachine", func() {
 				It("should patch VMI when memory hotplug is requested", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					newMemory := resource.MustParse("128Mi")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &newMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						Memory: &virtv1.LiveUpdateMemory{
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &newMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						Memory: &v1.LiveUpdateMemory{
 							MaxGuest: &maxGuestFromSpec,
 						},
 					}
 
 					vmi := api.NewMinimalVMI(vm.Name)
 					guestMemory := resource.MustParse("64Mi")
-					vmi.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
+					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
 					memReqBuffer := resource.MustParse("100Mi")
 					memoryRequest := guestMemory.DeepCopy()
 					memoryRequest.Add(memReqBuffer)
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = memoryRequest
 
-					vmi.Status.Memory = &virtv1.MemoryStatus{
+					vmi.Status.Memory = &v1.MemoryStatus{
 						GuestAtBoot:    &guestMemory,
 						GuestCurrent:   &guestMemory,
 						GuestRequested: &guestMemory,
@@ -5134,7 +5133,7 @@ var _ = Describe("VirtualMachine", func() {
 						newVMIBytes, err := patchJSON.Apply(originalVMIBytes)
 						Expect(err).ToNot(HaveOccurred())
 
-						var newVMI *virtv1.VirtualMachineInstance
+						var newVMI *v1.VirtualMachineInstance
 						err = json.Unmarshal(newVMIBytes, &newVMI)
 						Expect(err).ToNot(HaveOccurred())
 
@@ -5154,25 +5153,25 @@ var _ = Describe("VirtualMachine", func() {
 				It("should not patch VMI if memory hotplug is already in progress", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					newMemory := resource.MustParse("128Mi")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &newMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						Memory: &virtv1.LiveUpdateMemory{
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &newMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						Memory: &v1.LiveUpdateMemory{
 							MaxGuest: &maxGuestFromSpec,
 						},
 					}
 
 					vmi := api.NewMinimalVMI(vm.Name)
 					guestMemory := resource.MustParse("64Mi")
-					vmi.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
+					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = guestMemory
-					vmi.Status.Memory = &virtv1.MemoryStatus{
+					vmi.Status.Memory = &v1.MemoryStatus{
 						GuestAtBoot:    &guestMemory,
 						GuestCurrent:   &guestMemory,
 						GuestRequested: &guestMemory,
 					}
 
-					condition := virtv1.VirtualMachineInstanceCondition{
-						Type:   virtv1.VirtualMachineInstanceMemoryChange,
+					condition := v1.VirtualMachineInstanceCondition{
+						Type:   v1.VirtualMachineInstanceMemoryChange,
 						Status: k8sv1.ConditionTrue,
 					}
 					virtcontroller.NewVirtualMachineInstanceConditionManager().UpdateCondition(vmi, &condition)
@@ -5184,23 +5183,23 @@ var _ = Describe("VirtualMachine", func() {
 				It("should not patch VMI if a migration is in progress", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					newMemory := resource.MustParse("128Mi")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &newMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						Memory: &virtv1.LiveUpdateMemory{
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &newMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						Memory: &v1.LiveUpdateMemory{
 							MaxGuest: &maxGuestFromSpec,
 						},
 					}
 
 					vmi := api.NewMinimalVMI(vm.Name)
 					guestMemory := resource.MustParse("64Mi")
-					vmi.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
+					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = guestMemory
-					vmi.Status.Memory = &virtv1.MemoryStatus{
+					vmi.Status.Memory = &v1.MemoryStatus{
 						GuestAtBoot:  &guestMemory,
 						GuestCurrent: &guestMemory,
 					}
 					migrationStart := metav1.Now()
-					vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+					vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 						StartTimestamp: &migrationStart,
 					}
 
@@ -5211,17 +5210,17 @@ var _ = Describe("VirtualMachine", func() {
 				It("should not patch VMI if guest memory did not change", func() {
 					guestMemory := resource.MustParse("64Mi")
 					vm, _ := DefaultVirtualMachine(true)
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
-					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
-						Memory: &virtv1.LiveUpdateMemory{
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+					vm.Spec.LiveUpdateFeatures = &v1.LiveUpdateFeatures{
+						Memory: &v1.LiveUpdateMemory{
 							MaxGuest: &maxGuestFromSpec,
 						},
 					}
 
 					vmi := api.NewMinimalVMI(vm.Name)
-					vmi.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
+					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = guestMemory
-					vmi.Status.Memory = &virtv1.MemoryStatus{
+					vmi.Status.Memory = &v1.MemoryStatus{
 						GuestAtBoot:  &guestMemory,
 						GuestCurrent: &guestMemory,
 					}
@@ -5239,13 +5238,13 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						Expect(arg.(*virtv1.VirtualMachineInstance).Status.CurrentCPUTopology).To(Not(BeNil()))
+						Expect(arg.(*v1.VirtualMachineInstance).Status.CurrentCPUTopology).To(Not(BeNil()))
 					}).Return(vmi, nil)
 
 					// expect update status is called
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-						Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+						Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+						Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 					}).Return(nil, nil)
 
 					controller.Execute()
@@ -5269,7 +5268,7 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 
 					vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						currentCPUTopology := arg.(*virtv1.VirtualMachineInstance).Status.CurrentCPUTopology
+						currentCPUTopology := arg.(*v1.VirtualMachineInstance).Status.CurrentCPUTopology
 						Expect(currentCPUTopology).To(Not(BeNil()))
 						Expect(currentCPUTopology.Sockets).To(Equal(numOfSockets))
 						Expect(currentCPUTopology.Cores).To(Equal(numOfCores))
@@ -5278,8 +5277,8 @@ var _ = Describe("VirtualMachine", func() {
 
 					// expect update status is called
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-						Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
-						Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+						Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+						Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
 					}).Return(nil, nil)
 
 					controller.Execute()
@@ -5291,12 +5290,12 @@ var _ = Describe("VirtualMachine", func() {
 	})
 })
 
-func VirtualMachineFromVMI(name string, vmi *virtv1.VirtualMachineInstance, started bool) *virtv1.VirtualMachine {
-	vm := &virtv1.VirtualMachine{
+func VirtualMachineFromVMI(name string, vmi *v1.VirtualMachineInstance, started bool) *v1.VirtualMachine {
+	vm := &v1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: vmi.ObjectMeta.Namespace, ResourceVersion: "1", UID: vmUID},
-		Spec: virtv1.VirtualMachineSpec{
+		Spec: v1.VirtualMachineSpec{
 			Running: &started,
-			Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   vmi.ObjectMeta.Name,
 					Labels: vmi.ObjectMeta.Labels,
@@ -5304,10 +5303,10 @@ func VirtualMachineFromVMI(name string, vmi *virtv1.VirtualMachineInstance, star
 				Spec: vmi.Spec,
 			},
 		},
-		Status: virtv1.VirtualMachineStatus{
-			Conditions: []virtv1.VirtualMachineCondition{
+		Status: v1.VirtualMachineStatus{
+			Conditions: []v1.VirtualMachineCondition{
 				{
-					Type:   virtv1.VirtualMachineReady,
+					Type:   v1.VirtualMachineReady,
 					Status: k8sv1.ConditionFalse,
 					Reason: "VMINotExists",
 				},
@@ -5317,16 +5316,16 @@ func VirtualMachineFromVMI(name string, vmi *virtv1.VirtualMachineInstance, star
 	return vm
 }
 
-func DefaultVirtualMachineWithNames(started bool, vmName string, vmiName string) (*virtv1.VirtualMachine, *virtv1.VirtualMachineInstance) {
+func DefaultVirtualMachineWithNames(started bool, vmName string, vmiName string) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
 	vmi := api.NewMinimalVMI(vmiName)
 	vmi.GenerateName = "prettyrandom"
-	vmi.Status.Phase = virtv1.Running
-	vmi.Finalizers = append(vmi.Finalizers, virtv1.VirtualMachineControllerFinalizer)
+	vmi.Status.Phase = v1.Running
+	vmi.Finalizers = append(vmi.Finalizers, v1.VirtualMachineControllerFinalizer)
 	vm := VirtualMachineFromVMI(vmName, vmi, started)
-	vm.Finalizers = append(vm.Finalizers, virtv1.VirtualMachineControllerFinalizer)
+	vm.Finalizers = append(vm.Finalizers, v1.VirtualMachineControllerFinalizer)
 	vmi.OwnerReferences = []metav1.OwnerReference{{
-		APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-		Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
+		APIVersion:         v1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+		Kind:               v1.VirtualMachineGroupVersionKind.Kind,
 		Name:               vm.ObjectMeta.Name,
 		UID:                vm.ObjectMeta.UID,
 		Controller:         &t,
@@ -5337,10 +5336,10 @@ func DefaultVirtualMachineWithNames(started bool, vmName string, vmiName string)
 	return vm, vmi
 }
 
-func DefaultVirtualMachine(started bool) (*virtv1.VirtualMachine, *virtv1.VirtualMachineInstance) {
+func DefaultVirtualMachine(started bool) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
 	return DefaultVirtualMachineWithNames(started, "testvmi", "testvmi")
 }
 
-func markVmAsReady(vm *virtv1.VirtualMachine) {
-	virtcontroller.NewVirtualMachineConditionManager().UpdateCondition(vm, &virtv1.VirtualMachineCondition{Type: virtv1.VirtualMachineReady, Status: k8sv1.ConditionTrue})
+func markVmAsReady(vm *v1.VirtualMachine) {
+	virtcontroller.NewVirtualMachineConditionManager().UpdateCondition(vm, &v1.VirtualMachineCondition{Type: v1.VirtualMachineReady, Status: k8sv1.ConditionTrue})
 }

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -53,7 +53,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
@@ -69,7 +68,7 @@ import (
 
 type PodVmIfaceStatus struct {
 	podIfaceStatus *networkv1.NetworkStatus
-	vmIfaceStatus  *virtv1.VirtualMachineInstanceNetworkInterface
+	vmIfaceStatus  *v1.VirtualMachineInstanceNetworkInterface
 }
 
 var _ = Describe("VirtualMachineInstance watcher", func() {
@@ -109,7 +108,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
 			update, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
-			Expect(update.GetObject().(*k8sv1.Pod).Labels[virtv1.CreatedByLabel]).To(Equal(string(uid)))
+			Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.CreatedByLabel]).To(Equal(string(uid)))
 			Expect(update.GetObject().(*k8sv1.Pod)).To(SatisfyAny(matchers...))
 			return true, update.GetObject(), nil
 		})
@@ -120,7 +119,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
 			update, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
-			Expect(update.GetObject().(*k8sv1.Pod).Labels[virtv1.CreatedByLabel]).To(Equal(string(uid)))
+			Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.CreatedByLabel]).To(Equal(string(uid)))
 			return true, update.GetObject(), nil
 		})
 	}
@@ -174,11 +173,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 	}
 
-	shouldExpectVirtualMachineHandover := func(vmi *virtv1.VirtualMachineInstance) {
+	shouldExpectVirtualMachineHandover := func(vmi *v1.VirtualMachineInstance) {
 		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduled))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Scheduled))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
+			Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
 		}).Return(vmi, nil)
 	}
 
@@ -189,33 +188,33 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 	}
 
-	shouldExpectVirtualMachineSchedulingState := func(vmi *virtv1.VirtualMachineInstance) {
+	shouldExpectVirtualMachineSchedulingState := func(vmi *v1.VirtualMachineInstance) {
 		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduling))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
-				Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Scheduling))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
+				Fields{"Type": Equal(v1.VirtualMachineInstanceReady)})))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
+			Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
 		}).Return(vmi, nil)
 	}
 
-	shouldExpectVirtualMachineScheduledState := func(vmi *virtv1.VirtualMachineInstance) {
+	shouldExpectVirtualMachineScheduledState := func(vmi *v1.VirtualMachineInstance) {
 		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduled))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
-				Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Scheduled))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
+				Fields{"Type": Equal(v1.VirtualMachineInstanceReady)})))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
+			Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
 		}).Return(vmi, nil)
 	}
 
-	shouldExpectVirtualMachineFailedState := func(vmi *virtv1.VirtualMachineInstance) {
+	shouldExpectVirtualMachineFailedState := func(vmi *v1.VirtualMachineInstance) {
 		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Failed))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
-				Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Failed))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
+				Fields{"Type": Equal(v1.VirtualMachineInstanceReady)})))
+			Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
+			Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
 		}).Return(vmi, nil)
 	}
 
@@ -250,15 +249,15 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 
-		vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, kvcontroller.GetVMIInformerIndexers())
-		vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachine{}, kvcontroller.GetVirtualMachineInformerIndexers())
+		vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstance{}, kvcontroller.GetVMIInformerIndexers())
+		vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachine{}, kvcontroller.GetVirtualMachineInformerIndexers())
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 
-		kubevirtFakeConfig := &virtv1.KubeVirtConfiguration{
-			DeveloperConfiguration: &virtv1.DeveloperConfiguration{
+		kubevirtFakeConfig := &v1.KubeVirtConfiguration{
+			DeveloperConfiguration: &v1.DeveloperConfiguration{
 				MinimumClusterTSCFrequency: pointer.Int64(12345),
 			},
 		}
@@ -309,7 +308,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		Expect(recorder.Events).To(BeEmpty())
 	})
 
-	addVirtualMachine := func(vmi *virtv1.VirtualMachineInstance) {
+	addVirtualMachine := func(vmi *v1.VirtualMachineInstance) {
 		mockQueue.ExpectAdds(1)
 		vmiSource.Add(vmi)
 		mockQueue.Wait()
@@ -317,15 +316,15 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 	Context("On valid VirtualMachineInstance given with DataVolume source", func() {
 
-		dvVolumeSource := virtv1.VolumeSource{
-			DataVolume: &virtv1.DataVolumeSource{
+		dvVolumeSource := v1.VolumeSource{
+			DataVolume: &v1.DataVolumeSource{
 				Name: "test1",
 			},
 		}
 		It("should create a corresponding Pod on VMI creation when DataVolume is ready", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: dvVolumeSource,
 			})
@@ -348,7 +347,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should create a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: dvVolumeSource,
 			})
@@ -364,8 +363,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
-					Fields{"Type": Equal(virtv1.VirtualMachineInstanceProvisioning)})))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+					Fields{"Type": Equal(v1.VirtualMachineInstanceProvisioning)})))
 			}).Return(vmi, nil)
 
 			IsPodWithoutVmPayload := WithTransform(
@@ -392,9 +391,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should not delete a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Annotations[virtv1.EphemeralProvisioningObject] = "true"
+			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: dvVolumeSource,
 			})
@@ -417,10 +416,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			dataVolumeFeeder.Add(dataVolume)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Pending))
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).
-					To(ContainElement(virtv1.VirtualMachineInstanceCondition{
-						Type:   virtv1.VirtualMachineInstanceProvisioning,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Pending))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).
+					To(ContainElement(v1.VirtualMachineInstanceCondition{
+						Type:   v1.VirtualMachineInstanceProvisioning,
 						Status: k8sv1.ConditionTrue,
 					}))
 			}).Return(vmi, nil)
@@ -433,9 +432,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should delete a doppleganger Pod on VMI creation when DataVolume is no longer in WaitForFirstConsumer state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Annotations[virtv1.EphemeralProvisioningObject] = "true"
+			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: dvVolumeSource,
 			})
@@ -465,7 +464,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should only get WFFC pods that are associated with current VMI", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Annotations[virtv1.EphemeralProvisioningObject] = "true"
+			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
 			Expect(podInformer.GetIndexer().Add(pod)).To(Succeed())
 
 			// Non owned pod that shouldn't be found by waitForFirstConsumerTemporaryPods
@@ -474,7 +473,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Name:      "unowned-test-pod",
 					Namespace: vmi.Namespace,
 					Annotations: map[string]string{
-						virtv1.EphemeralProvisioningObject: "true",
+						v1.EphemeralProvisioningObject: "true",
 					},
 				},
 				Status: k8sv1.PodStatus{
@@ -489,14 +488,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 
 		DescribeTable("VMI should handle doppleganger Pod status while DV is in WaitForFirstConsumer phase",
-			func(phase k8sv1.PodPhase, conditions []k8sv1.PodCondition, expectedPhase virtv1.VirtualMachineInstancePhase) {
+			func(phase k8sv1.PodPhase, conditions []k8sv1.PodCondition, expectedPhase v1.VirtualMachineInstancePhase) {
 				vmi := NewPendingVirtualMachine("testvmi")
 				pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-				pod.Annotations[virtv1.EphemeralProvisioningObject] = "true"
+				pod.Annotations[v1.EphemeralProvisioningObject] = "true"
 				pod.Status.Phase = phase
 				pod.Status.Conditions = conditions
 
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 					Name:         "test1",
 					VolumeSource: dvVolumeSource,
 				})
@@ -516,7 +515,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				dataVolumeFeeder.Add(dataVolume)
 
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(expectedPhase))
+					Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(expectedPhase))
 				}).Return(vmi, nil)
 				kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
 					return true, dvPVC, nil
@@ -524,21 +523,21 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 				controller.Execute()
 			},
-			Entry("fail if pod in failed state", k8sv1.PodFailed, nil, virtv1.Failed),
-			Entry("do nothing if pod succeed", k8sv1.PodSucceeded, nil, virtv1.Pending),
+			Entry("fail if pod in failed state", k8sv1.PodFailed, nil, v1.Failed),
+			Entry("do nothing if pod succeed", k8sv1.PodSucceeded, nil, v1.Pending),
 			//The PodReasonUnschedulable is a transient condition. It can clear up if more resources are added to the cluster
 			Entry("do nothing if pod Pending Unschedulable",
 				k8sv1.PodPending,
 				[]k8sv1.PodCondition{{
 					Type:   k8sv1.PodScheduled,
 					Status: k8sv1.ConditionFalse,
-					Reason: k8sv1.PodReasonUnschedulable}}, virtv1.Pending),
+					Reason: k8sv1.PodReasonUnschedulable}}, v1.Pending),
 		)
 
 		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: dvVolumeSource,
 			})
@@ -557,15 +556,15 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 	Context("On valid VirtualMachineInstance given with PVC source, ownedRef of DataVolume", func() {
 
-		pvcVolumeSource := virtv1.VolumeSource{
-			PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+		pvcVolumeSource := v1.VolumeSource{
+			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 				ClaimName: "test1",
 			}},
 		}
 		It("should create a corresponding Pod on VMI creation when DataVolume is ready", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: pvcVolumeSource,
 			})
@@ -588,7 +587,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should create a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: pvcVolumeSource,
 			})
@@ -604,8 +603,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
-					Fields{"Type": Equal(virtv1.VirtualMachineInstanceProvisioning)})))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+					Fields{"Type": Equal(v1.VirtualMachineInstanceProvisioning)})))
 			}).Return(vmi, nil)
 
 			IsPodWithoutVmPayload := WithTransform(
@@ -628,9 +627,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should not delete a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Annotations[virtv1.EphemeralProvisioningObject] = "true"
+			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: pvcVolumeSource,
 			})
@@ -653,10 +652,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			dataVolumeFeeder.Add(dataVolume)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Pending))
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).
-					To(ContainElement(virtv1.VirtualMachineInstanceCondition{
-						Type:   virtv1.VirtualMachineInstanceProvisioning,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Pending))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).
+					To(ContainElement(v1.VirtualMachineInstanceCondition{
+						Type:   v1.VirtualMachineInstanceProvisioning,
 						Status: k8sv1.ConditionTrue,
 					}))
 			}).Return(vmi, nil)
@@ -666,9 +665,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should delete a doppleganger Pod on VMI creation when DataVolume is no longer in WaitForFirstConsumer state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Annotations[virtv1.EphemeralProvisioningObject] = "true"
+			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: pvcVolumeSource,
 			})
@@ -700,7 +699,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: pvcVolumeSource,
 			})
@@ -722,7 +721,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should create a corresponding Pod on VMI creation when PVC is not controlled by a DataVolume", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name:         "test1",
 				VolumeSource: pvcVolumeSource,
 			})
@@ -749,7 +748,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("should not patch network-pci-map when no SR-IOV networks exist", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Running
+			vmi.Status.Phase = v1.Running
 			vmi = addDefaultNetwork(vmi, defaultNetworkName)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			addVirtualMachine(vmi)
@@ -775,7 +774,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		It("should patch network-pci-map when SR-IOV networks exist", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Running
+			vmi.Status.Phase = v1.Running
 			vmi = addDefaultNetwork(vmi, defaultNetworkName)
 			vmi = addDefaultNetworkStatus(vmi, defaultNetworkName)
 			vmi = addSRIOVNetwork(vmi, sriovNetworkName, netAttachDefName)
@@ -829,16 +828,16 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 		})
-		DescribeTable("should delete the corresponding Pods on VirtualMachineInstance deletion with vmi", func(phase virtv1.VirtualMachineInstancePhase) {
+		DescribeTable("should delete the corresponding Pods on VirtualMachineInstance deletion with vmi", func(phase v1.VirtualMachineInstancePhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Status.Phase = phase
 			vmi.DeletionTimestamp = now()
 
 			if vmi.IsRunning() {
-				setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodConditionMissingReason)
+				setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodConditionMissingReason)
 			} else {
-				setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
+				setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
 			}
 
 			// 2 pods are owned by VMI
@@ -879,19 +878,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 		},
-			Entry("in running state", virtv1.Running),
-			Entry("in unset state", virtv1.VmPhaseUnset),
-			Entry("in pending state", virtv1.Pending),
-			Entry("in succeeded state", virtv1.Succeeded),
-			Entry("in failed state", virtv1.Failed),
-			Entry("in scheduled state", virtv1.Scheduled),
-			Entry("in scheduling state", virtv1.Scheduling),
+			Entry("in running state", v1.Running),
+			Entry("in unset state", v1.VmPhaseUnset),
+			Entry("in pending state", v1.Pending),
+			Entry("in succeeded state", v1.Succeeded),
+			Entry("in failed state", v1.Failed),
+			Entry("in scheduled state", v1.Scheduled),
+			Entry("in scheduling state", v1.Scheduling),
 		)
 		It("should not try to delete a pod again, which is already marked for deletion and go to failed state, when in scheduling state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
 
-			vmi.Status.Phase = virtv1.Scheduling
+			vmi.Status.Phase = v1.Scheduling
 			vmi.DeletionTimestamp = now()
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
@@ -914,9 +913,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			controller.Execute()
 		})
-		DescribeTable("should not delete the corresponding Pod if the vmi is in", func(phase virtv1.VirtualMachineInstancePhase) {
+		DescribeTable("should not delete the corresponding Pod if the vmi is in", func(phase v1.VirtualMachineInstancePhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
 
 			vmi.Status.Phase = phase
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
@@ -927,12 +926,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			controller.Execute()
 		},
-			Entry("succeeded state", virtv1.Failed),
-			Entry("failed state", virtv1.Succeeded),
+			Entry("succeeded state", v1.Failed),
+			Entry("failed state", v1.Succeeded),
 		)
 		It("should do nothing if the vmi is in final state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Failed
+			vmi.Status.Phase = v1.Failed
 			vmi.Finalizers = []string{}
 
 			addVirtualMachine(vmi)
@@ -949,9 +948,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
-						"Type":   Equal(virtv1.VirtualMachineInstanceSynchronized),
+						"Type":   Equal(v1.VirtualMachineInstanceSynchronized),
 						"Status": Equal(k8sv1.ConditionFalse),
 						"Reason": Equal("FailedCreate"),
 					})))
@@ -971,9 +970,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
-						"Type":   Equal(virtv1.VirtualMachineInstanceSynchronized),
+						"Type":   Equal(v1.VirtualMachineInstanceSynchronized),
 						"Status": Equal(k8sv1.ConditionFalse),
 						"Reason": Equal("FailedCreate"),
 					})))
@@ -988,7 +987,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should remove the error condition if the sync finally succeeds", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
-			vmi.Status.Conditions = append(vmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{Type: virtv1.VirtualMachineInstanceSynchronized})
+			vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{Type: v1.VirtualMachineInstanceSynchronized})
 
 			addVirtualMachine(vmi)
 
@@ -996,14 +995,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
 				update, ok := action.(testing.CreateAction)
 				Expect(ok).To(BeTrue())
-				Expect(update.GetObject().(*k8sv1.Pod).Labels[virtv1.CreatedByLabel]).To(Equal(string(vmi.UID)))
+				Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.CreatedByLabel]).To(Equal(string(vmi.UID)))
 				return true, update.GetObject(), nil
 			})
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).ToNot(ContainElement(MatchFields(IgnoreExtras,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).ToNot(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
-						"Type": Equal(virtv1.VirtualMachineInstanceSynchronized),
+						"Type": Equal(v1.VirtualMachineInstanceSynchronized),
 					})))
 			}).Return(vmi, nil)
 
@@ -1012,19 +1011,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 		})
 		DescribeTable("should never proceed to creating the launcher pod if not all PVCs are there to determine if they are WFFC and/or an import is done",
-			func(syncReason string, volumeSource virtv1.VolumeSource) {
+			func(syncReason string, volumeSource v1.VolumeSource) {
 
-				expectConditions := func(vmi *virtv1.VirtualMachineInstance) {
+				expectConditions := func(vmi *v1.VirtualMachineInstance) {
 					// PodScheduled and Synchronized (as well as Ready)
 					Expect(vmi.Status.Conditions).To(HaveLen(3), "there should be exactly 3 conditions")
 
-					getType := func(c virtv1.VirtualMachineInstanceCondition) string { return string(c.Type) }
-					getReason := func(c virtv1.VirtualMachineInstanceCondition) string { return c.Reason }
+					getType := func(c v1.VirtualMachineInstanceCondition) string { return string(c.Type) }
+					getReason := func(c v1.VirtualMachineInstanceCondition) string { return c.Reason }
 					Expect(vmi.Status.Conditions).To(
 						And(
 							ContainElement(
 								And(
-									WithTransform(getType, Equal(string(virtv1.VirtualMachineInstanceSynchronized))),
+									WithTransform(getType, Equal(string(v1.VirtualMachineInstanceSynchronized))),
 									WithTransform(getReason, Equal(syncReason)),
 								),
 							),
@@ -1041,9 +1040,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				}
 
 				vmi := NewPendingVirtualMachine("testvmi")
-				setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodNotExistsReason)
+				setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodNotExistsReason)
 
-				vmi.Spec.Volumes = []virtv1.Volume{
+				vmi.Spec.Volumes = []v1.Volume{
 					{
 						Name:         "test",
 						VolumeSource: volumeSource,
@@ -1051,7 +1050,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				}
 				addVirtualMachine(vmi)
 				update := vmiInterface.EXPECT().Update(context.Background(), gomock.Any())
-				update.Do(func(ctx context.Context, vmi *virtv1.VirtualMachineInstance) {
+				update.Do(func(ctx context.Context, vmi *v1.VirtualMachineInstance) {
 					expectConditions(vmi)
 					_ = vmiInformer.GetStore().Update(vmi)
 					key := kvcontroller.VirtualMachineInstanceKey(vmi)
@@ -1066,7 +1065,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				addVirtualMachine(vmi)
 
 				// make sure that during next iteration we do not add the same condition again
-				vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, vmi *virtv1.VirtualMachineInstance) {
+				vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, vmi *v1.VirtualMachineInstance) {
 					expectConditions(vmi)
 				}).Return(vmi, nil)
 
@@ -1075,16 +1074,16 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Expect(mockQueue.GetRateLimitedEnqueueCount()).To(BeZero())
 			},
 			Entry("when PVC does not exist", FailedPvcNotFoundReason,
-				virtv1.VolumeSource{
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+				v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "something",
 						},
 					},
 				}),
 			Entry("when DataVolume does not exist", FailedPvcNotFoundReason,
-				virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "something",
 					},
 				}),
@@ -1095,9 +1094,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod := NewPodForVirtualMachine(vmi, phase)
 			pod.Status.ContainerStatuses[0].Ready = isReady
 
-			unreadyReason := virtv1.GuestNotRunningReason
+			unreadyReason := v1.GuestNotRunningReason
 			if phase == k8sv1.PodSucceeded || phase == k8sv1.PodFailed {
-				unreadyReason = virtv1.PodTerminatingReason
+				unreadyReason = v1.PodTerminatingReason
 			}
 			setReadyCondition(vmi, k8sv1.ConditionFalse, unreadyReason)
 
@@ -1124,8 +1123,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		Context("when pod failed to schedule", func() {
 			It("should set scheduling pod condition on the VirtualMachineInstance", func() {
 				vmi := NewPendingVirtualMachine("testvmi")
-				setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-				vmi.Status.Phase = virtv1.Scheduling
+				setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+				vmi.Status.Phase = v1.Scheduling
 
 				pod := NewPodForVirtualMachine(vmi, k8sv1.PodPending)
 
@@ -1140,10 +1139,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				podFeeder.Add(pod)
 
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduling))
-					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+					Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Scheduling))
+					Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 						Fields{
-							"Type":    Equal(virtv1.VirtualMachineInstanceConditionType((k8sv1.PodScheduled))),
+							"Type":    Equal(v1.VirtualMachineInstanceConditionType((k8sv1.PodScheduled))),
 							"Status":  Equal(k8sv1.ConditionFalse),
 							"Reason":  Equal("Unschedulable"),
 							"Message": Equal("Insufficient memory"),
@@ -1157,25 +1156,25 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		Context("when Pod recovers from scheduling issues", func() {
 			DescribeTable("it should remove scheduling pod condition from the VirtualMachineInstance if the pod", func(owner string, podPhase k8sv1.PodPhase) {
 				vmi := NewPendingVirtualMachine("testvmi")
-				setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodConditionMissingReason)
-				vmi.Status.Phase = virtv1.Scheduling
+				setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodConditionMissingReason)
+				vmi.Status.Phase = v1.Scheduling
 
 				pod := NewPodForVirtualMachine(vmi, podPhase)
 
-				vmi.Status.Conditions = append(vmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
+				vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
 					Message: "Insufficient memory",
 					Reason:  "Unschedulable",
 					Status:  k8sv1.ConditionFalse,
-					Type:    virtv1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled),
+					Type:    v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled),
 				})
 
 				addVirtualMachine(vmi)
 				podFeeder.Add(pod)
 
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).ToNot(ContainElement(MatchFields(IgnoreExtras,
+					Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).ToNot(ContainElement(MatchFields(IgnoreExtras,
 						Fields{
-							"Type": Equal(virtv1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled)),
+							"Type": Equal(v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled)),
 						})))
 				}).Return(vmi, nil)
 
@@ -1193,7 +1192,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("should move the vmi to failed state if the pod disappears and the vmi is in scheduling state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Scheduling
+			vmi.Status.Phase = v1.Scheduling
 
 			addVirtualMachine(vmi)
 
@@ -1213,8 +1212,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		DescribeTable("should hand over pod to virt-handler if pod is ready and running", func(containerStatus []k8sv1.ContainerStatus) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-			vmi.Status.Phase = virtv1.Scheduling
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.ContainerStatuses = containerStatus
 
@@ -1241,8 +1240,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 		DescribeTable("should not hand over pod to virt-handler if pod is ready and running", func(containerStatus []k8sv1.ContainerStatus) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-			vmi.Status.Phase = virtv1.Scheduling
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.ContainerStatuses = containerStatus
 
@@ -1260,7 +1259,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			),
 		)
 
-		DescribeTable("With a virt-launcher pod and an attachment pod, it", func(attachmentPodPhase k8sv1.PodPhase, expectedPhase virtv1.VirtualMachineInstancePhase) {
+		DescribeTable("With a virt-launcher pod and an attachment pod, it", func(attachmentPodPhase k8sv1.PodPhase, expectedPhase v1.VirtualMachineInstancePhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimBound)
 			Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
@@ -1275,18 +1274,18 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
 			Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
-			volume := virtv1.Volume{
+			volume := v1.Volume{
 				Name: "test-dv",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name:         "test-dv",
 						Hotpluggable: true,
 					},
 				},
 			}
-			vmi.Spec.Volumes = []virtv1.Volume{volume}
-			vmi.Status.Phase = virtv1.Scheduling
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
+			vmi.Spec.Volumes = []v1.Volume{volume}
+			vmi.Status.Phase = v1.Scheduling
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
 				Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
@@ -1306,34 +1305,34 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(attachmentPod)
 
 			switch expectedPhase {
-			case virtv1.Scheduled:
+			case v1.Scheduled:
 				shouldExpectVirtualMachineScheduledState(vmi)
-			case virtv1.Scheduling:
+			case v1.Scheduling:
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduling))
-					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
-						Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
-					Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).To(BeEmpty())
+					Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Scheduling))
+					Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
+						Fields{"Type": Equal(v1.VirtualMachineInstanceReady)})))
+					Expect(arg.(*v1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).To(BeEmpty())
 				}).Return(vmi, nil)
 			}
 
 			controller.Execute()
 
 			switch expectedPhase {
-			case virtv1.Scheduled:
+			case v1.Scheduled:
 				testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
-			case virtv1.Scheduling:
+			case v1.Scheduling:
 				break
 			}
 		},
-			Entry("should hand over pods if both are ready and running", k8sv1.PodRunning, virtv1.Scheduled),
-			Entry("should hand over pods even if the attachment pod is not ready and running", k8sv1.PodPending, virtv1.Scheduled),
+			Entry("should hand over pods if both are ready and running", k8sv1.PodRunning, v1.Scheduled),
+			Entry("should hand over pods even if the attachment pod is not ready and running", k8sv1.PodPending, v1.Scheduled),
 		)
 
 		It("should ignore migration target pods", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodConditionMissingReason)
-			vmi.Status.Phase = virtv1.Running
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodConditionMissingReason)
+			vmi.Status.Phase = v1.Running
 			vmi.Status.NodeName = "curnode"
 
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
@@ -1362,7 +1361,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("should set an error condition if deleting the virtual machine pod fails", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
 			vmi.DeletionTimestamp = now()
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
@@ -1375,9 +1374,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
-						"Type":   Equal(virtv1.VirtualMachineInstanceSynchronized),
+						"Type":   Equal(v1.VirtualMachineInstanceSynchronized),
 						"Status": Equal(k8sv1.ConditionFalse),
 						"Reason": Equal(FailedDeletePodReason),
 					})))
@@ -1389,9 +1388,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		It("should set an error condition if when pod cannot guarantee resources when cpu pinning has been requested", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-			vmi.Status.Phase = virtv1.Scheduling
-			vmi.Spec.Domain.CPU = &virtv1.CPU{DedicatedCPUPlacement: true}
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+			vmi.Status.Phase = v1.Scheduling
+			vmi.Spec.Domain.CPU = &v1.CPU{DedicatedCPUPlacement: true}
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Spec = k8sv1.PodSpec{
 				Containers: []k8sv1.Container{
@@ -1410,9 +1409,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
-						"Type":   Equal(virtv1.VirtualMachineInstanceSynchronized),
+						"Type":   Equal(v1.VirtualMachineInstanceSynchronized),
 						"Status": Equal(k8sv1.ConditionFalse),
 						"Reason": Equal(FailedGuaranteePodResourcesReason),
 					})))
@@ -1433,9 +1432,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
-						"Type":   Equal(virtv1.VirtualMachineInstanceSynchronized),
+						"Type":   Equal(v1.VirtualMachineInstanceSynchronized),
 						"Status": Equal(k8sv1.ConditionFalse),
 						"Reason": Equal(FailedCreatePodReason),
 					})))
@@ -1447,8 +1446,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		It("should update the virtual machine to scheduled if pod is ready, runnning and handed over to virt-handler", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-			vmi.Status.Phase = virtv1.Scheduling
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			addVirtualMachine(vmi)
@@ -1460,8 +1459,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		It("should update the virtual machine QOS class if the pod finally has a QOS class assigned", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-			vmi.Status.Phase = virtv1.Scheduling
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.QOSClass = k8sv1.PodQOSGuaranteed
 
@@ -1469,15 +1468,15 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(*arg.(*virtv1.VirtualMachineInstance).Status.QOSClass).To(Equal(k8sv1.PodQOSGuaranteed))
+				Expect(*arg.(*v1.VirtualMachineInstance).Status.QOSClass).To(Equal(k8sv1.PodQOSGuaranteed))
 			}).Return(vmi, nil)
 
 			controller.Execute()
 		})
 		It("should update the virtual machine to scheduled if pod is ready, triggered by pod change", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-			vmi.Status.Phase = virtv1.Scheduling
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodPending)
 
 			addVirtualMachine(vmi)
@@ -1496,9 +1495,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		It("should update the virtual machine to failed if pod was not ready, triggered by pod delete", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodPending)
-			vmi.Status.Phase = virtv1.Scheduling
+			vmi.Status.Phase = v1.Scheduling
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
@@ -1514,10 +1513,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 		It("should update the virtual machine to failed if compute container is terminated while still scheduling", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodTerminatingReason)
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodTerminatingReason)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodPending)
 			pod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{Name: "compute", State: k8sv1.ContainerState{Terminated: &k8sv1.ContainerStateTerminated{}}}}
-			vmi.Status.Phase = virtv1.Scheduling
+			vmi.Status.Phase = v1.Scheduling
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
@@ -1526,47 +1525,47 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			controller.Execute()
 		})
-		DescribeTable("should remove the fore ground finalizer if no pod is present and the vmi is in ", func(phase virtv1.VirtualMachineInstancePhase) {
+		DescribeTable("should remove the fore ground finalizer if no pod is present and the vmi is in ", func(phase v1.VirtualMachineInstancePhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = phase
 			vmi.Status.LauncherContainerImageVersion = "madeup"
 			vmi.Labels = map[string]string{}
-			vmi.Labels[virtv1.OutdatedLauncherImageLabel] = ""
-			vmi.Finalizers = append(vmi.Finalizers, virtv1.VirtualMachineInstanceFinalizer)
-			Expect(vmi.Finalizers).To(ContainElement(virtv1.VirtualMachineInstanceFinalizer))
+			vmi.Labels[v1.OutdatedLauncherImageLabel] = ""
+			vmi.Finalizers = append(vmi.Finalizers, v1.VirtualMachineInstanceFinalizer)
+			Expect(vmi.Finalizers).To(ContainElement(v1.VirtualMachineInstanceFinalizer))
 
 			addVirtualMachine(vmi)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
 				// outdated launcher label should get cleared after being finalized
-				_, ok := arg.(*virtv1.VirtualMachineInstance).Labels[virtv1.OutdatedLauncherImageLabel]
+				_, ok := arg.(*v1.VirtualMachineInstance).Labels[v1.OutdatedLauncherImageLabel]
 				Expect(ok).To(BeFalse())
 				// outdated launcher image should get cleared after being finalized
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.LauncherContainerImageVersion).To(Equal(""))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.LauncherContainerImageVersion).To(Equal(""))
 
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(phase))
-				Expect(arg.(*virtv1.VirtualMachineInstance).Finalizers).ToNot(ContainElement(virtv1.VirtualMachineInstanceFinalizer))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(phase))
+				Expect(arg.(*v1.VirtualMachineInstance).Finalizers).ToNot(ContainElement(v1.VirtualMachineInstanceFinalizer))
 			}).Return(vmi, nil)
 
 			controller.Execute()
 		},
-			Entry("succeeded state", virtv1.Succeeded),
-			Entry("failed state", virtv1.Failed),
+			Entry("succeeded state", v1.Succeeded),
+			Entry("failed state", v1.Failed),
 		)
 
 		DescribeTable("VM controller finalizer", func(hasOwner, vmExists, expectFinalizer bool) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Finalizers = append(vmi.Finalizers, virtv1.VirtualMachineControllerFinalizer, virtv1.VirtualMachineInstanceFinalizer)
-			vmi.Status.Phase = virtv1.Succeeded
-			Expect(vmi.Finalizers).To(ContainElement(virtv1.VirtualMachineControllerFinalizer))
+			vmi.Finalizers = append(vmi.Finalizers, v1.VirtualMachineControllerFinalizer, v1.VirtualMachineInstanceFinalizer)
+			vmi.Status.Phase = v1.Succeeded
+			Expect(vmi.Finalizers).To(ContainElement(v1.VirtualMachineControllerFinalizer))
 
 			vm := VirtualMachineFromVMI(vmi.Name, vmi, true)
 			vm.UID = "123"
 			if hasOwner {
 				t := true
 				vmi.OwnerReferences = []metav1.OwnerReference{{
-					APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-					Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
+					APIVersion:         v1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+					Kind:               v1.VirtualMachineGroupVersionKind.Kind,
 					Name:               vm.ObjectMeta.Name,
 					UID:                vm.ObjectMeta.UID,
 					Controller:         &t,
@@ -1586,11 +1585,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
 				if !expectFinalizer {
-					Expect(arg.(*virtv1.VirtualMachineInstance).Finalizers).ToNot(ContainElement(virtv1.VirtualMachineControllerFinalizer))
+					Expect(arg.(*v1.VirtualMachineInstance).Finalizers).ToNot(ContainElement(v1.VirtualMachineControllerFinalizer))
 				} else {
-					Expect(arg.(*virtv1.VirtualMachineInstance).Finalizers).To(ContainElement(virtv1.VirtualMachineControllerFinalizer))
+					Expect(arg.(*v1.VirtualMachineInstance).Finalizers).To(ContainElement(v1.VirtualMachineControllerFinalizer))
 				}
-				Expect(arg.(*virtv1.VirtualMachineInstance).Finalizers).ToNot(ContainElement(virtv1.VirtualMachineInstanceFinalizer))
+				Expect(arg.(*v1.VirtualMachineInstance).Finalizers).ToNot(ContainElement(v1.VirtualMachineInstanceFinalizer))
 			}).Return(vmi, nil)
 
 			controller.Execute()
@@ -1602,12 +1601,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Scheduled
+			vmi.Status.Phase = v1.Scheduled
 			pod := NewPodForVirtualMachine(vmi, phase)
 
-			unreadyReason := virtv1.GuestNotRunningReason
+			unreadyReason := v1.GuestNotRunningReason
 			if phase == k8sv1.PodSucceeded || phase == k8sv1.PodFailed {
-				unreadyReason = virtv1.PodTerminatingReason
+				unreadyReason = v1.PodTerminatingReason
 			}
 			setReadyCondition(vmi, k8sv1.ConditionFalse, unreadyReason)
 
@@ -1627,7 +1626,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should add outdated label if pod's image is outdated and VMI is in running state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			setReadyCondition(vmi, k8sv1.ConditionTrue, "")
-			vmi.Status.Phase = virtv1.Running
+			vmi.Status.Phase = v1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
@@ -1655,7 +1654,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should remove outdated label if pod's image up-to-date and VMI is in running state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			setReadyCondition(vmi, k8sv1.ConditionTrue, "")
-			vmi.Status.Phase = virtv1.Running
+			vmi.Status.Phase = v1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
@@ -1663,7 +1662,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				vmi.Labels = make(map[string]string)
 			}
 
-			vmi.Labels[virtv1.OutdatedLauncherImageLabel] = ""
+			vmi.Labels[v1.OutdatedLauncherImageLabel] = ""
 
 			pod.Spec.Containers = append(pod.Spec.Containers, k8sv1.Container{
 				Image: controller.templateService.GetLauncherImage(),
@@ -1684,7 +1683,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should add a ready condition if it is present on the pod and the VMI is in running state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Status.Conditions = nil
-			vmi.Status.Phase = virtv1.Running
+			vmi.Status.Phase = v1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
@@ -1701,7 +1700,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		It("should indicate on the ready condition if the pod is terminating", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Status.Conditions = nil
-			vmi.Status.Phase = virtv1.Running
+			vmi.Status.Phase = v1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.DeletionTimestamp = now()
 			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
@@ -1710,19 +1709,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 			podFeeder.Add(pod)
 
-			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), &metav1.PatchOptions{}).DoAndReturn(func(ctx context.Context, _ string, _ interface{}, patchBytes []byte, options interface{}, _ ...string) (*virtv1.VirtualMachineInstance, error) {
+			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), &metav1.PatchOptions{}).DoAndReturn(func(ctx context.Context, _ string, _ interface{}, patchBytes []byte, options interface{}, _ ...string) (*v1.VirtualMachineInstance, error) {
 				patch, err := jsonpatch.DecodePatch(patchBytes)
 				Expect(err).ToNot(HaveOccurred())
 				vmiBytes, err := json.Marshal(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				vmiBytes, err = patch.Apply(vmiBytes)
 				Expect(err).ToNot(HaveOccurred())
-				patchedVMI := &virtv1.VirtualMachineInstance{}
+				patchedVMI := &v1.VirtualMachineInstance{}
 				err = json.Unmarshal(vmiBytes, patchedVMI)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(patchedVMI.Status.Conditions).To(HaveLen(1))
 				cond := patchedVMI.Status.Conditions[0]
-				Expect(cond.Reason).To(Equal(virtv1.PodTerminatingReason))
+				Expect(cond.Reason).To(Equal(v1.PodTerminatingReason))
 				Expect(string(cond.Type)).To(Equal(string(k8sv1.PodReady)))
 				Expect(cond.Status).To(Equal(k8sv1.ConditionFalse))
 				return patchedVMI, nil
@@ -1732,8 +1731,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("should add active pods to status if VMI is in running state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodConditionMissingReason)
-			vmi.Status.Phase = virtv1.Running
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodConditionMissingReason)
+			vmi.Status.Phase = v1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.UID = "someUID"
 			pod.Spec.NodeName = "someHost"
@@ -1749,10 +1748,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("should not remove sync conditions from virt-handler if it is in scheduled state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-			vmi.Status.Phase = virtv1.Scheduled
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+			vmi.Status.Phase = v1.Scheduled
 			vmi.Status.Conditions = append(vmi.Status.Conditions,
-				virtv1.VirtualMachineInstanceCondition{Type: virtv1.VirtualMachineInstanceSynchronized, Status: k8sv1.ConditionFalse})
+				v1.VirtualMachineInstanceCondition{Type: v1.VirtualMachineInstanceSynchronized, Status: k8sv1.ConditionFalse})
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
@@ -1763,7 +1762,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			controller.Execute()
 		})
 
-		DescribeTable("should do nothing if the vmi is handed over to virt-handler, the pod disappears", func(phase virtv1.VirtualMachineInstancePhase) {
+		DescribeTable("should do nothing if the vmi is handed over to virt-handler, the pod disappears", func(phase v1.VirtualMachineInstancePhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = phase
 
@@ -1771,14 +1770,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			controller.Execute()
 		},
-			Entry("and the vmi is in running state", virtv1.Running),
-			Entry("and the vmi is in scheduled state", virtv1.Scheduled),
+			Entry("and the vmi is in running state", v1.Running),
+			Entry("and the vmi is in scheduled state", v1.Scheduled),
 		)
 
 		DescribeTable("should move the vmi to failed if pod is not handed over", func(phase k8sv1.PodPhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodTerminatingReason)
-			vmi.Status.Phase = virtv1.Scheduling
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodTerminatingReason)
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, phase)
 
 			addVirtualMachine(vmi)
@@ -1794,7 +1793,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		DescribeTable("should set a Synchronized=False condition when pod runs into image pull errors", func(initContainer bool, containerWaitingReason string) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Scheduling
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodPending)
 
 			containerStatus := &pod.Status.ContainerStatuses[0]
@@ -1810,9 +1809,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
-						"Type":   Equal(virtv1.VirtualMachineInstanceSynchronized),
+						"Type":   Equal(v1.VirtualMachineInstanceSynchronized),
 						"Status": Equal(k8sv1.ConditionFalse),
 						"Reason": Equal(containerWaitingReason),
 					})))
@@ -1828,12 +1827,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		DescribeTable("should override Synchronized=False condition reason when it's already set", func(prevReason, newReason string) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Scheduling
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodPending)
 
-			vmi.Status.Conditions = []virtv1.VirtualMachineInstanceCondition{
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
-					Type:   virtv1.VirtualMachineInstanceSynchronized,
+					Type:   v1.VirtualMachineInstanceSynchronized,
 					Status: k8sv1.ConditionFalse,
 					Reason: prevReason,
 				},
@@ -1851,9 +1850,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
-						"Type":   Equal(virtv1.VirtualMachineInstanceSynchronized),
+						"Type":   Equal(v1.VirtualMachineInstanceSynchronized),
 						"Status": Equal(k8sv1.ConditionFalse),
 						"Reason": Equal(newReason),
 					})))
@@ -1866,17 +1865,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 		It("should add MigrationTransport to VMI status if MigrationTransportUnixAnnotation was set", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Scheduling
+			vmi.Status.Phase = v1.Scheduling
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Annotations[virtv1.MigrationTransportUnixAnnotation] = "true"
+			pod.Annotations[v1.MigrationTransportUnixAnnotation] = "true"
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.MigrationTransport).
-					To(Equal(virtv1.MigrationTransportUnix))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.MigrationTransport).
+					To(Equal(v1.MigrationTransportUnix))
 			}).Return(vmi, nil)
 			controller.Execute()
 		})
@@ -1890,7 +1889,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			DescribeTable("when VMI dynamic label set changes", func(td *testData) {
 				vmi := NewPendingVirtualMachine("testvmi")
-				vmi.Status.Phase = virtv1.Running
+				vmi.Status.Phase = v1.Running
 
 				pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
@@ -1921,10 +1920,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("when VMI and pod labels differ",
 					&testData{
 						vmiLabels: map[string]string{
-							virtv1.NodeNameLabel: "node2",
+							v1.NodeNameLabel: "node2",
 						},
 						podLabels: map[string]string{
-							virtv1.NodeNameLabel: "node1",
+							v1.NodeNameLabel: "node1",
 						},
 						expectedPatch: `[{ "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234","kubevirt.io/nodeName":"node1"} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234","kubevirt.io/nodeName":"node2"} }]`,
 					},
@@ -1932,10 +1931,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("when VMI and pod label are the same",
 					&testData{
 						vmiLabels: map[string]string{
-							virtv1.NodeNameLabel: "node1",
+							v1.NodeNameLabel: "node1",
 						},
 						podLabels: map[string]string{
-							virtv1.NodeNameLabel: "node1",
+							v1.NodeNameLabel: "node1",
 						},
 						expectedPatch: "",
 					},
@@ -1944,7 +1943,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 					&testData{
 						vmiLabels: map[string]string{
-							virtv1.NodeNameLabel: "node1",
+							v1.NodeNameLabel: "node1",
 						},
 						podLabels:     map[string]string{},
 						expectedPatch: `[{ "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234"} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234","kubevirt.io/nodeName":"node1"} }]`,
@@ -1961,7 +1960,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					&testData{
 						vmiLabels: map[string]string{},
 						podLabels: map[string]string{
-							virtv1.OutdatedLauncherImageLabel: "",
+							v1.OutdatedLauncherImageLabel: "",
 						},
 						expectedPatch: `[{ "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234","kubevirt.io/outdatedLauncherImage":""} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234"} }]`,
 					},
@@ -1971,17 +1970,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		DescribeTable("should set VirtualMachineUnpaused=False pod condition when VMI is paused", func(currUnpausedStatus k8sv1.ConditionStatus) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Running
-			kvcontroller.NewVirtualMachineInstanceConditionManager().UpdateCondition(vmi, &virtv1.VirtualMachineInstanceCondition{
-				Type:   virtv1.VirtualMachineInstancePaused,
+			vmi.Status.Phase = v1.Running
+			kvcontroller.NewVirtualMachineInstanceConditionManager().UpdateCondition(vmi, &v1.VirtualMachineInstanceCondition{
+				Type:   v1.VirtualMachineInstancePaused,
 				Status: k8sv1.ConditionTrue,
 			})
 
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			kvcontroller.NewPodConditionManager().RemoveCondition(pod, virtv1.VirtualMachineUnpaused)
+			kvcontroller.NewPodConditionManager().RemoveCondition(pod, v1.VirtualMachineUnpaused)
 			if currUnpausedStatus != k8sv1.ConditionUnknown {
 				pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{
-					Type:   virtv1.VirtualMachineUnpaused,
+					Type:   v1.VirtualMachineUnpaused,
 					Status: currUnpausedStatus,
 				})
 			}
@@ -1993,7 +1992,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), &metav1.PatchOptions{}).Return(vmi, nil)
 			kubeClient.Fake.PrependReactor("patch", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
 				patch, _ := action.(testing.PatchAction)
-				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"type":"%s"`, virtv1.VirtualMachineUnpaused)))
+				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"type":"%s"`, v1.VirtualMachineUnpaused)))
 				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"status":"%s"`, k8sv1.ConditionFalse)))
 
 				return true, nil, nil
@@ -2007,14 +2006,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		DescribeTable("should set VirtualMachineUnpaused=True pod condition when VMI is not paused", func(currUnpausedStatus k8sv1.ConditionStatus) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = virtv1.Running
-			kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, virtv1.VirtualMachineInstancePaused)
+			vmi.Status.Phase = v1.Running
+			kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, v1.VirtualMachineInstancePaused)
 
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			kvcontroller.NewPodConditionManager().RemoveCondition(pod, virtv1.VirtualMachineUnpaused)
+			kvcontroller.NewPodConditionManager().RemoveCondition(pod, v1.VirtualMachineUnpaused)
 			if currUnpausedStatus != k8sv1.ConditionUnknown {
 				pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{
-					Type:   virtv1.VirtualMachineUnpaused,
+					Type:   v1.VirtualMachineUnpaused,
 					Status: currUnpausedStatus,
 				})
 			}
@@ -2026,7 +2025,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), &metav1.PatchOptions{}).Return(vmi, nil)
 			kubeClient.Fake.PrependReactor("patch", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
 				patch, _ := action.(testing.PatchAction)
-				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"type":"%s"`, virtv1.VirtualMachineUnpaused)))
+				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"type":"%s"`, v1.VirtualMachineUnpaused)))
 				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"status":"%s"`, k8sv1.ConditionTrue)))
 
 				return true, nil, nil
@@ -2044,13 +2043,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				requestedGuestMemory := resource.MustParse("512Mi")
 
 				vmi := NewPendingVirtualMachine("testvmi")
-				vmi.Status.Phase = virtv1.Running
-				vmi.Status.Memory = &virtv1.MemoryStatus{
+				vmi.Status.Phase = v1.Running
+				vmi.Status.Memory = &v1.MemoryStatus{
 					GuestAtBoot:    &currentGuestMemory,
 					GuestCurrent:   &currentGuestMemory,
 					GuestRequested: &currentGuestMemory,
 				}
-				vmi.Spec.Domain.Memory = &virtv1.Memory{
+				vmi.Spec.Domain.Memory = &v1.Memory{
 					Guest:    &requestedGuestMemory,
 					MaxGuest: &requestedGuestMemory,
 				}
@@ -2071,11 +2070,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					newVMIBytes, err := patchJSON.Apply(originalVMIBytes)
 					Expect(err).ToNot(HaveOccurred())
 
-					var newVMI *virtv1.VirtualMachineInstance
+					var newVMI *v1.VirtualMachineInstance
 					err = json.Unmarshal(newVMIBytes, &newVMI)
 					Expect(err).ToNot(HaveOccurred())
 
-					memoryChange := kvcontroller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(newVMI, virtv1.VirtualMachineInstanceMemoryChange, k8sv1.ConditionTrue)
+					memoryChange := kvcontroller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(newVMI, v1.VirtualMachineInstanceMemoryChange, k8sv1.ConditionTrue)
 					Expect(memoryChange).To(BeTrue())
 
 				})
@@ -2088,11 +2087,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				requestedGuestMemory := resource.MustParse("512Mi")
 
 				vmi := NewPendingVirtualMachine("testvmi")
-				vmi.Status.Phase = virtv1.Running
-				vmi.Status.Memory = &virtv1.MemoryStatus{
+				vmi.Status.Phase = v1.Running
+				vmi.Status.Memory = &v1.MemoryStatus{
 					GuestCurrent: &currentGuestMemory,
 				}
-				vmi.Spec.Domain.Memory = &virtv1.Memory{
+				vmi.Spec.Domain.Memory = &v1.Memory{
 					Guest:    &requestedGuestMemory,
 					MaxGuest: &requestedGuestMemory,
 				}
@@ -2103,7 +2102,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 				controller.syncMemoryHotplug(vmi)
 
-				Expect(vmi.Labels).To(HaveKeyWithValue(virtv1.MemoryHotplugOverheadRatioLabel, overheadRatio))
+				Expect(vmi.Labels).To(HaveKeyWithValue(v1.MemoryHotplugOverheadRatioLabel, overheadRatio))
 			})
 		})
 	})
@@ -2173,13 +2172,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			addVirtualMachine(vmi)
 			podFeeder.Add(virtlauncherPod)
-			invalidVolume := &virtv1.Volume{
+			invalidVolume := &v1.Volume{
 				Name: "fake",
-				VolumeSource: virtv1.VolumeSource{
-					ConfigMap: &virtv1.ConfigMapVolumeSource{},
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{invalidVolume})
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*v1.Volume{invalidVolume})
 			Expect(pod).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
@@ -2192,17 +2191,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			addVirtualMachine(vmi)
 			podFeeder.Add(virtlauncherPod)
-			nopvcVolume := &virtv1.Volume{
+			nopvcVolume := &v1.Volume{
 				Name: "nopvc",
-				VolumeSource: virtv1.VolumeSource{
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "noclaim",
 						},
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{nopvcVolume})
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*v1.Volume{nopvcVolume})
 			Expect(pod).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
@@ -2219,20 +2218,20 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 			addVirtualMachine(vmi)
 			podFeeder.Add(virtlauncherPod)
-			volume := &virtv1.Volume{
+			volume := &v1.Volume{
 				Name: "test-pvc-volume",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "test-dv",
 					},
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "test-dv",
 						},
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{volume})
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*v1.Volume{volume})
 			Expect(pod).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
@@ -2254,30 +2253,30 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
 			addVirtualMachine(vmi)
 			podFeeder.Add(virtlauncherPod)
-			volume := &virtv1.Volume{
+			volume := &v1.Volume{
 				Name: "test-pvc-volume",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "test-dv",
 					},
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "test-dv",
 						},
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{volume})
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*v1.Volume{volume})
 			Expect(pod).To(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("CreateAttachmentPodTemplate should update status to bound if DV owning PVC is bound but not ready", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, virtv1.VolumeStatus{
+			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
 				Name:          "test-pvc-volume",
-				HotplugVolume: &virtv1.HotplugVolumeStatus{},
-				Phase:         virtv1.VolumePending,
+				HotplugVolume: &v1.HotplugVolumeStatus{},
+				Phase:         v1.VolumePending,
 				Message:       "some technical reason",
 				Reason:        PVCNotReadyReason,
 			})
@@ -2296,20 +2295,20 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
 			addVirtualMachine(vmi)
 			podFeeder.Add(virtlauncherPod)
-			volume := &virtv1.Volume{
+			volume := &v1.Volume{
 				Name: "test-pvc-volume",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "test-dv",
 					},
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "test-dv",
 						},
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{volume})
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*v1.Volume{volume})
 			Expect(pod).To(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -2332,20 +2331,20 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
 			addVirtualMachine(vmi)
 			podFeeder.Add(virtlauncherPod)
-			volume := &virtv1.Volume{
+			volume := &v1.Volume{
 				Name: "test-pvc-volume",
-				VolumeSource: virtv1.VolumeSource{
-					DataVolume: &virtv1.DataVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
 						Name: "test-dv",
 					},
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "test-dv",
 						},
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{volume})
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*v1.Volume{volume})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.GenerateName).To(Equal("hp-volume-"))
 			found := false
@@ -2398,13 +2397,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return makePodWithVirtlauncher(virtlauncherPod, indexes...)
 		}
 
-		makeVolumes := func(indexes ...int) []*virtv1.Volume {
-			res := make([]*virtv1.Volume, 0)
+		makeVolumes := func(indexes ...int) []*v1.Volume {
+			res := make([]*v1.Volume, 0)
 			for _, index := range indexes {
-				res = append(res, &virtv1.Volume{
+				res = append(res, &v1.Volume{
 					Name: fmt.Sprintf("volume%d", index),
-					VolumeSource: virtv1.VolumeSource{
-						PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 								ClaimName: fmt.Sprintf("claim%d", index),
 							},
@@ -2415,26 +2414,26 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return res
 		}
 
-		makeVolumesWithMemoryDump := func(total int, indexes ...int) []*virtv1.Volume {
-			res := make([]*virtv1.Volume, 0)
+		makeVolumesWithMemoryDump := func(total int, indexes ...int) []*v1.Volume {
+			res := make([]*v1.Volume, 0)
 			for i := 0; i < total; i++ {
 				memoryDump := false
 				for _, index := range indexes {
 					if i == index {
 						memoryDump = true
-						res = append(res, &virtv1.Volume{
+						res = append(res, &v1.Volume{
 							Name: fmt.Sprintf("volume%d", index),
-							VolumeSource: virtv1.VolumeSource{
+							VolumeSource: v1.VolumeSource{
 								MemoryDump: testutils.NewFakeMemoryDumpSource(fmt.Sprintf("claim%d", i)),
 							},
 						})
 					}
 				}
 				if !memoryDump {
-					res = append(res, &virtv1.Volume{
+					res = append(res, &v1.Volume{
 						Name: fmt.Sprintf("volume%d", i),
-						VolumeSource: virtv1.VolumeSource{
-							PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 								PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 									ClaimName: fmt.Sprintf("claim%d", i),
 								},
@@ -2461,55 +2460,55 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return res
 		}
 
-		DescribeTable("should calculate deleted volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*virtv1.Volume, expected []k8sv1.Volume) {
+		DescribeTable("should calculate deleted volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*v1.Volume, expected []k8sv1.Volume) {
 			res := controller.getDeletedHotplugVolumes(hotplugPods, hotplugVolumes)
 			Expect(res).To(HaveLen(len(expected)))
 			for i, volume := range res {
 				Expect(equality.Semantic.DeepEqual(volume, expected[i])).To(BeTrue(), "%v does not match %v", volume, expected[i])
 			}
 		},
-			Entry("should return empty if pods and volumes is empty", make([]*k8sv1.Pod, 0), make([]*virtv1.Volume, 0), make([]k8sv1.Volume, 0)),
+			Entry("should return empty if pods and volumes is empty", make([]*k8sv1.Pod, 0), make([]*v1.Volume, 0), make([]k8sv1.Volume, 0)),
 			Entry("should return empty if pods and volumes match", makePods(1), makeVolumes(1), make([]k8sv1.Volume, 0)),
 			Entry("should return empty if pods < volumes", makePods(1), makeVolumes(1, 2), make([]k8sv1.Volume, 0)),
 		)
 
-		DescribeTable("should calculate new volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*virtv1.Volume, expected []*virtv1.Volume) {
+		DescribeTable("should calculate new volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*v1.Volume, expected []*v1.Volume) {
 			res := controller.getNewHotplugVolumes(hotplugPods, hotplugVolumes)
 			Expect(res).To(HaveLen(len(expected)))
 			for i, volume := range res {
 				Expect(equality.Semantic.DeepEqual(volume, expected[i])).To(BeTrue(), "%v does not match %v", volume, expected[i])
 			}
 		},
-			Entry("should return empty if pods and volumes is empty", make([]*k8sv1.Pod, 0), make([]*virtv1.Volume, 0), make([]*virtv1.Volume, 0)),
-			Entry("should return empty if pods and volumes match", makePods(1), makeVolumes(1), make([]*virtv1.Volume, 0)),
+			Entry("should return empty if pods and volumes is empty", make([]*k8sv1.Pod, 0), make([]*v1.Volume, 0), make([]*v1.Volume, 0)),
+			Entry("should return empty if pods and volumes match", makePods(1), makeVolumes(1), make([]*v1.Volume, 0)),
 			Entry("should return empty if pods > volumes", makePods(1), makeVolumes(1, 2), makeVolumes(2)),
-			Entry("should return 1 value if pods < volumes by 1", makePods(1, 2), makeVolumes(1), make([]*virtv1.Volume, 0)),
+			Entry("should return 1 value if pods < volumes by 1", makePods(1, 2), makeVolumes(1), make([]*v1.Volume, 0)),
 		)
 
-		makeVolumeStatuses := func() []virtv1.VolumeStatus {
-			volumeStatuses := make([]virtv1.VolumeStatus, 0)
-			volumeStatuses = append(volumeStatuses, virtv1.VolumeStatus{
+		makeVolumeStatuses := func() []v1.VolumeStatus {
+			volumeStatuses := make([]v1.VolumeStatus, 0)
+			volumeStatuses = append(volumeStatuses, v1.VolumeStatus{
 				Name: "test-volume",
-				HotplugVolume: &virtv1.HotplugVolumeStatus{
+				HotplugVolume: &v1.HotplugVolumeStatus{
 					AttachPodName: "attach-pod",
 					AttachPodUID:  "abcd",
 				},
 			})
-			volumeStatuses = append(volumeStatuses, virtv1.VolumeStatus{
+			volumeStatuses = append(volumeStatuses, v1.VolumeStatus{
 				Name:          "test-volume2",
-				HotplugVolume: &virtv1.HotplugVolumeStatus{},
+				HotplugVolume: &v1.HotplugVolumeStatus{},
 			})
 			return volumeStatuses
 		}
 
-		DescribeTable("should determine if status contains the volume including a pod", func(volumeStatuses []virtv1.VolumeStatus, volume *virtv1.Volume, expected bool) {
+		DescribeTable("should determine if status contains the volume including a pod", func(volumeStatuses []v1.VolumeStatus, volume *v1.Volume, expected bool) {
 			res := controller.volumeStatusContainsVolumeAndPod(volumeStatuses, volume)
 			Expect(res).To(Equal(expected))
 		},
-			Entry("should return true if the volume with pod is in the status", makeVolumeStatuses(), &virtv1.Volume{
+			Entry("should return true if the volume with pod is in the status", makeVolumeStatuses(), &v1.Volume{
 				Name: "test-volume",
 			}, true),
-			Entry("should return false if the volume with pod is in the status", makeVolumeStatuses(), &virtv1.Volume{
+			Entry("should return false if the volume with pod is in the status", makeVolumeStatuses(), &v1.Volume{
 				Name: "test-volume2",
 			}, false),
 		)
@@ -2534,7 +2533,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 		}
 
-		DescribeTable("handleHotplugVolumes should properly react to input", func(hotplugVolumes []*virtv1.Volume, hotplugAttachmentPods []*k8sv1.Pod, createPodReaction func(*k8sv1.Pod, ...int), pvcFunc func(...int), pvcIndexes []int, orgStatus []virtv1.VolumeStatus, expectedEvent string, expectedErr syncError) {
+		DescribeTable("handleHotplugVolumes should properly react to input", func(hotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8sv1.Pod, createPodReaction func(*k8sv1.Pod, ...int), pvcFunc func(...int), pvcIndexes []int, orgStatus []v1.VolumeStatus, expectedEvent string, expectedErr syncError) {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Status.VolumeStatus = orgStatus
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
@@ -2576,7 +2575,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				nil),
 		)
 
-		DescribeTable("needsHandleHotplug", func(hotplugVolumes []*virtv1.Volume, hotplugAttachmentPods []*k8sv1.Pod, expected bool) {
+		DescribeTable("needsHandleHotplug", func(hotplugVolumes []*v1.Volume, hotplugAttachmentPods []*k8sv1.Pod, expected bool) {
 			res := controller.needsHandleHotplug(hotplugVolumes, hotplugAttachmentPods)
 			Expect(res).To(Equal(expected))
 		},
@@ -2632,7 +2631,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("should return number (2) of pods passed in", 2),
 		)
 
-		DescribeTable("getHotplugVolumes", func(virtlauncherVolumes []k8sv1.Volume, vmiVolumes []*virtv1.Volume, expectedIndexes ...int) {
+		DescribeTable("getHotplugVolumes", func(virtlauncherVolumes []k8sv1.Volume, vmiVolumes []*v1.Volume, expectedIndexes ...int) {
 			vmi := NewPendingVirtualMachine("testvmi")
 			for _, volume := range vmiVolumes {
 				vmi.Spec.Volumes = append(vmi.Spec.Volumes, *volume)
@@ -2663,20 +2662,20 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return fmt.Sprintf(str, args[:n]...)
 		}
 
-		makeVolumeStatusesForUpdateWithMessage := func(podName, podUID string, phase virtv1.VolumePhase, message, reason string, indexes ...int) []virtv1.VolumeStatus {
-			res := make([]virtv1.VolumeStatus, 0)
+		makeVolumeStatusesForUpdateWithMessage := func(podName, podUID string, phase v1.VolumePhase, message, reason string, indexes ...int) []v1.VolumeStatus {
+			res := make([]v1.VolumeStatus, 0)
 			for _, index := range indexes {
 				fsOverhead := storagetypes.DefaultFSOverhead
-				res = append(res, virtv1.VolumeStatus{
+				res = append(res, v1.VolumeStatus{
 					Name: fmt.Sprintf("volume%d", index),
-					HotplugVolume: &virtv1.HotplugVolumeStatus{
+					HotplugVolume: &v1.HotplugVolumeStatus{
 						AttachPodName: truncateSprintf(podName, index),
 						AttachPodUID:  types.UID(truncateSprintf(podUID, index)),
 					},
 					Phase:   phase,
 					Message: truncateSprintf(message, index, index),
 					Reason:  reason,
-					PersistentVolumeClaimInfo: &virtv1.PersistentVolumeClaimInfo{
+					PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
 						AccessModes: []k8sv1.PersistentVolumeAccessMode{
 							k8sv1.ReadOnlyMany,
 						},
@@ -2687,21 +2686,21 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return res
 		}
 
-		makeVolumeStatusesForUpdateWithMemoryDump := func(dumpIndex int, indexes ...int) []virtv1.VolumeStatus {
-			res := makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", virtv1.HotplugVolumeAttachedToNode, "Created hotplug attachment pod test-pod, for volume volume%d", SuccessfulCreatePodReason, indexes...)
-			res[dumpIndex].MemoryDumpVolume = &virtv1.DomainMemoryDumpInfo{
+		makeVolumeStatusesForUpdateWithMemoryDump := func(dumpIndex int, indexes ...int) []v1.VolumeStatus {
+			res := makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", v1.HotplugVolumeAttachedToNode, "Created hotplug attachment pod test-pod, for volume volume%d", SuccessfulCreatePodReason, indexes...)
+			res[dumpIndex].MemoryDumpVolume = &v1.DomainMemoryDumpInfo{
 				ClaimName: fmt.Sprintf("volume%d", dumpIndex),
 			}
 			return res
 		}
 
-		makeVolumeStatusesForUpdate := func(indexes ...int) []virtv1.VolumeStatus {
-			return makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", virtv1.HotplugVolumeAttachedToNode, "Created hotplug attachment pod test-pod, for volume volume%d", SuccessfulCreatePodReason, indexes...)
+		makeVolumeStatusesForUpdate := func(indexes ...int) []v1.VolumeStatus {
+			return makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", v1.HotplugVolumeAttachedToNode, "Created hotplug attachment pod test-pod, for volume volume%d", SuccessfulCreatePodReason, indexes...)
 		}
 
-		DescribeTable("updateVolumeStatus", func(oldStatus []virtv1.VolumeStatus, specVolumes []*virtv1.Volume, podIndexes []int, pvcIndexes []int, expectedStatus []virtv1.VolumeStatus, expectedEvents []string) {
+		DescribeTable("updateVolumeStatus", func(oldStatus []v1.VolumeStatus, specVolumes []*v1.Volume, podIndexes []int, pvcIndexes []int, expectedStatus []v1.VolumeStatus, expectedEvents []string) {
 			vmi := NewPendingVirtualMachine("testvmi")
-			volumes := make([]virtv1.Volume, 0)
+			volumes := make([]v1.Volume, 0)
 			for _, volume := range specVolumes {
 				volumes = append(volumes, *volume)
 			}
@@ -2743,21 +2742,21 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				makeVolumes(0),
 				[]int{},
 				[]int{0},
-				makeVolumeStatusesForUpdateWithMessage("", "", virtv1.VolumeBound, "PVC is in phase Bound", PVCNotReadyReason, 0),
+				makeVolumeStatusesForUpdateWithMessage("", "", v1.VolumeBound, "PVC is in phase Bound", PVCNotReadyReason, 0),
 				[]string{}),
 			Entry("should update volume status, if a existing volume is changed, and pod does not exist",
-				makeVolumeStatusesForUpdateWithMessage("", "", virtv1.VolumePending, "PVC is in phase Pending", PVCNotReadyReason, 0),
+				makeVolumeStatusesForUpdateWithMessage("", "", v1.VolumePending, "PVC is in phase Pending", PVCNotReadyReason, 0),
 				makeVolumes(0),
 				[]int{},
 				[]int{0},
-				makeVolumeStatusesForUpdateWithMessage("", "", virtv1.VolumeBound, "PVC is in phase Bound", PVCNotReadyReason, 0),
+				makeVolumeStatusesForUpdateWithMessage("", "", v1.VolumeBound, "PVC is in phase Bound", PVCNotReadyReason, 0),
 				[]string{}),
 			Entry("should keep status, if volume removed and if pod still exists",
 				makeVolumeStatusesForUpdate(0),
 				makeVolumes(),
 				[]int{0},
 				[]int{0},
-				makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", virtv1.HotplugVolumeDetaching, "Deleted hotplug attachment pod test-pod, for volume volume0", SuccessfulDeletePodReason, 0),
+				makeVolumeStatusesForUpdateWithMessage("test-pod", "abcd", v1.HotplugVolumeDetaching, "Deleted hotplug attachment pod test-pod, for volume volume0", SuccessfulDeletePodReason, 0),
 				[]string{SuccessfulDeletePodReason}),
 			Entry("should remove volume status, if volume is removed and pod is gone",
 				makeVolumeStatusesForUpdate(0),
@@ -2775,52 +2774,52 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				[]string{SuccessfulCreatePodReason}),
 		)
 
-		DescribeTable("Should properly calculate if it needs to handle hotplug volumes", func(hotplugVolumes []*virtv1.Volume, attachmentPods []*k8sv1.Pod, match gomegaTypes.GomegaMatcher) {
+		DescribeTable("Should properly calculate if it needs to handle hotplug volumes", func(hotplugVolumes []*v1.Volume, attachmentPods []*k8sv1.Pod, match gomegaTypes.GomegaMatcher) {
 			Expect(controller.needsHandleHotplug(hotplugVolumes, attachmentPods)).To(match)
 		},
 			Entry("nil volumes, nil attachmentPods", nil, nil, BeFalse()),
-			Entry("empty volumes, empty attachmentPods", []*virtv1.Volume{}, []*k8sv1.Pod{}, BeFalse()),
-			Entry("single volume, empty attachmentPods", []*virtv1.Volume{
+			Entry("empty volumes, empty attachmentPods", []*v1.Volume{}, []*k8sv1.Pod{}, BeFalse()),
+			Entry("single volume, empty attachmentPods", []*v1.Volume{
 				{
 					Name: "test",
 				},
 			}, []*k8sv1.Pod{}, BeTrue()),
-			Entry("no volume, single attachmentPod", []*virtv1.Volume{}, makePods(0), BeTrue()),
-			Entry("matching volume, single attachmentPod", []*virtv1.Volume{
+			Entry("no volume, single attachmentPod", []*v1.Volume{}, makePods(0), BeTrue()),
+			Entry("matching volume, single attachmentPod", []*v1.Volume{
 				{
 					Name: "volume0",
 				},
 			}, makePods(0), BeFalse()),
-			Entry("mismatched volume, single attachmentPod", []*virtv1.Volume{
+			Entry("mismatched volume, single attachmentPod", []*v1.Volume{
 				{
 					Name: "invalid",
 				},
 			}, makePods(0), BeTrue()),
-			Entry("matching volume, multiple attachmentPods", []*virtv1.Volume{
+			Entry("matching volume, multiple attachmentPods", []*v1.Volume{
 				{
 					Name: "volume0",
 				},
 			}, []*k8sv1.Pod{makePods(0)[0], makePods(1)[0]}, BeTrue()),
 		)
 
-		DescribeTable("Should find active and old pods", func(hotplugVolumes []*virtv1.Volume, attachmentPods []*k8sv1.Pod, expectedActive *k8sv1.Pod, expectedOld []*k8sv1.Pod) {
+		DescribeTable("Should find active and old pods", func(hotplugVolumes []*v1.Volume, attachmentPods []*k8sv1.Pod, expectedActive *k8sv1.Pod, expectedOld []*k8sv1.Pod) {
 			active, old := controller.getActiveAndOldAttachmentPods(hotplugVolumes, attachmentPods)
 			Expect(active).To(Equal(expectedActive))
 			Expect(old).To(ContainElements(expectedOld))
 		},
 			Entry("nil volumes, nil attachmentPods", nil, nil, nil, nil),
-			Entry("empty volumes, empty attachmentPods", []*virtv1.Volume{}, []*k8sv1.Pod{}, nil, []*k8sv1.Pod{}),
-			Entry("matching volume, single attachmentPod", []*virtv1.Volume{
+			Entry("empty volumes, empty attachmentPods", []*v1.Volume{}, []*k8sv1.Pod{}, nil, []*k8sv1.Pod{}),
+			Entry("matching volume, single attachmentPod", []*v1.Volume{
 				{
 					Name: "volume0",
 				},
 			}, makePods(0), makePods(0)[0], []*k8sv1.Pod{}),
-			Entry("matching volume, multiple attachmentPods, first pod matches", []*virtv1.Volume{
+			Entry("matching volume, multiple attachmentPods, first pod matches", []*v1.Volume{
 				{
 					Name: "volume0",
 				},
 			}, []*k8sv1.Pod{makePods(0)[0], makePods(1)[0]}, makePods(0)[0], makePods(1)),
-			Entry("matching volume, multiple attachmentPods, second pod matches", []*virtv1.Volume{
+			Entry("matching volume, multiple attachmentPods, second pod matches", []*v1.Volume{
 				{
 					Name: "volume1",
 				},
@@ -2915,22 +2914,22 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("Should properly create attachmentpod, if correct volume and disk are added", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodConditionMissingReason)
-			volumes := make([]virtv1.Volume, 0)
-			volumes = append(volumes, virtv1.Volume{
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodConditionMissingReason)
+			volumes := make([]v1.Volume, 0)
+			volumes = append(volumes, v1.Volume{
 				Name: "existing",
-				VolumeSource: virtv1.VolumeSource{
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "existing",
 						},
 					},
 				},
 			})
-			volumes = append(volumes, virtv1.Volume{
+			volumes = append(volumes, v1.Volume{
 				Name: "hotplug",
-				VolumeSource: virtv1.VolumeSource{
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "hotplug",
 						},
@@ -2938,26 +2937,26 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 			})
 			vmi.Spec.Volumes = volumes
-			disks := make([]virtv1.Disk, 0)
-			disks = append(disks, virtv1.Disk{
+			disks := make([]v1.Disk, 0)
+			disks = append(disks, v1.Disk{
 				Name: "existing",
-				DiskDevice: virtv1.DiskDevice{
-					Disk: &virtv1.DiskTarget{
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{
 						Bus: v1.DiskBusVirtio,
 					},
 				},
 			})
-			disks = append(disks, virtv1.Disk{
+			disks = append(disks, v1.Disk{
 				Name: "hotplug",
-				DiskDevice: virtv1.DiskDevice{
-					Disk: &virtv1.DiskTarget{
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{
 						Bus: v1.DiskBusSATA,
 					},
 				},
 			})
 			vmi.Spec.Domain.Devices.Disks = disks
-			vmi.Status.Phase = virtv1.Running
-			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, virtv1.VolumeStatus{
+			vmi.Status.Phase = v1.Running
+			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
 				Name:   "existing",
 				Target: "",
 			})
@@ -3005,41 +3004,41 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
-			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
+			Expect(vmi.Status.Phase).To(Equal(v1.Running))
 		})
 
 		It("Should properly delete attachment, if volume and disk are removed", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodConditionMissingReason)
-			volumes := make([]virtv1.Volume, 0)
-			volumes = append(volumes, virtv1.Volume{
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodConditionMissingReason)
+			volumes := make([]v1.Volume, 0)
+			volumes = append(volumes, v1.Volume{
 				Name: "existing",
-				VolumeSource: virtv1.VolumeSource{
-					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "existing",
 					}},
 				},
 			})
 			vmi.Spec.Volumes = volumes
-			disks := make([]virtv1.Disk, 0)
-			disks = append(disks, virtv1.Disk{
+			disks := make([]v1.Disk, 0)
+			disks = append(disks, v1.Disk{
 				Name: "existing",
-				DiskDevice: virtv1.DiskDevice{
-					Disk: &virtv1.DiskTarget{
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{
 						Bus: v1.DiskBusVirtio,
 					},
 				},
 			})
 			vmi.Spec.Domain.Devices.Disks = disks
-			vmi.Status.Phase = virtv1.Running
-			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, virtv1.VolumeStatus{
+			vmi.Status.Phase = v1.Running
+			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
 				Name:   "existing",
 				Target: "",
 			})
-			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, virtv1.VolumeStatus{
+			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
 				Name:   "hotplug",
 				Target: "",
-				HotplugVolume: &virtv1.HotplugVolumeStatus{
+				HotplugVolume: &v1.HotplugVolumeStatus{
 					AttachPodName: "hp-volume-hotplug",
 					AttachPodUID:  "abcd",
 				},
@@ -3095,7 +3094,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
-			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
+			Expect(vmi.Status.Phase).To(Equal(v1.Running))
 		})
 
 		DescribeTable("Should requeue if pod is not created before", func(pod *k8sv1.Pod, creationTimeAdd, requeueTime time.Duration, expected bool) {
@@ -3116,7 +3115,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("created in 2 seconds, with second requeue time, should requeue now", &k8sv1.Pod{}, 2*time.Second, time.Second, true),
 		)
 
-		DescribeTable("should clean up attachment pods, based on the number of volumes", func(readyVolumes []*virtv1.Volume, currentPod *k8sv1.Pod, oldPods []*k8sv1.Pod, expectDelete bool) {
+		DescribeTable("should clean up attachment pods, based on the number of volumes", func(readyVolumes []*v1.Volume, currentPod *k8sv1.Pod, oldPods []*k8sv1.Pod, expectDelete bool) {
 			vmi := NewRunningVirtualMachine("testvmi", &k8sv1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testnode",
@@ -3161,7 +3160,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Phase: k8sv1.PodRunning,
 				},
 			}, nil, true),
-			Entry("a volume, running current pod", []*virtv1.Volume{{}}, &k8sv1.Pod{
+			Entry("a volume, running current pod", []*v1.Volume{{}}, &k8sv1.Pod{
 				Status: k8sv1.PodStatus{
 					Phase: k8sv1.PodRunning,
 				},
@@ -3190,11 +3189,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 	Context("topology hints", func() {
 
-		getVmiWithInvTsc := func() *virtv1.VirtualMachineInstance {
+		getVmiWithInvTsc := func() *v1.VirtualMachineInstance {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Spec.Architecture = "amd64"
 			vmi.Spec.Domain.CPU = &v1.CPU{
-				Features: []virtv1.CPUFeature{
+				Features: []v1.CPUFeature{
 					{
 						Name:   "invtsc",
 						Policy: "require",
@@ -3205,7 +3204,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			return vmi
 		}
 
-		getVmiWithReenlightenment := func() *virtv1.VirtualMachineInstance {
+		getVmiWithReenlightenment := func() *v1.VirtualMachineInstance {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Spec.Architecture = "amd64"
 			vmi.Spec.Domain.Features = &v1.Features{
@@ -3218,16 +3217,16 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		}
 
 		expectTopologyHintsUpdate := func() {
-			var vmi *virtv1.VirtualMachineInstance
+			var vmi *v1.VirtualMachineInstance
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				vmi = arg.(*virtv1.VirtualMachineInstance)
+				vmi = arg.(*v1.VirtualMachineInstance)
 				Expect(topology.AreTSCFrequencyTopologyHintsDefined(vmi)).To(BeTrue())
 			}).Return(vmi, nil)
 		}
 
 		Context("needs to be set when", func() {
 
-			runController := func(vmi *virtv1.VirtualMachineInstance) {
+			runController := func(vmi *v1.VirtualMachineInstance) {
 				addVirtualMachine(vmi)
 				shouldExpectPodCreation(vmi.UID)
 				controller.Execute()
@@ -3277,7 +3276,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		Context("pod creation", func() {
 
-			runController := func(vmi *virtv1.VirtualMachineInstance) {
+			runController := func(vmi *v1.VirtualMachineInstance) {
 				addVirtualMachine(vmi)
 				controller.Execute()
 			}
@@ -3312,16 +3311,16 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	Context("auto attach VSOCK", func() {
 		It("should allocate CID when VirtualMachineInstance is scheduled", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
-			vmi.Status.Phase = virtv1.Scheduling
+			setReadyCondition(vmi, k8sv1.ConditionFalse, v1.GuestNotRunningReason)
+			vmi.Status.Phase = v1.Scheduling
 			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
 
-			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg *virtv1.VirtualMachineInstance) {
-				Expect(arg.Status.Phase).To(Equal(virtv1.Scheduled))
+			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg *v1.VirtualMachineInstance) {
+				Expect(arg.Status.Phase).To(Equal(v1.Scheduled))
 				Expect(arg.Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
 				Expect(arg.Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
 				Expect(arg.Status.VSOCKCID).NotTo(BeNil())
@@ -3333,7 +3332,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 			Expect(controller.cidsMap.Allocate(vmi)).To(Succeed())
-			vmi.Status.Phase = virtv1.Succeeded
+			vmi.Status.Phase = v1.Succeeded
 			addVirtualMachine(vmi)
 
 			Expect(vmiInformer.GetIndexer().Delete(vmi)).To(Succeed())
@@ -3349,7 +3348,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		var (
 			pod *k8sv1.Pod
-			vmi *virtv1.VirtualMachineInstance
+			vmi *v1.VirtualMachineInstance
 		)
 
 		expectPodStatusUpdateFailed := func(pod *k8sv1.Pod) {
@@ -3376,7 +3375,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				)
 				vmi.Spec.Domain.Devices.Interfaces = append(
 					vmi.Spec.Domain.Devices.Interfaces,
-					virtv1.Interface{Name: firstVMInterface}, virtv1.Interface{Name: secondVMInterface},
+					v1.Interface{Name: firstVMInterface}, v1.Interface{Name: secondVMInterface},
 				)
 
 				var err error
@@ -3452,9 +3451,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 					vmi.Spec.Networks = []v1.Network{{
 						Name:          "red",
-						NetworkSource: v1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "red-net"}}}, {
+						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "red-net"}}}, {
 						Name:          "blue",
-						NetworkSource: v1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "blue-net"}}}}
+						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "blue-net"}}}}
 
 					pod, err := NewPodForVirtualMachineWithMultusAnnotations(vmi, k8sv1.PodRunning, config, testPodNetworkStatus...)
 					Expect(err).ToNot(HaveOccurred())
@@ -3499,10 +3498,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				networkName = "meganet"
 			)
 
-			DescribeTable("updateInterfaceStatus", func(vmi *virtv1.VirtualMachineInstance, ifaceStatus ...PodVmIfaceStatus) {
+			DescribeTable("updateInterfaceStatus", func(vmi *v1.VirtualMachineInstance, ifaceStatus ...PodVmIfaceStatus) {
 				var (
 					podIfaceStatus []networkv1.NetworkStatus
-					vmIfaceStatus  []virtv1.VirtualMachineInstanceNetworkInterface
+					vmIfaceStatus  []v1.VirtualMachineInstanceNetworkInterface
 				)
 				for i, ifaceState := range ifaceStatus {
 					if ifaceState.podIfaceStatus != nil {
@@ -3551,7 +3550,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						ifaceName,
 					),
 					PodVmIfaceStatus{
-						vmIfaceStatus: &virtv1.VirtualMachineInstanceNetworkInterface{
+						vmIfaceStatus: &v1.VirtualMachineInstanceNetworkInterface{
 							InterfaceName: ifaceName,
 							InfoSource:    vmispec.InfoSourceGuestAgent,
 						},
@@ -3609,29 +3608,29 @@ func NewPvcWithOwner(namespace string, name string, ownerName string, isControll
 	}
 }
 
-func NewPendingVirtualMachine(name string) *virtv1.VirtualMachineInstance {
+func NewPendingVirtualMachine(name string) *v1.VirtualMachineInstance {
 	vmi := api.NewMinimalVMI(name)
 	vmi.UID = "1234"
-	vmi.Status.Phase = virtv1.Pending
-	setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodNotExistsReason)
+	vmi.Status.Phase = v1.Pending
+	setReadyCondition(vmi, k8sv1.ConditionFalse, v1.PodNotExistsReason)
 	kvcontroller.SetLatestApiVersionAnnotation(vmi)
 	vmi.Status.ActivePods = make(map[types.UID]string)
-	vmi.Status.VolumeStatus = make([]virtv1.VolumeStatus, 0)
+	vmi.Status.VolumeStatus = make([]v1.VolumeStatus, 0)
 	return vmi
 }
 
-func setReadyCondition(vmi *virtv1.VirtualMachineInstance, status k8sv1.ConditionStatus, reason string) {
-	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, virtv1.VirtualMachineInstanceReady)
-	vmi.Status.Conditions = append(vmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
-		Type:   virtv1.VirtualMachineInstanceReady,
+func setReadyCondition(vmi *v1.VirtualMachineInstance, status k8sv1.ConditionStatus, reason string) {
+	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, v1.VirtualMachineInstanceReady)
+	vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
+		Type:   v1.VirtualMachineInstanceReady,
 		Status: status,
 		Reason: reason,
 	})
 }
 
-func NewPodForVirtualMachine(vmi *virtv1.VirtualMachineInstance, phase k8sv1.PodPhase) *k8sv1.Pod {
+func NewPodForVirtualMachine(vmi *v1.VirtualMachineInstance, phase k8sv1.PodPhase) *k8sv1.Pod {
 	podAnnotations := map[string]string{
-		virtv1.DomainAnnotation: vmi.Name,
+		v1.DomainAnnotation: vmi.Name,
 	}
 	return &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3639,8 +3638,8 @@ func NewPodForVirtualMachine(vmi *virtv1.VirtualMachineInstance, phase k8sv1.Pod
 			Namespace: vmi.Namespace,
 			UID:       "virt-launch-uid",
 			Labels: map[string]string{
-				virtv1.AppLabel:       "virt-launcher",
-				virtv1.CreatedByLabel: string(vmi.UID),
+				v1.AppLabel:       "virt-launcher",
+				v1.CreatedByLabel: string(vmi.UID),
 			},
 			Annotations: podAnnotations,
 		},
@@ -3651,7 +3650,7 @@ func NewPodForVirtualMachine(vmi *virtv1.VirtualMachineInstance, phase k8sv1.Pod
 			},
 			Conditions: []k8sv1.PodCondition{
 				{
-					Type:   virtv1.VirtualMachineUnpaused,
+					Type:   v1.VirtualMachineUnpaused,
 					Status: k8sv1.ConditionTrue,
 				},
 			},
@@ -3659,7 +3658,7 @@ func NewPodForVirtualMachine(vmi *virtv1.VirtualMachineInstance, phase k8sv1.Pod
 	}
 }
 
-func NewPodForVirtualMachineWithMultusAnnotations(vmi *virtv1.VirtualMachineInstance, phase k8sv1.PodPhase, config *virtconfig.ClusterConfig, podNetworkStatus ...networkv1.NetworkStatus) (*k8sv1.Pod, error) {
+func NewPodForVirtualMachineWithMultusAnnotations(vmi *v1.VirtualMachineInstance, phase k8sv1.PodPhase, config *virtconfig.ClusterConfig, podNetworkStatus ...networkv1.NetworkStatus) (*k8sv1.Pod, error) {
 	pod := NewPodForVirtualMachine(vmi, phase)
 
 	multusAnnotations, err := services.GenerateMultusCNIAnnotation(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, config)
@@ -3750,25 +3749,25 @@ func now() *metav1.Time {
 	return &now
 }
 
-func markAsReady(vmi *virtv1.VirtualMachineInstance) {
+func markAsReady(vmi *v1.VirtualMachineInstance) {
 	kvcontroller.NewVirtualMachineInstanceConditionManager().AddPodCondition(vmi, &k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 }
 
-func markAsPodTerminating(vmi *virtv1.VirtualMachineInstance) {
-	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
-	kvcontroller.NewVirtualMachineInstanceConditionManager().AddPodCondition(vmi, &k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionFalse, Reason: virtv1.PodTerminatingReason})
+func markAsPodTerminating(vmi *v1.VirtualMachineInstance) {
+	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, v1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+	kvcontroller.NewVirtualMachineInstanceConditionManager().AddPodCondition(vmi, &k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionFalse, Reason: v1.PodTerminatingReason})
 }
 
-func markAsNonReady(vmi *virtv1.VirtualMachineInstance) {
-	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+func markAsNonReady(vmi *v1.VirtualMachineInstance) {
+	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, v1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
 	kvcontroller.NewVirtualMachineInstanceConditionManager().AddPodCondition(vmi, &k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionFalse})
 }
 
-func unmarkReady(vmi *virtv1.VirtualMachineInstance) {
-	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+func unmarkReady(vmi *v1.VirtualMachineInstance) {
+	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, v1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
 }
 
-func addActivePods(vmi *virtv1.VirtualMachineInstance, podUID types.UID, hostName string) *virtv1.VirtualMachineInstance {
+func addActivePods(vmi *v1.VirtualMachineInstance, podUID types.UID, hostName string) *v1.VirtualMachineInstance {
 
 	if vmi.Status.ActivePods != nil {
 		vmi.Status.ActivePods[podUID] = hostName
@@ -3780,108 +3779,108 @@ func addActivePods(vmi *virtv1.VirtualMachineInstance, podUID types.UID, hostNam
 	return vmi
 }
 
-func addDefaultNetwork(vmi *virtv1.VirtualMachineInstance, networkName string) *virtv1.VirtualMachineInstance {
+func addDefaultNetwork(vmi *v1.VirtualMachineInstance, networkName string) *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, newMasqueradePrimaryInterface(networkName))
 	vmi.Spec.Networks = append(vmi.Spec.Networks, newMasqueradeDefaultNetwork(networkName))
 	return vmi
 }
 
-func addDefaultNetworkStatus(vmi *virtv1.VirtualMachineInstance, networkName string) *virtv1.VirtualMachineInstance {
-	vmi.Status.Interfaces = append(vmi.Status.Interfaces, virtv1.VirtualMachineInstanceNetworkInterface{Name: networkName})
+func addDefaultNetworkStatus(vmi *v1.VirtualMachineInstance, networkName string) *v1.VirtualMachineInstance {
+	vmi.Status.Interfaces = append(vmi.Status.Interfaces, v1.VirtualMachineInstanceNetworkInterface{Name: networkName})
 	return vmi
 }
 
-func addSRIOVNetwork(vmi *virtv1.VirtualMachineInstance, networkName, nadName string) *virtv1.VirtualMachineInstance {
+func addSRIOVNetwork(vmi *v1.VirtualMachineInstance, networkName, nadName string) *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, newSRIOVInterface(networkName))
 	vmi.Spec.Networks = append(vmi.Spec.Networks, newMultusNetwork(networkName, nadName))
 	return vmi
 }
 
-func newSRIOVInterface(name string) virtv1.Interface {
-	return virtv1.Interface{
+func newSRIOVInterface(name string) v1.Interface {
+	return v1.Interface{
 		Name:                   name,
-		InterfaceBindingMethod: virtv1.InterfaceBindingMethod{SRIOV: &virtv1.InterfaceSRIOV{}},
+		InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
 	}
 }
 
-func newMasqueradePrimaryInterface(name string) virtv1.Interface {
-	return virtv1.Interface{
+func newMasqueradePrimaryInterface(name string) v1.Interface {
+	return v1.Interface{
 		Name:                   name,
-		InterfaceBindingMethod: virtv1.InterfaceBindingMethod{Masquerade: &virtv1.InterfaceMasquerade{}},
+		InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 	}
 }
 
-func newMasqueradeDefaultNetwork(name string) virtv1.Network {
-	return virtv1.Network{
+func newMasqueradeDefaultNetwork(name string) v1.Network {
+	return v1.Network{
 		Name: name,
-		NetworkSource: virtv1.NetworkSource{
-			Pod: &virtv1.PodNetwork{},
+		NetworkSource: v1.NetworkSource{
+			Pod: &v1.PodNetwork{},
 		},
 	}
 }
 
-func newMultusNetwork(name, networkName string) virtv1.Network {
-	return virtv1.Network{
+func newMultusNetwork(name, networkName string) v1.Network {
+	return v1.Network{
 		Name: name,
-		NetworkSource: virtv1.NetworkSource{
-			Multus: &virtv1.MultusNetwork{
+		NetworkSource: v1.NetworkSource{
+			Multus: &v1.MultusNetwork{
 				NetworkName: networkName,
 			},
 		},
 	}
 }
 
-func newNetwork(netAttachDefName string, name string) virtv1.Network {
-	return virtv1.Network{
+func newNetwork(netAttachDefName string, name string) v1.Network {
+	return v1.Network{
 		Name: name,
-		NetworkSource: virtv1.NetworkSource{
-			Multus: &virtv1.MultusNetwork{
+		NetworkSource: v1.NetworkSource{
+			Multus: &v1.MultusNetwork{
 				NetworkName: netAttachDefName,
 			},
 		},
 	}
 }
 
-func newVMIWithOneIface(vmi *virtv1.VirtualMachineInstance, networkName string, ifaceName string) *virtv1.VirtualMachineInstance {
+func newVMIWithOneIface(vmi *v1.VirtualMachineInstance, networkName string, ifaceName string) *v1.VirtualMachineInstance {
 	vmi.Spec.Networks = append(
 		vmi.Spec.Networks,
-		virtv1.Network{
+		v1.Network{
 			Name: ifaceName,
-			NetworkSource: virtv1.NetworkSource{
-				Multus: &virtv1.MultusNetwork{
+			NetworkSource: v1.NetworkSource{
+				Multus: &v1.MultusNetwork{
 					NetworkName: networkName,
 				},
 			},
 		})
 	vmi.Spec.Domain.Devices.Interfaces = append(
 		vmi.Spec.Domain.Devices.Interfaces,
-		virtv1.Interface{
+		v1.Interface{
 			Name: ifaceName,
 		})
 	return vmi
 }
 
-func newVMIWithOneIfaceStatus(vmi *virtv1.VirtualMachineInstance, ifaceName string) *virtv1.VirtualMachineInstance {
+func newVMIWithOneIfaceStatus(vmi *v1.VirtualMachineInstance, ifaceName string) *v1.VirtualMachineInstance {
 	vmi.Status.Interfaces = append(vmi.Status.Interfaces, *simpleIfaceStatus(ifaceName))
 	return vmi
 }
 
-func simpleIfaceStatus(ifaceName string) *virtv1.VirtualMachineInstanceNetworkInterface {
-	return &virtv1.VirtualMachineInstanceNetworkInterface{
+func simpleIfaceStatus(ifaceName string) *v1.VirtualMachineInstanceNetworkInterface {
+	return &v1.VirtualMachineInstanceNetworkInterface{
 		Name:          ifaceName,
 		InterfaceName: ifaceName,
 	}
 }
 
-func readyHotpluggedIfaceStatus(ifaceName string) *virtv1.VirtualMachineInstanceNetworkInterface {
-	return &virtv1.VirtualMachineInstanceNetworkInterface{
+func readyHotpluggedIfaceStatus(ifaceName string) *v1.VirtualMachineInstanceNetworkInterface {
+	return &v1.VirtualMachineInstanceNetworkInterface{
 		Name:       ifaceName,
 		InfoSource: vmispec.InfoSourceMultusStatus,
 	}
 }
 
-func newVMIWithGuestAgentInterface(vmi *virtv1.VirtualMachineInstance, ifaceName string) *virtv1.VirtualMachineInstance {
-	vmi.Status.Interfaces = append(vmi.Status.Interfaces, virtv1.VirtualMachineInstanceNetworkInterface{
+func newVMIWithGuestAgentInterface(vmi *v1.VirtualMachineInstance, ifaceName string) *v1.VirtualMachineInstance {
+	vmi.Status.Interfaces = append(vmi.Status.Interfaces, v1.VirtualMachineInstanceNetworkInterface{
 		InterfaceName: ifaceName,
 		InfoSource:    vmispec.InfoSourceGuestAgent,
 	})

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/clientcmd"
 
-	v12 "kubevirt.io/api/core/v1"
-
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -316,7 +314,7 @@ func convertIPFamilyPolicy(strIPFamilyPolicy string, ipFamilies []v1.IPFamily) (
 	}
 }
 
-func podNetworkPorts(vmiSpec *v12.VirtualMachineInstanceSpec) []v1.ServicePort {
+func podNetworkPorts(vmiSpec *virtv1.VirtualMachineInstanceSpec) []v1.ServicePort {
 	podNetworkName := ""
 	for _, network := range vmiSpec.Networks {
 		if network.Pod != nil {

--- a/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Kubevirt VirtualMachine Client", func() {
@@ -237,7 +236,7 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 			ghttp.VerifyRequest("PUT", path.Join(proxyPath, subVMPath, "migrate")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err = client.VirtualMachine(k8sv1.NamespaceDefault).Migrate(context.Background(), "testvm", &virtv1.MigrateOptions{})
+		err = client.VirtualMachine(k8sv1.NamespaceDefault).Migrate(context.Background(), "testvm", &v1.MigrateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
 	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
@@ -488,7 +487,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause2.Field).To(Equal(cpuThreadsField))
 		})
 
-		DescribeTable("[test_id:CNV-9301] should fail if the VirtualMachine has ", func(resources virtv1.ResourceRequirements, expectedField string) {
+		DescribeTable("[test_id:CNV-9301] should fail if the VirtualMachine has ", func(resources v1.ResourceRequirements, expectedField string) {
 
 			vmi := libvmi.NewCirros()
 			instancetype := newVirtualMachineInstancetype(vmi)
@@ -515,22 +514,22 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Message).To(Equal(fmt.Sprintf(instancetypepkg.VMFieldConflictErrorFmt, expectedField)))
 			Expect(cause.Field).To(Equal(expectedField))
 		},
-			Entry("CPU resource requests", virtv1.ResourceRequirements{
+			Entry("CPU resource requests", v1.ResourceRequirements{
 				Requests: k8sv1.ResourceList{
 					k8sv1.ResourceCPU: resource.MustParse("1"),
 				},
 			}, "spec.template.spec.domain.resources.requests.cpu"),
-			Entry("CPU resource limits", virtv1.ResourceRequirements{
+			Entry("CPU resource limits", v1.ResourceRequirements{
 				Limits: k8sv1.ResourceList{
 					k8sv1.ResourceCPU: resource.MustParse("1"),
 				},
 			}, "spec.template.spec.domain.resources.limits.cpu"),
-			Entry("Memory resource requests", virtv1.ResourceRequirements{
+			Entry("Memory resource requests", v1.ResourceRequirements{
 				Requests: k8sv1.ResourceList{
 					k8sv1.ResourceMemory: resource.MustParse("128Mi"),
 				},
 			}, "spec.template.spec.domain.resources.requests.memory"),
-			Entry("Memory resource limits", virtv1.ResourceRequirements{
+			Entry("Memory resource limits", v1.ResourceRequirements{
 				Limits: k8sv1.ResourceList{
 					k8sv1.ResourceMemory: resource.MustParse("128Mi"),
 				},
@@ -892,11 +891,11 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				vmi := libvmi.NewCirros()
 				removeResourcesAndPreferencesFromVMI(vmi)
 				vm := tests.NewRandomVirtualMachine(vmi, false)
-				vm.Spec.Instancetype = &virtv1.InstancetypeMatcher{
+				vm.Spec.Instancetype = &v1.InstancetypeMatcher{
 					Name:         "dummy",
 					RevisionName: instancetypeRevision.Name,
 				}
-				vm.Spec.Preference = &virtv1.PreferenceMatcher{
+				vm.Spec.Preference = &v1.PreferenceMatcher{
 					Name:         "dummy",
 					RevisionName: preferenceRevision.Name,
 				}
@@ -1348,7 +1347,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		It("should ignore failure when trying to infer defaults from DataVolumeSpec with unsupported DataVolumeSource when policy is set", func() {
 			guestMemory := resource.MustParse("512Mi")
-			vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{
+			vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
 				Guest: &guestMemory,
 			}
 
@@ -1380,7 +1379,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		DescribeTable("should reject VM creation when inference was successful but memory and RejectInferFromVolumeFailure were set", func(explicit bool) {
 			guestMemory := resource.MustParse("512Mi")
-			vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{
+			vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
 				Guest: &guestMemory,
 			}
 

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -30,7 +30,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kvirtv1 "kubevirt.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
@@ -54,7 +53,7 @@ var _ = SIGDescribe("Infosource", func() {
 	})
 
 	Context("VMI with 3 interfaces", func() {
-		var vmi *kvirtv1.VirtualMachineInstance
+		var vmi *v1.VirtualMachineInstance
 
 		const (
 			nadName                 = "infosrc"
@@ -80,7 +79,7 @@ var _ = SIGDescribe("Infosource", func() {
 			secondaryLinuxBridgeInterface2 := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork2.Name)
 			vmiSpec := libvmi.NewFedora(
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(&defaultBridgeInterface, primaryInterfaceMac)),
-				libvmi.WithNetwork(kvirtv1.DefaultPodNetwork()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(&secondaryLinuxBridgeInterface1, secondaryInterface1Mac)),
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(&secondaryLinuxBridgeInterface2, secondaryInterface2Mac)),
 				libvmi.WithNetwork(secondaryNetwork1),
@@ -100,7 +99,7 @@ var _ = SIGDescribe("Infosource", func() {
 			infoSourceDomainAndGAAndMultusStatus := netvmispec.NewInfoSource(
 				netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent, netvmispec.InfoSourceMultusStatus)
 
-			expectedInterfaces := []kvirtv1.VirtualMachineInstanceNetworkInterface{
+			expectedInterfaces := []v1.VirtualMachineInstanceNetworkInterface{
 				{
 					InfoSource: netvmispec.InfoSourceDomain,
 					MAC:        primaryInterfaceMac,
@@ -162,7 +161,7 @@ var _ = SIGDescribe("Infosource", func() {
 	})
 })
 
-func dummyInterfaceExists(vmi *kvirtv1.VirtualMachineInstance) bool {
+func dummyInterfaceExists(vmi *v1.VirtualMachineInstance) bool {
 	for i := range vmi.Status.Interfaces {
 		if vmi.Status.Interfaces[i].InterfaceName == dummyInterfaceName {
 			return true

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -25,7 +25,6 @@ import (
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	"kubevirt.io/api/core"
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
@@ -604,12 +603,12 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				preference, err := virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(nil)).Create(context.Background(), preference, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				vm.Spec.Template.Spec.Domain.Resources = virtv1.ResourceRequirements{}
-				vm.Spec.Instancetype = &virtv1.InstancetypeMatcher{
+				vm.Spec.Template.Spec.Domain.Resources = v1.ResourceRequirements{}
+				vm.Spec.Instancetype = &v1.InstancetypeMatcher{
 					Name: instancetype.Name,
 					Kind: "VirtualMachineInstanceType",
 				}
-				vm.Spec.Preference = &virtv1.PreferenceMatcher{
+				vm.Spec.Preference = &v1.PreferenceMatcher{
 					Name: preference.Name,
 					Kind: "VirtualMachinePreference",
 				}

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -41,7 +41,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
@@ -65,7 +64,7 @@ const (
 var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
-	var vmi *virtv1.VirtualMachineInstance
+	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -145,9 +144,9 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
 		},
-			Entry("(privileged virtiofsd)", testsuite.NamespacePrivileged, func(instance *virtv1.VirtualMachineInstance) {}, func(instance *virtv1.VirtualMachineInstance) {}),
+			Entry("(privileged virtiofsd)", testsuite.NamespacePrivileged, func(instance *v1.VirtualMachineInstance) {}, func(instance *v1.VirtualMachineInstance) {}),
 			Entry("with passt enabled (privileged virtiofsd)", testsuite.NamespacePrivileged, libvmi.WithPasstInterfaceWithPort(), libvmi.WithNetwork(v1.DefaultPodNetwork())),
-			Entry("(unprivileged virtiofsd)", util.NamespaceTestDefault, func(instance *virtv1.VirtualMachineInstance) {}, func(instance *virtv1.VirtualMachineInstance) {}),
+			Entry("(unprivileged virtiofsd)", util.NamespaceTestDefault, func(instance *v1.VirtualMachineInstance) {}, func(instance *v1.VirtualMachineInstance) {}),
 			Entry("with passt enabled (unprivileged virtiofsd)", util.NamespaceTestDefault, libvmi.WithPasstInterfaceWithPort(), libvmi.WithNetwork(v1.DefaultPodNetwork())),
 		)
 	})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -61,7 +61,6 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
@@ -1686,7 +1685,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 			}
 
-			getComputeMemoryRequest := func(vmi *virtv1.VirtualMachineInstance) resource.Quantity {
+			getComputeMemoryRequest := func(vmi *v1.VirtualMachineInstance) resource.Quantity {
 				launcherPod := tests.GetPodByVirtualMachineInstance(vmi)
 				computeContainer := tests.GetComputeContainerOfPod(launcherPod)
 				return computeContainer.Resources.Requests[kubev1.ResourceMemory]
@@ -2068,7 +2067,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 		When("a ResourceQuota with memory and cpu limits is associated to the creation namespace", func() {
 			var (
-				vmi                       *virtv1.VirtualMachineInstance
+				vmi                       *v1.VirtualMachineInstance
 				expectedLauncherMemLimits *resource.Quantity
 				expectedLauncherCPULimits resource.Quantity
 				vmiRequest                resource.Quantity
@@ -2739,7 +2738,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 				Expect(kvmpitmask).To(Equal(vcpuzeromask))
 			},
-				Entry(" with explicit resources set", &virtv1.ResourceRequirements{
+				Entry(" with explicit resources set", &v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
 						kubev1.ResourceCPU:    resource.MustParse("2"),
 						kubev1.ResourceMemory: resource.MustParse("256Mi"),


### PR DESCRIPTION
Too often, we import the same module twice, in two different names. This adds to the mental burden of the code reader.

```release-note
NONE
```
