### PR TITLE
[release-1.1] fix(vmclone): delete snapshot and restore after pvc bound

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -744,6 +744,19 @@ func GetVirtualMachineCloneInformerIndexers() cache.Indexers {
 
 			return nil, nil
 		},
+		// Gets: restore key. Returns: clones in phase Succeeded
+		string(clonev1alpha1.Succeeded): func(obj interface{}) ([]string, error) {
+			vmClone, ok := obj.(*clonev1alpha1.VirtualMachineClone)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			if vmClone.Status.Phase == clonev1alpha1.Succeeded && vmClone.Status.RestoreName != nil {
+				return []string{getkey(vmClone, *vmClone.Status.RestoreName)}, nil
+			}
+
+			return nil, nil
+		},
 	}
 }
 

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	restoreNameAnnotation = "restore.kubevirt.io/name"
+	RestoreNameAnnotation = "restore.kubevirt.io/name"
 
 	populatedForPVCAnnotation = "cdi.kubevirt.io/storage.populatedFor"
 
@@ -755,7 +755,7 @@ func (t *vmRestoreTarget) createDataVolume(dvt kubevirtv1.DataVolumeTemplateSpec
 	if newDataVolume.Annotations == nil {
 		newDataVolume.Annotations = make(map[string]string)
 	}
-	newDataVolume.Annotations[restoreNameAnnotation] = t.vmRestore.Name
+	newDataVolume.Annotations[RestoreNameAnnotation] = t.vmRestore.Name
 
 	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(t.vm.Namespace).Create(context.Background(), newDataVolume, v1.CreateOptions{}); err != nil {
 		t.controller.Recorder.Eventf(t.vm, corev1.EventTypeWarning, restoreDataVolumeCreateErrorEvent, "Error creating restore DataVolume %s: %v", newDataVolume.Name, err)
@@ -1065,7 +1065,7 @@ func CreateRestorePVCDefFromVMRestore(vmRestoreName, restorePVCName string, volu
 	}
 	pvc.Labels[restoreSourceNameLabel] = sourceVmName
 	pvc.Labels[restoreSourceNamespaceLabel] = sourceVmNamespace
-	pvc.Annotations[restoreNameAnnotation] = vmRestoreName
+	pvc.Annotations[RestoreNameAnnotation] = vmRestoreName
 	return pvc
 }
 

--- a/pkg/storage/snapshot/restore_base.go
+++ b/pkg/storage/snapshot/restore_base.go
@@ -189,7 +189,7 @@ func (ctrl *VMRestoreController) handleDataVolume(obj interface{}) {
 	}
 
 	if dv, ok := obj.(*v1beta1.DataVolume); ok {
-		restoreName, ok := dv.Annotations[restoreNameAnnotation]
+		restoreName, ok := dv.Annotations[RestoreNameAnnotation]
 		if !ok {
 			return
 		}
@@ -207,7 +207,7 @@ func (ctrl *VMRestoreController) handlePVC(obj interface{}) {
 	}
 
 	if pvc, ok := obj.(*corev1.PersistentVolumeClaim); ok {
-		restoreName, ok := pvc.Annotations[restoreNameAnnotation]
+		restoreName, ok := pvc.Annotations[RestoreNameAnnotation]
 		if !ok {
 			return
 		}

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -846,7 +846,7 @@ func (vca *VirtControllerApp) initCloneController() {
 	var err error
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "clone-controller")
 	vca.vmCloneController, err = clone.NewVmCloneController(
-		vca.clientSet, vca.vmCloneInformer, vca.vmSnapshotInformer, vca.vmRestoreInformer, vca.vmInformer, vca.vmSnapshotContentInformer, recorder,
+		vca.clientSet, vca.vmCloneInformer, vca.vmSnapshotInformer, vca.vmRestoreInformer, vca.vmInformer, vca.vmSnapshotContentInformer, vca.persistentVolumeClaimInformer, recorder,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -229,6 +229,7 @@ var _ = Describe("Application", func() {
 			vmRestoreInformer,
 			vmInformer,
 			vmSnapshotContentInformer,
+			pvcInformer,
 			recorder,
 		)
 

--- a/pkg/virt-controller/watch/clone/clone_base.go
+++ b/pkg/virt-controller/watch/clone/clone_base.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"time"
 
+	k8scorev1 "k8s.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/storage/snapshot"
+
 	"kubevirt.io/api/clone"
 	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 
@@ -32,6 +36,7 @@ const (
 	RestoreCreationFailed Event = "RestoreCreationFailed"
 	RestoreReady          Event = "RestoreReady"
 	TargetVMCreated       Event = "TargetVMCreated"
+	PVCBound              Event = "PVCBound"
 
 	SnapshotDeleted    Event = "SnapshotDeleted"
 	SourceDoesNotExist Event = "SourceDoesNotExist"
@@ -44,6 +49,7 @@ type VMCloneController struct {
 	restoreInformer         cache.SharedIndexInformer
 	vmInformer              cache.SharedIndexInformer
 	snapshotContentInformer cache.SharedIndexInformer
+	pvcInformer             cache.SharedIndexInformer
 	recorder                record.EventRecorder
 
 	vmCloneQueue       workqueue.RateLimitingInterface
@@ -51,7 +57,7 @@ type VMCloneController struct {
 	cloneStatusUpdater *status.CloneStatusUpdater
 }
 
-func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapshotInformer, restoreInformer, vmInformer, snapshotContentInformer cache.SharedIndexInformer, recorder record.EventRecorder) (*VMCloneController, error) {
+func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapshotInformer, restoreInformer, vmInformer, snapshotContentInformer, pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder) (*VMCloneController, error) {
 	ctrl := VMCloneController{
 		client:                  client,
 		vmCloneInformer:         vmCloneInformer,
@@ -59,6 +65,7 @@ func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapsh
 		restoreInformer:         restoreInformer,
 		vmInformer:              vmInformer,
 		snapshotContentInformer: snapshotContentInformer,
+		pvcInformer:             pvcInformer,
 		recorder:                recorder,
 		vmCloneQueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-vmclone"),
 		vmStatusUpdater:         status.NewVMStatusUpdater(client),
@@ -94,6 +101,18 @@ func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapsh
 			AddFunc:    ctrl.handleRestore,
 			UpdateFunc: func(oldObj, newObj interface{}) { ctrl.handleRestore(newObj) },
 			DeleteFunc: ctrl.handleRestore,
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = ctrl.pvcInformer.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    ctrl.handlePVC,
+			UpdateFunc: func(oldObj, newObj interface{}) { ctrl.handlePVC(newObj) },
+			DeleteFunc: ctrl.handlePVC,
 		},
 	)
 
@@ -190,6 +209,43 @@ func (ctrl *VMCloneController) handleRestore(obj interface{}) {
 	}
 
 	for _, key := range restoreWaitingKeys {
+		ctrl.vmCloneQueue.AddRateLimited(key)
+	}
+}
+
+func (ctrl *VMCloneController) handlePVC(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+
+	pvc, ok := obj.(*k8scorev1.PersistentVolumeClaim)
+	if !ok {
+		log.Log.Errorf(unknownTypeErrFmt, "persistentvolumeclaim")
+		return
+	}
+
+	var (
+		restoreName string
+		exists      bool
+	)
+
+	if restoreName, exists = pvc.Annotations[snapshot.RestoreNameAnnotation]; !exists {
+		return
+	}
+
+	if pvc.Status.Phase != k8scorev1.ClaimBound {
+		return
+	}
+
+	restoreKey := getKey(restoreName, pvc.Namespace)
+
+	succeededWaitingKeys, err := ctrl.vmCloneInformer.GetIndexer().IndexKeys(string(clonev1alpha1.Succeeded), restoreKey)
+	if err != nil {
+		log.Log.Object(pvc).Reason(err).Error("cannot get clone succeededWaitingKeys from " + string(clonev1alpha1.Succeeded) + " indexer")
+		return
+	}
+
+	for _, key := range succeededWaitingKeys {
 		ctrl.vmCloneQueue.AddRateLimited(key)
 	}
 }

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
@@ -488,6 +490,10 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())
 
+				if !running && libstorage.IsStorageClassBindingModeWaitForFirstConsumer(storageClass) {
+					return vm
+				}
+
 				for _, dvt := range vm.Spec.DataVolumeTemplates {
 					libstorage.EventuallyDVWith(vm.Namespace, dvt.Name, 180, HaveSucceeded())
 				}
@@ -698,6 +704,63 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 					expectVMRunnable(targetVMCloneFromClone)
 					expectEqualLabels(targetVMCloneFromClone, sourceVM)
 					expectEqualAnnotations(targetVMCloneFromClone, sourceVM)
+				})
+
+				Context("with WaitForFirstConsumer binding mode", func() {
+					BeforeEach(func() {
+						snapshotStorageClass, err = libstorage.GetWFFCStorageSnapshotClass(virtClient)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(snapshotStorageClass).ToNot(BeEmpty(), "no storage class with snapshot support and wffc binding mode")
+					})
+
+					It("should not delete the vmsnapshot and vmrestore until all the pvc(s) are bound", func() {
+						addCloneAnnotationAndLabelFilters := func(vmClone *clonev1alpha1.VirtualMachineClone) {
+							filters := []string{"somekey/*"}
+							vmClone.Spec.LabelFilters = filters
+							vmClone.Spec.AnnotationFilters = filters
+						}
+						generateCloneWithFilters := func(sourceVM *virtv1.VirtualMachine, targetVMName string) *clonev1alpha1.VirtualMachineClone {
+							vmclone := generateCloneFromVMWithParams(sourceVM, targetVMName)
+							addCloneAnnotationAndLabelFilters(vmclone)
+							return vmclone
+						}
+
+						sourceVM = createVMWithStorageClass(snapshotStorageClass, true)
+						vmClone = generateCloneWithFilters(sourceVM, targetVMName)
+						StopVirtualMachine(sourceVM)
+
+						createCloneAndWaitForFinish(vmClone)
+
+						By(fmt.Sprintf("Getting the target VM %s", targetVMName))
+						targetVM, err = virtClient.VirtualMachine(sourceVM.Namespace).Get(context.Background(), targetVMName, &v1.GetOptions{})
+						Expect(err).ShouldNot(HaveOccurred())
+
+						vmClone, err = virtClient.VirtualMachineClone(vmClone.Namespace).Get(context.Background(), vmClone.Name, v1.GetOptions{})
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(vmClone.Status.SnapshotName).ShouldNot(BeNil())
+						vmSnapshotName := vmClone.Status.SnapshotName
+						Expect(vmClone.Status.RestoreName).ShouldNot(BeNil())
+						vmRestoreName := vmClone.Status.RestoreName
+						Consistently(func(g Gomega) {
+							vmSnapshot, err := virtClient.VirtualMachineSnapshot(vmClone.Namespace).Get(context.Background(), *vmSnapshotName, v1.GetOptions{})
+							g.Expect(err).ShouldNot(HaveOccurred())
+							g.Expect(vmSnapshot).ShouldNot(BeNil())
+							vmRestore, err := virtClient.VirtualMachineRestore(vmClone.Namespace).Get(context.Background(), *vmRestoreName, v1.GetOptions{})
+							g.Expect(err).ShouldNot(HaveOccurred())
+							g.Expect(vmRestore).ShouldNot(BeNil())
+						}, 30*time.Second).Should(Succeed(), "vmsnapshot and vmrestore should not be deleted until the pvc is bound")
+
+						By(fmt.Sprintf("Starting the target VM %s", targetVMName))
+						err = virtClient.VirtualMachine(testsuite.GetTestNamespace(targetVM)).Start(context.Background(), targetVMName, &virtv1.StartOptions{Paused: false})
+						Expect(err).ToNot(HaveOccurred())
+						Eventually(func(g Gomega) {
+							_, err := virtClient.VirtualMachineSnapshot(vmClone.Namespace).Get(context.Background(), *vmSnapshotName, v1.GetOptions{})
+							g.Expect(errors.IsNotFound(err)).Should(BeTrue())
+							_, err = virtClient.VirtualMachineRestore(vmClone.Namespace).Get(context.Background(), *vmRestoreName, v1.GetOptions{})
+							g.Expect(errors.IsNotFound(err)).Should(BeTrue())
+						}, 1*time.Minute).Should(Succeed(), "vmsnapshot and vmrestore should be deleted once the pvc is bound")
+					})
+
 				})
 
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is an manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/10888

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bugfix] Clone VM with WaitForFirstConsumer binding mode PVC now works.
```
/cc @acardace 