### PR TITLE
tests,swap: Cosmetics

### DIFF
--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -61,8 +61,6 @@ import (
 )
 
 const (
-	// Define relevant k8s versions
-	k8sSwapVer = "1.22"
 	//20% of the default size which is 2G in kubevirt-ci
 	maxSwapSizeToUseKib = 415948
 	swapPartToUse       = 0.2

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -101,7 +101,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 
 			By("Allowing post-copy")
 			kv := util.GetCurrentKv(virtClient)
-			oldMigrationConfiguration := kv.Spec.Configuration.MigrationConfiguration
 			kv.Spec.Configuration.MigrationConfiguration = &virtv1.MigrationConfiguration{
 				AllowPostCopy:           pointer.P(true),
 				CompletionTimeoutPerGiB: pointer.P(int64(1)),
@@ -149,11 +148,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 
 			By("Waiting for VMI to disappear")
 			libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
-
-			kv = util.GetCurrentKv(virtClient)
-			kv.Spec.Configuration.MigrationConfiguration = oldMigrationConfiguration
-			tests.UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
-
 		})
 
 		It("Migration of vmi to memory overcommited node", func() {

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -282,7 +282,11 @@ func skipIfSwapOff(message string) {
 
 func getAffinityForTargetNode(targetNode *v1.Node) (nodeAffinity *v1.Affinity, err error) {
 	nodeAffinityRuleForVmiToFill, err := libmigration.CreateNodeAffinityRuleToMigrateFromSourceToTargetAndBack(targetNode, targetNode)
+	if err != nil {
+		return nil, err
+	}
+
 	return &v1.Affinity{
 		NodeAffinity: nodeAffinityRuleForVmiToFill,
-	}, err
+	}, nil
 }

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -227,28 +227,28 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 	})
 })
 
-func getMemInfoByString(node v1.Node, field string) (size int) {
+func getMemInfoByString(node v1.Node, field string) int {
 	stdout, stderr, err := tests.ExecuteCommandOnNodeThroughVirtHandler(kubevirt.Client(), node.Name, []string{"grep", field, "/proc/meminfo"})
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("stderr: %v \n", stderr))
 	fields := strings.Fields(stdout)
-	size, err = strconv.Atoi(fields[1])
+	size, err := strconv.Atoi(fields[1])
 	Expect(err).ToNot(HaveOccurred())
 	return size
 }
 
-func getAvailableMemSizeInKib(node v1.Node) (size int) {
+func getAvailableMemSizeInKib(node v1.Node) int {
 	return getMemInfoByString(node, "MemAvailable")
 }
 
-func getTotalMemSizeInKib(node v1.Node) (size int) {
+func getTotalMemSizeInKib(node v1.Node) int {
 	return getMemInfoByString(node, "MemTotal")
 }
 
-func getSwapFreeSizeInKib(node v1.Node) (size int) {
+func getSwapFreeSizeInKib(node v1.Node) int {
 	return getMemInfoByString(node, "SwapFree")
 }
 
-func getSwapSizeInKib(node v1.Node) (size int) {
+func getSwapSizeInKib(node v1.Node) int {
 	return getMemInfoByString(node, "SwapTotal")
 }
 

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -37,8 +39,6 @@ import (
 	expect "github.com/google/goexpect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/utils/pointer"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -105,8 +105,8 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			kv := util.GetCurrentKv(virtClient)
 			oldMigrationConfiguration := kv.Spec.Configuration.MigrationConfiguration
 			kv.Spec.Configuration.MigrationConfiguration = &virtv1.MigrationConfiguration{
-				AllowPostCopy:           pointer.BoolPtr(true),
-				CompletionTimeoutPerGiB: pointer.Int64Ptr(1),
+				AllowPostCopy:           pointer.P(true),
+				CompletionTimeoutPerGiB: pointer.P(int64(1)),
 			}
 			tests.UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
 

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -229,10 +229,10 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 
 func getMemInfoByString(node v1.Node, field string) int {
 	stdout, stderr, err := tests.ExecuteCommandOnNodeThroughVirtHandler(kubevirt.Client(), node.Name, []string{"grep", field, "/proc/meminfo"})
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("stderr: %v \n", stderr))
+	ExpectWithOffset(2, err).ToNot(HaveOccurred(), fmt.Sprintf("stderr: %v \n", stderr))
 	fields := strings.Fields(stdout)
 	size, err := strconv.Atoi(fields[1])
-	Expect(err).ToNot(HaveOccurred())
+	ExpectWithOffset(2, err).ToNot(HaveOccurred())
 	return size
 }
 
@@ -264,10 +264,10 @@ func confirmMigrationMode(vmi *virtv1.VirtualMachineInstance, expectedMode virtv
 	var err error
 	By("Retrieving the VMI post migration")
 	vmi, err = kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("couldn't find vmi err: %v \n", err))
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), fmt.Sprintf("couldn't find vmi err: %v \n", err))
 
 	By("Verifying the VMI's migration mode")
-	Expect(vmi.Status.MigrationState.Mode).To(Equal(expectedMode), fmt.Sprintf("expected migration state: %v got :%v \n", vmi.Status.MigrationState.Mode, expectedMode))
+	ExpectWithOffset(1, vmi.Status.MigrationState.Mode).To(Equal(expectedMode), fmt.Sprintf("expected migration state: %v got :%v \n", vmi.Status.MigrationState.Mode, expectedMode))
 }
 
 func skipIfSwapOff(message string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
* Get rid or deprecated pointer package.
* Remove unused const.
* Remove named variables, most of the places even didnt use them.
* Add offset to expects.
* Refactor function to fail fast and not return a value in case of an error.
* Remove non required kubevirt configuration restoration 
(it is done already on global AfterEach).

### Why we need it and why it was done in this way
Improve readability and maintainability.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

