### PR TITLE
[chore] Address a ginkgolinter warning

### DIFF
--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -105,7 +105,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 						foundContainer = true
 					}
 				}
-				Expect(foundContainer).To(Equal(true))
+				Expect(foundContainer).To(BeTrue())
 
 				By("Triggering a shutdown from the guest OS")
 				Expect(console.LoginToCirros(vmi)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
Address a ginkgolinter warning
introduced with https://github.com/kubevirt/kubevirt/pull/10993 since it's currently preventing a backport
of it to a stabilization branch
where ginkgolinter is enforcing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/pull/11026

**Special notes for your reviewer**:
No real code changes, it's simply addressing a ginkolinter warning. 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
