### PR TITLE
test/swap: Refactor lambda functions to regular functions

### DIFF
--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -73,16 +73,6 @@ const (
 var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute, func() {
 	var virtClient kubecli.KubevirtClient
 
-	skipIfSwapOff := func(message string) {
-		nodes := libnode.GetAllSchedulableNodes(virtClient)
-		for _, node := range nodes.Items {
-			swapSizeKib := getSwapSizeInKib(node)
-			if swapSizeKib < maxSwapSizeToUseKib {
-				Skip(message)
-			}
-		}
-	}
-
 	getAffinityForTargetNode := func(targetNode *v1.Node) (nodeAffinity *v1.Affinity, err error) {
 		nodeAffinityRuleForVmiToFill, err := libmigration.CreateNodeAffinityRuleToMigrateFromSourceToTargetAndBack(targetNode, targetNode)
 		return &v1.Affinity{
@@ -287,4 +277,14 @@ func confirmMigrationMode(vmi *virtv1.VirtualMachineInstance, expectedMode virtv
 
 	By("Verifying the VMI's migration mode")
 	Expect(vmi.Status.MigrationState.Mode).To(Equal(expectedMode), fmt.Sprintf("expected migration state: %v got :%v \n", vmi.Status.MigrationState.Mode, expectedMode))
+}
+
+func skipIfSwapOff(message string) {
+	nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
+	for _, node := range nodes.Items {
+		swapSizeKib := getSwapSizeInKib(node)
+		if swapSizeKib < maxSwapSizeToUseKib {
+			Skip(message)
+		}
+	}
 }

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -74,10 +74,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	getSwapFreeSizeInKib := func(node v1.Node) (size int) {
-		return getMemInfoByString(node, "SwapFree")
-	}
-
 	getSwapSizeInKib := func(node v1.Node) (size int) {
 		return getMemInfoByString(node, "SwapTotal")
 	}
@@ -290,4 +286,8 @@ func getAvailableMemSizeInKib(node v1.Node) (size int) {
 
 func getTotalMemSizeInKib(node v1.Node) (size int) {
 	return getMemInfoByString(node, "MemTotal")
+}
+
+func getSwapFreeSizeInKib(node v1.Node) (size int) {
+	return getMemInfoByString(node, "SwapFree")
 }

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -74,10 +74,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	runVMIAndExpectLaunch := func(vmi *virtv1.VirtualMachineInstance, timeout int) *virtv1.VirtualMachineInstance {
-		return tests.RunVMIAndExpectLaunch(vmi, timeout)
-	}
-
 	fillMemWithStressFedoraVMI := func(vmi *virtv1.VirtualMachineInstance, memToUseInTheVmKib int) error {
 		_, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{
 			&expect.BSnd{S: fmt.Sprintf("stress-ng --vm-bytes %db --vm-keep -m 1 &\n", memToUseInTheVmKib*bytesInKib)},
@@ -162,7 +158,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			vmi.Spec.Domain.Memory = &virtv1.Memory{Guest: &vmiMemSizeMi}
 
 			By("Starting the VirtualMachineInstance")
-			vmi = runVMIAndExpectLaunch(vmi, 240)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 			By("Consume more memory than the node's memory")
 			err = fillMemWithStressFedoraVMI(vmi, memToUseInTheVmKib)
@@ -221,7 +217,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			vmiToFillTargetNodeMem.Spec.Domain.Resources.Requests["memory"] = vmiMemReq
 
 			By("Starting the VirtualMachineInstance")
-			vmiToFillTargetNodeMem = runVMIAndExpectLaunch(vmiToFillTargetNodeMem, 240)
+			vmiToFillTargetNodeMem = tests.RunVMIAndExpectLaunch(vmiToFillTargetNodeMem, 240)
 			Expect(console.LoginToFedora(vmiToFillTargetNodeMem)).To(Succeed())
 
 			By("reaching memory overcommitment in the target node")
@@ -238,7 +234,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			//add label the source node to make sure that the vm we want to migrate will be scheduled to the source node
 
 			By("Starting the VirtualMachineInstance that we should migrate to the target node")
-			vmiToMigrate = runVMIAndExpectLaunch(vmiToMigrate, 240)
+			vmiToMigrate = tests.RunVMIAndExpectLaunch(vmiToMigrate, 240)
 			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
 
 			// execute a migration, wait for finalized state

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -74,14 +74,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	fillMemWithStressFedoraVMI := func(vmi *virtv1.VirtualMachineInstance, memToUseInTheVmKib int) error {
-		_, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{
-			&expect.BSnd{S: fmt.Sprintf("stress-ng --vm-bytes %db --vm-keep -m 1 &\n", memToUseInTheVmKib*bytesInKib)},
-			&expect.BExp{R: console.PromptExpression},
-		}, 15)
-		return err
-	}
-
 	confirmMigrationMode := func(vmi *virtv1.VirtualMachineInstance, expectedMode virtv1.MigrationMode) {
 		By("Retrieving the VMI post migration")
 		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
@@ -287,4 +279,12 @@ func getSwapFreeSizeInKib(node v1.Node) (size int) {
 
 func getSwapSizeInKib(node v1.Node) (size int) {
 	return getMemInfoByString(node, "SwapTotal")
+}
+
+func fillMemWithStressFedoraVMI(vmi *virtv1.VirtualMachineInstance, memToUseInTheVmKib int) error {
+	_, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{
+		&expect.BSnd{S: fmt.Sprintf("stress-ng --vm-bytes %db --vm-keep -m 1 &\n", memToUseInTheVmKib*bytesInKib)},
+		&expect.BExp{R: console.PromptExpression},
+	}, 15)
+	return err
 }

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -74,14 +74,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	getMemInfoByString := func(node v1.Node, field string) (size int) {
-		stdout, stderr, err := tests.ExecuteCommandOnNodeThroughVirtHandler(virtClient, node.Name, []string{"grep", field, "/proc/meminfo"})
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("stderr: %v \n", stderr))
-		fields := strings.Fields(stdout)
-		size, err = strconv.Atoi(fields[1])
-		Expect(err).ToNot(HaveOccurred())
-		return size
-	}
 	getAvailableMemSizeInKib := func(node v1.Node) (size int) {
 		return getMemInfoByString(node, "MemAvailable")
 	}
@@ -289,3 +281,12 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 
 	})
 })
+
+func getMemInfoByString(node v1.Node, field string) (size int) {
+	stdout, stderr, err := tests.ExecuteCommandOnNodeThroughVirtHandler(kubevirt.Client(), node.Name, []string{"grep", field, "/proc/meminfo"})
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("stderr: %v \n", stderr))
+	fields := strings.Fields(stdout)
+	size, err = strconv.Atoi(fields[1])
+	Expect(err).ToNot(HaveOccurred())
+	return size
+}

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -73,13 +73,6 @@ const (
 var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute, func() {
 	var virtClient kubecli.KubevirtClient
 
-	getAffinityForTargetNode := func(targetNode *v1.Node) (nodeAffinity *v1.Affinity, err error) {
-		nodeAffinityRuleForVmiToFill, err := libmigration.CreateNodeAffinityRuleToMigrateFromSourceToTargetAndBack(targetNode, targetNode)
-		return &v1.Affinity{
-			NodeAffinity: nodeAffinityRuleForVmiToFill,
-		}, err
-	}
-
 	BeforeEach(func() {
 		checks.SkipIfMigrationIsNotPossible()
 
@@ -287,4 +280,11 @@ func skipIfSwapOff(message string) {
 			Skip(message)
 		}
 	}
+}
+
+func getAffinityForTargetNode(targetNode *v1.Node) (nodeAffinity *v1.Affinity, err error) {
+	nodeAffinityRuleForVmiToFill, err := libmigration.CreateNodeAffinityRuleToMigrateFromSourceToTargetAndBack(targetNode, targetNode)
+	return &v1.Affinity{
+		NodeAffinity: nodeAffinityRuleForVmiToFill,
+	}, err
 }

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -71,17 +71,7 @@ const (
 )
 
 var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute, func() {
-	var err error
 	var virtClient kubecli.KubevirtClient
-
-	confirmMigrationMode := func(vmi *virtv1.VirtualMachineInstance, expectedMode virtv1.MigrationMode) {
-		By("Retrieving the VMI post migration")
-		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("couldn't find vmi err: %v \n", err))
-
-		By("Verifying the VMI's migration mode")
-		Expect(vmi.Status.MigrationState.Mode).To(Equal(expectedMode), fmt.Sprintf("expected migration state: %v got :%v \n", vmi.Status.MigrationState.Mode, expectedMode))
-	}
 
 	skipIfSwapOff := func(message string) {
 		nodes := libnode.GetAllSchedulableNodes(virtClient)
@@ -287,4 +277,14 @@ func fillMemWithStressFedoraVMI(vmi *virtv1.VirtualMachineInstance, memToUseInTh
 		&expect.BExp{R: console.PromptExpression},
 	}, 15)
 	return err
+}
+
+func confirmMigrationMode(vmi *virtv1.VirtualMachineInstance, expectedMode virtv1.MigrationMode) {
+	var err error
+	By("Retrieving the VMI post migration")
+	vmi, err = kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("couldn't find vmi err: %v \n", err))
+
+	By("Verifying the VMI's migration mode")
+	Expect(vmi.Status.MigrationState.Mode).To(Equal(expectedMode), fmt.Sprintf("expected migration state: %v got :%v \n", vmi.Status.MigrationState.Mode, expectedMode))
 }

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -74,9 +74,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	getTotalMemSizeInKib := func(node v1.Node) (size int) {
-		return getMemInfoByString(node, "MemTotal")
-	}
 	getSwapFreeSizeInKib := func(node v1.Node) (size int) {
 		return getMemInfoByString(node, "SwapFree")
 	}
@@ -289,4 +286,8 @@ func getMemInfoByString(node v1.Node, field string) (size int) {
 
 func getAvailableMemSizeInKib(node v1.Node) (size int) {
 	return getMemInfoByString(node, "MemAvailable")
+}
+
+func getTotalMemSizeInKib(node v1.Node) (size int) {
+	return getMemInfoByString(node, "MemTotal")
 }

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -22,6 +22,7 @@ package tests_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -72,13 +73,6 @@ const (
 var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
-
-	min := func(a, b int) int {
-		if a < b {
-			return a
-		}
-		return b
-	}
 
 	getMemInfoByString := func(node v1.Node, field string) (size int) {
 		stdout, stderr, err := tests.ExecuteCommandOnNodeThroughVirtHandler(virtClient, node.Name, []string{"grep", field, "/proc/meminfo"})
@@ -162,9 +156,9 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			availableMemSizeKib := getAvailableMemSizeInKib(*sourceNode)
 			availableSwapSizeKib := getSwapFreeSizeInKib(*sourceNode)
 			swapSizeKib := getSwapSizeInKib(*sourceNode)
-			swapSizeToUseKib := min(maxSwapSizeToUseKib, int(swapPartToUse*float64(availableSwapSizeKib)))
-
 			Expect(availableSwapSizeKib).Should(BeNumerically(">", maxSwapSizeToUseKib), "not enough available swap space")
+
+			swapSizeToUseKib := int(math.Min(maxSwapSizeToUseKib, swapPartToUse*float64(availableSwapSizeKib)))
 			//use more memory than what node can handle without swap memory
 			memToUseInTheVmKib := availableMemSizeKib + swapSizeToUseKib
 
@@ -231,7 +225,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			vmMemoryRequestkib := 512000
 			availableMemSizeKib := getAvailableMemSizeInKib(*targetNode)
 			availableSwapSizeKib := getSwapFreeSizeInKib(*targetNode)
-			swapSizeToUsekib := min(maxSwapSizeToUseKib, int(swapPartToUse*float64(availableSwapSizeKib)))
+			swapSizeToUsekib := int(math.Min(maxSwapSizeToUseKib, swapPartToUse*float64(availableSwapSizeKib)))
 
 			//make sure that the vm migrate data to swap space (leave enough space for the vm that we will migrate)
 			memToUseInTargetNodeVmKib := availableMemSizeKib + swapSizeToUsekib - vmMemoryRequestkib

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -74,10 +74,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	getAvailableMemSizeInKib := func(node v1.Node) (size int) {
-		return getMemInfoByString(node, "MemAvailable")
-	}
-
 	getTotalMemSizeInKib := func(node v1.Node) (size int) {
 		return getMemInfoByString(node, "MemTotal")
 	}
@@ -289,4 +285,8 @@ func getMemInfoByString(node v1.Node, field string) (size int) {
 	size, err = strconv.Atoi(fields[1])
 	Expect(err).ToNot(HaveOccurred())
 	return size
+}
+
+func getAvailableMemSizeInKib(node v1.Node) (size int) {
+	return getMemInfoByString(node, "MemAvailable")
 }

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -74,9 +74,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	getSwapSizeInKib := func(node v1.Node) (size int) {
-		return getMemInfoByString(node, "SwapTotal")
-	}
 	runVMIAndExpectLaunch := func(vmi *virtv1.VirtualMachineInstance, timeout int) *virtv1.VirtualMachineInstance {
 		return tests.RunVMIAndExpectLaunch(vmi, timeout)
 	}
@@ -290,4 +287,8 @@ func getTotalMemSizeInKib(node v1.Node) (size int) {
 
 func getSwapFreeSizeInKib(node v1.Node) (size int) {
 	return getMemInfoByString(node, "SwapFree")
+}
+
+func getSwapSizeInKib(node v1.Node) (size int) {
+	return getMemInfoByString(node, "SwapTotal")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes closure functions from the swap tests file

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
