### PR TITLE
virt-controller, services: Remove passt memory overhead

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -392,14 +392,6 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 		overhead.Add(resource.MustParse("53Mi"))
 	}
 
-	// Additional overhead for each interface with Passt binding, that forwards all ports.
-	// More information can be found here: https://bugs.passt.top/show_bug.cgi?id=20
-	for _, net := range vmi.Spec.Domain.Devices.Interfaces {
-		if net.Passt != nil && len(net.Ports) == 0 {
-			overhead.Add(resource.MustParse("800Mi"))
-		}
-	}
-
 	// Multiplying the ratio is expected to be the last calculation before returning overhead
 	if additionalOverheadRatio != nil && *additionalOverheadRatio != "" {
 		ratio, err := strconv.ParseFloat(*additionalOverheadRatio, 64)

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -461,7 +461,6 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 		downwardmetricsOverhead *resource.Quantity
 		sevOverhead             *resource.Quantity
 		tpmOverhead             *resource.Quantity
-		passtOverhead           *resource.Quantity
 	)
 
 	BeforeEach(func() {
@@ -488,7 +487,6 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 		downwardmetricsOverhead = pointer.P(resource.MustParse("1Mi"))
 		sevOverhead = pointer.P(resource.MustParse("256Mi"))
 		tpmOverhead = pointer.P(resource.MustParse("53Mi"))
-		passtOverhead = pointer.P(resource.MustParse("800Mi"))
 	})
 
 	When("the vmi is not requesting any specific device or cpu or whatever", func() {
@@ -663,31 +661,6 @@ var _ = Describe("GetMemoryOverhead calculation", func() {
 			expected.Add(*videoRAMOverhead)
 			expected.Add(*coresOverhead)
 			expected.Add(*tpmOverhead)
-			overhead := GetMemoryOverhead(vmi, "amd64", nil)
-			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
-		})
-	})
-
-	When("the vmi requests interfaces with Passt binding", func() {
-		BeforeEach(func() {
-			vmi.Spec.Domain.Devices = v1.Devices{
-				Interfaces: []v1.Interface{
-					{Name: "passt1", InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}}},
-					{Name: "passt2", InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}}},
-					{Name: "passt3", InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}}},
-					{Name: "nonpasst", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
-				},
-			}
-		})
-
-		It("should add passt overhead for each interface", func() {
-			expected := resource.NewScaledQuantity(0, resource.Kilo)
-			expected.Add(*baseOverhead)
-			expected.Add(*staticOverhead)
-			expected.Add(*videoRAMOverhead)
-			expected.Add(*coresOverhead)
-			value := passtOverhead.Value() * 3
-			expected.Add(*resource.NewQuantity(value, passtOverhead.Format))
 			overhead := GetMemoryOverhead(vmi, "amd64", nil)
 			Expect(overhead.Value()).To(BeEquivalentTo(expected.Value()))
 		})

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -51,7 +51,6 @@ var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
 			libvmi.WithInterface(v1.Interface{
 				Name:                   v1.DefaultPodNetwork().Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}},
-				Ports:                  []v1.Port{{Port: 1234, Protocol: "TCP"}},
 				MacAddress:             macAddress,
 			}),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),


### PR DESCRIPTION
### What this PR does

Remove passt memory overhead.

Passt binding required additional memory when no TCP/UDP ports are specified (i.e. all ports are forwarded to guest).
Once we used passt with binding plugins, we noticed that it works even without the overhead memory.

This change removes the overhead memory and checks it for the previous (deprecated) passt configuration.

TODO: Revert the `vmi_pass` test changes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

