### PR TITLE
[guest-log] Explicitly trap more exit signals on virt-tail

### DIFF
--- a/cmd/virt-tail/main.go
+++ b/cmd/virt-tail/main.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -178,6 +179,7 @@ func (v *VirtTail) watchFS() error {
 			log.Log.V(3).Infof("watcher error: %v", werr)
 			return werr
 		case <-v.ctx.Done():
+			log.Log.V(3).Infof("ctx.Done")
 			return v.ctx.Err()
 		}
 	}
@@ -200,7 +202,7 @@ func main() {
 	}
 
 	// Create context that listens for the interrupt signal from the container runtime.
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGCHLD)
 	defer cancel()
 
 	g, gctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:
According to the CI results,
we have the feeling that the kubelet/CRI-O
is getting lazy (minutes) removing the virt-launcher pod although guest-console-log container and virt-tail process are clearly terminated at node level.
This is visible just with CRI-O >= 1.28 and
only when setting spec.terminationGracePeriodSeconds=0 at the VMI.
Although this smells like a bug in the Kubelet/CRI-O area, up to now we are able to hit this only for
the guest-console-log container so something there is probably leading to some corner case.

Still not clear (at least to me) why,
it seems that we are not able to reproduce the issue with this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-36682

**Special notes for your reviewer**:
Honestly I'm not able to explain why this should fix the issue, on the other side I have the evidence that with this I'm not able to reproduce it.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
