### PR TITLE
Disable guest console log in CI

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -325,6 +325,8 @@ for i in ${namespaces[@]}; do
   kubectl get pods -n $i
 done
 
+kubectl patch -n kubevirt kv kubevirt --type='merge' --patch '{"spec": {"configuration": {"virtualMachineOptions": {"disableSerialConsoleLog": {}} } }}'
+
 kubectl version
 
 mkdir -p "$ARTIFACTS_PATH"

--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -136,7 +136,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
    http://cirros-cloud.net
 `
 
-			It("it should fetch logs for a running VM with logs API", func() {
+			It("[QUARANTINE] it should fetch logs for a running VM with logs API", decorators.Quarantine, func() {
 				vmi = tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -257,7 +257,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 				}
 				return virtlauncherPod
 			}, 30*time.Second, 1*time.Second).ShouldNot(BeNil())
-			Expect(virtlauncherPod.Spec.Containers).To(HaveLen(4))
+			Expect(virtlauncherPod.Spec.Containers).To(HaveLen(3))
 			foundContainer := false
 			virtiofsContainerName := fmt.Sprintf("virtiofs-%s", pvcName)
 			for _, container := range virtlauncherPod.Spec.Containers {

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -143,7 +143,7 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 					}
 					return virtlauncherPod
 				}, 30*time.Second, 1*time.Second).ShouldNot(BeNil())
-				Expect(virtlauncherPod.Spec.Containers).To(HaveLen(4))
+				Expect(virtlauncherPod.Spec.Containers).To(HaveLen(3))
 				foundContainer := false
 				for _, container := range virtlauncherPod.Spec.Containers {
 					if container.Name == "hook-sidecar-0" {


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an issue with slower VMI deletion[1] that is causing widespread
test flakes which is severely impacting CI.

This issue does not seem to occur when the guest console log is disabled.

Update the automation/test.sh to disable guest console log before
running the test suites.

[1] https://issues.redhat.com/browse/CNV-36682

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc none
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
