### PR TITLE
Update go base image to use current stable debian 12 base

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -281,16 +281,16 @@ container_deps()
 # Pull go_image_base
 container_pull(
     name = "go_image_base",
-    digest = "sha256:6c871aa3c9019984dfd7f520635bd658d740ad20c6268a82faa433f69dfc9a0b",
+    digest = "sha256:9d6c97c160bff0f78a443b583811dd0c8dde5c5086fe8fd2aaf2c23ee7e9590a",
     registry = "gcr.io",
-    repository = "distroless/base",
+    repository = "distroless/base-debian12",
 )
 
 container_pull(
     name = "go_image_base_aarch64",
-    digest = "sha256:4f81adb2fa054fd2ea49a918e2eb025325992b1235733da5ba51ab75bf9bd386",
+    digest = "sha256:b251ebd844116427f92523668ca5e9f8d803e479eef44705b62090176d5e8cc7",
     registry = "gcr.io",
-    repository = "distroless/base",
+    repository = "distroless/base-debian12",
 )
 
 # Pull nfs-server image

--- a/cmd/sidecars/network-passt-binding/BUILD.bazel
+++ b/cmd/sidecars/network-passt-binding/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
 go_binary(
     name = "network-passt-binding",
     embed = [":go_default_library"],
-    static = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -75,14 +75,6 @@ container_image(
     files = [
         ":conformance-config.json",
     ],
-    tars = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": [
-            "//rpm:testimage_aarch64",
-        ],
-        "//conditions:default": [
-            "//rpm:testimage_x86_64",
-        ],
-    }),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The builder image (centos stream 9) uses glibc verion 2.34 - the old stable go base image (debian 11) has
glibc verion 2.31.

This causes issues with running binaries that are built by the builder image
and run inside of containers based on the go base image.

```
/usr/bin/csv-generator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/bin/csv-generator)
/usr/bin/csv-generator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/bin/csv-generator)
```

Updating the base image to the current stable debian 12 resolves these
issues as the current stable has glibc version 2.36[1]

[1] https://tracker.debian.org/pkg/glibc


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
Update container base image to use current stable debian 12 base
```
