### PR TITLE
Detector cleanup

### DIFF
--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -50,10 +50,6 @@ type PodIsolationDetector interface {
 
 	DetectForSocket(vm *v1.VirtualMachineInstance, socket string) (IsolationResult, error)
 
-	// Allowlist allows specifying cgroup controller which should be considered to detect the cgroup slice
-	// It returns a PodIsolationDetector to allow configuring the PodIsolationDetector via the builder pattern.
-	Allowlist(controller []string) PodIsolationDetector
-
 	// Adjust system resources to run the passed VM
 	AdjustResources(vm *v1.VirtualMachineInstance, additionalOverheadRatio *string) error
 }
@@ -61,16 +57,14 @@ type PodIsolationDetector interface {
 const isolationDialTimeout = 5
 
 type socketBasedIsolationDetector struct {
-	socketDir  string
-	controller []string
+	socketDir string
 }
 
 // NewSocketBasedIsolationDetector takes socketDir and creates a socket based IsolationDetector
 // It returns a PodIsolationDetector which detects pid, cgroups and namespaces of the socket owner.
 func NewSocketBasedIsolationDetector(socketDir string) PodIsolationDetector {
 	return &socketBasedIsolationDetector{
-		socketDir:  socketDir,
-		controller: []string{"devices"},
+		socketDir: socketDir,
 	}
 }
 
@@ -100,11 +94,6 @@ func (s *socketBasedIsolationDetector) DetectForSocket(vm *v1.VirtualMachineInst
 	}
 
 	return NewIsolationResult(pid, ppid), nil
-}
-
-func (s *socketBasedIsolationDetector) Allowlist(controller []string) PodIsolationDetector {
-	s.controller = controller
-	return s
 }
 
 func (s *socketBasedIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance, additionalOverheadRatio *string) error {

--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -79,16 +79,14 @@ func (s *socketBasedIsolationDetector) Detect(vm *v1.VirtualMachineInstance) (Is
 }
 
 func (s *socketBasedIsolationDetector) DetectForSocket(vm *v1.VirtualMachineInstance, socket string) (IsolationResult, error) {
-	var pid int
-	var ppid int
-	var err error
-
-	if pid, err = s.getPid(socket); err != nil {
+	pid, err := s.getPid(socket)
+	if err != nil {
 		log.Log.Object(vm).Reason(err).Errorf("Could not get owner Pid of socket %s", socket)
 		return nil, err
 	}
 
-	if ppid, err = getPPid(pid); err != nil {
+	ppid, err := getPPid(pid)
+	if err != nil {
 		log.Log.Object(vm).Reason(err).Errorf("Could not get owner PPid of socket %s", socket)
 		return nil, err
 	}

--- a/pkg/virt-handler/isolation/detector_test.go
+++ b/pkg/virt-handler/isolation/detector_test.go
@@ -94,25 +94,25 @@ var _ = Describe("Isolation Detector", func() {
 		})
 
 		It("Should detect the PID of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir).Allowlist([]string{"devices"}).Detect(vm)
+			result, err := NewSocketBasedIsolationDetector(tmpDir).Detect(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Pid()).To(Equal(os.Getpid()))
 		})
 
 		It("Should detect the PID namespace of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir).Allowlist([]string{"devices"}).Detect(vm)
+			result, err := NewSocketBasedIsolationDetector(tmpDir).Detect(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.PIDNamespace()).To(Equal(fmt.Sprintf("/proc/%d/ns/pid", os.Getpid())))
 		})
 
 		It("Should detect the Parent PID of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir).Allowlist([]string{"devices"}).Detect(vm)
+			result, err := NewSocketBasedIsolationDetector(tmpDir).Detect(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.PPid()).To(Equal(os.Getppid()))
 		})
 
 		It("Should detect the Mount root of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir).Allowlist([]string{"devices"}).Detect(vm)
+			result, err := NewSocketBasedIsolationDetector(tmpDir).Detect(vm)
 			Expect(err).ToNot(HaveOccurred())
 			root, err := result.MountRoot()
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-handler/isolation/generated_mock_detector.go
+++ b/pkg/virt-handler/isolation/generated_mock_detector.go
@@ -51,16 +51,6 @@ func (_mr *_MockPodIsolationDetectorRecorder) DetectForSocket(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetectForSocket", arg0, arg1)
 }
 
-func (_m *MockPodIsolationDetector) Allowlist(controller []string) PodIsolationDetector {
-	ret := _m.ctrl.Call(_m, "Allowlist", controller)
-	ret0, _ := ret[0].(PodIsolationDetector)
-	return ret0
-}
-
-func (_mr *_MockPodIsolationDetectorRecorder) Allowlist(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Allowlist", arg0)
-}
-
 func (_m *MockPodIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance, additionalOverheadRatio *string) error {
 	ret := _m.ctrl.Call(_m, "AdjustResources", vm, additionalOverheadRatio)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes unused function of `PodIsolationDetector`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
