### PR TITLE
Tests: fix flake by ensuring source-protection finalizer is removed

### DIFF
--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/reservation:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Hey all,

We've seen [some flakes](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/11182/pull-kubevirt-e2e-k8s-1.29-sig-storage/1757245360088027136) in CI caused by a finalizer preventing a VM from being deleted. The finalizer is being left by [this test,](https://github.com/kubevirt/kubevirt/pull/11051/files#diff-37151b0a9221caa50060dafcc63f46652faa5997399872d1a23ea4df4888cf84R743) which creates a failed snapshot but doesn't wait for the deadline to exceed. The test finishes with the finalizer being left on the VM.

This PR aims to fix this behavior by ensuring the snapshot fails and the finalizer is removed.

### Why we need it and why it was done in this way

Follow up for: https://github.com/kubevirt/kubevirt/pull/11051.

### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

