### PR TITLE
Remove qinqon from owners aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,7 +69,6 @@ aliases:
     - ormergi
     - oshoval
     - phoracek
-    - qinqon
   sig-network-approvers:
     - AlonaKaplan
 


### PR DESCRIPTION
### What this PR does
Before this PR: Qinqon at owner lists

After this PR: Qinqon not longer at owner lists