### PR TITLE
[release-1.1] Aggregate DVs conditions on VMI (and so VM) (simplified)

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -562,6 +562,8 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		}
 	}
 
+	c.aggregateDataVolumesConditions(vmiCopy, dataVolumes)
+
 	switch {
 	case vmi.IsUnprocessed():
 		if vmiPodExists {
@@ -2405,4 +2407,45 @@ func (c *VMIController) syncMemoryHotplug(vmi *virtv1.VirtualMachineInstance) {
 		}
 		vmi.Labels[virtv1.MemoryHotplugOverheadRatioLabel] = *overheadRatio
 	}
+}
+
+func (c *VMIController) aggregateDataVolumesConditions(vmiCopy *virtv1.VirtualMachineInstance, dvs []*cdiv1.DataVolume) {
+	if len(dvs) == 0 {
+		return
+	}
+
+	dvsReadyCondition := virtv1.VirtualMachineInstanceCondition{
+		Status:  k8sv1.ConditionTrue,
+		Type:    virtv1.VirtualMachineInstanceDataVolumesReady,
+		Reason:  virtv1.VirtualMachineInstanceReasonAllDVsReady,
+		Message: "All of the VMI's DVs are bound and not running",
+	}
+
+	for _, dv := range dvs {
+		cStatus := statusOfReadyCondition(dv.Status.Conditions)
+		if cStatus != k8sv1.ConditionTrue {
+			dvsReadyCondition.Reason = virtv1.VirtualMachineInstanceReasonNotAllDVsReady
+			if cStatus == k8sv1.ConditionFalse {
+				dvsReadyCondition.Status = cStatus
+			} else if dvsReadyCondition.Status == k8sv1.ConditionTrue {
+				dvsReadyCondition.Status = cStatus
+			}
+		}
+	}
+
+	if dvsReadyCondition.Status != k8sv1.ConditionTrue {
+		dvsReadyCondition.Message = "Not all of the VMI's DVs are ready"
+	}
+
+	vmiConditions := controller.NewVirtualMachineInstanceConditionManager()
+	vmiConditions.UpdateCondition(vmiCopy, &dvsReadyCondition)
+}
+
+func statusOfReadyCondition(conditions []cdiv1.DataVolumeCondition) k8sv1.ConditionStatus {
+	for _, condition := range conditions {
+		if condition.Type == cdiv1.DataVolumeReady {
+			return condition.Status
+		}
+	}
+	return k8sv1.ConditionUnknown
 }

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -192,7 +192,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	shouldExpectVirtualMachineSchedulingState := func(vmi *virtv1.VirtualMachineInstance) {
 		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduling))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
+			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 				Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
@@ -202,7 +202,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	shouldExpectVirtualMachineScheduledState := func(vmi *virtv1.VirtualMachineInstance) {
 		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduled))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
+			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 				Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
@@ -212,10 +212,24 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	shouldExpectVirtualMachineFailedState := func(vmi *virtv1.VirtualMachineInstance) {
 		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Failed))
-			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
+			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 				Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
 			Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).ToNot(HaveLen(len(vmi.Status.PhaseTransitionTimestamps)))
+		}).Return(vmi, nil)
+	}
+
+	shouldExpectVirtualMachineDataVolumesReadyCondition := func(vmi *virtv1.VirtualMachineInstance, expectedStatus k8sv1.ConditionStatus) {
+		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
+			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Fields{"Type": BeEquivalentTo(virtv1.VirtualMachineInstanceDataVolumesReady), "Status": BeEquivalentTo(expectedStatus)})))
+		}).Return(vmi, nil)
+	}
+
+	shouldExpectVirtualMachineDataVolumesReadyConditionWithMessage := func(vmi *virtv1.VirtualMachineInstance, expectedStatus k8sv1.ConditionStatus, expectedMessage string) {
+		vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
+			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Fields{"Type": BeEquivalentTo(virtv1.VirtualMachineInstanceDataVolumesReady), "Status": BeEquivalentTo(expectedStatus), "Message": BeEquivalentTo(expectedMessage)})))
 		}).Return(vmi, nil)
 	}
 
@@ -339,6 +353,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
+			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
 			shouldExpectPodCreation(vmi.UID)
 
 			controller.Execute()
@@ -364,8 +379,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
-					Fields{"Type": Equal(virtv1.VirtualMachineInstanceProvisioning)})))
+				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElements(
+					MatchFields(IgnoreExtras, Fields{"Type": BeEquivalentTo(virtv1.VirtualMachineInstanceProvisioning)}),
+					MatchFields(IgnoreExtras, Fields{"Type": BeEquivalentTo(virtv1.VirtualMachineInstanceDataVolumesReady), "Status": BeEquivalentTo(k8sv1.ConditionFalse)}),
+				))
 			}).Return(vmi, nil)
 
 			IsPodWithoutVmPayload := WithTransform(
@@ -453,6 +470,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 			addActivePods(vmi, pod.UID, "")
 			dataVolumeFeeder.Add(dataVolume)
+			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
 			shouldExpectPodDeletion(pod)
 
 			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
@@ -550,7 +568,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
-
+			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionFalse)
 			controller.Execute()
 		})
 	})
@@ -579,6 +597,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
+			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
 			shouldExpectPodCreation(vmi.UID)
 
 			controller.Execute()
@@ -689,6 +708,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 			dataVolumeFeeder.Add(dataVolume)
 			shouldExpectPodDeletion(pod)
+			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
 			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
 				return true, dvPVC, nil
 			})
@@ -715,6 +735,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
+			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionFalse)
 
 			controller.Execute()
 		})
@@ -3475,10 +3496,158 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			)
 		})
 	})
+
+	Context("Aggregating DataVolume conditions", func() {
+
+		dvVolumeSource1 := virtv1.VolumeSource{
+			DataVolume: &virtv1.DataVolumeSource{
+				Name: "test1",
+			},
+		}
+		dvVolumeSource2 := virtv1.VolumeSource{
+			DataVolume: &virtv1.DataVolumeSource{
+				Name: "test2",
+			},
+		}
+		dvVolumeSource3 := virtv1.VolumeSource{
+			DataVolume: &virtv1.DataVolumeSource{
+				Name: "test3",
+			},
+		}
+		DescribeTable("Should aggregate conditions from 3 DataVolumes on VMI status",
+			func(dvConds1, dvConds2, dvConds3 []cdiv1.DataVolumeCondition, expectedStatus k8sv1.ConditionStatus, expectedMessage string) {
+				vmi := NewPendingVirtualMachine("testvmi")
+
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+					Name:         "test1",
+					VolumeSource: dvVolumeSource1,
+				})
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+					Name:         "test2",
+					VolumeSource: dvVolumeSource2,
+				})
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+					Name:         "test3",
+					VolumeSource: dvVolumeSource3,
+				})
+
+				dvPVC1 := NewPvc(vmi.Namespace, "test1")
+				dvPVC2 := NewPvc(vmi.Namespace, "test2")
+				dvPVC3 := NewPvc(vmi.Namespace, "test3")
+				// we are mocking a successful DataVolume. we expect the PVC to
+				// be available in the store if DV is successful.
+				Expect(pvcInformer.GetIndexer().Add(dvPVC1)).To(Succeed())
+				Expect(pvcInformer.GetIndexer().Add(dvPVC2)).To(Succeed())
+				Expect(pvcInformer.GetIndexer().Add(dvPVC3)).To(Succeed())
+
+				dataVolume1 := NewDv(vmi.Namespace, "test1", cdiv1.Unknown)
+				dataVolume2 := NewDv(vmi.Namespace, "test2", cdiv1.Unknown)
+				dataVolume3 := NewDv(vmi.Namespace, "test3", cdiv1.Unknown)
+				for _, c := range dvConds1 {
+					setDataVolumeCondition(dataVolume1, c)
+				}
+				for _, c := range dvConds2 {
+					setDataVolumeCondition(dataVolume2, c)
+				}
+				for _, c := range dvConds3 {
+					setDataVolumeCondition(dataVolume3, c)
+				}
+
+				addVirtualMachine(vmi)
+				dataVolumeFeeder.Add(dataVolume1)
+				dataVolumeFeeder.Add(dataVolume2)
+				dataVolumeFeeder.Add(dataVolume3)
+				shouldExpectVirtualMachineDataVolumesReadyConditionWithMessage(vmi, expectedStatus, expectedMessage)
+				shouldExpectPodCreation(vmi.UID)
+
+				controller.Execute()
+				testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+			},
+			Entry("3 ready DataVolumes",
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				k8sv1.ConditionTrue,
+				"All of the VMI's DVs are bound and not running",
+			),
+			Entry("2 ready DataVolumes, 1 not ready",
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionFalse},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				k8sv1.ConditionFalse,
+				"Not all of the VMI's DVs are ready",
+			),
+			Entry("3 Unknown DataVolumes",
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionUnknown},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionUnknown},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionUnknown},
+				},
+				k8sv1.ConditionUnknown,
+				"Not all of the VMI's DVs are ready",
+			),
+			Entry("2 ready, 1 unknown",
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionUnknown},
+				},
+				k8sv1.ConditionUnknown,
+				"Not all of the VMI's DVs are ready",
+			),
+			Entry("1 ready, 1 not ready, 1 unknown",
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionFalse},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionUnknown},
+				},
+				k8sv1.ConditionFalse,
+				"Not all of the VMI's DVs are ready",
+			),
+			Entry("1 ready, 1 unknown, 1 not ready",
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionTrue},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionUnknown},
+				},
+				[]cdiv1.DataVolumeCondition{
+					{Type: cdiv1.DataVolumeReady, Status: k8sv1.ConditionFalse},
+				},
+				k8sv1.ConditionFalse,
+				"Not all of the VMI's DVs are ready",
+			),
+		)
+
+	})
 })
 
 func NewDv(namespace string, name string, phase cdiv1.DataVolumePhase) *cdiv1.DataVolume {
-	return &cdiv1.DataVolume{
+	dv := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -3487,6 +3656,116 @@ func NewDv(namespace string, name string, phase cdiv1.DataVolumePhase) *cdiv1.Da
 			Phase: phase,
 		},
 	}
+
+	// mock phase coherent conditions
+	switch phase {
+	case cdiv1.Pending,
+		cdiv1.WaitForFirstConsumer,
+		cdiv1.PendingPopulation:
+		dv.Status.Conditions = []cdiv1.DataVolumeCondition{
+			{
+				Type:   cdiv1.DataVolumeBound,
+				Status: k8sv1.ConditionFalse,
+			},
+			{
+				Type:   cdiv1.DataVolumeRunning,
+				Status: k8sv1.ConditionFalse,
+			},
+			{
+				Type:   cdiv1.DataVolumeReady,
+				Status: k8sv1.ConditionFalse,
+			},
+		}
+	case cdiv1.PVCBound:
+		dv.Status.Conditions = []cdiv1.DataVolumeCondition{
+			{
+				Type:   cdiv1.DataVolumeBound,
+				Status: k8sv1.ConditionTrue,
+			},
+			{
+				Type:   cdiv1.DataVolumeRunning,
+				Status: k8sv1.ConditionFalse,
+			},
+			{
+				Type:   cdiv1.DataVolumeReady,
+				Status: k8sv1.ConditionFalse,
+			},
+		}
+	case cdiv1.ImportScheduled,
+		cdiv1.ImportInProgress,
+		cdiv1.CloneScheduled,
+		cdiv1.CloneInProgress,
+		cdiv1.SnapshotForSmartCloneInProgress,
+		cdiv1.CloneFromSnapshotSourceInProgress,
+		cdiv1.SmartClonePVCInProgress,
+		cdiv1.CSICloneInProgress,
+		cdiv1.ExpansionInProgress,
+		cdiv1.NamespaceTransferInProgress,
+		cdiv1.UploadScheduled,
+		cdiv1.UploadReady:
+		dv.Status.Conditions = []cdiv1.DataVolumeCondition{
+			{
+				Type:   cdiv1.DataVolumeBound,
+				Status: k8sv1.ConditionTrue,
+			},
+			{
+				Type:   cdiv1.DataVolumeRunning,
+				Status: k8sv1.ConditionTrue,
+			},
+			{
+				Type:   cdiv1.DataVolumeReady,
+				Status: k8sv1.ConditionFalse,
+			},
+		}
+	case cdiv1.Succeeded:
+		dv.Status.Conditions = []cdiv1.DataVolumeCondition{
+			{
+				Type:   cdiv1.DataVolumeBound,
+				Status: k8sv1.ConditionTrue,
+			},
+			{
+				Type:   cdiv1.DataVolumeRunning,
+				Status: k8sv1.ConditionFalse,
+			},
+			{
+				Type:   cdiv1.DataVolumeReady,
+				Status: k8sv1.ConditionTrue,
+			},
+		}
+	case cdiv1.Failed, cdiv1.Paused:
+		dv.Status.Conditions = []cdiv1.DataVolumeCondition{
+			{
+				Type:   cdiv1.DataVolumeBound,
+				Status: k8sv1.ConditionTrue,
+			},
+			{
+				Type:   cdiv1.DataVolumeRunning,
+				Status: k8sv1.ConditionFalse,
+			},
+			{
+				Type:   cdiv1.DataVolumeReady,
+				Status: k8sv1.ConditionFalse,
+			},
+		}
+	case cdiv1.Unknown:
+	default:
+		dv.Status.Conditions = []cdiv1.DataVolumeCondition{
+			{
+				Type:   cdiv1.DataVolumeBound,
+				Status: k8sv1.ConditionUnknown,
+			},
+			{
+				Type:   cdiv1.DataVolumeRunning,
+				Status: k8sv1.ConditionUnknown,
+			},
+			{
+				Type:   cdiv1.DataVolumeReady,
+				Status: k8sv1.ConditionUnknown,
+			},
+		}
+	}
+
+	return dv
 }
 
 func NewPvc(namespace string, name string) *k8sv1.PersistentVolumeClaim {
@@ -3538,6 +3817,18 @@ func setReadyCondition(vmi *virtv1.VirtualMachineInstance, status k8sv1.Conditio
 		Status: status,
 		Reason: reason,
 	})
+}
+
+func setDataVolumeCondition(dv *cdiv1.DataVolume, cond cdiv1.DataVolumeCondition) {
+	for _, c := range dv.Status.Conditions {
+		if c.Type == cond.Type {
+			c.Status = cond.Status
+			c.Message = cond.Message
+			c.Reason = cond.Reason
+			return
+		}
+	}
+	dv.Status.Conditions = append(dv.Status.Conditions, cond)
 }
 
 func NewPodForVirtualMachine(vmi *virtv1.VirtualMachineInstance, phase k8sv1.PodPhase) *k8sv1.Pod {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -558,6 +558,14 @@ const (
 	VirtualMachineInstanceVCPUChange = "HotVCPUChange"
 	// Indicates that the VMI is hot(un)plugging memory
 	VirtualMachineInstanceMemoryChange = "HotMemoryChange"
+
+	// Summarizes that all the DataVolumes attached to the VMI are Ready or not
+	VirtualMachineInstanceDataVolumesReady = "DataVolumesReady"
+
+	// Reason means that not all of the VMI's DVs are ready
+	VirtualMachineInstanceReasonNotAllDVsReady = "NotAllDVsReady"
+	// Reason means that all of the VMI's DVs are bound and not running
+	VirtualMachineInstanceReasonAllDVsReady = "AllDVsReady"
 )
 
 const (

--- a/tests/framework/matcher/BUILD.bazel
+++ b/tests/framework/matcher/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//tests/framework/matcher/helper:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/format:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/framework/matcher/phase.go
+++ b/tests/framework/matcher/phase.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"reflect"
 
+	v1 "kubevirt.io/api/core/v1"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -156,4 +160,12 @@ func collectPhasesForPrinting(actual interface{}) (phases []string) {
 
 func getExpectedPhase(actual interface{}) string {
 	return reflect.ValueOf(actual).String()
+}
+
+func HavePrintableStatus(status v1.VirtualMachinePrintableStatus) types.GomegaMatcher {
+	return PointTo(MatchFields(IgnoreExtras, Fields{
+		"Status": MatchFields(IgnoreExtras, Fields{
+			"PrintableStatus": Equal(status),
+		}),
+	}))
 }

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -401,7 +401,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					libvmi.WithDataVolume(dataVolume2.Name, dataVolume2.Name),
 					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 				)
-				vmSpec := libvmi.NewVirtualMachine(vmi, libvmi.WithRunning())
+				vmSpec := tests.NewRandomVirtualMachine(vmi, true)
 
 				vm, err := virtClient.VirtualMachine(vmSpec.Namespace).Create(context.Background(), vmSpec)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -594,7 +594,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			vm := createRunningVM(virtClient, vmi)
 
 			By("Verifying that the VM status eventually gets set to FailedUnschedulable")
-			Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(havePrintableStatus(v1.VirtualMachineStatusUnschedulable))
+			Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(HavePrintableStatus(v1.VirtualMachineStatusUnschedulable))
 		},
 			Entry("[test_id:6867]with unsatisfiable resource requirements", func(vmi *v1.VirtualMachineInstance) {
 				vmi.Spec.Domain.Resources.Requests = corev1.ResourceList{
@@ -621,14 +621,14 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Verifying that the status toggles between ErrImagePull and ImagePullBackOff")
 			const times = 2
 			for i := 0; i < times; i++ {
-				Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(havePrintableStatus(v1.VirtualMachineStatusErrImagePull))
-				Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(havePrintableStatus(v1.VirtualMachineStatusImagePullBackOff))
+				Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(HavePrintableStatus(v1.VirtualMachineStatusErrImagePull))
+				Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(HavePrintableStatus(v1.VirtualMachineStatusImagePullBackOff))
 			}
 		})
 
 		DescribeTable("should report an error status when a VM with a missing PVC/DV is started", func(vmiFunc func() *v1.VirtualMachineInstance, status v1.VirtualMachinePrintableStatus) {
 			vm := createRunningVM(virtClient, vmiFunc())
-			Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(havePrintableStatus(status))
+			Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(HavePrintableStatus(status))
 		},
 			Entry(
 				"[test_id:7596]missing PVC",
@@ -671,7 +671,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying that the VM status eventually gets set to DataVolumeError")
-			Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(havePrintableStatus(v1.VirtualMachineStatusDataVolumeError))
+			Eventually(ThisVM(vm), 300*time.Second, 1*time.Second).Should(HavePrintableStatus(v1.VirtualMachineStatusDataVolumeError))
 		})
 
 		Context("Using virtctl interface", func() {
@@ -1289,7 +1289,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(startCommand()).To(Succeed())
 
 					By("Waiting for VM to be in Starting status")
-					Eventually(ThisVM(vm), 160*time.Second, 1*time.Second).Should(havePrintableStatus(v1.VirtualMachineStatusStarting))
+					Eventually(ThisVM(vm), 160*time.Second, 1*time.Second).Should(HavePrintableStatus(v1.VirtualMachineStatusStarting))
 
 					By("Waiting for VMI to fail")
 					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 480*time.Second, 1*time.Second).Should(BeInPhase(v1.Failed))
@@ -2035,14 +2035,6 @@ func notBeInCrashLoop() gomegatypes.GomegaMatcher {
 	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 		"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 			"StartFailure": BeNil(),
-		}),
-	}))
-}
-
-func havePrintableStatus(status v1.VirtualMachinePrintableStatus) gomegatypes.GomegaMatcher {
-	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-		"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-			"PrintableStatus": Equal(status),
 		}),
 	}))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/10905 due to the need of amending the functional test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11030 

**Special notes for your reviewer**:
A small change on the functional test  is needed due to the lack
of `NewVirtualMachine` helper function on older branches.
See #10947

/assign acardace

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Aggregate DVs conditions on VMI (and so VM)
```
