### PR TITLE
libvmi: less public constants

### DIFF
--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	DefaultInterfaceName = "default"
-	PasstBindingName     = "passt"
+	PasstBindingName = "passt"
 )
 
 // WithInterface adds a Domain Device Interface.
@@ -62,7 +61,7 @@ func WithPasstInterfaceWithPort() Option {
 // InterfaceDeviceWithMasqueradeBinding returns an Interface named "default" with masquerade binding.
 func InterfaceDeviceWithMasqueradeBinding(ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{
-		Name: DefaultInterfaceName,
+		Name: kvirtv1.DefaultPodNetwork().Name,
 		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
 			Masquerade: &kvirtv1.InterfaceMasquerade{},
 		},
@@ -104,7 +103,7 @@ func InterfaceDeviceWithSRIOVBinding(name string) kvirtv1.Interface {
 // InterfaceWithPasstBinding returns an Interface named "default" with passt binding plugin.
 func InterfaceWithPasstBindingPlugin(ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{
-		Name:    DefaultInterfaceName,
+		Name:    kvirtv1.DefaultPodNetwork().Name,
 		Binding: &kvirtv1.PluginBinding{Name: PasstBindingName},
 		Ports:   ports,
 	}

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -25,10 +25,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-const (
-	PasstBindingName = "passt"
-)
-
 // WithInterface adds a Domain Device Interface.
 func WithInterface(iface kvirtv1.Interface) Option {
 	return func(vmi *kvirtv1.VirtualMachineInstance) {
@@ -102,9 +98,10 @@ func InterfaceDeviceWithSRIOVBinding(name string) kvirtv1.Interface {
 
 // InterfaceWithPasstBinding returns an Interface named "default" with passt binding plugin.
 func InterfaceWithPasstBindingPlugin(ports ...kvirtv1.Port) kvirtv1.Interface {
+	const passtBindingName = "passt"
 	return kvirtv1.Interface{
 		Name:    kvirtv1.DefaultPodNetwork().Name,
-		Binding: &kvirtv1.PluginBinding{Name: PasstBindingName},
+		Binding: &kvirtv1.PluginBinding{Name: passtBindingName},
 		Ports:   ports,
 	}
 }

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -90,7 +90,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					libnet.SkipWhenClusterNotSupportIpv4()
 					var err error
 
-					vmi, err = newFedoraWithGuestAgentAndDefaultInterface(libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName))
+					vmi, err = newFedoraWithGuestAgentAndDefaultInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name))
 					Expect(err).NotTo(HaveOccurred())
 
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -140,7 +140,7 @@ var _ = SIGDescribe("Services", func() {
 
 		createVMISpecWithBridgeInterface := func() *v1.VirtualMachineInstance {
 			return libvmi.NewCirros(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName)),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()))
 		}
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -410,7 +410,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
 		It("[test_id:1773]should configure custom MAC address", func() {
 			By(checkingEth0MACAddr)
-			slirpIface := libvmi.InterfaceDeviceWithSlirpBinding(libvmi.DefaultInterfaceName)
+			slirpIface := libvmi.InterfaceDeviceWithSlirpBinding(v1.DefaultPodNetwork().Name)
 			slirpIface.MacAddress = "de:ad:00:00:be:af"
 			deadbeafVMI := libvmi.NewAlpine(
 				libvmi.WithInterface(slirpIface),

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -49,7 +49,7 @@ var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
 
 		vmi := libvmi.NewAlpineWithTestTooling(
 			libvmi.WithInterface(v1.Interface{
-				Name:                   libvmi.DefaultInterfaceName,
+				Name:                   v1.DefaultPodNetwork().Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}},
 				Ports:                  []v1.Port{{Port: 1234, Protocol: "TCP"}},
 				MacAddress:             macAddress,

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -100,11 +100,11 @@ var _ = SIGDescribe("Slirp Networking", decorators.Networking, func() {
 			genericVmi = libvmi.NewCirros(
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithInterface(
-					libvmi.InterfaceDeviceWithSlirpBinding(libvmi.DefaultInterfaceName, ports...)))
+					libvmi.InterfaceDeviceWithSlirpBinding(v1.DefaultPodNetwork().Name, ports...)))
 			deadbeafVmi = libvmi.NewCirros(
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithInterface(
-					libvmi.InterfaceDeviceWithSlirpBinding(libvmi.DefaultInterfaceName, ports...)))
+					libvmi.InterfaceDeviceWithSlirpBinding(v1.DefaultPodNetwork().Name, ports...)))
 			deadbeafVmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de:ad:00:00:be:af"
 		})
 

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -148,7 +148,7 @@ func fedoraMasqueradeVMI() *v1.VirtualMachineInstance {
 
 func fedoraBridgeBindingVMI() *v1.VirtualMachineInstance {
 	return libvmi.NewFedora(
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName)),
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 }
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -179,7 +179,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, 
 		Context("with bridge binding", func() {
 			BeforeEach(func() {
 				By("Starting Windows VirtualMachineInstance with bridge binding")
-				windowsVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName)}
+				windowsVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)}
 				var err error
 				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), windowsVMI)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
libvmi/network exposes two public constants, `DefaultInterfaceName` and `PasstBindingName` that should be used elsewhere and are not used elsewhere, respectively. Removing them makes `libvmi` API cleaner and more precise.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
