### PR TITLE
fix: Reduce VM recovery times

### DIFF
--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1763,11 +1763,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			controller.Execute()
 		})
 
-		DescribeTable("should do nothing if the vmi is handed over to virt-handler, the pod disappears", func(phase virtv1.VirtualMachineInstancePhase) {
+		DescribeTable("should mark the vmi as Failed if launcher-pod does not exist", func(phase virtv1.VirtualMachineInstancePhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = phase
 
 			addVirtualMachine(vmi)
+
+			patch := fmt.Sprintf(`[{ "op": "test", "path": "/status/phase", "value": "%s" }, { "op": "replace", "path": "/status/phase", "value": "Failed" }]`, phase)
+			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 
 			controller.Execute()
 		},

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -274,6 +274,7 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
+        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters:go_default_library",
     ],

--- a/tests/libpod/BUILD.bazel
+++ b/tests/libpod/BUILD.bazel
@@ -2,14 +2,20 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["render.go"],
+    srcs = [
+        "blackhole.go",
+        "render.go",
+    ],
     importpath = "kubevirt.io/kubevirt/tests/libpod",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/testsuite:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],

--- a/tests/libpod/blackhole.go
+++ b/tests/libpod/blackhole.go
@@ -1,0 +1,51 @@
+package libpod
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/exec"
+)
+
+func AddKubernetesApiBlackhole(pods *v1.PodList, containerName string) {
+	kubernetesApiServiceBlackhole(pods, containerName, true)
+}
+
+func DeleteKubernetesApiBlackhole(pods *v1.PodList, containerName string) {
+	kubernetesApiServiceBlackhole(pods, containerName, false)
+}
+
+func kubernetesApiServiceBlackhole(pods *v1.PodList, containerName string, present bool) {
+	virtCli, err := kubecli.GetKubevirtClient()
+	Expect(err).NotTo(HaveOccurred())
+
+	serviceIp := getKubernetesApiServiceIp(virtCli)
+
+	var addOrDel string
+	if present {
+		addOrDel = "add"
+	} else {
+		addOrDel = "del"
+	}
+
+	for _, pod := range pods.Items {
+		_, err = exec.ExecuteCommandOnPod(virtCli, &pod, containerName, []string{"ip", "route", addOrDel, "blackhole", serviceIp})
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func getKubernetesApiServiceIp(virtClient kubecli.KubevirtClient) string {
+	const kubernetesServiceName = "kubernetes"
+	const kubernetesServiceNamespace = "default"
+
+	kubernetesService, err := virtClient.CoreV1().Services(kubernetesServiceNamespace).Get(context.Background(), kubernetesServiceName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	return kubernetesService.Spec.ClusterIP
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
It aims to reduce the VM recovery time when an operator such as [NodeHealthCheck](https://github.com/medik8s/node-healthcheck-operator/) is used to remediate unhealthy nodes, i.e. nodes no longer responsive.

In such scenario, the launcher pod is deleted, and the VMi needs to be rescheduled if the spec `runStrategy` is configured as `Always` or `RerunOnFailure`. The VM's Phase is `Running` but VM has the following condition:

```
Status:
  Conditions:
    Last Probe Time:       2023-12-18T16:31:31Z
    Last Transition Time:  2023-12-18T16:31:31Z
    Message:               virt-launcher pod has not yet been scheduled
    Reason:                PodNotExists
```

Eventually, the VMi is rescheduled and the virt-launcher pod recreated.  However, it takes over than 100 seconds in best case. In the following figure, the total VM recovery time break down can be seen where:

- Vm_not_ready: Time for the VMi to be READY=False.
- Launcher_terminating: Time until launcher pod changes state to terminating.
- Launcher_deleted: Time until the launcher pod is deleted from the cluster.
- Launcher_respawned: Time until the launcher pod is respawned (respanwed: in any state pending, running, …).
- Vm_ready: Time for the VMi to be READY=True.

Please note that those measures are taken from the previous step until the step is finished. Regarding the vm_not_ready measurement, this time starts from the point where kubelet is stopped (this is the way to force a node to be unhealthy) until this VMi state is reached.
For instance, launcher_terminating measurement starts when vm_not_ready, i.e.  the VMi READY field is False, until the launcher pod updates its status to terminating.

![kubevirtci-vm-break-down](https://github.com/kubevirt/kubevirt/assets/110104425/82f4c813-c7de-40f0-bb48-0cdab9d450ce)

As can be seen, the vm_launcher_respawned speed-up is approximately 100x.

The issue is: if a VMi in Phase `Running` on a given node, and the node becomes unhealthy, VMis are not marked as `Failed`. This is due to the fact that the main responsible for this task is the virt-handler pod, which own the VMi. However, the virt-handler pod will be unresponsive, unable to be redeployed and unable to mark the VMi as `Failed`.  The secondary responsible for this action is the node controller. Nevertheless, the node controller requires that heartbeats from the virt-handler have not been received for a certain period of time (5 minutes).

Therefore, in order to transition the VMi to a FAILED state, it is required to wait until:

1. The node to get healthy again, the virt-handler to be recreated, the virt-handler to detect that VMi is on `Running` phase without a launcher-pod, and to mark the VMi as `Failed`. 

https://github.com/kubevirt/kubevirt/blob/4d095205df627bff1fe6ae10495e281a1475edc6/pkg/virt-handler/vm.go#L3280-L3283

2. The node controller to detect that the virt-handler has been unresponsive for a given amount of time (5 minutes by default), to detect VMis without virt-launcher pod and to mark the VMis as `Failed`.

https://github.com/kubevirt/kubevirt/blob/d4e5e11c84d0630c1c688b1bfffe7a0133f9675d/pkg/virt-controller/watch/node.go#L462-L477

It reduces the virt-launcher pod respawn time by short-circuiting the feedback loop that the node controller would already handle and the virt-handler recreation. Therefore, the virt-controller will mark the VMi as `Failed` and it will force the VMi to be rescheduled on another node faster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-36137](https://issues.redhat.com/browse/CNV-36137)

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reduced VM rescheduling time on node failure
```
