### PR TITLE
[WIP] [release-1.1] fix: Add ClusterRoleBinding for instancetype:view ClusterRole

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -89,9 +89,9 @@ const (
 
 	NAMESPACE = "kubevirt-test"
 
-	resourceCount = 76
+	resourceCount = 77
 	patchCount    = 50
-	updateCount   = 27
+	updateCount   = 28
 )
 
 type KubeVirtTestData struct {
@@ -2469,7 +2469,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(kvTestData.controller.stores.ServiceAccountCache.List()).To(HaveLen(4))
 			Expect(kvTestData.controller.stores.ClusterRoleCache.List()).To(HaveLen(9))
-			Expect(kvTestData.controller.stores.ClusterRoleBindingCache.List()).To(HaveLen(6))
+			Expect(kvTestData.controller.stores.ClusterRoleBindingCache.List()).To(HaveLen(7))
 			Expect(kvTestData.controller.stores.RoleCache.List()).To(HaveLen(5))
 			Expect(kvTestData.controller.stores.RoleBindingCache.List()).To(HaveLen(5))
 			Expect(kvTestData.controller.stores.CrdCache.List()).To(HaveLen(16))

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	NameDefault = "kubevirt.io:default"
+	NameDefault                     = "kubevirt.io:default"
+	instancetypeViewClusterRoleName = "instancetype.kubevirt.io:view"
 
 	ApiVersion            = "version"
 	ApiGuestFs            = "guestfs"
@@ -92,6 +93,7 @@ func GetAllCluster() []runtime.Object {
 		newEditClusterRole(),
 		newViewClusterRole(),
 		newInstancetypeViewClusterRole(),
+		newInstancetypeViewClusterRoleBinding(),
 	}
 }
 
@@ -686,7 +688,10 @@ func newInstancetypeViewClusterRole() *rbacv1.ClusterRole {
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "instancetype.kubevirt.io:view",
+			Name: instancetypeViewClusterRoleName,
+			Labels: map[string]string{
+				virtv1.AppLabel: "",
+			},
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -700,6 +705,36 @@ func newInstancetypeViewClusterRole() *rbacv1.ClusterRole {
 				Verbs: []string{
 					"get", "list", "watch",
 				},
+			},
+		},
+	}
+}
+
+func newInstancetypeViewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: VersionNamev1,
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: instancetypeViewClusterRoleName,
+			Labels: map[string]string{
+				virtv1.AppLabel: "",
+			},
+			Annotations: map[string]string{
+				"rbac.authorization.kubernetes.io/autoupdate": "true",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: VersionName,
+			Kind:     "ClusterRole",
+			Name:     instancetypeViewClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "Group",
+				APIGroup: VersionName,
+				Name:     "system:authenticated",
 			},
 		},
 	}

--- a/pkg/virt-operator/resource/generate/rbac/cluster_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster_test.go
@@ -256,12 +256,29 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 		Context("instance type view cluster role", func() {
 
 			DescribeTable("should contain rule to", func(apiGroup, resource string, verbs ...string) {
-				clusterRole := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRole{}), "instancetype.kubevirt.io:view").(*rbacv1.ClusterRole)
+				clusterRole := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRole{}), instancetypeViewClusterRoleName).(*rbacv1.ClusterRole)
 				Expect(clusterRole).ToNot(BeNil())
 				expectExactRuleExists(clusterRole.Rules, apiGroup, resource, verbs...)
 			},
 				Entry(fmt.Sprintf("get, list, watch %s/%s", instancetype.GroupName, instancetype.ClusterPluralResourceName), instancetype.GroupName, instancetype.ClusterPluralResourceName, "get", "list", "watch"),
 				Entry(fmt.Sprintf("get, list, watch %s/%s", instancetype.GroupName, instancetype.ClusterPluralPreferenceResourceName), instancetype.GroupName, instancetype.ClusterPluralPreferenceResourceName, "get", "list", "watch"),
+			)
+		})
+
+		Context("instance type view cluster role binding", func() {
+
+			It("should contain RoleRef to instancetype view cluster role", func() {
+				clusterRoleBinding := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRoleBinding{}), instancetypeViewClusterRoleName).(*rbacv1.ClusterRoleBinding)
+				Expect(clusterRoleBinding).ToNot(BeNil())
+				expectRoleRefToBe(clusterRoleBinding.RoleRef, "ClusterRole", instancetypeViewClusterRoleName)
+			})
+
+			DescribeTable("should contain subject to refer", func(kind, name string, verbs ...string) {
+				clusterRoleBinding := getObject(clusterObjects, reflect.TypeOf(&rbacv1.ClusterRoleBinding{}), instancetypeViewClusterRoleName).(*rbacv1.ClusterRoleBinding)
+				Expect(clusterRoleBinding).ToNot(BeNil())
+				expectSubjectExists(clusterRoleBinding.Subjects, kind, name)
+			},
+				Entry("system:authenticated", "Group", "system:authenticated"),
 			)
 		})
 	})

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -190,6 +190,9 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		if !clusterWide {
 			sar.Spec.ResourceAttributes.Namespace = namespace
 		}
+		if role == "default" {
+			sar.Spec.Groups = []string{"system:authenticated"}
+		}
 
 		result, err := authClient.SubjectAccessReviews().Create(context.Background(), sar, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -339,7 +342,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				denyAllFor("edit"),
 				denyAllFor("view"),
 				denyModificationsFor("instancetype:view"),
-				denyAllFor("default")),
+				denyModificationsFor("default")),
 			Entry("[test_id:TODO]given a virtualmachineclusterpreference",
 				instancetypeapi.GroupName,
 				instancetypeapi.ClusterPluralResourceName,
@@ -349,7 +352,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				denyAllFor("edit"),
 				denyAllFor("view"),
 				denyModificationsFor("instancetype:view"),
-				denyAllFor("default")),
+				denyModificationsFor("default")),
 		)
 
 		DescribeTable("should verify permissions on subresources are correct for view, edit, admin and default", func(resource string, subresource string, accessRights ...rights) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of #11025 

This adds a ClusterRolebinding which grants every authorized user read access to VirtualMachineCluster{Instancetype,Preference} CRs.

This allows unprivileged users to make use of
VirtualMachineCluster{Instancetypes,Preferences} by default.

Conflicts:
  pkg/virt-operator/resource/generate/rbac/cluster.go

Note:
  The conflict is due to a code refactoring in cluster.go that was not
  backported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow unprivileged users read-only access to VirtualMachineCluster{Instancetypes,Preferences} by default.
```
