### PR TITLE
kernel devices: use modprobe as fallback

### DIFF
--- a/pkg/virt-handler/device-manager/generic_device.go
+++ b/pkg/virt-handler/device-manager/generic_device.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -119,6 +120,12 @@ func (dpi *GenericDevicePlugin) Start(stop <-chan struct{}) (err error) {
 		devnode, err := os.Open(dpi.devicePath)
 		if err == nil {
 			devnode.Close()
+		} else {
+			cmd := exec.Command("modprobe", dpi.deviceName)
+			err := cmd.Run()
+			if err != nil {
+				return fmt.Errorf("error loading kernel module %s: %v", dpi.deviceName, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
The current logic to make sure that modules like vhost-net, tun are loaded is to open / close the corresponding /dev/<module> file.

In some cases, open / close of the module device files does not autoload the module, needing an actual modprobe run.

**Which issue(s) this PR fixes**:

Potentially Fixes # https://github.com/flatcar/Flatcar/issues/1336 (updated the correct link)

