### PR TITLE
virt-handler: Fix panic when listing devices on host without USB devices

### DIFF
--- a/pkg/virt-handler/device-manager/usb_device.go
+++ b/pkg/virt-handler/device-manager/usb_device.go
@@ -44,8 +44,8 @@ import (
 	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
 )
 
-const (
-	PathToUSBDevices = "/sys/bus/usb/devices"
+var (
+	pathToUSBDevices = "/sys/bus/usb/devices"
 )
 
 var discoverLocalUSBDevicesFunc = discoverPluggedUSBDevices
@@ -558,7 +558,10 @@ func (l *LocalDevices) fetch(selectors []v1.USBSelector) ([]*USBDevice, bool) {
 
 func discoverPluggedUSBDevices() *LocalDevices {
 	usbDevices := make(map[int][]*USBDevice, 0)
-	err := filepath.Walk(PathToUSBDevices, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(pathToUSBDevices, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		// Ignore named usb controllers
 		if strings.HasPrefix(info.Name(), "usb") {
 			return nil

--- a/pkg/virt-handler/device-manager/usb_device_test.go
+++ b/pkg/virt-handler/device-manager/usb_device_test.go
@@ -216,6 +216,16 @@ var _ = Describe("USB Device", func() {
 			},
 		),
 	)
+	It("Should return empty when encountering an error", func() {
+		originalPath := pathToUSBDevices
+		defer func() {
+			pathToUSBDevices = originalPath
+		}()
+		pathToUSBDevices = "/this/path/does/not/exist"
+
+		devices := discoverPluggedUSBDevices()
+		Expect(devices.devices).To(BeEmpty())
+	})
 })
 
 func expectMatch(a, b *USBDevice) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix a panic when trying to list USB Devices on host without USB devices

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix potential crash when trying to list USB devices on host without any
```
