### PR TITLE
test/utils: hide deprecatedBeforeAll inside operator tests

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -166,7 +166,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		fetchVirtHandlerCommand                func() string
 	)
 
-	tests.DeprecatedBeforeAll(func() {
+	deprecatedBeforeAll(func() {
 		virtClient = kubevirt.Client()
 		config, err := kubecli.GetKubevirtClientConfig()
 		util2.PanicOnError(err)
@@ -3475,6 +3475,18 @@ func nodeSelectorExistInDeployment(virtClient kubecli.KubevirtClient, deployment
 		return false
 	}
 	return true
+}
+
+// Deprecated: deprecatedBeforeAll must not be used. Tests need to be self-contained to allow sane cleanup, accurate reporting and
+// parallel execution.
+func deprecatedBeforeAll(fn func()) {
+	first := true
+	BeforeEach(func() {
+		if first {
+			fn()
+			first = false
+		}
+	})
 }
 
 func usesSha(image string) bool {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1308,18 +1308,6 @@ func LibvirtDomainIsPaused(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMac
 	return strings.Contains(stdout, "paused"), nil
 }
 
-// Deprecated: DeprecatedBeforeAll must not be used. Tests need to be self-contained to allow sane cleanup, accurate reporting and
-// parallel execution.
-func DeprecatedBeforeAll(fn func()) {
-	first := true
-	BeforeEach(func() {
-		if first {
-			fn()
-			first = false
-		}
-	})
-}
-
 func GenerateVMJson(vm *v1.VirtualMachine, generateDirectory string) (string, error) {
 	data, err := json.Marshal(vm)
 	if err != nil {


### PR DESCRIPTION
I don't understand why operator.go uses the forbidden function deprecatedBeforeAll. But at least make sure that this is the only user of this deprecated function.

/sig code-quality

```release-note
NONE
```
