### PR TITLE
lint: Cover tests/libpod using the linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ lint:
 	  pkg/network/sriov/... \
 	  tests/console/... \
 	  tests/libnet/... \
+	  tests/libpod/... \
 	  tests/libvmi/... \
 	  && \
 	  golangci-lint run --disable-all -E ginkgolinter --timeout 10m --verbose --no-config \

--- a/tests/libpod/blackhole.go
+++ b/tests/libpod/blackhole.go
@@ -13,19 +13,19 @@ import (
 	"kubevirt.io/kubevirt/tests/exec"
 )
 
-func AddKubernetesApiBlackhole(pods *v1.PodList, containerName string) {
-	kubernetesApiServiceBlackhole(pods, containerName, true)
+func AddKubernetesAPIBlackhole(pods *v1.PodList, containerName string) {
+	kubernetesAPIServiceBlackhole(pods, containerName, true)
 }
 
-func DeleteKubernetesApiBlackhole(pods *v1.PodList, containerName string) {
-	kubernetesApiServiceBlackhole(pods, containerName, false)
+func DeleteKubernetesAPIBlackhole(pods *v1.PodList, containerName string) {
+	kubernetesAPIServiceBlackhole(pods, containerName, false)
 }
 
-func kubernetesApiServiceBlackhole(pods *v1.PodList, containerName string, present bool) {
+func kubernetesAPIServiceBlackhole(pods *v1.PodList, containerName string, present bool) {
 	virtCli, err := kubecli.GetKubevirtClient()
 	Expect(err).NotTo(HaveOccurred())
 
-	serviceIp := getKubernetesApiServiceIp(virtCli)
+	serviceIP := getKubernetesAPIServiceIP(virtCli)
 
 	var addOrDel string
 	if present {
@@ -34,17 +34,17 @@ func kubernetesApiServiceBlackhole(pods *v1.PodList, containerName string, prese
 		addOrDel = "del"
 	}
 
-	for _, pod := range pods.Items {
-		_, err = exec.ExecuteCommandOnPod(virtCli, &pod, containerName, []string{"ip", "route", addOrDel, "blackhole", serviceIp})
+	for idx := range pods.Items {
+		_, err = exec.ExecuteCommandOnPod(virtCli, &pods.Items[idx], containerName, []string{"ip", "route", addOrDel, "blackhole", serviceIP})
 		Expect(err).NotTo(HaveOccurred())
 	}
 }
 
-func getKubernetesApiServiceIp(virtClient kubecli.KubevirtClient) string {
-	const kubernetesServiceName = "kubernetes"
-	const kubernetesServiceNamespace = "default"
+func getKubernetesAPIServiceIP(virtClient kubecli.KubevirtClient) string {
+	const serviceName = "kubernetes"
+	const serviceNamespace = "default"
 
-	kubernetesService, err := virtClient.CoreV1().Services(kubernetesServiceNamespace).Get(context.Background(), kubernetesServiceName, metav1.GetOptions{})
+	kubernetesService, err := virtClient.CoreV1().Services(serviceNamespace).Get(context.Background(), serviceName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	return kubernetesService.Spec.ClusterIP

--- a/tests/libpod/query.go
+++ b/tests/libpod/query.go
@@ -30,13 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetRunningPodByLabel(
-	virtCli kubecli.KubevirtClient,
-	label string,
-	labelType string,
-	namespace string,
-	node string) (*k8sv1.Pod, error) {
-
+func GetRunningPodByLabel(virtCli kubecli.KubevirtClient, label, labelType, namespace, node string) (*k8sv1.Pod, error) {
 	labelSelector := fmt.Sprintf("%s=%s", labelType, label)
 	var fieldSelector string
 	if node != "" {

--- a/tests/libpod/render.go
+++ b/tests/libpod/render.go
@@ -107,7 +107,8 @@ func renderPrivilegedContainerSpec(imgPath string, name string, cmd []string, ar
 	}
 }
 
-func RenderHostPathPod(podName string, dir string, hostPathType v1.HostPathType, mountPropagation v1.MountPropagationMode, cmd []string, args []string) *v1.Pod {
+func RenderHostPathPod(
+	podName string, dir string, hostPathType v1.HostPathType, mountPropagation v1.MountPropagationMode, cmd []string, args []string) *v1.Pod {
 	pod := RenderPrivilegedPod(podName, cmd, args)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
 		Name:             "hostpath-mount",

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -257,13 +257,13 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 				Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically(">", 0))
 
 				By("blocking connection to API on pods")
-				libpod.AddKubernetesApiBlackhole(getHandlerPods(), componentName)
+				libpod.AddKubernetesAPIBlackhole(getHandlerPods(), componentName)
 
 				By("ensuring we no longer have a ready pod")
 				Eventually(readyFunc, 120*time.Second, time.Second).Should(BeNumerically("==", 0))
 
 				By("removing blockage to API")
-				libpod.DeleteKubernetesApiBlackhole(getHandlerPods(), componentName)
+				libpod.DeleteKubernetesAPIBlackhole(getHandlerPods(), componentName)
 
 				By("ensuring we now have a ready virt-handler daemonset")
 				Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically("==", desiredDeamonsSetCount))

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1961,7 +1961,7 @@ status:
 		var nodeName string
 
 		AfterEach(func() {
-			libpod.DeleteKubernetesApiBlackhole(getHandlerNodePod(virtClient, nodeName), componentName)
+			libpod.DeleteKubernetesAPIBlackhole(getHandlerNodePod(virtClient, nodeName), componentName)
 			Eventually(func(g Gomega) {
 				g.Expect(getHandlerNodePod(virtClient, nodeName).Items[0]).To(HaveConditionTrue(k8sv1.PodReady))
 			}, 120*time.Second, time.Second).Should(Succeed())
@@ -1980,7 +1980,7 @@ status:
 			oldUID := vmi.UID
 
 			By("Blocking virt-handler from reconciling the VMI")
-			libpod.AddKubernetesApiBlackhole(getHandlerNodePod(virtClient, nodeName), componentName)
+			libpod.AddKubernetesAPIBlackhole(getHandlerNodePod(virtClient, nodeName), componentName)
 			Eventually(func(g Gomega) {
 				g.Expect(getHandlerNodePod(virtClient, nodeName).Items[0]).To(HaveConditionFalse(k8sv1.PodReady))
 			}, 120*time.Second, time.Second).Should(Succeed())


### PR DESCRIPTION
### What this PR does

Cover `tests/libpod` with the linter checks.

The following errors have been resolved to allow this:
```
tests/libpod/blackhole.go:37:2: rangeValCopy: each iteration copies 1048 bytes (consider pointers or indexing) (gocritic)
        for _, pod := range pods.Items {
        ^
tests/libpod/blackhole.go:38:46: G601: Implicit memory aliasing in for loop. (gosec)
                _, err = exec.ExecuteCommandOnPod(virtCli, &pod, containerName, []string{"ip", "route", addOrDel, "blackhole", serviceIp})
                                                           ^
tests/libpod/blackhole.go:47: line is 153 characters (lll)
        kubernetesService, err := virtClient.CoreV1().Services(kubernetesServiceNamespace).Get(context.Background(), kubernetesServiceName, metav1.GetOptions{})
tests/libpod/render.go:110: line is 161 characters (lll)
func RenderHostPathPod(podName string, dir string, hostPathType v1.HostPathType, mountPropagation v1.MountPropagationMode, cmd []string, args []string) *v1.Pod {
tests/libpod/query.go:38: unnecessary leading newline (whitespace)
        node string) (*k8sv1.Pod, error) {

tests/libpod/blackhole.go:16:6: ST1003: func AddKubernetesApiBlackhole should be AddKubernetesAPIBlackhole (stylecheck)
func AddKubernetesApiBlackhole(pods *v1.PodList, containerName string) {
     ^
tests/libpod/blackhole.go:20:6: ST1003: func DeleteKubernetesApiBlackhole should be DeleteKubernetesAPIBlackhole (stylecheck)
func DeleteKubernetesApiBlackhole(pods *v1.PodList, containerName string) {
     ^
tests/libpod/blackhole.go:24:6: ST1003: func kubernetesApiServiceBlackhole should be kubernetesAPIServiceBlackhole (stylecheck)
func kubernetesApiServiceBlackhole(pods *v1.PodList, containerName string, present bool) {
     ^
tests/libpod/blackhole.go:28:2: ST1003: var serviceIp should be serviceIP (stylecheck)
        serviceIp := getKubernetesApiServiceIp(virtCli)
        ^
tests/libpod/blackhole.go:43:6: ST1003: func getKubernetesApiServiceIp should be getKubernetesAPIServiceIP (stylecheck)
func getKubernetesApiServiceIp(virtClient kubecli.KubevirtClient) string {
     ^

```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

