### PR TITLE
PR Template: Added a little more guidance on how to structure PR desc…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,14 +3,24 @@
 2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
 -->
 
-**What this PR does / why we need it**:
+## What this PR does
+Before this PR 
 
-**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+After this PR 
+
+<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
 Fixes #
 
-**Special notes for your reviewer**:
+## Why we need it and why it was done in this way
+The following tradeoffs were made:
 
-**Checklist**
+The following alternatives were considered:
+
+## Special notes for your reviewer
+
+None/Some
+
+## Checklist
 
 This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
 Approvers are expected to review this list.
@@ -24,7 +34,7 @@ Approvers are expected to review this list.
 - [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
 - [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
 
-**Release note**:
+## Release note
 <!--  Write your release note:
 1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
 2. If no release note is required, just write "NONE".
@@ -32,3 +42,4 @@ Approvers are expected to review this list.
 ```release-note
 
 ```
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,24 +3,24 @@
 2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
 -->
 
-## What this PR does
-Before this PR 
+### What this PR does
+Before this PR:
 
-After this PR 
+After this PR:
 
 <!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
 Fixes #
 
-## Why we need it and why it was done in this way
+### Why we need it and why it was done in this way
 The following tradeoffs were made:
 
 The following alternatives were considered:
 
-## Special notes for your reviewer
+### Special notes for your reviewer
 
-None/Some
+<!-- optional -->
 
-## Checklist
+### Checklist
 
 This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
 Approvers are expected to review this list.
@@ -34,7 +34,7 @@ Approvers are expected to review this list.
 - [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
 - [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
 
-## Release note
+### Release note
 <!--  Write your release note:
 1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
 2. If no release note is required, just write "NONE".

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,9 @@ The following tradeoffs were made:
 
 The following alternatives were considered:
 
+Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
+-
+
 ### Special notes for your reviewer
 
 <!-- optional -->


### PR DESCRIPTION
### What this PR does
Before this PR there was less guidance on how to describe the scope of a PR

After this PR some more hints are left in the PR template to provide a better structure to described the changes of a PR

### Why we need it and why it was done in this way
The following tradeoffs were made: The goal was to document better WHY changes were made, and the reasoning history of them. Thus I added a few more quetsions, but still tried to keep it lean.

The following alternatives were considered: Keep it as is.

### Special notes for your reviewer

Please remember that this change will help people in future to understand the reasoning of PRs better

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

## Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
