### PR TITLE
virtctl: add VM level log verbosity to the log-verbosity subcommand

### DIFF
--- a/pkg/virtctl/adm/logverbosity/BUILD.bazel
+++ b/pkg/virtctl/adm/logverbosity/BUILD.bazel
@@ -34,7 +34,11 @@ go_test(
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
     ],
 )

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -1,6 +1,7 @@
 package logverbosity
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,35 +27,34 @@ type Command struct {
 	command      string
 }
 
-// for command parsing
+// constants and variables for command parsing
 const (
 	// Verbosity must be 0-9.
 	// https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-output-verbosity-and-debugging
-	minVerbosity = uint(0)
-	maxVerbosity = uint(9)
-	// noArg and NoFlag: Any number between 10 and MaxUint is fine.
-	// Select less weird numbers, because these numbers will be shown in the help menu.
-	// There is no option to hide the default value from the help menu.
-	// See pflag.FlagUsages, which calls the FlagUsagesWrapped function:
-	// https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L677
-	noArg         = 10    // Default value if no argument specified
-	NoFlag        = 11    // Default value if no flag is specified
-	allComponents = "all" // Use in multiple places, so make it a constant
+	minVerbosity  = uint(0)
+	maxVerbosity  = uint(9)
+	noArg         = "show" // default value if no argument specified
+	NoFlag        = ""     // default value if no flag is specified (exposed to the test file)
+	allComponents = "all"  // all KubeVirt components
 )
 
-// for receiving the flag argument
-var isReset bool
+var virtComponents = map[string]*string{
+	"virt-api":        new(string),
+	"virt-controller": new(string),
+	"virt-handler":    new(string),
+	"virt-launcher":   new(string),
+	"virt-operator":   new(string),
+	allComponents:     new(string),
+}
 
-// Log verbosity can be set per KubeVirt component.
-// https://kubevirt.io/user-guide/operations/debug/#setting-verbosity-per-kubevirt-component
-// TODO: set verbosity per nodes
-var virtComponents = map[string]*uint{
-	"virt-api":        new(uint),
-	"virt-controller": new(uint),
-	"virt-handler":    new(uint),
-	"virt-launcher":   new(uint),
-	"virt-operator":   new(uint),
-	allComponents:     new(uint),
+var resetNames = []string{}
+var vmNames = []string{}
+var vmLevels = []string{}
+
+type vmProperties struct {
+	name  string
+	level string
+	obj   *v1.VirtualMachine
 }
 
 // operation type of log-verbosity command
@@ -66,30 +66,34 @@ const (
 	nop
 )
 
-// for patch operation
+// constants for patch operation
+// for the details of the patch,
+// see https://www.rfc-editor.org/rfc/rfc6902
 const (
-	// Just "add" is fine, no need of "replace" and "remove".
-	// https://www.rfc-editor.org/rfc/rfc6902
-	patchAdd = patch.PatchAddOp
-	dcPath   = "/spec/configuration/developerConfiguration"
-	lvPath   = "/spec/configuration/developerConfiguration/logVerbosity"
+	patchAdd    = patch.PatchAddOp
+	patchRemove = patch.PatchRemoveOp
+	dcPath      = "/spec/configuration/developerConfiguration"
+	lvPath      = "/spec/configuration/developerConfiguration/logVerbosity"
+	labelPath   = "/spec/template/metadata/labels/logVerbosity"
 )
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "log-verbosity",
-		Short: "Show, Set or Reset log verbosity. The verbosity value must be 0-9. The default cluster config is normally 2.\n",
-		Long: `- To show the log verbosity of one or more components
-  (when the log verbosity is unattended in the KubeVirt CR, show the default verbosity).
-- To set the log verbosity of one or more components.
-- To reset the log verbosity of all components
-  (empty the log verbosity field, which means reset to the default verbosity).
+		Short: "Show, Set or Reset the log verbosity. The verbosity value must be 0-9. The default cluster config is normally 2.\n",
+		Long: `- To show the log verbosity of one or more KubeVirt components and/or one or more VMs
+- To set the log verbosity of one or more KubeVirt components and/or one or more VMs
+- To reset the log verbosity of all KubeVirt components and/or one or more VMs
+  - For KubeVirt components, empty the log verbosity field, i.e. reset to the default verbosity
+  - For VMs, remove the logVerbosity label from the VMs
 
-- The components are <virt-api | virt-controller | virt-handler | virt-launcher | virt-operator>.
+- The KubeVirt components are <virt-api | virt-controller | virt-handler | virt-launcher | virt-operator>.
 - Show and Set/Reset cannot coexist.
 - The verbosity value must be 0-9. The default cluster config is normally 2.
-- The verbosity value 10 is accepted but the operation is "show" instead of "set" (e.g. "--virt-api=10" = "--virt-api").
-- Flag syntax must be "flag=arg" ("flag arg" not supported).`,
+- For the KubeVirt components, flag syntax must be "flag=arg" ("flag arg" not supported).
+- For the VM, the new verbosity is applied when the VM is (re)started.
+  - When the VM is not running, show the verbosity when the VM starts running.
+  - When the VM is running, show the verbosity of the currently running VMI, even if the new verbosity was set after the VMI started.`,
 		Example: usage(),
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -98,72 +102,93 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().UintVar(virtComponents["virt-api"], "virt-api", NoFlag, "show/set virt-api log verbosity (0-9)")
 	// A flag without an argument should only be used for boolean flags.
-	// However, we want to use a flag without an argument (e.g. --virt-api) to show verbosity.
+	// However, we want to use a flag without an argument (e.g. --virt-api) to show virt component verbosity.
 	// To do this, we set the default value (NoOptDefVal=noArg) when the flag has no argument.
 	// Otherwise, the pflag package will return an error due to a missing argument.
-	// The caveat is that there is no way to distinguish between user-specified 10 and NoOptDefVal=noArg after the following point.
-	// https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L989
-	// So, we accept "flag=10" but the operation is "show" instead of "set".
-	cmd.Flags().Lookup("virt-api").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().StringVar(virtComponents["virt-api"], "virt-api", NoFlag, "show/set the log verbosity (0-9) of virt-api")
+	cmd.Flags().Lookup("virt-api").NoOptDefVal = noArg
 
-	cmd.Flags().UintVar(virtComponents["virt-controller"], "virt-controller", NoFlag, "show/set virt-controller log verbosity (0-9)")
-	cmd.Flags().Lookup("virt-controller").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().StringVar(virtComponents["virt-controller"], "virt-controller", NoFlag, "show/set the log verbosity (0-9) of virt-controller")
+	cmd.Flags().Lookup("virt-controller").NoOptDefVal = noArg
 
-	cmd.Flags().UintVar(virtComponents["virt-handler"], "virt-handler", NoFlag, "show/set virt-handler log verbosity (0-9)")
-	cmd.Flags().Lookup("virt-handler").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().StringVar(virtComponents["virt-handler"], "virt-handler", NoFlag, "show/set the log verbosity (0-9) of virt-handler")
+	cmd.Flags().Lookup("virt-handler").NoOptDefVal = noArg
 
-	cmd.Flags().UintVar(virtComponents["virt-launcher"], "virt-launcher", NoFlag, "show/set virt-launcher log verbosity (0-9)")
-	cmd.Flags().Lookup("virt-launcher").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().StringVar(virtComponents["virt-launcher"], "virt-launcher", NoFlag, "show/set the log verbosity (0-9) of virt-launcher")
+	cmd.Flags().Lookup("virt-launcher").NoOptDefVal = noArg
 
-	cmd.Flags().UintVar(virtComponents["virt-operator"], "virt-operator", NoFlag, "show/set virt-operator log verbosity (0-9)")
-	cmd.Flags().Lookup("virt-operator").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().StringVar(virtComponents["virt-operator"], "virt-operator", NoFlag, "show/set the log verbosity (0-9) of virt-operator")
+	cmd.Flags().Lookup("virt-operator").NoOptDefVal = noArg
 
-	cmd.Flags().UintVar(virtComponents[allComponents], allComponents, NoFlag, "show/set all component log verbosity (0-9)")
-	cmd.Flags().Lookup(allComponents).NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().StringVar(virtComponents[allComponents], allComponents, NoFlag, "show/set the log verbosity (0-9) of all KubeVirt components")
+	cmd.Flags().Lookup(allComponents).NoOptDefVal = noArg
 
-	cmd.Flags().BoolVar(&isReset, "reset", false, "reset log verbosity to the default verbosity (2) (empty the log verbosity)")
+	cmd.Flags().StringSliceVar(&resetNames, "reset", []string{}, "reset the log verbosity of all KubeVirt components to the default verbosity (2) and remove the logVerbosity label in the VM object")
+	cmd.Flags().Lookup("reset").NoOptDefVal = allComponents
 
-	// cannot specify "reset" and "all" flag at the same time
-	cmd.MarkFlagsMutuallyExclusive("reset", allComponents)
+	// VM related flags always have an argument.
+	cmd.Flags().StringSliceVar(&vmNames, "vm", []string{}, "VM name")
+
+	cmd.Flags().StringSliceVar(&vmLevels, "level", []string{}, "the log verbosity (0-9) for a VM")
 
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
 
-// Command line flag syntax:
+// Command line flag syntax (for KubeVirt components):
 //
 //	OK: --flag=x
 //	NG: --flag x
 //
-// Another caveat of NoOptDefVal is that
+// A caveat of NoOptDefVal is that
 // we cannot use the "--flag x" syntax, because "--flag x" only applies to flags without a default value.
-// See vendor/github.com/spf13/pflag/flag.go, especially note the order of the if clause below.
-// https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L983C1-L998C3
+// See https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L983C1-L998C3
 func usage() string {
-	return `  # reset (to default) log-verbosity for all components:
-  {{ProgramName}} adm logVerbosity --reset
-
-  # show log-verbosity for all components:
-  {{ProgramName}} adm log-verbosity --all
-  # set log-verbosity to 3 for all components:
-  {{ProgramName}} adm log-verbosity --all=3
-
-  # show log-verbosity for virt-handler:
-  {{ProgramName}} adm log-verbosity --virt-handler
-  # set log-verbosity to 7 for virt-handler:
-  {{ProgramName}} adm log-verbosity --virt-handler=7
-
-  # show log-verbosity for virt-handler and virt-launcher:
+	return `  1. KubeVirt component
+  # show the log verbosity of virt-handler and virt-launcher:
   {{ProgramName}} adm log-verbosity --virt-handler --virt-launcher
-  # set log-verbosity for virt-handler to 7 and virt-launcher to 3:
-  {{ProgramName}} adm log-verbosity --virt-handler=7 --virt-launcher=3
+  # show the log verbosity of all components:
+  {{ProgramName}} adm log-verbosity --all  
 
+  # set the log verbosity for virt-handler to 7 and virt-launcher to 3:
+  {{ProgramName}} adm log-verbosity --virt-handler=7 --virt-launcher=3
+  # set the log verbosity for all components to 3:
+  {{ProgramName}} adm log-verbosity --all=3
+  # set all components to 3 besides virt-handler which is 7:
+  {{ProgramName}} adm log-verbosity --all=3 --virt-handler=7
+
+  # reset the log verbosity for all components (to default):
+  {{ProgramName}} adm logVerbosity --reset
   # reset all components to default besides virt-handler which is 7:
   {{ProgramName}} adm log-verbosity --reset --virt-handler=7
-  # set all components to 3 besides virt-handler which is 7:
-  {{ProgramName}} adm log-verbosity --all=3 --virt-handler=7`
+
+  2. VM
+  # show the log verbosity of testvm1 and testvm2
+  {{ProgramName}} adm log-verbosity --vm=testvm1 --vm=testvm2
+  
+  # set the log verbosity for testvm1 to 5 and for testvm2 to 6
+  {{ProgramName}} adm log-verbosity --vm=testvm1 --level=5 --vm=testvm2 --level=6
+  
+  # reset (remove the logVerbosity label from) testvm1 and testvm2
+  {{ProgramName}} adm log-verbosity --reset=testvm1 --reset=testvm2
+  # reset (remove the logVerbosity label from) testvm1 and set log-verbosity for testvm2 to 5
+  {{ProgramName}} adm log-verbosity --reset=testvm1 --vm=testvm2 --level=5
+  
+  3. both KubeVirt component and VM
+  # show the log verbosity of virt-api and testvm
+  {{ProgramName}} adm log-verbosity --virt-api --vm=testvm
+  # show the log verbosity of all virt components and testvm
+  {{ProgramName}} adm log-verbosity --all --vm=testvm
+  
+  # set the log verbosity for virt-api to 3 and testvm to 5
+  {{ProgramName}} adm log-verbosity --virt-api=3 --vm=testvm --level=5
+  # set the log verbosity for all components to 3 and testvm to 5
+  {{ProgramName}} adm log-verbosity --all=3 --vm=testvm --level=5
+  # reset the log verbosity of all components (to default) and (remove the logVerbosity label from) testvm
+  {{ProgramName}} adm log-verbosity --reset --reset=testvm
+  # reset the log verbosity of all components (to default) and set the log verbosity for testvm to 5
+  {{ProgramName}} adm log-verbosity --reset --vm=testvm --level=5`
 }
 
 // component name to JSON name
@@ -201,11 +226,10 @@ func hasVerbosityInKV(kv *v1.KubeVirt) (map[string]uint, bool, error) {
 
 	if kv.Spec.Configuration.DeveloperConfiguration == nil {
 		// If DeveloperConfiguration is absent in the KubeVirt CR, need to add it before adding LogVerbosity.
-		// So set the hasDeveloperConfiguration flag to false.
+		// Set the hasDeveloperConfiguration flag to false.
 		hasDeveloperConfiguration = false
 	} else if kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity != nil {
-		// If LogVerbosity is present in the KubeVirt CR,
-		// get the logVerbosity field, and put it to verbosityMap.
+		// If LogVerbosity is present in the KubeVirt CR, get the logVerbosity field, and put it to verbosityMap.
 		lvJSON, err := json.Marshal(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity)
 		if err != nil {
 			return nil, hasDeveloperConfiguration, err
@@ -218,29 +242,65 @@ func hasVerbosityInKV(kv *v1.KubeVirt) (map[string]uint, bool, error) {
 	return verbosityMap, hasDeveloperConfiguration, nil
 }
 
-func createOutputLines(verbosityVal map[string]uint) []string {
-	var lines []string
-
+func createKvOutputLines(lines *[]string, verbosityVal map[string]uint) {
 	allIsSet := (*virtComponents[allComponents] != NoFlag)
-
 	for componentName, verbosity := range virtComponents {
 		if componentName == allComponents {
 			continue
 		}
 		JSONName := getJSONNameByComponentName(componentName)
 		if *verbosity != NoFlag || allIsSet {
-			line := fmt.Sprintf("%s=%d", componentName, verbosityVal[JSONName])
-			lines = append(lines, line)
+			line := fmt.Sprintf("%s = %d", componentName, verbosityVal[JSONName])
+			*lines = append(*lines, line)
 		}
 	}
-
-	// output message sorted by lexicographical order of component name
-	sort.Strings(lines)
-
-	return lines
+	// virt component output message sorted by lexicographical order of component name
+	sort.Strings(*lines)
 }
 
-func createShowMessage(currentLv map[string]uint) []string {
+func createVMOutputLines(lines *[]string, verbosityVal map[string]uint, vms []vmProperties) error {
+	for _, vm := range vms {
+		line := fmt.Sprintf("%s = %d", vm.name, verbosityVal[vm.name])
+		*lines = append(*lines, line)
+
+		// When the VM is running, return the verbosity set on the running VM.
+		// Get the verbosity set on the running VM, and if it is different from the verbosity of the VM object, add a warning message
+		obj := vm.obj
+		var val uint
+		var err error
+		if verbosity, exist := obj.Spec.Template.ObjectMeta.Labels["logVerbosity"]; exist {
+			// if label is specified, use the label in the vm object
+			if val, err = atou(verbosity); err != nil {
+				return err
+			}
+		} else {
+			// if label is not specified, use the virt-launcher log verbosity
+			// Note: verbosityVal[] always has the "virt-launcher" key
+			val = verbosityVal[getJSONNameByComponentName("virt-launcher")]
+		}
+		if verbosityVal[vm.name] != val {
+			line := fmt.Sprintf("%s: updated verbosity %d will be applied after the VM is restarted", vm.name, val)
+			*lines = append(*lines, line)
+		}
+	}
+	return nil
+}
+
+func createOutputLines(verbosityVal map[string]uint, vms []vmProperties) ([]string, error) {
+	var lines []string
+
+	// for virt component output message
+	createKvOutputLines(&lines, verbosityVal)
+
+	// for vm output message
+	if err := createVMOutputLines(&lines, verbosityVal, vms); err != nil {
+		return nil, err
+	}
+
+	return lines, nil
+}
+
+func createShowMessage(currentLv map[string]uint, vms []vmProperties) ([]string, error) {
 	// fill the unattended verbosity with default verbosity
 	// key: JSONName, value: verbosity
 	var verbosityVal = map[string]uint{
@@ -251,14 +311,21 @@ func createShowMessage(currentLv map[string]uint) []string {
 		"virtOperator":   virtconfig.DefaultVirtOperatorLogVerbosity,
 	}
 
-	// update the verbosity based on the existing verbosity in the KubeVirt CR
+	for _, vm := range vms {
+		verbosityVal[vm.name] = virtconfig.DefaultVirtLauncherLogVerbosity
+	}
+
+	// update the verbosity based on the existing verbosity in the KubeVirt CR and the logVerbosity label of VM
 	for key, value := range currentLv {
 		verbosityVal[key] = value
 	}
 
-	lines := createOutputLines(verbosityVal)
+	lines, err := createOutputLines(verbosityVal, vms)
+	if err != nil {
+		return nil, err
+	}
 
-	return lines
+	return lines, nil
 }
 
 func addPatch(patchData *[]patch.PatchOperation, op string, path string, value interface{}) {
@@ -269,7 +336,7 @@ func addPatch(patchData *[]patch.PatchOperation, op string, path string, value i
 	})
 }
 
-func setVerbosity(currentLv map[string]uint, patchData *[]patch.PatchOperation, hasDeveloperConfiguration bool) {
+func createKvComponentPatch(currentLv map[string]uint, hasDeveloperConfiguration *bool, patchData *[]patch.PatchOperation) {
 	// update currentLv based on the user-specified verbosity for all components
 	if *virtComponents[allComponents] != NoFlag {
 		for componentName := range virtComponents {
@@ -277,7 +344,7 @@ func setVerbosity(currentLv map[string]uint, patchData *[]patch.PatchOperation, 
 				continue
 			}
 			JSONName := getJSONNameByComponentName(componentName)
-			currentLv[JSONName] = *virtComponents[allComponents]
+			currentLv[JSONName], _ = atou(*virtComponents[allComponents])
 		}
 	}
 
@@ -287,67 +354,120 @@ func setVerbosity(currentLv map[string]uint, patchData *[]patch.PatchOperation, 
 			continue
 		}
 		JSONName := getJSONNameByComponentName(componentName)
-		currentLv[JSONName] = *verbosity
+		currentLv[JSONName], _ = atou(*verbosity)
 	}
 
 	// in case of just reset (no set operation after the reset), don't need to add another patch
+	if !*hasDeveloperConfiguration {
+		// if DeveloperConfiguration is absent, add DeveloperConfiguration first
+		addPatch(patchData, patchAdd, dcPath, &v1.DeveloperConfiguration{})
+	}
+	addPatch(patchData, patchAdd, lvPath, currentLv)
+}
+
+func createKvResetPatch(currentLv map[string]uint, hasDeveloperConfiguration *bool, patchData *[]patch.PatchOperation) {
+	// reset only if verbosity exists, otherwise do nothing
 	if len(currentLv) != 0 {
-		if !hasDeveloperConfiguration {
+		if !*hasDeveloperConfiguration {
 			// if DeveloperConfiguration is absent, add DeveloperConfiguration first
 			addPatch(patchData, patchAdd, dcPath, &v1.DeveloperConfiguration{})
+			*hasDeveloperConfiguration = true
 		}
+		// add an empty object
+		currentLv = map[string]uint{}
 		addPatch(patchData, patchAdd, lvPath, currentLv)
 	}
 }
 
-func createPatch(currentLv map[string]uint, hasDeveloperConfiguration bool) ([]byte, error) {
-	patchData := []patch.PatchOperation{}
-
-	// reset only if verbosity exists, otherwise do nothing
-	if isReset && len(currentLv) != 0 {
-		if !hasDeveloperConfiguration {
-			// if DeveloperConfiguration is absent, add DeveloperConfiguration first
-			addPatch(&patchData, patchAdd, dcPath, &v1.DeveloperConfiguration{})
-			hasDeveloperConfiguration = true
-		}
-		// add an empty object
-		currentLv = map[string]uint{}
-		addPatch(&patchData, patchAdd, lvPath, currentLv)
+func createKvPatch(isReset, isComponent bool, kv *v1.KubeVirt, lines *[]string) ([]byte, error) {
+	// "Add" patch removes the value if we do not specify the value, even if we do not change the existing value.
+	// So, we need to get the existing verbosity in the KubeVirt CR.
+	// Also, "Add" patch needs a DeveloperConfiguration entry before adding a LogVerbosity entry.
+	// So, we need to know if DeveloperConfiguration is present or absent.
+	currentLv, hasDeveloperConfiguration, err := hasVerbosityInKV(kv)
+	if err != nil {
+		return nil, err
 	}
-
-	setVerbosity(currentLv, &patchData, hasDeveloperConfiguration)
-
+	patchData := []patch.PatchOperation{}
+	if isReset {
+		createKvResetPatch(currentLv, &hasDeveloperConfiguration, &patchData)
+		currentLv = map[string]uint{}
+		line := "successfully reset the verbosity of all KubeVirt components to default (2)"
+		*lines = append(*lines, line)
+	}
+	if isComponent {
+		createKvComponentPatch(currentLv, &hasDeveloperConfiguration, &patchData)
+		line := "successfully set the verbosity of the KubeVirt component(s)"
+		*lines = append(*lines, line)
+	}
 	return json.Marshal(patchData)
 }
 
-func findOperation(cmd *cobra.Command) (operation, error) {
-	isShow, isSet := false, false
+func processVMFlags(isShow, isSet *bool, vms *[]vmProperties) error {
+	vmNamesLen := len(vmNames)
+	vmLevelsLen := len(vmLevels)
+	switch {
+	case vmNamesLen > 0 && vmLevelsLen == 0:
+		*isShow = true
+	case vmNamesLen > 0 && vmLevelsLen > 0:
+		if vmNamesLen != vmLevelsLen {
+			return fmt.Errorf("number of vm flags %d not equal to number of level flags %d", vmNamesLen, vmLevelsLen)
+		}
+		// set the specified verbosity level in the vm struct
+		for i, level := range vmLevels {
+			val, err := strconv.Atoi(level)
+			if val > int(maxVerbosity) || val < int(minVerbosity) || err != nil {
+				return fmt.Errorf("%s: log verbosity must be %d-%d", (*vms)[i].name, minVerbosity, maxVerbosity)
+			}
+			(*vms)[i].level = level
+		}
+		*isSet = true
+	}
+	return nil
+}
 
+func processVirtComponents(cmd *cobra.Command, isShow, isSet, isComponent *bool) error {
 	for componentName, verbosity := range virtComponents {
 		// check if the flag for the component is specified
-		// cannot use NoFlag to check, because user can accidentally specify the same number as NoFlag for the verbosity
-		if !cmd.Flags().Changed(componentName) {
+		// check NoFlag is not enough, because user can accidentally specify the same number as NoFlag for the verbosity
+		if !cmd.Flags().Changed(componentName) || *verbosity == NoFlag {
 			continue
 		}
+
+		*isComponent = true // the operation for virt components
 
 		// if flag is specified, it means either set or show
 		// if the value = noArg, it means show
 		// if the value != noArg, it means set
-		isShow = isShow || *verbosity == noArg
-		isSet = isSet || *verbosity != noArg
+		*isShow = *isShow || *verbosity == noArg
+		*isSet = *isSet || *verbosity != noArg
 
 		// check whether the verbosity is in the range
-		// Note that noArg is acceptable but operation is show instead of set.
-		if *verbosity != noArg && *verbosity > maxVerbosity {
-			return nop, fmt.Errorf("%s: log verbosity must be %d-%d", componentName, minVerbosity, maxVerbosity)
+		if *verbosity != noArg {
+			val, err := strconv.Atoi(*verbosity)
+			if val > int(maxVerbosity) || val < int(minVerbosity) || err != nil {
+				return fmt.Errorf("%s: log verbosity must be %d-%d", componentName, minVerbosity, maxVerbosity)
+			}
 		}
 	}
+	return nil
+}
 
+func findOperation(cmd *cobra.Command, isReset, isVMReset bool, isComponent *bool, vms *[]vmProperties) (operation, error) {
+	isShow, isSet := false, false
+	// for vm
+	if err := processVMFlags(&isShow, &isSet, vms); err != nil {
+		return nop, err
+	}
+	// for virt components
+	if err := processVirtComponents(cmd, &isShow, &isSet, isComponent); err != nil {
+		return nop, err
+	}
 	// do not distinguish between set and reset at this point, because set and reset can coexist
-	if isReset {
+	if isReset || isVMReset {
 		isSet = true
 	}
-
+	// determine operation
 	switch {
 	case isShow && isSet:
 		return nop, errors.New("only show or set is allowed")
@@ -360,22 +480,190 @@ func findOperation(cmd *cobra.Command) (operation, error) {
 	}
 }
 
+func processRunningVM(virtClient kubecli.KubevirtClient, currentLv map[string]uint, vmName, vmNamespace string) error {
+	podList, err := virtClient.CoreV1().Pods(vmNamespace).List(context.Background(), k8smetav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.GenerateName != "virt-launcher-"+vmName+"-" {
+			continue
+		}
+		for _, container := range pod.Spec.Containers {
+			if container.Name != "compute" {
+				continue
+			}
+			for _, env := range container.Env {
+				if env.Name == "VIRT_LAUNCHER_LOG_VERBOSITY" {
+					level, err := atou(env.Value)
+					if err != nil {
+						return err
+					}
+					currentLv[vmName] = level
+					return nil
+				}
+				// if there is no VIRT_LAUNCHER_LOG_VERBOSITY, the virt-launcher verbosity was set as default
+			}
+		}
+	}
+	return nil
+}
+
+func processStoppedVM(currentLv map[string]uint, vmName string, obj *v1.VirtualMachine) error {
+	if verbosity, exist := obj.Spec.Template.ObjectMeta.Labels["logVerbosity"]; exist {
+		// if label is specified, use the label in the vm object
+		level, err := atou(verbosity)
+		if err != nil {
+			return err
+		}
+		currentLv[vmName] = level
+	} else if val, exist := currentLv["virtLauncher"]; exist {
+		// if label is not specified, use the virt-launcher log verbosity
+		currentLv[vmName] = val
+	}
+	return nil
+}
+
+func getVMVerbosity(virtClient kubecli.KubevirtClient, currentLv map[string]uint, vmNamespace string, vms []vmProperties) error {
+	for _, vm := range vms {
+		obj := vm.obj
+		if *obj.Spec.Running {
+			// check pod object's environmental variable VIRT_LAUNCHER_LOG_VERBOSITY
+			if err := processRunningVM(virtClient, currentLv, vm.name, vmNamespace); err != nil {
+				return err
+			}
+		} else {
+			if err := processStoppedVM(currentLv, vm.name, obj); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func atou(s string) (uint, error) {
+	val, err := strconv.Atoi(s)
+	if err != nil {
+		return uint(val), fmt.Errorf("verbosity %s cannot cast to int: %v", s, err)
+	}
+	if val < 0 {
+		return uint(val), fmt.Errorf("verbosity %s is negative", s)
+	}
+	return uint(val), err
+}
+
+func createVMPatch(cmd *cobra.Command, vm vmProperties) ([]byte, error) {
+	patchData := []patch.PatchOperation{}
+	obj := vm.obj
+	if cmd.Flags().Changed("vm") {
+		if obj.Spec.Template.ObjectMeta.Labels == nil || len(obj.Spec.Template.ObjectMeta.Labels) == 0 {
+			// if vm.Spec.Template.ObjectMeta.Labels == map[string]string{}, add patch operation returns an error
+			// (missing path: "/spec/template/metadata/labels/logVerbosity": missing value)
+			addPatch(&patchData, patchAdd, "/spec/template/metadata/labels", map[string]string{"logVerbosity": ""})
+		}
+		verbosity := vm.level
+		addPatch(&patchData, patchAdd, labelPath, verbosity)
+	}
+	return json.Marshal(patchData)
+}
+
+func createResetVMPatch(cmd *cobra.Command, vm vmProperties) ([]byte, error) {
+	patchData := []patch.PatchOperation{}
+	obj := vm.obj
+	if _, exist := obj.Spec.Template.ObjectMeta.Labels["logVerbosity"]; exist {
+		patchData = append(patchData, patch.PatchOperation{
+			Op:   patchRemove,
+			Path: labelPath,
+		})
+	}
+	return json.Marshal(patchData)
+}
+
+func setVMProperties(virtClient kubecli.KubevirtClient, name string, vmNamespace string, item *vmProperties) error {
+	var err error
+	item.name = name
+	// at this point, we do not know whether to show or set, so enter noArg (in case of set, enter the verbosity level later)
+	item.level = noArg
+	item.obj, err = virtClient.VirtualMachine(vmNamespace).Get(context.Background(), name, &k8smetav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error fetching Virtual Machine: %v", err)
+	}
+	return nil
+}
+
+func parseResetFlag(virtClient kubecli.KubevirtClient, cmd *cobra.Command, vmNamespace string, isReset, isVMReset *bool, resetVms *[]vmProperties) error {
+	if cmd.Flags().Changed("reset") {
+		for _, name := range resetNames {
+			*isReset = *isReset || name == allComponents
+			*isVMReset = *isVMReset || name != allComponents
+			if name != allComponents {
+				var item vmProperties
+				if err := setVMProperties(virtClient, name, vmNamespace, &item); err != nil {
+					return err
+				}
+				*resetVms = append(*resetVms, item)
+			}
+		}
+	}
+	return nil
+}
+
+func parseVMFlag(virtClient kubecli.KubevirtClient, vmNamespace string, vms *[]vmProperties) error {
+	vmNamesLen := len(vmNames)
+	vmLevelsLen := len(vmLevels)
+	if vmNamesLen == 0 && vmLevelsLen != 0 {
+		return fmt.Errorf("level: need vm flag")
+	} else if vmNamesLen != 0 {
+		for _, name := range vmNames {
+			item := vmProperties{}
+			if err := setVMProperties(virtClient, name, vmNamespace, &item); err != nil {
+				return err
+			}
+			*vms = append(*vms, item)
+		}
+	}
+	return nil
+}
+
 func (c *Command) RunE(cmd *cobra.Command) error {
+	isReset, isVMReset, isComponent := false, false, false
+	vms := []vmProperties{}
+	resetVms := []vmProperties{}
+
 	virtClient, err := kubecli.GetKubevirtClientFromClientConfig(c.clientConfig)
 	if err != nil {
 		return err
 	}
-	namespace, name, err := detectInstallNamespaceAndName(virtClient)
+
+	kvNamespace, kvName, err := detectInstallNamespaceAndName(virtClient)
 	if err != nil {
 		return err
 	}
-	kv, err := virtClient.KubeVirt(namespace).Get(name, &k8smetav1.GetOptions{})
+	kv, err := virtClient.KubeVirt(kvNamespace).Get(kvName, &k8smetav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	vmNamespace, _, err := c.clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	// parse vm flag (set the specified vm name and vm object in the vm struct)
+	err = parseVMFlag(virtClient, vmNamespace, &vms)
+	if err != nil {
+		return err
+	}
+
+	// parse reset flag (set the specified vm name and vm object in the vm struct)
+	err = parseResetFlag(virtClient, cmd, vmNamespace, &isReset, &isVMReset, &resetVms)
 	if err != nil {
 		return err
 	}
 
 	// check the operation type (nop/show/set)
-	op, err := findOperation(cmd)
+	op, err := findOperation(cmd, isReset, isVMReset, &isComponent, &vms)
 	if err != nil {
 		return err
 	}
@@ -392,28 +680,66 @@ func (c *Command) RunE(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		lines := createShowMessage(currentLv)
+		// if vm flag is specified, put the verbosity of vm in currentLv
+		if len(vmNames) > 0 {
+			err = getVMVerbosity(virtClient, currentLv, vmNamespace, vms)
+			if err != nil {
+				return err
+			}
+		}
+		lines, err := createShowMessage(currentLv, vms)
+		if err != nil {
+			return err
+		}
 		for _, line := range lines {
 			cmd.Println(line)
 		}
 	case set: // set and/or reset
-		// "Add" patch removes the value if we do not specify the value, even if we do not change the existing value.
-		// So, we need to get the existing verbosity in the KubeVirt CR.
-		// Also, "Add" patch needs a DeveloperConfiguration entry before adding a LogVerbosity entry.
-		// So, we need to know if DeveloperConfiguration is present or absent.
-		currentLv, hasDeveloperConfiguration, err := hasVerbosityInKV(kv)
-		if err != nil {
-			return err
+		// patch KubeVirt CR
+		if isComponent || isReset {
+			lines := []string{}
+			patchByte, err := createKvPatch(isReset, isComponent, kv, &lines)
+			if err != nil {
+				return err
+			}
+			_, err = virtClient.KubeVirt(kvNamespace).Patch(kvName, types.JSONPatchType, patchByte, &k8smetav1.PatchOptions{})
+			if err != nil {
+				return err
+			}
+			for _, line := range lines {
+				cmd.Println(line)
+			}
 		}
-		patchData, err := createPatch(currentLv, hasDeveloperConfiguration)
-		if err != nil {
-			return err
+		// reset VM object
+		if isVMReset {
+			for _, vm := range resetVms {
+				patchByte, err := createResetVMPatch(cmd, vm)
+				if err != nil {
+					return err
+				}
+				_, err = virtClient.VirtualMachine(vmNamespace).Patch(
+					context.Background(), vm.name, types.JSONPatchType, patchByte, &k8smetav1.PatchOptions{},
+				)
+				if err != nil {
+					return err
+				}
+				cmd.Println(fmt.Sprintf("%s: successfully removed the logVerbosity label - need to (re)start vm to apply the reset", vm.name))
+			}
 		}
-		_, err = virtClient.KubeVirt(namespace).Patch(name, types.JSONPatchType, patchData, &k8smetav1.PatchOptions{})
-		if err != nil {
-			return err
+		// patch VM object
+		for _, vm := range vms {
+			patchByte, err := createVMPatch(cmd, vm)
+			if err != nil {
+				return err
+			}
+			_, err = virtClient.VirtualMachine(vmNamespace).Patch(
+				context.Background(), vm.name, types.JSONPatchType, patchByte, &k8smetav1.PatchOptions{},
+			)
+			if err != nil {
+				return err
+			}
+			cmd.Println(fmt.Sprintf("%s: successfully set the logVerbosity label - need to (re)start vm to apply the new verbosity", vm.name))
 		}
-		cmd.Println("successfully set/reset the log verbosity")
 	default:
 		return fmt.Errorf("op: an unknown operation: %v", op)
 	}

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -1,6 +1,7 @@
 package logverbosity_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,12 +11,16 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
 
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
 	"kubevirt.io/client-go/kubecli"
 
+	corev1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
 
@@ -23,6 +28,7 @@ import (
 )
 
 var _ = Describe("Log Verbosity", func() {
+	// for virt component verbosity
 	var kvInterface *kubecli.MockKubeVirtInterface
 
 	var kv *v1.KubeVirt
@@ -33,26 +39,54 @@ var _ = Describe("Log Verbosity", func() {
 		installName      = "kubevirt"
 	)
 
+	// for vm level verbosity
+	var kubeClient *fake.Clientset
+	var vmInterface *kubecli.MockVirtualMachineInterface
+
+	var testVM1 *v1.VirtualMachine
+	var testVM2 *v1.VirtualMachine
+
+	var patchedVM1 *v1.VirtualMachine
+	var patchedVM2 *v1.VirtualMachine
+
+	var virtLauncherPod1 *corev1.Pod
+	var virtLauncherPod2 *corev1.Pod
+	var virtLauncerPodDummy *corev1.Pod
+	var provisionerPod *corev1.Pod
+	var pods *corev1.PodList
+
+	const (
+		vmName1                  = "testvm1"
+		vmName2                  = "testvm2"
+		vmNamespace              = "default"
+		virtLauncherPodName      = "virt-launcher-"
+		dummyVirtLauncherPodName = "virt-launcher-dummy-"
+		provisionerPodName       = "local-volume-provisioner-"
+	)
+
+	// for virt component verbosity
 	commonShowDescribeTable := func() {
-		DescribeTable("show operation", commonShowTest,
-			Entry("all components", []uint{2, 2, 2, 2, 2}, "--all"),
+		DescribeTable("show operation", commonCompShowTest,
+			Entry("all components", []string{"2", "2", "2", "2", "2"}, "--all"),
 			Entry(
 				"one component (1st component (i.e. virt-api))",
-				[]uint{2, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag},
+				[]string{"2", logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag},
 				"--virt-api",
 			),
 			Entry(
 				"one component (last component (i.e. virt-operator))",
-				[]uint{logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, 2},
+				[]string{logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, "2"},
 				"--virt-operator",
 			),
 			Entry(
 				"two components",
-				[]uint{logverbosity.NoFlag, 2, 2, logverbosity.NoFlag, logverbosity.NoFlag},
+				[]string{logverbosity.NoFlag, "2", "2", logverbosity.NoFlag, logverbosity.NoFlag},
 				"--virt-controller",
 				"--virt-handler",
 			),
-			Entry("all + one component", []uint{2, 2, 2, 2, 2}, "--all", "--virt-launcher"),
+			Entry("all + one component", []string{"2", "2", "2", "2", "2"}, "--all", "--virt-launcher"),
+			// corner case
+			Entry("all=noArg", []string{"2", "2", "2", "2", "2"}, "--all=show"),
 		)
 	}
 
@@ -71,6 +105,40 @@ var _ = Describe("Log Verbosity", func() {
 			// corner case
 			Entry("same component different verbosity (last one is a winner)", []uint{4, 0, 0, 0, 0}, "--virt-api=3", "--virt-api=4"),
 		)
+	}
+
+	// for vm level verbosity
+	setRunningState := func(state bool) {
+		testVM1.Spec.Running = &state
+		testVM2.Spec.Running = &state
+	}
+
+	configureAndStartVMs := func() {
+		setRunningState(true)
+
+		virtLauncherPod1 = createVirtLauncherPod(virtLauncherPodName+vmName1+"-", vmNamespace, vmName1, getVerbosityFromLabels(testVM1))
+		virtLauncherPod2 = createVirtLauncherPod(virtLauncherPodName+vmName2+"-", vmNamespace, vmName2, getVerbosityFromLabels(testVM2))
+		virtLauncerPodDummy = newPodNoVerbosity(dummyVirtLauncherPodName, vmNamespace)
+		provisionerPod = newPodNoVerbosity(provisionerPodName, vmNamespace)
+
+		pods = newPodList(*virtLauncherPod1, *virtLauncherPod2, *virtLauncerPodDummy, *provisionerPod)
+	}
+
+	expectedPatch := func(vm1, vm2 *v1.VirtualMachine) {
+		vmInterface.EXPECT().Patch(gomock.Any(), gomock.Any(), types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ any, name string, _ any, patchData []byte, _ any, _ ...any) (*v1.VirtualMachine, error) {
+				var err error
+				switch name {
+				case vmName1:
+					patchedVM1, err = applyVMPatch(patchData, vm1)
+					return patchedVM1, err
+				case vmName2:
+					patchedVM2, err = applyVMPatch(patchData, vm2)
+					return patchedVM2, err
+				default:
+					return nil, errors.New("patch error")
+				}
+			}).AnyTimes()
 	}
 
 	BeforeEach(func() {
@@ -92,7 +160,8 @@ var _ = Describe("Log Verbosity", func() {
 
 				patch, err := jsonpatch.DecodePatch(patchData)
 				Expect(err).ToNot(HaveOccurred())
-				kvJSON, err := json.Marshal(kv)
+
+				kvJSON, err := json.Marshal(kvs.Items[0])
 				Expect(err).ToNot(HaveOccurred())
 				modifiedKvJSON, err := patch.Apply(kvJSON)
 				Expect(err).ToNot(HaveOccurred())
@@ -105,6 +174,23 @@ var _ = Describe("Log Verbosity", func() {
 				Expect(err).ToNot(HaveOccurred())
 				return kv, nil
 			}).AnyTimes()
+
+		// for VM level verbosity
+		vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
+		kubeClient = fake.NewSimpleClientset()
+
+		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(vmNamespace).Return(vmInterface).AnyTimes()
+		kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
+
+		kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (bool, runtime.Object, error) {
+			return true, pods, nil
+		})
+
+		testVM1 = newVMNoVerbosityLabel(vmName1, vmNamespace)
+		testVM2 = newVMNoVerbosityLabel(vmName2, vmNamespace)
+
+		vmInterface.EXPECT().Get(context.Background(), testVM1.Name, gomock.Any()).Return(testVM1, nil).AnyTimes()
+		vmInterface.EXPECT().Get(context.Background(), testVM2.Name, gomock.Any()).Return(testVM2, nil).AnyTimes()
 	})
 
 	When("with erroneous running environment", func() {
@@ -181,9 +267,10 @@ var _ = Describe("Log Verbosity", func() {
 			expectGetKv()
 			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut("adm", "log-verbosity", "--all")()
 			Expect(err).To(Succeed())
-			output := []uint{2, 2, 2, 2, 2}
-			message := createOutputMessage(output)
-			Expect(string(bytes)).To(ContainSubstring(*message))
+			output := []string{"2", "2", "2", "2", "2"}
+			lines := createOutputMessage(output)
+			message := strings.Join(lines, "\n")
+			Expect(string(bytes)).To(ContainSubstring(message))
 		})
 
 		It("set: should succeed", func() {
@@ -209,14 +296,21 @@ var _ = Describe("Log Verbosity", func() {
 			})
 		})
 
+		Context("same as the NoFlag variable", func() {
+			It("return help", func() {
+				cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--all="+logverbosity.NoFlag)
+				err := cmd()
+				Expect(err).NotTo(Succeed())
+				Expect(err).To(MatchError(ContainSubstring("no flag specified - expecting at least one flag")))
+			})
+		})
+
 		DescribeTable("should fail handled by the CLI package", func(args ...string) {
-			argStr := strings.Join(args, ",")
-			cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", argStr)
+			commandAndArgs := []string{"adm", "log-verbosity"}
+			commandAndArgs = append(commandAndArgs, args...)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
 			Expect(cmd()).NotTo(Succeed())
 		},
-			Entry("reset and all coexist", "--reset", "--all=3"),
-			Entry("invalid argument (negative verbosity)", "--virt-api=-1"),
-			Entry("invalid argument (character)", "--virt-api=a"),
 			Entry("unknown flag", "--node"),
 			Entry("invalid flag format", "--all", "3"),
 		)
@@ -231,8 +325,9 @@ var _ = Describe("Log Verbosity", func() {
 		},
 			Entry("show and set mix", "only show or set is allowed", "--virt-handler", "--virt-launcher=3"),
 			Entry("show and reset mix", "only show or set is allowed", "--reset", "--virt-launcher"),
-			Entry("invalid verbosity (=noFlag)", "virt-api: log verbosity must be 0-9", "--virt-api=11"),
-			Entry("invalid verbosity", "virt-api: log verbosity must be 0-9", "--virt-api=20"),
+			Entry("invalid verbosity (negative verbosity)", "virt-api: log verbosity must be 0-9", "--virt-api=-1"),
+			Entry("invalid verbosity (character)", "virt-api: log verbosity must be 0-9", "--virt-api=a"),
+			Entry("invalid verbosity (boarder)", "virt-api: log verbosity must be 0-9", "--virt-api=10"),
 			Entry("one valid verbosity, one invalid verbosity", "virt-handler: log verbosity must be 0-9", "--virt-api=5", "--virt-handler=20"),
 		)
 	})
@@ -302,26 +397,24 @@ var _ = Describe("Log Verbosity", func() {
 		// should show the verbosity for components from the KubeVirt CR
 		// get and show the attended verbosity
 		// show the default verbosity (2), when the logVerbosity is unattended
-		DescribeTable("show operation", commonShowTest,
-			Entry("all components", []uint{5, 6, 2, 3, 4}, "--all"),
+		DescribeTable("show operation", commonCompShowTest,
+			Entry("all components", []string{"5", "6", "2", "3", "4"}, "--all"),
 			Entry(
 				"one component attended verbosity",
-				[]uint{5, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag},
+				[]string{"5", logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag},
 				"--virt-api",
 			),
 			Entry(
 				"one component unattended verbosity",
-				[]uint{logverbosity.NoFlag, logverbosity.NoFlag, 2, logverbosity.NoFlag, logverbosity.NoFlag},
+				[]string{logverbosity.NoFlag, logverbosity.NoFlag, "2", logverbosity.NoFlag, logverbosity.NoFlag},
 				"--virt-handler",
 			),
 			Entry(
 				"two components with one unattended verbosity",
-				[]uint{logverbosity.NoFlag, 6, 2, logverbosity.NoFlag, logverbosity.NoFlag},
+				[]string{logverbosity.NoFlag, "6", "2", logverbosity.NoFlag, logverbosity.NoFlag},
 				"--virt-handler",
 				"--virt-controller",
 			),
-			// corner case
-			Entry("all components with default argument (equals show operation)", []uint{5, 6, 2, 3, 4}, "--all=10"),
 		)
 
 		Describe("set operation", func() {
@@ -339,6 +432,7 @@ var _ = Describe("Log Verbosity", func() {
 				Entry("two components", []uint{5, 0, 9, 3, 4}, "--virt-controller=0", "--virt-handler=9"),
 				Entry("set all and then set two components", []uint{9, 0, 8, 8, 8}, "--all=8", "--virt-api=9", "--virt-controller=0"),
 				Entry("reset and then set two components", []uint{0, 0, 1, 2, 0}, "--reset", "--virt-handler=1", "--virt-launcher=2"),
+				Entry("set all and reset", []uint{3, 3, 3, 3, 3}, "--all=3", "--reset"),
 				// corner case
 				Entry("two same operations (come down to one operation)", []uint{3, 6, 0, 3, 4}, "--virt-api=3", "--virt-api=3"),
 				Entry("same component different verbosity (last one is a winner)", []uint{4, 6, 0, 3, 4}, "--virt-api=3", "--virt-api=4"),
@@ -346,33 +440,705 @@ var _ = Describe("Log Verbosity", func() {
 		})
 	})
 
+	/*
+	 * for vm level verbosity
+	 */
+	When("with invalid set of flags and arguments for vm", func() {
+		BeforeEach(func() {
+			commonSetup(kvInterface, kvs)
+		})
+
+		Context("same as the default variable", func() {
+			It("vm flag: return help", func() {
+				cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--vm=")
+				err := cmd()
+				Expect(err).NotTo(Succeed())
+				Expect(err).To(MatchError(ContainSubstring("no flag specified - expecting at least one flag")))
+			})
+			It("level flag: should succeed (just ignore --level flag)", func() {
+				// start VMs with no label, and virt-launcher=empty (default)
+				configureAndStartVMs()
+				compOutput := []string{logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag}
+				vmOutput := []string{vmName1 + " = 2", ""}
+				commonVMShowTest(compOutput, vmOutput, "--vm="+vmName1, "--level=")
+			})
+		})
+
+		Context("Get function has an error", func() {
+			// when the specified name is different from the vm name, Get function returns an error
+			expectGetError := func(testName string) {
+				vmInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ any, name string, _ any) (*v1.VirtualMachine, error) {
+						Expect(name).NotTo(Equal(testName))
+						return nil, errors.New("Get error")
+					}).AnyTimes()
+			}
+
+			DescribeTable("should fail", func(args ...string) {
+				expectGetError(testVM1.Name)
+
+				commandAndArgs := []string{"adm", "log-verbosity"}
+				commandAndArgs = append(commandAndArgs, args...)
+				cmd := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
+				err := cmd()
+				Expect(err).NotTo(Succeed())
+				Expect(err).To(MatchError(ContainSubstring("Get error")))
+			},
+				Entry("vm: unknown vm name", "--vm=unknown"),
+				Entry("reset: unknown vm name", "--reset=unknown"),
+				// coexistence of virt components and vm
+				Entry("error on vm (show): unknown vm name", "--virt-api", "--vm=unknown"),
+				Entry("error on vm (set): unknown vm name", "--virt-api=1", "--vm=unknown", "--level=5"),
+				Entry("error on vm (vm first): vm no arg", "--vm", "--virt-api"), // --virt-api as a parameter of --vm flag
+			)
+		})
+
+		DescribeTable("should fail handled by the CLI package", func(args ...string) {
+			commandAndArgs := []string{"adm", "log-verbosity"}
+			commandAndArgs = append(commandAndArgs, args...)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
+			Expect(cmd()).NotTo(Succeed())
+		},
+			Entry("vm: no arg", "--vm"),
+			Entry("level: no arg", "--vm="+vmName1, "--level"),
+			Entry("reset + vm: no arg", "--reset="+vmName1, "--vm"),
+			Entry("reset + level: no arg", "--reset="+vmName1, "--vm=testvm1", "--level"),
+			// coexistence of virt components and vm
+			Entry("error on vm (vm last): vm no arg", "--virt-api", "--vm"),
+			Entry("error on vm: level no arg", "--virt=api=1", "--vm="+vmName1, "--level"),
+		)
+
+		DescribeTable("should fail handled by error handler", func(output string, args ...string) {
+			commandAndArgs := []string{"adm", "log-verbosity"}
+			commandAndArgs = append(commandAndArgs, args...)
+			_, err := clientcmd.NewRepeatableVirtctlCommandWithOut(commandAndArgs...)()
+			Expect(err).NotTo(Succeed())
+
+			Expect(err).To(MatchError(ContainSubstring(output)))
+		},
+			Entry("level: no vm flag", "level: need vm flag", "--level=5"),
+			Entry("reset + level: no vm flag", "level: need vm flag", "--reset="+vmName1, "--level=5"),
+			Entry("invalid verbosity (boarder)", vmName1+": log verbosity must be 0-9", "--vm="+vmName1, "--level=10"),
+			Entry("invalid verbosity (negative)", vmName1+": log verbosity must be 0-9", "--vm="+vmName1, "--level=-1"),
+			Entry("invalid verbosity (character)", vmName1+": log verbosity must be 0-9", "--vm="+vmName1, "--level=a"),
+			Entry("show and reset mix (same vm)", "only show or set is allowed", "--reset="+vmName1, "--vm="+vmName1),
+			Entry("show and reset mix (different vm)", "only show or set is allowed", "--reset="+vmName1, "--vm="+vmName2),
+			Entry(
+				"show and set mix (same vm)",
+				"number of vm flags 2 not equal to number of level flags 1",
+				"--vm="+vmName1, "--vm="+vmName1, "--level=5",
+			),
+			Entry(
+				"show and set mix (different vm)",
+				"number of vm flags 2 not equal to number of level flags 1",
+				"--vm="+vmName1, "--vm="+vmName2, "--level=5",
+			),
+			// coexistence of virt components and vm
+			Entry("error on component: invalid verbosity (boarder)", "virt-api: log verbosity must be 0-9", "--virt-api=10", "--vm="+vmName1),
+			Entry("error on vm: invalid verbosity (boarder)", vmName1+": log verbosity must be 0-9", "--virt-api=1", "--vm="+vmName1, "--level=10"),
+			Entry("error on vm: invalid verbosity (negative)", vmName1+": log verbosity must be 0-9", "--virt-api=1", "--vm="+vmName1, "--level=-1"),
+			Entry("show (vm) and set (comp) mix", "only show or set is allowed", "--virt-api=1", "--vm="+vmName1),
+			Entry("show (vm) and set (all comp) mix", "only show or set is allowed", "--all=1", "--vm="+vmName1),
+			Entry("show (vm) and set (reset comp) mix", "only show or set is allowed", "--reset", "--vm="+vmName1),
+			Entry("show (comp) and set (vm) mix", "only show or set is allowed", "--virt-api", "--vm="+vmName1, "--level=5"),
+			Entry("show (all comp) and set (vm) mix", "only show or set is allowed", "--all", "--vm="+vmName1, "--level=5"),
+			Entry("show (comp) and set (reset vm) mix", "only show or set is allowed", "--virt-api", "--reset="+vmName1),
+			Entry("show (all comp) and set (rest vm) mix", "only show or set is allowed", "--all", "--reset="+vmName1),
+		)
+	})
+
+	When("only vm related flags and args", func() {
+		BeforeEach(func() {
+			// virt-launcher=default (no DeveloperConfiguration field in the KubeVirt CR)
+			commonSetup(kvInterface, kvs)
+		})
+
+		DescribeTable("set and show 1 VM",
+			func(testCase func(), vmOutput []string) {
+				// start VMs with no label, and virt-launcher=empty (default)
+				configureAndStartVMs()
+				testCase()
+				if vmOutput != nil {
+					compOutput := []string{logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag}
+					commonVMShowTest(compOutput, vmOutput, "--vm="+vmName1)
+				}
+			},
+			Entry("1 VM, show before setting label",
+				func() {
+					// No additional setup needed for this case
+				},
+				[]string{vmName1 + " = 2", ""},
+			),
+			Entry("1 VM, set logVerbosity label",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--vm="+vmName1, "--level=5")
+					Expect(cmd()).To(Succeed())
+					Expect(patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal("5"))
+				},
+				nil,
+			),
+			Entry("1 VM, show before restarting VM",
+				func() {
+					// set the logVerbosity label to an VM object
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "5"
+				},
+				[]string{vmName1 + " = 2", vmName1 + ": updated verbosity 5 will be applied after the VM is restarted"},
+			),
+			Entry("1 VM, show after restarting VM",
+				func() {
+					// restart VMs with label
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "5"
+					configureAndStartVMs()
+				},
+				[]string{vmName1 + " = 5", ""},
+			),
+		)
+
+		DescribeTable("set and show multiple VMs",
+			func(testCase func(), vmOutput []string) {
+				// start VMs with no label, and virt-launcher=empty (default)
+				configureAndStartVMs()
+				testCase()
+				if vmOutput != nil {
+					compOutput := []string{logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag}
+					commonVMShowTest(compOutput, vmOutput, "--vm="+vmName1, "--vm="+vmName2)
+				}
+			},
+			Entry("2 VMs, show before setting label",
+				func() {
+					// No additional setup needed for this case
+				},
+				[]string{vmName1 + " = 2", "", vmName2 + " = 2", ""},
+			),
+			Entry("2 VMs, set logVerbosity label",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--vm="+vmName1, "--level=8", "--vm="+vmName2, "--level=9")
+					Expect(cmd()).To(Succeed())
+					Expect(patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal("8"))
+					Expect(patchedVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal("9"))
+				},
+				nil,
+			),
+			Entry("2 VMs, show before restarting VM",
+				func() {
+					// set the logVerbosity label to VM objects
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "8"
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "9"
+				},
+				[]string{
+					vmName1 + " = 2",
+					vmName1 + ": updated verbosity 8 will be applied after the VM is restarted",
+					vmName2 + " = 2",
+					vmName2 + ": updated verbosity 9 will be applied after the VM is restarted",
+				},
+			),
+			Entry("2 VMs, show after restarting VM",
+				func() {
+					// restart VMs with label
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "8"
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "9"
+					configureAndStartVMs()
+				},
+				[]string{vmName1 + " = 8", "", vmName2 + " = 9", ""},
+			),
+			Entry("2 VMs (2 --level and then 2 --vm)",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--level=8", "--level=9", "--vm="+vmName1, "--vm="+vmName2)
+					Expect(cmd()).To(Succeed())
+					Expect(patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal("8"))
+					Expect(patchedVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal("9"))
+				},
+				nil,
+			),
+		)
+
+		DescribeTable("reset 2 VMs",
+			func(testCase func(), vmOutput []string, presetLabel bool) {
+				if presetLabel {
+					// start VMs with label (testvm1=5, testvm2=6)
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "5"
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "6"
+				}
+				configureAndStartVMs()
+				testCase()
+				if vmOutput != nil {
+					compOutput := []string{logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag}
+					commonVMShowTest(compOutput, vmOutput, "--vm="+vmName1, "--vm="+vmName2)
+				}
+			},
+			Entry("show before setting label",
+				func() {
+					// No additional setup needed for this case
+				},
+				[]string{vmName1 + " = 5", "", vmName2 + " = 6", ""},
+				true,
+			),
+			Entry("reset logVerbosity label",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--reset="+vmName1, "--reset="+vmName2)
+					Expect(cmd()).To(Succeed())
+					_, exist := patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]
+					Expect(exist).To(BeFalse())
+					_, exist = patchedVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"]
+					Expect(exist).To(BeFalse())
+				},
+				nil,
+				true,
+			),
+			Entry("show before restarting VM",
+				func() {
+					// reset/remove the logVerbosity label
+					delete(testVM1.Spec.Template.ObjectMeta.Labels, "logVerbosity")
+					delete(testVM2.Spec.Template.ObjectMeta.Labels, "logVerbosity")
+				},
+				[]string{
+					vmName1 + " = 5",
+					vmName1 + ": updated verbosity 2 will be applied after the VM is restarted",
+					vmName2 + " = 6",
+					vmName2 + ": updated verbosity 2 will be applied after the VM is restarted",
+				},
+				true,
+			),
+			Entry("show after restarting VM",
+				func() {
+					// restart VMs (start VMs with no label)
+				},
+				[]string{vmName1 + " = 2", "", vmName2 + " = 2", ""},
+				false,
+			),
+		)
+
+		DescribeTable("reset 1 VM and set 2 VMs",
+			func(vm1Label, vm2Label, resetLabel1, resetLabel2 string, vmOutput []string) {
+				// start VMs with label (testvm1=vm1Label, testvm2=vm2Label)
+				testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = vm1Label
+				testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = vm2Label
+				configureAndStartVMs()
+				if resetLabel1 != "" && resetLabel2 != "" && vmOutput != nil {
+					// reset and set labels
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = resetLabel1
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = resetLabel2
+				}
+
+				if vmOutput == nil {
+					// for reset test
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity",
+						"--reset="+vmName1, "--reset="+vmName2,
+						"--vm="+vmName1, "--level="+resetLabel1,
+						"--vm="+vmName2, "--level="+resetLabel2,
+					)
+					Expect(cmd()).To(Succeed())
+					Expect(patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal(resetLabel1))
+					Expect(patchedVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal(resetLabel2))
+				} else {
+					// for show test
+					args := []string{"--vm=" + vmName1, "--vm=" + vmName2}
+					compOutput := []string{logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag, logverbosity.NoFlag}
+					commonVMShowTest(compOutput, vmOutput, args...)
+				}
+			},
+			Entry("show 2 VMs before reset", "5", "6", "", "", []string{vmName1 + " = 5", "", vmName2 + " = 6", ""}),
+			Entry("reset and set the logVerbosity label", "5", "6", "7", "8", nil),
+			Entry("show before restart VMs", "5", "6", "7", "8",
+				[]string{
+					vmName1 + " = 5",
+					vmName1 + ": updated verbosity 7 will be applied after the VM is restarted",
+					vmName2 + " = 6",
+					vmName2 + ": updated verbosity 8 will be applied after the VM is restarted",
+				},
+			),
+			Entry("show after restarting VMs", "7", "8", "", "", []string{vmName1 + " = 7", "", vmName2 + " = 8", ""}),
+		)
+	})
+
+	When("coexistence of virt components and vm", func() {
+		BeforeEach(func() {
+			// virt-launcher=default (no DeveloperConfiguration field in the KubeVirt CR)
+			commonSetup(kvInterface, kvs)
+		})
+
+		DescribeTable("set 1 virt component and 1 VM",
+			func(testCase func(), virtOutput, vmOutput []string, virtSetting bool) {
+				if virtSetting {
+					// set virt-handler=3
+					dc := &v1.DeveloperConfiguration{
+						LogVerbosity: &v1.LogVerbosity{
+							VirtHandler: 3,
+						},
+					}
+					kvs.Items[0].Spec.Configuration.DeveloperConfiguration = dc
+				}
+				configureAndStartVMs()
+				testCase()
+				if virtOutput != nil || vmOutput != nil {
+					args := []string{"--virt-handler", "--vm=" + vmName2}
+					commonVMShowTest(virtOutput, vmOutput, args...)
+				}
+			},
+			Entry("show before setting label",
+				func() {
+					// No additional setup needed for this case
+				},
+				[]string{logverbosity.NoFlag, logverbosity.NoFlag, "2", logverbosity.NoFlag, logverbosity.NoFlag},
+				[]string{vmName2 + " = 2", ""},
+				false,
+			),
+			Entry("reset logVerbosity label",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--virt-handler=3", "--vm="+vmName2, "--level=6")
+					Expect(cmd()).To(Succeed())
+					output := []uint{0, 0, 3, 0, 0}
+					expectAllComponentVerbosity(kv, output)
+					Expect(patchedVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal("6"))
+				},
+				nil,
+				nil,
+				false,
+			),
+			Entry("show before restarting VM",
+				func() {
+					// set the logVerbosity label
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "6"
+				},
+				[]string{logverbosity.NoFlag, logverbosity.NoFlag, "3", logverbosity.NoFlag, logverbosity.NoFlag},
+				[]string{
+					vmName2 + " = 2",
+					vmName2 + ": updated verbosity 6 will be applied after the VM is restarted",
+				},
+				true, // set virt component
+			),
+			Entry("show after restarting VM",
+				func() {
+					// restart VMs
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "6"
+					configureAndStartVMs()
+				},
+				[]string{logverbosity.NoFlag, logverbosity.NoFlag, "3", logverbosity.NoFlag, logverbosity.NoFlag},
+				[]string{vmName2 + " = 6", ""},
+				true, // set virt component
+			),
+		)
+
+		DescribeTable("set all virt components and 1 VM",
+			func(testCase func(), virtOutput, vmOutput []string, virtSetting bool) {
+				if virtSetting {
+					// set all=3
+					dc := &v1.DeveloperConfiguration{
+						LogVerbosity: &v1.LogVerbosity{
+							VirtAPI:        3,
+							VirtController: 3,
+							VirtHandler:    3,
+							VirtLauncher:   3,
+							VirtOperator:   3,
+						},
+					}
+					kvs.Items[0].Spec.Configuration.DeveloperConfiguration = dc
+				}
+				configureAndStartVMs()
+				testCase()
+				if virtOutput != nil || vmOutput != nil {
+					args := []string{"--all", "--vm=" + vmName1}
+					commonVMShowTest(virtOutput, vmOutput, args...)
+				}
+			},
+			Entry("show before setting label",
+				func() {
+					// No additional setup needed for this case
+				},
+				[]string{"2", "2", "2", "2", "2"},
+				[]string{vmName1 + " = 2", ""},
+				false,
+			),
+			Entry("reset logVerbosity label",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--all=3", "--vm="+vmName1, "--level=7")
+					Expect(cmd()).To(Succeed())
+					output := []uint{3, 3, 3, 3, 3}
+					expectAllComponentVerbosity(kv, output)
+					Expect(patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal("7"))
+				},
+				nil,
+				nil,
+				false,
+			),
+			Entry("show before restarting VM",
+				func() {
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "7"
+				},
+				[]string{"3", "3", "3", "3", "3"},
+				[]string{
+					vmName1 + " = 2",
+					vmName1 + ": updated verbosity 7 will be applied after the VM is restarted",
+				},
+				true, // set virt component
+			),
+			Entry("show after restarting VM",
+				func() {
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "7"
+					configureAndStartVMs()
+				},
+				[]string{"3", "3", "3", "3", "3"},
+				[]string{vmName1 + " = 7", ""},
+				true, // set virt component
+			),
+		)
+
+		DescribeTable("reset all virt components and reset 2 VMs",
+			func(testCase func(), virtOutput, vmOutput []string, preVirtSetting, preLabelSetting bool) {
+				if preVirtSetting {
+					// set all=3
+					dc := &v1.DeveloperConfiguration{
+						LogVerbosity: &v1.LogVerbosity{
+							VirtAPI:        3,
+							VirtController: 3,
+							VirtHandler:    3,
+							VirtLauncher:   3,
+							VirtOperator:   3,
+						},
+					}
+					kvs.Items[0].Spec.Configuration.DeveloperConfiguration = dc
+				} else {
+					// reset all components
+					dc := &v1.DeveloperConfiguration{
+						LogVerbosity: &v1.LogVerbosity{},
+					}
+					kvs.Items[0].Spec.Configuration.DeveloperConfiguration = dc
+				}
+				if preLabelSetting {
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "5"
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "6"
+				}
+				configureAndStartVMs()
+				testCase()
+				if virtOutput != nil || vmOutput != nil {
+					args := []string{"--all", "--vm=" + vmName1, "--vm=" + vmName2}
+					commonVMShowTest(virtOutput, vmOutput, args...)
+				}
+			},
+			Entry("show before setting label",
+				func() {
+					// No additional setup needed for this case
+				},
+				[]string{"3", "3", "3", "3", "3"},
+				[]string{vmName1 + " = 5", "", vmName2 + " = 6", ""},
+				true, // has virt component verbosity before reset
+				true, // label set before reset
+			),
+			Entry("reset logVerbosity label",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--reset", "--reset="+vmName1, "--reset="+vmName2)
+					Expect(cmd()).To(Succeed())
+					output := []uint{0, 0, 0, 0, 0}
+					expectAllComponentVerbosity(kv, output)
+					Expect(cmd()).To(Succeed())
+
+					_, exist := patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]
+					Expect(exist).To(BeFalse())
+					_, exist = patchedVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"]
+					Expect(exist).To(BeFalse())
+				},
+				nil,
+				nil,
+				true,
+				true,
+			),
+			Entry("show before restarting VM",
+				func() {
+					// reset VM1 and VM2
+					delete(testVM1.Spec.Template.ObjectMeta.Labels, "logVerbosity")
+					delete(testVM2.Spec.Template.ObjectMeta.Labels, "logVerbosity")
+				},
+				[]string{"2", "2", "2", "2", "2"},
+				[]string{
+					vmName1 + " = 5",
+					vmName1 + ": updated verbosity 2 will be applied after the VM is restarted",
+					vmName2 + " = 6",
+					vmName2 + ": updated verbosity 2 will be applied after the VM is restarted",
+				},
+				false,
+				true,
+			),
+			Entry("show after restarting VM",
+				func() {
+					// restart virt components and VMs (start vms no label, virt-launcher=empty (default))
+				},
+				[]string{"2", "2", "2", "2", "2"},
+				[]string{vmName1 + " = 2", "", vmName2 + " = 2", ""},
+				false,
+				false,
+			),
+		)
+
+		DescribeTable("reset all virt components + set 1 vrit component + reset 1 VM + set 1 VM",
+			func(testCase func(), virtOutput, vmOutput []string, preVirtSetting, preLabelSetting bool) {
+				if preVirtSetting {
+					dc := &v1.DeveloperConfiguration{
+						LogVerbosity: &v1.LogVerbosity{
+							VirtAPI:        3,
+							VirtController: 3,
+							VirtHandler:    3,
+							VirtLauncher:   3,
+							VirtOperator:   3,
+						},
+					}
+					kvs.Items[0].Spec.Configuration.DeveloperConfiguration = dc
+				} else {
+					dc := &v1.DeveloperConfiguration{
+						LogVerbosity: &v1.LogVerbosity{
+							VirtHandler: 3,
+						},
+					}
+					kvs.Items[0].Spec.Configuration.DeveloperConfiguration = dc
+				}
+				if preLabelSetting {
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "5"
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "6"
+				}
+				configureAndStartVMs()
+				testCase()
+				if virtOutput != nil || vmOutput != nil {
+					args := []string{"--all", "--vm=" + vmName1, "--vm=" + vmName2}
+					commonVMShowTest(virtOutput, vmOutput, args...)
+				}
+			},
+			// "show before setting label" test
+			// same as the test "reset all virt components and reset 2 VMs"
+			Entry("reset logVerbosity label",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand(
+						"adm", "log-verbosity",
+						"--reset", "--virt-handler=3", "--reset="+vmName1, "--vm="+vmName2, "--level=7",
+					)
+					Expect(cmd()).To(Succeed())
+					output := []uint{0, 0, 3, 0, 0}
+					expectAllComponentVerbosity(kv, output)
+					Expect(cmd()).To(Succeed())
+
+					_, exist := patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]
+					Expect(exist).To(BeFalse())
+					Expect(patchedVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"]).To(Equal("7"))
+				},
+				nil, nil, true, true,
+			),
+			Entry("show before restarting VM",
+				func() {
+					// reset VM1 and set VM2
+					delete(testVM1.Spec.Template.ObjectMeta.Labels, "logVerbosity")
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "7"
+				},
+				[]string{"2", "2", "3", "2", "2"},
+				[]string{
+					vmName1 + " = 5",
+					vmName1 + ": updated verbosity 2 will be applied after the VM is restarted",
+					vmName2 + " = 6",
+					vmName2 + ": updated verbosity 7 will be applied after the VM is restarted",
+				},
+				false,
+				true,
+			),
+			Entry("show after restarting VM",
+				func() {
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "7"
+					configureAndStartVMs()
+				},
+				[]string{"2", "2", "3", "2", "2"},
+				[]string{vmName1 + " = 2", "", vmName2 + " = 7", ""},
+				false,
+				false,
+			),
+		)
+
+		DescribeTable("virt-launcher=3, reset 1 VM",
+			func(testCase func(), virtOutput, vmOutput []string, preVirtSetting, preLabelSetting bool) {
+				if !preVirtSetting {
+					dc := &v1.DeveloperConfiguration{
+						LogVerbosity: &v1.LogVerbosity{
+							VirtLauncher: 3,
+						},
+					}
+					kvs.Items[0].Spec.Configuration.DeveloperConfiguration = dc
+				}
+				if preLabelSetting {
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "5"
+				}
+				configureAndStartVMs()
+				testCase()
+				if virtOutput != nil || vmOutput != nil {
+					args := []string{"--all", "--vm=" + vmName1, "--vm=" + vmName2}
+					commonVMShowTest(virtOutput, vmOutput, args...)
+				}
+			},
+			Entry("show before setting label",
+				func() {
+					// No additional setup needed for this case
+				},
+				[]string{"2", "2", "2", "2", "2"},
+				[]string{vmName1 + " = 5", "", vmName2 + " = 2", ""},
+				true, // has virt component verbosity before reset
+				true, // label set before reset
+			),
+			Entry("reset logVerbosity label",
+				func() {
+					expectedPatch(testVM1, testVM2)
+
+					cmd := clientcmd.NewRepeatableVirtctlCommand("adm", "log-verbosity", "--virt-launcher=3", "--reset="+vmName1)
+					Expect(cmd()).To(Succeed())
+					output := []uint{0, 0, 0, 3, 0}
+					expectAllComponentVerbosity(kv, output)
+					Expect(cmd()).To(Succeed())
+
+					_, exist := patchedVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"]
+					Expect(exist).To(BeFalse())
+				},
+				nil, nil, true, true,
+			),
+			Entry("show before restarting VM",
+				func() {
+					// reset VM1
+					delete(testVM1.Spec.Template.ObjectMeta.Labels, "logVerbosity")
+				},
+				[]string{"2", "2", "2", "3", "2"},
+				[]string{
+					vmName1 + " = 5",
+					vmName1 + ": updated verbosity 3 will be applied after the VM is restarted",
+					vmName2 + " = 2",
+					vmName2 + ": updated verbosity 3 will be applied after the VM is restarted",
+				},
+				false,
+				true,
+			),
+			Entry("show after restarting VM",
+				func() {
+					testVM1.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "3"
+					testVM2.Spec.Template.ObjectMeta.Labels["logVerbosity"] = "3"
+					configureAndStartVMs()
+				},
+				[]string{"2", "2", "2", "3", "2"},
+				[]string{vmName1 + " = 3", "", vmName2 + " = 3", ""},
+				false,
+				false,
+			),
+		)
+	})
 })
-
-func expectAllComponentVerbosity(kv *v1.KubeVirt, output []uint) {
-	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtAPI).To(Equal(output[0]))
-	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtController).To(Equal(output[1]))
-	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtHandler).To(Equal(output[2]))
-	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtLauncher).To(Equal(output[3]))
-	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtOperator).To(Equal(output[4]))
-}
-
-// create an expected output message
-func createOutputMessage(output []uint) *string {
-	var message string
-	var components = []string{"virt-api", "virt-controller", "virt-handler", "virt-launcher", "virt-operator"}
-	for component := 0; component < len(components); component++ {
-		if output[component] == logverbosity.NoFlag {
-			continue
-		}
-		// output format is [componentName]=[verbosity] like:
-		// 		virt-api=1
-		// 		virt-controller=2
-		componentName := components[component]
-		verbosity := output[component]
-		message += fmt.Sprintf("%s=%d\n", componentName, verbosity)
-	}
-	return &message
-}
 
 func NewKubeVirtWithoutDeveloperConfiguration(namespace, name string) *v1.KubeVirt {
 	return &v1.KubeVirt{
@@ -396,14 +1162,61 @@ func commonSetup(kvInterface *kubecli.MockKubeVirtInterface, kvs *v1.KubeVirtLis
 	kvInterface.EXPECT().Get(kvs.Items[0].Name, gomock.Any()).Return(&kvs.Items[0], nil).AnyTimes()
 }
 
-func commonShowTest(output []uint, args ...string) {
+func createOutputMessage(output []string) []string {
+	lines := []string{}
+	var components = []string{"virt-api", "virt-controller", "virt-handler", "virt-launcher", "virt-operator"}
+	for component := 0; component < len(components); component++ {
+		if output[component] == logverbosity.NoFlag {
+			continue
+		}
+		// output format is [componentName] =　[verbosity] like:
+		// 		virt-api = 1
+		// 		virt-controller = 2
+		componentName := components[component]
+		verbosity := output[component]
+		line := fmt.Sprintf("%s = %s", componentName, verbosity)
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func createVMOutputMessage(output []string, lines []string) []string {
+	for _, line := range output {
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func commonShowTest(compOutput, vmOutput []string, args ...string) {
 	commandAndArgs := []string{"adm", "log-verbosity"}
 	commandAndArgs = append(commandAndArgs, args...)
 	bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(commandAndArgs...)()
 	Expect(err).To(Succeed())
 
-	message := createOutputMessage(output) // create an expected output message
-	Expect(string(bytes)).To(ContainSubstring(*message))
+	lines := createOutputMessage(compOutput)
+	lines = createVMOutputMessage(vmOutput, lines)
+	message := strings.Join(lines, "\n")
+
+	Expect(string(bytes)).To(ContainSubstring(message))
+}
+
+func commonCompShowTest(compOutput []string, args ...string) {
+	commonShowTest(compOutput, nil, args...)
+}
+
+func commonVMShowTest(compOutput, vmOutput []string, args ...string) {
+	commonShowTest(compOutput, vmOutput, args...)
+}
+
+func expectAllComponentVerbosity(kv *v1.KubeVirt, output []uint) {
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtAPI).To(Equal(output[0]))
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtController).To(Equal(output[1]))
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtHandler).To(Equal(output[2]))
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtLauncher).To(Equal(output[3]))
+	Expect(kv.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtOperator).To(Equal(output[4]))
 }
 
 func commonSetCommand(args ...string) {
@@ -411,4 +1224,107 @@ func commonSetCommand(args ...string) {
 	commandAndArgs = append(commandAndArgs, args...)
 	cmd := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
 	Expect(cmd()).To(Succeed())
+}
+
+func newVMNoVerbosityLabel(name, namespace string) *v1.VirtualMachine {
+	return &v1.VirtualMachine{
+		TypeMeta: k8smetav1.TypeMeta{
+			APIVersion: v1.GroupVersion.String(),
+			Kind:       "VirtualMachine",
+		},
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.VirtualMachineSpec{
+			Running: new(bool),
+			Template: &v1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: k8smetav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.AppLabel:                "virt-launcher",
+						v1.DomainAnnotation:        name,
+						v1.VirtualMachineNameLabel: name,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newPodBase(name, namespace string, verbosityVar ...corev1.EnvVar) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: k8smetav1.ObjectMeta{
+			GenerateName: name,
+			Namespace:    namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "compute",
+					Env:  verbosityVar,
+				},
+				{
+					Name: "volumecontainerdisk",
+				},
+				{
+					Name: "guest-console-log",
+				},
+			},
+		},
+	}
+}
+
+func newPodNoVerbosity(name, namespace string) *corev1.Pod {
+	return newPodBase(name, namespace)
+}
+
+func newPodWithVerbosity(name, namespace, verbosity string) *corev1.Pod {
+	verbosityVar := []corev1.EnvVar{
+		{
+			Name:  "VIRT_LAUNCHER_LOG_VERBOSITY",
+			Value: verbosity,
+		},
+	}
+	return newPodBase(name, namespace, verbosityVar...)
+}
+
+func newPodList(pods ...corev1.Pod) *corev1.PodList {
+	return &corev1.PodList{
+		TypeMeta: k8smetav1.TypeMeta{
+			APIVersion: v1.GroupVersion.String(),
+			Kind:       "List",
+		},
+		Items: pods,
+	}
+}
+
+func createVirtLauncherPod(name, namespace, vmName, verbosity string) *corev1.Pod {
+	if verbosity != "" {
+		return newPodWithVerbosity(name, namespace, verbosity)
+	}
+	return newPodNoVerbosity(name, namespace)
+}
+
+func getVerbosityFromLabels(vm *v1.VirtualMachine) string {
+	if verbosity, exist := vm.Spec.Template.ObjectMeta.Labels["logVerbosity"]; exist {
+		return verbosity
+	}
+	return ""
+}
+
+func applyVMPatch(patchData []byte, target *v1.VirtualMachine) (*v1.VirtualMachine, error) {
+	patch, err := jsonpatch.DecodePatch(patchData)
+	Expect(err).ToNot(HaveOccurred())
+
+	vmJSON, err := json.Marshal(target)
+	Expect(err).ToNot(HaveOccurred())
+
+	modifiedVMJSON, err := patch.Apply(vmJSON)
+	Expect(err).ToNot(HaveOccurred())
+
+	target = &v1.VirtualMachine{}
+	err = json.Unmarshal(modifiedVMJSON, target)
+	Expect(err).ToNot(HaveOccurred())
+
+	return target, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add showing and setting the verbosity per VM to the `log-verbosity` command.

`virtctl adm log-verbosity --vm=vmName [--level=verbosity]`
`virtctl adm log-verbosity –reset=vmName`

- To show the log verbosity of a VM
   - when the VM is not running, show the verbosity when the VM starts running.
      - when `logVerbosity` label is specified, show the label on the VM object
      - when `logVerbosity` label is not specified, show the `virt-launcher` log verbosity
   - **When the VM is running, show the verbosity of the currently running VMI, even if the new verbosity was set after the VMI started running.** This is because the new verbosity is applied when the VMI is restarted.
      - show the pod object's `VIRT_LAUNCHER_LOG_VERBOSITY` environment variable
      - if `VIRT_LAUNCHER_LOG_VERBOSITY` does not exist, the `virt-launcher` verbosity has been set as default, so show the default verbosity (2)
- To set the log verbosity of a VM
   - Set the `logVerbosity` label on the VM object
- To reset the log verbosity of a VM
   - Clear the `logVerbosity` label on the VM object

Note:
- Two (2) new flags have been introduced. `--vm` | `--level`
- The verbosity value must in the range of `0-9`.
- The priority order of the log verbosity setting on the VM is below.
   - `logVerbosity` label > `virt-launcher` log verbosity > `virt-launcher` default verbosity
- The VM level log-verbosity flags can coexist with the cluster-wide (virt component) log verbosity flags.
   - `--virt-api` | `--virt-controller` | `--virt-handler` | `--virt-launcher` | `--virt-operator` | `--all`
- Reset: added an argument to the `--reset` flag
   - `--reset=vmName` to reset the vm log verbosity (remove the logVerbosity label)
   - `--reset` is to reset the log verbosity of all cluster-wide virt components (no change)
- All: no change
   - `--all` is to show and set cluster-wide (virt component) log verbosity
   - VMs are not covered by the all flag.
- Show and Set/Reset cannot coexist

Examples:

Only VM related flags and args exist:
```
// show
$virtctl adm log-verbosity --vm=testvm // show log-verbosity of testvm
$virtctl adm log-verbosity --vm=testvm1 --vm=testvm2 // show log-verbosity of testvm1 and testvm2
$virtctl adm log-verbosity --vm=testvm --level= // default arg for the level flag (i.e.ignore the level flag = show log-verbosity of testvm)

// set
$virtctl adm log-verbosity --vm=testvm --level=5 // set log-verbosity 5 to testvm
$virtctl adm log-verbosity --vm=testvm1 --level=5 --vm=testvm2 --level=6 // set log-verbosity 5 to testvm1 and 6 to testvm2

// reset
$virtctl adm log-verbosity --reset=testvm // reset testvm
$virtctl adm log-verbosity --reset=testvm1 --reset=testvm2 // reset testvm1 and testvm2
$virtctl adm log-verbosity --reset=testvm1 --vm=testvm2 --level=5 // reset testvm1 and set log-verbosity 5 to testvm2

// error
$virtctl adm log-verbosity --vm // no arg for the vm flag
$virtctl adm log-verbosity --vm= // default arg for the vm flag (i.e. ignore the vm flag = show help menu)
$virtctl adm log-verbosity --level=5 // no vm flag
$virtctl adm log-verbosity --vm=testvm --level=10  // verbosity out of range
$virtctl adm log-verbosity --vm=testvm --vm=testvm --level=5 // show and set
$virtctl adm log-verbosity --vm=testvm1 --vm=testvm2 --level=5 // show and set (different vm)
$virtctl adm log-verbosity --vm=testvm --reset=testvm  // show and set
$virtctl adm log-verbosity --vm=testvm1 --reset=testvm2  // show and set (different vm)
```

Co-existence of VM and virt components:
```
// show
$virtctl adm log-verbosity --virt-api --vm=testvm // show virt-api and testvm
$virtctl adm log-verbosity --all --vm=testvm // show all virt components and testvm

// set
$virtctl adm log-verbosity --virt-api=3 --vm=testvm --level=5 // virt-api to 3 and testvm to 5
$virtctl adm log-verbosity --all=3 --vm=testvm --level=5 // all components to 3 and testvm to 5
$virtctl adm log-verbosity --reset --reset=testvm // reset all components and testvm
$virtctl adm log-verbosity --reset --vm=testvm --level=6 // reset all components and set testvm to 6
$virtctl adm log-verbosity --reset --vm=testvm --level=6 --reset=testvm2 // reset all components, set testvm1 to 6, and reset testvm2

// error
$virtctl adm log-verbosity --virt-api=1 --vm=testvm  // show and set
$virtctl adm log-verbosity --all=1 --vm=testvm  // show and set
$virtctl adm log-verbosity --reset --vm=testvm  // show and set
$virtctl adm log-verbosity --virt-api --vm=testvm --level=5  // show and set
$virtctl adm log-verbosity --all --vm=testvm --level=5  // show and set
$virtctl adm log-verbosity --virt-api --reset=testvm  // show and set
$virtctl adm log-verbosity --all --reset=testvm  // show and set
```

**Which issue(s) this PR fixes**:

Fixes #8155

#8155 includes both the KubeVirt components (cluster-wide) log verbosity and the VM level log verbosity. #10244 supports the verbosity per KubeVirt component. This PR complements #10244, and supports the verbosity per VM.

Out of scope
- Node level verbosity
- Log filters (libvirt, qemu)
   - log verbosity is the target of this command.
   - Setting `log_filters` to libvirt/qemu or changing the mapping between log verbosity and `log_filters` is not the target.

**Special notes for your reviewer**:

- To set the log verbosity of VM, we use the `logVerbosity` label in the `VirtualMachine` object.
```
v1.VirtualMachine{
	TypeMeta: k8smetav1.TypeMeta{
		APIVersion: v1.GroupVersion.String(),
		Kind:       "VirtualMachine",
	},
	ObjectMeta: k8smetav1.ObjectMeta{
		Name:      name,
		Namespace: namespace,
	},
	Spec: v1.VirtualMachineSpec{
		Running: new(bool),
		Template: &v1.VirtualMachineInstanceTemplateSpec{
			ObjectMeta: k8smetav1.ObjectMeta{
				Labels: map[string]string{
					“lobVerbosity”: verbosity
				},
			},
		},
	},
}
```

- The new verbosity is applied when the VMI is (re)started.

**Release note**:
```release-note
Added showing and setting the log verbosity per VM to the log-verbosity command. The command is:
- To show the log verbosity of a VM
- To set the log verbosity of a VM
- To reset the log verbosity of a VM (remove logVerbosity label).

Changed the cluster-wide components that the verbosity value 10 is not accepted.
- The verbosity value 10 for the cluster-wide components was accepted but the operation was show instead of set. The verbosity value 10 is not accepted any more.
```