### PR TITLE
Change macvtap tests to use the network plugin binding API 

### DIFF
--- a/tests/exec/execute.go
+++ b/tests/exec/execute.go
@@ -26,6 +26,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
+
 	"kubevirt.io/client-go/kubecli"
 )
 

--- a/tests/libnet/interface.go
+++ b/tests/libnet/interface.go
@@ -37,6 +37,28 @@ func InterfaceExists(vmi *v1.VirtualMachineInstance, interfaceName string) error
 	return nil
 }
 
+func AddIPAddress(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAddress string) error {
+	const addrAddTimeout = time.Second * 5
+	setStaticIPCmd := fmt.Sprintf("ip addr add %s dev %s\n", interfaceAddress, interfaceName)
+
+	if err := console.RunCommand(vmi, setStaticIPCmd, addrAddTimeout); err != nil {
+		return fmt.Errorf("could not configure address %s for interface %s on VMI %s: %w", interfaceAddress, interfaceName, vmi.Name, err)
+	}
+
+	return nil
+}
+
+func SetInterfaceUp(vmi *v1.VirtualMachineInstance, interfaceName string) error {
+	const ifaceUpTimeout = time.Second * 5
+	setUpCmd := fmt.Sprintf("ip link set %s up\n", interfaceName)
+
+	if err := console.RunCommand(vmi, setUpCmd, ifaceUpTimeout); err != nil {
+		return fmt.Errorf("could not set interface %s up on VMI %s: %w", interfaceName, vmi.Name, err)
+	}
+
+	return nil
+}
+
 func LookupNetworkByName(networks []v1.Network, name string) *v1.Network {
 	for i, net := range networks {
 		if net.Name == name {

--- a/tests/libnet/network_attachment_definition.go
+++ b/tests/libnet/network_attachment_definition.go
@@ -39,6 +39,25 @@ func CreatePasstNetworkAttachmentDefinition(namespace string) error {
 	)
 }
 
+func CreateMacvtapNetworkAttachmentDefinition(namespace, networkName, macvtapLowerDevice string) error {
+	const macvtapNADFmt = `{
+		"apiVersion":"k8s.cni.cncf.io/v1",
+		"kind":"NetworkAttachmentDefinition",
+		"metadata":{
+			"name":"%s",
+			"namespace":"%s", 
+			"annotations": {
+				"k8s.v1.cni.cncf.io/resourceName": "macvtap.network.kubevirt.io/%s"
+			}
+		},
+		"spec":{
+			"config":"{\"cniVersion\": \"0.3.1\",\"name\": \"%s\",\"type\": \"macvtap\"}"
+		}
+	}`
+	macvtapNad := fmt.Sprintf(macvtapNADFmt, networkName, namespace, macvtapLowerDevice, networkName)
+	return CreateNetworkAttachmentDefinition(networkName, namespace, macvtapNad)
+}
+
 func CreateNetworkAttachmentDefinition(name, namespace, netConf string) error {
 	const postURL = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
 	return kubevirt.Client().RestClient().

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -106,6 +106,15 @@ func InterfaceWithPasstBindingPlugin(ports ...kvirtv1.Port) kvirtv1.Interface {
 	}
 }
 
+// InterfaceWithMacvtapBindingPlugin returns an Interface named "default" with "macvtap" binding plugin.
+func InterfaceWithMacvtapBindingPlugin(name string) *kvirtv1.Interface {
+	const macvtapBindingName = "macvtap"
+	return &kvirtv1.Interface{
+		Name:    name,
+		Binding: &kvirtv1.PluginBinding{Name: macvtapBindingName},
+	}
+}
+
 func InterfaceWithBindingPlugin(name string, binding kvirtv1.PluginBinding, ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{
 		Name:    name,

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bindingplugin.go",
+        "bindingplugin_macvtap.go",
         "bindingplugin_passt.go",
         "dual_stack_cluster.go",
         "expose.go",

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -1,0 +1,258 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libkvconfig"
+	"kubevirt.io/kubevirt/tests/libmigration"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnode"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin", decorators.Macvtap, decorators.NetCustomBindingPlugins, Serial, func() {
+	const (
+		macvtapLowerDevice = "eth0"
+		macvtapNetworkName = "net1"
+	)
+
+	BeforeEach(func() {
+		tests.EnableFeatureGate(virtconfig.NetworkBindingPlugingsGate)
+	})
+
+	BeforeEach(func() {
+		const macvtapBindingName = "macvtap"
+		err := libkvconfig.WithNetBindingPlugin(macvtapBindingName, v1.InterfaceBindingPlugin{
+			DomainAttachmentType: v1.Tap,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	BeforeEach(func() {
+		ns := testsuite.GetTestNamespace(nil)
+		Expect(libnet.CreateMacvtapNetworkAttachmentDefinition(ns, macvtapNetworkName, macvtapLowerDevice)).To(Succeed(),
+			"A macvtap network named %s should be provisioned", macvtapNetworkName)
+	})
+
+	It("should successfully create a VM with macvtap interface with custom MAC address", func() {
+		const mac = "02:00:00:00:00:02"
+		vmi, err := createAlpineVMIRandomNode(macvtapNetworkName, mac)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(vmi.Status.Interfaces).To(HaveLen(1), "should have a single interface")
+		Expect(vmi.Status.Interfaces[0].MAC).To(Equal(mac), "the expected MAC address should be set in the VMI")
+	})
+
+	It("two VMs with macvtap interface should be able to communicate over macvtap network", func() {
+		nodeList := libnode.GetAllSchedulableNodes(kubevirt.Client())
+		Expect(nodeList.Items).NotTo(BeEmpty(), "schedulable kubernetes nodes must be present")
+		nodeName := nodeList.Items[0].Name
+
+		chosenMACHW, err := GenerateRandomMac()
+		Expect(err).ToNot(HaveOccurred())
+		chosenMAC := chosenMACHW.String()
+
+		serverCIDR := "192.0.2.102/24"
+		serverIP, err := libnet.CidrToIP(serverCIDR)
+		Expect(err).ToNot(HaveOccurred())
+
+		_ = createAlpineVMIStaticIPOnNode(nodeName, macvtapNetworkName, "eth0", serverCIDR, &chosenMAC)
+		clientVMI := createAlpineVMIStaticIPOnNode(nodeName, macvtapNetworkName, "eth0", "192.0.2.101/24", nil)
+
+		Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
+	})
+
+	Context("VMI migration", func() {
+		var clientVMI *v1.VirtualMachineInstance
+
+		BeforeEach(checks.SkipIfMigrationIsNotPossible)
+
+		BeforeEach(func() {
+			macAddressHW, err := GenerateRandomMac()
+			Expect(err).ToNot(HaveOccurred())
+			macAddress := macAddressHW.String()
+			clientVMI, err = createAlpineVMIRandomNode(macvtapNetworkName, macAddress)
+			Expect(err).NotTo(HaveOccurred(), "must succeed creating a VMI on a random node")
+		})
+
+		It("should be successful when the VMI MAC address is defined in its spec", func() {
+			By("starting the migration")
+			migration := libmigration.New(clientVMI.Name, clientVMI.Namespace)
+			migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
+
+			// check VMI, confirm migration state
+			libmigration.ConfirmVMIPostMigration(kubevirt.Client(), clientVMI, migration)
+		})
+
+		Context("with live traffic", func() {
+			var serverVMI *v1.VirtualMachineInstance
+			var serverVMIPodName string
+			var serverIP string
+
+			const macvtapIfaceIPReportTimeout = 4 * time.Minute
+
+			BeforeEach(func() {
+				macAddressHW, err := GenerateRandomMac()
+				Expect(err).ToNot(HaveOccurred())
+				macAddress := macAddressHW.String()
+
+				serverVMI, err = createFedoraVMIRandomNode(macvtapNetworkName, macAddress)
+				Expect(err).NotTo(HaveOccurred(), "must have succeeded creating a fedora VMI on a random node")
+				Expect(serverVMI.Status.Interfaces).NotTo(BeEmpty(), "a migrate-able VMI must have network interfaces")
+				serverVMIPodName = tests.GetVmPodName(kubevirt.Client(), serverVMI)
+
+				serverIP, err = waitVMMacvtapIfaceIPReport(serverVMI, macAddress, macvtapIfaceIPReportTimeout)
+				Expect(err).NotTo(HaveOccurred(), "should have managed to figure out the IP of the server VMI")
+			})
+
+			BeforeEach(func() {
+				// TODO test also the IPv6 address (issue- https://github.com/kubevirt/kubevirt/issues/7506)
+				libnet.SkipWhenClusterNotSupportIpv4()
+				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed(), "connectivity is expected *before* migrating the VMI")
+			})
+
+			It("should keep connectivity after a migration", func() {
+				const containerCompletionWaitTime = 60
+				migration := libmigration.New(serverVMI.Name, serverVMI.GetNamespace())
+				_ = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
+				// In case of clientVMI and serverVMI running on the same node before migration, the serverVMI
+				// will be reachable only when the original launcher pod terminates.
+				Eventually(func() error {
+					return waitForPodCompleted(serverVMI.Namespace, serverVMIPodName)
+				}, containerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod: %s", serverVMIPodName))
+				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed(), "connectivity is expected *after* migrating the VMI")
+			})
+		})
+	})
+})
+
+func createAlpineVMIStaticIPOnNode(nodeName string, networkName string, ifaceName string, ipCIDR string, mac *string) *v1.VirtualMachineInstance {
+	var vmi *v1.VirtualMachineInstance
+	if mac != nil {
+		vmi = libvmi.NewAlpineWithTestTooling(
+			libvmi.WithInterface(*libvmi.InterfaceWithMac(libvmi.InterfaceWithMacvtapBindingPlugin(networkName), *mac)),
+			libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
+			libvmi.WithNodeAffinityFor(nodeName),
+		)
+	} else {
+		vmi = libvmi.NewAlpine(
+			libvmi.WithInterface(*libvmi.InterfaceWithMacvtapBindingPlugin(networkName)),
+			libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
+			libvmi.WithNodeAffinityFor(nodeName),
+		)
+	}
+	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
+	// configure the client VMI
+	Expect(libnet.AddIPAddress(vmi, ifaceName, ipCIDR)).To(Succeed())
+	return vmi
+}
+
+func createAlpineVMIRandomNode(networkName string, mac string) (*v1.VirtualMachineInstance, error) {
+	runningVMI := tests.RunVMIAndExpectLaunch(
+		libvmi.NewAlpineWithTestTooling(
+			libvmi.WithInterface(*libvmi.InterfaceWithMac(libvmi.InterfaceWithMacvtapBindingPlugin(networkName), mac)),
+			libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
+		),
+		180,
+	)
+	err := console.LoginToAlpine(runningVMI)
+	return runningVMI, err
+}
+
+func createFedoraVMIRandomNode(networkName string, mac string) (*v1.VirtualMachineInstance, error) {
+	runningVMI := tests.RunVMIAndExpectLaunch(
+		newFedoraVMIWithExplicitMacAndGuestAgent(networkName, mac),
+		180,
+	)
+	err := console.LoginToFedora(runningVMI)
+	return runningVMI, err
+}
+
+func newFedoraVMIWithExplicitMacAndGuestAgent(macvtapNetworkName string, mac string) *v1.VirtualMachineInstance {
+	return libvmi.NewFedora(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithInterface(
+			*libvmi.InterfaceWithMac(
+				libvmi.InterfaceWithMacvtapBindingPlugin(macvtapNetworkName), mac)),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)))
+}
+
+func waitForPodCompleted(podNamespace string, podName string) error {
+	pod, err := kubevirt.Client().CoreV1().Pods(podNamespace).Get(context.Background(), podName, k8smetav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if pod.Status.Phase == k8sv1.PodSucceeded || pod.Status.Phase == k8sv1.PodFailed {
+		return nil
+	}
+	return fmt.Errorf("pod hasn't completed, current Phase: %s", pod.Status.Phase)
+}
+
+func waitVMMacvtapIfaceIPReport(vmi *v1.VirtualMachineInstance, macAddress string, timeout time.Duration) (string, error) {
+	var vmiIP string
+	err := wait.PollImmediate(time.Second, timeout, func() (done bool, err error) {
+		vmi, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &k8smetav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		for _, iface := range vmi.Status.Interfaces {
+			if iface.MAC == macAddress {
+				if ip := iface.IP; ip != "" {
+					vmiIP = ip
+					return true, nil
+				}
+				return false, nil
+			}
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return vmiIP, nil
+}

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -157,7 +157,8 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 			const ip2 = "10.1.1.2"
 
 			By("Configuring static IP address on the hotplugged interface inside the guest")
-			Expect(configInterface(hotPluggedVMI, vmIfaceName, ip1+subnetMask)).To(Succeed())
+			Expect(libnet.AddIPAddress(hotPluggedVMI, vmIfaceName, ip1+subnetMask)).To(Succeed())
+			Expect(libnet.SetInterfaceUp(hotPluggedVMI, vmIfaceName)).To(Succeed())
 
 			By("creating another VM connected to the same secondary network")
 			net := v1.Network{

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -190,7 +190,8 @@ func createAlpineVMIStaticIPOnNode(nodeName string, networkName string, ifaceNam
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 	// configure the client VMI
-	Expect(configInterface(vmi, ifaceName, ipCIDR)).To(Succeed())
+	Expect(libnet.AddIPAddress(vmi, ifaceName, ipCIDR)).To(Succeed())
+	Expect(libnet.SetInterfaceUp(vmi, ifaceName)).To(Succeed())
 	return vmi
 }
 

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -49,10 +49,6 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-const (
-	macvtapNetworkConfNAD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s", "annotations": {"k8s.v1.cni.cncf.io/resourceName": "macvtap.network.kubevirt.io/%s"}},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"name\": \"%s\", \"type\": \"macvtap\"}"}}`
-)
-
 var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 	const (
 		macvtapLowerDevice = "eth0"
@@ -61,18 +57,14 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 
 	var virtClient kubecli.KubevirtClient
 
-	createMacvtapNetworkAttachmentDefinition := func(namespace, networkName, macvtapLowerDevice string) error {
-		macvtapNad := fmt.Sprintf(macvtapNetworkConfNAD, networkName, namespace, macvtapLowerDevice, networkName)
-		return libnet.CreateNetworkAttachmentDefinition(networkName, namespace, macvtapNad)
-	}
-
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 	})
 
 	BeforeEach(func() {
-		Expect(createMacvtapNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), macvtapNetworkName, macvtapLowerDevice)).
-			To(Succeed(), "A macvtap network named %s should be provisioned", macvtapNetworkName)
+		ns := testsuite.GetTestNamespace(nil)
+		Expect(libnet.CreateMacvtapNetworkAttachmentDefinition(ns, macvtapNetworkName, macvtapLowerDevice)).To(Succeed(),
+			"A macvtap network named %s should be provisioned", macvtapNetworkName)
 	})
 
 	newFedoraVMIWithExplicitMacAndGuestAgent := func(macvtapNetworkName string, mac string) *v1.VirtualMachineInstance {

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -21,20 +21,11 @@ package network
 
 import (
 	"context"
-	"fmt"
-	"time"
-
-	"kubevirt.io/kubevirt/tests/libmigration"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	k8sv1 "k8s.io/api/core/v1"
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -43,7 +34,8 @@ import (
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmi"
@@ -78,7 +70,6 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, Serial, func() {
 		var chosenMAC string
 		var nodeList *k8sv1.NodeList
 		var nodeName string
-		var serverIP string
 
 		BeforeEach(func() {
 			nodeList = libnode.GetAllSchedulableNodes(virtClient)
@@ -87,185 +78,21 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, Serial, func() {
 			chosenMACHW, err := GenerateRandomMac()
 			Expect(err).ToNot(HaveOccurred())
 			chosenMAC = chosenMACHW.String()
-			serverCIDR := "192.0.2.102/24"
 
-			serverIP, err = libnet.CidrToIP(serverCIDR)
+			const macvtapNetName = "test-macvtap"
+			serverVMI := libvmi.NewAlpineWithTestTooling(
+				libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultMacvtapNetworkInterface(macvtapNetName), chosenMAC)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetName, macvtapNetworkName)),
+				libvmi.WithNodeAffinityFor(nodeName),
+			)
+			serverVMI, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(serverVMI)).Create(context.Background(), serverVMI)
 			Expect(err).ToNot(HaveOccurred())
-
-			serverVMI = createAlpineVMIStaticIPOnNode(nodeName, macvtapNetworkName, "eth0", serverCIDR, &chosenMAC)
+			serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToAlpine)
 		})
 
 		It("should have the specified MAC address reported back via the API", func() {
 			Expect(serverVMI.Status.Interfaces).To(HaveLen(1), "should have a single interface")
 			Expect(serverVMI.Status.Interfaces[0].MAC).To(Equal(chosenMAC), "the expected MAC address should be set in the VMI")
 		})
-
-		Context("and another virtual machine connected to the same network", func() {
-			var clientVMI *v1.VirtualMachineInstance
-			BeforeEach(func() {
-				clientVMI = createAlpineVMIStaticIPOnNode(nodeName, macvtapNetworkName, "eth0", "192.0.2.101/24", nil)
-			})
-			It("can communicate with the virtual machine in the same network", func() {
-				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
-			})
-		})
-	})
-
-	Context("VMI migration", func() {
-		var clientVMI *v1.VirtualMachineInstance
-
-		BeforeEach(func() {
-			checks.SkipIfMigrationIsNotPossible()
-		})
-
-		BeforeEach(func() {
-			macAddressHW, err := GenerateRandomMac()
-			Expect(err).ToNot(HaveOccurred())
-			macAddress := macAddressHW.String()
-			clientVMI, err = createAlpineVMIRandomNode(macvtapNetworkName, macAddress)
-			Expect(err).NotTo(HaveOccurred(), "must succeed creating a VMI on a random node")
-		})
-
-		It("should be successful when the VMI MAC address is defined in its spec", func() {
-			By("starting the migration")
-			migration := libmigration.New(clientVMI.Name, clientVMI.Namespace)
-			migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
-
-			// check VMI, confirm migration state
-			libmigration.ConfirmVMIPostMigration(virtClient, clientVMI, migration)
-		})
-
-		Context("with live traffic", func() {
-			var serverVMI *v1.VirtualMachineInstance
-			var serverVMIPodName string
-			var serverIP string
-
-			macvtapIfaceIPReportTimeout := 4 * time.Minute
-
-			BeforeEach(func() {
-				macAddressHW, err := GenerateRandomMac()
-				Expect(err).ToNot(HaveOccurred())
-				macAddress := macAddressHW.String()
-
-				serverVMI, err = createFedoraVMIRandomNode(macvtapNetworkName, macAddress)
-				Expect(err).NotTo(HaveOccurred(), "must have succeeded creating a fedora VMI on a random node")
-				Expect(serverVMI.Status.Interfaces).NotTo(BeEmpty(), "a migrate-able VMI must have network interfaces")
-				serverVMIPodName = tests.GetVmPodName(virtClient, serverVMI)
-
-				serverIP, err = waitVMMacvtapIfaceIPReport(serverVMI, macAddress, macvtapIfaceIPReportTimeout)
-				Expect(err).NotTo(HaveOccurred(), "should have managed to figure out the IP of the server VMI")
-			})
-
-			BeforeEach(func() {
-				// TODO test also the IPv6 address (issue- https://github.com/kubevirt/kubevirt/issues/7506)
-				libnet.SkipWhenClusterNotSupportIpv4()
-				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed(), "connectivity is expected *before* migrating the VMI")
-			})
-
-			It("should keep connectivity after a migration", func() {
-				const containerCompletionWaitTime = 60
-				migration := libmigration.New(serverVMI.Name, serverVMI.GetNamespace())
-				_ = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
-				// In case of clientVMI and serverVMI running on the same node before migration, the serverVMI
-				// will be reachable only when the original launcher pod terminates.
-				Eventually(func() error {
-					return waitForPodCompleted(serverVMI.Namespace, serverVMIPodName)
-				}, containerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod: %s", serverVMIPodName))
-				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed(), "connectivity is expected *after* migrating the VMI")
-			})
-		})
 	})
 })
-
-func createAlpineVMIStaticIPOnNode(nodeName string, networkName string, ifaceName string, ipCIDR string, mac *string) *v1.VirtualMachineInstance {
-	var vmi *v1.VirtualMachineInstance
-	if mac != nil {
-		vmi = libvmi.NewAlpineWithTestTooling(
-			libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultMacvtapNetworkInterface(networkName), *mac)),
-			libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
-			libvmi.WithNodeAffinityFor(nodeName),
-		)
-	} else {
-		vmi = libvmi.NewAlpine(
-			libvmi.WithInterface(*v1.DefaultMacvtapNetworkInterface(networkName)),
-			libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
-			libvmi.WithNodeAffinityFor(nodeName),
-		)
-	}
-	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
-	// configure the client VMI
-	Expect(libnet.AddIPAddress(vmi, ifaceName, ipCIDR)).To(Succeed())
-	Expect(libnet.SetInterfaceUp(vmi, ifaceName)).To(Succeed())
-	return vmi
-}
-
-func createAlpineVMIRandomNode(networkName string, mac string) (*v1.VirtualMachineInstance, error) {
-	runningVMI := tests.RunVMIAndExpectLaunch(
-		libvmi.NewAlpineWithTestTooling(
-			libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultMacvtapNetworkInterface(networkName), mac)),
-			libvmi.WithNetwork(libvmi.MultusNetwork(networkName, networkName)),
-		),
-		180,
-	)
-	err := console.LoginToAlpine(runningVMI)
-	return runningVMI, err
-}
-
-func createFedoraVMIRandomNode(networkName string, mac string) (*v1.VirtualMachineInstance, error) {
-	runningVMI := tests.RunVMIAndExpectLaunch(
-		newFedoraVMIWithExplicitMacAndGuestAgent(networkName, mac),
-		180,
-	)
-	err := console.LoginToFedora(runningVMI)
-	return runningVMI, err
-}
-
-func newFedoraVMIWithExplicitMacAndGuestAgent(macvtapNetworkName string, mac string) *v1.VirtualMachineInstance {
-	return libvmi.NewFedora(
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-		libvmi.WithInterface(
-			*libvmi.InterfaceWithMac(
-				v1.DefaultMacvtapNetworkInterface(macvtapNetworkName), mac)),
-		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)))
-}
-
-func waitVMMacvtapIfaceIPReport(vmi *v1.VirtualMachineInstance, macAddress string, timeout time.Duration) (string, error) {
-	var vmiIP string
-	err := wait.PollImmediate(time.Second, timeout, func() (done bool, err error) {
-		vmi, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &k8smetav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		for _, iface := range vmi.Status.Interfaces {
-			if iface.MAC == macAddress {
-				if ip := iface.IP; ip != "" {
-					vmiIP = ip
-					return true, nil
-				}
-				return false, nil
-			}
-		}
-
-		return false, nil
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return vmiIP, nil
-}
-
-func waitForPodCompleted(podNamespace string, podName string) error {
-	pod, err := kubevirt.Client().CoreV1().Pods(podNamespace).Get(context.Background(), podName, k8smetav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	if pod.Status.Phase == k8sv1.PodSucceeded || pod.Status.Phase == k8sv1.PodFailed {
-		return nil
-	}
-	return fmt.Errorf("pod hasn't completed, current Phase: %s", pod.Status.Phase)
-}

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -54,9 +54,12 @@ const (
 )
 
 var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
+	const (
+		macvtapLowerDevice = "eth0"
+		macvtapNetworkName = "net1"
+	)
+
 	var virtClient kubecli.KubevirtClient
-	var macvtapLowerDevice string
-	var macvtapNetworkName string
 
 	createMacvtapNetworkAttachmentDefinition := func(namespace, networkName, macvtapLowerDevice string) error {
 		macvtapNad := fmt.Sprintf(macvtapNetworkConfNAD, networkName, namespace, macvtapLowerDevice, networkName)
@@ -65,9 +68,6 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		macvtapLowerDevice = "eth0"
-		macvtapNetworkName = "net1"
 	})
 
 	BeforeEach(func() {

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -39,6 +39,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/virt-config/deprecation"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -49,7 +51,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
+var _ = SIGDescribe("Macvtap", decorators.Macvtap, Serial, func() {
 	const (
 		macvtapLowerDevice = "eth0"
 		macvtapNetworkName = "net1"
@@ -59,6 +61,10 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
+	})
+
+	BeforeEach(func() {
+		tests.EnableFeatureGate(deprecation.MacvtapGate)
 	})
 
 	BeforeEach(func() {

--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
-        "//pkg/virt-config/deprecation:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -42,7 +42,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-config/deprecation"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/util"
@@ -103,7 +102,6 @@ func AdjustKubeVirtResource() {
 		virtconfig.HotplugVolumesGate,
 		virtconfig.DownwardMetricsFeatureGate,
 		virtconfig.NUMAFeatureGate,
-		deprecation.MacvtapGate,
 		virtconfig.ExpandDisksGate,
 		virtconfig.WorkloadEncryptionSEV,
 		virtconfig.VMExportGate,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR changes the macvtap tests to use the network binding plugin API.
Only one test is left to cover the old macvtap interface API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
