### PR TITLE
Collect VMI OS info from the Guest agent

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -152,6 +152,12 @@ var _ = Describe("Utility functions", func() {
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
 						Phase: "Pending",
+						GuestOSInfo: k6tv1.VirtualMachineInstanceGuestOSInfo{
+							KernelRelease: "6.5.6-300.fc39.x86_64",
+							Machine:       "x86_64",
+							Name:          "Fedora Linux",
+							VersionID:     "39",
+						},
 					},
 				},
 				{
@@ -189,28 +195,40 @@ var _ = Describe("Utility functions", func() {
 			Expect(countMap).To(HaveLen(3))
 
 			running := vmiCountMetric{
-				Phase:        "running",
-				OS:           "centos8",
-				Workload:     "server",
-				Flavor:       "tiny",
-				InstanceType: "<none>",
-				Preference:   "<none>",
+				Phase:                "running",
+				OS:                   "centos8",
+				Workload:             "server",
+				Flavor:               "tiny",
+				GuestOSKernelRelease: "<none>",
+				GuestOSMachine:       "<none>",
+				GuestOSName:          "<none>",
+				GuestOSVersionID:     "<none>",
+				InstanceType:         "<none>",
+				Preference:           "<none>",
 			}
 			pending := vmiCountMetric{
-				Phase:        "pending",
-				OS:           "fedora33",
-				Workload:     "workstation",
-				Flavor:       "large",
-				InstanceType: "<none>",
-				Preference:   "<none>",
+				Phase:                "pending",
+				OS:                   "fedora33",
+				Workload:             "workstation",
+				Flavor:               "large",
+				InstanceType:         "<none>",
+				Preference:           "<none>",
+				GuestOSKernelRelease: "6.5.6-300.fc39.x86_64",
+				GuestOSMachine:       "x86_64",
+				GuestOSName:          "Fedora Linux",
+				GuestOSVersionID:     "39",
 			}
 			scheduling := vmiCountMetric{
-				Phase:        "scheduling",
-				OS:           "centos7",
-				Workload:     "server",
-				Flavor:       "medium",
-				InstanceType: "<none>",
-				Preference:   "<none>",
+				Phase:                "scheduling",
+				OS:                   "centos7",
+				Workload:             "server",
+				Flavor:               "medium",
+				GuestOSKernelRelease: "<none>",
+				GuestOSMachine:       "<none>",
+				GuestOSName:          "<none>",
+				GuestOSVersionID:     "<none>",
+				InstanceType:         "<none>",
+				Preference:           "<none>",
 			}
 			bogus := vmiCountMetric{
 				Phase: "bogus",
@@ -243,7 +261,7 @@ var _ = Describe("Utility functions", func() {
 			Expect(phaseResultMetric).ToNot(BeNil())
 			Expect(phaseResultMetric.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_phase_count"))
 			Expect(phaseResultMetric.Value).To(BeEquivalentTo(1))
-			Expect(phaseResultMetric.Labels).To(HaveLen(7))
+			Expect(phaseResultMetric.Labels).To(HaveLen(11))
 			Expect(phaseResultMetric.Labels[5]).To(Equal(expected))
 		},
 			Entry("with no instance type expect <none>", k6tv1.InstancetypeAnnotation, "", "<none>"),
@@ -276,7 +294,7 @@ var _ = Describe("Utility functions", func() {
 
 			Expect(phaseResultMetric.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_phase_count"))
 			Expect(phaseResultMetric.Value).To(BeEquivalentTo(1))
-			Expect(phaseResultMetric.Labels).To(HaveLen(7))
+			Expect(phaseResultMetric.Labels).To(HaveLen(11))
 			Expect(phaseResultMetric.Labels[6]).To(Equal(expected))
 		},
 			Entry("with no preference expect <none>", k6tv1.PreferenceAnnotation, "", "<none>"),

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -28,6 +28,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 
 	corev1 "k8s.io/api/core/v1"
@@ -246,6 +247,25 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		})
 	})
 
+	Context("VM metrics that are based on the guest agent", func() {
+		It("should have kubevirt_vmi_phase_count correctly configured with guest OS labels", func() {
+			agentVMI := createAgentVMI()
+			Expect(agentVMI.Status.GuestOSInfo.KernelRelease).ToNot(BeEmpty())
+			Expect(agentVMI.Status.GuestOSInfo.Machine).ToNot(BeEmpty())
+			Expect(agentVMI.Status.GuestOSInfo.Name).ToNot(BeEmpty())
+			Expect(agentVMI.Status.GuestOSInfo.VersionID).ToNot(BeEmpty())
+
+			labels := map[string]string{
+				"guest_os_kernel_release": agentVMI.Status.GuestOSInfo.KernelRelease,
+				"guest_os_machine":        agentVMI.Status.GuestOSInfo.Machine,
+				"guest_os_name":           agentVMI.Status.GuestOSInfo.Name,
+				"guest_os_version_id":     agentVMI.Status.GuestOSInfo.VersionID,
+			}
+
+			libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_phase_count", 1, labels, 1)
+		})
+	})
+
 	Context("VM alerts", func() {
 		var scales *libmonitoring.Scaling
 
@@ -304,3 +324,21 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		})
 	})
 })
+
+func createAgentVMI() *v1.VirtualMachineInstance {
+	virtClient := kubevirt.Client()
+	vmiAgentConnectedConditionMatcher := MatchFields(IgnoreExtras, Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})
+	vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...), 180)
+
+	var err error
+	var agentVMI *v1.VirtualMachineInstance
+
+	By("VMI has the guest agent connected condition")
+	Eventually(func() []v1.VirtualMachineInstanceCondition {
+		agentVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return agentVMI.Status.Conditions
+	}, 240*time.Second, 1*time.Second).Should(ContainElement(vmiAgentConnectedConditionMatcher), "Should have agent connected condition")
+
+	return agentVMI
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
No guest agent info was collected and exposed through vmi metrics.
After this PR:
`kernelRelease`, `machine`, `name` and `versionId` fields from `vmi.status.guestOsInfo` are collected and added as labels to `kubevirt_vmi_phase_count` metric.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-37369

### Why we need it and why it was done in this way
We would like to have more visibility regarding VMIs OS, so we can differentiate between running VMs, and alert for specific OS issues (e.g. https://issues.redhat.com/browse/CNV-38482).

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Collect VMI OS info from the Guest agent as `kubevirt_vmi_phase_count` metric labels
```

