### PR TITLE
Add compute folder to unit tests run

### DIFF
--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -4,7 +4,7 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
-WHAT=${WHAT:=-"//staging/src/kubevirt.io/client-go/... //pkg/... //cmd/... //tests/framework/..."}
+WHAT=${WHAT:=-"//staging/src/kubevirt.io/client-go/... //pkg/... //cmd/... //tests/framework/... //tests/compute/..."}
 
 rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
 


### PR DESCRIPTION
### What this PR does
Add the "//tests/compute/..." path to the make test command

Before this PR:
The compute folder under tests would not run as part of any CI tests

After this PR:
The /tests/compute folder should run all tests as part of the unit tests CI

### Special notes for your reviewer
Previously the compute tests were under the pkg folder, they were moved in previous PR's such as [this](https://github.com/kubevirt/kubevirt/commit/4106d79f5913f50fd932c62bbd0e5ad440c51c2c), up until this patch they were not being run at all.

### Release note
```release-note
NONE
```

