### PR TITLE
unit test: Convert unneeded lambda functions

### DIFF
--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//tests/clientcmd:go_default_library",
+        "//tests/libdv:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
@@ -61,6 +62,5 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
-        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -57,32 +57,6 @@ var _ = Describe("Add volume command", func() {
 		coreClient = fake.NewSimpleClientset()
 	})
 
-	createTestDataVolume := func() *v1beta1.DataVolume {
-		return &v1beta1.DataVolume{
-			ObjectMeta: k8smetav1.ObjectMeta{
-				Name: "testvolume",
-			},
-		}
-	}
-
-	createTestPVC := func() *k8sv1.PersistentVolumeClaim {
-		return &k8sv1.PersistentVolumeClaim{
-			ObjectMeta: k8smetav1.ObjectMeta{
-				Name: "testvolume",
-			},
-		}
-	}
-
-	verifyVolumeSource := func(volumeOptions interface{}, useDv bool) {
-		if useDv {
-			Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.DataVolume).ToNot(BeNil())
-			Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.PersistentVolumeClaim).To(BeNil())
-		} else {
-			Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.DataVolume).To(BeNil())
-			Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.PersistentVolumeClaim).ToNot(BeNil())
-		}
-	}
-
 	expectVMIEndpointAddVolume := func(vmiName, volumeName string, useDv bool) {
 		kubecli.MockKubevirtClientInstance.
 			EXPECT().
@@ -185,3 +159,29 @@ var _ = Describe("Add volume command", func() {
 		Entry("addvolume dv, with LUN-type disk should call VMI endpoint", "addvolume", "testvmi", "testvolume", true, expectVMIEndpointAddVolume, "--disk-type", "lun"),
 	)
 })
+
+func createTestDataVolume() *v1beta1.DataVolume {
+	return &v1beta1.DataVolume{
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name: "testvolume",
+		},
+	}
+}
+
+func createTestPVC() *k8sv1.PersistentVolumeClaim {
+	return &k8sv1.PersistentVolumeClaim{
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name: "testvolume",
+		},
+	}
+}
+
+func verifyVolumeSource(volumeOptions interface{}, useDv bool) {
+	if useDv {
+		Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.DataVolume).ToNot(BeNil())
+		Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.PersistentVolumeClaim).To(BeNil())
+	} else {
+		Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.DataVolume).To(BeNil())
+		Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.PersistentVolumeClaim).ToNot(BeNil())
+	}
+}

--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -64,8 +64,9 @@ var _ = Describe("Add volume command", func() {
 			Return(vmiInterface).
 			Times(1)
 		vmiInterface.EXPECT().AddVolume(context.Background(), vmiName, gomock.Any()).DoAndReturn(func(ctx context.Context, arg0, arg1 interface{}) interface{} {
-			Expect(arg1.(*v1.AddVolumeOptions).Name).To(Equal(volumeName))
-			verifyVolumeSource(arg1, useDv)
+			volumeOptions := arg1.(*v1.AddVolumeOptions)
+			Expect(volumeOptions.Name).To(Equal(volumeName))
+			verifyVolumeSource(volumeOptions, useDv)
 			return nil
 		})
 	}
@@ -77,8 +78,9 @@ var _ = Describe("Add volume command", func() {
 			Return(vmInterface).
 			Times(1)
 		vmInterface.EXPECT().AddVolume(context.Background(), vmiName, gomock.Any()).DoAndReturn(func(ctx context.Context, arg0, arg1 interface{}) interface{} {
-			Expect(arg1.(*v1.AddVolumeOptions).Name).To(Equal(volumeName))
-			verifyVolumeSource(arg1, useDv)
+			volumeOptions := arg1.(*v1.AddVolumeOptions)
+			Expect(volumeOptions.Name).To(Equal(volumeName))
+			verifyVolumeSource(volumeOptions, useDv)
 			return nil
 		})
 	}
@@ -176,12 +178,12 @@ func createTestPVC() *k8sv1.PersistentVolumeClaim {
 	}
 }
 
-func verifyVolumeSource(volumeOptions interface{}, useDv bool) {
+func verifyVolumeSource(volumeOptions *v1.AddVolumeOptions, useDv bool) {
 	if useDv {
-		Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.DataVolume).ToNot(BeNil())
-		Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.PersistentVolumeClaim).To(BeNil())
+		ExpectWithOffset(3, volumeOptions.VolumeSource.DataVolume).ToNot(BeNil())
+		ExpectWithOffset(3, volumeOptions.VolumeSource.PersistentVolumeClaim).To(BeNil())
 	} else {
-		Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.DataVolume).To(BeNil())
-		Expect(volumeOptions.(*v1.AddVolumeOptions).VolumeSource.PersistentVolumeClaim).ToNot(BeNil())
+		ExpectWithOffset(3, volumeOptions.VolumeSource.DataVolume).To(BeNil())
+		ExpectWithOffset(3, volumeOptions.VolumeSource.PersistentVolumeClaim).ToNot(BeNil())
 	}
 }

--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -64,7 +64,9 @@ var _ = Describe("Add volume command", func() {
 			Return(vmiInterface).
 			Times(1)
 		vmiInterface.EXPECT().AddVolume(context.Background(), vmiName, gomock.Any()).DoAndReturn(func(ctx context.Context, arg0, arg1 interface{}) interface{} {
-			volumeOptions := arg1.(*v1.AddVolumeOptions)
+			volumeOptions, ok := arg1.(*v1.AddVolumeOptions)
+			Expect(ok).To(BeTrue())
+			Expect(volumeOptions).ToNot(BeNil())
 			Expect(volumeOptions.Name).To(Equal(volumeName))
 			verifyVolumeSource(volumeOptions, useDv)
 			return nil
@@ -78,7 +80,9 @@ var _ = Describe("Add volume command", func() {
 			Return(vmInterface).
 			Times(1)
 		vmInterface.EXPECT().AddVolume(context.Background(), vmiName, gomock.Any()).DoAndReturn(func(ctx context.Context, arg0, arg1 interface{}) interface{} {
-			volumeOptions := arg1.(*v1.AddVolumeOptions)
+			volumeOptions, ok := arg1.(*v1.AddVolumeOptions)
+			Expect(ok).To(BeTrue())
+			Expect(volumeOptions).ToNot(BeNil())
 			Expect(volumeOptions.Name).To(Equal(volumeName))
 			verifyVolumeSource(volumeOptions, useDv)
 			return nil
@@ -177,6 +181,7 @@ func createTestPVC() *k8sv1.PersistentVolumeClaim {
 }
 
 func verifyVolumeSource(volumeOptions *v1.AddVolumeOptions, useDv bool) {
+	Expect(volumeOptions.VolumeSource).ToNot(BeNil())
 	if useDv {
 		ExpectWithOffset(3, volumeOptions.VolumeSource.DataVolume).ToNot(BeNil())
 		ExpectWithOffset(3, volumeOptions.VolumeSource.PersistentVolumeClaim).To(BeNil())

--- a/tests/libdv/dv.go
+++ b/tests/libdv/dv.go
@@ -62,6 +62,12 @@ func WithNamespace(namespace string) dvOption {
 	}
 }
 
+func WithName(name string) dvOption {
+	return func(dv *v1beta1.DataVolume) {
+		dv.ObjectMeta.Name = name
+	}
+}
+
 type pvcOption func(*corev1.PersistentVolumeClaimSpec)
 
 // WithPVC is a dvOption to add a PVCOption spec to the DataVolume


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Convert inline functions to static functions.
Defining it as a named lambda needlessly adds mental burden, as the read need to keep in mind that it
may change in the future.

Beside that:
Remove unrequired interface usage, by using the casted variable.
Use libdv, and add WithName decorator for libdv.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
