### PR TITLE
fix(vmclone) Delete vmclone resource when target vm is deleted

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -704,6 +704,7 @@ func GetVirtualMachineCloneInformerIndexers() cache.Indexers {
 	}
 
 	return cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
 		// Gets: snapshot key. Returns: clones that their source is the specified snapshot
 		"snapshotSource": func(obj interface{}) ([]string, error) {
 			vmClone, ok := obj.(*clonev1alpha1.VirtualMachineClone)

--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -64,6 +65,5 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -312,6 +312,14 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 				By("Making sure snapshot and restore objects are cleaned up")
 				Expect(vmClone.Status.SnapshotName).To(BeNil())
 				Expect(vmClone.Status.RestoreName).To(BeNil())
+
+				err = virtClient.VirtualMachine(targetVM.Namespace).Delete(context.Background(), targetVM.Name, &v1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Eventually(func() error {
+					_, err := virtClient.VirtualMachineClone(vmClone.Namespace).Get(context.Background(), vmClone.Name, v1.GetOptions{})
+					return err
+				}, 120*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "VM clone should be successfully deleted")
 			})
 
 			It("simple clone with snapshot source", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Once the target vm is deleted the vm clone can be
deleted since it is referring to a resource that cannot be
retrieved anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
jira-ticket: https://issues.redhat.com/browse/CNV-30877

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix(vmclone): delete vmclone resource when the target vm is deleted
```
