### PR TITLE
Move GetProcessName from util

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -259,20 +259,6 @@ func getPodsByLabel(label, labelType, namespace string) (*k8sv1.PodList, error) 
 	return pods, nil
 }
 
-func GetProcessName(pod *k8sv1.Pod, pid string) (output string, err error) {
-	virtClient := kubevirt.Client()
-
-	fPath := "/proc/" + pid + "/comm"
-	output, err = exec.ExecuteCommandOnPod(
-		virtClient,
-		pod,
-		"compute",
-		[]string{"cat", fPath},
-	)
-
-	return
-}
-
 func GetVcpuMask(pod *k8sv1.Pod, emulator, cpu string) (output string, err error) {
 	virtClient := kubevirt.Client()
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2717,7 +2717,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					if len(pid) == 0 {
 						continue
 					}
-					output, err = tests.GetProcessName(readyPod, pid)
+					output, err = getProcessName(readyPod, pid)
 					if err != nil {
 						getProcessNameErrors++
 						continue
@@ -3432,5 +3432,19 @@ func listCgroupThreads(pod *k8sv1.Pod) (output string, err error) {
 		"compute",
 		[]string{"cat", "/sys/fs/cgroup/cgroup.threads"},
 	)
+	return
+}
+
+func getProcessName(pod *k8sv1.Pod, pid string) (output string, err error) {
+	virtClient := kubevirt.Client()
+
+	fPath := "/proc/" + pid + "/comm"
+	output, err = exec.ExecuteCommandOnPod(
+		virtClient,
+		pod,
+		"compute",
+		[]string{"cat", fPath},
+	)
+
 	return
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The tests/utils.go:GetProcessName function only used in one place.

This change move this function to the file that actually use it.

### Why we need it and why it was done in this way
code cleanup

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None

```

