### PR TITLE
Vm controller copy fix

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -297,6 +297,7 @@ func (c *VMController) execute(key string) error {
 		return nil
 	}
 	vm := obj.(*virtv1.VirtualMachine)
+	vm = vm.DeepCopy()
 
 	logger := log.Log.Object(vm)
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -3881,9 +3881,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
-
 				})
 
 				It("should apply VirtualMachineClusterInstancetype to VirtualMachineInstance", func() {
@@ -3990,9 +3987,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
-
 				})
 
 				It("should reject request if an invalid InstancetypeMatcher Kind is provided", func() {
@@ -4399,9 +4393,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
-
 				})
 
 				It("should apply VirtualMachineClusterPreference to VirtualMachineInstance", func() {
@@ -4509,9 +4500,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
-
 				})
 
 				It("should reject the request if an invalid PreferenceMatcher Kind is provided", func() {


### PR DESCRIPTION
### What this PR does
Before this PR:
A cache is corrupted.

After this PR:
A cache is not corrupted ;)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

This is a suboptimal patch to be able to backport this for the latest releases.

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: VM controller doesn't corrupt its cache anymore
```

