### PR TITLE
[guest-log] Avoid reporting error if the socket file got closed

### DIFF
--- a/tests/guestlog/BUILD.bazel
+++ b/tests/guestlog/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//tests/decorators:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/testsuite:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",

--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -26,6 +26,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -90,6 +91,38 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				Entry("without AutoattachSerialConsole but with LogSerialConsole", false, true, false),
 				Entry("without AutoattachSerialConsole and without LogSerialConsole", false, false, false),
 			)
+
+			It("it should exit cleanly when the shutdown is initiated by the guest", func() {
+				By("Starting a VMI")
+				vmi := tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
+
+				By("Finding virt-launcher pod")
+				virtlauncherPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
+				Expect(err).ToNot(HaveOccurred())
+				foundContainer := false
+				for _, container := range virtlauncherPod.Spec.Containers {
+					if container.Name == "guest-console-log" {
+						foundContainer = true
+					}
+				}
+				Expect(foundContainer).To(Equal(true))
+
+				By("Triggering a shutdown from the guest OS")
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "sudo poweroff\n"},
+					&expect.BExp{R: "The system is going down NOW!"},
+				}, 240)).To(Succeed())
+
+				By("Ensuring virt-launcher pod is not reporting errors")
+				Eventually(func(g Gomega) {
+					virtlauncherPod, err := ThisPod(virtlauncherPod)()
+					g.Expect(err).ToNot(HaveOccurred())
+					Expect(virtlauncherPod).ToNot(BeInPhase(k8sv1.PodFailed))
+					g.Expect(virtlauncherPod).To(BeInPhase(k8sv1.PodSucceeded))
+				}, 60*time.Second, 1*time.Second).Should(Succeed(), "virt-launcher should reach the PodSucceeded phase never hitting the PodFailed one")
+			})
+
 		})
 
 		Context("fetch logs", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a shutdown of the guest OS got
triggered from the guest,
the socket file for the serial console
device could get removed even before virt-launcher-monitor detects that the VM is down and made virt-tail aware.

Due to that, virt-tail should not exit with an error when the socket file for the serial console gets removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [https://issues.redhat.com/browse/CNV-36451](https://issues.redhat.com/browse/CNV-36451)

**Special notes for your reviewer**:
None

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
