### PR TITLE
[e2e] Use expect rather than panics for error handling in operator tests

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -3279,10 +3279,7 @@ func prometheusRuleEnabled() bool {
 	virtClient := kubevirt.Client()
 
 	prometheusRuleEnabled, err := util.IsPrometheusRuleEnabled(virtClient)
-	if err != nil {
-		fmt.Printf("ERROR: Can't verify PrometheusRule CRD %v\n", err)
-		panic(err)
-	}
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Unable to verify PrometheusRule CRD")
 
 	return prometheusRuleEnabled
 }
@@ -3291,10 +3288,7 @@ func serviceMonitorEnabled() bool {
 	virtClient := kubevirt.Client()
 
 	serviceMonitorEnabled, err := util.IsServiceMonitorEnabled(virtClient)
-	if err != nil {
-		fmt.Printf("ERROR: Can't verify ServiceMonitor CRD %v\n", err)
-		panic(err)
-	}
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Unable to verify ServiceMonitor CRD")
 
 	return serviceMonitorEnabled
 }
@@ -3365,9 +3359,7 @@ func detectLatestUpstreamOfficialTag() (string, error) {
 			continue
 		}
 		v, err := semver.NewVersion(*release.TagName)
-		if err != nil {
-			panic(err)
-		}
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to parse latest release tag")
 		vs = append(vs, v)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Use expect rather than panics for error handling in operator tests.

Follow up to a previous PR review comment[1]

[1] https://github.com/kubevirt/kubevirt/pull/11053#discussion_r1463266953

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @dhiller 
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:

```release-note
NONE
```
