### PR TITLE
network: pod IPs should be stored in a cache file for binding plugin

### DIFF
--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -101,7 +101,6 @@ var _ = Describe("netconf", func() {
 		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupDummyNoop)).To(Succeed())
 		Expect(stateCache.stateCache).To(BeEmpty())
 	},
-		Entry("binding", v1.InterfaceBindingMethod{}),
 		Entry("SR-IOV", v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}),
 		Entry("macvtap", v1.InterfaceBindingMethod{Macvtap: &v1.InterfaceMacvtap{}}),
 	)

--- a/pkg/network/setup/netpod/discover.go
+++ b/pkg/network/setup/netpod/discover.go
@@ -96,8 +96,15 @@ func (n NetPod) discover(currentStatus *nmstate.Status) error {
 				return err
 			}
 
-		// Skip the discovery for all other known network interface bindings.
 		case vmiSpecIface.Binding != nil:
+			// The existence of the pod interface depends on the network binding plugin implementation
+			if podIfaceExists {
+				if err := n.storePodInterfaceData(vmiSpecIface, podIfaceStatus); err != nil {
+					return err
+				}
+			}
+
+		// Skip the discovery for all other known network interface bindings.
 		case vmiSpecIface.Macvtap != nil:
 		case vmiSpecIface.SRIOV != nil:
 		default:

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -548,7 +548,7 @@ func filterSupportedBindingNetworks(specNetworks []v1.Network, specInterfaces []
 			return nil, fmt.Errorf("no iface matching with network %s", network.Name)
 		}
 
-		if iface.Binding != nil || iface.SRIOV != nil || iface.Macvtap != nil {
+		if iface.SRIOV != nil || iface.Macvtap != nil {
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Otherwise, the status of the VMI will contain only the GA IPs.

This fix was done because of a bug discovered in passt binding plugin tests.
In passt the guest IP6 is not the same as the pod one (in case the guest has not DHCPv6 client).
The fact that the pod IPv6 wasn't cached, caused the internal GA IPv6 to be in the VMI status.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Report IP of interfaces using network binding plugin.
```
