### PR TITLE
[release-1.0] tests, network, hot-unplug: Drop the VM restart step

### DIFF
--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -386,23 +386,6 @@ var _ = SIGDescribe("nic-hotunplug", func() {
 				g.Expect(libnet.LookupNetworkByName(updatedVMI.Spec.Networks, linuxBridgeNetworkName2)).To(BeNil(),
 					"unplugged iface corresponding network should be cleared from VMI spec")
 			}, 30*time.Second, 3*time.Second).Should(Succeed())
-
-			By("restarting the VM")
-			Expect(kubevirt.Client().VirtualMachine(vm.Namespace).Restart(context.Background(), vm.Name, &v1.RestartOptions{})).To(Succeed())
-
-			By("wait for new VMI to start")
-			var newVMI *v1.VirtualMachineInstance
-			Eventually(func() error {
-				var err error
-				newVMI, err = kubevirt.Client().VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
-				if err != nil || vmi.UID == newVMI.UID {
-					return fmt.Errorf("vmi did not create yet")
-				}
-				return nil
-			}, 90*time.Second, 1*time.Second).Should(Succeed())
-			libwait.WaitUntilVMIReady(newVMI, console.LoginToAlpine)
-
-			_ = verifyDynamicInterfaceChange(newVMI, plugMethod)
 		},
 			Entry("In place", decorators.InPlaceHotplugNICs, inPlace),
 			Entry("Migration based", decorators.MigrationBasedHotplugNICs, migrationBased),


### PR DESCRIPTION
### What this PR does

This is a backport from #10755 to reduce stable branch e2e test flakes.

Restarting the VM after the interfaces in the spec are gone is redundant. The VM will obviously be re-created based on the new spec.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

