### PR TITLE
[release-1.0] vm controller copy fix

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -296,6 +296,7 @@ func (c *VMController) execute(key string) error {
 		return nil
 	}
 	vm := obj.(*virtv1.VirtualMachine)
+	vm = vm.DeepCopy()
 
 	logger := log.Log.Object(vm)
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -3813,9 +3813,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
-
 				})
 
 				It("should apply VirtualMachineClusterInstancetype to VirtualMachineInstance", func() {
@@ -3922,9 +3919,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
-
 				})
 
 				It("should reject request if an invalid InstancetypeMatcher Kind is provided", func() {
@@ -4331,9 +4325,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
-
 				})
 
 				It("should apply VirtualMachineClusterPreference to VirtualMachineInstance", func() {
@@ -4441,9 +4432,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
-
 				})
 
 				It("should reject the request if an invalid PreferenceMatcher Kind is provided", func() {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -15,6 +15,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	k8score "k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -302,6 +303,12 @@ var _ = Describe("VirtualMachine", func() {
 			mockQueue.Wait()
 		}
 
+		sanityExecute := func(vm *virtv1.VirtualMachine) {
+			added := vm.DeepCopy()
+			controller.Execute()
+			Expect(equality.Semantic.DeepEqual(vm, added)).To(BeTrue(), "A cached VM was modified")
+		}
+
 		It("should create missing DataVolume for VirtualMachineInstance", func() {
 			vm, _ := DefaultVirtualMachine(true)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
@@ -349,7 +356,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
 			})
 
-			controller.Execute()
+			sanityExecute(vm)
 			Expect(createCount).To(Equal(1))
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 		})
@@ -386,7 +393,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 
 			Entry("that is running", true),
@@ -435,7 +442,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 
 			Entry("that is running", true),
@@ -480,7 +487,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 
 			Entry("that is running", true),
@@ -512,7 +519,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 
 			Entry("that is running", true),
@@ -566,7 +573,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			Expect(deletionCount).To(Equal(0))
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
@@ -616,7 +623,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
 		})
@@ -668,7 +675,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
 		})
@@ -705,7 +712,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
-			controller.Execute()
+			sanityExecute(vm)
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
@@ -743,7 +750,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
-			controller.Execute()
+			sanityExecute(vm)
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
@@ -780,7 +787,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
-			controller.Execute()
+			sanityExecute(vm)
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
@@ -811,7 +818,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiFeeder.Add(vmi)
 			vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
-			controller.Execute()
+			sanityExecute(vm)
 			testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 		})
 
@@ -851,7 +858,7 @@ var _ = Describe("VirtualMachine", func() {
 			createCount := 0
 			shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": string(vm.UID)}, map[string]string{}, &createCount)
 
-			controller.Execute()
+			sanityExecute(vm)
 			Expect(createCount).To(Equal(2))
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 		})
@@ -882,7 +889,7 @@ var _ = Describe("VirtualMachine", func() {
 			createCount := 0
 			shouldExpectDataVolumeCreationPriorityClass(vm.UID, map[string]string{"kubevirt.io/created-by": string(vm.UID)}, map[string]string{}, expectedPriorityClass, &createCount)
 
-			controller.Execute()
+			sanityExecute(vm)
 			Expect(createCount).To(Equal(1))
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 		},
@@ -913,7 +920,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				shouldExpectVMIFinalizerRemoval(vmi)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 				testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 			})
@@ -947,7 +954,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				shouldExpectVMIFinalizerRemoval(vmi)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 				testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 			})
@@ -981,7 +988,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure).To(BeNil())
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 			})
 
@@ -1024,7 +1031,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				shouldExpectVMIFinalizerRemoval(vmi)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 				if runStrategy != virtv1.RunStrategyManual && runStrategy != virtv1.RunStrategyOnce {
 					testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
@@ -1270,7 +1277,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					return true, "", nil
 				}
-				controller.Execute()
+				sanityExecute(vm)
 				if fail {
 					Expect(createCount).To(Equal(0))
 					testutils.ExpectEvent(recorder, UnauthorizedDataVolumeCreateReason)
@@ -1310,7 +1317,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
@@ -1338,7 +1345,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
@@ -1383,7 +1390,7 @@ var _ = Describe("VirtualMachine", func() {
 						}).Return(vm, nil).Times(1)
 				}
 
-				controller.Execute()
+				sanityExecute(vm)
 
 				testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 			},
@@ -1802,7 +1809,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(arg.(*virtv1.VirtualMachine).Status.DesiredGeneration).To(Equal(desiredDesiredGeneration))
 					}).Return(nil, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 					Entry(
 						// Expect no patch on vmi annotations, and vm status to be correct
@@ -1922,7 +1929,7 @@ var _ = Describe("VirtualMachine", func() {
 					}).Return(vm, nil).Times(1)
 			}
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		},
@@ -1949,7 +1956,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
@@ -1967,7 +1974,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should update status to created and ready when vmi is running and running", func() {
@@ -1983,7 +1990,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeTrue())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should have stable firmware UUIDs", func() {
@@ -2021,7 +2028,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 		})
@@ -2035,7 +2042,7 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectVMFinalizerAddition(vm)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should add controller finalizer only once", func() {
@@ -2048,7 +2055,7 @@ var _ = Describe("VirtualMachine", func() {
 			//Expect only update status, not Patch on vmInterface
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should delete VirtualMachineInstance when VirtualMachine marked for deletion", func() {
@@ -2062,7 +2069,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 		})
@@ -2077,7 +2084,7 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectVMFinalizerRemoval(vm)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		DescribeTable("should not delete VirtualMachineInstance when vmi failed", func(runStrategy virtv1.VirtualMachineRunStrategy) {
@@ -2094,7 +2101,7 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectVMIFinalizerRemoval(vmi)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 		},
 
@@ -2111,7 +2118,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should ignore non-matching VMIs", func() {
@@ -2128,7 +2135,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Return(vmi, nil)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(2).Return(vm, nil).AnyTimes()
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
@@ -2144,7 +2151,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Return(vm, nil)
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.ObjectMeta.Name, gomock.Any(), gomock.Any(), &metav1.PatchOptions{})
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should detect that a DataVolume already exists and adopt it", func() {
@@ -2187,7 +2194,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInterface.EXPECT().Get(context.Background(), vm.ObjectMeta.Name, gomock.Any()).Return(vm, nil)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should detect that it has nothing to do beside updating the status", func() {
@@ -2198,7 +2205,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should add a fail condition if start up fails", func() {
@@ -2220,7 +2227,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 		})
@@ -2243,7 +2250,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			})
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvents(recorder, FailedDeleteVirtualMachineReason)
 		})
@@ -2264,7 +2271,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(status))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 			Entry("VMI Ready condition is True", markAsReady, k8sv1.ConditionTrue),
 			Entry("VMI Ready condition is False", markAsNonReady, k8sv1.ConditionFalse),
@@ -2363,7 +2370,7 @@ var _ = Describe("VirtualMachine", func() {
 				}
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should add ready condition when VMI doesn't exists", func() {
@@ -2381,7 +2388,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Return(vmi, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should add paused condition", func() {
@@ -2403,7 +2410,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should remove paused condition", func() {
@@ -2424,7 +2431,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond).To(BeNil())
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should back off if a sync error occurs", func() {
@@ -2445,7 +2452,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			})
 
-			controller.Execute()
+			sanityExecute(vm)
 			Expect(mockQueue.Len()).To(Equal(0))
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(1))
 			testutils.ExpectEvents(recorder, FailedDeleteVirtualMachineReason)
@@ -2463,7 +2470,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should copy kubevirt ignitiondata annotation from spec.template to vmi", func() {
@@ -2478,7 +2485,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should copy kubernetes annotations from spec.template to vmi", func() {
@@ -2493,7 +2500,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		Context("VM memory dump", func() {
@@ -2576,7 +2583,7 @@ var _ = Describe("VirtualMachine", func() {
 				}).Return(vm, nil)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should update memory dump phase to InProgress when memory dump in vm volumes", func() {
@@ -2604,7 +2611,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should change status to unmounting when memory dump timestamp updated", func() {
@@ -2647,7 +2654,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should update status to failed when memory dump failed", func() {
@@ -2688,7 +2695,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should remove memory dump volume from vmi volumes and update pvc annotation", func(phase virtv1.MemoryDumpPhase, expectedAnnotation string) {
@@ -2731,7 +2738,7 @@ var _ = Describe("VirtualMachine", func() {
 				shouldExpectVMIVolumesRemovePatched(vmi)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 				Eventually(func() bool {
 					select {
 					case updated := <-pvcAnnotationUpdated:
@@ -2772,7 +2779,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should remove memory dump volume from vm volumes list when status is Dissociating", func() {
@@ -2791,7 +2798,7 @@ var _ = Describe("VirtualMachine", func() {
 				}).Return(vm, nil)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should dissociate memory dump request when status is Dissociating and not in vm volumes", func() {
@@ -2809,7 +2816,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(BeNil())
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should not setup vmi with memory dump if memory dump", func(phase virtv1.MemoryDumpPhase) {
@@ -2841,7 +2848,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStopped))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should set a Stopped status when VMI exists but stopped", func(phase virtv1.VirtualMachineInstancePhase, deletionTimestamp *metav1.Time) {
@@ -2867,7 +2874,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				shouldExpectVMIFinalizerRemoval(vmi)
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 
 				Entry("in Succeeded state", virtv1.Succeeded, nil),
@@ -2887,7 +2894,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStarting))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("Should set a Starting status when VMI is in a startup phase", func(phase virtv1.VirtualMachineInstancePhase) {
@@ -2903,7 +2910,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStarting))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 
 				Entry("VMI has no phase set", virtv1.VmPhaseUnset),
@@ -2940,7 +2947,7 @@ var _ = Describe("VirtualMachine", func() {
 						}).Return(vm, nil).Times(1)
 				}
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 
 				Entry("vm with runStrategy always and crash loop",
@@ -3067,7 +3074,7 @@ var _ = Describe("VirtualMachine", func() {
 						vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Return(vmi, nil)
 					}
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 					Entry("Started VM PendingPopulation", true, cdiv1.PendingPopulation, virtv1.VirtualMachineStatusWaitingForVolumeBinding),
 					Entry("Started VM WFFC", true, cdiv1.WaitForFirstConsumer, virtv1.VirtualMachineStatusWaitingForVolumeBinding),
@@ -3095,7 +3102,7 @@ var _ = Describe("VirtualMachine", func() {
 							Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
 						})
 
-						controller.Execute()
+						sanityExecute(vm)
 					},
 
 					Entry("DataVolume is in ImportScheduled phase", cdiv1.ImportScheduled),
@@ -3115,7 +3122,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusDataVolumeError))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 					Entry(
@@ -3153,7 +3160,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("Should set a Provisioning status when one DataVolume is ready and another isn't", func() {
@@ -3196,7 +3203,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 			})
 
@@ -3237,7 +3244,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusWaitingForVolumeBinding))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 					Entry("PersistentVolumeClaim is in Pending phase", k8sv1.ClaimPending),
@@ -3259,7 +3266,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusRunning))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should set a Paused status when VMI is running but is paused", func() {
@@ -3279,7 +3286,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusPaused))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should set a Stopping status when VMI has a deletion timestamp set", func(phase virtv1.VirtualMachineInstancePhase, condType virtv1.VirtualMachineInstanceConditionType) {
@@ -3302,7 +3309,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStopping))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 
 				Entry("when VMI is pending", virtv1.Pending, virtv1.VirtualMachineInstanceConditionType("")),
@@ -3335,7 +3342,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 					Entry("when VMI is pending", virtv1.Pending, virtv1.VirtualMachineInstanceConditionType("")),
@@ -3361,7 +3368,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				DescribeTable("when VMI does not exist", func(running bool) {
@@ -3377,7 +3384,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 					Entry("with running: true", true),
@@ -3401,7 +3408,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusMigrating))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should set an Unknown status when VMI is in unknown phase", func() {
@@ -3417,7 +3424,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusUnknown))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should set a failure status in accordance to VMI condition",
@@ -3435,7 +3442,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(status))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 				Entry("FailedUnschedulable", virtv1.VirtualMachineStatusUnschedulable,
@@ -3473,7 +3480,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachinePrintableStatus(reason)))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 				Entry("Reason: ErrImagePull", ErrImagePullReason),
 				Entry("Reason: ImagePullBackOff", ImagePullBackOffReason),
@@ -3628,7 +3635,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					revision, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), expectedRevisionName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -3672,7 +3679,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 				},
 					Entry("using v1alpha1 and VirtualMachineInstancetypeSpecRevision with APIVersion", func() []byte {
@@ -3805,7 +3812,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
 
@@ -3840,7 +3847,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					revision, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), expectedRevisionName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -3878,7 +3885,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 				})
 
@@ -3914,7 +3921,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
 
@@ -3938,7 +3945,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("got unexpected kind in InstancetypeMatcher"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -3961,7 +3968,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -3984,7 +3991,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4015,7 +4022,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("spec.template.spec.domain.cpu"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 				})
@@ -4046,7 +4053,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("found existing ControllerRevision with unexpected data"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4135,7 +4142,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					preferenceRevision, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), expectedPreferenceRevisionName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -4178,7 +4185,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 				},
 					Entry("using v1alpha1 and VirtualMachinePreferenceSpecRevision with APIVersion", func() []byte {
@@ -4323,7 +4330,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
 
@@ -4360,7 +4367,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					preferenceRevision, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), expectedPreferenceRevisionName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -4397,7 +4404,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 				})
 
@@ -4433,7 +4440,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
 
@@ -4457,7 +4464,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("got unexpected kind in PreferenceMatcher"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4480,7 +4487,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4503,7 +4510,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4537,7 +4544,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("found existing ControllerRevision with unexpected data"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4571,7 +4578,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferredAutoattachPodInterface and skip adding default network interface", func() {
@@ -4620,7 +4627,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferences to default volume disk", func() {
@@ -4674,7 +4681,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferences to AutoattachInputDevice attached input device", func() {
@@ -4706,7 +4713,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferences to preferredAutoattachInputDevice attached input device", func() {
@@ -4754,7 +4761,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferredAutoattachInputDevice and skip adding default input device", func() {
@@ -4799,7 +4806,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 			})
 		})
@@ -4845,7 +4852,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 			},
 			Entry("as bridge", "bridge"),
@@ -4868,7 +4875,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 		},
 			Entry("interfaces and networks are non-empty", []v1.Interface{{Name: "a"}}, []v1.Network{{Name: "b"}}),
@@ -4905,7 +4912,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 		})
 
@@ -4930,7 +4937,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 		},
 			Entry("add default input device when enabled in VirtualMachine", pointer.Bool(true), []v1.Input{}, &v1.Input{Name: "default-0"}),
@@ -5037,7 +5044,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 					}).Return(nil, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 				})
@@ -5071,7 +5078,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 					}).Return(nil, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 				})


### PR DESCRIPTION
### What this PR does
Cherry-pick of https://github.com/kubevirt/kubevirt/pull/11265

Before this PR:
A cache is corrupted.

After this PR:
A cache is not corrupted ;)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

This is a suboptimal patch to be able to backport this for the latest releases.

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: VM controller doesn't corrupt its cache anymore
```

