### PR TITLE
Change passt tests to use the passt plugin binding

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -168,7 +168,6 @@ go_test(
         "//pkg/network/dns:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/testutils:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "interface.go",
         "ipaddress.go",
         "namespace.go",
+        "network_attachment_definition.go",
         "ping.go",
         "plumbing.go",
         "skips.go",

--- a/tests/libnet/network_attachment_definition.go
+++ b/tests/libnet/network_attachment_definition.go
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package libnet
+
+import (
+	"context"
+	"fmt"
+
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+)
+
+const postUrl = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
+
+func CreateNetworkAttachmentDefinition(name, namespace, netConf string) error {
+	return kubevirt.Client().RestClient().
+		Post().
+		RequestURI(fmt.Sprintf(postUrl, namespace, name)).
+		Body([]byte(netConf)).
+		Do(context.Background()).
+		Error()
+}

--- a/tests/libnet/network_attachment_definition.go
+++ b/tests/libnet/network_attachment_definition.go
@@ -26,12 +26,24 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 )
 
-const postUrl = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
+const PasstNetAttDef = "netbindingpasst"
+
+func CreatePasstNetworkAttachmentDefinition(namespace string) error {
+	const passtType = "kubevirt-passt-binding" // #nosec G101
+	const netAttDefFmt = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":%q,"namespace":%q},` +
+		`"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"name\": \"%s\", \"plugins\": [{\"type\": \"%s\"}]}"}}`
+	return CreateNetworkAttachmentDefinition(
+		PasstNetAttDef,
+		namespace,
+		fmt.Sprintf(netAttDefFmt, PasstNetAttDef, namespace, PasstNetAttDef, passtType),
+	)
+}
 
 func CreateNetworkAttachmentDefinition(name, namespace, netConf string) error {
+	const postURL = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
 	return kubevirt.Client().RestClient().
 		Post().
-		RequestURI(fmt.Sprintf(postUrl, namespace, name)).
+		RequestURI(fmt.Sprintf(postURL, namespace, name)).
 		Body([]byte(netConf)).
 		Do(context.Background()).
 		Error()

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -25,7 +25,10 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-const DefaultInterfaceName = "default"
+const (
+	DefaultInterfaceName = "default"
+	PasstBindingName     = "passt"
+)
 
 // WithInterface adds a Domain Device Interface.
 func WithInterface(iface kvirtv1.Interface) Option {
@@ -50,6 +53,10 @@ func WithMasqueradeNetworking(ports ...kvirtv1.Port) []Option {
 		WithNetwork(kvirtv1.DefaultPodNetwork()),
 		WithCloudInitNoCloudNetworkData(networkData),
 	}
+}
+
+func WithPasstInterfaceWithPort() Option {
+	return WithInterface(InterfaceWithPasstBindingPlugin([]kvirtv1.Port{{Port: 1234, Protocol: "TCP"}}...))
 }
 
 // InterfaceDeviceWithMasqueradeBinding returns an Interface named "default" with masquerade binding.
@@ -94,21 +101,20 @@ func InterfaceDeviceWithSRIOVBinding(name string) kvirtv1.Interface {
 	}
 }
 
-// InterfaceDeviceWithPasstBinding returns an Interface named "default" with passt binding.
-func InterfaceDeviceWithPasstBinding(ports ...kvirtv1.Port) kvirtv1.Interface {
+// InterfaceWithPasstBinding returns an Interface named "default" with passt binding plugin.
+func InterfaceWithPasstBindingPlugin(ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{
-		Name: DefaultInterfaceName,
-		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
-			Passt: &kvirtv1.InterfacePasst{},
-		},
-		Ports: ports,
+		Name:    DefaultInterfaceName,
+		Binding: &kvirtv1.PluginBinding{Name: PasstBindingName},
+		Ports:   ports,
 	}
 }
 
-func InterfaceDeviceWithBindingPlugin(name string, binding kvirtv1.PluginBinding) kvirtv1.Interface {
+func InterfaceWithBindingPlugin(name string, binding kvirtv1.PluginBinding, ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{
 		Name:    name,
 		Binding: &binding,
+		Ports:   ports,
 	}
 }
 

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -247,10 +247,6 @@ func WithCPUFeature(featureName, policy string) Option {
 	}
 }
 
-func WithPasstInterfaceWithPort() Option {
-	return WithInterface(InterfaceDeviceWithPasstBinding([]v1.Port{{Port: 1234, Protocol: "TCP"}}...))
-}
-
 func WithNodeAffinityFor(node *k8sv1.Node) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		nodeSelectorTerm := k8sv1.NodeSelectorTerm{

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bindingplugin.go",
+        "bindingplugin_passt.go",
         "dual_stack_cluster.go",
         "expose.go",
         "framework.go",
@@ -41,7 +42,6 @@ go_library(
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-config:go_default_library",
-        "//pkg/virt-config/deprecation:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-config/deprecation:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -47,7 +47,7 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 		tests.EnableFeatureGate(virtconfig.NetworkBindingPlugingsGate)
 	})
 
-	Context("passt", func() {
+	Context("with CNI and Sidecar", func() {
 		BeforeEach(func() {
 			const passtBindingName = "passt"
 			const passtSidecarImage = "registry:5000/kubevirt/network-passt-binding:devel"
@@ -95,7 +95,7 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 		})
 	})
 
-	Context("macvtap", func() {
+	Context("with domain attachment type", func() {
 		const (
 			macvtapNetworkConfNAD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s", "annotations": {"k8s.v1.cni.cncf.io/resourceName": "macvtap.network.kubevirt.io/%s"}},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"name\": \"%s\", \"type\": \"macvtap\"}"}}`
 			macvtapBindingName    = "macvtap"

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -58,14 +58,13 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 		BeforeEach(func() {
 			err := libkvconfig.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
 				SidecarImage:                passtSidecarImage,
-				NetworkAttachmentDefinition: passtNetAttDef,
+				NetworkAttachmentDefinition: libnet.PasstNetAttDef,
 			})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		BeforeEach(func() {
-			namespace := testsuite.GetTestNamespace(nil)
-			Expect(createBasicNetworkAttachmentDefinition(namespace, passtNetAttDef, passtType)).To(Succeed())
+			Expect(libnet.CreatePasstNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil))).To(Succeed())
 		})
 
 		It("can be used by a VM as its primary network", func() {
@@ -151,12 +150,3 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 
 	})
 })
-
-func createBasicNetworkAttachmentDefinition(namespace, nadName, typeName string) error {
-	const netAttDefBasicFormat = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":%q,"namespace":%q},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"name\": \"%s\", \"plugins\": [{\"type\": \"%s\"}]}"}}`
-	return libnet.CreateNetworkAttachmentDefinition(
-		nadName,
-		namespace,
-		fmt.Sprintf(netAttDefBasicFormat, nadName, namespace, nadName, typeName),
-	)
-}

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -41,13 +41,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-const (
-	passtBindingName  = "passt"
-	passtSidecarImage = "registry:5000/kubevirt/network-passt-binding:devel"
-	passtNetAttDef    = "netbindingpasst"
-	passtType         = "kubevirt-passt-binding"
-)
-
 var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCustomBindingPlugins, func() {
 
 	BeforeEach(func() {
@@ -56,6 +49,9 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 
 	Context("passt", func() {
 		BeforeEach(func() {
+			const passtBindingName = "passt"
+			const passtSidecarImage = "registry:5000/kubevirt/network-passt-binding:devel"
+
 			err := libkvconfig.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
 				SidecarImage:                passtSidecarImage,
 				NetworkAttachmentDefinition: libnet.PasstNetAttDef,
@@ -71,9 +67,7 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 			const (
 				macAddress = "02:00:00:00:00:02"
 			)
-			passtIface := libvmi.InterfaceDeviceWithBindingPlugin(
-				libvmi.DefaultInterfaceName, v1.PluginBinding{Name: passtBindingName},
-			)
+			passtIface := libvmi.InterfaceWithPasstBindingPlugin()
 			passtIface.MacAddress = macAddress
 			vmi := libvmi.NewAlpineWithTestTooling(
 				libvmi.WithInterface(passtIface),
@@ -130,7 +124,7 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 			chosenMAC = chosenMACHW.String()
 
 			ifaceName := "macvtapIface"
-			macvtapIface := libvmi.InterfaceDeviceWithBindingPlugin(
+			macvtapIface := libvmi.InterfaceWithBindingPlugin(
 				ifaceName, v1.PluginBinding{Name: macvtapBindingName},
 			)
 			vmi = libvmi.NewAlpineWithTestTooling(

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -33,6 +33,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkvconfig"
+	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -112,7 +113,7 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 		BeforeEach(func() {
 			macvtapNad := fmt.Sprintf(macvtapNetworkConfNAD, macvtapNetworkName, testsuite.GetTestNamespace(nil), macvtapLowerDevice, macvtapNetworkName)
 			namespace := testsuite.GetTestNamespace(nil)
-			Expect(createNetworkAttachmentDefinition(kubevirt.Client(), macvtapNetworkName, namespace, macvtapNad)).
+			Expect(libnet.CreateNetworkAttachmentDefinition(macvtapNetworkName, namespace, macvtapNad)).
 				To(Succeed(), "A macvtap network named %s should be provisioned", macvtapNetworkName)
 		})
 
@@ -153,8 +154,7 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 
 func createBasicNetworkAttachmentDefinition(namespace, nadName, typeName string) error {
 	const netAttDefBasicFormat = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":%q,"namespace":%q},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"name\": \"%s\", \"plugins\": [{\"type\": \"%s\"}]}"}}`
-	return createNetworkAttachmentDefinition(
-		kubevirt.Client(),
+	return libnet.CreateNetworkAttachmentDefinition(
 		nadName,
 		namespace,
 		fmt.Sprintf(netAttDefBasicFormat, nadName, namespace, nadName, typeName),

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -1,0 +1,335 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	expect "github.com/google/goexpect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
+
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libkvconfig"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = SIGDescribe("[Serial] VirtualMachineInstance with passt network binding plugin", decorators.NetCustomBindingPlugins, Serial, func() {
+	var err error
+
+	BeforeEach(func() {
+		tests.EnableFeatureGate(virtconfig.NetworkBindingPlugingsGate)
+	})
+
+	BeforeEach(func() {
+		const passtBindingName = "passt"
+		const passtSidecarImage = "registry:5000/kubevirt/network-passt-binding:devel"
+
+		err := libkvconfig.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
+			SidecarImage:                passtSidecarImage,
+			NetworkAttachmentDefinition: libnet.PasstNetAttDef,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	BeforeEach(func() {
+		Expect(libnet.CreatePasstNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil))).To(Succeed())
+	})
+
+	It("should apply the interface configuration", func() {
+		const testMACAddr = "02:02:02:02:02:02"
+		const testPCIAddr = "0000:01:00.0"
+		passtIface := libvmi.InterfaceWithPasstBindingPlugin()
+		passtIface.Ports = []v1.Port{{Port: 1234, Protocol: "TCP"}}
+		passtIface.MacAddress = testMACAddr
+		passtIface.PciAddress = testPCIAddr
+		vmi := libvmi.NewAlpineWithTestTooling(
+			libvmi.WithInterface(passtIface),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
+
+		vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
+		Expect(err).ToNot(HaveOccurred())
+		vmi = libwait.WaitUntilVMIReady(
+			vmi,
+			console.LoginToAlpine,
+			libwait.WithFailOnWarnings(false),
+			libwait.WithTimeout(180),
+		)
+
+		Expect(vmi.Status.Interfaces).To(HaveLen(1))
+		Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
+		Expect(vmi.Status.Interfaces[0].IP).NotTo(BeEmpty())
+		Expect(vmi.Status.Interfaces[0].MAC).To(Equal(testMACAddr))
+
+		guestIfaceName := vmi.Status.Interfaces[0].InterfaceName
+		cmd := fmt.Sprintf("ls /sys/bus/pci/devices/%s/virtio0/net/%s", testPCIAddr, guestIfaceName)
+		Expect(console.RunCommand(vmi, cmd, time.Second*5)).To(Succeed())
+	})
+
+	Context("should allow regular network connection", func() {
+		Context("should have client server connectivity", func() {
+			var clientVMI *v1.VirtualMachineInstance
+			var serverVMI *v1.VirtualMachineInstance
+
+			startServerVMI := func(ports []v1.Port) {
+				passtIface := libvmi.InterfaceWithPasstBindingPlugin(ports...)
+				serverVMI = libvmi.NewAlpineWithTestTooling(
+					libvmi.WithInterface(passtIface),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+
+				serverVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), serverVMI)
+				Expect(err).ToNot(HaveOccurred())
+				serverVMI = libwait.WaitUntilVMIReady(
+					serverVMI,
+					console.LoginToAlpine,
+					libwait.WithFailOnWarnings(false),
+					libwait.WithTimeout(180),
+				)
+			}
+
+			Context("TCP", func() {
+				checkConnectionToServer := func(serverIP string, port int, expectSuccess bool) []expect.Batcher {
+					expectResult := console.ShellFail
+					if expectSuccess {
+						expectResult = console.ShellSuccess
+					}
+
+					clientCommand := fmt.Sprintf("echo test | nc %s %d -i 1 -w 1 1> /dev/null\n", serverIP, port)
+
+					return []expect.Batcher{
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: clientCommand},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: tests.EchoLastReturnValue},
+						&expect.BExp{R: expectResult},
+					}
+				}
+
+				verifyClientServerConnectivity := func(clientVMI *v1.VirtualMachineInstance, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
+					serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
+					err := libnet.PingFromVMConsole(clientVMI, serverIP)
+					if err != nil {
+						return err
+					}
+
+					By("Connecting from the client VM")
+					err = console.SafeExpectBatch(clientVMI, checkConnectionToServer(serverIP, tcpPort, true), 30)
+					if err != nil {
+						return err
+					}
+
+					return nil
+				}
+
+				startClientVMI := func() {
+					clientVMI = libvmi.NewAlpineWithTestTooling(
+						libvmi.WithPasstInterfaceWithPort(),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					)
+
+					clientVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI)
+					Expect(err).ToNot(HaveOccurred())
+					clientVMI = libwait.WaitUntilVMIReady(clientVMI,
+						console.LoginToAlpine,
+						libwait.WithFailOnWarnings(false),
+						libwait.WithTimeout(180),
+					)
+				}
+				DescribeTable("Client server connectivity", func(ports []v1.Port, tcpPort int, ipFamily k8sv1.IPFamily) {
+					libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
+
+					By("starting a client VMI")
+					startClientVMI()
+
+					By("starting a server VMI")
+					startServerVMI(ports)
+
+					By("starting a TCP server")
+					tests.StartTCPServer(serverVMI, tcpPort, console.LoginToAlpine)
+
+					Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, ipFamily)).To(Succeed())
+
+					if len(ports) != 0 {
+						By("starting a TCP server on a port not specified on the VM spec")
+						vmPort := int(ports[0].Port)
+						serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
+
+						tests.StartTCPServer(serverVMI, vmPort+1, console.LoginToAlpine)
+
+						By("Connecting from the client VM to a port not specified on the VM spec")
+						Expect(console.SafeExpectBatch(clientVMI, checkConnectionToServer(serverIP, tcpPort+1, true), 30)).To(Not(Succeed()))
+					}
+				},
+					Entry("with a specific port number [IPv4]", []v1.Port{{Name: "http", Port: 8080, Protocol: "TCP"}}, 8080, k8sv1.IPv4Protocol),
+					Entry("with a specific lower port number [IPv4]", []v1.Port{{Name: "http", Port: 80, Protocol: "TCP"}}, 80, k8sv1.IPv4Protocol),
+					Entry("without a specific port number [IPv4]", []v1.Port{}, 8080, k8sv1.IPv4Protocol),
+					Entry("with a specific port number [IPv6]", []v1.Port{{Name: "http", Port: 8080, Protocol: "TCP"}}, 8080, k8sv1.IPv6Protocol),
+					Entry("without a specific port number [IPv6]", []v1.Port{}, 8080, k8sv1.IPv6Protocol),
+				)
+			})
+
+			Context("UDP", func() {
+				startAndVerifyUDPClient := func(vmi *v1.VirtualMachineInstance, serverIP string, serverPort int, ipFamily k8sv1.IPFamily) error {
+					var inetSuffix string
+					if ipFamily == k8sv1.IPv6Protocol {
+						inetSuffix = "6"
+					}
+
+					createClientScript := fmt.Sprintf(`cat >udp_client.py <<EOL
+import socket
+try:
+  client = socket.socket(socket.AF_INET%s, socket.SOCK_DGRAM);
+  client.sendto("Hello Server".encode(), ("%s",%d));
+  client.settimeout(5);
+  response = client.recv(1024);
+  print(response.decode("utf-8"));
+
+except socket.timeout:
+    client.close();
+EOL`, inetSuffix, serverIP, serverPort)
+					runClient := "python3 udp_client.py"
+					return console.ExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: fmt.Sprintf("%s\n", createClientScript)},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: fmt.Sprintf("%s\n", runClient)},
+						&expect.BExp{R: console.RetValue("Hello Client")},
+						&expect.BSnd{S: tests.EchoLastReturnValue},
+						&expect.BExp{R: console.ShellSuccess},
+					}, 60*time.Second)
+				}
+				DescribeTable("Client server connectivity", func(ipFamily k8sv1.IPFamily) {
+					libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
+
+					const SERVER_PORT = 1700
+
+					By("Starting server VMI")
+					startServerVMI([]v1.Port{{Port: SERVER_PORT, Protocol: "UDP"}})
+					serverVMI = libwait.WaitUntilVMIReady(serverVMI,
+						console.LoginToAlpine,
+						libwait.WithFailOnWarnings(false),
+						libwait.WithTimeout(180),
+					)
+
+					By("Starting a UDP server")
+					tests.StartPythonUDPServer(serverVMI, SERVER_PORT, ipFamily)
+
+					By("Starting client VMI")
+					clientVMI = libvmi.NewAlpineWithTestTooling(
+						libvmi.WithInterface(libvmi.InterfaceWithPasstBindingPlugin()),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					)
+					clientVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI)
+					Expect(err).ToNot(HaveOccurred())
+					clientVMI = libwait.WaitUntilVMIReady(clientVMI,
+						console.LoginToAlpine,
+						libwait.WithFailOnWarnings(false),
+						libwait.WithTimeout(180),
+					)
+
+					By("Starting and verifying UDP client")
+					// Due to a passt bug, at least one UDPv6 message has to be sent from a machine before it can receive UDPv6 messages
+					// Tracking bug - https://bugs.passt.top/show_bug.cgi?id=16
+					if ipFamily == k8sv1.IPv6Protocol {
+						clientIP := libnet.GetVmiPrimaryIPByFamily(clientVMI, ipFamily)
+						Expect(libnet.PingFromVMConsole(serverVMI, clientIP)).To(Succeed())
+					}
+					serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
+					Expect(startAndVerifyUDPClient(clientVMI, serverIP, SERVER_PORT, ipFamily)).To(Succeed())
+				},
+					Entry("[IPv4]", k8sv1.IPv4Protocol),
+					Entry("[IPv6]", k8sv1.IPv6Protocol),
+				)
+			})
+		})
+
+		It("[outside_connectivity]should be able to reach the outside world [IPv4]", func() {
+			libnet.SkipWhenClusterNotSupportIpv4()
+			ipv4Address := "8.8.8.8"
+			if flags.IPV4ConnectivityCheckAddress != "" {
+				ipv4Address = flags.IPV4ConnectivityCheckAddress
+			}
+			dns := "google.com"
+			if flags.ConnectivityCheckDNS != "" {
+				dns = flags.ConnectivityCheckDNS
+			}
+
+			vmi := libvmi.NewAlpineWithTestTooling(
+				libvmi.WithPasstInterfaceWithPort(),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
+			Expect(err).ToNot(HaveOccurred())
+			vmi = libwait.WaitUntilVMIReady(vmi,
+				console.LoginToAlpine,
+				libwait.WithFailOnWarnings(false),
+				libwait.WithTimeout(180),
+			)
+
+			By("Checking ping (IPv4)")
+			Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
+			Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
+		})
+
+		It("[outside_connectivity]should be able to reach the outside world [IPv6]", func() {
+			libnet.SkipWhenClusterNotSupportIpv6()
+			// Cluster nodes subnet (docker network gateway)
+			// Docker network subnet cidr definition:
+			// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
+			ipv6Address := "2001:db8:1::1"
+			if flags.IPV6ConnectivityCheckAddress != "" {
+				ipv6Address = flags.IPV6ConnectivityCheckAddress
+			}
+
+			vmi := libvmi.NewAlpineWithTestTooling(
+				libvmi.WithPasstInterfaceWithPort(),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
+			Expect(err).ToNot(HaveOccurred())
+			vmi = libwait.WaitUntilVMIReady(vmi,
+				console.LoginToAlpine,
+				libwait.WithFailOnWarnings(false),
+				libwait.WithTimeout(180),
+			)
+
+			By("Checking ping (IPv6) from VM to cluster nodes gateway")
+			Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
+		})
+	})
+})

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -347,8 +347,7 @@ var _ = SIGDescribe("bridge nic-hotunplug", func() {
 })
 
 func createBridgeNetworkAttachmentDefinition(namespace, networkName string, bridgeName string) error {
-	return createNetworkAttachmentDefinition(
-		kubevirt.Client(),
+	return libnet.CreateNetworkAttachmentDefinition(
 		networkName,
 		namespace,
 		fmt.Sprintf(linuxBridgeNAD, networkName, namespace, bridgeCNIType, bridgeName),

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -111,8 +111,7 @@ var _ = SIGDescribe("[Serial] SRIOV nic-hotplug", Serial, decorators.SRIOV, func
 })
 
 func createSRIOVNetworkAttachmentDefinition(namespace, networkName string, sriovResourceName string) error {
-	return createNetworkAttachmentDefinition(
-		kubevirt.Client(),
+	return libnet.CreateNetworkAttachmentDefinition(
 		networkName,
 		namespace,
 		fmt.Sprintf(sriovConfNAD, networkName, namespace, sriovResourceName),

--- a/tests/network/kubectl.go
+++ b/tests/network/kubectl.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
+	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -63,7 +64,7 @@ var _ = SIGDescribe("kubectl", func() {
 
 	createBridgeNetworkAttachmentDefinition := func(namespace, networkName string, bridgeCNIType string, bridgeName string) error {
 		bridgeNad := fmt.Sprintf(linuxBridgeNAD, networkName, namespace, bridgeCNIType, bridgeName)
-		return createNetworkAttachmentDefinition(virtClient, networkName, namespace, bridgeNad)
+		return libnet.CreateNetworkAttachmentDefinition(networkName, namespace, bridgeNad)
 	}
 
 	BeforeEach(func() {

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -60,7 +60,7 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 
 	createMacvtapNetworkAttachmentDefinition := func(namespace, networkName, macvtapLowerDevice string) error {
 		macvtapNad := fmt.Sprintf(macvtapNetworkConfNAD, networkName, namespace, macvtapLowerDevice, networkName)
-		return createNetworkAttachmentDefinition(virtClient, networkName, namespace, macvtapNad)
+		return libnet.CreateNetworkAttachmentDefinition(networkName, namespace, macvtapNad)
 	}
 
 	BeforeEach(func() {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -84,7 +84,7 @@ var _ = Describe("[Serial]SRIOV", Serial, decorators.SRIOV, func() {
 
 	createSriovNetworkAttachmentDefinition := func(networkName string, namespace string, networkAttachmentDefinition string) error {
 		sriovNad := fmt.Sprintf(networkAttachmentDefinition, networkName, namespace, sriovResourceName)
-		return createNetworkAttachmentDefinition(virtClient, networkName, namespace, sriovNad)
+		return libnet.CreateNetworkAttachmentDefinition(networkName, namespace, sriovNad)
 	}
 
 	BeforeEach(func() {

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -22,21 +22,25 @@ package network
 import (
 	"context"
 
-	"kubevirt.io/kubevirt/tests/decorators"
-
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/virt-config/deprecation"
+
+	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
+	BeforeEach(func() {
+		tests.EnableFeatureGate(deprecation.PasstGate)
+	})
 
 	It("can be used by a VM as its primary network", func() {
 		const (

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -21,305 +21,55 @@ package network
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
-	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
-
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/virt-config/deprecation"
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
-	var err error
-	var virtClient kubecli.KubevirtClient
 
-	BeforeEach(func() {
-		Expect(checks.HasFeature(deprecation.PasstGate)).To(BeTrue())
-	})
+	It("can be used by a VM as its primary network", func() {
+		const (
+			macAddress = "02:00:00:00:00:02"
+		)
 
-	BeforeEach(func() {
-		virtClient = kubevirt.Client()
-	})
+		vmi := libvmi.NewAlpineWithTestTooling(
+			libvmi.WithInterface(v1.Interface{
+				Name:                   libvmi.DefaultInterfaceName,
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}},
+				Ports:                  []v1.Port{{Port: 1234, Protocol: "TCP"}},
+				MacAddress:             macAddress,
+			}),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
+		vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunning())
 
-	Context("VirtualMachineInstance with passt binding mechanism", func() {
+		var err error
+		namespace := testsuite.GetTestNamespace(nil)
+		vm, err = kubevirt.Client().VirtualMachine(namespace).Create(context.Background(), vm)
+		Expect(err).ToNot(HaveOccurred())
 
-		It("should apply the interface configuration", func() {
-			const testMACAddr = "02:02:02:02:02:02"
-			const testPCIAddr = "0000:01:00.0"
-			vmi := libvmi.NewAlpineWithTestTooling(
-				libvmi.WithInterface(v1.Interface{
-					Name:                   libvmi.DefaultInterfaceName,
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}},
-					Ports:                  []v1.Port{{Port: 1234, Protocol: "TCP"}},
-					MacAddress:             testMACAddr,
-					PciAddress:             testPCIAddr,
-				}),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
+		vmi.Namespace = vm.Namespace
+		vmi = libwait.WaitUntilVMIReady(
+			vmi,
+			console.LoginToAlpine,
+			libwait.WithFailOnWarnings(false),
+			libwait.WithTimeout(180),
+		)
 
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
-			Expect(err).ToNot(HaveOccurred())
-			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
-
-			Expect(vmi.Status.Interfaces).To(HaveLen(1))
-			Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
-			Expect(vmi.Status.Interfaces[0].IP).NotTo(BeEmpty())
-			Expect(vmi.Status.Interfaces[0].MAC).To(Equal(testMACAddr))
-
-			guestIfaceName := vmi.Status.Interfaces[0].InterfaceName
-			cmd := fmt.Sprintf("ls /sys/bus/pci/devices/%s/virtio0/net/%s", testPCIAddr, guestIfaceName)
-			Expect(console.RunCommand(vmi, cmd, time.Second*5)).To(Succeed())
-		})
-
-		Context("should allow regular network connection", func() {
-			Context("should have client server connectivity", func() {
-				var clientVMI *v1.VirtualMachineInstance
-				var serverVMI *v1.VirtualMachineInstance
-
-				startServerVMI := func(ports []v1.Port) {
-					serverVMI = libvmi.NewAlpineWithTestTooling(
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(ports...)),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					)
-
-					serverVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), serverVMI)
-					Expect(err).ToNot(HaveOccurred())
-					serverVMI = libwait.WaitForSuccessfulVMIStart(
-						serverVMI,
-						libwait.WithFailOnWarnings(false),
-						libwait.WithTimeout(180),
-					)
-					Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
-				}
-
-				Context("TCP", func() {
-					checkConnectionToServer := func(serverIP string, port int, expectSuccess bool) []expect.Batcher {
-						expectResult := console.ShellFail
-						if expectSuccess {
-							expectResult = console.ShellSuccess
-						}
-
-						clientCommand := fmt.Sprintf("echo test | nc %s %d -i 1 -w 1 1> /dev/null\n", serverIP, port)
-
-						return []expect.Batcher{
-							&expect.BSnd{S: "\n"},
-							&expect.BExp{R: console.PromptExpression},
-							&expect.BSnd{S: clientCommand},
-							&expect.BExp{R: console.PromptExpression},
-							&expect.BSnd{S: tests.EchoLastReturnValue},
-							&expect.BExp{R: expectResult},
-						}
-					}
-
-					verifyClientServerConnectivity := func(clientVMI *v1.VirtualMachineInstance, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
-						serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
-						err := libnet.PingFromVMConsole(clientVMI, serverIP)
-						if err != nil {
-							return err
-						}
-
-						By("Connecting from the client VM")
-						err = console.SafeExpectBatch(clientVMI, checkConnectionToServer(serverIP, tcpPort, true), 30)
-						if err != nil {
-							return err
-						}
-
-						return nil
-					}
-
-					startClientVMI := func() {
-						clientVMI = libvmi.NewAlpineWithTestTooling(
-							libvmi.WithPasstInterfaceWithPort(),
-							libvmi.WithNetwork(v1.DefaultPodNetwork()),
-						)
-
-						clientVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI)
-						Expect(err).ToNot(HaveOccurred())
-						clientVMI = libwait.WaitForSuccessfulVMIStart(clientVMI,
-							libwait.WithFailOnWarnings(false),
-							libwait.WithTimeout(180),
-						)
-						Expect(console.LoginToAlpine(clientVMI)).To(Succeed())
-					}
-					DescribeTable("Client server connectivity", func(ports []v1.Port, tcpPort int, ipFamily k8sv1.IPFamily) {
-						libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
-
-						By("starting a client VMI")
-						startClientVMI()
-
-						By("starting a server VMI")
-						startServerVMI(ports)
-
-						By("starting a TCP server")
-						tests.StartTCPServer(serverVMI, tcpPort, console.LoginToAlpine)
-
-						Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, ipFamily)).To(Succeed())
-
-						if len(ports) != 0 {
-							By("starting a TCP server on a port not specified on the VM spec")
-							vmPort := int(ports[0].Port)
-							serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
-
-							tests.StartTCPServer(serverVMI, vmPort+1, console.LoginToAlpine)
-
-							By("Connecting from the client VM to a port not specified on the VM spec")
-							Expect(console.SafeExpectBatch(clientVMI, checkConnectionToServer(serverIP, tcpPort+1, true), 30)).To(Not(Succeed()))
-						}
-					},
-						Entry("with a specific port number [IPv4]", []v1.Port{{Name: "http", Port: 8080, Protocol: "TCP"}}, 8080, k8sv1.IPv4Protocol),
-						Entry("with a specific lower port number [IPv4]", []v1.Port{{Name: "http", Port: 80, Protocol: "TCP"}}, 80, k8sv1.IPv4Protocol),
-						Entry("without a specific port number [IPv4]", []v1.Port{}, 8080, k8sv1.IPv4Protocol),
-						Entry("with a specific port number [IPv6]", []v1.Port{{Name: "http", Port: 8080, Protocol: "TCP"}}, 8080, k8sv1.IPv6Protocol),
-						Entry("without a specific port number [IPv6]", []v1.Port{}, 8080, k8sv1.IPv6Protocol),
-					)
-				})
-
-				Context("UDP", func() {
-					startAndVerifyUDPClient := func(vmi *v1.VirtualMachineInstance, serverIP string, serverPort int, ipFamily k8sv1.IPFamily) error {
-						var inetSuffix string
-						if ipFamily == k8sv1.IPv6Protocol {
-							inetSuffix = "6"
-						}
-
-						createClientScript := fmt.Sprintf(`cat >udp_client.py <<EOL
-import socket
-try:
-  client = socket.socket(socket.AF_INET%s, socket.SOCK_DGRAM);
-  client.sendto("Hello Server".encode(), ("%s",%d));
-  client.settimeout(5);
-  response = client.recv(1024);
-  print(response.decode("utf-8"));
-
-except socket.timeout:
-    client.close();
-EOL`, inetSuffix, serverIP, serverPort)
-						runClient := "python3 udp_client.py"
-						return console.ExpectBatch(vmi, []expect.Batcher{
-							&expect.BSnd{S: fmt.Sprintf("%s\n", createClientScript)},
-							&expect.BExp{R: console.PromptExpression},
-							&expect.BSnd{S: fmt.Sprintf("%s\n", runClient)},
-							&expect.BExp{R: console.RetValue("Hello Client")},
-							&expect.BSnd{S: tests.EchoLastReturnValue},
-							&expect.BExp{R: console.ShellSuccess},
-						}, 60*time.Second)
-					}
-					DescribeTable("Client server connectivity", func(ipFamily k8sv1.IPFamily) {
-						libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
-
-						const SERVER_PORT = 1700
-
-						By("Starting server VMI")
-						startServerVMI([]v1.Port{{Port: SERVER_PORT, Protocol: "UDP"}})
-						serverVMI = libwait.WaitForSuccessfulVMIStart(serverVMI,
-							libwait.WithFailOnWarnings(false),
-							libwait.WithTimeout(180),
-						)
-						Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
-
-						By("Starting a UDP server")
-						tests.StartPythonUDPServer(serverVMI, SERVER_PORT, ipFamily)
-
-						By("Starting client VMI")
-						clientVMI = libvmi.NewAlpineWithTestTooling(
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding()),
-							libvmi.WithNetwork(v1.DefaultPodNetwork()),
-						)
-						clientVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientVMI)
-						Expect(err).ToNot(HaveOccurred())
-						clientVMI = libwait.WaitForSuccessfulVMIStart(clientVMI,
-							libwait.WithFailOnWarnings(false),
-							libwait.WithTimeout(180),
-						)
-						Expect(console.LoginToAlpine(clientVMI)).To(Succeed())
-
-						By("Starting and verifying UDP client")
-						// Due to a passt bug, at least one UDPv6 message has to be sent from a machine before it can receive UDPv6 messages
-						// Tracking bug - https://bugs.passt.top/show_bug.cgi?id=16
-						if ipFamily == k8sv1.IPv6Protocol {
-							clientIP := libnet.GetVmiPrimaryIPByFamily(clientVMI, ipFamily)
-							Expect(libnet.PingFromVMConsole(serverVMI, clientIP)).To(Succeed())
-						}
-						serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
-						Expect(startAndVerifyUDPClient(clientVMI, serverIP, SERVER_PORT, ipFamily)).To(Succeed())
-					},
-						Entry("[IPv4]", k8sv1.IPv4Protocol),
-						Entry("[IPv6]", k8sv1.IPv6Protocol),
-					)
-				})
-			})
-
-			It("[outside_connectivity]should be able to reach the outside world [IPv4]", func() {
-				libnet.SkipWhenClusterNotSupportIpv4()
-				ipv4Address := "8.8.8.8"
-				if flags.IPV4ConnectivityCheckAddress != "" {
-					ipv4Address = flags.IPV4ConnectivityCheckAddress
-				}
-				dns := "google.com"
-				if flags.ConnectivityCheckDNS != "" {
-					dns = flags.ConnectivityCheckDNS
-				}
-
-				vmi := libvmi.NewAlpineWithTestTooling(
-					libvmi.WithPasstInterfaceWithPort(),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				)
-				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
-				Expect(err).ToNot(HaveOccurred())
-				vmi = libwait.WaitForSuccessfulVMIStart(vmi,
-					libwait.WithFailOnWarnings(false),
-					libwait.WithTimeout(180),
-				)
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-				By("Checking ping (IPv4)")
-				Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
-				Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
-			})
-
-			It("[outside_connectivity]should be able to reach the outside world [IPv6]", func() {
-				libnet.SkipWhenClusterNotSupportIpv6()
-				// Cluster nodes subnet (docker network gateway)
-				// Docker network subnet cidr definition:
-				// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
-				ipv6Address := "2001:db8:1::1"
-				if flags.IPV6ConnectivityCheckAddress != "" {
-					ipv6Address = flags.IPV6ConnectivityCheckAddress
-				}
-
-				vmi := libvmi.NewAlpineWithTestTooling(
-					libvmi.WithPasstInterfaceWithPort(),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				)
-				Expect(err).ToNot(HaveOccurred())
-				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi)
-				Expect(err).ToNot(HaveOccurred())
-				vmi = libwait.WaitForSuccessfulVMIStart(vmi,
-					libwait.WithFailOnWarnings(false),
-					libwait.WithTimeout(180),
-				)
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-				By("Checking ping (IPv6) from VM to cluster nodes gateway")
-				Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
-			})
-		})
+		Expect(vmi.Status.Interfaces).To(HaveLen(1))
+		Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
+		Expect(vmi.Status.Interfaces[0].IP).NotTo(BeEmpty())
+		Expect(vmi.Status.Interfaces[0].MAC).To(Equal(macAddress))
 	})
 })

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -104,7 +104,6 @@ func AdjustKubeVirtResource() {
 		virtconfig.DownwardMetricsFeatureGate,
 		virtconfig.NUMAFeatureGate,
 		deprecation.MacvtapGate,
-		deprecation.PasstGate,
 		virtconfig.ExpandDisksGate,
 		virtconfig.WorkloadEncryptionSEV,
 		virtconfig.VMExportGate,

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -82,7 +82,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		}
 
-		DescribeTable("[Serial] should be successfully started and accessible", Serial, func(namespace string, option1, option2 libvmi.Option) {
+		DescribeTable("[Serial] should be successfully started and accessible", Serial, func(namespace string) {
 			if namespace == testsuite.NamespacePrivileged {
 				tests.EnableFeatureGate(virtconfig.VirtIOFSGate)
 			} else {
@@ -112,7 +112,6 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 				libvmi.WithFilesystemPVC(pvc1),
 				libvmi.WithFilesystemPVC(pvc2),
 				libvmi.WithNamespace(namespace),
-				option1, option2,
 			)
 
 			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
@@ -145,10 +144,8 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
 		},
-			Entry("(privileged virtiofsd)", testsuite.NamespacePrivileged, func(instance *virtv1.VirtualMachineInstance) {}, func(instance *virtv1.VirtualMachineInstance) {}),
-			Entry("with passt enabled (privileged virtiofsd)", testsuite.NamespacePrivileged, libvmi.WithPasstInterfaceWithPort(), libvmi.WithNetwork(v1.DefaultPodNetwork())),
-			Entry("(unprivileged virtiofsd)", util.NamespaceTestDefault, func(instance *virtv1.VirtualMachineInstance) {}, func(instance *virtv1.VirtualMachineInstance) {}),
-			Entry("with passt enabled (unprivileged virtiofsd)", util.NamespaceTestDefault, libvmi.WithPasstInterfaceWithPort(), libvmi.WithNetwork(v1.DefaultPodNetwork())),
+			Entry("(privileged virtiofsd)", testsuite.NamespacePrivileged),
+			Entry("(unprivileged virtiofsd)", util.NamespaceTestDefault),
 		)
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The PR changes the passt tests to use the passt plugin binding.
Only one test is left to cover the old passt binding API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Depends on PR https://github.com/kubevirt/kubevirt/pull/10981

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
