### PR TITLE
unit tests, volumes: Refactor in order to reduce unrequired parameters and ease readability

### DIFF
--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -147,6 +147,12 @@ var _ = Describe("Add volume command", func() {
 			libdv.NewDataVolume(libdv.WithName(volumeName)),
 			k8smetav1.CreateOptions{})
 
+		verifyDVVolumeSource := func(volumeOptions *v1.AddVolumeOptions) {
+			Expect(volumeOptions.VolumeSource).ToNot(BeNil())
+			Expect(volumeOptions.VolumeSource.DataVolume).ToNot(BeNil())
+			Expect(volumeOptions.VolumeSource.PersistentVolumeClaim).To(BeNil())
+		}
+
 		expectFunc(vmiName, volumeName, verifyDVVolumeSource)
 		commandAndArgs := append([]string{"addvolume", vmiName, fmt.Sprintf("--volume-name=%s", volumeName)}, args...)
 		cmd := clientcmd.NewVirtctlCommand(commandAndArgs...)
@@ -174,6 +180,12 @@ var _ = Describe("Add volume command", func() {
 			createTestPVC(),
 			k8smetav1.CreateOptions{})
 
+		verifyPVCVolumeSource := func(volumeOptions *v1.AddVolumeOptions) {
+			Expect(volumeOptions.VolumeSource).ToNot(BeNil())
+			Expect(volumeOptions.VolumeSource.DataVolume).To(BeNil())
+			Expect(volumeOptions.VolumeSource.PersistentVolumeClaim).ToNot(BeNil())
+		}
+
 		expectFunc(vmiName, volumeName, verifyPVCVolumeSource)
 		commandAndArgs := append([]string{"addvolume", vmiName, fmt.Sprintf("--volume-name=%s", volumeName)}, args...)
 		cmd := clientcmd.NewVirtctlCommand(commandAndArgs...)
@@ -195,16 +207,4 @@ func createTestPVC() *k8sv1.PersistentVolumeClaim {
 			Name: "testvolume",
 		},
 	}
-}
-
-func verifyDVVolumeSource(volumeOptions *v1.AddVolumeOptions) {
-	Expect(volumeOptions.VolumeSource).ToNot(BeNil())
-	ExpectWithOffset(3, volumeOptions.VolumeSource.DataVolume).ToNot(BeNil())
-	ExpectWithOffset(3, volumeOptions.VolumeSource.PersistentVolumeClaim).To(BeNil())
-}
-
-func verifyPVCVolumeSource(volumeOptions *v1.AddVolumeOptions) {
-	Expect(volumeOptions.VolumeSource).ToNot(BeNil())
-	ExpectWithOffset(3, volumeOptions.VolumeSource.DataVolume).To(BeNil())
-	ExpectWithOffset(3, volumeOptions.VolumeSource.PersistentVolumeClaim).ToNot(BeNil())
 }

--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -44,7 +44,7 @@ const (
 	volumeName = "testvolume"
 )
 
-type VerifyFunc func(*v1.AddVolumeOptions)
+type verifyFunc func(*v1.AddVolumeOptions)
 
 var _ = Describe("Add volume command", func() {
 	var vmInterface *kubecli.MockVirtualMachineInterface
@@ -64,7 +64,7 @@ var _ = Describe("Add volume command", func() {
 		coreClient = fake.NewSimpleClientset()
 	})
 
-	expectVMIEndpointAddVolume := func(vmiName, volumeName string, verifyFunc VerifyFunc) {
+	expectVMIEndpointAddVolume := func(vmiName, volumeName string, verifyFn verifyFunc) {
 		kubecli.MockKubevirtClientInstance.
 			EXPECT().
 			VirtualMachineInstance(k8smetav1.NamespaceDefault).
@@ -75,12 +75,12 @@ var _ = Describe("Add volume command", func() {
 			Expect(ok).To(BeTrue())
 			Expect(volumeOptions).ToNot(BeNil())
 			Expect(volumeOptions.Name).To(Equal(volumeName))
-			verifyFunc(volumeOptions)
+			verifyFn(volumeOptions)
 			return nil
 		})
 	}
 
-	expectVMEndpointAddVolume := func(vmiName, volumeName string, verifyFunc VerifyFunc) {
+	expectVMEndpointAddVolume := func(vmiName, volumeName string, verifyFn verifyFunc) {
 		kubecli.MockKubevirtClientInstance.
 			EXPECT().
 			VirtualMachine(k8smetav1.NamespaceDefault).
@@ -91,7 +91,7 @@ var _ = Describe("Add volume command", func() {
 			Expect(ok).To(BeTrue())
 			Expect(volumeOptions).ToNot(BeNil())
 			Expect(volumeOptions.Name).To(Equal(volumeName))
-			verifyFunc(volumeOptions)
+			verifyFn(volumeOptions)
 			return nil
 		})
 	}
@@ -140,7 +140,7 @@ var _ = Describe("Add volume command", func() {
 		Entry("with dry-run arg", true),
 	)
 
-	DescribeTable("with DataVolume addvolume cmd, should call correct endpoint", func(expectFunc func(vmiName, volumeName string, verifyFunc VerifyFunc), args ...string) {
+	DescribeTable("with DataVolume addvolume cmd, should call correct endpoint", func(expectFunc func(vmiName, volumeName string, verifyFn verifyFunc), args ...string) {
 		kubecli.MockKubevirtClientInstance.EXPECT().CdiClient().Return(cdiClient)
 		cdiClient.CdiV1beta1().DataVolumes(k8smetav1.NamespaceDefault).Create(
 			context.Background(),
@@ -167,7 +167,7 @@ var _ = Describe("Add volume command", func() {
 		Entry("with LUN-type disk should call VMI endpoint", expectVMIEndpointAddVolume, "--disk-type", "lun"),
 	)
 
-	DescribeTable("with PVC addvolume cmd, should call correct endpoint", func(expectFunc func(vmiName, volumeName string, verifyFunc VerifyFunc), args ...string) {
+	DescribeTable("with PVC addvolume cmd, should call correct endpoint", func(expectFunc func(vmiName, volumeName string, verifyFn verifyFunc), args ...string) {
 		kubecli.MockKubevirtClientInstance.EXPECT().CdiClient().Return(cdiClient)
 		kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(coreClient.CoreV1())
 		coreClient.CoreV1().PersistentVolumeClaims(k8smetav1.NamespaceDefault).Create(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Discard function boolean arg by splitting to two functions.
Discard unrequired args which are the same all over the table entries.

Split DV and PVC to two DescribeTable blocks.
It ease maintenance, when each blocks is focused on one time,
and removes args and condition.
The common code that it saved is not big and added mental burden.

Inline single usage functions, and get rid of the offset.

Replaced strings with consts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
