### PR TITLE
Quarantine flaky virt handler rate limiter test

### DIFF
--- a/tests/infrastructure/k8s-client-changes.go
+++ b/tests/infrastructure/k8s-client-changes.go
@@ -22,6 +22,7 @@ package infrastructure
 import (
 	"time"
 
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -99,7 +100,7 @@ var _ = DescribeInfra("changes to the kubernetes client", func() {
 		Expect(slowDuration.Seconds()).To(BeNumerically(">", 2*fastDuration.Seconds()))
 	})
 
-	It("on the virt handler rate limiter should lead to delayed VMI running states", func() {
+	It("[QUARANTINE] on the virt handler rate limiter should lead to delayed VMI running states", decorators.Quarantine, func() {
 		By("first getting the basetime for a replicaset")
 		targetNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
 		vmi := libvmi.New(


### PR DESCRIPTION
**What this PR does / why we need it**:

The following test appears to be very flaky over the past week[1]

`Infrastructure changes to the kubernetes client on the virt handler rate limiter should lead to delayed VMI running states`

It is causing over 24% impact to the sig-compute 1.28 presubmit lane in the last 2 days[2]

This test should be quarantined to reduce impact on merge queue PRs and allow time for investigation.

[1] https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2024-01-01-168h.html#row0
[2] https://search.ci.kubevirt.io/?search=Infrastructure+changes+to+the+kubernetes+client+on+the+virt+handler+rate+limiter+should+lead+to+delayed+VMI+running+state&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @EdDev @enp0s3 
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
