### PR TITLE
tests, network, vmi_passt: Create the VMI object directly

### DIFF
--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -42,7 +42,7 @@ var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
 		tests.EnableFeatureGate(deprecation.PasstGate)
 	})
 
-	It("can be used by a VM as its primary network", func() {
+	It("can be used by a VMI as its primary network", func() {
 		const (
 			macAddress = "02:00:00:00:00:02"
 		)
@@ -56,14 +56,12 @@ var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
 			}),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
-		vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunning())
 
 		var err error
 		namespace := testsuite.GetTestNamespace(nil)
-		vm, err = kubevirt.Client().VirtualMachine(namespace).Create(context.Background(), vm)
+		vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(context.Background(), vmi)
 		Expect(err).ToNot(HaveOccurred())
 
-		vmi.Namespace = vm.Namespace
 		vmi = libwait.WaitUntilVMIReady(
 			vmi,
 			console.LoginToAlpine,


### PR DESCRIPTION
### What this PR does

Waiting of a VMI object readiness before it actually exists causes flakes.

There is no apparent reason to use a VM in this case. Directly using a VMI simplifies the test and avoids the detected flake.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

