### PR TITLE
virtwrap: Add <vmport state="off"/> to libvirt XML

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -307,6 +307,7 @@ type Features struct {
 	KVM        *FeatureKVM        `xml:"kvm,omitempty"`
 	PVSpinlock *FeaturePVSpinlock `xml:"pvspinlock,omitempty"`
 	PMU        *FeatureState      `xml:"pmu,omitempty"`
+	VMPort     *FeatureState      `xml:"vmport,omitempty"`
 }
 
 type FeatureHyperv struct {

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -161,6 +161,7 @@ var _ = ginkgo.Describe("Schema", func() {
 			},
 			PVSpinlock: &FeaturePVSpinlock{State: "off"},
 			PMU:        &FeatureState{State: "off"},
+			VMPort:     &FeatureState{State: "off"},
 		}
 		exampleDomain.Spec.SysInfo = &SysInfo{
 			Type: "smbios",

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_arm64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_arm64.xml.tmpl
@@ -66,6 +66,7 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_ppc64le.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_ppc64le.xml.tmpl
@@ -66,6 +66,7 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_x86_64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_x86_64.xml.tmpl
@@ -66,6 +66,7 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1130,6 +1130,12 @@ func Convert_v1_Features_To_api_Features(source *v1.Features, features *api.Feat
 			State: boolToOnOff(source.Pvspinlock.Enabled, true),
 		}
 	}
+	features.PMU = &api.FeatureState{
+		State: "off",
+	}
+	features.VMPort = &api.FeatureState{
+		State: "off",
+	}
 	return nil
 }
 


### PR DESCRIPTION
According to https://libvirt.org/formatdomain.html, the feature <vmport> exists to enable emulation of the VMWare IO port, for vmmouse and so forth.  Libvirt defaults it to on, but containers generally don't make use of the port, so it is better to explicitly disable this feature without even bothering to export it to consumers.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: The virt-launcher API builds libvirt XML without the feature `<vmport state=.../>`; in this case, libvirt defaults to state="on", but that spends resources on exposing things like vmmouse that a container doesn't need.

After this PR: Libvirt XML is generated with explicit `<vmport state="off">`

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
Working with @vladikr 

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

