### PR TITLE
tests, utils: Extract container lookup helpers to libpod

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 )
@@ -270,7 +271,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 func getContainerDiskContainerOfPod(pod *k8sv1.Pod, volumeName string) *k8sv1.Container {
 	diskContainerName := fmt.Sprintf("volume%s", volumeName)
-	return tests.GetContainerOfPod(pod, diskContainerName)
+	return libpod.LookupContainer(pod, diskContainerName)
 }
 
 func hasContainerDisk(pods []k8sv1.Pod) bool {

--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libmigration:go_default_library",
+        "//tests/libpod:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/libwait:go_default_library",
         "//tests/migration:go_default_library",

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -36,6 +36,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
@@ -106,7 +107,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Ensuring the compute container has 200m CPU")
-			compute := tests.GetComputeContainerOfPod(tests.GetVmiPod(virtClient, vmi))
+			compute := libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
 
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqCpu := compute.Resources.Requests.Cpu().Value()
@@ -155,7 +156,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			}))
 
 			By("Ensuring the virt-launcher pod now has 400m CPU")
-			compute = tests.GetComputeContainerOfPod(tests.GetVmiPod(virtClient, vmi))
+			compute = libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqCpu = compute.Resources.Requests.Cpu().Value()
 			expCpu = resource.MustParse("400m")
@@ -205,7 +206,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Ensuring the compute container has 2 CPU")
-			compute := tests.GetComputeContainerOfPod(tests.GetVmiPod(virtClient, vmi))
+			compute := libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
 
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqCpu := compute.Resources.Requests.Cpu().Value()
@@ -252,7 +253,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			}))
 
 			By("Ensuring the virt-launcher pod now has 4 CPU")
-			compute = tests.GetComputeContainerOfPod(tests.GetVmiPod(virtClient, vmi))
+			compute = libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
 
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqCpu = compute.Resources.Requests.Cpu().Value()

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -27,6 +27,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
@@ -102,7 +103,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			migration.CreateMigrationPolicy(virtClient, migration.PreparePolicyAndVMIWithBandwidthLimitation(vmi, migrationBandwidthLimit))
 
 			By("Ensuring the compute container has at least 128Mi of memory")
-			compute := tests.GetComputeContainerOfPod(tests.GetVmiPod(virtClient, vmi))
+			compute := libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
 
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqMemory := compute.Resources.Requests.Memory().Value()
@@ -147,7 +148,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			}, 240*time.Second, time.Second).Should(BeNumerically(">", guest.Value()))
 
 			By("Ensuring the virt-launcher pod now has at least more than 256Mi of memory")
-			compute = tests.GetComputeContainerOfPod(tests.GetVmiPod(virtClient, vmi))
+			compute = libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqMemory = compute.Resources.Requests.Memory().Value()
 			Expect(reqMemory).To(BeNumerically(">=", maxGuest.Value()))

--- a/tests/libpod/BUILD.bazel
+++ b/tests/libpod/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "blackhole.go",
+        "container.go",
         "query.go",
         "render.go",
         "sort.go",

--- a/tests/libpod/container.go
+++ b/tests/libpod/container.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package libpod
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	computeContainerName = "compute"
+)
+
+func LookupComputeContainer(pod *v1.Pod) *v1.Container {
+	return LookupContainer(pod, computeContainerName)
+}
+
+func LookupContainer(pod *v1.Pod, containerName string) *v1.Container {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == containerName {
+			return &pod.Spec.Containers[i]
+		}
+	}
+	panic(fmt.Errorf("could not find the %s container", containerName))
+}

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -3524,7 +3524,7 @@ func libvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.Virtua
 	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(
 		virtClient,
 		vmiPod,
-		tests.GetComputeContainerOfPod(vmiPod).Name,
+		libpod.LookupComputeContainer(vmiPod).Name,
 		[]string{"virsh", "--quiet", "list", "--persistent", "--name"},
 	)
 	if err != nil {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -393,24 +393,6 @@ func GetPodCPUSet(pod *k8sv1.Pod) (output string, err error) {
 	return
 }
 
-func GetComputeContainerOfPod(pod *k8sv1.Pod) *k8sv1.Container {
-	return GetContainerOfPod(pod, "compute")
-}
-
-func GetContainerOfPod(pod *k8sv1.Pod, containerName string) *k8sv1.Container {
-	var computeContainer *k8sv1.Container
-	for _, container := range pod.Spec.Containers {
-		if container.Name == containerName {
-			computeContainer = &container
-			break
-		}
-	}
-	if computeContainer == nil {
-		util2.PanicOnError(fmt.Errorf("could not find the %s container", containerName))
-	}
-	return computeContainer
-}
-
 // NewRandomVirtualMachineInstanceWithDisk
 //
 // Deprecated: Use libvmi directly
@@ -908,7 +890,7 @@ func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient
 	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(
 		virtClient,
 		vmiPod,
-		GetComputeContainerOfPod(vmiPod).Name,
+		libpod.LookupComputeContainer(vmiPod).Name,
 		command,
 	)
 	if err != nil {
@@ -926,7 +908,7 @@ func LibvirtDomainIsPaused(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMac
 	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(
 		virtClient,
 		vmiPod,
-		GetComputeContainerOfPod(vmiPod).Name,
+		libpod.LookupComputeContainer(vmiPod).Name,
 		[]string{"virsh", "--quiet", "domstate", vmi.Namespace + "_" + vmi.Name},
 	)
 	if err != nil {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -76,6 +76,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libdv"
 	"kubevirt.io/kubevirt/tests/libnode"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -1679,7 +1680,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 			getComputeMemoryRequest := func(vmi *virtv1.VirtualMachineInstance) resource.Quantity {
 				launcherPod := tests.GetPodByVirtualMachineInstance(vmi)
-				computeContainer := tests.GetComputeContainerOfPod(launcherPod)
+				computeContainer := libpod.LookupComputeContainer(launcherPod)
 				return computeContainer.Resources.Requests[kubev1.ResourceMemory]
 			}
 
@@ -1957,7 +1958,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 			readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
 			Expect(err).ToNot(HaveOccurred())
-			computeContainer := tests.GetComputeContainerOfPod(readyPod)
+			computeContainer := libpod.LookupComputeContainer(readyPod)
 			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
 			Expect(cpuRequest.String()).To(Equal("500m"))
 		})
@@ -1968,7 +1969,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 			readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
 			Expect(err).ToNot(HaveOccurred())
-			computeContainer := tests.GetComputeContainerOfPod(readyPod)
+			computeContainer := libpod.LookupComputeContainer(readyPod)
 			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
 			Expect(cpuRequest.String()).To(Equal("100m"))
 		})
@@ -1986,7 +1987,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 			readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
 			Expect(err).ToNot(HaveOccurred())
-			computeContainer := tests.GetComputeContainerOfPod(readyPod)
+			computeContainer := libpod.LookupComputeContainer(readyPod)
 			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
 			Expect(cpuRequest.String()).To(Equal("800m"))
 		})
@@ -2010,7 +2011,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			By("Ensuring no CPU limit is set")
 			readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
 			Expect(err).ToNot(HaveOccurred())
-			computeContainer := tests.GetComputeContainerOfPod(readyPod)
+			computeContainer := libpod.LookupComputeContainer(readyPod)
 			_, exists := computeContainer.Resources.Limits[kubev1.ResourceCPU]
 			Expect(exists).To(BeFalse(), "CPU limit set on the compute container when none was expected")
 		})
@@ -2031,7 +2032,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			By("Ensuring the CPU limit is set to the correct value")
 			readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
 			Expect(err).ToNot(HaveOccurred())
-			computeContainer := tests.GetComputeContainerOfPod(readyPod)
+			computeContainer := libpod.LookupComputeContainer(readyPod)
 			limits, exists := computeContainer.Resources.Limits[kubev1.ResourceCPU]
 			Expect(exists).To(BeTrue(), "expected CPU limit not set on the compute container")
 			Expect(limits.String()).To(Equal("1"))
@@ -2049,7 +2050,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				By("Ensuring no memory and cpu limits are set")
 				readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
-				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				computeContainer := libpod.LookupComputeContainer(readyPod)
 				_, exists := computeContainer.Resources.Limits[kubev1.ResourceMemory]
 				Expect(exists).To(BeFalse(), "Memory limits set on the compute container when none was expected")
 				_, exists = computeContainer.Resources.Limits[kubev1.ResourceCPU]
@@ -2106,7 +2107,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				By("Ensuring the memory and cpu limits are set to the correct values")
 				readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
-				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				computeContainer := libpod.LookupComputeContainer(readyPod)
 				memLimits, exists := computeContainer.Resources.Limits[kubev1.ResourceMemory]
 				Expect(exists).To(BeTrue(), "expected memory limits set on the compute container")
 				Expect(memLimits.Value()).To(BeEquivalentTo(expectedLauncherMemLimits.Value()))

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -46,6 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -93,7 +94,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 
 				readyPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
-				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				computeContainer := libpod.LookupComputeContainer(readyPod)
 
 				Expect(computeContainer.Resources.Requests.Memory().String()).To(Equal("100M"))
 			})
@@ -108,7 +109,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 
 				readyPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
-				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				computeContainer := libpod.LookupComputeContainer(readyPod)
 
 				Expect(computeContainer.Resources.Requests.Memory().String()).ToNot(Equal("100M"))
 			})
@@ -121,11 +122,11 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 
 				readyPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
-				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				computeContainer := libpod.LookupComputeContainer(readyPod)
 
 				normalReadyPod, err := libvmi.GetPodByVirtualMachineInstance(normalVmi, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
-				normalComputeContainer := tests.GetComputeContainerOfPod(normalReadyPod)
+				normalComputeContainer := libpod.LookupComputeContainer(normalReadyPod)
 
 				memDiff := normalComputeContainer.Resources.Requests.Memory()
 				memDiff.Sub(*computeContainer.Resources.Requests.Memory())


### PR DESCRIPTION
### What this PR does

Extract the helpers out of utils and rename them to fit nicely in their new home package.

Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```