### PR TITLE
sig-buildsystem: Set some ownership

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,9 @@ filters:
       - approvers
     emeritus_approvers:
       - emeritus_approvers
+
+  "BUILD.bazel":
+    reviewers:
+      - sig-buildsystem-reviewers
+    approvers:
+      - sig-buildsystem-approvers

--- a/OWNERS
+++ b/OWNERS
@@ -9,7 +9,7 @@ filters:
     emeritus_approvers:
       - emeritus_approvers
 
-  "BUILD.bazel":
+  "BUILD.bazel|WORKSPACE":
     reviewers:
       - sig-buildsystem-reviewers
     approvers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -139,8 +139,10 @@ aliases:
   # SIG Buildsystem
   # Owns bazel, and ensures that kubevirt can be build.
   #
-  sig-buildsystem-approvers: []
-  sig-buildsystem-reviewers: []
+  sig-buildsystem-approvers:
+    - dhiller
+  sig-buildsystem-reviewers:
+    - brianmcarey
 
   #
   # SIG Architecture

--- a/bazel/OWNERS
+++ b/bazel/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-buildsystem-reviewers
+approvers:
+  - sig-buildsystem-approvers
+labels:
+  - sig/buildsystem


### PR DESCRIPTION
Setting some ownership to make it clear who can help to merge stuff

**What this PR does / why we need it**:
Setting owners for build - mostly bazel - related things.
We want this in order to know who can help, and who should care.

The list is loosely based on the git history on some bazel files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

What other files/directories should be owned by sig-buildsystem

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
