### PR TITLE
[release-1.0] Fix migration when VM has rng devices and hotplugged block volume

### DIFF
--- a/pkg/virt-handler/cgroup/util.go
+++ b/pkg/virt-handler/cgroup/util.go
@@ -129,6 +129,19 @@ func generateDeviceRulesForVMI(vmi *v1.VirtualMachineInstance, isolationRes isol
 			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
 		}
 	}
+	if vmi.Spec.Domain.Devices.Rng != nil {
+		path, err := safepath.JoinNoFollow(mountRoot, "/dev/urandom")
+		if err != nil {
+			return nil, err
+		}
+		if deviceRule, err := newAllowedDeviceRule(path); err != nil {
+			return nil, fmt.Errorf("failed to create device rule for %s: %v", path, err)
+		} else if deviceRule != nil {
+			log.Log.V(loggingVerbosity).Infof("device rule for volume rng: %v", deviceRule)
+			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
+		}
+	}
+
 	return vmiDeviceRules, nil
 }
 

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1074,15 +1074,6 @@ var _ = SIGDescribe("Hotplug", func() {
 			var (
 				vmi *v1.VirtualMachineInstance
 				sc  string
-
-				numberOfMigrations int
-				hotplugLabelKey    string
-				sourceNode         string
-				targetNode         string
-			)
-
-			const (
-				hotplugLabelValue = "true"
 			)
 
 			containerDiskVMIFunc := func() *v1.VirtualMachineInstance {
@@ -1092,12 +1083,24 @@ var _ = SIGDescribe("Hotplug", func() {
 				)
 			}
 			persistentDiskVMIFunc := func() *v1.VirtualMachineInstance {
-				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(
-					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
-					testsuite.GetTestNamespace(nil),
-					corev1.ReadWriteMany,
+				dataVolume := libdv.NewDataVolume(
+					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
+					libdv.WithPVC(
+						libdv.PVCWithStorageClass(sc),
+						libdv.PVCWithVolumeSize(cd.CirrosVolumeSize),
+						libdv.PVCWithReadWriteManyAccessMode(),
+						libdv.PVCWithBlockVolumeMode(),
+					),
 				)
-				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+				dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vmi := libvmi.New(
+					libvmi.WithDataVolume("disk0", dataVolume.Name),
+					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithCloudInitNoCloudUserData("#!/bin/bash\n echo hello\n", true),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
 
 				return vmi
 			}
@@ -1108,47 +1111,11 @@ var _ = SIGDescribe("Hotplug", func() {
 				if !exists {
 					Skip("Skip test when RWXBlock storage class is not present")
 				}
-
-				// Workaround for the issue with CPU manager and runc prior to version v1.0.0:
-				// CPU manager periodically updates cgroup settings via the container runtime
-				// interface. Runc prior to version v1.0.0 drops all 'custom' cgroup device
-				// rules on 'update' and that causes a race with live migration when block volumes
-				// are hotplugged. Try to setup the test in a way so that the VMI is migrated to
-				// a node without CPU manager.
-				sourceNode = ""
-				targetNode = ""
-				for _, node := range libnode.GetAllSchedulableNodes(virtClient).Items {
-					labels := node.GetLabels()
-					if val, ok := labels[v1.CPUManager]; ok && val == "true" {
-						// Use a node with CPU manager as migration source
-						sourceNode = node.Name
-					} else {
-						// Use a node without CPU manager as migration target
-						targetNode = node.Name
-					}
-				}
-				if sourceNode == "" || targetNode == "" {
-					Skip("Two schedulable nodes are required for migration tests")
-				} else {
-					numberOfMigrations = 1
-				}
-				// Ensure the virt-launcher pod is scheduled on the chosen source node and then
-				// migrated to the proper target.
-				hotplugLabelKey = fmt.Sprintf("%s-hotplug-disk-migration", testsuite.GetTestNamespace(nil))
-				libnode.AddLabelToNode(sourceNode, hotplugLabelKey, hotplugLabelValue)
-			})
-
-			AfterEach(func() {
-				// Cleanup node labels
-				libnode.RemoveLabelFromNode(sourceNode, hotplugLabelKey)
-				libnode.RemoveLabelFromNode(targetNode, hotplugLabelKey)
 			})
 
 			DescribeTable("should allow live migration with attached hotplug volumes", func(vmiFunc func() *v1.VirtualMachineInstance) {
 				vmi = vmiFunc()
-				vmi.Spec.NodeSelector = map[string]string{hotplugLabelKey: hotplugLabelValue}
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
-				libnode.AddLabelToNode(targetNode, hotplugLabelKey, hotplugLabelValue)
 				volumeName := "testvolume"
 				volumeMode := corev1.PersistentVolumeBlock
 				addVolumeFunc := addDVVolumeVMI
@@ -1177,31 +1144,29 @@ var _ = SIGDescribe("Hotplug", func() {
 				targets := verifyHotplugAttachedAndUseable(vmi, []string{volumeName})
 				Expect(targets).To(HaveLen(1))
 
-				By("Starting the migration multiple times")
-				for i := 0; i < numberOfMigrations; i++ {
-					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					sourceAttachmentPods := []string{}
-					for _, volumeStatus := range vmi.Status.VolumeStatus {
-						if volumeStatus.HotplugVolume != nil {
-							sourceAttachmentPods = append(sourceAttachmentPods, volumeStatus.HotplugVolume.AttachPodName)
-						}
+				By("Starting the migration")
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				sourceAttachmentPods := []string{}
+				for _, volumeStatus := range vmi.Status.VolumeStatus {
+					if volumeStatus.HotplugVolume != nil {
+						sourceAttachmentPods = append(sourceAttachmentPods, volumeStatus.HotplugVolume.AttachPodName)
 					}
-					Expect(sourceAttachmentPods).To(HaveLen(1))
-
-					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-					migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
-					tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
-					By("Verifying the volume is still accessible and usable")
-					verifyVolumeAccessible(vmi, targets[0])
-					verifyWriteReadData(vmi, targets[0])
-
-					By("Verifying the source attachment pods are deleted")
-					Eventually(func() bool {
-						_, err := virtClient.CoreV1().Pods(vmi.Namespace).Get(context.Background(), sourceAttachmentPods[0], metav1.GetOptions{})
-						return errors.IsNotFound(err)
-					}, 60*time.Second, 1*time.Second).Should(BeTrue())
 				}
+				Expect(sourceAttachmentPods).To(HaveLen(1))
+
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
+				By("Verifying the volume is still accessible and usable")
+				verifyVolumeAccessible(vmi, targets[0])
+				verifyWriteReadData(vmi, targets[0])
+
+				By("Verifying the source attachment pods are deleted")
+				Eventually(func() bool {
+					_, err := virtClient.CoreV1().Pods(vmi.Namespace).Get(context.Background(), sourceAttachmentPods[0], metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				}, 60*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("Verifying the volume can be detached and reattached after migration")
 				removeVolumeFunc(vmi.Name, vmi.Namespace, volumeName, false)

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1100,6 +1100,8 @@ var _ = SIGDescribe("Hotplug", func() {
 					libvmi.WithCloudInitNoCloudUserData("#!/bin/bash\n echo hello\n", true),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					// Stir things up, /dev/urandom access will be needed
+					libvmi.WithRng(),
 				)
 
 				return vmi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is a backport of https://github.com/kubevirt/kubevirt/pull/11205

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix migration breaking in case the VM has an rng device after hotplugging a block volume on cgroupsv2
```

