### PR TITLE
[release-1.1] vmi update admission webhook: fix volume miscount when using filesystems

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -77,7 +77,7 @@ func (admitter *VMIUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admis
 	return &reviewResponse
 }
 
-func getExpectedDisks(newVolumes []v1.Volume) int {
+func getExpectedDisksAndFilesystems(newVolumes []v1.Volume) int {
 	numMemoryDumpVolumes := 0
 	for _, volume := range newVolumes {
 		if volume.MemoryDump != nil {
@@ -89,12 +89,13 @@ func getExpectedDisks(newVolumes []v1.Volume) int {
 
 // admitHotplugStorage compares the old and new volumes and disks, and ensures that they match and are valid.
 func admitHotplugStorage(newVolumes, oldVolumes []v1.Volume, newDisks, oldDisks []v1.Disk, volumeStatuses []v1.VolumeStatus, newVMI *v1.VirtualMachineInstance, config *virtconfig.ClusterConfig) *admissionv1.AdmissionResponse {
-	expectedDisks := getExpectedDisks(newVolumes)
-	if expectedDisks != len(newDisks) {
+	expectedDisksAndFilesystems := getExpectedDisksAndFilesystems(newVolumes)
+	observedDisksAndFilesystems := len(newDisks) + len(newVMI.Spec.Domain.Devices.Filesystems)
+	if expectedDisksAndFilesystems != observedDisksAndFilesystems {
 		return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
 			{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("number of disks (%d) does not equal the number of volumes (%d)", len(newDisks), expectedDisks),
+				Message: fmt.Sprintf("number of disks and filesystems (%d) does not equal the number of volumes (%d)", observedDisksAndFilesystems, expectedDisksAndFilesystems),
 			},
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/11038

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @xpivarc 
