### PR TITLE
tests/operator: define one less lambda

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -153,7 +153,6 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		deleteOperator                         func(string)
 		deleteTestingManifests                 func(string)
 		deleteAllKvAndWait                     func(bool)
-		usesSha                                func(string) bool
 		ensureShasums                          func()
 		getVirtLauncherSha                     func() string
 		generatePreviousVersionVmYamls         func(string, string)
@@ -672,10 +671,6 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 			}, 240*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
-		}
-
-		usesSha = func(image string) bool {
-			return strings.Contains(image, "@sha256:")
 		}
 
 		ensureShasums = func() {
@@ -3480,4 +3475,8 @@ func nodeSelectorExistInDeployment(virtClient kubecli.KubevirtClient, deployment
 		return false
 	}
 	return true
+}
+
+func usesSha(image string) bool {
+	return strings.Contains(image, "@sha256:")
 }


### PR DESCRIPTION
tests/operator/operator.go is very long and complex. This PR makes a very small simplification in it, hoping to show the way how it could become more readable.

usesSha() is a single static function. Defining it as a named lambda
needlessly adds mental burden, as the read need to keep in mind that it
may change in the future.

With this change, there is no need to declare usesSha in one place, and
define it elsewhere, and indentation level is reduced.

```release-note
NONE
```
