### PR TITLE
[e2e] Quarantine tests effected by slower VMI deletion issue

### DIFF
--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -204,7 +204,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 		Expect(err.Error()).To(ContainSubstring("admission webhook \"virtualmachinepool-validator.kubevirt.io\" denied the request: spec.virtualMachineTemplate.spec.template.spec.domain.devices.disks[2].Name 'testdisk' not found"))
 	})
 
-	It("should remove VMs once they are marked for deletion", func() {
+	It("[QUARANTINE] should remove VMs once they are marked for deletion", decorators.Quarantine, func() {
 		newPool := newVirtualMachinePool()
 		// Create a pool with two replicas
 		doScale(newPool.ObjectMeta.Name, 2)
@@ -441,7 +441,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 		}, 5*time.Second, 1*time.Second).Should(BeNil())
 	})
 
-	It("should roll out VMI template changes and proactively roll out new VMIs", func() {
+	It("[QUARANTINE] should roll out VMI template changes and proactively roll out new VMIs", decorators.Quarantine, func() {
 		newPool := newVirtualMachinePool()
 		doScale(newPool.ObjectMeta.Name, 1)
 		waitForVMIs(newPool.Namespace, 1)

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -376,7 +376,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		}, 10*time.Second, 1*time.Second).Should(Equal(int32(2)))
 	})
 
-	It("[test_id:1418]should replace finished VMIs", func() {
+	It("[test_id:1418][QUARANTINE] should replace finished VMIs", decorators.Quarantine, func() {
 		By("Creating new replica set")
 		rs := newReplicaSet()
 		doScale(rs.ObjectMeta.Name, int32(2))


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an issue with slower VMI deletion[1] that is causing widespread test flakes which is severely impacting CI.

Quarantine the three tests that are flaking the most due to this issue.

Tests were identified from the latest flakefinder report
https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2024-01-21-168h.html

[1] https://issues.redhat.com/browse/CNV-36682

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
