### PR TITLE
downwardmetrics: add safety checks in StopServer()

### DIFF
--- a/pkg/virt-handler/dmetrics-manager/dmetrics-manager.go
+++ b/pkg/virt-handler/dmetrics-manager/dmetrics-manager.go
@@ -86,8 +86,10 @@ func (m *DownwardMetricsManager) StopServer(vmi *v1.VirtualMachineInstance) {
 	// Even it's not strictly required for stopping the server,
 	// since the server will stop when the VM closes the unix socket,
 	// we cancel the context to avoid leaking it
-	m.stopServer[vmi.UID]()
-	delete(m.stopServer, vmi.UID)
+	if cancelCtx, exists := m.stopServer[vmi.UID]; exists {
+		cancelCtx()
+		delete(m.stopServer, vmi.UID)
+	}
 }
 
 // StartServer start a new DownwardMetrics server if the VM request it and is not already started


### PR DESCRIPTION
Actually check if the VMI still exists in the DownwardMetricsManager `stopServer` map before calling the related Context canceling function as `processVmCleanup()` could be called multiple times by virt-handler's reconciliation loop when cleaning up the VMI.

This prevents virt-handler from panicking because of a segfault.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

