### PR TITLE
[release-1.1] Allow kubevirt:default clusterRole to get,list kubevirts

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -847,6 +847,13 @@ spec:
           - list
           - watch
         - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+        - apiGroups:
           - subresources.kubevirt.io
           resources:
           - version

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -787,6 +787,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubevirt.io
+  resources:
+  - kubevirts
+  verbs:
+  - get
+  - list
+- apiGroups:
   - subresources.kubevirt.io
   resources:
   - version

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -165,11 +165,6 @@ func newDefaultClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 				APIGroup: VersionName,
 				Name:     "system:authenticated",
 			},
-			{
-				Kind:     "Group",
-				APIGroup: VersionName,
-				Name:     "system:unauthenticated",
-			},
 		},
 	}
 }

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -36,52 +36,52 @@ import (
 )
 
 const (
-	NameDefault = "kubevirt.io:default"
+	defaultClusterRoleName = "kubevirt.io:default"
 
-	ApiVersion            = "version"
-	ApiGuestFs            = "guestfs"
-	ApiExpandVmSpec       = "expand-vm-spec"
-	ApiKubevirts          = "kubevirts"
-	ApiVM                 = "virtualmachines"
-	ApiVMInstances        = "virtualmachineinstances"
-	ApiVMIPresets         = "virtualmachineinstancepresets"
-	ApiVMIReplicasets     = "virtualmachineinstancereplicasets"
-	ApiVMIMigrations      = "virtualmachineinstancemigrations"
-	ApiVMSnapshots        = "virtualmachinesnapshots"
-	ApiVMSnapshotContents = "virtualmachinesnapshotcontents"
-	ApiVMRestores         = "virtualmachinerestores"
-	ApiVMExports          = "virtualmachineexports"
-	ApiVMClones           = "virtualmachineclones"
-	ApiVMPools            = "virtualmachinepools"
+	apiVersion            = "version"
+	apiGuestFs            = "guestfs"
+	apiExpandVmSpec       = "expand-vm-spec"
+	apiKubevirts          = "kubevirts"
+	apiVM                 = "virtualmachines"
+	apiVMInstances        = "virtualmachineinstances"
+	apiVMIPresets         = "virtualmachineinstancepresets"
+	apiVMIReplicasets     = "virtualmachineinstancereplicasets"
+	apiVMIMigrations      = "virtualmachineinstancemigrations"
+	apiVMSnapshots        = "virtualmachinesnapshots"
+	apiVMSnapshotContents = "virtualmachinesnapshotcontents"
+	apiVMRestores         = "virtualmachinerestores"
+	apiVMExports          = "virtualmachineexports"
+	apiVMClones           = "virtualmachineclones"
+	apiVMPools            = "virtualmachinepools"
 
-	ApiVMExpandSpec   = "virtualmachines/expand-spec"
-	ApiVMPortForward  = "virtualmachines/portforward"
-	ApiVMStart        = "virtualmachines/start"
-	ApiVMStop         = "virtualmachines/stop"
-	ApiVMRestart      = "virtualmachines/restart"
-	ApiVMAddVolume    = "virtualmachines/addvolume"
-	ApiVMRemoveVolume = "virtualmachines/removevolume"
-	ApiVMMigrate      = "virtualmachines/migrate"
-	ApiVMMemoryDump   = "virtualmachines/memorydump"
+	apiVMExpandSpec   = "virtualmachines/expand-spec"
+	apiVMPortForward  = "virtualmachines/portforward"
+	apiVMStart        = "virtualmachines/start"
+	apiVMStop         = "virtualmachines/stop"
+	apiVMRestart      = "virtualmachines/restart"
+	apiVMAddVolume    = "virtualmachines/addvolume"
+	apiVMRemoveVolume = "virtualmachines/removevolume"
+	apiVMMigrate      = "virtualmachines/migrate"
+	apiVMMemoryDump   = "virtualmachines/memorydump"
 
-	ApiVMInstancesConsole                   = "virtualmachineinstances/console"
-	ApiVMInstancesVNC                       = "virtualmachineinstances/vnc"
-	ApiVMInstancesVNCScreenshot             = "virtualmachineinstances/vnc/screenshot"
-	ApiVMInstancesPortForward               = "virtualmachineinstances/portforward"
-	ApiVMInstancesPause                     = "virtualmachineinstances/pause"
-	ApiVMInstancesUnpause                   = "virtualmachineinstances/unpause"
-	ApiVMInstancesAddVolume                 = "virtualmachineinstances/addvolume"
-	ApiVMInstancesRemoveVolume              = "virtualmachineinstances/removevolume"
-	ApiVMInstancesFreeze                    = "virtualmachineinstances/freeze"
-	ApiVMInstancesUnfreeze                  = "virtualmachineinstances/unfreeze"
-	ApiVMInstancesSoftReboot                = "virtualmachineinstances/softreboot"
-	ApiVMInstancesGuestOSInfo               = "virtualmachineinstances/guestosinfo"
-	ApiVMInstancesFileSysList               = "virtualmachineinstances/filesystemlist"
-	ApiVMInstancesUserList                  = "virtualmachineinstances/userlist"
-	ApiVMInstancesSEVFetchCertChain         = "virtualmachineinstances/sev/fetchcertchain"
-	ApiVMInstancesSEVQueryLaunchMeasurement = "virtualmachineinstances/sev/querylaunchmeasurement"
-	ApiVMInstancesSEVSetupSession           = "virtualmachineinstances/sev/setupsession"
-	ApiVMInstancesSEVInjectLaunchSecret     = "virtualmachineinstances/sev/injectlaunchsecret"
+	apiVMInstancesConsole                   = "virtualmachineinstances/console"
+	apiVMInstancesVNC                       = "virtualmachineinstances/vnc"
+	apiVMInstancesVNCScreenshot             = "virtualmachineinstances/vnc/screenshot"
+	apiVMInstancesPortForward               = "virtualmachineinstances/portforward"
+	apiVMInstancesPause                     = "virtualmachineinstances/pause"
+	apiVMInstancesUnpause                   = "virtualmachineinstances/unpause"
+	apiVMInstancesAddVolume                 = "virtualmachineinstances/addvolume"
+	apiVMInstancesRemoveVolume              = "virtualmachineinstances/removevolume"
+	apiVMInstancesFreeze                    = "virtualmachineinstances/freeze"
+	apiVMInstancesUnfreeze                  = "virtualmachineinstances/unfreeze"
+	apiVMInstancesSoftReboot                = "virtualmachineinstances/softreboot"
+	apiVMInstancesGuestOSInfo               = "virtualmachineinstances/guestosinfo"
+	apiVMInstancesFileSysList               = "virtualmachineinstances/filesystemlist"
+	apiVMInstancesUserList                  = "virtualmachineinstances/userlist"
+	apiVMInstancesSEVFetchCertChain         = "virtualmachineinstances/sev/fetchcertchain"
+	apiVMInstancesSEVQueryLaunchMeasurement = "virtualmachineinstances/sev/querylaunchmeasurement"
+	apiVMInstancesSEVSetupSession           = "virtualmachineinstances/sev/setupsession"
+	apiVMInstancesSEVInjectLaunchSecret     = "virtualmachineinstances/sev/injectlaunchsecret"
 )
 
 func GetAllCluster() []runtime.Object {
@@ -102,7 +102,7 @@ func newDefaultClusterRole() *rbacv1.ClusterRole {
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: NameDefault,
+			Name: defaultClusterRoleName,
 			Labels: map[string]string{
 				virtv1.AppLabel:               "",
 				"kubernetes.io/bootstrapping": "rbac-defaults",
@@ -117,7 +117,7 @@ func newDefaultClusterRole() *rbacv1.ClusterRole {
 					GroupName,
 				},
 				Resources: []string{
-					ApiKubevirts,
+					apiKubevirts,
 				},
 				Verbs: []string{
 					"get", "list",
@@ -128,8 +128,8 @@ func newDefaultClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVersion,
-					ApiGuestFs,
+					apiVersion,
+					apiGuestFs,
 				},
 				Verbs: []string{
 					"get", "list",
@@ -146,7 +146,7 @@ func newDefaultClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 			Kind:       "ClusterRoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: NameDefault,
+			Name: defaultClusterRoleName,
 			Labels: map[string]string{
 				virtv1.AppLabel: "",
 			},
@@ -157,7 +157,7 @@ func newDefaultClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: VersionName,
 			Kind:     "ClusterRole",
-			Name:     NameDefault,
+			Name:     defaultClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -193,15 +193,15 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMInstancesConsole,
-					ApiVMInstancesVNC,
-					ApiVMInstancesVNCScreenshot,
-					ApiVMInstancesPortForward,
-					ApiVMInstancesGuestOSInfo,
-					ApiVMInstancesFileSysList,
-					ApiVMInstancesUserList,
-					ApiVMInstancesSEVFetchCertChain,
-					ApiVMInstancesSEVQueryLaunchMeasurement,
+					apiVMInstancesConsole,
+					apiVMInstancesVNC,
+					apiVMInstancesVNCScreenshot,
+					apiVMInstancesPortForward,
+					apiVMInstancesGuestOSInfo,
+					apiVMInstancesFileSysList,
+					apiVMInstancesUserList,
+					apiVMInstancesSEVFetchCertChain,
+					apiVMInstancesSEVQueryLaunchMeasurement,
 				},
 				Verbs: []string{
 					"get",
@@ -212,15 +212,15 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMInstancesPause,
-					ApiVMInstancesUnpause,
-					ApiVMInstancesAddVolume,
-					ApiVMInstancesRemoveVolume,
-					ApiVMInstancesFreeze,
-					ApiVMInstancesUnfreeze,
-					ApiVMInstancesSoftReboot,
-					ApiVMInstancesSEVSetupSession,
-					ApiVMInstancesSEVInjectLaunchSecret,
+					apiVMInstancesPause,
+					apiVMInstancesUnpause,
+					apiVMInstancesAddVolume,
+					apiVMInstancesRemoveVolume,
+					apiVMInstancesFreeze,
+					apiVMInstancesUnfreeze,
+					apiVMInstancesSoftReboot,
+					apiVMInstancesSEVSetupSession,
+					apiVMInstancesSEVInjectLaunchSecret,
 				},
 				Verbs: []string{
 					"update",
@@ -231,8 +231,8 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMExpandSpec,
-					ApiVMPortForward,
+					apiVMExpandSpec,
+					apiVMPortForward,
 				},
 				Verbs: []string{
 					"get",
@@ -243,13 +243,13 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMStart,
-					ApiVMStop,
-					ApiVMRestart,
-					ApiVMAddVolume,
-					ApiVMRemoveVolume,
-					ApiVMMigrate,
-					ApiVMMemoryDump,
+					apiVMStart,
+					apiVMStop,
+					apiVMRestart,
+					apiVMAddVolume,
+					apiVMRemoveVolume,
+					apiVMMigrate,
+					apiVMMemoryDump,
 				},
 				Verbs: []string{
 					"update",
@@ -260,7 +260,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiExpandVmSpec,
+					apiExpandVmSpec,
 				},
 				Verbs: []string{
 					"update",
@@ -271,11 +271,11 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					GroupName,
 				},
 				Resources: []string{
-					ApiVM,
-					ApiVMInstances,
-					ApiVMIPresets,
-					ApiVMIReplicasets,
-					ApiVMIMigrations,
+					apiVM,
+					apiVMInstances,
+					apiVMIPresets,
+					apiVMIReplicasets,
+					apiVMIMigrations,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch", "deletecollection",
@@ -286,9 +286,9 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					snapshot.GroupName,
 				},
 				Resources: []string{
-					ApiVMSnapshots,
-					ApiVMSnapshotContents,
-					ApiVMRestores,
+					apiVMSnapshots,
+					apiVMSnapshotContents,
+					apiVMRestores,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch", "deletecollection",
@@ -299,7 +299,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					export.GroupName,
 				},
 				Resources: []string{
-					ApiVMExports,
+					apiVMExports,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch", "deletecollection",
@@ -310,7 +310,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					clone.GroupName,
 				},
 				Resources: []string{
-					ApiVMClones,
+					apiVMClones,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch", "deletecollection",
@@ -335,7 +335,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					pool.GroupName,
 				},
 				Resources: []string{
-					ApiVMPools,
+					apiVMPools,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch", "deletecollection",
@@ -375,15 +375,15 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMInstancesConsole,
-					ApiVMInstancesVNC,
-					ApiVMInstancesVNCScreenshot,
-					ApiVMInstancesPortForward,
-					ApiVMInstancesGuestOSInfo,
-					ApiVMInstancesFileSysList,
-					ApiVMInstancesUserList,
-					ApiVMInstancesSEVFetchCertChain,
-					ApiVMInstancesSEVQueryLaunchMeasurement,
+					apiVMInstancesConsole,
+					apiVMInstancesVNC,
+					apiVMInstancesVNCScreenshot,
+					apiVMInstancesPortForward,
+					apiVMInstancesGuestOSInfo,
+					apiVMInstancesFileSysList,
+					apiVMInstancesUserList,
+					apiVMInstancesSEVFetchCertChain,
+					apiVMInstancesSEVQueryLaunchMeasurement,
 				},
 				Verbs: []string{
 					"get",
@@ -394,15 +394,15 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMInstancesPause,
-					ApiVMInstancesUnpause,
-					ApiVMInstancesAddVolume,
-					ApiVMInstancesRemoveVolume,
-					ApiVMInstancesFreeze,
-					ApiVMInstancesUnfreeze,
-					ApiVMInstancesSoftReboot,
-					ApiVMInstancesSEVSetupSession,
-					ApiVMInstancesSEVInjectLaunchSecret,
+					apiVMInstancesPause,
+					apiVMInstancesUnpause,
+					apiVMInstancesAddVolume,
+					apiVMInstancesRemoveVolume,
+					apiVMInstancesFreeze,
+					apiVMInstancesUnfreeze,
+					apiVMInstancesSoftReboot,
+					apiVMInstancesSEVSetupSession,
+					apiVMInstancesSEVInjectLaunchSecret,
 				},
 				Verbs: []string{
 					"update",
@@ -413,8 +413,8 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMExpandSpec,
-					ApiVMPortForward,
+					apiVMExpandSpec,
+					apiVMPortForward,
 				},
 				Verbs: []string{
 					"get",
@@ -425,13 +425,13 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMStart,
-					ApiVMStop,
-					ApiVMRestart,
-					ApiVMAddVolume,
-					ApiVMRemoveVolume,
-					ApiVMMigrate,
-					ApiVMMemoryDump,
+					apiVMStart,
+					apiVMStop,
+					apiVMRestart,
+					apiVMAddVolume,
+					apiVMRemoveVolume,
+					apiVMMigrate,
+					apiVMMemoryDump,
 				},
 				Verbs: []string{
 					"update",
@@ -442,7 +442,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiExpandVmSpec,
+					apiExpandVmSpec,
 				},
 				Verbs: []string{
 					"update",
@@ -453,11 +453,11 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					GroupName,
 				},
 				Resources: []string{
-					ApiVM,
-					ApiVMInstances,
-					ApiVMIPresets,
-					ApiVMIReplicasets,
-					ApiVMIMigrations,
+					apiVM,
+					apiVMInstances,
+					apiVMIPresets,
+					apiVMIReplicasets,
+					apiVMIMigrations,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch",
@@ -468,9 +468,9 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					snapshot.GroupName,
 				},
 				Resources: []string{
-					ApiVMSnapshots,
-					ApiVMSnapshotContents,
-					ApiVMRestores,
+					apiVMSnapshots,
+					apiVMSnapshotContents,
+					apiVMRestores,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch",
@@ -481,7 +481,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					export.GroupName,
 				},
 				Resources: []string{
-					ApiVMExports,
+					apiVMExports,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch",
@@ -492,7 +492,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					clone.GroupName,
 				},
 				Resources: []string{
-					ApiVMClones,
+					apiVMClones,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch",
@@ -517,7 +517,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					pool.GroupName,
 				},
 				Resources: []string{
-					ApiVMPools,
+					apiVMPools,
 				},
 				Verbs: []string{
 					"get", "delete", "create", "update", "patch", "list", "watch",
@@ -528,7 +528,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					GroupName,
 				},
 				Resources: []string{
-					ApiKubevirts,
+					apiKubevirts,
 				},
 				Verbs: []string{
 					"get", "list",
@@ -568,7 +568,7 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					GroupName,
 				},
 				Resources: []string{
-					ApiKubevirts,
+					apiKubevirts,
 				},
 				Verbs: []string{
 					"get", "list",
@@ -579,12 +579,12 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiVMExpandSpec,
-					ApiVMInstancesGuestOSInfo,
-					ApiVMInstancesFileSysList,
-					ApiVMInstancesUserList,
-					ApiVMInstancesSEVFetchCertChain,
-					ApiVMInstancesSEVQueryLaunchMeasurement,
+					apiVMExpandSpec,
+					apiVMInstancesGuestOSInfo,
+					apiVMInstancesFileSysList,
+					apiVMInstancesUserList,
+					apiVMInstancesSEVFetchCertChain,
+					apiVMInstancesSEVQueryLaunchMeasurement,
 				},
 				Verbs: []string{
 					"get",
@@ -595,7 +595,7 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{
-					ApiExpandVmSpec,
+					apiExpandVmSpec,
 				},
 				Verbs: []string{
 					"update",
@@ -606,11 +606,11 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					GroupName,
 				},
 				Resources: []string{
-					ApiVM,
-					ApiVMInstances,
-					ApiVMIPresets,
-					ApiVMIReplicasets,
-					ApiVMIMigrations,
+					apiVM,
+					apiVMInstances,
+					apiVMIPresets,
+					apiVMIReplicasets,
+					apiVMIMigrations,
 				},
 				Verbs: []string{
 					"get", "list", "watch",
@@ -621,9 +621,9 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					snapshot.GroupName,
 				},
 				Resources: []string{
-					ApiVMSnapshots,
-					ApiVMSnapshotContents,
-					ApiVMRestores,
+					apiVMSnapshots,
+					apiVMSnapshotContents,
+					apiVMRestores,
 				},
 				Verbs: []string{
 					"get", "list", "watch",
@@ -634,7 +634,7 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					export.GroupName,
 				},
 				Resources: []string{
-					ApiVMExports,
+					apiVMExports,
 				},
 				Verbs: []string{
 					"get", "list", "watch",
@@ -645,7 +645,7 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					clone.GroupName,
 				},
 				Resources: []string{
-					ApiVMClones,
+					apiVMClones,
 				},
 				Verbs: []string{
 					"get", "list", "watch",
@@ -670,7 +670,7 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					pool.GroupName,
 				},
 				Resources: []string{
-					ApiVMPools,
+					apiVMPools,
 				},
 				Verbs: []string{
 					"get", "list", "watch",

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -114,6 +114,17 @@ func newDefaultClusterRole() *rbacv1.ClusterRole {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{
+					GroupName,
+				},
+				Resources: []string{
+					ApiKubevirts,
+				},
+				Verbs: []string{
+					"get", "list",
+				},
+			},
+			{
+				APIGroups: []string{
 					virtv1.SubresourceGroupName,
 				},
 				Resources: []string{

--- a/pkg/virt-operator/resource/generate/rbac/cluster_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster_test.go
@@ -75,7 +75,6 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 				expectSubjectExists(clusterRoleBinding.Subjects, kind, name)
 			},
 				Entry("system:authenticated", "Group", "system:authenticated"),
-				Entry("system:unauthenticated", "Group", "system:unauthenticated"),
 			)
 		})
 

--- a/pkg/virt-operator/resource/generate/rbac/cluster_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 				expectExactRuleExists(clusterRole.Rules, apiGroup, resource, verbs...)
 
 			},
+				Entry(fmt.Sprintf("get and list %s/%s", GroupName, ApiKubevirts), GroupName, ApiKubevirts, "get", "list"),
 				Entry(fmt.Sprintf("get and list %s/%s", virtv1.SubresourceGroupName, ApiVersion), virtv1.SubresourceGroupName, ApiVersion, "get", "list"),
 				Entry(fmt.Sprintf("get and list %s/%s", virtv1.SubresourceGroupName, ApiGuestFs), virtv1.SubresourceGroupName, ApiGuestFs, "get", "list"),
 			)

--- a/pkg/virt-operator/resource/generate/rbac/cluster_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster_test.go
@@ -50,27 +50,27 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 		Context("default cluster role", func() {
 
 			DescribeTable("should contain rule to", func(apiGroup, resource string, verbs ...string) {
-				clusterRole := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRole{}), NameDefault).(*rbacv1.ClusterRole)
+				clusterRole := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRole{}), defaultClusterRoleName).(*rbacv1.ClusterRole)
 				Expect(clusterRole).ToNot(BeNil())
 				expectExactRuleExists(clusterRole.Rules, apiGroup, resource, verbs...)
 
 			},
-				Entry(fmt.Sprintf("get and list %s/%s", GroupName, ApiKubevirts), GroupName, ApiKubevirts, "get", "list"),
-				Entry(fmt.Sprintf("get and list %s/%s", virtv1.SubresourceGroupName, ApiVersion), virtv1.SubresourceGroupName, ApiVersion, "get", "list"),
-				Entry(fmt.Sprintf("get and list %s/%s", virtv1.SubresourceGroupName, ApiGuestFs), virtv1.SubresourceGroupName, ApiGuestFs, "get", "list"),
+				Entry(fmt.Sprintf("get and list %s/%s", GroupName, apiKubevirts), GroupName, apiKubevirts, "get", "list"),
+				Entry(fmt.Sprintf("get and list %s/%s", virtv1.SubresourceGroupName, apiVersion), virtv1.SubresourceGroupName, apiVersion, "get", "list"),
+				Entry(fmt.Sprintf("get and list %s/%s", virtv1.SubresourceGroupName, apiGuestFs), virtv1.SubresourceGroupName, apiGuestFs, "get", "list"),
 			)
 		})
 
 		Context("default cluster role binding", func() {
 
 			It("should contain RoleRef to default cluster role", func() {
-				clusterRoleBinding := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRoleBinding{}), NameDefault).(*rbacv1.ClusterRoleBinding)
+				clusterRoleBinding := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRoleBinding{}), defaultClusterRoleName).(*rbacv1.ClusterRoleBinding)
 				Expect(clusterRoleBinding).ToNot(BeNil())
-				expectRoleRefToBe(clusterRoleBinding.RoleRef, "ClusterRole", NameDefault)
+				expectRoleRefToBe(clusterRoleBinding.RoleRef, "ClusterRole", defaultClusterRoleName)
 			})
 
 			DescribeTable("should contain subject to refer", func(kind, name string, verbs ...string) {
-				clusterRoleBinding := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRoleBinding{}), NameDefault).(*rbacv1.ClusterRoleBinding)
+				clusterRoleBinding := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRoleBinding{}), defaultClusterRoleName).(*rbacv1.ClusterRoleBinding)
 				Expect(clusterRoleBinding).ToNot(BeNil())
 				expectSubjectExists(clusterRoleBinding.Subjects, kind, name)
 			},
@@ -86,59 +86,59 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 				Expect(clusterRole).ToNot(BeNil())
 				expectExactRuleExists(clusterRole.Rules, apiGroup, resource, verbs...)
 			},
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesConsole), virtv1.SubresourceGroupName, ApiVMInstancesConsole, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesVNC), virtv1.SubresourceGroupName, ApiVMInstancesVNC, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesVNCScreenshot), virtv1.SubresourceGroupName, ApiVMInstancesVNCScreenshot, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesPortForward), virtv1.SubresourceGroupName, ApiVMInstancesPortForward, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesGuestOSInfo), virtv1.SubresourceGroupName, ApiVMInstancesGuestOSInfo, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesFileSysList), virtv1.SubresourceGroupName, ApiVMInstancesFileSysList, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesUserList), virtv1.SubresourceGroupName, ApiVMInstancesUserList, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVFetchCertChain), virtv1.SubresourceGroupName, ApiVMInstancesSEVFetchCertChain, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVQueryLaunchMeasurement), virtv1.SubresourceGroupName, ApiVMInstancesSEVQueryLaunchMeasurement, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesConsole), virtv1.SubresourceGroupName, apiVMInstancesConsole, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesVNC), virtv1.SubresourceGroupName, apiVMInstancesVNC, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesVNCScreenshot), virtv1.SubresourceGroupName, apiVMInstancesVNCScreenshot, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesPortForward), virtv1.SubresourceGroupName, apiVMInstancesPortForward, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesGuestOSInfo), virtv1.SubresourceGroupName, apiVMInstancesGuestOSInfo, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesFileSysList), virtv1.SubresourceGroupName, apiVMInstancesFileSysList, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesUserList), virtv1.SubresourceGroupName, apiVMInstancesUserList, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVFetchCertChain), virtv1.SubresourceGroupName, apiVMInstancesSEVFetchCertChain, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVQueryLaunchMeasurement), virtv1.SubresourceGroupName, apiVMInstancesSEVQueryLaunchMeasurement, "get"),
 
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesPause), virtv1.SubresourceGroupName, ApiVMInstancesPause, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesUnpause), virtv1.SubresourceGroupName, ApiVMInstancesUnpause, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesAddVolume), virtv1.SubresourceGroupName, ApiVMInstancesAddVolume, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesRemoveVolume), virtv1.SubresourceGroupName, ApiVMInstancesRemoveVolume, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesFreeze), virtv1.SubresourceGroupName, ApiVMInstancesFreeze, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesUnfreeze), virtv1.SubresourceGroupName, ApiVMInstancesUnfreeze, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSoftReboot), virtv1.SubresourceGroupName, ApiVMInstancesSoftReboot, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVSetupSession), virtv1.SubresourceGroupName, ApiVMInstancesSEVSetupSession, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVInjectLaunchSecret), virtv1.SubresourceGroupName, ApiVMInstancesSEVInjectLaunchSecret, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesPause), virtv1.SubresourceGroupName, apiVMInstancesPause, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesUnpause), virtv1.SubresourceGroupName, apiVMInstancesUnpause, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesAddVolume), virtv1.SubresourceGroupName, apiVMInstancesAddVolume, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesRemoveVolume), virtv1.SubresourceGroupName, apiVMInstancesRemoveVolume, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesFreeze), virtv1.SubresourceGroupName, apiVMInstancesFreeze, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesUnfreeze), virtv1.SubresourceGroupName, apiVMInstancesUnfreeze, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSoftReboot), virtv1.SubresourceGroupName, apiVMInstancesSoftReboot, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVSetupSession), virtv1.SubresourceGroupName, apiVMInstancesSEVSetupSession, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVInjectLaunchSecret), virtv1.SubresourceGroupName, apiVMInstancesSEVInjectLaunchSecret, "update"),
 
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMExpandSpec), virtv1.SubresourceGroupName, ApiVMExpandSpec, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMPortForward), virtv1.SubresourceGroupName, ApiVMPortForward, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMExpandSpec), virtv1.SubresourceGroupName, apiVMExpandSpec, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMPortForward), virtv1.SubresourceGroupName, apiVMPortForward, "get"),
 
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMStart), virtv1.SubresourceGroupName, ApiVMStart, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMStop), virtv1.SubresourceGroupName, ApiVMInstancesSEVInjectLaunchSecret, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMRestart), virtv1.SubresourceGroupName, ApiVMStop, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMAddVolume), virtv1.SubresourceGroupName, ApiVMRestart, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMRemoveVolume), virtv1.SubresourceGroupName, ApiVMAddVolume, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMMigrate), virtv1.SubresourceGroupName, ApiVMMigrate, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMMemoryDump), virtv1.SubresourceGroupName, ApiVMMemoryDump, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMStart), virtv1.SubresourceGroupName, apiVMStart, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMStop), virtv1.SubresourceGroupName, apiVMInstancesSEVInjectLaunchSecret, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMRestart), virtv1.SubresourceGroupName, apiVMStop, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMAddVolume), virtv1.SubresourceGroupName, apiVMRestart, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMRemoveVolume), virtv1.SubresourceGroupName, apiVMAddVolume, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMMigrate), virtv1.SubresourceGroupName, apiVMMigrate, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMMemoryDump), virtv1.SubresourceGroupName, apiVMMemoryDump, "update"),
 
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiExpandVmSpec), virtv1.SubresourceGroupName, ApiExpandVmSpec, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiExpandVmSpec), virtv1.SubresourceGroupName, apiExpandVmSpec, "update"),
 
-				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, ApiVM), GroupName, ApiVM, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
-				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, ApiVMInstances), GroupName, ApiVMInstances, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
-				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, ApiVMIPresets), GroupName, ApiVMIPresets, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
-				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, ApiVMIReplicasets), GroupName, ApiVMIReplicasets, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
-				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, ApiVMIMigrations), GroupName, ApiVMIMigrations, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, apiVM), GroupName, apiVM, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, apiVMInstances), GroupName, apiVMInstances, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, apiVMIPresets), GroupName, apiVMIPresets, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, apiVMIReplicasets), GroupName, apiVMIReplicasets, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", GroupName, apiVMIMigrations), GroupName, apiVMIMigrations, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 
-				Entry(fmt.Sprintf("do all operations to %s/%s", snapshot.GroupName, ApiVMSnapshots), snapshot.GroupName, ApiVMSnapshots, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
-				Entry(fmt.Sprintf("do all operations to %s/%s", snapshot.GroupName, ApiVMSnapshotContents), snapshot.GroupName, ApiVMSnapshotContents, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
-				Entry(fmt.Sprintf("do all operations to %s/%s", snapshot.GroupName, ApiVMRestores), snapshot.GroupName, ApiVMRestores, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", snapshot.GroupName, apiVMSnapshots), snapshot.GroupName, apiVMSnapshots, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", snapshot.GroupName, apiVMSnapshotContents), snapshot.GroupName, apiVMSnapshotContents, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", snapshot.GroupName, apiVMRestores), snapshot.GroupName, apiVMRestores, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 
-				Entry(fmt.Sprintf("do all operations to %s/%s", export.GroupName, ApiVMExports), export.GroupName, ApiVMExports, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", export.GroupName, apiVMExports), export.GroupName, apiVMExports, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 
-				Entry(fmt.Sprintf("do all operations to %s/%s", clone.GroupName, ApiVMClones), clone.GroupName, ApiVMClones, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", clone.GroupName, apiVMClones), clone.GroupName, apiVMClones, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 
 				Entry(fmt.Sprintf("do all operations to %s/%s", instancetype.GroupName, instancetype.PluralResourceName), instancetype.GroupName, instancetype.PluralResourceName, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 				Entry(fmt.Sprintf("do all operations to %s/%s", instancetype.GroupName, instancetype.ClusterPluralResourceName), instancetype.GroupName, instancetype.ClusterPluralResourceName, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 				Entry(fmt.Sprintf("do all operations to %s/%s", instancetype.GroupName, instancetype.PluralPreferenceResourceName), instancetype.GroupName, instancetype.PluralPreferenceResourceName, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 				Entry(fmt.Sprintf("do all operations to %s/%s", instancetype.GroupName, instancetype.ClusterPluralPreferenceResourceName), instancetype.GroupName, instancetype.ClusterPluralPreferenceResourceName, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 
-				Entry(fmt.Sprintf("do all operations to %s/%s", pool.GroupName, ApiVMPools), pool.GroupName, ApiVMPools, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
+				Entry(fmt.Sprintf("do all operations to %s/%s", pool.GroupName, apiVMPools), pool.GroupName, apiVMPools, "get", "delete", "create", "update", "patch", "list", "watch", "deletecollection"),
 
 				Entry(fmt.Sprintf("get, list, watch %s/%s", migrations.GroupName, migrations.ResourceMigrationPolicies), migrations.GroupName, migrations.ResourceMigrationPolicies, "get", "list", "watch"),
 			)
@@ -151,61 +151,61 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 				Expect(clusterRole).ToNot(BeNil())
 				expectExactRuleExists(clusterRole.Rules, apiGroup, resource, verbs...)
 			},
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesConsole), virtv1.SubresourceGroupName, ApiVMInstancesConsole, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesVNC), virtv1.SubresourceGroupName, ApiVMInstancesVNC, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesVNCScreenshot), virtv1.SubresourceGroupName, ApiVMInstancesVNCScreenshot, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesPortForward), virtv1.SubresourceGroupName, ApiVMInstancesPortForward, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesGuestOSInfo), virtv1.SubresourceGroupName, ApiVMInstancesGuestOSInfo, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesFileSysList), virtv1.SubresourceGroupName, ApiVMInstancesFileSysList, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesUserList), virtv1.SubresourceGroupName, ApiVMInstancesUserList, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVFetchCertChain), virtv1.SubresourceGroupName, ApiVMInstancesSEVFetchCertChain, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVQueryLaunchMeasurement), virtv1.SubresourceGroupName, ApiVMInstancesSEVQueryLaunchMeasurement, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesConsole), virtv1.SubresourceGroupName, apiVMInstancesConsole, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesVNC), virtv1.SubresourceGroupName, apiVMInstancesVNC, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesVNCScreenshot), virtv1.SubresourceGroupName, apiVMInstancesVNCScreenshot, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesPortForward), virtv1.SubresourceGroupName, apiVMInstancesPortForward, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesGuestOSInfo), virtv1.SubresourceGroupName, apiVMInstancesGuestOSInfo, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesFileSysList), virtv1.SubresourceGroupName, apiVMInstancesFileSysList, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesUserList), virtv1.SubresourceGroupName, apiVMInstancesUserList, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVFetchCertChain), virtv1.SubresourceGroupName, apiVMInstancesSEVFetchCertChain, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVQueryLaunchMeasurement), virtv1.SubresourceGroupName, apiVMInstancesSEVQueryLaunchMeasurement, "get"),
 
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesPause), virtv1.SubresourceGroupName, ApiVMInstancesPause, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesUnpause), virtv1.SubresourceGroupName, ApiVMInstancesUnpause, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesAddVolume), virtv1.SubresourceGroupName, ApiVMInstancesAddVolume, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesRemoveVolume), virtv1.SubresourceGroupName, ApiVMInstancesRemoveVolume, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesFreeze), virtv1.SubresourceGroupName, ApiVMInstancesFreeze, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesUnfreeze), virtv1.SubresourceGroupName, ApiVMInstancesUnfreeze, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSoftReboot), virtv1.SubresourceGroupName, ApiVMInstancesSoftReboot, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVSetupSession), virtv1.SubresourceGroupName, ApiVMInstancesSEVSetupSession, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVInjectLaunchSecret), virtv1.SubresourceGroupName, ApiVMInstancesSEVInjectLaunchSecret, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesPause), virtv1.SubresourceGroupName, apiVMInstancesPause, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesUnpause), virtv1.SubresourceGroupName, apiVMInstancesUnpause, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesAddVolume), virtv1.SubresourceGroupName, apiVMInstancesAddVolume, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesRemoveVolume), virtv1.SubresourceGroupName, apiVMInstancesRemoveVolume, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesFreeze), virtv1.SubresourceGroupName, apiVMInstancesFreeze, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesUnfreeze), virtv1.SubresourceGroupName, apiVMInstancesUnfreeze, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSoftReboot), virtv1.SubresourceGroupName, apiVMInstancesSoftReboot, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVSetupSession), virtv1.SubresourceGroupName, apiVMInstancesSEVSetupSession, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVInjectLaunchSecret), virtv1.SubresourceGroupName, apiVMInstancesSEVInjectLaunchSecret, "update"),
 
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMExpandSpec), virtv1.SubresourceGroupName, ApiVMExpandSpec, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMPortForward), virtv1.SubresourceGroupName, ApiVMPortForward, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMExpandSpec), virtv1.SubresourceGroupName, apiVMExpandSpec, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMPortForward), virtv1.SubresourceGroupName, apiVMPortForward, "get"),
 
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMStart), virtv1.SubresourceGroupName, ApiVMStart, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMStop), virtv1.SubresourceGroupName, ApiVMInstancesSEVInjectLaunchSecret, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMRestart), virtv1.SubresourceGroupName, ApiVMStop, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMAddVolume), virtv1.SubresourceGroupName, ApiVMRestart, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMRemoveVolume), virtv1.SubresourceGroupName, ApiVMAddVolume, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMMigrate), virtv1.SubresourceGroupName, ApiVMMigrate, "update"),
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiVMMemoryDump), virtv1.SubresourceGroupName, ApiVMMemoryDump, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMStart), virtv1.SubresourceGroupName, apiVMStart, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMStop), virtv1.SubresourceGroupName, apiVMInstancesSEVInjectLaunchSecret, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMRestart), virtv1.SubresourceGroupName, apiVMStop, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMAddVolume), virtv1.SubresourceGroupName, apiVMRestart, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMRemoveVolume), virtv1.SubresourceGroupName, apiVMAddVolume, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMMigrate), virtv1.SubresourceGroupName, apiVMMigrate, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiVMMemoryDump), virtv1.SubresourceGroupName, apiVMMemoryDump, "update"),
 
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiExpandVmSpec), virtv1.SubresourceGroupName, ApiExpandVmSpec, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiExpandVmSpec), virtv1.SubresourceGroupName, apiExpandVmSpec, "update"),
 
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, ApiVM), GroupName, ApiVM, "get", "delete", "create", "update", "patch", "list", "watch"),
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, ApiVMInstances), GroupName, ApiVMInstances, "get", "delete", "create", "update", "patch", "list", "watch"),
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, ApiVMIPresets), GroupName, ApiVMIPresets, "get", "delete", "create", "update", "patch", "list", "watch"),
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, ApiVMIReplicasets), GroupName, ApiVMIReplicasets, "get", "delete", "create", "update", "patch", "list", "watch"),
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, ApiVMIMigrations), GroupName, ApiVMIMigrations, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, apiVM), GroupName, apiVM, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, apiVMInstances), GroupName, apiVMInstances, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, apiVMIPresets), GroupName, apiVMIPresets, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, apiVMIReplicasets), GroupName, apiVMIReplicasets, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", GroupName, apiVMIMigrations), GroupName, apiVMIMigrations, "get", "delete", "create", "update", "patch", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", snapshot.GroupName, ApiVMSnapshots), snapshot.GroupName, ApiVMSnapshots, "get", "delete", "create", "update", "patch", "list", "watch"),
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", snapshot.GroupName, ApiVMSnapshotContents), snapshot.GroupName, ApiVMSnapshotContents, "get", "delete", "create", "update", "patch", "list", "watch"),
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", snapshot.GroupName, ApiVMRestores), snapshot.GroupName, ApiVMRestores, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", snapshot.GroupName, apiVMSnapshots), snapshot.GroupName, apiVMSnapshots, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", snapshot.GroupName, apiVMSnapshotContents), snapshot.GroupName, apiVMSnapshotContents, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", snapshot.GroupName, apiVMRestores), snapshot.GroupName, apiVMRestores, "get", "delete", "create", "update", "patch", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", export.GroupName, ApiVMExports), export.GroupName, ApiVMExports, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", export.GroupName, apiVMExports), export.GroupName, apiVMExports, "get", "delete", "create", "update", "patch", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", clone.GroupName, ApiVMClones), clone.GroupName, ApiVMClones, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", clone.GroupName, apiVMClones), clone.GroupName, apiVMClones, "get", "delete", "create", "update", "patch", "list", "watch"),
 
 				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", instancetype.GroupName, instancetype.PluralResourceName), instancetype.GroupName, instancetype.PluralResourceName, "get", "delete", "create", "update", "patch", "list", "watch"),
 				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", instancetype.GroupName, instancetype.ClusterPluralResourceName), instancetype.GroupName, instancetype.ClusterPluralResourceName, "get", "delete", "create", "update", "patch", "list", "watch"),
 				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", instancetype.GroupName, instancetype.PluralPreferenceResourceName), instancetype.GroupName, instancetype.PluralPreferenceResourceName, "get", "delete", "create", "update", "patch", "list", "watch"),
 				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", instancetype.GroupName, instancetype.ClusterPluralPreferenceResourceName), instancetype.GroupName, instancetype.ClusterPluralPreferenceResourceName, "get", "delete", "create", "update", "patch", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", pool.GroupName, ApiVMPools), pool.GroupName, ApiVMPools, "get", "delete", "create", "update", "patch", "list", "watch"),
+				Entry(fmt.Sprintf("get, delete, create, update, patch, list, watch %s/%s", pool.GroupName, apiVMPools), pool.GroupName, apiVMPools, "get", "delete", "create", "update", "patch", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, list %s/%s", GroupName, ApiKubevirts), GroupName, ApiKubevirts, "get", "list"),
+				Entry(fmt.Sprintf("get, list %s/%s", GroupName, apiKubevirts), GroupName, apiKubevirts, "get", "list"),
 
 				Entry(fmt.Sprintf("get, list, watch %s/%s", migrations.GroupName, migrations.ResourceMigrationPolicies), migrations.GroupName, migrations.ResourceMigrationPolicies, "get", "list", "watch"),
 			)
@@ -218,37 +218,37 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 				Expect(clusterRole).ToNot(BeNil())
 				expectExactRuleExists(clusterRole.Rules, apiGroup, resource, verbs...)
 			},
-				Entry(fmt.Sprintf("get, list %s/%s", GroupName, ApiKubevirts), GroupName, ApiKubevirts, "get", "list"),
+				Entry(fmt.Sprintf("get, list %s/%s", GroupName, apiKubevirts), GroupName, apiKubevirts, "get", "list"),
 
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMExpandSpec), virtv1.SubresourceGroupName, ApiVMExpandSpec, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesGuestOSInfo), virtv1.SubresourceGroupName, ApiVMInstancesGuestOSInfo, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesFileSysList), virtv1.SubresourceGroupName, ApiVMInstancesFileSysList, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesUserList), virtv1.SubresourceGroupName, ApiVMInstancesUserList, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVFetchCertChain), virtv1.SubresourceGroupName, ApiVMInstancesSEVFetchCertChain, "get"),
-				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, ApiVMInstancesSEVQueryLaunchMeasurement), virtv1.SubresourceGroupName, ApiVMInstancesSEVQueryLaunchMeasurement, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMExpandSpec), virtv1.SubresourceGroupName, apiVMExpandSpec, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesGuestOSInfo), virtv1.SubresourceGroupName, apiVMInstancesGuestOSInfo, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesFileSysList), virtv1.SubresourceGroupName, apiVMInstancesFileSysList, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesUserList), virtv1.SubresourceGroupName, apiVMInstancesUserList, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVFetchCertChain), virtv1.SubresourceGroupName, apiVMInstancesSEVFetchCertChain, "get"),
+				Entry(fmt.Sprintf("get %s/%s", virtv1.SubresourceGroupName, apiVMInstancesSEVQueryLaunchMeasurement), virtv1.SubresourceGroupName, apiVMInstancesSEVQueryLaunchMeasurement, "get"),
 
-				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, ApiExpandVmSpec), virtv1.SubresourceGroupName, ApiExpandVmSpec, "update"),
+				Entry(fmt.Sprintf("update %s/%s", virtv1.SubresourceGroupName, apiExpandVmSpec), virtv1.SubresourceGroupName, apiExpandVmSpec, "update"),
 
-				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, ApiVM), GroupName, ApiVM, "get", "list", "watch"),
-				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, ApiVMInstances), GroupName, ApiVMInstances, "get", "list", "watch"),
-				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, ApiVMIPresets), GroupName, ApiVMIPresets, "get", "list", "watch"),
-				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, ApiVMIReplicasets), GroupName, ApiVMIReplicasets, "get", "list", "watch"),
-				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, ApiVMIMigrations), GroupName, ApiVMIMigrations, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, apiVM), GroupName, apiVM, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, apiVMInstances), GroupName, apiVMInstances, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, apiVMIPresets), GroupName, apiVMIPresets, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, apiVMIReplicasets), GroupName, apiVMIReplicasets, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", GroupName, apiVMIMigrations), GroupName, apiVMIMigrations, "get", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, list, watch %s/%s", snapshot.GroupName, ApiVMSnapshots), snapshot.GroupName, ApiVMSnapshots, "get", "list", "watch"),
-				Entry(fmt.Sprintf("get, list, watch %s/%s", snapshot.GroupName, ApiVMSnapshotContents), snapshot.GroupName, ApiVMSnapshotContents, "get", "list", "watch"),
-				Entry(fmt.Sprintf("get, list, watch %s/%s", snapshot.GroupName, ApiVMRestores), snapshot.GroupName, ApiVMRestores, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", snapshot.GroupName, apiVMSnapshots), snapshot.GroupName, apiVMSnapshots, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", snapshot.GroupName, apiVMSnapshotContents), snapshot.GroupName, apiVMSnapshotContents, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", snapshot.GroupName, apiVMRestores), snapshot.GroupName, apiVMRestores, "get", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, list, watch %s/%s", export.GroupName, ApiVMExports), export.GroupName, ApiVMExports, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", export.GroupName, apiVMExports), export.GroupName, apiVMExports, "get", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, list, watch %s/%s", clone.GroupName, ApiVMClones), clone.GroupName, ApiVMClones, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", clone.GroupName, apiVMClones), clone.GroupName, apiVMClones, "get", "list", "watch"),
 
 				Entry(fmt.Sprintf("get, list, watch %s/%s", instancetype.GroupName, instancetype.PluralResourceName), instancetype.GroupName, instancetype.PluralResourceName, "get", "list", "watch"),
 				Entry(fmt.Sprintf("get, list, watch %s/%s", instancetype.GroupName, instancetype.ClusterPluralResourceName), instancetype.GroupName, instancetype.ClusterPluralResourceName, "get", "list", "watch"),
 				Entry(fmt.Sprintf("get, list, watch %s/%s", instancetype.GroupName, instancetype.PluralPreferenceResourceName), instancetype.GroupName, instancetype.PluralPreferenceResourceName, "get", "list", "watch"),
 				Entry(fmt.Sprintf("get, list, watch %s/%s", instancetype.GroupName, instancetype.ClusterPluralPreferenceResourceName), instancetype.GroupName, instancetype.ClusterPluralPreferenceResourceName, "get", "list", "watch"),
 
-				Entry(fmt.Sprintf("get, list, watch %s/%s", pool.GroupName, ApiVMPools), pool.GroupName, ApiVMPools, "get", "list", "watch"),
+				Entry(fmt.Sprintf("get, list, watch %s/%s", pool.GroupName, apiVMPools), pool.GroupName, apiVMPools, "get", "list", "watch"),
 
 				Entry(fmt.Sprintf("get, list, watch %s/%s", migrations.GroupName, migrations.ResourceMigrationPolicies), migrations.GroupName, migrations.ResourceMigrationPolicies, "get", "list", "watch"),
 			)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is an manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/11001 and https://github.com/kubevirt/kubevirt/pull/11050

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow `kubevirt.io:default` clusterRole to get,list kubevirts
```