### PR TITLE
add s390x support for kubevirt builder.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ client-python:
 	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} ./hack/gen-client-python/generate.sh"
 
 go-build:
-	hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} KUBEVIRT_RELEASE=${KUBEVIRT_RELEASE} ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
+	KUBEVIRT_NO_BAZEL=true hack/dockerized "export KUBEVIRT_VERSION=${KUBEVIRT_VERSION} && KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} KUBEVIRT_RELEASE=${KUBEVIRT_RELEASE} ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
 
 go-build-functests:
 	hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} ./hack/go-build-functests.sh"
@@ -77,7 +77,7 @@ goveralls:
 	SYNC_OUT=false hack/dockerized "COVERALLS_TOKEN_FILE=${COVERALLS_TOKEN_FILE} COVERALLS_TOKEN=${COVERALLS_TOKEN} CI_NAME=prow CI_BRANCH=${PULL_BASE_REF} CI_PR_NUMBER=${PULL_NUMBER} GIT_ID=${PULL_PULL_SHA} PROW_JOB_ID=${PROW_JOB_ID} ./hack/bazel-goveralls.sh"
 
 go-test: go-build
-	SYNC_OUT=false hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} ./hack/build-go.sh test ${WHAT}"
+	SYNC_OUT=false KUBEVIRT_NO_BAZEL=true hack/dockerized "export KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} && ./hack/build-go.sh test ${WHAT}"
 
 test: bazel-test
 

--- a/hack/bazel-server.sh
+++ b/hack/bazel-server.sh
@@ -1,5 +1,10 @@
-BAZEL_PID=$(bazel info | grep server_pid | cut -d " " -f 2)
-while kill -0 $BAZEL_PID 2>/dev/null; do sleep 1; done
-# Might not be necessary, just to be sure that exec shutdowns always succeed
-# and are not killed by docker.
-sleep 1
+# Execute unit tests without relying on Bazel.
+if [ "$KUBEVIRT_NO_BAZEL" = true ]; then
+    sleep infinity
+else
+    BAZEL_PID=$(bazel info | grep server_pid | cut -d " " -f 2)
+    while kill -0 $BAZEL_PID 2>/dev/null; do sleep 1; done
+    # Might not be necessary, just to be sure that exec shutdowns always succeed
+    # and are not killed by docker.
+    sleep 1
+fi

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,5 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
+ARG ARCH
 ARG SONOBUOY_ARCH
 ARG BAZEL_ARCH
 
@@ -132,8 +133,10 @@ COPY entrypoint.sh /entrypoint.sh
 
 COPY create_bazel_cache_rcs.sh /create_bazel_cache_rcs.sh
 
-RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${BAZEL_ARCH} && \
-    chmod u+x /usr/bin/bazel
+RUN if test "${ARCH}" != "s390x"; then \
+       curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${BAZEL_ARCH} && \
+       chmod u+x /usr/bin/bazel; \
+    fi
 
 # Add /root/go/src/kubevirt.io/kubevirt and mark it as a safe directory for git
 RUN mkdir -p /root/go/src/kubevirt.io/kubevirt && git config --global --add safe.directory /root/go/src/kubevirt.io/kubevirt

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -36,7 +36,7 @@ for ARCH in ${ARCHITECTURES}; do
         ;;
     esac
     ${KUBEVIRT_CRI} >&2 pull --platform="linux/${ARCH}" quay.io/centos/centos:stream9
-    ${KUBEVIRT_CRI} >&2 build --platform="linux/${ARCH}" -t "${DOCKER_PREFIX}/${DOCKER_IMAGE}:${VERSION}-${ARCH}" --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
+    ${KUBEVIRT_CRI} >&2 build --platform="linux/${ARCH}" -t "${DOCKER_PREFIX}/${DOCKER_IMAGE}:${VERSION}-${ARCH}" --build-arg ARCH=${ARCH} --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
 done
 
 # Print the version for use by other callers such as publish.sh

--- a/hack/builder/common.sh
+++ b/hack/builder/common.sh
@@ -2,4 +2,4 @@ DOCKER_PREFIX=${DOCKER_PREFIX:-"quay.io/kubevirt"}
 DOCKER_IMAGE=${DOCKER_IMAGE:-"builder"}
 
 # TODO: reenable ppc64le when new builds are available
-ARCHITECTURES="amd64 arm64"
+ARCHITECTURES="amd64 arm64 s390x"

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ SYNC_VENDOR=${SYNC_VENDOR:-false}
 
 TEMPFILE=".rsynctemp"
 
-CONTAINER_ENV="--env HTTP_PROXY=${HTTP_PROXY} --env HTTPS_PROXY=${HTTP_PROXY} --env NO_PROXY=${NO_PROXY}"
+CONTAINER_ENV="--env HTTP_PROXY=${HTTP_PROXY} --env HTTPS_PROXY=${HTTP_PROXY} --env NO_PROXY=${NO_PROXY} --env KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL}"
 
 # Create the persistent container volume
 if [ -z "$($KUBEVIRT_CRI volume list | grep ${BUILDER})" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This pr adds the s390x support to kubevirt builder image.
The kubevirt builder image for s390x does not contain Bazel. We are not including the Bazel because at the moment there is no upstream official support of Bazel for s390x. We are working with Bazel community to get the support. But it will take lot of time to get the support as the Bazel community has other priorities and they are not willing to add the support now. We also thought to publish the natively compiled Bazel Binary for s390x, We were not able to do it because of legal issues. We will include the Bazel in the  kubevirt builder once we get the Bazel support on s390x.
**How we are proceeding for unit and E2E Tests**.
Unit Test:
We will run the unit-tests using Golang . We will publish the kubevirt builder image without Bazel to the public and use that image to run the unit tests using make go-test.

E2E Test:
We will use our own kubevirt builder image (which contains Bazel) from our internal registry, and we will override the used image using environment variable to run the e2e tests.

cc: @brianmcarey 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add s390x support for kubevirt builder
```
