### PR TITLE
Bump memory requests above highest values seen in production

### DIFF
--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -323,7 +323,7 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 			corev1.ResourceCPU: resource.MustParse("10m"),
 			// 325Mi - base memory request
 			// +32Mi - to account for the buffer used to verify containerdisk checksums
-			corev1.ResourceMemory: resource.MustParse("357Mi"),
+			corev1.ResourceMemory: resource.MustParse("375Mi"),
 		},
 	}
 	if prHelperImage == "" {

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -374,7 +374,7 @@ func NewApiServerDeployment(namespace, repository, imagePrefix, version, product
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("5m"),
-			corev1.ResourceMemory: resource.MustParse("500Mi"),
+			corev1.ResourceMemory: resource.MustParse("525Mi"),
 		},
 	}
 
@@ -471,7 +471,7 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("275Mi"),
+			corev1.ResourceMemory: resource.MustParse("289Mi"),
 		},
 	}
 
@@ -593,7 +593,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("450Mi"),
+									corev1.ResourceMemory: resource.MustParse("472Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
Based on the values we absoved in prudaction on a cluster with 24 nodes, and listing the metrics for the last 2 weeks.

![image](https://github.com/kubevirt/kubevirt/assets/5116363/d2423eb8-f6d6-4cbc-ac36-98adc5a50ca0)

![image](https://github.com/kubevirt/kubevirt/assets/5116363/ce543a59-e04c-4789-ba92-ae09ab43fb29)

* virt-controller seems to have an issue with memory, as it consumed  more then 2G, so I'm ignoring it values, and using only the latest values of the past day.

This should resolve #11124