### PR TITLE
OWNERS: Add sig/ or area/ to every OWNERS file which was missing it.

### DIFF
--- a/cmd/virtctl/OWNERS
+++ b/cmd/virtctl/OWNERS
@@ -3,3 +3,6 @@ reviewers:
   - oshoval
 approvers:
   - 0xFelix
+labels:
+  - area/virtctl
+  - sig/cluster

--- a/pkg/handler-launcher-com/OWNERS
+++ b/pkg/handler-launcher-com/OWNERS
@@ -3,3 +3,7 @@ reviewers:
   - sig-node-reviewers
 approvers:
   - sig-node-approvers
+labels:
+  - area/virt-handler
+  - area/virt-launcher
+  - sig/node

--- a/pkg/virt-handler/OWNERS
+++ b/pkg/virt-handler/OWNERS
@@ -3,3 +3,6 @@ reviewers:
   - sig-node-reviewers
 approvers:
   - sig-node-approvers
+labels:
+  - area/virt-handler
+  - sig/node

--- a/pkg/virtctl/OWNERS
+++ b/pkg/virtctl/OWNERS
@@ -3,3 +3,6 @@ reviewers:
   - oshoval
 approvers:
   - 0xFelix
+labels:
+  - area/virtctl
+  - sig/cluster

--- a/tests/libvmi/OWNERS
+++ b/tests/libvmi/OWNERS
@@ -1,5 +1,3 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
   - EdDev
-labels:
-  - sig/test

--- a/tests/libvmi/OWNERS
+++ b/tests/libvmi/OWNERS
@@ -1,3 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
   - EdDev
+labels:
+  - sig/test


### PR DESCRIPTION
### What this PR does
Before this PR: OWNERS files without label based sig or area assignment existed.

After this PR: All OWNERS files have label based sig or area assignments, this helps to make sure that this ownership is bubbling up into labels during PR reviews.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made: N/A

The following alternatives were considered: N/A

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

None

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

