### PR TITLE
refactor: tests/utils.go cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ format:
 fmt: format
 
 lint:
-	if [ $$(wc -l < tests/utils.go) -gt 2350 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
+	if [ $$(wc -l < tests/utils.go) -gt 2100 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
 	hack/dockerized "golangci-lint run --timeout 20m --verbose \
 	  pkg/instancetype/... \

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -165,6 +165,7 @@ go_test(
         "//pkg/hooks/v1alpha3:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/network/dns:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util/cluster:go_default_library",

--- a/tests/libvmi/BUILD.bazel
+++ b/tests/libvmi/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "factory.go",
         "memory.go",
         "network.go",
+        "selector.go",
         "status.go",
         "storage.go",
         "vm.go",

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -41,7 +41,7 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	fedoraOptions := []Option{
 		WithResourceMemory("512Mi"),
 		WithRng(),
-		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)),
+		WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)),
 	}
 	opts = append(fedoraOptions, opts...)
 	return New(opts...)
@@ -53,7 +53,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	withNonEmptyUserData := WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
 
 	cirrosOpts := []Option{
-		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
+		WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 		withNonEmptyUserData,
 		WithResourceMemory(cirrosMemory()),
 	}
@@ -65,7 +65,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	alpineMemory := cirrosMemory
 	alpineOpts := []Option{
-		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpine)),
+		WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskAlpine)),
 		WithResourceMemory(alpineMemory()),
 		WithRng(),
 	}
@@ -78,7 +78,7 @@ func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	withNonEmptyUserData := WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
 	alpineMemory := cirrosMemory
 	alpineOpts := []Option{
-		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
+		WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
 		withNonEmptyUserData,
 		WithResourceMemory(alpineMemory()),
 		WithRng(),

--- a/tests/libvmi/selector.go
+++ b/tests/libvmi/selector.go
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package libvmi
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
+)
+
+// WithNodeSelectorFor ensures that the VMI gets scheduled on the specified node
+func WithNodeSelectorFor(node *k8sv1.Node) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.NodeSelector == nil {
+			vmi.Spec.NodeSelector = map[string]string{}
+		}
+		vmi.Spec.NodeSelector["kubernetes.io/hostname"] = node.Name
+	}
+}
+
+func WithNodeAffinityFor(nodeName string) Option {
+	return WithNodeAffinityForLabel("kubernetes.io/hostname", nodeName)
+}
+
+func WithNodeAffinityForLabel(nodeLabelKey, nodeLabelValue string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		nodeSelectorTerm := k8sv1.NodeSelectorTerm{
+			MatchExpressions: []k8sv1.NodeSelectorRequirement{
+				{Key: nodeLabelKey, Operator: k8sv1.NodeSelectorOpIn, Values: []string{nodeLabelValue}},
+			},
+		}
+
+		if vmi.Spec.Affinity == nil {
+			vmi.Spec.Affinity = &k8sv1.Affinity{}
+		}
+
+		if vmi.Spec.Affinity.NodeAffinity == nil {
+			vmi.Spec.Affinity.NodeAffinity = &k8sv1.NodeAffinity{}
+		}
+
+		if vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+			vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &k8sv1.NodeSelector{}
+		}
+
+		if vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms == nil {
+			vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []k8sv1.NodeSelectorTerm{}
+		}
+
+		vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms =
+			append(vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, nodeSelectorTerm)
+	}
+}

--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -28,6 +28,10 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
+const (
+	defaultDiskSize = "1Gi"
+)
+
 // WithContainerDisk specifies the disk name and the name of the container image to be used.
 func WithContainerDisk(diskName, imageName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
@@ -96,6 +100,13 @@ func WithPersistentVolumeClaimLun(diskName, pvcName string, reservation bool) Op
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDisk(vmi, newLun(diskName, reservation))
 		addVolume(vmi, newPersistentVolumeClaimVolume(diskName, pvcName))
+	}
+}
+
+func WithHostDisk(diskName, path string, diskType v1.HostDiskType) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDisk(vmi, newDisk(diskName, v1.DiskBusVirtio))
+		addVolume(vmi, newHostDisk(diskName, path, diskType))
 	}
 }
 
@@ -254,6 +265,23 @@ func newEmptyDisk(name string, capacity resource.Quantity) v1.Volume {
 			EmptyDisk: &v1.EmptyDiskSource{
 				Capacity: capacity,
 			},
+		},
+	}
+}
+
+func newHostDisk(name, path string, diskType v1.HostDiskType) v1.Volume {
+	hostDisk := v1.HostDisk{
+		Path: path,
+		Type: diskType,
+	}
+	if diskType == v1.HostDiskExistsOrCreate {
+		hostDisk.Capacity = resource.MustParse(defaultDiskSize)
+	}
+
+	return v1.Volume{
+		Name: name,
+		VolumeSource: v1.VolumeSource{
+			HostDisk: &hostDisk,
 		},
 	}
 }

--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -28,12 +28,11 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-// WithContainerImage specifies the name of the container image to be used.
-func WithContainerImage(name string) Option {
+// WithContainerDisk specifies the disk name and the name of the container image to be used.
+func WithContainerDisk(diskName, imageName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		diskName := "disk0"
 		addDisk(vmi, newDisk(diskName, v1.DiskBusVirtio))
-		addVolume(vmi, newContainerVolume(diskName, name))
+		addVolume(vmi, newContainerVolume(diskName, imageName))
 	}
 }
 

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -247,11 +247,11 @@ func WithCPUFeature(featureName, policy string) Option {
 	}
 }
 
-func WithNodeAffinityFor(node *k8sv1.Node) Option {
+func WithNodeAffinityFor(nodeName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		nodeSelectorTerm := k8sv1.NodeSelectorTerm{
 			MatchExpressions: []k8sv1.NodeSelectorRequirement{
-				{Key: "kubernetes.io/hostname", Operator: k8sv1.NodeSelectorOpIn, Values: []string{node.Name}},
+				{Key: "kubernetes.io/hostname", Operator: k8sv1.NodeSelectorOpIn, Values: []string{nodeName}},
 			},
 		}
 

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -171,16 +171,6 @@ func WithDownwardMetricsChannel() Option {
 	}
 }
 
-// WithNodeSelectorFor ensures that the VMI gets scheduled on the specified node
-func WithNodeSelectorFor(node *k8sv1.Node) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		if vmi.Spec.NodeSelector == nil {
-			vmi.Spec.NodeSelector = map[string]string{}
-		}
-		vmi.Spec.NodeSelector["kubernetes.io/hostname"] = node.Name
-	}
-}
-
 // WithUefi configures EFI bootloader and SecureBoot.
 func WithUefi(secureBoot bool) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
@@ -244,35 +234,6 @@ func WithCPUFeature(featureName, policy string) Option {
 			Name:   featureName,
 			Policy: policy,
 		})
-	}
-}
-
-func WithNodeAffinityFor(nodeName string) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		nodeSelectorTerm := k8sv1.NodeSelectorTerm{
-			MatchExpressions: []k8sv1.NodeSelectorRequirement{
-				{Key: "kubernetes.io/hostname", Operator: k8sv1.NodeSelectorOpIn, Values: []string{nodeName}},
-			},
-		}
-
-		if vmi.Spec.Affinity == nil {
-			vmi.Spec.Affinity = &k8sv1.Affinity{}
-		}
-
-		if vmi.Spec.Affinity.NodeAffinity == nil {
-			vmi.Spec.Affinity.NodeAffinity = &k8sv1.NodeAffinity{}
-		}
-
-		if vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-			vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &k8sv1.NodeSelector{}
-		}
-
-		if vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms == nil {
-			vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []k8sv1.NodeSelectorTerm{}
-		}
-
-		vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms =
-			append(vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, nodeSelectorTerm)
 	}
 }
 

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -834,7 +834,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 			It("should automatically cancel unschedulable migration after a timeout period", func() {
 				// Add node affinity to ensure VMI affinity rules block target pod from being created
-				vmi := tests.NewRandomFedoraVMI(libvmi.WithNodeAffinityFor(&nodes.Items[0]))
+				vmi := tests.NewRandomFedoraVMI(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 				By("Starting the VirtualMachineInstance")

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -180,7 +180,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 			vmi := libvmi.NewFedora(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithNodeAffinityFor(&nodes.Items[0]),
+				libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
 			)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 			labels := map[string]string{

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -35,7 +35,6 @@ import (
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -182,8 +181,10 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithInterface(iface),
 				libvmi.WithNetwork(&net),
-				libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", ip2+subnetMask)))
-			anotherVmi = tests.CreateVmiOnNode(anotherVmi, hotPluggedVMI.Status.NodeName)
+				libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", ip2+subnetMask)),
+				libvmi.WithNodeAffinityFor(hotPluggedVMI.Status.NodeName))
+			anotherVmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(anotherVmi)).Create(context.Background(), anotherVmi)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			libwait.WaitUntilVMIReady(anotherVmi, console.LoginToFedora)
 
 			By("Ping from the VM with hotplugged interface to the other VM")

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -75,21 +75,6 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 			To(Succeed(), "A macvtap network named %s should be provisioned", macvtapNetworkName)
 	})
 
-	newAlpineVMIWithMacvtapNetwork := func(macvtapNetworkName string) *v1.VirtualMachineInstance {
-		return libvmi.NewAlpine(
-			libvmi.WithInterface(
-				*v1.DefaultMacvtapNetworkInterface(macvtapNetworkName)),
-			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)))
-	}
-
-	newAlpineVMIWithExplicitMac := func(macvtapNetworkName string, mac string) *v1.VirtualMachineInstance {
-		return libvmi.NewAlpineWithTestTooling(
-			libvmi.WithInterface(
-				*libvmi.InterfaceWithMac(
-					v1.DefaultMacvtapNetworkInterface(macvtapNetworkName), mac)),
-			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)))
-	}
-
 	newFedoraVMIWithExplicitMacAndGuestAgent := func(macvtapNetworkName string, mac string) *v1.VirtualMachineInstance {
 		return libvmi.NewFedora(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -103,13 +88,21 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 	createAlpineVMIStaticIPOnNode := func(nodeName string, networkName string, ifaceName string, ipCIDR string, mac *string) *v1.VirtualMachineInstance {
 		var vmi *v1.VirtualMachineInstance
 		if mac != nil {
-			vmi = newAlpineVMIWithExplicitMac(networkName, *mac)
+			vmi = libvmi.NewAlpineWithTestTooling(
+				libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultMacvtapNetworkInterface(networkName), *mac)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
+				libvmi.WithNodeAffinityFor(nodeName),
+			)
 		} else {
-			vmi = newAlpineVMIWithMacvtapNetwork(networkName)
+			vmi = libvmi.NewAlpine(
+				libvmi.WithInterface(*v1.DefaultMacvtapNetworkInterface(networkName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
+				libvmi.WithNodeAffinityFor(nodeName),
+			)
 		}
-		vmi = libwait.WaitUntilVMIReady(
-			tests.CreateVmiOnNode(vmi, nodeName),
-			console.LoginToAlpine)
+		vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 		// configure the client VMI
 		Expect(configInterface(vmi, ifaceName, ipCIDR)).To(Succeed())
 		return vmi
@@ -117,7 +110,10 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 
 	createAlpineVMIRandomNode := func(networkName string, mac string) (*v1.VirtualMachineInstance, error) {
 		runningVMI := tests.RunVMIAndExpectLaunch(
-			newAlpineVMIWithExplicitMac(networkName, mac),
+			libvmi.NewAlpineWithTestTooling(
+				libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultMacvtapNetworkInterface(networkName), mac)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
+			),
 			180,
 		)
 		err := console.LoginToAlpine(runningVMI)

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -62,7 +62,7 @@ var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", 
 		const noMask = ""
 		vmi = libvmi.New(
 			libvmi.WithRng(),
-			libvmi.WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime)),
+			libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime)),
 			libvmi.WithCloudInitNoCloudEncodedUserData(tuneAdminRealtimeCloudInitData),
 			libvmi.WithResourceCPU("2"),
 			libvmi.WithLimitCPU("2"),

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libdv"
 
@@ -555,7 +557,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 
 		// set new replica count while still being paused
 		By("Updating the number of replicas")
-		patchData, err := patch.GenerateTestReplacePatch("/spec/replicas", pool.Spec.Replicas, tests.NewInt32(1))
+		patchData, err := patch.GenerateTestReplacePatch("/spec/replicas", pool.Spec.Replicas, pointer.P(1))
 		Expect(err).ToNot(HaveOccurred())
 		pool, err = virtClient.VirtualMachinePool(pool.ObjectMeta.Namespace).Patch(context.Background(), pool.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -43,7 +43,7 @@ bootcmd:
 func newFedoraRealtime(realtimeMask string) *v1.VirtualMachineInstance {
 	return libvmi.New(
 		libvmi.WithRng(),
-		libvmi.WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime)),
+		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime)),
 		libvmi.WithCloudInitNoCloudEncodedUserData(tuneAdminRealtimeCloudInitData),
 		libvmi.WithLimitMemory(memory),
 		libvmi.WithLimitCPU("2"),

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
@@ -337,7 +339,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		// set new replica count while still being paused
 		By("Updating the number of replicas")
-		patchData, err := patch.GenerateTestReplacePatch("/spec/replicas", rs.Spec.Replicas, tests.NewInt32(2))
+		patchData, err := patch.GenerateTestReplacePatch("/spec/replicas", rs.Spec.Replicas, pointer.P(2))
 		Expect(err).ToNot(HaveOccurred())
 		rs, err = virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, patchData)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -231,10 +231,12 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 		It("Should successfully start a VM with persistent reservation", func() {
 			By("Create VMI with the SCSI disk")
 			vmi := libvmi.NewFedora(
+				libvmi.WithNamespace(util.NamespaceTestDefault),
 				libvmi.WithPersistentVolumeClaimLun("lun0", pvc.Name, true),
+				libvmi.WithNodeAffinityFor(node),
 			)
-			vmi.Namespace = util.NamespaceTestDefault
-			vmi = tests.CreateVmiOnNode(vmi, node)
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+			Expect(err).ToNot(HaveOccurred())
 			libwait.WaitForSuccessfulVMIStart(vmi,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
@@ -258,20 +260,24 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 		It("Should successfully start 2 VMs with persistent reservation on the same LUN", func() {
 			By("Create 2 VMs with the SCSI disk")
 			vmi := libvmi.NewFedora(
+				libvmi.WithNamespace(util.NamespaceTestDefault),
 				libvmi.WithPersistentVolumeClaimLun("lun0", pvc.Name, true),
+				libvmi.WithNodeAffinityFor(node),
 			)
-			vmi.Namespace = util.NamespaceTestDefault
-			vmi = tests.CreateVmiOnNode(vmi, node)
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+			Expect(err).ToNot(HaveOccurred())
 			libwait.WaitForSuccessfulVMIStart(vmi,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),
 			)
 
 			vmi2 := libvmi.NewFedora(
+				libvmi.WithNamespace(util.NamespaceTestDefault),
 				libvmi.WithPersistentVolumeClaimLun("lun0", pvc.Name, true),
+				libvmi.WithNodeAffinityFor(node),
 			)
-			vmi2.Namespace = util.NamespaceTestDefault
-			vmi2 = tests.CreateVmiOnNode(vmi2, node)
+			vmi2, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi2)).Create(context.Background(), vmi2)
+			Expect(err).ToNot(HaveOccurred())
 			libwait.WaitForSuccessfulVMIStart(vmi2,
 				libwait.WithFailOnWarnings(false),
 				libwait.WithTimeout(180),

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/checks"
+
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1229,7 +1231,18 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 				originalPVCName := pvc.Name
 
-				vmi = tests.NewRandomVMIWithPVCAndUserData(pvc.Name, bashHelloScript)
+				memory := "128Mi"
+				if checks.IsARM64(testsuite.Arch) {
+					memory = "256Mi"
+				}
+				vmi = libvmi.New(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+					libvmi.WithResourceMemory(memory),
+					libvmi.WithPersistentVolumeClaim("disk0", pvc.Name),
+					libvmi.WithCloudInitNoCloudEncodedUserData(bashHelloScript),
+				)
 				vm = libvmi.NewVirtualMachine(vmi)
 
 				vm, vmi = createAndStartVM(vm)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1551,28 +1551,6 @@ func GetVmPodName(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance
 	return podName
 }
 
-// AppendEmptyDisk
-//
-// Deprecated: Use libvmi
-func AppendEmptyDisk(vmi *v1.VirtualMachineInstance, diskName string, busName v1.DiskBus, diskSize string) {
-	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-		Name: diskName,
-		DiskDevice: v1.DiskDevice{
-			Disk: &v1.DiskTarget{
-				Bus: busName,
-			},
-		},
-	})
-	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-		Name: diskName,
-		VolumeSource: v1.VolumeSource{
-			EmptyDisk: &v1.EmptyDiskSource{
-				Capacity: resource.MustParse(diskSize),
-			},
-		},
-	})
-}
-
 func GetRunningVMIDomainSpec(vmi *v1.VirtualMachineInstance) (*launcherApi.DomainSpec, error) {
 	runningVMISpec := launcherApi.DomainSpec{}
 	cli := kubevirt.Client()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1354,11 +1354,6 @@ func CreateVmiOnNodeLabeled(vmi *v1.VirtualMachineInstance, nodeLabel, labelValu
 	return vmi
 }
 
-// CreateVmiOnNode creates a VMI on the specified node
-func CreateVmiOnNode(vmi *v1.VirtualMachineInstance, nodeName string) *v1.VirtualMachineInstance {
-	return CreateVmiOnNodeLabeled(vmi, util2.KubernetesIoHostName, nodeName)
-}
-
 func GetVmiPod(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
 	pods, err := virtClient.CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), UnfinishedVMIPodSelector(vmi))
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -43,7 +43,7 @@ import (
 
 	v12 "k8s.io/api/apps/v1"
 
-	k6tpointer "kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/pointer"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
@@ -1061,10 +1061,6 @@ func AddWatchdog(vmi *v1.VirtualMachineInstance, action v1.WatchdogAction) {
 	}
 }
 
-func NewInt32(x int32) *int32 {
-	return &x
-}
-
 func NewRandomReplicaSetFromVMI(vmi *v1.VirtualMachineInstance, replicas int32) *v1.VirtualMachineInstanceReplicaSet {
 	name := "replicaset" + rand.String(5)
 	rs := &v1.VirtualMachineInstanceReplicaSet{
@@ -1084,10 +1080,6 @@ func NewRandomReplicaSetFromVMI(vmi *v1.VirtualMachineInstance, replicas int32) 
 		},
 	}
 	return rs
-}
-
-func NewBool(x bool) *bool {
-	return &x
 }
 
 // CreateExecutorPodWithPVC creates a Pod with the passed in PVC mounted under /pvc. You can then use the executor utilities to
@@ -1153,9 +1145,9 @@ func ChangeImgFilePermissionsToNonQEMU(pvc *k8sv1.PersistentVolumeClaim) {
 		Capabilities: &k8sv1.Capabilities{
 			Drop: []k8sv1.Capability{"ALL"},
 		},
-		Privileged:   NewBool(true),
+		Privileged:   pointer.P(true),
 		RunAsUser:    &rootUser,
-		RunAsNonRoot: NewBool(false),
+		RunAsNonRoot: pointer.P(false),
 	}
 
 	RunPodAndExpectCompletion(pod)
@@ -1428,7 +1420,7 @@ func StopVirtualMachineWithTimeout(vm *v1.VirtualMachine, timeout time.Duration)
 	Eventually(func() error {
 		updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		updatedVM.Spec.Running = k6tpointer.P(false)
+		updatedVM.Spec.Running = pointer.P(false)
 		updatedVM.Spec.RunStrategy = nil
 		_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(context.Background(), updatedVM)
 		return err
@@ -1463,7 +1455,7 @@ func StartVirtualMachine(vm *v1.VirtualMachine) *v1.VirtualMachine {
 	Eventually(func() error {
 		updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		updatedVM.Spec.Running = k6tpointer.P(true)
+		updatedVM.Spec.Running = pointer.P(true)
 		updatedVM.Spec.RunStrategy = nil
 		_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(context.Background(), updatedVM)
 		return err

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1330,30 +1330,6 @@ func CreateHostDiskImage(diskPath string) *k8sv1.Pod {
 	return pod
 }
 
-// CreateVmiOnNodeLabeled creates a VMI a node that has a give label set to a given value
-func CreateVmiOnNodeLabeled(vmi *v1.VirtualMachineInstance, nodeLabel, labelValue string) *v1.VirtualMachineInstance {
-	virtClient := kubevirt.Client()
-
-	vmi.Spec.Affinity = &k8sv1.Affinity{
-		NodeAffinity: &k8sv1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
-				NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
-					{
-						MatchExpressions: []k8sv1.NodeSelectorRequirement{
-							{Key: nodeLabel, Operator: k8sv1.NodeSelectorOpIn, Values: []string{labelValue}},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var err error
-	vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	return vmi
-}
-
 func GetVmiPod(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
 	pods, err := virtClient.CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), UnfinishedVMIPodSelector(vmi))
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -936,17 +936,6 @@ func NewRandomVMIWithPVC(claimName string) *v1.VirtualMachineInstance {
 	return vmi
 }
 
-// NewRandomVMIWithPVCAndUserData
-//
-// Deprecated: Use libvmi
-func NewRandomVMIWithPVCAndUserData(claimName, userData string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMI()
-
-	vmi = AddPVCDisk(vmi, "disk0", v1.DiskBusVirtio, claimName)
-	AddUserData(vmi, "disk1", userData)
-	return vmi
-}
-
 func DeletePvAndPvc(name string) {
 	virtCli := kubevirt.Client()
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -961,65 +961,6 @@ func DeletePvAndPvc(name string) {
 	}
 }
 
-// AddHostDisk
-//
-// Deprecated: Use libvmi
-func AddHostDisk(vmi *v1.VirtualMachineInstance, path string, diskType v1.HostDiskType, name string) {
-	hostDisk := v1.HostDisk{
-		Path: path,
-		Type: diskType,
-	}
-	if diskType == v1.HostDiskExistsOrCreate {
-		hostDisk.Capacity = resource.MustParse(defaultDiskSize)
-	}
-
-	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-		Name: name,
-		DiskDevice: v1.DiskDevice{
-			Disk: &v1.DiskTarget{
-				Bus: v1.DiskBusVirtio,
-			},
-		},
-	})
-	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-		Name: name,
-		VolumeSource: v1.VolumeSource{
-			HostDisk: &hostDisk,
-		},
-	})
-
-	// hostdisk needs a privileged namespace
-	vmi.Namespace = testsuite.NamespacePrivileged
-}
-
-// NewRandomVMIWithHostDisk
-//
-// Deprecated: Use libvmi
-func NewRandomVMIWithHostDisk(diskPath string, diskType v1.HostDiskType, nodeName string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMI()
-	AddHostDisk(vmi, diskPath, diskType, "host-disk")
-	if nodeName != "" {
-		vmi.Spec.Affinity = &k8sv1.Affinity{
-			NodeAffinity: &k8sv1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
-					NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
-						{
-							MatchExpressions: []k8sv1.NodeSelectorRequirement{
-								{
-									Key:      util2.KubernetesIoHostName,
-									Operator: k8sv1.NodeSelectorOpIn,
-									Values:   []string{nodeName},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-	return vmi
-}
-
 // AddConfigMapDisk
 //
 // Deprecated: Use libvmi

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -586,7 +586,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		DescribeTable("should report an error status when VM scheduling error occurs", func(unschedulableFunc func(vmi *v1.VirtualMachineInstance)) {
 			vmi := libvmi.New(
-				libvmi.WithContainerImage("no-such-image"),
+				libvmi.WithContainerDisk("disk0", "no-such-image"),
 				libvmi.WithResourceMemory("128Mi"),
 			)
 			unschedulableFunc(vmi)
@@ -612,7 +612,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		It("[test_id:6869]should report an error status when image pull error occurs", func() {
 			vmi := libvmi.New(
-				libvmi.WithContainerImage("no-such-image"),
+				libvmi.WithContainerDisk("disk0", "no-such-image"),
 				libvmi.WithResourceMemory("128Mi"),
 			)
 

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	expect "github.com/google/goexpect"
@@ -223,7 +225,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vm := &v1.VirtualMachine{
 					ObjectMeta: vmi.ObjectMeta,
 					Spec: v1.VirtualMachineSpec{
-						Running: tests.NewBool(false),
+						Running: pointer.P(false),
 						Template: &v1.VirtualMachineInstanceTemplateSpec{
 							Spec: vmi.Spec,
 						},

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -30,6 +30,8 @@ import (
 	"time"
 	"unicode"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -47,7 +49,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
@@ -146,7 +147,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				libvmi.WithWatchdog(v1.WatchdogActionPoweroff),
 			)
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.VirtIO, Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
-			vmi.Spec.Domain.Devices.UseVirtioTransitional = pointer.BoolPtr(true)
+			vmi.Spec.Domain.Devices.UseVirtioTransitional = pointer.P(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
 			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
@@ -578,7 +579,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				vmi.Spec.Domain.Firmware = &v1.Firmware{
 					Bootloader: &v1.Bootloader{
 						BIOS: &v1.BIOS{
-							UseSerial: tests.NewBool(true),
+							UseSerial: pointer.P(true),
 						},
 					},
 				}
@@ -1700,7 +1701,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				requestWithHeadroom := getComputeMemoryRequest(vmiWithHeadroom)
 
 				overheadWithoutHeadroom := services.GetMemoryOverhead(vmiWithoutHeadroom, runtime.GOARCH, nil)
-				overheadWithHeadroom := services.GetMemoryOverhead(vmiWithoutHeadroom, runtime.GOARCH, pointer.String(ratio))
+				overheadWithHeadroom := services.GetMemoryOverhead(vmiWithoutHeadroom, runtime.GOARCH, pointer.P(ratio))
 
 				expectedDiffBetweenRequests := overheadWithHeadroom.DeepCopy()
 				expectedDiffBetweenRequests.Sub(overheadWithoutHeadroom)
@@ -3366,7 +3367,7 @@ func withSerialBIOS() libvmi.Option {
 		if vmi.Spec.Domain.Firmware.Bootloader.BIOS == nil {
 			vmi.Spec.Domain.Firmware.Bootloader.BIOS = &v1.BIOS{}
 		}
-		vmi.Spec.Domain.Firmware.Bootloader.BIOS.UseSerial = pointer.Bool(true)
+		vmi.Spec.Domain.Firmware.Bootloader.BIOS.UseSerial = pointer.P(true)
 	}
 }
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -800,13 +800,13 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:1635]the vmi with tolerations should be scheduled", func() {
-				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(&nodes.Items[0]))
+				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi.Spec.Tolerations = []k8sv1.Toleration{{Key: "test", Value: "123"}}
 				tests.RunVMIAndExpectLaunch(vmi, 30)
 			})
 
 			It("[test_id:1636]the vmi without tolerations should not be scheduled", func() {
-				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(&nodes.Items[0]))
+				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 				By("Waiting for the VirtualMachineInstance to be unschedulable")
@@ -832,7 +832,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:1637]the vmi with node affinity and no conflicts should be scheduled", func() {
-				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(&nodes.Items[0]))
+				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
@@ -841,13 +841,13 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:1638]the vmi with node affinity and anti-pod affinity should not be scheduled", func() {
-				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(&nodes.Items[0]))
+				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 				Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "VMI should run on the same node")
 
-				vmiB := libvmi.NewCirros(libvmi.WithNodeAffinityFor(&nodes.Items[0]))
+				vmiB := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 
 				vmiB.Spec.Affinity.PodAntiAffinity = &k8sv1.PodAntiAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
@@ -1188,7 +1188,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 				// Add node affinity first to test later on that although there is node affinity to
 				// the specific node - the feature policy 'forbid' will deny shceduling on that node.
-				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(&nodes.Items[0]))
+				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Cores: 1,
 					Features: []v1.CPUFeature{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`tests/utils.go` file contains some utility functions that can be considered as duplicated.
In fact many things can be achieved with the already present `libvmi`/etc funcions.
Other times, it is possible to extract functions from `utils` to `libvmi`.
This PR aims to extract and refactor a small part of the tests/utils.go file.
In particular, in this PR we:
- extract `libvmi.WithHostDisk`.
- extend `utils.NewRandomVMI` function to accept libvmi options.
- remove `utils.NewRandomVMIWithPVCAndUserData`, `NewInt32`, `NewBool` and `CreateVmiOnNode` functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/sig code-quality
