### PR TITLE
fix(vmclone): generate vm patches from vmsnapshotcontent vm

### DIFF
--- a/pkg/virt-controller/watch/clone/clone.go
+++ b/pkg/virt-controller/watch/clone/clone.go
@@ -192,7 +192,12 @@ func (ctrl *VMCloneController) syncSourceVMTargetVM(source *k6tv1.VirtualMachine
 		}
 
 		if vmClone.Status.RestoreName == nil {
-			syncInfo = ctrl.createRestoreFromVm(vmClone, source, snapshot.Name, syncInfo)
+			vm, err := ctrl.getVmFromSnapshot(snapshot)
+			if err != nil {
+				return addErrorToSyncInfo(syncInfo, fmt.Errorf("cannot get VM manifest from snapshot: %v", err))
+			}
+
+			syncInfo = ctrl.createRestoreFromVm(vmClone, vm, snapshot.Name, syncInfo)
 			return syncInfo
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
vm clone can filter out labels and annotations with filtering. These filters result in a set of patches that will be applied to the target vm.
If the vm clone source is a vm, it could happen that between the snapshot creation and the subsequent restore, some new annotations or labels are added.
If the latter should be filtered out, the vmrestore patches will cover them as well.
But the restore process tries to apply the patches to the vmsnapshotcontent, not the current vm, resulting in a failure with `Unable to remove nonexistent key...`.

To avoid this situation, intead of the current vm, the vmrestore pathes should be always generated from the vmsnapshotcontent vm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This will solve the flaky test:
`[Serial]VirtualMachineClone Tests VM clone [sig-compute]simple VM and cloning operations clone with only some of labels/annotations`
https://search.ci.kubevirt.io/?search=simple+VM+and+cloning+operations+clone+with+only+some+of+labels%2Fannotations&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix(vmclone): Generate VM patches from vmsnapshotcontent, instead of current VM
```
/kind flake