### PR TITLE
tests: fix datarace in hotplug test and make it faster

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -955,26 +955,31 @@ var _ = SIGDescribe("Hotplug", func() {
 				libwait.WaitForSuccessfulVMIStart(vmi,
 					libwait.WithTimeout(240),
 				)
-				testVolumes := make([]string, 0)
-				dvNames := make([]string, 0)
-				for i := 0; i < 75; i = i + 5 {
+
+				const howManyVolumes = 75
+
+				dvNames := make([]string, howManyVolumes)
+				testVolumes := make([]string, howManyVolumes)
+
+				for i := 0; i < howManyVolumes; i = i + 5 {
 					var wg sync.WaitGroup
 					for j := 0; j < 5; j++ {
-						volumeName := fmt.Sprintf("volume%d", i+j)
-						testVolumes = append(testVolumes, volumeName)
+						volumeNumber := i + j
+						volumeName := fmt.Sprintf("volume%d", volumeNumber)
+						testVolumes[volumeNumber] = volumeName
 						wg.Add(1)
 
 						go func() {
 							defer GinkgoRecover()
 							defer wg.Done()
 							dv := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeFilesystem)
-							dvNames = append(dvNames, dv.Name)
+							dvNames[volumeNumber] = dv.Name
 						}()
 					}
 					wg.Wait()
 				}
 
-				for i := 0; i < 75; i++ {
+				for i := 0; i < howManyVolumes; i++ {
 					By("Adding volume " + strconv.Itoa(i) + " to running VM, dv name:" + dvNames[i])
 					addDVVolumeVM(vm.Name, vm.Namespace, testVolumes[i], dvNames[i], v1.DiskBusSCSI, false, "")
 					if i > 0 && i%5 == 0 {


### PR DESCRIPTION
`dvNames` was read/written concurrently, so it needs to be protected by a mutex or accessed safely (this PR does the latter), otherwise, data-races will occur.

Also prealloc `dvNames` and `testVolumes` to avoid reallocations.

Reported by the check-tests-for-flakes lane: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/11205/pull-kubevirt-check-tests-for-flakes/1756981198619414528

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

