### PR TITLE
Remove the listCgroupThreads func from utils

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -294,29 +294,6 @@ func GetVcpuMask(pod *k8sv1.Pod, emulator, cpu string) (output string, err error
 	return strings.TrimSpace(output), err
 }
 
-func ListCgroupThreads(pod *k8sv1.Pod) (output string, err error) {
-	virtClient := kubevirt.Client()
-
-	output, err = exec.ExecuteCommandOnPod(
-		virtClient,
-		pod,
-		"compute",
-		[]string{"cat", "/sys/fs/cgroup/cpuset/tasks"},
-	)
-
-	if err == nil {
-		// Cgroup V1
-		return
-	}
-	output, err = exec.ExecuteCommandOnPod(
-		virtClient,
-		pod,
-		"compute",
-		[]string{"cat", "/sys/fs/cgroup/cgroup.threads"},
-	)
-	return
-}
-
 func GetPodCPUSet(pod *k8sv1.Pod) (output string, err error) {
 	const (
 		cgroupV1cpusetPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"


### PR DESCRIPTION
### What this PR does
The tests/utils.go::listCgroupThreads function only used in one place.

This change move this function to the file that actually use it.
### Why we need it and why it was done in this way
code cleanup
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

