### PR TITLE
[test] avoid testing with terminationGracePeriod=0 by default for VMIs

### DIFF
--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -37,6 +37,9 @@ const (
 // NewFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options.
 // This image has tooling for the guest agent, stress, SR-IOV and more.
+// By default, terminationGracePeriod=1 to imply that
+// the corresponded pod will not be deleted with force trying to
+// kill containers and unmount volumes first.
 func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	fedoraOptions := []Option{
 		WithResourceMemory("512Mi"),
@@ -48,6 +51,9 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 }
 
 // NewCirros instantiates a new CirrOS based VMI configuration
+// By default, terminationGracePeriod=1 to imply that
+// the corresponded pod will not be deleted with force trying to
+// kill containers and unmount volumes first.
 func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	// Supplied with no user data, Cirros image takes 230s to allow login
 	withNonEmptyUserData := WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
@@ -62,6 +68,9 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 }
 
 // NewAlpine instantiates a new Alpine based VMI configuration
+// By default, terminationGracePeriod=1 to imply that
+// the corresponded pod will not be deleted with force trying to
+// kill containers and unmount volumes first.
 func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	alpineMemory := cirrosMemory
 	alpineOpts := []Option{

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -35,10 +35,16 @@ type Option func(vmi *v1.VirtualMachineInstance)
 
 // New instantiates a new VMI configuration,
 // building its properties based on the specified With* options.
+// By default, terminationGracePeriod=1 to imply that
+// the corresponded pod will not be deleted with force trying to
+// kill containers and unmount volumes first.
 func New(opts ...Option) *v1.VirtualMachineInstance {
 	vmi := baseVmi(randName())
 
-	WithTerminationGracePeriod(0)(vmi)
+	// The behavior for pods with spec.terminationGracePeriod: 0
+	// deleted without force is different, let's avoid that.
+	// See: https://github.com/kubernetes/kubernetes/issues/120671
+	WithTerminationGracePeriod(1)(vmi)
 	for _, f := range opts {
 		f(vmi)
 	}

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -295,8 +295,11 @@ var _ = SIGDescribe("Storage", func() {
 				)
 			})
 
-			DescribeTable("should be successfully started and stopped multiple times", func(newVMI VMICreationFunc) {
+			DescribeTable("should be successfully started and stopped multiple times", func(newVMI VMICreationFunc, terminationGracePeriod *int64) {
 				vmi = newVMI(tests.DiskAlpineHostPath)
+				if terminationGracePeriod != nil {
+					vmi.Spec.TerminationGracePeriodSeconds = terminationGracePeriod
+				}
 
 				num := 3
 				By("Starting and stopping the VirtualMachineInstance number of times")
@@ -315,8 +318,10 @@ var _ = SIGDescribe("Storage", func() {
 					libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 				}
 			},
-				Entry("[test_id:3132]with Disk PVC", newRandomVMIWithPVC),
-				Entry("[test_id:3133]with CDRom PVC", newRandomVMIWithCDRom),
+				Entry("[test_id:3132]with Disk PVC", newRandomVMIWithPVC, nil),
+				Entry("[test_id:3133]with CDRom PVC", newRandomVMIWithCDRom, nil),
+				Entry("with Disk PVC and terminationGracePeriod = 0", newRandomVMIWithPVC, pointer.P(int64(0))),
+				Entry("with CDRom PVC and terminationGracePeriod = 0", newRandomVMIWithCDRom, pointer.P(int64(0))),
 			)
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
To speedup our test suite, in the past we configured terminationGracePeriod=0 by default for all the VMIs used in the functional tests.

This has a few potential implications that should
be carefully considered.

The major one is:
https://github.com/kubernetes/kubernetes/issues/120671 : When a pod with spec.terminationGracePeriod: 0 is deleted without force, (which is exactly what we are doing by default for our test VMIs!) it's force-deleted from the API server, without kubelet killing its containers and unmounting its volumes first.

This could be dangerous because:
- the deletion flow in the test is different from what probably 99.9% of our users will rely on
- we are not really sure that the node resources got really freed up as expected before starting the next test introducing potential flakiness.

Setting by default spec.terminationGracePeriod: 1 on our test VMIs should only barely slow down the test suite although ensuring we are going to rely on the regular flow for pod deletion.

Extend one of the existing tests
("should be successfully started and stopped multiple times")
to ensure we are still also covering
the terminationGracePeriod=0 case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [https://issues.redhat.com/browse/CNV-36682](https://issues.redhat.com/browse/CNV-36682)

**Special notes for your reviewer**:
See https://github.com/kubernetes/kubernetes/issues/120671 for an explanation of the issue

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
