### PR TITLE
sidecars: Reuse sidecar-shim skeleton code

### DIFF
--- a/cmd/sidecars/BUILD.bazel
+++ b/cmd/sidecars/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/cmd/sidecars",
     visibility = ["//visibility:private"],
     deps = [
+        "//cmd/sidecars/launcher:go_default_library",
         "//pkg/cloud-init:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/hooks/info:go_default_library",

--- a/cmd/sidecars/launcher/BUILD.bazel
+++ b/cmd/sidecars/launcher/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["launcher.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/launcher",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)

--- a/cmd/sidecars/launcher/launcher.go
+++ b/cmd/sidecars/launcher/launcher.go
@@ -1,0 +1,58 @@
+package launcher
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"google.golang.org/grpc"
+	"kubevirt.io/client-go/log"
+)
+
+type registerCallbackServersFn func(*grpc.Server, chan struct{})
+
+func Run(socketPath string, registerCallbackServers registerCallbackServersFn) error {
+	socket, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("Failed to initialized socket on path %q: %v", socket, err)
+	}
+	defer func() {
+		os.Remove(socketPath)
+	}()
+
+	shutdownChan := make(chan struct{})
+	server := grpc.NewServer([]grpc.ServerOption{}...)
+	registerCallbackServers(server, shutdownChan)
+
+	// Handle signals to properly shutdown process
+	signalStopChan := make(chan os.Signal, 1)
+	signal.Notify(signalStopChan, os.Interrupt,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	)
+
+	log.Log.Infof("shim is now exposing its services on socket %s", socketPath)
+	errChan := make(chan error)
+	go func() {
+		errChan <- server.Serve(socket)
+	}()
+
+	select {
+	case s := <-signalStopChan:
+		log.Log.Infof("sidecar-shim received signal: %s", s.String())
+	case err = <-errChan:
+		log.Log.Reason(err).Error("Failed to run grpc server")
+	case <-shutdownChan:
+		log.Log.Info("Exiting")
+	}
+
+	if err == nil {
+		server.GracefulStop()
+	}
+
+	return nil
+}

--- a/cmd/sidecars/network-passt-binding/BUILD.bazel
+++ b/cmd/sidecars/network-passt-binding/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/cmd/sidecars/network-passt-binding",
     visibility = ["//visibility:private"],
     deps = [
+        "//cmd/sidecars/launcher:go_default_library",
         "//cmd/sidecars/network-passt-binding/server:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/hooks/info:go_default_library",

--- a/cmd/sidecars/network-slirp-binding/BUILD.bazel
+++ b/cmd/sidecars/network-slirp-binding/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/cmd/sidecars/network-slirp-binding",
     visibility = ["//visibility:private"],
     deps = [
+        "//cmd/sidecars/launcher:go_default_library",
         "//cmd/sidecars/network-slirp-binding/dns:go_default_library",
         "//cmd/sidecars/network-slirp-binding/server:go_default_library",
         "//pkg/hooks:go_default_library",

--- a/cmd/sidecars/sidecar_shim.go
+++ b/cmd/sidecars/sidecar_shim.go
@@ -24,12 +24,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
@@ -44,6 +41,8 @@ import (
 	hooksV1alpha1 "kubevirt.io/kubevirt/pkg/hooks/v1alpha1"
 	hooksV1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
 	hooksV1alpha3 "kubevirt.io/kubevirt/pkg/hooks/v1alpha3"
+
+	"kubevirt.io/kubevirt/cmd/sidecars/launcher"
 )
 
 const (
@@ -276,46 +275,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	socket, err := net.Listen("unix", socketPath)
-	if err != nil {
-		log.Log.Reason(err).Errorf("Failed to initialized socket on path: %s", socket)
+	registerCallbacks := func(server *grpc.Server, shutdownCh chan struct{}) {
+		hooksInfo.RegisterInfoServer(server, infoServer{Version: version})
+		hooksV1alpha1.RegisterCallbacksServer(server, v1Alpha1Server{})
+		hooksV1alpha2.RegisterCallbacksServer(server, v1Alpha2Server{})
+		hooksV1alpha3.RegisterCallbacksServer(server, v1Alpha3Server{done: shutdownCh})
+	}
+	if err := launcher.Run(socketPath, registerCallbacks); err != nil {
+		log.Log.Errorf("failed to launch sidecar: %v", err)
 		os.Exit(1)
-	}
-	defer os.Remove(socketPath)
-
-	server := grpc.NewServer([]grpc.ServerOption{}...)
-	hooksInfo.RegisterInfoServer(server, infoServer{Version: version})
-	hooksV1alpha1.RegisterCallbacksServer(server, v1Alpha1Server{})
-	hooksV1alpha2.RegisterCallbacksServer(server, v1Alpha2Server{})
-
-	shutdownChan := make(chan struct{})
-	hooksV1alpha3.RegisterCallbacksServer(server, v1Alpha3Server{done: shutdownChan})
-
-	// Handle signals to properly shutdown process
-	signalStopChan := make(chan os.Signal, 1)
-	signal.Notify(signalStopChan, os.Interrupt,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT,
-	)
-
-	log.Log.Infof("shim is now exposing its services on socket %s", socketPath)
-	errChan := make(chan error)
-	go func() {
-		errChan <- server.Serve(socket)
-	}()
-
-	select {
-	case s := <-signalStopChan:
-		log.Log.Infof("sidecar-shim received signal: %s", s.String())
-	case err = <-errChan:
-		log.Log.Reason(err).Error("Failed to run grpc server")
-	case <-shutdownChan:
-		log.Log.Info("Exiting")
-	}
-
-	if err == nil {
-		server.GracefulStop()
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The sidecar-shim main function has additional logic that solve issues with migration that other sidecar implementations may suffer from (e.g.: slirp & passt sidecars).

This PR export the sidecar-shim main function to new package 'launcher'.
The new package exposes the Run() function:
It exposes an entrypoint for registering callback server
which is the difference between sidecar implementations.

With the new launcher package we provide single skeleton for all sidecar implementations (w or w/o sidecar shim layer) and streamline sidecar developing experience a bit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
