### PR TITLE
[release-1.2] Manual backport of improve error reporting when fsfreeze fails

### DIFF
--- a/pkg/virt-handler/rest/lifecycle.go
+++ b/pkg/virt-handler/rest/lifecycle.go
@@ -38,6 +38,7 @@ import (
 
 const (
 	failedRetrieveVMI      = "Failed to retrieve VMI"
+	failedFreezeVMI        = "Failed to freeze VMI"
 	failedDetectCmdClient  = "Failed to detect cmd client"
 	failedConnectCmdClient = "Failed to connect cmd client"
 )
@@ -121,8 +122,9 @@ func (lh *LifecycleHandler) FreezeHandler(request *restful.Request, response *re
 	unfreezeTimeoutSeconds := int32(unfreezeTimeout.UnfreezeTimeout.Seconds())
 	err = client.FreezeVirtualMachine(vmi, unfreezeTimeoutSeconds)
 	if err != nil {
-		log.Log.Object(vmi).Reason(err).Error("Failed to freeze VMI")
+		log.Log.Object(vmi).Reason(err).Error(failedFreezeVMI)
 		response.WriteError(http.StatusBadRequest, err)
+		lh.recorder.Eventf(vmi, k8sv1.EventTypeWarning, "FreezeError", "%s: %s", failedFreezeVMI, err.Error())
 		return
 	}
 

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -734,7 +734,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				}
 			})
 
-			It("should report appropriate event when freeze fails", func() {
+			It("[QUARANTINE] should report appropriate event when freeze fails", decorators.Quarantine, func() {
 				// Activate SELinux and reboot machine so we can force fsfreeze failure
 				const userData = "#cloud-config\n" +
 					"password: fedora\n" +

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/watcher"
 
 	expect "github.com/google/goexpect"
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -731,6 +732,71 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					}
 					Expect(found).To(BeTrue())
 				}
+			})
+
+			It("should report appropriate event when freeze fails", func() {
+				// Activate SELinux and reboot machine so we can force fsfreeze failure
+				const userData = "#cloud-config\n" +
+					"password: fedora\n" +
+					"chpasswd: { expire: False }\n" +
+					"runcmd:\n" +
+					"  - sudo sed -i 's/^SELINUX=.*/SELINUX=enforcing/' /etc/selinux/config\n"
+
+				vmi := libvmi.NewFedora(
+					libvmi.WithCloudInitNoCloudUserData(userData),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)))
+
+				dv := libdv.NewDataVolume(
+					libdv.WithBlankImageSource(),
+					libdv.WithPVC(libdv.PVCWithStorageClass(snapshotStorageClass), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
+				)
+
+				vm = libvmi.NewVirtualMachine(vmi, libvmi.WithDataVolumeTemplate(dv))
+				// Adding snapshotable volume
+				libstorage.AddDataVolume(vm, "blank", dv)
+
+				vm, vmi = createAndStartVM(vm)
+				libwait.WaitForSuccessfulVMIStart(vmi,
+					libwait.WithTimeout(300),
+				)
+
+				Eventually(matcher.ThisVMI(vmi), 1*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				// Restart VM again to enable SELinux
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).SoftReboot(context.Background(), vmi.Name)).ToNot(HaveOccurred())
+				Eventually(matcher.ThisVMI(vmi), 3*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				blankDisk := "/dev/"
+				Eventually(func() bool {
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for _, volStatus := range vmi.Status.VolumeStatus {
+						if volStatus.Name == "blank" {
+							blankDisk += volStatus.Target
+							return true
+						}
+					}
+					return false
+				}, 30*time.Second, time.Second).Should(BeTrue())
+
+				// Recreating one specific SELinux error.
+				// Better described in https://bugzilla.redhat.com/show_bug.cgi?id=2237678
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "mkdir /mount_dir\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: fmt.Sprintf("mkfs.ext4 %s\n", blankDisk)},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: fmt.Sprintf("mount %s /mount_dir\n", blankDisk)},
+					&expect.BExp{R: console.PromptExpression},
+				}, 20)).To(Succeed())
+
+				snapshot = newSnapshot()
+				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(30) * time.Second)
+				objectEventWatcher.WaitFor(context.Background(), watcher.WarningEvent, "FreezeError")
 			})
 
 			It("Calling Velero hooks should freeze/unfreeze VM", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This is a manual backport of https://github.com/kubevirt/kubevirt/pull/11051. I'm adding the quarantined test for consistency, but feel free to argue otherwise.

Fixes # https://issues.redhat.com/browse/CNV-32664

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Improve error reporting when fsfreeze fails
```

