### PR TITLE
Slightly delay virt-tail termination to bypass a race condition in CRI-O

### DIFF
--- a/cmd/virt-tail/main.go
+++ b/cmd/virt-tail/main.go
@@ -226,6 +226,16 @@ func main() {
 			os.Exit(1)
 		}
 		// Exit cleanly on clean termination errors
+		// TODO: fix me: Delay program termination
+		// We suspect a race condition in CRI-O handling pod deletion events
+		// and under some still unclear circumstances the event gets lost
+		// with the pod hanging in termination status for minutes (altought all
+		// the pod containers are clearly terminated).
+		// (maybe introduced with https://github.com/cri-o/cri-o/pull/7168 ? )
+		// Slightly delaying a clean termination of virt-tail seems enough
+		// to prevent hitting the critical path.
+		log.Log.V(3).Infof("Delay virt-tail termination")
+		time.Sleep(2 * time.Second)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We suspect a race condition in CRI-O handling pod deletion events and under some still unclear circumstances the event gets lost with the pod hanging in termination status for minutes (although all the pod containers are clearly terminated).
(maybe introduced with https://github.com/cri-o/cri-o/pull/7168 ? ). Slightly delaying a clean termination of virt-tail seems enough to prevent hitting the critical path.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [https://issues.redhat.com/browse/CNV-36682](https://issues.redhat.com/browse/CNV-36682)

**Special notes for your reviewer**:
I recognise that introducing an arbitrary delay to bypass a race condition is not really a fix but just a workaround,
but at the moment we are still not able to provide any better fix and this could unlock our CI.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
