### PR TITLE
fix: `Eventually()` missing `Should()` statement and sync error

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1957,6 +1957,17 @@ status:
 
 	Context("[Serial] when node becomes unhealthy", Serial, func() {
 		const componentName = "virt-handler"
+		var nodeName string
+
+		AfterEach(func() {
+			libpod.DeleteKubernetesApiBlackhole(getHandlerNodePod(virtClient, nodeName), componentName)
+			Eventually(func(g Gomega) {
+				g.Expect(getHandlerNodePod(virtClient, nodeName).Items[0]).To(HaveConditionTrue(k8sv1.PodReady))
+			}, 120*time.Second, time.Second).Should(Succeed())
+
+			tests.WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", util.GetCurrentKv(virtClient).ResourceVersion,
+				tests.ExpectResourceVersionToBeLessEqualThanConfigVersion, 120*time.Second)
+		})
 
 		It("[Serial] the VMs running in that node should be respawned", func() {
 			By("Starting VM")
@@ -1964,17 +1975,14 @@ status:
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			nodeName := vmi.Status.NodeName
+			nodeName = vmi.Status.NodeName
 			oldUID := vmi.UID
 
 			By("Blocking virt-handler from reconciling the VMI")
 			libpod.AddKubernetesApiBlackhole(getHandlerNodePod(virtClient, nodeName), componentName)
-			Eventually(getHandlerNodePod(virtClient, nodeName).Items[0], 120*time.Second, time.Second, HaveConditionFalse(k8sv1.PodReady))
-
-			DeferCleanup(func() {
-				libpod.DeleteKubernetesApiBlackhole(getHandlerNodePod(virtClient, nodeName), componentName)
-				Eventually(getHandlerNodePod(virtClient, nodeName).Items[0], 120*time.Second, time.Second, HaveConditionTrue(k8sv1.PodReady))
-			})
+			Eventually(func(g Gomega) {
+				g.Expect(getHandlerNodePod(virtClient, nodeName).Items[0]).To(HaveConditionFalse(k8sv1.PodReady))
+			}, 120*time.Second, time.Second).Should(Succeed())
 
 			pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
The linter enforces the usage of `Should()` statements when a `Eventually` check is used.
It adds the missing `Eventually()` statements `Should()` checks.

Also, `DeferCleanup` has been dropped in favor of `defer`. The [`resetToDefaultConfig()` ](https://github.com/kubevirt/kubevirt/blob/cb1b6e53540189d6664c4a8c126ab6e0a84ff8c4/tests/utils.go#L1842) is called before the test `DeferCleanup`, creating the following error:

```
  [FAILED] in [AfterEach] - tests/utils.go:1601 @ 01/29/24 15:32:28.576
  << Timeline
  [FAILED] Timed out after 10.001s.
  Unexpected error:
      <*errors.errorString | 0xc006203230>: 
      resource & config versions (5548 and 4736 respectively) are not as expected. component: "virt-handler", pod: "virt-handler-zdv7f" 
      {
          s: "resource & config versions (5548 and 4736 respectively) are not as expected. component: \"virt-handler\", pod: \"virt-handler-zdv7f\" ",
      }
  occurred
  In [AfterEach] at: tests/utils.go:1601 @ 01/29/24 15:32:28.576
  Full Stack Trace
    kubevirt.io/kubevirt/tests.resetToDefaultConfig()
        tests/utils.go:1601 +0x85
    kubevirt.io/kubevirt/tests.TestCleanup()
        tests/utils.go:113 +0x6f
    kubevirt.io/kubevirt/tests_test.glob..func21()
        tests/tests_suite_test.go:108 +0xf
```

This is because the `virt-handler` will not be ready (intentionally for the purposes of the test), and the `resetToDefaultConfig()` will force the `virt-handler` to reconcile, which will fail, but the `virt-handler` `resourceVersion` will be updated. Therefore, the Kubevirt object will be out of sync.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
