### PR TITLE
refactor: use patch package instead of hardcoded operations

### DIFF
--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -21,6 +21,7 @@ import (
 	"kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
@@ -109,10 +110,12 @@ var _ = Describe("Disruptionbudget", func() {
 			Expect(ok).To(BeTrue())
 			Expect(patchAction.GetName()).To(Equal("pdb-" + vmi.Name))
 			Expect(patchAction.GetPatchType()).To(Equal(types.JSONPatchType))
-
-			expectedPatch := fmt.Sprintf(`[{ "op": "replace", "path": "/spec/minAvailable", "value": 1 }, { "op": "remove", "path": "/metadata/labels/%s" }]`,
-				patch.EscapeJSONPointer(v1.MigrationNameLabel))
-			Expect(string(patchAction.GetPatch())).To(Equal(expectedPatch))
+			patches := patch.New()
+			patches.Replace("/spec/minAvailable", 1)
+			patches.Remove(fmt.Sprintf("/metadata/labels/%s", patch.EscapeJSONPointer(virtv1.MigrationNameLabel)))
+			expectedPatch, err := patches.GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(patchAction.GetPatch())).To(Equal(string(expectedPatch)))
 			return true, &policyv1.PodDisruptionBudget{}, nil
 		})
 	}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -31,9 +31,10 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/virt-controller/network"
 
-	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
 
@@ -556,11 +557,6 @@ func applyMemoryDumpVolumeRequestOnVMISpec(vmiSpec *virtv1.VirtualMachineInstanc
 }
 
 func (c *VMController) generateVMIMemoryDumpVolumePatch(vmi *virtv1.VirtualMachineInstance, request *virtv1.VirtualMachineMemoryDumpRequest, addVolume bool) error {
-	patchVerb := "add"
-	if len(vmi.Spec.Volumes) > 0 {
-		patchVerb = "replace"
-	}
-
 	foundRemoveVol := false
 	for _, volume := range vmi.Spec.Volumes {
 		if request.ClaimName == volume.Name {
@@ -583,21 +579,14 @@ func (c *VMController) generateVMIMemoryDumpVolumePatch(vmi *virtv1.VirtualMachi
 		vmiCopy.Spec = *removeMemoryDumpVolumeFromVMISpec(&vmiCopy.Spec, request.ClaimName)
 	}
 
-	oldJson, err := json.Marshal(vmi.Spec.Volumes)
+	patches := patch.New()
+	patches.Test("/spec/volumes", vmi.Spec.Volumes)
+	patches.AddOrReplace("/spec/volumes", vmiCopy.Spec.Volumes, len(vmi.Spec.Volumes) == 0)
+	patch, err := patches.GeneratePayload()
 	if err != nil {
 		return err
 	}
-
-	newJson, err := json.Marshal(vmiCopy.Spec.Volumes)
-	if err != nil {
-		return err
-	}
-
-	test := fmt.Sprintf(`{ "op": "test", "path": "/spec/volumes", "value": %s}`, string(oldJson))
-	update := fmt.Sprintf(`{ "op": "%s", "path": "/spec/volumes", "value": %s}`, patchVerb, string(newJson))
-	patch := fmt.Sprintf("[%s, %s]", test, update)
-
-	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), v1.PatchOptions{})
+	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patch, v1.PatchOptions{})
 	return err
 }
 
@@ -639,11 +628,14 @@ func (c *VMController) updatePVCMemoryDumpAnnotation(vm *virtv1.VirtualMachine) 
 }
 
 func (c *VMController) VMICPUsPatch(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
-	test := fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/cpu/sockets", "value": %s}`, strconv.FormatUint(uint64(vmi.Spec.Domain.CPU.Sockets), 10))
-	update := fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/cpu/sockets", "value": %s}`, strconv.FormatUint(uint64(vm.Spec.Template.Spec.Domain.CPU.Sockets), 10))
-	patch := fmt.Sprintf("[%s, %s]", test, update)
-
-	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), v1.PatchOptions{})
+	patches := patch.New()
+	patches.TestAndReplace("/spec/domain/cpu/sockets", vmi.Spec.Domain.CPU.Sockets,
+		vm.Spec.Template.Spec.Domain.CPU.Sockets)
+	patch, err := patches.GeneratePayload()
+	if err != nil {
+		return err
+	}
+	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patch, v1.PatchOptions{})
 
 	return err
 }
@@ -693,7 +685,7 @@ func (c *VMController) handleCPUChangeRequest(vm *virtv1.VirtualMachine, vmi *vi
 }
 
 func (c *VMController) VMNodeSelectorPatch(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
-	var ops []string
+	patches := patch.New()
 
 	if vm.Spec.Template.Spec.NodeSelector != nil {
 		vmNodeSelector := maps.Clone(vm.Spec.Template.Spec.NodeSelector)
@@ -701,55 +693,44 @@ func (c *VMController) VMNodeSelectorPatch(vm *virtv1.VirtualMachine, vmi *virtv
 			vmNodeSelector = make(map[string]string)
 		}
 
-		vmNodeSelectorJson, err := json.Marshal(vmNodeSelector)
-		if err != nil {
-			return err
-		}
-
 		if vmi.Spec.NodeSelector == nil {
-			ops = append(ops, fmt.Sprintf(`{ "op": "add", "path": "/spec/nodeSelector", "value": %s }`, string(vmNodeSelectorJson)))
+			patches.Add("/spec/nodeSelector", vmNodeSelector)
 		} else {
-			currentVMINodeSelector, err := json.Marshal(vmi.Spec.NodeSelector)
-			if err != nil {
-				return err
-			}
-			ops = append(ops, fmt.Sprintf(`{ "op": "test", "path": "/spec/nodeSelector", "value": %s }`, string(currentVMINodeSelector)))
-			ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/spec/nodeSelector", "value": %s }`, string(vmNodeSelectorJson)))
+			patches.TestAndReplace("/spec/nodeSelector", vmi.Spec.NodeSelector, vmNodeSelector)
 		}
 
 	} else {
-		ops = append(ops, fmt.Sprintf(`{ "op": "remove", "path": "/spec/nodeSelector" }`))
+		patches.Remove("/spec/nodeSelector")
 	}
-	generatedPatch := controller.GeneratePatchBytes(ops)
+	generatedPatch, err := patches.GeneratePayload()
+	if err != nil {
+		return err
+	}
 
-	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, generatedPatch, v1.PatchOptions{})
+	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, generatedPatch, v1.PatchOptions{})
 	return err
 }
 
 func (c *VMController) VMIAffinityPatch(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
-	var ops []string
+	patches := patch.New()
 
 	if vm.Spec.Template.Spec.Affinity != nil {
-		vmAffinityJson, err := json.Marshal(vm.Spec.Template.Spec.Affinity)
-		if err != nil {
-			return err
-		}
+		vmAffinity := vm.Spec.Template.Spec.Affinity.DeepCopy()
 		if vmi.Spec.Affinity == nil {
-			ops = append(ops, fmt.Sprintf(`{ "op": "add", "path": "/spec/affinity", "value": %s }`, string(vmAffinityJson)))
+			patches.Add("/spec/affinity", vmAffinity)
 		} else {
-			currentVMIAffinity, err := json.Marshal(vmi.Spec.Affinity)
-			if err != nil {
-				return err
-			}
-			ops = append(ops, fmt.Sprintf(`{ "op": "test", "path": "/spec/affinity", "value": %s }`, string(currentVMIAffinity)))
-			ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/spec/affinity", "value": %s }`, string(vmAffinityJson)))
+			patches.TestAndReplace("/spec/affinity", vmi.Spec.Affinity, vmAffinity)
 		}
 
 	} else {
-		ops = append(ops, fmt.Sprintf(`{ "op": "remove", "path": "/spec/affinity" }`))
+		patches.Remove("/spec/affinity")
+	}
+	generatedPatch, err := patches.GeneratePayload()
+	if err != nil {
+		return err
 	}
 
-	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, controller.GeneratePatchBytes(ops), v1.PatchOptions{})
+	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, generatedPatch, v1.PatchOptions{})
 	return err
 }
 
@@ -1226,18 +1207,12 @@ func (c *VMController) patchVmGenerationAnnotationOnVmi(generation int64, vmi *v
 
 	setGenerationAnnotationOnVmi(generation, vmi)
 
-	var ops []string
-	oldAnnotations, err := json.Marshal(origVmi.Annotations)
+	patch, err := patch.TestAndReplaceAnnotations(origVmi.Annotations, vmi.Annotations)
 	if err != nil {
 		return err
 	}
-	newAnnotations, err := json.Marshal(vmi.Annotations)
-	if err != nil {
-		return err
-	}
-	ops = append(ops, fmt.Sprintf(`{ "op": "test", "path": "/metadata/annotations", "value": %s }`, string(oldAnnotations)))
-	ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/metadata/annotations", "value": %s }`, string(newAnnotations)))
-	_, err = c.clientset.VirtualMachineInstance(origVmi.Namespace).Patch(context.Background(), origVmi.Name, types.JSONPatchType, controller.GeneratePatchBytes(ops), v1.PatchOptions{})
+
+	_, err = c.clientset.VirtualMachineInstance(origVmi.Namespace).Patch(context.Background(), origVmi.Name, types.JSONPatchType, patch, v1.PatchOptions{})
 	if err != nil {
 		return err
 	}
@@ -2232,23 +2207,6 @@ func (c *VMController) enqueueVm(obj interface{}) {
 	c.Queue.Add(key)
 }
 
-func (c *VMController) getPatchFinalizerOps(oldFinalizers, newFinalizers []string) ([]string, error) {
-	joldFinalizers, err := json.Marshal(oldFinalizers)
-	if err != nil {
-		return nil, err
-	}
-
-	jnewFinalizers, err := json.Marshal(newFinalizers)
-	if err != nil {
-		return nil, err
-	}
-
-	return []string{
-		fmt.Sprintf(`{ "op": "test", "path": "/metadata/finalizers", "value": %s }`, joldFinalizers),
-		fmt.Sprintf(`{ "op": "replace", "path": "/metadata/finalizers", "value": %s }`, jnewFinalizers),
-	}, nil
-}
-
 func (c *VMController) removeVMIFinalizer(vmi *virtv1.VirtualMachineInstance) error {
 	if !controller.HasFinalizer(vmi, virtv1.VirtualMachineControllerFinalizer) {
 		return nil
@@ -2264,12 +2222,12 @@ func (c *VMController) removeVMIFinalizer(vmi *virtv1.VirtualMachineInstance) er
 		}
 	}
 
-	ops, err := c.getPatchFinalizerOps(vmi.Finalizers, newFinalizers)
+	ops, err := patch.TestAndReplaceFinalizers(vmi.Finalizers, newFinalizers)
 	if err != nil {
 		return err
 	}
 
-	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, controller.GeneratePatchBytes(ops), v1.PatchOptions{})
+	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, ops, v1.PatchOptions{})
 	return err
 }
 
@@ -2288,12 +2246,12 @@ func (c *VMController) removeVMFinalizer(vm *virtv1.VirtualMachine) (*virtv1.Vir
 		}
 	}
 
-	ops, err := c.getPatchFinalizerOps(vm.Finalizers, newFinalizers)
+	ops, err := patch.TestAndReplaceFinalizers(vm.Finalizers, newFinalizers)
 	if err != nil {
 		return vm, err
 	}
 
-	vm, err = c.clientset.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, controller.GeneratePatchBytes(ops), &v1.PatchOptions{})
+	vm, err = c.clientset.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, ops, &v1.PatchOptions{})
 	return vm, err
 }
 
@@ -2308,12 +2266,12 @@ func (c *VMController) addVMFinalizer(vm *virtv1.VirtualMachine) (*virtv1.Virtua
 	copy(newFinalizers, vm.Finalizers)
 	newFinalizers = append(newFinalizers, virtv1.VirtualMachineControllerFinalizer)
 
-	ops, err := c.getPatchFinalizerOps(vm.Finalizers, newFinalizers)
+	ops, err := patch.TestAndReplaceFinalizers(vm.Finalizers, newFinalizers)
 	if err != nil {
 		return vm, err
 	}
 
-	return c.clientset.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, controller.GeneratePatchBytes(ops), &v1.PatchOptions{})
+	return c.clientset.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, ops, &v1.PatchOptions{})
 }
 
 // parseGeneration will parse for the last value after a '-'. It is assumed the
@@ -3236,25 +3194,21 @@ func (c *VMController) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi
 		// adjusting memoryDelta too for the new limits computation (if required)
 		memoryDelta = resource.NewQuantity(vm.Spec.Template.Spec.Domain.Memory.Guest.Value()-newMemoryReq.Value(), resource.BinarySI)
 	}
-
-	patches := []string{
-		fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/memory/guest", "value": "%s"}`, vmi.Spec.Domain.Memory.Guest.String()),
-		fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/memory/guest", "value": "%s"}`, vm.Spec.Template.Spec.Domain.Memory.Guest.String()),
-		fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/requests/memory", "value": "%s"}`, vmi.Spec.Domain.Resources.Requests.Memory().String()),
-		fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/resources/requests/memory", "value": "%s"}`, newMemoryReq.String()),
-	}
+	patches := patch.New()
+	patches.TestAndReplace("/spec/domain/memory/guest", vmi.Spec.Domain.Memory.Guest,
+		vm.Spec.Template.Spec.Domain.Memory.Guest)
+	patches.TestAndReplace("/spec/domain/resources/requests/memory", vmi.Spec.Domain.Resources.Requests.Memory(), newMemoryReq)
 
 	if !vm.Spec.Template.Spec.Domain.Resources.Limits.Memory().IsZero() {
 		newMemoryLimit := vmi.Spec.Domain.Resources.Limits.Memory().DeepCopy()
 		newMemoryLimit.Add(*memoryDelta)
-
-		patches = append(patches, fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/limits/memory", "value": "%s"}`, vmi.Spec.Domain.Resources.Limits.Memory().String()))
-		patches = append(patches, fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/resources/limits/memory", "value": "%s"}`, newMemoryLimit.String()))
+		patches.TestAndReplace("/spec/domain/resources/limits/memory", vmi.Spec.Domain.Resources.Limits.Memory(), newMemoryLimit)
 	}
-
-	memoryPatch := controller.GeneratePatchBytes(patches)
-
-	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, memoryPatch, v1.PatchOptions{})
+	patch, err := patches.GeneratePayload()
+	if err != nil {
+		return err
+	}
+	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patch, v1.PatchOptions{})
 	if err != nil {
 		return err
 	}
@@ -3269,36 +3223,16 @@ func (c *VMController) vmiInterfacesPatch(newVmiSpec *virtv1.VirtualMachineInsta
 		return nil
 	}
 
-	oldIfacesJSON, err := json.Marshal(vmi.Spec.Domain.Devices.Interfaces)
+	patches := patch.New()
+	patches.TestAndAdd("/spec/networks", vmi.Spec.Networks, newVmiSpec.Networks)
+	patches.TestAndAdd("/spec/domain/devices/interfaces", vmi.Spec.Domain.Devices.Interfaces,
+		newVmiSpec.Domain.Devices.Interfaces)
+	patch, err := patches.GeneratePayload()
 	if err != nil {
 		return err
 	}
 
-	newIfacesJSON, err := json.Marshal(newVmiSpec.Domain.Devices.Interfaces)
-	if err != nil {
-		return err
-	}
-
-	oldNetworksJSON, err := json.Marshal(vmi.Spec.Networks)
-	if err != nil {
-		return err
-	}
-
-	newNetworksJSON, err := json.Marshal(newVmiSpec.Networks)
-	if err != nil {
-		return err
-	}
-
-	const verb = "add"
-	testNetworks := fmt.Sprintf(`{ "op": "test", "path": "/spec/networks", "value": %s}`, string(oldNetworksJSON))
-	updateNetworks := fmt.Sprintf(`{ "op": %q, "path": "/spec/networks", "value": %s}`, verb, string(newNetworksJSON))
-
-	testInterfaces := fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/devices/interfaces", "value": %s}`, string(oldIfacesJSON))
-	updateInterfaces := fmt.Sprintf(`{ "op": %q, "path": "/spec/domain/devices/interfaces", "value": %s}`, verb, string(newIfacesJSON))
-
-	patch := fmt.Sprintf("[%s, %s, %s, %s]", testNetworks, testInterfaces, updateNetworks, updateInterfaces)
-
-	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), v1.PatchOptions{})
+	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patch, v1.PatchOptions{})
 
 	return err
 }

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1182,7 +1182,9 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 			if err != nil {
 				return &syncErrorImpl{err, FailedPodPatchReason}
 			}
-			*pod = *patchedPod
+			if patchedPod != nil {
+				*pod = *patchedPod
+			}
 		}
 
 		hotplugVolumes := getHotplugVolumes(vmi, pod)
@@ -2295,7 +2297,9 @@ func (c *VMIController) updateMultusAnnotation(namespace string, interfaces []vi
 		if err != nil {
 			return err
 		}
-		*pod = *patchedPod
+		if patchedPod != nil {
+			*pod = *patchedPod
+		}
 	}
 
 	return nil

--- a/pkg/virt-controller/watch/workload-updater/BUILD.bazel
+++ b/pkg/virt-controller/watch/workload-updater/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/workload-updater",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/status:go_default_library",
@@ -20,7 +21,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
@@ -36,6 +36,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -20,6 +20,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -196,7 +197,12 @@ var _ = Describe("Workload Updater", func() {
 
 			kubeVirtInterface.EXPECT().PatchStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) {
 				str := string(data)
-				Expect(str).To(Equal("[{ \"op\": \"test\", \"path\": \"/status/outdatedVirtualMachineInstanceWorkloads\", \"value\": 0}, { \"op\": \"replace\", \"path\": \"/status/outdatedVirtualMachineInstanceWorkloads\", \"value\": 100}]"))
+				patches := patch.New()
+				patches.Test("/status/outdatedVirtualMachineInstanceWorkloads", 0)
+				patches.Replace("/status/outdatedVirtualMachineInstanceWorkloads", 100)
+				patch, err := patches.GeneratePayload()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(str).To(Equal(string(patch)))
 
 			}).Return(nil, nil).Times(1)
 

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-operator",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/monitoring/metrics/virt-operator:go_default_library",

--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-operator/resource/apply",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -397,22 +397,13 @@ var _ = Describe("Apply", func() {
 				ops, err := generateServicePatch(cachedService, targetService)
 				Expect(err).ToNot(HaveOccurred())
 
-				hasSubstring := func(ops []string, substring string) bool {
-					for _, op := range ops {
-						if strings.Contains(op, substring) {
-							return true
-						}
-					}
-					return false
-				}
-
 				if expectLabelsAnnotationsPatch {
-					Expect(hasSubstring(ops, "/metadata/labels")).To(BeTrue())
-					Expect(hasSubstring(ops, "/metadata/annotations")).To(BeTrue())
+					Expect(strings.Contains(string(ops), "/metadata/labels")).To(BeTrue())
+					Expect(strings.Contains(string(ops), "/metadata/annotations")).To(BeTrue())
 				}
 
 				if expectSpecPatch {
-					Expect(hasSubstring(ops, "/spec")).To(BeTrue())
+					Expect(strings.Contains(string(ops), "/spec")).To(BeTrue())
 				}
 
 				if !expectSpecPatch && !expectLabelsAnnotationsPatch {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
In the code we have in multiple places hardcoded patches with  [`GeneratePatchBytes`](https://github.com/kubevirt/kubevirt/blob/main/pkg/controller/controller.go#L311) or  [`GenerateTestReplacePatch`](https://github.com/kubevirt/kubevirt/blob/main/pkg/apimachinery/patch/patch.go#L54)

After this PR:
The code will be much consistent by using the new API all over the places and we eliminate hardcoded patch operations

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

