### PR TITLE
tests, network: Move `vmi_servers` to a new `network/vmnetserver` pkg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,8 @@ linters-settings:
         ignored-functions:
           - '^Eventually$'
           - '^EventuallyWithOffset$'
+          - '^console\.ExpectBatch$'
+          - '^console\.RunCommand$'
   govet:
     check-shadowing: true
   lll:

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,6 @@ fmt: format
 
 lint:
 	if [ $$(wc -l < tests/utils.go) -gt 2027 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
-
 	hack/dockerized "golangci-lint run --timeout 20m --verbose \
 	  pkg/instancetype/... \
 	  pkg/network/namescheme/... \

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
         "io_utils.go",
         "pod_servers.go",
         "utils.go",
-        "vmi_servers.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests",
     visibility = ["//visibility:public"],

--- a/tests/libnet/vmnetserver/BUILD.bazel
+++ b/tests/libnet/vmnetserver/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["servers.go"],
+    importpath = "kubevirt.io/kubevirt/tests/libnet/vmnetserver",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//tests/console:go_default_library",
+        "//vendor/github.com/google/goexpect:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
+)

--- a/tests/libnet/vmnetserver/servers.go
+++ b/tests/libnet/vmnetserver/servers.go
@@ -1,12 +1,32 @@
-package tests
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package vmnetserver
 
 import (
 	"fmt"
 	"strings"
 	"time"
 
-	expect "github.com/google/goexpect"
 	. "github.com/onsi/gomega"
+
+	expect "github.com/google/goexpect"
 	k8sv1 "k8s.io/api/core/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -64,7 +84,7 @@ EOL`, inetSuffix, port)
 	Expect(console.ExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: fmt.Sprintf("%s\n", serverCommand)},
 		&expect.BExp{R: console.PromptExpression},
-		&expect.BSnd{S: EchoLastReturnValue},
+		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: console.ShellSuccess},
 	}, 60*time.Second)).To(Succeed())
 

--- a/tests/libnet/vmnetserver/servers.go
+++ b/tests/libnet/vmnetserver/servers.go
@@ -55,12 +55,12 @@ func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int, loginTo console.L
 	HTTPServer.Start(vmi, port)
 }
 
-func StartHTTPServerWithSourceIp(vmi *v1.VirtualMachineInstance, port int, sourceIP string, loginTo console.LoginToFunction) {
+func StartHTTPServerWithSourceIP(vmi *v1.VirtualMachineInstance, port int, sourceIP string, loginTo console.LoginToFunction) {
 	ExpectWithOffset(1, loginTo(vmi)).To(Succeed())
 	HTTPServer.Start(vmi, port, fmt.Sprintf("-s %s", sourceIP))
 }
 
-func StartPythonHttpServer(vmi *v1.VirtualMachineInstance, port int) {
+func StartPythonHTTPServer(vmi *v1.VirtualMachineInstance, port int) {
 	Expect(console.RunCommand(vmi, "echo 'Hello World!' > index.html", 60*time.Second)).To(Succeed())
 
 	serverCommand := fmt.Sprintf("python3 -m http.server %d --bind ::0 &\n", port)

--- a/tests/migration/BUILD.bazel
+++ b/tests/migration/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//tests/libnet:go_default_library",
         "//tests/libnet/job:go_default_library",
         "//tests/libnet/service:go_default_library",
+        "//tests/libnet/vmnetserver:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/libstorage:go_default_library",

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -44,6 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libnet/job"
 	"kubevirt.io/kubevirt/tests/libnet/service"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 
@@ -234,7 +235,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Starting hello world in the VM")
-			tests.StartTCPServer(vmi, port, console.LoginToCirros)
+			vmnetserver.StartTCPServer(vmi, port, console.LoginToCirros)
 
 			By("Exposing headless service matching subdomain")
 			service := service.BuildHeadlessSpec(subdomain, port, port, labelKey, labelValue)

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
         "//tests/libnet/dns:go_default_library",
         "//tests/libnet/job:go_default_library",
         "//tests/libnet/service:go_default_library",
+        "//tests/libnet/vmnetserver:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/libvmi:go_default_library",

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -185,7 +186,7 @@ var _ = SIGDescribe("[Serial] VirtualMachineInstance with passt network binding 
 					startServerVMI(ports)
 
 					By("starting a TCP server")
-					tests.StartTCPServer(serverVMI, tcpPort, console.LoginToAlpine)
+					vmnetserver.StartTCPServer(serverVMI, tcpPort, console.LoginToAlpine)
 
 					Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, ipFamily)).To(Succeed())
 
@@ -194,7 +195,7 @@ var _ = SIGDescribe("[Serial] VirtualMachineInstance with passt network binding 
 						vmPort := int(ports[0].Port)
 						serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
 
-						tests.StartTCPServer(serverVMI, vmPort+1, console.LoginToAlpine)
+						vmnetserver.StartTCPServer(serverVMI, vmPort+1, console.LoginToAlpine)
 
 						By("Connecting from the client VM to a port not specified on the VM spec")
 						Expect(console.SafeExpectBatch(clientVMI, checkConnectionToServer(serverIP, tcpPort+1, true), 30)).To(Not(Succeed()))
@@ -251,7 +252,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 					)
 
 					By("Starting a UDP server")
-					tests.StartPythonUDPServer(serverVMI, SERVER_PORT, ipFamily)
+					vmnetserver.StartPythonUDPServer(serverVMI, SERVER_PORT, ipFamily)
 
 					By("Starting client VMI")
 					clientVMI = libvmi.NewAlpineWithTestTooling(

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -25,9 +25,9 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -431,8 +431,8 @@ func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, server
 	serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToAlpine)
 
 	By("Start HTTP server at serverVMI on ports 80 and 81")
-	tests.HTTPServer.Start(serverVMI, 80)
-	tests.HTTPServer.Start(serverVMI, 81)
+	vmnetserver.HTTPServer.Start(serverVMI, 80)
+	vmnetserver.HTTPServer.Start(serverVMI, 81)
 
 	return serverVMI, nil
 }

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -75,7 +75,7 @@ var _ = SIGDescribe("Port-forward", func() {
 			}
 
 			vmi := createCirrosVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
-			vmnetserver.StartHTTPServerWithSourceIp(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToCirros)
+			vmnetserver.StartHTTPServerWithSourceIP(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToCirros)
 
 			localPort = 1500 + GinkgoParallelProcess()
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 )
@@ -74,7 +75,7 @@ var _ = SIGDescribe("Port-forward", func() {
 			}
 
 			vmi := createCirrosVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
-			tests.StartHTTPServerWithSourceIp(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToCirros)
+			vmnetserver.StartHTTPServerWithSourceIp(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToCirros)
 
 			localPort = 1500 + GinkgoParallelProcess()
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -23,6 +23,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -357,9 +358,9 @@ func isHTTPProbe(probe v1.Probe) bool {
 
 func serverStarter(vmi *v1.VirtualMachineInstance, probe *v1.Probe, port int) {
 	if isHTTPProbe(*probe) {
-		tests.StartHTTPServer(vmi, port, console.LoginToAlpine)
+		vmnetserver.StartHTTPServer(vmi, port, console.LoginToAlpine)
 	} else {
-		tests.StartTCPServer(vmi, port, console.LoginToAlpine)
+		vmnetserver.StartTCPServer(vmi, port, console.LoginToAlpine)
 	}
 }
 

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -40,11 +40,11 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/job"
 	netservice "kubevirt.io/kubevirt/tests/libnet/service"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 )
@@ -157,7 +157,7 @@ var _ = SIGDescribe("Services", func() {
 			hostname := "inbound"
 
 			inboundVMI = createReadyVMIWithBridgeBindingAndExposedService(hostname, subdomain)
-			tests.StartTCPServer(inboundVMI, servicePort, console.LoginToCirros)
+			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToCirros)
 		})
 
 		AfterEach(func() {
@@ -253,7 +253,7 @@ var _ = SIGDescribe("Services", func() {
 			hostname := "inbound"
 
 			inboundVMI = createReadyVMIWithMasqueradeBindingAndExposedService(hostname, subdomain)
-			tests.StartTCPServer(inboundVMI, servicePort, console.LoginToFedora)
+			vmnetserver.StartTCPServer(inboundVMI, servicePort, console.LoginToFedora)
 		})
 
 		AfterEach(func() {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -119,7 +119,7 @@ var istioTests = func(vmType VmType) {
 	Context("Virtual Machine with istio supported interface", func() {
 		createJobCheckingVMIReachability := func(serverVMI *v1.VirtualMachineInstance, targetPort int) (*batchv1.Job, error) {
 			By("Starting HTTP Server")
-			vmnetserver.StartPythonHttpServer(vmi, targetPort)
+			vmnetserver.StartPythonHTTPServer(vmi, targetPort)
 
 			By("Getting back the VMI IP")
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
@@ -362,7 +362,7 @@ var istioTests = func(vmType VmType) {
 
 				By("Starting HTTP Server")
 				Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
-				vmnetserver.StartPythonHttpServer(serverVMI, vmiServerTestPort)
+				vmnetserver.StartPythonHTTPServer(serverVMI, vmiServerTestPort)
 
 				By("Creating Istio VirtualService")
 				virtualServicesRes := schema.GroupVersionResource{Group: networkingIstioIO, Version: istioApiVersion, Resource: "virtualservices"}

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -54,6 +54,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libnet/job"
 	netservice "kubevirt.io/kubevirt/tests/libnet/service"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -118,7 +119,7 @@ var istioTests = func(vmType VmType) {
 	Context("Virtual Machine with istio supported interface", func() {
 		createJobCheckingVMIReachability := func(serverVMI *v1.VirtualMachineInstance, targetPort int) (*batchv1.Job, error) {
 			By("Starting HTTP Server")
-			tests.StartPythonHttpServer(vmi, targetPort)
+			vmnetserver.StartPythonHttpServer(vmi, targetPort)
 
 			By("Getting back the VMI IP")
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
@@ -361,7 +362,7 @@ var istioTests = func(vmType VmType) {
 
 				By("Starting HTTP Server")
 				Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
-				tests.StartPythonHttpServer(serverVMI, vmiServerTestPort)
+				vmnetserver.StartPythonHttpServer(serverVMI, vmiServerTestPort)
 
 				By("Creating Istio VirtualService")
 				virtualServicesRes := schema.GroupVersionResource{Group: networkingIstioIO, Version: istioApiVersion, Resource: "virtualservices"}

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -65,6 +65,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
+	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 )
@@ -230,7 +231,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				inboundVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), inboundVMI)
 				Expect(err).ToNot(HaveOccurred())
 				inboundVMI = libwait.WaitUntilVMIReady(inboundVMI, console.LoginToCirros)
-				tests.StartTCPServer(inboundVMI, testPort, console.LoginToCirros)
+				vmnetserver.StartTCPServer(inboundVMI, testPort, console.LoginToCirros)
 
 				ip := inboundVMI.Status.Interfaces[0].IP
 
@@ -736,7 +737,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 
 				By("starting a tcp server")
-				tests.StartTCPServer(serverVMI, tcpPort, console.LoginToCirros)
+				vmnetserver.StartTCPServer(serverVMI, tcpPort, console.LoginToCirros)
 
 				if networkCIDR == "" {
 					networkCIDR = api.DefaultVMCIDR
@@ -799,7 +800,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 
 				By("starting a http server")
-				tests.StartPythonHttpServer(serverVMI, tcpPort)
+				vmnetserver.StartPythonHttpServer(serverVMI, tcpPort)
 
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv6Protocol)).To(Succeed())
 			},

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -800,7 +800,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 
 				By("starting a http server")
-				vmnetserver.StartPythonHttpServer(serverVMI, tcpPort)
+				vmnetserver.StartPythonHTTPServer(serverVMI, tcpPort)
 
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv6Protocol)).To(Succeed())
 			},

--- a/tests/vmi_servers.go
+++ b/tests/vmi_servers.go
@@ -72,25 +72,6 @@ EOL`, inetSuffix, port)
 	Expect(console.RunCommand(vmi, serverCommand, 60*time.Second)).To(Succeed())
 }
 
-func StartExampleGuestAgent(vmi *v1.VirtualMachineInstance, useTLS bool, port uint32) error {
-
-	serverArgs := fmt.Sprintf("--port %v", port)
-	if useTLS {
-		serverArgs = strings.Join([]string{serverArgs, "--use-tls"}, " ")
-	}
-
-	return console.ExpectBatch(vmi, []expect.Batcher{
-		&expect.BSnd{S: "chmod +x /usr/bin/example-guest-agent\n"},
-		&expect.BExp{R: console.PromptExpression},
-		&expect.BSnd{S: EchoLastReturnValue},
-		&expect.BExp{R: console.ShellSuccess},
-		&expect.BSnd{S: fmt.Sprintf("/usr/bin/example-guest-agent %s 2>&1 &\n", serverArgs)},
-		&expect.BExp{R: console.PromptExpression},
-		&expect.BSnd{S: EchoLastReturnValue},
-		&expect.BExp{R: console.ShellSuccess},
-	}, 60*time.Second)
-}
-
 func (s server) Start(vmi *v1.VirtualMachineInstance, port int, extraArgs ...string) {
 	Expect(console.RunCommand(vmi, s.composeNetcatServerCommand(port, extraArgs...), 60*time.Second)).To(Succeed())
 }


### PR DESCRIPTION
### What this PR does

Move the helpers closer to its common users and maintainers.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

