### PR TITLE
e2e,guestlog: Reduce log rotate test runtime

### DIFF
--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -192,17 +192,17 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				virtlauncherPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Generating 9MB of log data to force log rotation and discarding")
-				generateHugeLogData(vmi, 9)
+				By("Generating 1MB of log data to force log rotation and discarding")
+				generateHugeLogData(vmi, 1)
 
 				By("Ensuring that log fetching is not failing")
 				_, err = getConsoleLogs(virtClient, virtlauncherPod)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Ensuring that we have 4 rotated log files (+term one)")
+				By("Ensuring that we have 1 rotated log file (+term one)")
 				outputString, err := exec.ExecuteCommandOnPod(virtClient, virtlauncherPod, "guest-console-log", []string{"/bin/ls", "-l", fmt.Sprintf("/var/run/kubevirt-private/%v", vmi.UID)})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(strings.Count(outputString, "virt-serial0-log")).To(Equal(4 + 1))
+				Expect(strings.Count(outputString, "virt-serial0-log")).To(Equal(1 + 1))
 			})
 
 			It("it should not skip any log line even trying to flood the serial console for QOSGuaranteed VMs", func() {

--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -38,16 +38,11 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 
 	var (
 		virtClient kubecli.KubevirtClient
-		alpineVmi  *v1.VirtualMachineInstance
 		cirrosVmi  *v1.VirtualMachineInstance
 	)
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		alpineVmi = libvmi.NewAlpine()
-		alpineVmi.Spec.Domain.Devices.AutoattachSerialConsole = pointer.P(true)
-		alpineVmi.Spec.Domain.Devices.LogSerialConsole = pointer.P(true)
 
 		cirrosVmi = libvmi.NewCirros()
 		cirrosVmi.Spec.Domain.Devices.AutoattachSerialConsole = pointer.P(true)
@@ -58,9 +53,9 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 		Context("set LogSerialConsole", func() {
 			DescribeTable("should successfully start with LogSerialConsole", func(autoattachSerialConsole, logSerialConsole, expected bool) {
 				By("Starting a VMI")
-				alpineVmi.Spec.Domain.Devices.AutoattachSerialConsole = pointer.P(autoattachSerialConsole)
-				alpineVmi.Spec.Domain.Devices.LogSerialConsole = pointer.P(logSerialConsole)
-				vmi := tests.RunVMIAndExpectLaunch(alpineVmi, cirrosStartupTimeout)
+				cirrosVmi.Spec.Domain.Devices.AutoattachSerialConsole = pointer.P(autoattachSerialConsole)
+				cirrosVmi.Spec.Domain.Devices.LogSerialConsole = pointer.P(logSerialConsole)
+				vmi := tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")
 				virtlauncherPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))


### PR DESCRIPTION
**What this PR does / why we need it**:

The guestlog log rotate test takes on average over 7 and a half minutes
to run which makes it one of longest e2e tests.

The majority of this time is taken up with writing data to the log file
to force the log to rotate.

Reducing the amount of data written to the log and reducing the number
of expected rotated log files greatly reduces the test run time

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc none

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
