### PR TITLE
Add annotation to DataVolumeTemplates to better handle DR/Restore

### DIFF
--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -122,6 +122,10 @@ func GenerateDataVolumeFromTemplate(clientset kubecli.KubevirtClient, dataVolume
 	for k, v := range dataVolumeTemplate.Annotations {
 		annotations[k] = v
 	}
+
+	// passed to PVC by DataVolume controller
+	annotations[allowClaimAdoptionAnnotation] = "true"
+
 	newDataVolume.ObjectMeta.Annotations = annotations
 
 	if newDataVolume.Spec.PriorityClassName == "" && priorityClassName != "" {

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -36,7 +36,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 
-const MiB = 1024 * 1024
+const (
+	MiB = 1024 * 1024
+
+	allowClaimAdoptionAnnotation = "cdi.kubevirt.io/allowClaimAdoption"
+
+	dataVolumeGarbageCollectionAnnotation = "cdi.kubevirt.io/garbageCollected"
+)
 
 type PvcNotFoundError struct {
 	Reason string
@@ -44,6 +50,10 @@ type PvcNotFoundError struct {
 
 func (e PvcNotFoundError) Error() string {
 	return e.Reason
+}
+
+func IsDataVolumeGarbageCollected(pvc *k8sv1.PersistentVolumeClaim) bool {
+	return pvc != nil && pvc.Annotations[dataVolumeGarbageCollectionAnnotation] == "true"
 }
 
 func IsPVCBlockFromStore(store cache.Store, namespace string, claimName string) (pvc *k8sv1.PersistentVolumeClaim, exists bool, isBlockDevice bool, err error) {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -486,8 +486,14 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 			c.dataVolumeExpectations.ExpectCreations(vmKey, 1)
 			curDataVolume, err = c.clientset.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Create(context.Background(), newDataVolume, v1.CreateOptions{})
 			if err != nil {
-				c.recorder.Eventf(vm, k8score.EventTypeWarning, FailedDataVolumeCreateReason, "Error creating DataVolume %s: %v", newDataVolume.Name, err)
 				c.dataVolumeExpectations.CreationObserved(vmKey)
+				if pvc != nil && strings.Contains(err.Error(), "already exists") {
+					// If the PVC already exists, we can ignore the error and continue
+					// probably old version of CDI
+					log.Log.Object(vm).Reason(err).Warning("Appear to be running a version of CDI that does not support claim adoption annotation")
+					continue
+				}
+				c.recorder.Eventf(vm, k8score.EventTypeWarning, FailedDataVolumeCreateReason, "Error creating DataVolume %s: %v", newDataVolume.Name, err)
 				return ready, fmt.Errorf("failed to create DataVolume: %v", err)
 			}
 			c.recorder.Eventf(vm, k8score.EventTypeNormal, SuccessfulDataVolumeCreateReason, "Created DataVolume %s", curDataVolume.Name)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -463,8 +463,12 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 			if err != nil {
 				return false, err
 			}
+
 			if pvc != nil {
-				continue
+				// don't want to keep creating DataVolumes that will be garbage collected
+				if storagetypes.IsDataVolumeGarbageCollected(pvc) {
+					continue
+				}
 			}
 
 			// ready = false because encountered DataVolume that is not created yet


### PR DESCRIPTION
Currently DataVolume ownership is not preserved under certain DR/Restore scenarios.  This is because PVCs are typically created very early in the failover/restore process and until recently [1] CDI did not allow "adopting" existing volumes.  So let's make sure that we always request that volumes are adoptable.  We also have to make sure that we don't attempt to adopt previously garbage collected DVs.  To help CDI added this PR [2]

If volumes are not adopted, they will not be owned by the VM and therefore will not be deleted when the VM is deleted (or relocated back to primary cluster in DR scenario).  Because of this, this PR should be considered a bug fix not a feature.  DR is currently broken.

[1] https://github.com/kubevirt/containerized-data-importer/pull/3029
[2] https://github.com/kubevirt/containerized-data-importer/pull/3059

~~To preserve existing behavior for old DVs/PVCs, a new annotation "kubevirt.io/owned-by-vm" is added to all new DataVolumeTemplates.  PVCs without that annotation will not be adopted.~~

After discussion with @aglitke, decided that it was more important to apply this new behavior to all existing DataVolumeTemplates not just newly created ones

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

https://issues.redhat.com/browse/CNV-35100

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Ensure DataVolumes created by virt-controller (DataVolumeTemplates) are recreated and owned by the VM in the case of DR and backup/restore.
```

