### PR TITLE
[e2e] Quarantine flaky live-migrate eviction strategy test

### DIFF
--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -26,6 +26,7 @@ import (
 
 	kvpointer "kubevirt.io/kubevirt/pkg/pointer"
 
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
@@ -150,7 +151,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 				Expect(resVMI.Status.EvacuationNodeName).To(Equal(""), "vmi evacuation state should be clean")
 			})
 
-			It("[sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreated", func() {
+			It("[sig-compute][test_id:3243][QUARANTINE] should recreate the PDB if VMIs with similar names are recreated", decorators.Quarantine, func() {
 				for x := 0; x < 3; x++ {
 					By("creating the VMI")
 					_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:

The following flaky test has caused 9% impact to the compute-migrations presubmit lane over the last week[1] which means that it qualifies for quarantining.

`Live Migration with a live-migrate eviction strategy set [ref_id:2293] with a VMI running with an eviction strategy set [sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreate`

[1] https://search.ci.kubevirt.io/?search=should+recreate+the+PDB+if+VMIs+with+similar+names+are+recreated&maxAge=168h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @fossedihelm @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
