### PR TITLE
tests/utils.go: Get rid of RunVMI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ format:
 fmt: format
 
 lint:
-	if [ $$(wc -l < tests/utils.go) -gt 2100 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
+	if [ $$(wc -l < tests/utils.go) -gt 2027 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
 	hack/dockerized "golangci-lint run --timeout 20m --verbose \
 	  pkg/instancetype/... \

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -350,12 +350,13 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 				expectedSEVMeasurementInfo v1.SEVMeasurementInfo
 			)
 
-			vmi := newSEVFedora(false, libvmi.WithSEVAttestation())
-			vmi = tests.RunVMI(vmi, 30)
-			Eventually(ThisVMI(vmi), 60).Should(BeInPhase(v1.Scheduled))
-
 			virtClient, err := kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())
+
+			vmi := newSEVFedora(false, libvmi.WithSEVAttestation())
+			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(ThisVMI(vmi), 60).Should(BeInPhase(v1.Scheduled))
 
 			By("Querying virsh nodesevinfo")
 			nodeSevInfo := tests.RunCommandOnVmiPod(vmi, []string{"virsh", "nodesevinfo"})

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -292,7 +292,8 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		It("should fire VMCannotBeEvicted alert", func() {
 			By("starting non-migratable VMI with eviction strategy set to LiveMigrate ")
 			vmi := libvmi.NewAlpine(libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate))
-			vmi = tests.RunVMI(vmi, 240)
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for VMCannotBeEvicted alert")
 			verifyAlertExist(virtClient, "VMCannotBeEvicted")

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -117,8 +117,9 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 				v1.SetDefaults_NetworkInterface(bridgeVMI)
 				Expect(bridgeVMI.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
 
-				By("starting a VMI with bridged network on a node")
-				bridgeVMI = tests.RunVMI(bridgeVMI, 40)
+				By("creating a VMI with bridged network on a node")
+				bridgeVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(bridgeVMI)).Create(context.Background(), bridgeVMI)
+				Expect(err).ToNot(HaveOccurred())
 
 				// Start a VirtualMachineInstance with bridged networking
 				By("Waiting the VirtualMachineInstance start")

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -576,7 +576,9 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 240, Value: "private.options.kubevirt.io"}},
 			}
 
-			dhcpVMI = libwait.WaitUntilVMIReady(tests.RunVMI(dhcpVMI, 40), console.LoginToFedora)
+			dhcpVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(dhcpVMI)).Create(context.Background(), dhcpVMI)
+			Expect(err).ToNot(HaveOccurred())
+			dhcpVMI = libwait.WaitUntilVMIReady(dhcpVMI, console.LoginToFedora)
 
 			err = console.SafeExpectBatch(dhcpVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
@@ -615,7 +617,9 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Nameservers: []string{"8.8.8.8", "4.2.2.1", DNSNameserverWithLeadingZeros},
 				Searches:    []string{"example.com"},
 			}
-			dnsVMI = libwait.WaitUntilVMIReady(tests.RunVMI(dnsVMI, 40), console.LoginToCirros)
+			dnsVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(dnsVMI)).Create(context.Background(), dnsVMI)
+			Expect(err).ToNot(HaveOccurred())
+			dnsVMI = libwait.WaitUntilVMIReady(dnsVMI, console.LoginToCirros)
 			err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2943,11 +2943,11 @@ spec:
 				tests.UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
 
 				By("Checking launcher seccomp policy")
-				vmi := libvmi.NewCirros()
-				vmi = tests.RunVMI(vmi, 60)
+				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), libvmi.NewCirros())
+				Expect(err).ToNot(HaveOccurred())
 				fetchVMI := matcher.ThisVMI(vmi)
 				psaRelatedErrorDetected := false
-				err := wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
+				err = wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
 					vmi, err := fetchVMI()
 					if err != nil {
 						return done, err

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -291,7 +291,9 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					vmi = tests.RunVMI(vmi, 60)
+					vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+					Expect(err).ToNot(HaveOccurred())
+
 					vmis = append(vmis, vmi)
 					dvs = append(dvs, dataVolume)
 				}

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -876,7 +876,8 @@ var _ = SIGDescribe("Storage", func() {
 						libvmi.WithNamespace(testsuite.NamespacePrivileged),
 					)
 					vmi.Spec.Volumes[0].HostDisk.Capacity = resource.MustParse(strconv.Itoa(int(float64(diskSize) * 1.2)))
-					tests.RunVMI(vmi, 30)
+					vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+					Expect(err).ToNot(HaveOccurred())
 
 					By("Checking events")
 					objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(120) * time.Second)
@@ -972,9 +973,8 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithResourceMemory("128Mi"),
 					libvmi.WithPersistentVolumeClaim("disk0", pvcName),
 				)
-				vmi = tests.RunVMI(vmi, 10)
-
-				virtClient := kubevirt.Client()
+				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() bool {
 					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -236,21 +236,10 @@ func DeleteSecret(name, namespace string) {
 		util2.PanicOnError(err)
 	}
 }
-func RunVMI(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
-	By("Starting a VirtualMachineInstance")
-	virtCli := kubevirt.Client()
-
-	var obj *v1.VirtualMachineInstance
-	var err error
-	Eventually(func() error {
-		obj, err = virtCli.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
-		return err
-	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
-	return obj
-}
 
 func RunVMIAndExpectLaunch(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
-	vmi = RunVMI(vmi, timeout)
+	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+	Expect(err).ToNot(HaveOccurred())
 	By(waitingVMInstanceStart)
 	return libwait.WaitForVMIPhase(vmi,
 		[]v1.VirtualMachineInstancePhase{v1.Running},
@@ -259,7 +248,8 @@ func RunVMIAndExpectLaunch(vmi *v1.VirtualMachineInstance, timeout int) *v1.Virt
 }
 
 func RunVMIAndExpectLaunchWithDataVolume(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume, timeout int) *v1.VirtualMachineInstance {
-	vmi = RunVMI(vmi, timeout)
+	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+	Expect(err).ToNot(HaveOccurred())
 	By("Waiting until the DataVolume is ready")
 	libstorage.EventuallyDV(dv, timeout, HaveSucceeded())
 	By(waitingVMInstanceStart)
@@ -272,9 +262,10 @@ func RunVMIAndExpectLaunchWithDataVolume(vmi *v1.VirtualMachineInstance, dv *cdi
 }
 
 func RunVMIAndExpectLaunchIgnoreWarnings(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
-	obj := RunVMI(vmi, timeout)
+	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+	Expect(err).ToNot(HaveOccurred())
 	By(waitingVMInstanceStart)
-	return libwait.WaitForSuccessfulVMIStart(obj,
+	return libwait.WaitForSuccessfulVMIStart(vmi,
 		libwait.WithFailOnWarnings(false),
 		libwait.WithTimeout(timeout),
 	)
@@ -286,7 +277,8 @@ func RunVMIAndExpectScheduling(vmi *v1.VirtualMachineInstance, timeout int) *v1.
 }
 
 func RunVMIAndExpectSchedulingWithWarningPolicy(vmi *v1.VirtualMachineInstance, timeout int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
-	vmi = RunVMI(vmi, timeout)
+	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+	Expect(err).ToNot(HaveOccurred())
 	By("Waiting until the VirtualMachineInstance will be scheduled")
 	return libwait.WaitForVMIPhase(vmi,
 		[]v1.VirtualMachineInstancePhase{v1.Scheduling, v1.Scheduled, v1.Running},

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -557,8 +557,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				guestMemory := resource.MustParse("4096M")
 				vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
-				runningVMI := tests.RunVMI(vmi, 30)
-				Expect(runningVMI.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("2048M"))
+				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("2048M"))
 			})
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This function was giving the false impression of allowing the caller to
wait for the VMI to be running by allowing to supply a timeout.

In reality this function only created a VMI and was using a nonsensical
Eventually loop around the Create call.

Get rid of RunVMI by replacing all its usages with direct calls to the
kubevirt client.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
