### PR TITLE
[e2e] Move operator test functions from utils to operator suite

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2406,7 +2406,7 @@ spec:
 	Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Disabled", func() {
 
 		BeforeEach(func() {
-			if tests.ServiceMonitorEnabled() {
+			if serviceMonitorEnabled() {
 				Skip("Test applies on when ServiceMonitor is not defined")
 			}
 		})
@@ -2430,7 +2430,7 @@ spec:
 	Context("With PrometheusRule Enabled", func() {
 
 		BeforeEach(func() {
-			if !tests.PrometheusRuleEnabled() {
+			if !prometheusRuleEnabled() {
 				Skip("Test applies on when PrometheusRule is defined")
 			}
 		})
@@ -2449,7 +2449,7 @@ spec:
 	Context("With PrometheusRule Disabled", func() {
 
 		BeforeEach(func() {
-			if tests.PrometheusRuleEnabled() {
+			if prometheusRuleEnabled() {
 				Skip("Test applies on when PrometheusRule is not defined")
 			}
 		})
@@ -2464,7 +2464,7 @@ spec:
 	Context("[rfe_id:2937][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Enabled", func() {
 
 		BeforeEach(func() {
-			if !tests.ServiceMonitorEnabled() {
+			if !serviceMonitorEnabled() {
 				Skip("Test requires ServiceMonitor to be valid")
 			}
 		})
@@ -3271,6 +3271,32 @@ func patchCRD(orig *extv1.CustomResourceDefinition, modified *extv1.CustomResour
 	patch, err := jsonpatch.CreateMergePatch(origCRDByte, crdByte)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	return patch
+}
+
+// prometheusRuleEnabled returns true if the PrometheusRule CRD is enabled
+// and false otherwise.
+func prometheusRuleEnabled() bool {
+	virtClient := kubevirt.Client()
+
+	prometheusRuleEnabled, err := util.IsPrometheusRuleEnabled(virtClient)
+	if err != nil {
+		fmt.Printf("ERROR: Can't verify PrometheusRule CRD %v\n", err)
+		panic(err)
+	}
+
+	return prometheusRuleEnabled
+}
+
+func serviceMonitorEnabled() bool {
+	virtClient := kubevirt.Client()
+
+	serviceMonitorEnabled, err := util.IsServiceMonitorEnabled(virtClient)
+	if err != nil {
+		fmt.Printf("ERROR: Can't verify ServiceMonitor CRD %v\n", err)
+		panic(err)
+	}
+
+	return serviceMonitorEnabled
 }
 
 // verifyOperatorWebhookCertificate can be used when inside tests doing reinstalls of kubevirt, to ensure that virt-operator already got the new certificate.

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -193,32 +193,6 @@ func CreateSecret(name, namespace string, data map[string]string) {
 	}
 }
 
-func ServiceMonitorEnabled() bool {
-	virtClient := kubevirt.Client()
-
-	serviceMonitorEnabled, err := util.IsServiceMonitorEnabled(virtClient)
-	if err != nil {
-		fmt.Printf("ERROR: Can't verify ServiceMonitor CRD %v\n", err)
-		panic(err)
-	}
-
-	return serviceMonitorEnabled
-}
-
-// PrometheusRuleEnabled returns true if the PrometheusRule CRD is enabled
-// and false otherwise.
-func PrometheusRuleEnabled() bool {
-	virtClient := kubevirt.Client()
-
-	prometheusRuleEnabled, err := util.IsPrometheusRuleEnabled(virtClient)
-	if err != nil {
-		fmt.Printf("ERROR: Can't verify PrometheusRule CRD %v\n", err)
-		panic(err)
-	}
-
-	return prometheusRuleEnabled
-}
-
 func DeleteConfigMap(name, namespace string) {
 	virtCli := kubevirt.Client()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

PrometheusRuleEnabled and ServiceMonitorEnabled are only used in the operator tests - move these functions from utils to the operator suite.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
None
```
