### PR TITLE
tests, network: Refactor services test

### DIFF
--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -129,3 +129,17 @@ func MultusNetwork(name, nadName string) *kvirtv1.Network {
 		},
 	}
 }
+
+// WithHostname sets the hostname parameter.
+func WithHostname(hostname string) Option {
+	return func(vmi *kvirtv1.VirtualMachineInstance) {
+		vmi.Spec.Hostname = hostname
+	}
+}
+
+// WithSubdomain sets the subdomain parameter.
+func WithSubdomain(subdomain string) Option {
+	return func(vmi *kvirtv1.VirtualMachineInstance) {
+		vmi.Spec.Subdomain = subdomain
+	}
+}

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -61,17 +61,6 @@ const (
 var _ = SIGDescribe("Services", func() {
 	var virtClient kubecli.KubevirtClient
 
-	cleanupVMI := func(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
-		By("Deleting the VMI")
-		Expect(virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.GetName(), &k8smetav1.DeleteOptions{})).To(Succeed())
-
-		By("Waiting for the VMI to be gone")
-		Eventually(func() error {
-			_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(context.Background(), vmi.GetName(), &k8smetav1.GetOptions{})
-			return err
-		}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
-	}
-
 	cleanupService := func(namespace string, serviceName string) error {
 		return virtClient.CoreV1().Services(namespace).Delete(context.Background(), serviceName, k8smetav1.DeleteOptions{})
 	}
@@ -109,7 +98,6 @@ var _ = SIGDescribe("Services", func() {
 
 		AfterEach(func() {
 			Expect(inboundVMI).NotTo(BeNil(), "the VMI object must exist in order to be deleted.")
-			cleanupVMI(virtClient, inboundVMI)
 		})
 
 		Context("with a service matching the vmi exposed", func() {
@@ -212,7 +200,6 @@ var _ = SIGDescribe("Services", func() {
 
 		AfterEach(func() {
 			Expect(inboundVMI).NotTo(BeNil(), "the VMI object must exist in order to be deleted.")
-			cleanupVMI(virtClient, inboundVMI)
 		})
 
 		Context("with a service matching the vmi exposed", func() {

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -224,8 +224,8 @@ var _ = SIGDescribe("Services", func() {
 		}
 
 		BeforeEach(func() {
-			subdomain := "vmi"
-			hostname := "inbound"
+			const subdomain = "vmi"
+			const hostname = "inbound"
 
 			inboundVMI = createReadyVMIWithMasqueradeBindingAndExposedService(hostname, subdomain)
 			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToFedora)
@@ -248,7 +248,7 @@ var _ = SIGDescribe("Services", func() {
 				By("setting up resources to expose the VMI via a service", func() {
 					libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 					if ipFamily == k8sv1.IPv6Protocol {
-						serviceName = serviceName + "v6"
+						serviceName += "v6"
 						service = netservice.BuildIPv6Spec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
 					} else {
 						service = netservice.BuildSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -101,9 +101,9 @@ var _ = SIGDescribe("Services", func() {
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
+				libvmi.WithSubdomain(subdomain),
+				libvmi.WithHostname(hostname),
 			)
-			vmi.Spec.Subdomain = subdomain
-			vmi.Spec.Hostname = hostname
 			return readyVMI(vmi, console.LoginToCirros)
 		}
 
@@ -208,9 +208,9 @@ var _ = SIGDescribe("Services", func() {
 			vmi := libvmi.NewFedora(append(
 				libnet.WithMasqueradeNetworking(),
 				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
+				libvmi.WithSubdomain(subdomain),
+				libvmi.WithHostname(hostname),
 			)...)
-			vmi.Spec.Subdomain = subdomain
-			vmi.Spec.Hostname = hostname
 			return readyVMI(vmi, console.LoginToFedora)
 		}
 


### PR DESCRIPTION
### What this PR does

Refactor the e2e network services tests and helpers.

This is part of a bigger goal to cover all network tests by the linter.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

