### PR TITLE
fix(virt-launcher): Add missing struct data to handle vhostuser disk

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -668,13 +668,21 @@ type DiskSecret struct {
 type ReadOnly struct{}
 
 type DiskSource struct {
-	Dev           string          `xml:"dev,attr,omitempty"`
-	File          string          `xml:"file,attr,omitempty"`
-	StartupPolicy string          `xml:"startupPolicy,attr,omitempty"`
-	Protocol      string          `xml:"protocol,attr,omitempty"`
-	Name          string          `xml:"name,attr,omitempty"`
-	Host          *DiskSourceHost `xml:"host,omitempty"`
-	Reservations  *Reservations   `xml:"reservations,omitempty"`
+	Dev           string               `xml:"dev,attr,omitempty"`
+	File          string               `xml:"file,attr,omitempty"`
+	StartupPolicy string               `xml:"startupPolicy,attr,omitempty"`
+	Protocol      string               `xml:"protocol,attr,omitempty"`
+	Path          string               `xml:"path,attr,omitempty"`
+	Name          string               `xml:"name,attr,omitempty"`
+	Type          string               `xml:"type,attr,omitempty"`
+	Reconnect     *DiskSourceReconnect `xml:"reconnect,omitempty"`
+	Host          *DiskSourceHost      `xml:"host,omitempty"`
+	Reservations  *Reservations        `xml:"reservations,omitempty"`
+}
+
+type DiskSourceReconnect struct {
+	Enabled string `xml:"enabled,attr,omitempty"`
+	Timeout *uint  `xml:"timeout,attr,omitempty"`
 }
 
 type DiskTarget struct {


### PR DESCRIPTION
### What this PR does
Fixes #11276 

### Why we need it and why it was done in this way
Links to places where the discussion took place: 
Slack: https://kubernetes.slack.com/archives/C0163DT0R8X/p1708053231751239

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

