### PR TITLE
libvmi: panic if a disk already exists

### DIFF
--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -33,8 +33,13 @@ func WithCloudInitNoCloudUserData(data string) Option {
 		addDiskVolumeWithCloudInitNoCloud(vmi, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
+		if volume.CloudInitNoCloud.UserData != "" {
+			panic("User Data are already set in NoCloud")
+		}
+		if volume.CloudInitNoCloud.UserDataBase64 != "" {
+			panic("User Data (base64) are already set in NoCloud")
+		}
 		volume.CloudInitNoCloud.UserData = data
-		volume.CloudInitNoCloud.UserDataBase64 = ""
 	}
 }
 

--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -30,7 +30,7 @@ const cloudInitDiskName = "disk1"
 // WithCloudInitNoCloudUserData adds cloud-init no-cloud user data.
 func WithCloudInitNoCloudUserData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+		addDiskVolumeWithCloudInitNoCloud(vmi, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
 		volume.CloudInitNoCloud.UserData = data
@@ -41,7 +41,7 @@ func WithCloudInitNoCloudUserData(data string) Option {
 // WithCloudInitNoCloudEncodedUserData adds cloud-init no-cloud base64-encoded user data
 func WithCloudInitNoCloudEncodedUserData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+		addDiskVolumeWithCloudInitNoCloud(vmi, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
 		encodedData := base64.StdEncoding.EncodeToString([]byte(data))
@@ -53,7 +53,7 @@ func WithCloudInitNoCloudEncodedUserData(data string) Option {
 // WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data.
 func WithCloudInitNoCloudNetworkData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+		addDiskVolumeWithCloudInitNoCloud(vmi, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
 		volume.CloudInitNoCloud.NetworkData = data
@@ -78,9 +78,9 @@ func addDiskVolumeWithCloudInitConfigDrive(vmi *v1.VirtualMachineInstance, diskN
 	addVolume(vmi, v)
 }
 
-func addDiskVolumeWithCloudInitNoCloud(vmi *v1.VirtualMachineInstance, diskName string, bus v1.DiskBus) {
-	addDisk(vmi, newDisk(diskName, bus))
-	v := newVolume(diskName)
+func addDiskVolumeWithCloudInitNoCloud(vmi *v1.VirtualMachineInstance, bus v1.DiskBus) {
+	addDisk(vmi, newDisk(cloudInitDiskName, bus))
+	v := newVolume(cloudInitDiskName)
 	setCloudInitNoCloud(&v, &v1.CloudInitNoCloudSource{})
 	addVolume(vmi, v)
 }

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -63,10 +63,9 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 
 // NewAlpine instantiates a new Alpine based VMI configuration
 func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	alpineMemory := cirrosMemory
 	alpineOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpine)),
-		WithResourceMemory(alpineMemory()),
+		WithAlpineResourceMemory(),
 		WithRng(),
 	}
 	alpineOpts = append(alpineOpts, opts...)
@@ -76,11 +75,10 @@ func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	// Supplied with no user data, AlpimeWithTestTooling image takes more than 200s to allow login
 	withNonEmptyUserData := WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
-	alpineMemory := cirrosMemory
 	alpineOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
 		withNonEmptyUserData,
-		WithResourceMemory(alpineMemory()),
+		WithAlpineResourceMemory(),
 		WithRng(),
 	}
 	alpineOpts = append(alpineOpts, opts...)
@@ -128,4 +126,8 @@ func NewWindows(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	}
 	vmi.Spec.Domain.Firmware = &kvirtv1.Firmware{UUID: WindowsFirmware}
 	return vmi
+}
+
+func WithAlpineResourceMemory() Option {
+	return WithResourceMemory(cirrosMemory())
 }

--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -101,15 +101,18 @@ func WithPersistentVolumeClaimLun(diskName, pvcName string, reservation bool) Op
 }
 
 func addDisk(vmi *v1.VirtualMachineInstance, disk v1.Disk) {
-	if !diskExists(vmi, disk) {
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
+	if diskExists(vmi, disk) {
+		panic(fmt.Sprintf("Conflic! disk %s already exists", disk.Name))
 	}
+	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
 }
 
 func addVolume(vmi *v1.VirtualMachineInstance, volume v1.Volume) {
-	if !volumeExists(vmi, volume) {
-		vmi.Spec.Volumes = append(vmi.Spec.Volumes, volume)
+	if volumeExists(vmi, volume) {
+		panic(fmt.Sprintf("Conflic! volume %s already exists", volume.Name))
 	}
+	vmi.Spec.Volumes = append(vmi.Spec.Volumes, volume)
+
 }
 
 func addFilesystem(vmi *v1.VirtualMachineInstance, filesystem v1.Filesystem) {

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -602,8 +602,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	Context("VirtualMachineInstance with custom dns", func() {
 		It("[test_id:1779]should have custom resolv.conf", func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
-			userData := "#cloud-config\n"
-			dnsVMI := libvmi.NewCirros(libvmi.WithCloudInitNoCloudUserData(userData))
+			dnsVMI := libvmi.NewCirros()
 
 			dnsVMI.Spec.DNSPolicy = "None"
 

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -86,8 +87,12 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 
 	DescribeTable("should copy a local file back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
-		vmi := libvmi.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
+		vmi := libvmi.New(
+			libvmi.WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
+			libvmi.WithAlpineResourceMemory(),
+			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)),
+			libvmi.WithRng(),
+		)
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -110,8 +115,12 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 
 	DescribeTable("should copy a local directory back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
-		vmi := libvmi.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
+		vmi := libvmi.New(
+			libvmi.WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
+			libvmi.WithAlpineResourceMemory(),
+			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)),
+			libvmi.WithRng(),
+		)
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -80,8 +81,12 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 
 	DescribeTable("should succeed to execute a command on the VM", func(cmdFn func(string)) {
 		By("injecting a SSH public key into a VMI")
-		vmi := libvmi.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
+		vmi := libvmi.New(
+			libvmi.WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
+			libvmi.WithAlpineResourceMemory(),
+			libvmi.WithRng(),
+			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)),
+		)
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -171,11 +171,10 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		}
 		privateKeyPath, publicKey, err := libssh.GenerateKeyPair(GinkgoT().TempDir())
 		Expect(err).ToNot(HaveOccurred())
-		userData := libssh.RenderUserDataWithKey(publicKey)
 		vmi := libvmi.NewFedora(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			libvmi.WithCloudInitNoCloudUserData(userData),
+			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(publicKey)),
 		)
 		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As of now the `libvmi` is silently ignoring any `Option` that would add a new disk/volume that has the same name as the existing disk/volume. This can lead to a situation where a test could test something that was not intended.

Therefore this PR is changing ignore to panic.

This change reveals that there is a problem with handling the cloud-init. The current `Option`s have semantic "last wins" and this as well can lead to tests that test something that was not intended. 

Therefore the second change is trying to fix a few Cloud-Init related `Option`s. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
