### PR TITLE
e2e tests: libvmi: add annotation with test name to new VMIs

### DIFF
--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -46,6 +46,12 @@ func New(opts ...Option) *v1.VirtualMachineInstance {
 	return vmi
 }
 
+var defaultOptions []Option
+
+func RegisterDefaultOption(opt Option) {
+	defaultOptions = append(defaultOptions, opt)
+}
+
 // randName returns a random name for a virtual machine
 func randName() string {
 	const randomPostfixLen = 5
@@ -263,5 +269,10 @@ func baseVmi(name string) *v1.VirtualMachineInstance {
 		APIVersion: v1.GroupVersion.String(),
 		Kind:       "VirtualMachineInstance",
 	}
+
+	for _, opt := range defaultOptions {
+		opt(vmi)
+	}
+
 	return vmi
 }

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -100,6 +100,13 @@ func SynchronizedBeforeTestSetup() []byte {
 	return nil
 }
 
+func addTestAnnotation(vmi *v1.VirtualMachineInstance) {
+	if vmi.Annotations == nil {
+		vmi.Annotations = map[string]string{}
+	}
+	vmi.Annotations["kubevirt.io/created-by-test"] = GinkgoT().Name()
+}
+
 func BeforeTestSuiteSetup(_ []byte) {
 
 	worker := GinkgoParallelProcess()
@@ -137,6 +144,7 @@ func BeforeTestSuiteSetup(_ []byte) {
 	SetDefaultEventuallyPollingInterval(defaultEventuallyPollingInterval)
 
 	libvmi.RegisterArchitecture(Arch)
+	libvmi.RegisterDefaultOption(addTestAnnotation)
 }
 
 func EnsureKubevirtReady() {

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -380,7 +380,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying VMI")
-			Expect(newVmi.Annotations).To(BeNil())
+			Expect(newVmi.Annotations).To(Equal(vmi.Annotations))
 
 			label, ok := vmi.Labels[overrideKey]
 			Expect(ok).To(BeTrue())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an annotation to VMIs created by libvmi with the name of the current test (if available).
This will help identify which test created any rogue VMI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
