### PR TITLE
tests, sriov: Drop IPv6 connectivity test

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -451,7 +451,7 @@ var _ = Describe("[Serial]SRIOV", Serial, decorators.SRIOV, func() {
 				To(Succeed(), shouldCreateNetwork)
 		})
 
-		It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {
+		It("[test_id:3956]should connect to another machine with sriov interface over IP", func() {
 			cidrA := "192.168.1.1/24"
 			cidrB := "192.168.1.2/24"
 			ipA, err := libnet.CidrToIP(cidrA)
@@ -477,35 +477,6 @@ var _ = Describe("[Serial]SRIOV", Serial, decorators.SRIOV, func() {
 			}, 15*time.Second, time.Second).Should(Succeed())
 			Eventually(func() error {
 				return libnet.PingFromVMConsole(vmi2, ipA)
-			}, 15*time.Second, time.Second).Should(Succeed())
-		})
-
-		It("[test_id:3957]should connect to another machine with sriov interface over IPv6", func() {
-			vmi1CIDR := "fc00::1/64"
-			vmi2CIDR := "fc00::2/64"
-			vmi1IP, err := libnet.CidrToIP(vmi1CIDR)
-			Expect(err).ToNot(HaveOccurred())
-			vmi2IP, err := libnet.CidrToIP(vmi2CIDR)
-			Expect(err).ToNot(HaveOccurred())
-
-			//create two vms on the same sriov network
-			vmi1, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, vmi1CIDR)
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(deleteVMI, vmi1)
-			vmi2, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, vmi2CIDR)
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(deleteVMI, vmi2)
-
-			vmi1, err = waitVMI(vmi1)
-			Expect(err).NotTo(HaveOccurred())
-			vmi2, err = waitVMI(vmi2)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi1, vmi2IP)
-			}, 15*time.Second, time.Second).Should(Succeed())
-			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi2, vmi1IP)
 			}, 15*time.Second, time.Second).Should(Succeed())
 		})
 


### PR DESCRIPTION
### What this PR does

In a SR-IOV setup, the node and pod stack is not involved at all. Only the guest stack is IP stack aware and that is not something Kubevirt is interested to cover in the e2e tests.

An attempt to bump the guest OS has exposed this redundant dependency. The new guest OS (Fedora) had issues to handle the IPv6 cloudinit configuration when IPv4 was not set.

In order to continue checking the connectivity, IPv4 guest setups tests have been left.

Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
-

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

