### PR TITLE
tests: move LibvirtDomainIsPaused()

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -818,24 +818,6 @@ func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient
 	return stdout, err
 }
 
-func LibvirtDomainIsPaused(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (bool, error) {
-	vmiPod, err := getRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
-	if err != nil {
-		return false, err
-	}
-
-	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(
-		virtClient,
-		vmiPod,
-		libpod.LookupComputeContainer(vmiPod).Name,
-		[]string{"virsh", "--quiet", "domstate", vmi.Namespace + "_" + vmi.Name},
-	)
-	if err != nil {
-		return false, fmt.Errorf("could not get libvirt domstate (remotely on pod): %v: %s", err, stderr)
-	}
-	return strings.Contains(stdout, "paused"), nil
-}
-
 func GenerateVMJson(vm *v1.VirtualMachine, generateDirectory string) (string, error) {
 	data, err := json.Marshal(vm)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Move LibvirtDomainIsPaused() out of utils
to the only place where it is used.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```