### PR TITLE
Add namespace to VM specific alerts descriptions

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -667,7 +667,7 @@ tests:
         alertname: VMCannotBeEvicted
         exp_alerts:
           - exp_annotations:
-              description: "Eviction policy for vm-evict-nonmigratable (on node node1) is set to Live Migration but the VM is not migratable"
+              description: "Eviction policy for VirtualMachine vm-evict-nonmigratable in namespace ns-test (on node node1) is set to Live Migration but the VM is not migratable"
               summary: "The VM's eviction strategy is set to Live Migration but the VM is not migratable"
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VMCannotBeEvicted"
             exp_labels:
@@ -726,7 +726,7 @@ tests:
   # Excessive VMI Migrations in a period of time
   - interval: 1h
     input_series:
-      - series: 'kubevirt_vmi_migration_succeeded{vmi="vmi-example-1"}'
+      - series: 'kubevirt_vmi_migration_succeeded{vmi="vmi-example-1", namespace="namespace-example-1"}'
         # time:  0 1 2 3 4 5
         values: "_ _ _ 1 7 13"
 
@@ -740,7 +740,7 @@ tests:
         alertname: KubeVirtVMIExcessiveMigrations
         exp_alerts:
           - exp_annotations:
-              description: "VirtualMachineInstance vmi-example-1 has been migrated more than 12 times during the last 24 hours"
+              description: "VirtualMachineInstance vmi-example-1 in namespace namespace-example-1 has been migrated more than 12 times during the last 24 hours"
               summary: "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMIExcessiveMigrations"
             exp_labels:
@@ -749,11 +749,12 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               vmi: vmi-example-1
+              namespace: namespace-example-1
       - eval_time: 24h
         alertname: KubeVirtVMIExcessiveMigrations
         exp_alerts:
           - exp_annotations:
-              description: "VirtualMachineInstance vmi-example-1 has been migrated more than 12 times during the last 24 hours"
+              description: "VirtualMachineInstance vmi-example-1 in namespace namespace-example-1 has been migrated more than 12 times during the last 24 hours"
               summary: "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMIExcessiveMigrations"
             exp_labels:
@@ -762,6 +763,7 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               vmi: vmi-example-1
+              namespace: namespace-example-1
       # will need to evaluate 24h after the alert is triggered to disregard the increases and clear the alert.
       - eval_time: 30h
         alertname: KubeVirtVMIExcessiveMigrations

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -59,7 +59,7 @@ var (
 			Expr:  intstr.FromString("kubevirt_vmi_non_evictable > 0"),
 			For:   ptr.To(promv1.Duration("1m")),
 			Annotations: map[string]string{
-				"description": "Eviction policy for {{ $labels.name }} (on node {{ $labels.node }}) is set to Live Migration but the VM is not migratable",
+				"description": "Eviction policy for VirtualMachine {{ $labels.name }} in namespace {{ $labels.namespace }} (on node {{ $labels.node }}) is set to Live Migration but the VM is not migratable",
 				"summary":     "The VM's eviction strategy is set to Live Migration but the VM is not migratable",
 			},
 			Labels: map[string]string{
@@ -69,9 +69,9 @@ var (
 		},
 		{
 			Alert: "KubeVirtVMIExcessiveMigrations",
-			Expr:  intstr.FromString("sum by (vmi) (max_over_time(kubevirt_vmi_migration_succeeded[1d])) >= 12"),
+			Expr:  intstr.FromString("sum by (vmi, namespace) (max_over_time(kubevirt_vmi_migration_succeeded[1d])) >= 12"),
 			Annotations: map[string]string{
-				"description": "VirtualMachineInstance {{ $labels.vmi }} has been migrated more than 12 times during the last 24 hours",
+				"description": "VirtualMachineInstance {{ $labels.vmi }} in namespace {{ $labels.namespace }} has been migrated more than 12 times during the last 24 hours",
 				"summary":     "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours.",
 			},
 			Labels: map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
`KubeVirtVMIExcessiveMigrations` and `VMCannotBeEvicted` alerts descriptions don't include the VM's namespace.
After this PR:
All specific VMs alerts descriptions mention the VM's namespace.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes: [CNV-35084](https://issues.redhat.com/browse/CNV-35084)

### Why we need it and why it was done in this way
When a specific VM alert is firing, it is important to know the namespace the VM belongs to, for easier mitigation.  

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

