### PR TITLE
VM controller: add ability to compare current and last seen VM specs

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -76,6 +76,9 @@ const (
 	fetchingRunStrategyErrFmt = "Error fetching RunStrategy: %v"
 	fetchingVMKeyErrFmt       = "Error fetching vmKey: %v"
 	startingVMIFailureFmt     = "Failure while starting VMI: %v"
+
+	revisionPrefixStart    = "start"
+	revisionPrefixLastSeen = "last-seen"
 )
 
 type CloneAuthFunc func(dv *cdiv1.DataVolume, requestNamespace, requestName string, proxy cdiv1.AuthorizationHelperProxy, saNamespace, saName string) (bool, string, error)
@@ -288,7 +291,6 @@ func (c *VMController) Execute() bool {
 }
 
 func (c *VMController) execute(key string) error {
-
 	obj, exists, err := c.vmInformer.GetStore().GetByKey(key)
 	if err != nil {
 		return nil
@@ -1123,7 +1125,7 @@ func (c *VMController) startVMI(vm *virtv1.VirtualMachine) error {
 
 	// start it
 	vmi := c.setupVMIFromVM(vm)
-	vmRevisionName, err := c.createVMRevision(vm)
+	vmRevisionName, err := c.createVMRevision(vm, revisionPrefixStart)
 	if err != nil {
 		log.Log.Object(vm).Reason(err).Error(failedCreateCRforVmErrMsg)
 		return err
@@ -1472,12 +1474,12 @@ func (c *VMController) stopVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMac
 	return nil
 }
 
-func vmRevisionNamePrefix(vmUID types.UID) string {
-	return fmt.Sprintf("revision-start-vm-%s", vmUID)
+func vmRevisionNamePrefix(vmUID types.UID, prefix string) string {
+	return fmt.Sprintf("revision-%s-vm-%s", prefix, vmUID)
 }
 
-func getVMRevisionName(vmUID types.UID, generation int64) string {
-	return fmt.Sprintf("%s-%d", vmRevisionNamePrefix(vmUID), generation)
+func getVMRevisionName(vmUID types.UID, generation int64, prefix string) string {
+	return fmt.Sprintf("%s-%d", vmRevisionNamePrefix(vmUID, prefix), generation)
 }
 
 func patchVMRevision(vm *virtv1.VirtualMachine) ([]byte, error) {
@@ -1497,7 +1499,7 @@ func patchVMRevision(vm *virtv1.VirtualMachine) ([]byte, error) {
 	return patch, err
 }
 
-func (c *VMController) deleteOlderVMRevision(vm *virtv1.VirtualMachine) (bool, error) {
+func (c *VMController) deleteOlderVMRevision(vm *virtv1.VirtualMachine, prefix string) (bool, error) {
 	keys, err := c.crInformer.GetIndexer().IndexKeys("vm", string(vm.UID))
 	if err != nil {
 		return false, err
@@ -1505,24 +1507,24 @@ func (c *VMController) deleteOlderVMRevision(vm *virtv1.VirtualMachine) (bool, e
 
 	createNotNeeded := false
 	for _, key := range keys {
+		if !strings.Contains(key, vmRevisionNamePrefix(vm.UID, prefix)) {
+			continue
+		}
+
 		storeObj, exists, err := c.crInformer.GetStore().GetByKey(key)
 		if !exists || err != nil {
 			return false, err
 		}
-
 		cr, ok := storeObj.(*appsv1.ControllerRevision)
 		if !ok {
 			return false, fmt.Errorf("unexpected resource %+v", storeObj)
 		}
 
-		// check the revision is of the revisions that are created in the vm startup
-		if !strings.HasPrefix(cr.Name, vmRevisionNamePrefix(vm.UID)) {
-			continue
-		}
 		if cr.Revision == vm.ObjectMeta.Generation {
 			createNotNeeded = true
 			continue
 		}
+
 		err = c.clientset.AppsV1().ControllerRevisions(vm.Namespace).Delete(context.Background(), cr.Name, v1.DeleteOptions{})
 		if err != nil {
 			return false, err
@@ -1546,9 +1548,80 @@ func (c *VMController) getControllerRevision(namespace string, name string) (*ap
 	return cr, nil
 }
 
-func (c *VMController) createVMRevision(vm *virtv1.VirtualMachine) (string, error) {
-	vmRevisionName := getVMRevisionName(vm.UID, vm.ObjectMeta.Generation)
-	createNotNeeded, err := c.deleteOlderVMRevision(vm)
+func (c *VMController) getVMSpecForKey(key string) (*virtv1.VirtualMachineSpec, error) {
+	obj, exists, err := c.crInformer.GetStore().GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("could not find key %s", key)
+	}
+
+	cr, ok := obj.(*appsv1.ControllerRevision)
+	if !ok {
+		return nil, fmt.Errorf("unexpected resource %+v", obj)
+	}
+
+	raw := map[string]interface{}{}
+	err = json.Unmarshal(cr.Data.Raw, &raw)
+	if err != nil {
+		return nil, err
+	}
+	patch, err := json.Marshal(raw["spec"])
+	if err != nil {
+		return nil, err
+	}
+	vmSpec := virtv1.VirtualMachineSpec{}
+	err = json.Unmarshal(patch, &vmSpec)
+	if err != nil {
+		return nil, err
+	}
+	return &vmSpec, nil
+}
+
+func genFromKey(key string) (int64, error) {
+	items := strings.Split(key, "-")
+	genString := items[len(items)-1]
+	return strconv.ParseInt(genString, 10, 64)
+}
+
+func (c *VMController) getLastVMRevisionSpec(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachineSpec, error) {
+	keys, err := c.crInformer.GetIndexer().IndexKeys("vm", string(vm.UID))
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	var highestGen int64 = 0
+	var key string
+	for _, k := range keys {
+		if !strings.Contains(k, vmRevisionNamePrefix(vm.UID, revisionPrefixLastSeen)) {
+			continue
+		}
+		gen, err := genFromKey(k)
+		if err != nil {
+			return nil, fmt.Errorf("invalid key: %s", k)
+		}
+		if gen > highestGen {
+			if key != "" {
+				log.Log.Object(vm).Warningf("expected no more than 1 revision, found at least 2")
+			}
+			highestGen = gen
+			key = k
+		}
+	}
+
+	if key == "" {
+		return nil, fmt.Errorf("no revision found")
+	}
+	return c.getVMSpecForKey(key)
+}
+
+func (c *VMController) createVMRevision(vm *virtv1.VirtualMachine, prefix string) (string, error) {
+	vmRevisionName := getVMRevisionName(vm.UID, vm.Generation, prefix)
+	createNotNeeded, err := c.deleteOlderVMRevision(vm, prefix)
 	if err != nil || createNotNeeded {
 		return vmRevisionName, err
 	}
@@ -2762,9 +2835,17 @@ func (c *VMController) trimDoneVolumeRequests(vm *virtv1.VirtualMachine) {
 func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, key string, dataVolumes []*cdiv1.DataVolume) (*virtv1.VirtualMachine, syncError, error) {
 	var syncErr syncError
 	var err error
+	var lastSeenVMSpec *virtv1.VirtualMachineSpec
 
 	if !c.needsSync(key) {
 		return vm, nil, nil
+	}
+
+	if vm.Generation > 1 {
+		lastSeenVMSpec, err = c.getLastVMRevisionSpec(vm)
+		if err != nil {
+			log.Log.Object(vm).Reason(err).Infof("no revision found")
+		}
 	}
 
 	conditionManager := controller.NewVirtualMachineConditionManager()
@@ -2880,9 +2961,11 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 			}
 		}
 
-		err = c.handleCPUChangeRequest(vmCopy, vmi)
-		if err != nil {
-			syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling CPU change request: %v", err), HotPlugCPUErrorReason}
+		if lastSeenVMSpec == nil || !equality.Semantic.DeepEqual(lastSeenVMSpec.Template.Spec.Domain.CPU, vm.Spec.Template.Spec.Domain.CPU) {
+			err = c.handleCPUChangeRequest(vmCopy, vmi)
+			if err != nil {
+				syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling CPU change request: %v", err), HotPlugCPUErrorReason}
+			}
 		}
 
 		if err := c.handleAffinityChangeRequest(vmCopy, vmi); err != nil {
@@ -2905,6 +2988,13 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 			}
 		}
 	}
+
+	_, err = c.createVMRevision(vm, revisionPrefixLastSeen)
+	if err != nil {
+		log.Log.Object(vm).Reason(err).Error(failedCreateCRforVmErrMsg)
+		return vm, syncErr, err
+	}
+
 	virtControllerVMWorkQueueTracer.StepTrace(key, "sync", trace.Field{Key: "VM Name", Value: vm.Name})
 
 	return vm, syncErr, nil

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -260,9 +260,8 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(ok).To(BeTrue())
 
 				createObj := created.GetObject().(*appsv1.ControllerRevision)
-				Expect(createObj).To(Equal(vmRevision))
 
-				return true, created.GetObject(), nil
+				return createObj == vmRevision, created.GetObject(), nil
 			})
 		}
 
@@ -282,10 +281,10 @@ var _ = Describe("VirtualMachine", func() {
 			return runtime.RawExtension{Raw: patch}
 		}
 
-		createVMRevision := func(vm *virtv1.VirtualMachine) *appsv1.ControllerRevision {
+		createVMRevision := func(vm *virtv1.VirtualMachine, prefix string) *appsv1.ControllerRevision {
 			return &appsv1.ControllerRevision{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      getVMRevisionName(vm.UID, vm.Generation),
+					Name:      getVMRevisionName(vm.UID, vm.Generation, prefix),
 					Namespace: vm.Namespace,
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
@@ -1303,11 +1302,13 @@ var _ = Describe("VirtualMachine", func() {
 
 			addVirtualMachine(vm)
 
-			vmRevision := createVMRevision(vm)
-			expectControllerRevisionCreation(vmRevision)
+			vmRevisionStart := createVMRevision(vm, revisionPrefixStart)
+			vmRevisionLastSeen := createVMRevision(vm, revisionPrefixLastSeen)
+			expectControllerRevisionCreation(vmRevisionStart)
+			expectControllerRevisionCreation(vmRevisionLastSeen)
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.VirtualMachineRevisionName).To(Equal(vmRevision.Name))
+				Expect(arg.(*virtv1.VirtualMachineInstance).Status.VirtualMachineRevisionName).To(Equal(vmRevisionStart.Name))
 			}).Return(vmi, nil)
 
 			// expect update status is called
@@ -1324,11 +1325,11 @@ var _ = Describe("VirtualMachine", func() {
 		It("should delete older vmRevision and create VMI with new one", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 			vm.Generation = 1
-			oldVMRevision := createVMRevision(vm)
+			oldVMRevision := createVMRevision(vm, revisionPrefixStart)
 
 			vm.Generation = 2
 			addVirtualMachine(vm)
-			vmRevision := createVMRevision(vm)
+			vmRevision := createVMRevision(vm, revisionPrefixStart)
 
 			expectControllerRevisionList(oldVMRevision)
 			expectControllerRevisionDelete(oldVMRevision)
@@ -1443,8 +1444,8 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(gen).To(Equal(desiredGeneration))
 				}
 			},
-				Entry("with standard name", getVMRevisionName("9160e5de-2540-476a-86d9-af0081aee68a", 3), asInt64Ptr(3)),
-				Entry("with one dash in name", getVMRevisionName("abcdef", 5), asInt64Ptr(5)),
+				Entry("with standard name", getVMRevisionName("9160e5de-2540-476a-86d9-af0081aee68a", 3, revisionPrefixStart), asInt64Ptr(3)),
+				Entry("with one dash in name", getVMRevisionName("abcdef", 5, revisionPrefixStart), asInt64Ptr(5)),
 				Entry("with no dash in name", "12345", nil),
 				Entry("with ill formatted generation", "123-456-2b3b", nil),
 			)
@@ -1464,7 +1465,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm.Generation = 1
 					vm.Spec = revisionVmSpec
 
-					crName, err := controller.createVMRevision(vm)
+					crName, err := controller.createVMRevision(vm, revisionPrefixStart)
 					Expect(err).ToNot(HaveOccurred())
 
 					_, err = virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), crName, metav1.GetOptions{})
@@ -1671,7 +1672,7 @@ var _ = Describe("VirtualMachine", func() {
 				vmi.ObjectMeta.Annotations = initialAnnotations
 				vm.Generation = revisionVmGeneration
 
-				crName, err := controller.createVMRevision(vm)
+				crName, err := controller.createVMRevision(vm, revisionPrefixStart)
 				Expect(err).ToNot(HaveOccurred())
 
 				vmi.Status.VirtualMachineRevisionName = crName
@@ -1778,7 +1779,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm.Generation = revisionVmGeneration
 					vm.Spec = revisionVmSpec
 
-					crName, err := controller.createVMRevision(vm)
+					crName, err := controller.createVMRevision(vm, revisionPrefixStart)
 					Expect(err).ToNot(HaveOccurred())
 
 					vmi.Status.VirtualMachineRevisionName = crName


### PR DESCRIPTION
**What this PR does / why we need it**:
The upcoming implementation for [0] will require the ability to compare the previous generation against the current one when changes are made to the VM spec.
That requires the VM controller execution code to know the spec of the last seen VM.
This PR creates a new variable, `lastSeenVMSpec`, that represents the previous state of the VM.
It will be used by the hotplug/rolloutStrategy code in an upcoming PR.

In short, this is preliminary work that should not affect current behavior.

[0] https://github.com/kubevirt/community/pull/242

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The logic implemented in this PR compares the current VM template spec to the last seen VM template spec to know if a generic change occurred and if the RestartRequired condition should be set. The last seen VM template spec is kept as a Controller Revision.
Ideally the VMI spec would be used in place of the last seen VM template spec, but it doesn't work here because the VMI spec diverges too much from the VM template spec to be usable for a generic comparison.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
