### PR TITLE
[test] use a default value for VMI removal timeout

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -92,7 +92,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					_, err = virtClient.RestClient().Delete().Resource("virtualmachineinstances").Namespace(vmi.GetObjectMeta().GetNamespace()).Name(vmi.GetObjectMeta().GetName()).Do(context.Background()).Get()
 					Expect(err).ToNot(HaveOccurred())
 					By("Waiting until the VirtualMachineInstance is gone")
-					libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+					libwait.WaitForVirtualMachineToDisappear(vmi)
 				}
 			})
 		})

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -190,7 +190,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, stopOptions)
 			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+			libwait.WaitForVirtualMachineToDisappear(vmi)
 
 			By("Restarting the VM")
 			err = virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})

--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -40,7 +40,13 @@ import (
 	"kubevirt.io/kubevirt/tests/watcher"
 )
 
-const defaultTimeout = 360
+const (
+	defaultTimeout = 360
+	// DefaultVMIRemovalTimeoutSeconds could be reduced to 120 once https://issues.redhat.com/browse/OCPBUGS-27949 is addressed
+	// TODO
+	DefaultVMIRemovalTimeoutSeconds             = 240
+	DefaultVirtLauncherPodRemovalTimeoutSeconds = 240
+)
 
 // Option represents an action that enables an option.
 type Option func(waiting *Waiting)
@@ -205,6 +211,11 @@ func WaitForVirtualMachineToDisappearWithTimeout(vmi *v1.VirtualMachineInstance,
 		_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 		return err
 	}, seconds, 1*time.Second).Should(gomega.SatisfyAll(gomega.HaveOccurred(), gomega.WithTransform(errors.IsNotFound, gomega.BeTrue())), "The VMI should be gone within the given timeout")
+}
+
+// WaitForVirtualMachineToDisappear blocks for a default amount of time until VirtualMachineInstance disappears
+func WaitForVirtualMachineToDisappear(vmi *v1.VirtualMachineInstance) {
+	WaitForVirtualMachineToDisappearWithTimeout(vmi, DefaultVMIRemovalTimeoutSeconds)
 }
 
 // WaitForMigrationToDisappearWithTimeout blocks for the passed seconds until the specified VirtualMachineInstanceMigration disappears

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -110,7 +110,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 
 			By("Waiting for VMI to disappear")
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+			libwait.WaitForVirtualMachineToDisappear(vmi)
 		})
 	})
 

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -172,7 +172,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 
 			By("Delete VMIs")
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+			libwait.WaitForVirtualMachineToDisappear(vmi)
 		})
 
 		It("Should correctly update metrics on failing VMIM", func() {
@@ -199,7 +199,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 
 			By("Deleting the VMI")
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+			libwait.WaitForVirtualMachineToDisappear(vmi)
 		})
 	})
 

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -34,7 +34,6 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -88,10 +87,7 @@ var _ = SIGDescribe("Services", func() {
 		Expect(virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.GetName(), &k8smetav1.DeleteOptions{})).To(Succeed())
 
 		By("Waiting for the VMI to be gone")
-		Eventually(func() error {
-			_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(context.Background(), vmi.GetName(), &k8smetav1.GetOptions{})
-			return err
-		}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
+		libwait.WaitForVirtualMachineToDisappear(vmi)
 	}
 
 	cleanupService := func(namespace string, serviceName string) error {

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -856,14 +856,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				if vmi != nil {
 					By("Delete VMI")
 					Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
-
-					Eventually(func() error {
-						_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-						return err
-					}, time.Minute, time.Second).Should(
-						SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())),
-						"The VMI should be gone within the given timeout",
-					)
+					By("Waiting for the VMI to be gone")
+					libwait.WaitForVirtualMachineToDisappear(vmi)
 				}
 			})
 

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -28,6 +28,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libdv"
+	"kubevirt.io/kubevirt/tests/libwait"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -217,7 +218,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 			vms, err := virtClient.VirtualMachine(newPool.ObjectMeta.Namespace).List(context.Background(), &v12.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return len(vms.Items)
-		}, 120*time.Second, 1*time.Second).Should(BeZero())
+		}, libwait.DefaultVMIRemovalTimeoutSeconds*time.Second, 1*time.Second).Should(BeZero())
 	})
 
 	It("should handle pool with dataVolumeTemplates", func() {
@@ -502,7 +503,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 				return fmt.Errorf("Expected vmi to pick up the new updated label")
 			}
 			return nil
-		}, 60*time.Second, 1*time.Second).Should(BeNil())
+		}, libwait.DefaultVMIRemovalTimeoutSeconds*time.Second, 1*time.Second).Should(BeNil())
 	})
 
 	It("should remove owner references on the VirtualMachine if it is orphan deleted", func() {

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -33,6 +33,7 @@ import (
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -402,7 +403,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				return true
 			}
 			return false
-		}, 120*time.Second, time.Second).Should(BeTrue())
+		}, libwait.DefaultVMIRemovalTimeoutSeconds*time.Second, time.Second).Should(BeTrue())
 
 		By("Checking number of RS VM's to see that we got a replacement")
 		vmis, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(rs)).List(context.Background(), &v12.ListOptions{})

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -261,7 +261,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+					libwait.WaitForVirtualMachineToDisappear(vmi)
 				}
 				libstorage.DeleteDataVolume(&dataVolume)
 			})
@@ -340,7 +340,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+				libwait.WaitForVirtualMachineToDisappear(vmi)
 				libstorage.DeleteDataVolume(&dataVolume)
 			})
 

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -88,6 +88,6 @@ var _ = SIGDescribe("[Serial]K8s IO events", Serial, func() {
 
 		err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred(), "Failed to delete VMI")
-		libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+		libwait.WaitForVirtualMachineToDisappear(vmi)
 	})
 })

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -150,7 +150,7 @@ var _ = SIGDescribe("Storage", func() {
 				By("Cleaning up")
 				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
-				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
+				libwait.WaitForVirtualMachineToDisappear(vmi)
 			}
 
 			BeforeEach(func() {
@@ -256,7 +256,7 @@ var _ = SIGDescribe("Storage", func() {
 					// Ensure VMI is deleted before bringing down the NFS server
 					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
-					libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+					libwait.WaitForVirtualMachineToDisappear(vmi)
 
 					if targetImagePath != testsuite.HostPathAlpine {
 						tests.DeleteAlpineWithNonQEMUPermissions()
@@ -312,7 +312,7 @@ var _ = SIGDescribe("Storage", func() {
 
 					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+					libwait.WaitForVirtualMachineToDisappear(vmi)
 				}
 			},
 				Entry("[test_id:3132]with Disk PVC", newRandomVMIWithPVC),
@@ -409,7 +409,7 @@ var _ = SIGDescribe("Storage", func() {
 						Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 
 						By("Waiting for VMI to disappear")
-						libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+						libwait.WaitForVirtualMachineToDisappear(vmi)
 					}
 				})
 
@@ -480,7 +480,7 @@ var _ = SIGDescribe("Storage", func() {
 				By("Killing a VirtualMachineInstance")
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForVirtualMachineToDisappearWithTimeout(createdVMI, 120)
+				libwait.WaitForVirtualMachineToDisappear(createdVMI)
 
 				By("Starting the VirtualMachineInstance again")
 				if isRunOnKindInfra {
@@ -847,10 +847,10 @@ var _ = SIGDescribe("Storage", func() {
 				AfterEach(func() {
 					if vmi != nil {
 						Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
-						libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+						libwait.WaitForVirtualMachineToDisappear(vmi)
 					}
 					Expect(virtClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})).To(Succeed())
-					waitForPodToDisappearWithTimeout(pod.Name, 120)
+					waitForPodToDisappearWithTimeout(pod.Name, libwait.DefaultVirtLauncherPodRemovalTimeoutSeconds)
 				})
 
 				configureToleration := func(toleration int) {
@@ -1314,7 +1314,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
-				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
+				libwait.WaitForVirtualMachineToDisappear(vmi)
 			},
 				Entry("PVC source", addPVCLunDisk),
 				Entry("DataVolume source", addDataVolumeLunDisk),
@@ -1375,7 +1375,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
-				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
+				libwait.WaitForVirtualMachineToDisappear(vmi)
 			})
 		})
 	})

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -217,7 +217,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 
 			By("Waiting for VMI to disappear")
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+			libwait.WaitForVirtualMachineToDisappear(vmi)
 
 			kv = util.GetCurrentKv(virtClient)
 			kv.Spec.Configuration.MigrationConfiguration = oldMigrationConfiguration
@@ -289,8 +289,8 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			Expect(virtClient.VirtualMachineInstance(vmiToMigrate.Namespace).Delete(context.Background(), vmiToMigrate.Name, &metav1.DeleteOptions{})).To(Succeed())
 
 			By("Waiting for VMIs to disappear")
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmiToFillTargetNodeMem, 240)
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmiToMigrate, 240)
+			libwait.WaitForVirtualMachineToDisappear(vmiToFillTargetNodeMem)
+			libwait.WaitForVirtualMachineToDisappear(vmiToMigrate)
 		})
 
 	})

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -60,7 +60,7 @@ var _ = Describe("[Serial][sig-compute][USB] host USB Passthrough", Serial, deco
 		// Make sure to delete the VMI before ending the test otherwise a device could still be taken
 		err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
-		libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
+		libwait.WaitForVirtualMachineToDisappear(vmi)
 	})
 
 	Context("with usb storage", func() {

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -354,7 +354,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+			libwait.WaitForVirtualMachineToDisappear(vmi)
 		},
 			Entry("unprivileged virtiofsd", util.NamespaceTestDefault),
 			Entry("privileged virtiofsd", testsuite.NamespacePrivileged),

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -94,7 +94,7 @@ var _ = Describe("[Serial][sig-compute]HostDevices", Serial, decorators.SigCompu
 			// Make sure to delete the VMI before ending the test otherwise a device could still be taken
 			err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
-			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
+			libwait.WaitForVirtualMachineToDisappear(vmi)
 		},
 			Entry("Should successfully passthrough an emulated PCI device", []string{"8086:2668"}),
 			Entry("Should successfully passthrough 2 emulated PCI devices", []string{"8086:2668", "8086:2415"}),

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1267,7 +1267,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				watcher.New(vmi).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, v1.Deleted)
-				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+				libwait.WaitForVirtualMachineToDisappear(vmi)
 
 				// Check if the stop event was logged
 				By("Checking that virt-handler logs VirtualMachineInstance deletion")
@@ -1283,7 +1283,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					data, err := logsQuery.DoRaw(context.Background())
 					Expect(err).ToNot(HaveOccurred(), "Should get the virthandler logs")
 					return string(data)
-				}, 30, 0.5).Should(SatisfyAny(
+				}, libwait.DefaultVirtLauncherPodRemovalTimeoutSeconds, 0.5).Should(SatisfyAny(
 					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is marked for deletion","name":"%s"`, vmi.GetObjectMeta().GetName()),               // Domain was deleted by virt-handler
 					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Shutoff reason Destroyed","name":"%s"`, vmi.GetObjectMeta().GetName()), // Domain was destroyed because the launcher pod is gone
 				), "Logs should confirm pod deletion")


### PR DESCRIPTION
**What this PR does / why we need it**:
Today many tests are waiting up to a certain
timeout for a VMI to disappear but some of
them for 120 seconds, others for 180
and others again for 240.
Let's use a single value across the whole
test suite and let's use
240 seconds to prevent us from
hitting: https://issues.redhat.com/browse/OCPBUGS-27949
In the future we will be able to reduce it
to 120 seconds with a one line change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Currently we have a mix of 120, 180 and 240 seconds here and there.
This will set a default value everywhere, and the value is currently set at 240 seconds.
This should help to avoid https://issues.redhat.com/browse/OCPBUGS-27949 .
Once that will be fixed, we will be able to reduce to 120 seconds.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
