### PR TITLE
vmexport: Reject volume exports when no output file is specified

### DIFF
--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -347,7 +347,7 @@ func (c *command) initVMExportInfo(vmeInfo *VMExportInfo) error {
 	vmeInfo.ExportSource = getExportSource()
 	vmeInfo.OutputFile = outputFile
 	// User wants the output in a file, create
-	if outputFile != "" {
+	if outputFile != "" && outputFile != "-" {
 		output, err := os.Create(vmeInfo.OutputFile)
 		if err != nil {
 			return err
@@ -962,6 +962,9 @@ func handleDownloadFlags() error {
 		if pvc != "" {
 			return fmt.Errorf(ErrIncompatibleFlag, PVC_FLAG, MANIFEST_FLAG)
 		}
+	}
+	if !exportManifest && outputFile == "" {
+		return fmt.Errorf("Warning: Binary output can mess up your terminal. Use '%s -' to output into stdout anyway or consider '%s <FILE>' to save to a file.", OUTPUT_FLAG, OUTPUT_FLAG)
 	}
 
 	return nil

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -292,6 +292,7 @@ var _ = Describe("vmexport", func() {
 			Entry("Using 'manifest' with invalid output_format_flag", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.OUTPUT_FORMAT_FLAG, "json/yaml"), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, "invalid")),
 			Entry("Using 'port-forward' with invalid port", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.LOCAL_PORT_FLAG, "valid port numbers"), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.PORT_FORWARD_FLAG, setflag(virtctlvmexport.LOCAL_PORT_FLAG, "test")),
 			Entry("Using 'format' with invalid download format", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.FORMAT_FLAG, "gzip/raw"), virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.FORMAT_FLAG, "test")),
+			Entry("Downloading volume without specifying output", fmt.Sprintf("Warning: Binary output can mess up your terminal. Use '%s -' to output into stdout anyway or consider '%s <FILE>' to save to a file.", virtctlvmexport.OUTPUT_FLAG, virtctlvmexport.OUTPUT_FLAG), virtctlvmexport.DOWNLOAD, vmexportName),
 		)
 
 		AfterEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: 

When no output is specified, all vmexport downloads are dumped into stdout. This Pull Request improves the error handling to reject volume downloads when no output file is specified to avoid unexpected binary dumps.

Example before fix:

```sh
# virtctl vmexport download vm --pvc=test
�����������������������������������������������������������������������������������_/���y��<u�'��&
��
$q��D5�$����{�H�

...

```

After fix:

```sh
# virtctl vmexport download vm --pvc=test
Warning: Binary output can mess up your terminal. Use '--output -' to output into stdout anyway or consider '--output <FILE>' to save to a file.
```

Manifest downloads are still able to dump into stdout without specifying output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #  https://issues.redhat.com/browse/CNV-36271

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Reject volume exports when no output is specified
```
