### PR TITLE
bazeldnf: Update to v0.5.9

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -118,11 +118,10 @@ cc_library(
         "@io_bazel_rules_go//go/platform:linux_arm64": ["//rpm:libvirt-libs_aarch64/usr/include/libvirt"],
         "//conditions:default": ["//rpm:libvirt-libs_x86_64/usr/include/libvirt"],
     }),
-    include_prefix = "libvirt",
     linkstatic = 1,
     strip_include_prefix = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": "/rpm/libvirt-libs_aarch64/",
-        "//conditions:default": "/rpm/libvirt-libs_x86_64/",
+        "@io_bazel_rules_go//go/platform:linux_arm64": "/rpm/libvirt-libs_aarch64/usr/include/",
+        "//conditions:default": "/rpm/libvirt-libs_x86_64/usr/include/",
     }),
     visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,10 +141,9 @@ http_file(
 
 http_archive(
     name = "bazeldnf",
-    sha256 = "9dfd5ab882cae4ff9e2a7c1352c05949fa0c175af6b4103b19db48657e6da8b8",
+    sha256 = "fb24d80ad9edad0f7bd3000e8cffcfbba89cc07e495c47a7d3b1f803bd527a40",
     urls = [
-        "https://github.com/rmohr/bazeldnf/releases/download/v0.5.6/bazeldnf-v0.5.6.tar.gz",
-        "https://storage.googleapis.com/builddeps/9dfd5ab882cae4ff9e2a7c1352c05949fa0c175af6b4103b19db48657e6da8b8",
+        "https://github.com/rmohr/bazeldnf/releases/download/v0.5.9/bazeldnf-v0.5.9.tar.gz",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update bazeldnf to v0.5.9-rc2.

Needed for s390x support, see https://github.com/kubevirt/kubevirt/pull/10490.

**Special notes for your reviewer**:

Once it's been verified that the update doesn't break anything, I will make sure that the final v0.5.9 release is tagged and pick it up before removing the draft status from this PR.

**Release note**:

```release-note
NONE
```