### PR TITLE
DEBUG: kubevirtci-kubevirt pipline

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -274,6 +274,13 @@ export IMAGE_PREFIX_ALT=${IMAGE_PREFIX_ALT:-kv-}
 
 build_images
 
+# Enforce using the k8s-1.28 provider, using k8s-1.28 node image that was created from kubevirt/kubevirtci latest main
+# quay.io/oshocal/k8s-1.28:latest
+export KUBEVIRTCI_CONTAINER_REGISTRY=quay.io
+export KUBEVIRTCI_CONTAINER_ORG=oshoval
+export KUBEVIRTCI_CONTAINER_SUFFIX=latest
+export KUBEVIRT_PROVIDER=k8s-1.28
+
 trap '{ collect_debug_logs; echo "Dump kubevirt state:"; make dump; }' ERR
 make cluster-up
 trap - ERR

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -920,6 +920,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(console.RunCommand(vmi, "sudo cirros-dhcpc up eth0\n", time.Second*time.Duration(15))).To(Succeed(), "failed to run dhcp client")
 
 				Expect(ping(podIP)).To(Succeed())
+
+				Expect(true).To(BeFalse(), "TEST PASSED, inject error to dump test artifacts")
 			},
 				Entry("without a specific port number", []v1.Port{}),
 				Entry("with explicit ports used by live migration", portsUsedByLiveMigration()),

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -899,6 +899,12 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(vmi.Status.Phase).To(Equal(v1.Running))
 
 				vmMigratedTs := time.Now()
+
+				// The following uptime fetch from guest fail due to the login session gone and its necessary to login
+				// again to exec the command inside the guest.
+				// The session seem to expire due to the guest unexpected reboot.
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
 				guestUptimeAfterMigration, err := vmiUptime(vmi)
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is PR is to debug the CI kubevirtci-kubevirt pipeline  on Kubevirt side 
The check-provision jobs for VM based providers are broken since two weeks ago 28/1/2024.
More details at https://github.com/kubevirt/kubevirtci/issues/1133

This PR make use of provisioned k8s-1.28 provider nodes image that been created locally:
quay.io/oshoval/k8s-1.28:latest 

And runs one of the failing test only:
```
Tests Suite: [sig-network] [rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking VirtualMachineInstance with masquerade binding mechanism when performing migration [Conformance] preserves connectivity - IPv4 without a specific port number expand_more
```
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/1124/check-provision-k8s-1.27/1756490976106385408

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

