### PR TITLE
chore: Inline SetupAlpineHostPath

### DIFF
--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
+        "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -96,7 +96,8 @@ var _ = SIGDescribe("Storage", func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		tests.SetupAlpineHostPath()
+		libstorage.CreateHostPathPv("alpine-host-path", testsuite.GetTestNamespace(nil), testsuite.HostPathAlpine)
+		libstorage.CreateHostPathPVC("alpine-host-path", testsuite.GetTestNamespace(nil), "1Gi")
 	})
 
 	Describe("Starting a VirtualMachineInstance", func() {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -148,7 +148,6 @@ func testCleanup() {
 	libnode.CleanNodes()
 	resetToDefaultConfig()
 	testsuite.EnsureKubevirtReady()
-	tests.SetupAlpineHostPath()
 	GinkgoWriter.Println("Global test cleanup ended.")
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -103,14 +103,7 @@ const (
 	DiskAlpineHostPath     = "disk-alpine-host-path"
 	DiskWindowsSysprep     = "disk-windows-sysprep"
 	DiskCustomHostPath     = "disk-custom-host-path"
-	defaultDiskSize        = "1Gi"
 )
-
-func SetupAlpineHostPath() {
-	const osAlpineHostPath = "alpine-host-path"
-	libstorage.CreateHostPathPv(osAlpineHostPath, testsuite.GetTestNamespace(nil), testsuite.HostPathAlpine)
-	libstorage.CreateHostPathPVC(osAlpineHostPath, testsuite.GetTestNamespace(nil), defaultDiskSize)
-}
 
 func GetSupportedCPUFeatures(nodes k8sv1.NodeList) []string {
 	var featureDenyList = map[string]bool{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

It does not make sense for SetupAlpineHostPath to be in the global testsuite cleanup, therefore remove it from there and inline it in the only other place where is is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
