### PR TITLE
[release-1.1] [guest-log] Avoid reporting error if the socket file got closed

### DIFF
--- a/cmd/virt-tail/main.go
+++ b/cmd/virt-tail/main.go
@@ -40,9 +40,14 @@ import (
 )
 
 type TermFileError struct{}
+type SocketFileError struct{}
 
 func (m *TermFileError) Error() string {
 	return "termFile got detected"
+}
+
+func (m *SocketFileError) Error() string {
+	return "socketFile got removed"
 }
 
 type VirtTail struct {
@@ -164,7 +169,7 @@ func (v *VirtTail) watchFS() error {
 			} else if event.Has(fsnotify.Remove) {
 				if event.Name == socketFile {
 					// socket file got deleted, we should quickly terminate
-					rerr := errors.New("socketFile got removed")
+					rerr := &SocketFileError{}
 					log.Log.V(3).Infof("watchFS error: %v", rerr)
 					return rerr
 				} else if event.Name == termFile {
@@ -215,11 +220,11 @@ func main() {
 
 	// wait for all errgroup goroutines
 	if err := g.Wait(); err != nil {
-		// Exit cleanly on clean termination errors
-		if !(errors.Is(err, context.Canceled) || errors.Is(err, &TermFileError{})) {
+		if !(errors.Is(err, context.Canceled) || errors.Is(err, &TermFileError{}) || errors.Is(err, &SocketFileError{})) {
 			log.Log.V(3).Infof("received error: %v", err)
 			os.Exit(1)
 		}
+		// Exit cleanly on clean termination errors
 	}
 }
 

--- a/tests/guestlog/BUILD.bazel
+++ b/tests/guestlog/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//tests/decorators:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/testsuite:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",

--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -103,7 +103,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 						foundContainer = true
 					}
 				}
-				Expect(foundContainer).To(Equal(true))
+				Expect(foundContainer).To(BeTrue())
 
 				By("Triggering a shutdown from the guest OS")
 				Expect(console.LoginToCirros(vmi)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of #10993 and #11034

/assign acardace

**Special notes for your reviewer**:
The additional commit from #11034 is simply addressing a ginkgolinter warning.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
