### PR TITLE
vmi update admission webhook: fix volume miscount when using filesystems

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/testutils"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )
 
@@ -58,8 +59,21 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			Phase: v1.KubeVirtPhaseDeploying,
 		},
 	}
-	config, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
+	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
 	vmiUpdateAdmitter := &VMIUpdateAdmitter{config}
+
+	enableFeatureGate := func(featureGate string) {
+		kvConfig := kv.DeepCopy()
+		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
+		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
+	}
+	disableFeatureGates := func() {
+		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kv)
+	}
+
+	AfterEach(func() {
+		disableFeatureGates()
+	})
 
 	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
 		input := map[string]interface{}{}
@@ -434,6 +448,17 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 		return res
 	}
 
+	makeFilesystems := func(indexes ...int) []v1.Filesystem {
+		res := make([]v1.Filesystem, 0)
+		for _, index := range indexes {
+			res = append(res, v1.Filesystem{
+				Name:     fmt.Sprintf("volume-name-%d", index),
+				Virtiofs: &v1.FilesystemVirtiofs{},
+			})
+		}
+		return res
+	}
+
 	makeStatus := func(statusCount, hotplugCount int) []v1.VolumeStatus {
 		res := make([]v1.VolumeStatus, 0)
 		for i := 0; i < statusCount; i++ {
@@ -483,19 +508,23 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 		Entry("Should return 3 volumes if  1 hotplugged volume", makeVolumes(0, 1, 2, 3), makeStatus(4, 1), makeResult(0, 1, 2)),
 	)
 
-	DescribeTable("Should return proper admission response", func(newVolumes, oldVolumes []v1.Volume, newDisks, oldDisks []v1.Disk, volumeStatuses []v1.VolumeStatus, expected *admissionv1.AdmissionResponse) {
+	testHotplugResponse := func(newVolumes, oldVolumes []v1.Volume, newDisks, oldDisks []v1.Disk, filesystems []v1.Filesystem, volumeStatuses []v1.VolumeStatus, expected *admissionv1.AdmissionResponse) {
 		newVMI := api.NewMinimalVMI("testvmi")
 		newVMI.Spec.Volumes = newVolumes
 		newVMI.Spec.Domain.Devices.Disks = newDisks
+		newVMI.Spec.Domain.Devices.Filesystems = filesystems
 
 		result := admitHotplugStorage(newVolumes, oldVolumes, newDisks, oldDisks, volumeStatuses, newVMI, vmiUpdateAdmitter.ClusterConfig)
 		Expect(equality.Semantic.DeepEqual(result, expected)).To(BeTrue(), "result: %v and expected: %v do not match", result, expected)
-	},
+	}
+
+	DescribeTable("Should return proper admission response", testHotplugResponse,
 		Entry("Should accept if no volumes are there or added",
 			makeVolumes(),
 			makeVolumes(),
 			makeDisks(),
 			makeDisks(),
+			makeFilesystems(),
 			makeStatus(0, 0),
 			nil),
 		Entry("Should reject if #volumes != #disks",
@@ -503,13 +532,15 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(1, 2),
 			makeDisks(1),
 			makeDisks(1),
+			makeFilesystems(),
 			makeStatus(0, 0),
-			makeExpected("number of disks (1) does not equal the number of volumes (2)", "")),
+			makeExpected("number of disks and filesystems (1) does not equal the number of volumes (2)", "")),
 		Entry("Should reject if we remove a permanent volume",
 			makeVolumes(),
 			makeVolumes(0),
 			makeDisks(),
 			makeDisks(0),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("Number of permanent volumes has changed", "")),
 		Entry("Should reject if we add a disk without a matching volume",
@@ -517,6 +548,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0),
 			makeDisksNoVolume(0, 1),
 			makeDisksNoVolume(0),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("Disk volume-name-1 does not exist", "")),
 		Entry("Should reject if we modify existing volume to be invalid",
@@ -524,6 +556,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0, 1),
 			makeDisksNoVolume(0, 1),
 			makeDisks(0, 1),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("permanent disk volume-name-0, changed", "")),
 		Entry("Should reject if a hotplug volume changed",
@@ -531,6 +564,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0, 1),
 			makeDisks(0, 1),
 			makeDisks(0, 1),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("hotplug volume volume-name-1, changed", "")),
 		Entry("Should reject if we add volumes that are not PVC or DV",
@@ -538,6 +572,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0),
 			makeDisks(0, 1),
 			makeDisks(0),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("volume volume-name-1 is not a PVC or DataVolume", "")),
 		Entry("Should accept if we add volumes and disk properly",
@@ -545,6 +580,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0, 1),
 			makeDisks(0, 1),
 			makeDisks(0, 1),
+			makeFilesystems(),
 			makeStatus(2, 1),
 			nil),
 		Entry("Should accept if we add LUN disk with valid SCSI bus",
@@ -552,6 +588,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0, 1),
 			makeLUNDisks(0, 1),
 			makeLUNDisks(0, 1),
+			makeFilesystems(),
 			makeStatus(2, 1),
 			nil),
 		Entry("Should reject if we add disk with invalid bus",
@@ -559,6 +596,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0),
 			makeDisksInvalidBusLastDisk(0, 1),
 			makeDisks(0),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("hotplugged Disk volume-name-1 does not use a scsi bus", "")),
 		Entry("Should reject if we add LUN disk with invalid bus",
@@ -566,6 +604,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0),
 			makeLUNDisksInvalidBusLastDisk(0, 1),
 			makeLUNDisks(0),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("hotplugged Disk volume-name-1 does not use a scsi bus", "")),
 		Entry("Should reject if we add disk with neither Disk nor LUN type",
@@ -573,6 +612,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0),
 			makeCDRomDisks(0, 1),
 			makeCDRomDisks(0),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("Disk volume-name-1 requires diskDevice of type 'disk' or 'lun' to be hotplugged.", "")),
 		Entry("Should reject if we add disk with invalid boot order",
@@ -580,6 +620,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0),
 			makeDisksInvalidBootOrder(0, 1),
 			makeDisks(0),
+			makeFilesystems(),
 			makeStatus(1, 0),
 			makeExpected("spec.domain.devices.disks[1] must have a boot order > 0, if supplied", "spec.domain.devices.disks[1].bootOrder")),
 		Entry("Should accept if memory dump volume exists without matching disk",
@@ -587,6 +628,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumes(0, 1),
 			makeDisks(0, 1),
 			makeDisks(0, 1),
+			makeFilesystems(),
 			makeStatus(3, 1),
 			nil),
 		Entry("Should reject if #volumes != #disks even when there is memory dump volume",
@@ -594,9 +636,35 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeVolumesWithMemoryDumpVol(3, 2),
 			makeDisks(1),
 			makeDisks(1),
+			makeFilesystems(),
 			makeStatus(0, 0),
-			makeExpected("number of disks (1) does not equal the number of volumes (2)", "")),
+			makeExpected("number of disks and filesystems (1) does not equal the number of volumes (2)", "")),
 	)
+
+	Context("with filesystem devices", func() {
+		BeforeEach(func() {
+			enableFeatureGate(virtconfig.VirtIOFSGate)
+		})
+
+		DescribeTable("Should return proper admission response", testHotplugResponse,
+			Entry("Should accept if volume without matching disk is used by filesystem",
+				makeVolumes(0, 1, 2),
+				makeVolumes(0, 1),
+				makeDisks(0, 2),
+				makeDisks(0),
+				makeFilesystems(1),
+				makeStatus(3, 1),
+				nil),
+			Entry("Should reject if #volumes != #disks even when there are volumes used by filesystems",
+				makeVolumes(0, 1, 2),
+				makeVolumes(0, 1, 2),
+				makeDisks(0),
+				makeDisks(0),
+				makeFilesystems(1),
+				makeStatus(2, 0),
+				makeExpected("number of disks and filesystems (2) does not equal the number of volumes (3)", "")),
+		)
+	})
 
 	DescribeTable("Admit or deny based on user", func(user string, expected types.GomegaMatcher) {
 		vmi := api.NewMinimalVMI("testvmi")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Volumes can be used for both filesystem and disk devices. When validating the VMI's volume count, both need to be considered.

The miscount causes problems when when hotplugging disks to a virtual machine that also uses virtiofs.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9653

**Special notes for your reviewer**:

Enabling the `ExperimentalVirtiofsSupport` feature gate during tests was necessary to crate VMIs with filesystems. I am unsure if that is the desired way to do this.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
