### PR TITLE
Tests: Use matchers to get better info in case of failures

### DIFF
--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -28,6 +28,7 @@ import (
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -291,15 +292,19 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, &metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
+			Eventually(func() v1.VirtualMachineStatus {
 				vm2, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				By(fmt.Sprintf("VM Statuses: %+v", vm2.Status))
-				return len(vm2.Status.VolumeSnapshotStatuses) == 2 &&
-					vm2.Status.VolumeSnapshotStatuses[0].Name == "disk0" &&
-					vm2.Status.VolumeSnapshotStatuses[1].Name == "disk1"
-			}, 180*time.Second, time.Second).Should(BeTrue())
+				return vm2.Status
+			}, 180*time.Second, time.Second).Should(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"VolumeSnapshotStatuses": HaveExactElements(
+					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name": Equal("disk0")}),
+					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name": Equal("disk1")}),
+				),
+			}))
 		})
 	})
 
@@ -331,14 +336,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				vm.Spec.Running = &t
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(func() bool {
-					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
-					if errors.IsNotFound(err) {
-						return false
-					}
-					Expect(err).ToNot(HaveOccurred())
-					return vmi.Status.Phase == v1.Running
-				}, 360*time.Second, time.Second).Should(BeTrue())
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
+				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				return vm, vmi
 			}
@@ -596,18 +596,18 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(func() bool {
+				Eventually(func() string {
 					updatedVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return updatedVMI.Status.FSFreezeStatus == "frozen"
-				}, time.Minute, 2*time.Second).Should(BeTrue())
+					return updatedVMI.Status.FSFreezeStatus
+				}, time.Minute, 2*time.Second).Should(Equal("frozen"))
 
 				deleteSnapshot()
-				Eventually(func() bool {
+				Eventually(func() string {
 					updatedVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return updatedVMI.Status.FSFreezeStatus == ""
-				}, time.Minute, 2*time.Second).Should(BeTrue())
+					return updatedVMI.Status.FSFreezeStatus
+				}, time.Minute, 2*time.Second).Should(BeEmpty())
 			})
 
 			It("[test_id:6949]should unfreeze vm if snapshot fails when deadline exceeded", func() {
@@ -627,36 +627,48 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(func() bool {
+				Eventually(func() *snapshotv1.VirtualMachineSnapshot {
 					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
+					return snapshot
+				}, 30*time.Second, 2*time.Second).Should(matcher.BeInPhase(snapshotv1.InProgress))
+				Eventually(func() string {
 					updatedVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return snapshot.Status != nil &&
-						snapshot.Status.Phase == snapshotv1.InProgress &&
-						updatedVMI.Status.FSFreezeStatus == "frozen"
-				}, 30*time.Second, 2*time.Second).Should(BeTrue())
+					return updatedVMI.Status.FSFreezeStatus
+				}, 10*time.Second, 2*time.Second).Should(Equal("frozen"))
 
-				contentName := fmt.Sprintf("%s-%s", vmSnapshotContent, snapshot.UID)
-				Eventually(func() bool {
+				Eventually(func() *snapshotv1.VirtualMachineSnapshotStatus {
 					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
+					return snapshot.Status
+				}, time.Minute, 2*time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Conditions": HaveExactElements(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Type":   Equal(snapshotv1.ConditionProgressing),
+							"Status": Equal(corev1.ConditionFalse),
+							"Reason": Equal(snapshotDeadlineExceeded)}),
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Type":   Equal(snapshotv1.ConditionReady),
+							"Status": Equal(corev1.ConditionFalse),
+							"Reason": Equal(notReady)}),
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Type":   Equal(snapshotv1.ConditionFailure),
+							"Status": Equal(corev1.ConditionTrue),
+							"Reason": Equal(snapshotDeadlineExceeded)}),
+					),
+					"Phase": Equal(snapshotv1.Failed),
+				})))
+				contentName := fmt.Sprintf("%s-%s", vmSnapshotContent, snapshot.UID)
+				Eventually(func() error {
+					_, contentErr := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
+					return contentErr
+				}, 30*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
+				Eventually(func() string {
 					updatedVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					_, contentErr := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
-					return snapshot.Status != nil &&
-						len(snapshot.Status.Conditions) == 3 &&
-						snapshot.Status.Conditions[0].Status == corev1.ConditionFalse &&
-						strings.Contains(snapshot.Status.Conditions[0].Reason, snapshotDeadlineExceeded) &&
-						snapshot.Status.Conditions[1].Status == corev1.ConditionFalse &&
-						strings.Contains(snapshot.Status.Conditions[1].Reason, notReady) &&
-						snapshot.Status.Conditions[2].Status == corev1.ConditionTrue &&
-						snapshot.Status.Conditions[2].Type == snapshotv1.ConditionFailure &&
-						strings.Contains(snapshot.Status.Conditions[2].Reason, snapshotDeadlineExceeded) &&
-						snapshot.Status.Phase == snapshotv1.Failed &&
-						updatedVMI.Status.FSFreezeStatus == "" &&
-						errors.IsNotFound(contentErr)
-				}, time.Minute, 2*time.Second).Should(BeTrue())
+					return updatedVMI.Status.FSFreezeStatus
+				}, 30*time.Second, 2*time.Second).Should(BeEmpty())
 			})
 
 			It("[test_id:7472]should succeed online snapshot with hot plug disk", func() {
@@ -827,11 +839,11 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					&expect.BSnd{S: tests.EchoLastReturnValue},
 					&expect.BExp{R: console.RetValue("0")},
 				}, 30)).To(Succeed())
-				Eventually(func() bool {
+				Eventually(func() string {
 					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return vmi.Status.FSFreezeStatus == "frozen"
-				}, 180*time.Second, time.Second).Should(BeTrue())
+					return vmi.Status.FSFreezeStatus
+				}, 180*time.Second, time.Second).Should(Equal("frozen"))
 
 				By("Calling Velero post-backup hook")
 				_, _, err = callVeleroHook(vmi, VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION)
@@ -845,11 +857,11 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					&expect.BSnd{S: tests.EchoLastReturnValue},
 					&expect.BExp{R: console.RetValue("0")},
 				}, 30)).To(Succeed())
-				Eventually(func() bool {
+				Eventually(func() string {
 					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return vmi.Status.FSFreezeStatus == ""
-				}, 180*time.Second, time.Second).Should(BeTrue())
+					return vmi.Status.FSFreezeStatus
+				}, 180*time.Second, time.Second).Should(BeEmpty())
 			})
 
 			It("[test_id:9647]Calling Velero hooks should not error if no guest agent", func() {
@@ -939,16 +951,13 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				}
 
 				waitMemoryDumpCompletion := func(vm *v1.VirtualMachine) {
-					Eventually(func() bool {
+					Eventually(func() *v1.VirtualMachineMemoryDumpRequest {
 						updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
-						if updatedVM.Status.MemoryDumpRequest == nil ||
-							updatedVM.Status.MemoryDumpRequest.Phase != v1.MemoryDumpCompleted {
-							return false
-						}
-
-						return true
-					}, 60*time.Second, time.Second).Should(BeTrue())
+						return updatedVM.Status.MemoryDumpRequest
+					}, 60*time.Second, time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Phase": Equal(v1.MemoryDumpCompleted),
+					})))
 				}
 
 				It("[test_id:8922]should include memory dump in vm snapshot", func() {
@@ -1052,63 +1061,52 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				origStatus := ss.Status
+				// zero out the times to be able to compare after
+				clearConditionsTimestamps(origStatus.Conditions)
 				ss.Status = nil
 				ss, err = virtClient.VirtualMachineSnapshot(ss.Namespace).Update(context.Background(), ss, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ss.Status).To(BeNil())
 
-				Eventually(func() bool {
+				Eventually(func() *snapshotv1.VirtualMachineSnapshotStatus {
 					ss, err = virtClient.VirtualMachineSnapshot(ss.Namespace).Get(context.Background(), ss.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					if ss.Status == nil {
-						return false
+						return nil
 					}
-					if *ss.Status.SourceUID != *origStatus.SourceUID ||
-						*ss.Status.VirtualMachineSnapshotContentName != *origStatus.VirtualMachineSnapshotContentName ||
-						*ss.Status.CreationTime != *origStatus.CreationTime ||
-						ss.Status.Phase != origStatus.Phase ||
-						*ss.Status.ReadyToUse != *origStatus.ReadyToUse {
-						return false
-					}
-					if len(ss.Status.Conditions) != len(origStatus.Conditions) {
-						return false
-					}
-					for i, c := range ss.Status.Conditions {
-						oc := origStatus.Conditions[i]
-						if c.Type != oc.Type ||
-							c.Status != oc.Status {
-							return false
-						}
-					}
-					if len(ss.Status.Indications) != len(origStatus.Indications) {
-						return false
-					}
-					for i := range ss.Status.Indications {
-						if ss.Status.Indications[i] != origStatus.Indications[i] {
-							return false
-						}
-					}
-					return true
-				}, 180*time.Second, time.Second).Should(BeTrue())
+					// zero out the times to be able to compare to the original status
+					clearConditionsTimestamps(ss.Status.Conditions)
+					return ss.Status
+				}, 180*time.Second, time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"SourceUID":                         gstruct.PointTo(Equal(*origStatus.SourceUID)),
+					"VirtualMachineSnapshotContentName": gstruct.PointTo(Equal(*origStatus.VirtualMachineSnapshotContentName)),
+					"CreationTime":                      gstruct.PointTo(Equal(*origStatus.CreationTime)),
+					"Phase":                             Equal(origStatus.Phase),
+					"ReadyToUse":                        gstruct.PointTo(Equal(*origStatus.ReadyToUse)),
+					"Conditions":                        HaveExactElements(origStatus.Conditions),
+					"Indications":                       HaveExactElements(origStatus.Indications),
+				})))
 			})
 
 			It("VM should contain snapshot status for all volumes", func() {
 				volumes := len(vm.Spec.Template.Spec.Volumes)
-				Eventually(func() int {
+				Eventually(func() []v1.VolumeSnapshotStatus {
 					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					return len(vm.Status.VolumeSnapshotStatuses)
-				}, 180*time.Second, time.Second).Should(Equal(volumes))
+					return vm.Status.VolumeSnapshotStatuses
+				}, 180*time.Second, time.Second).Should(HaveLen(volumes))
 
-				Eventually(func() bool {
+				Eventually(func() v1.VirtualMachineStatus {
 					vm2, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					By(fmt.Sprintf("VM Statuses: %+v", vm2.Status))
-					return len(vm2.Status.VolumeSnapshotStatuses) == 1 &&
-						vm2.Status.VolumeSnapshotStatuses[0].Enabled
-				}, 180*time.Second, time.Second).Should(BeTrue())
+					return vm2.Status
+				}, 180*time.Second, time.Second).Should(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"VolumeSnapshotStatuses": HaveExactElements(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Enabled": BeTrue()})),
+				}))
 			})
 
 			It("should error if VolumeSnapshot deleted", func() {
@@ -1133,11 +1131,11 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					Delete(context.Background(), *vb.VolumeSnapshotName, metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(func() bool {
+				Eventually(func() *bool {
 					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return *snapshot.Status.ReadyToUse
-				}, 180*time.Second, time.Second).Should(BeFalse())
+					return snapshot.Status.ReadyToUse
+				}, 180*time.Second, time.Second).Should(gstruct.PointTo(BeFalse()))
 
 				errStr := fmt.Sprintf("VolumeSnapshots (%s) missing", *vb.VolumeSnapshotName)
 				Expect(snapshot.Status.Error).ToNot(BeNil())
@@ -1186,18 +1184,20 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					return true
 				}, 180*time.Second, time.Second).Should(BeTrue())
 
-				Eventually(func() bool {
+				Eventually(func() *snapshotv1.VirtualMachineSnapshotContentStatus {
 					vmSnapshotContent, err = virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), *cn, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					vss := vmSnapshotContent.Status.VolumeSnapshotStatus[0]
-					if vss.Error != nil {
-						Expect(*vss.Error.Message).To(Equal(m))
-						Expect(vmSnapshotContent.Status.Error).To(BeNil())
-						Expect(*vmSnapshotContent.Status.ReadyToUse).To(BeTrue())
-						return true
-					}
-					return false
-				}, 180*time.Second, time.Second).Should(BeTrue())
+					return vmSnapshotContent.Status
+				}, 180*time.Second, time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"VolumeSnapshotStatus": ContainElements(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Error": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"Message": gstruct.PointTo(Equal(m)),
+							})),
+						})),
+					"Error":      BeNil(),
+					"ReadyToUse": gstruct.PointTo(BeTrue()),
+				})))
 
 				snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -1415,22 +1415,30 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(func() bool {
+				Eventually(func() v1.VirtualMachineStatus {
 					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return len(vm.Status.VolumeSnapshotStatuses) == 1 &&
-						!vm.Status.VolumeSnapshotStatuses[0].Enabled
-				}, 180*time.Second, 1*time.Second).Should(BeTrue())
+
+					return vm.Status
+				}, 180*time.Second, time.Second).Should(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"VolumeSnapshotStatuses": HaveExactElements(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Enabled": BeFalse()})),
+				}))
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(func() bool {
+				Eventually(func() v1.VirtualMachineStatus {
 					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return len(vm.Status.VolumeSnapshotStatuses) == 1 &&
-						vm.Status.VolumeSnapshotStatuses[0].Enabled
-				}, 180*time.Second, 1*time.Second).Should(BeTrue())
+
+					return vm.Status
+				}, 180*time.Second, time.Second).Should(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"VolumeSnapshotStatuses": HaveExactElements(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Enabled": BeTrue()})),
+				}))
 			},
 				Entry("with DataVolume volume", libvmi.WithDataVolume, "1Gi"),
 				Entry("with PVC volume", libvmi.WithPersistentVolumeClaim, "128Mi"),
@@ -1471,16 +1479,17 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())
 
-				volumeSnapshotStatusAsExpected := func(volumeSnapshotStatuses []v1.VolumeSnapshotStatus) bool {
-					return len(volumeSnapshotStatuses) == 2 &&
-						volumeSnapshotStatuses[0].Enabled &&
-						!volumeSnapshotStatuses[1].Enabled
-				}
-				Eventually(func() []v1.VolumeSnapshotStatus {
+				Eventually(func() v1.VirtualMachineStatus {
 					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.VolumeSnapshotStatuses
-				}, 180*time.Second, 3*time.Second).WithOffset(1).Should(Satisfy(volumeSnapshotStatusAsExpected))
+					return vm.Status
+				}, 180*time.Second, 3*time.Second).Should(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"VolumeSnapshotStatuses": HaveExactElements(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Enabled": BeTrue()}),
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Enabled": BeFalse()})),
+				}))
 
 				By("Create Snapshot")
 				snapshot = newSnapshot()
@@ -1601,4 +1610,12 @@ func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, 
 	verifyVolumeAndDiskVMIAdded(virtClient, vmi, addVolumeName)
 
 	return addVolumeName
+}
+
+func clearConditionsTimestamps(conditions []snapshotv1.Condition) {
+	emptyTime := metav1.Time{}
+	for i := range conditions {
+		conditions[i].LastProbeTime = emptyTime
+		conditions[i].LastTransitionTime = emptyTime
+	}
 }


### PR DESCRIPTION
Instead of returning true/false if something
is as expected we should use matchers that
will give explanations of why something
is not as expected.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Improve debug info in case of failures

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
-

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

