### PR TITLE
e2e: wait for all workers to enable cpumanager before starting

### DIFF
--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -173,11 +173,9 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 
 		It("should successfully plug guaranteed vCPUs", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
 			checks.ExpectAtLeastTwoWorkerNodesWithCPUManager(virtClient)
-			By("Creating a running VM with 1 socket and 2 max sockets")
-			const (
-				maxSockets uint32 = 3
-			)
+			const maxSockets uint32 = 3
 
+			By("Creating a running VM with 1 socket and 2 max sockets")
 			vmi := libvmi.NewAlpineWithTestTooling(
 				libvmi.WithMasqueradeNetworking()...,
 			)

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -138,21 +138,20 @@ func AdjustKubeVirtResource() {
 	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(kv.Name, types.JSONPatchType, []byte(patchData), &metav1.PatchOptions{})
 	util.PanicOnError(err)
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
-	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	if checks.HasFeature(virtconfig.CPUManager) && len(nodes.Items) > 1 {
-		// CPUManager is not enabled in the control-plane node
-		waitForSchedulableNodeWithCPUManager()
+	if checks.HasFeature(virtconfig.CPUManager) {
+		// CPUManager is not enabled in the control-plane node(s)
+		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/control-plane"})
+		Expect(err).NotTo(HaveOccurred())
+		waitForSchedulableNodesWithCPUManager(len(nodes.Items))
 	}
 }
 
-func waitForSchedulableNodeWithCPUManager() {
-
+func waitForSchedulableNodesWithCPUManager(n int) {
 	virtClient := kubevirt.Client()
 	Eventually(func() bool {
 		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true," + v1.CPUManager + "=true"})
 		Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
-		return len(nodes.Items) != 0
+		return len(nodes.Items) == n
 	}, 360, 1*time.Second).Should(BeTrue())
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Saw flakes on the migration lane because only 1 node has cpumanager ready.
This PR should fix that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
