### PR TITLE
Fix conformance make target

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -75,6 +75,14 @@ container_image(
     files = [
         ":conformance-config.json",
     ],
+    tars = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": [
+            "//rpm:testimage_aarch64",
+        ],
+        "//conditions:default": [
+            "//rpm:testimage_x86_64",
+        ],
+    }),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The conformance lanes are currently failing due to `go_default_test` being unable to find a required GLIBC version[1].
This is also preventing us from testing in the kubevirtci repo as we rely on the conformance tests there. 

The test_image[2] rpm bundle includes the required dependencies.

[1] https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-push-nightly-conformance/1742735308912332800/artifacts/podlogs/sonobuoy/sonobuoy-kubevirt-conformance-job-24808aede4884e3e/logs/plugin.txt
[2] https://github.com/kubevirt/kubevirt/blob/f9391ddcd4a8f6c72b80606e36cd0bcb555e1e7a/rpm/BUILD.bazel#L2003

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @dhiller @EdDev 
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
