### PR TITLE
[release-1.1] vm controller copy fix

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -299,6 +299,7 @@ func (c *VMController) execute(key string) error {
 		return nil
 	}
 	vm := obj.(*virtv1.VirtualMachine)
+	vm = vm.DeepCopy()
 
 	logger := log.Log.Object(vm)
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -3814,9 +3814,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
-
 				})
 
 				It("should apply VirtualMachineClusterInstancetype to VirtualMachineInstance", func() {
@@ -3923,9 +3920,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
-
 				})
 
 				It("should reject request if an invalid InstancetypeMatcher Kind is provided", func() {
@@ -4332,9 +4326,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
-
 				})
 
 				It("should apply VirtualMachineClusterPreference to VirtualMachineInstance", func() {
@@ -4442,9 +4433,6 @@ var _ = Describe("VirtualMachine", func() {
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
 					sanityExecute(vm)
-
-					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
-
 				})
 
 				It("should reject the request if an invalid PreferenceMatcher Kind is provided", func() {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -16,6 +16,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	k8score "k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -303,6 +304,12 @@ var _ = Describe("VirtualMachine", func() {
 			mockQueue.Wait()
 		}
 
+		sanityExecute := func(vm *virtv1.VirtualMachine) {
+			added := vm.DeepCopy()
+			controller.Execute()
+			Expect(equality.Semantic.DeepEqual(vm, added)).To(BeTrue(), "A cached VM was modified")
+		}
+
 		It("should create missing DataVolume for VirtualMachineInstance", func() {
 			vm, _ := DefaultVirtualMachine(true)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
@@ -350,7 +357,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
 			})
 
-			controller.Execute()
+			sanityExecute(vm)
 			Expect(createCount).To(Equal(1))
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 		})
@@ -387,7 +394,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 
 			Entry("that is running", true),
@@ -436,7 +443,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 
 			Entry("that is running", true),
@@ -481,7 +488,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 
 			Entry("that is running", true),
@@ -513,7 +520,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 
 			Entry("that is running", true),
@@ -567,7 +574,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			Expect(deletionCount).To(Equal(0))
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
@@ -617,7 +624,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
 		})
@@ -669,7 +676,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
 		})
@@ -706,7 +713,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
-			controller.Execute()
+			sanityExecute(vm)
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
@@ -744,7 +751,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
-			controller.Execute()
+			sanityExecute(vm)
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
@@ -781,7 +788,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
-			controller.Execute()
+			sanityExecute(vm)
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
@@ -812,7 +819,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiFeeder.Add(vmi)
 			vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Return(nil)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
-			controller.Execute()
+			sanityExecute(vm)
 			testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 		})
 
@@ -852,7 +859,7 @@ var _ = Describe("VirtualMachine", func() {
 			createCount := 0
 			shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": string(vm.UID)}, map[string]string{}, &createCount)
 
-			controller.Execute()
+			sanityExecute(vm)
 			Expect(createCount).To(Equal(2))
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 		})
@@ -883,7 +890,7 @@ var _ = Describe("VirtualMachine", func() {
 			createCount := 0
 			shouldExpectDataVolumeCreationPriorityClass(vm.UID, map[string]string{"kubevirt.io/created-by": string(vm.UID)}, map[string]string{}, expectedPriorityClass, &createCount)
 
-			controller.Execute()
+			sanityExecute(vm)
 			Expect(createCount).To(Equal(1))
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 		},
@@ -914,7 +921,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				shouldExpectVMIFinalizerRemoval(vmi)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 				testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 			})
@@ -948,7 +955,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				shouldExpectVMIFinalizerRemoval(vmi)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 				testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 			})
@@ -982,7 +989,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure).To(BeNil())
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 			})
 
@@ -1025,7 +1032,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				shouldExpectVMIFinalizerRemoval(vmi)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 				if runStrategy != virtv1.RunStrategyManual && runStrategy != virtv1.RunStrategyOnce {
 					testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
@@ -1271,7 +1278,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					return true, "", nil
 				}
-				controller.Execute()
+				sanityExecute(vm)
 				if fail {
 					Expect(createCount).To(Equal(0))
 					testutils.ExpectEvent(recorder, UnauthorizedDataVolumeCreateReason)
@@ -1311,7 +1318,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
@@ -1339,7 +1346,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
@@ -1384,7 +1391,7 @@ var _ = Describe("VirtualMachine", func() {
 						}).Return(vm, nil).Times(1)
 				}
 
-				controller.Execute()
+				sanityExecute(vm)
 
 				testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 			},
@@ -1803,7 +1810,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(arg.(*virtv1.VirtualMachine).Status.DesiredGeneration).To(Equal(desiredDesiredGeneration))
 					}).Return(nil, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 					Entry(
 						// Expect no patch on vmi annotations, and vm status to be correct
@@ -1923,7 +1930,7 @@ var _ = Describe("VirtualMachine", func() {
 					}).Return(vm, nil).Times(1)
 			}
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		},
@@ -1950,7 +1957,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
@@ -1968,7 +1975,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should update status to created and ready when vmi is running and running", func() {
@@ -1984,7 +1991,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeTrue())
 			}).Return(nil, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should have stable firmware UUIDs", func() {
@@ -2022,7 +2029,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 		})
@@ -2036,7 +2043,7 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectVMFinalizerAddition(vm)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should add controller finalizer only once", func() {
@@ -2049,7 +2056,7 @@ var _ = Describe("VirtualMachine", func() {
 			//Expect only update status, not Patch on vmInterface
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should delete VirtualMachineInstance when VirtualMachine marked for deletion", func() {
@@ -2063,7 +2070,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 		})
@@ -2078,7 +2085,7 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectVMFinalizerRemoval(vm)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		DescribeTable("should not delete VirtualMachineInstance when vmi failed", func(runStrategy virtv1.VirtualMachineRunStrategy) {
@@ -2095,7 +2102,7 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectVMIFinalizerRemoval(vmi)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 		},
 
@@ -2112,7 +2119,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should ignore non-matching VMIs", func() {
@@ -2129,7 +2136,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Return(vmi, nil)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(2).Return(vm, nil).AnyTimes()
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
@@ -2145,7 +2152,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Return(vm, nil)
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.ObjectMeta.Name, gomock.Any(), gomock.Any(), &metav1.PatchOptions{})
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should detect that a DataVolume already exists and adopt it", func() {
@@ -2188,7 +2195,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInterface.EXPECT().Get(context.Background(), vm.ObjectMeta.Name, gomock.Any()).Return(vm, nil)
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should detect that it has nothing to do beside updating the status", func() {
@@ -2199,7 +2206,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should add a fail condition if start up fails", func() {
@@ -2221,7 +2228,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 		})
@@ -2244,7 +2251,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			})
 
-			controller.Execute()
+			sanityExecute(vm)
 
 			testutils.ExpectEvents(recorder, FailedDeleteVirtualMachineReason)
 		})
@@ -2265,7 +2272,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(status))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		},
 			Entry("VMI Ready condition is True", markAsReady, k8sv1.ConditionTrue),
 			Entry("VMI Ready condition is False", markAsNonReady, k8sv1.ConditionFalse),
@@ -2364,7 +2371,7 @@ var _ = Describe("VirtualMachine", func() {
 				}
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should add ready condition when VMI doesn't exists", func() {
@@ -2382,7 +2389,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Return(vmi, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should add paused condition", func() {
@@ -2404,7 +2411,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should remove paused condition", func() {
@@ -2425,7 +2432,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond).To(BeNil())
 			}).Return(vm, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should back off if a sync error occurs", func() {
@@ -2446,7 +2453,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(cond.Status).To(Equal(k8sv1.ConditionTrue))
 			})
 
-			controller.Execute()
+			sanityExecute(vm)
 			Expect(mockQueue.Len()).To(Equal(0))
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(1))
 			testutils.ExpectEvents(recorder, FailedDeleteVirtualMachineReason)
@@ -2464,7 +2471,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should copy kubevirt ignitiondata annotation from spec.template to vmi", func() {
@@ -2479,7 +2486,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		It("should copy kubernetes annotations from spec.template to vmi", func() {
@@ -2494,7 +2501,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(obj.(*virtv1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
 
-			controller.Execute()
+			sanityExecute(vm)
 		})
 
 		Context("VM memory dump", func() {
@@ -2577,7 +2584,7 @@ var _ = Describe("VirtualMachine", func() {
 				}).Return(vm, nil)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should update memory dump phase to InProgress when memory dump in vm volumes", func() {
@@ -2605,7 +2612,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should change status to unmounting when memory dump timestamp updated", func() {
@@ -2648,7 +2655,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should update status to failed when memory dump failed", func() {
@@ -2689,7 +2696,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should remove memory dump volume from vmi volumes and update pvc annotation", func(phase virtv1.MemoryDumpPhase, expectedAnnotation string) {
@@ -2732,7 +2739,7 @@ var _ = Describe("VirtualMachine", func() {
 				shouldExpectVMIVolumesRemovePatched(vmi)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 				Eventually(func() bool {
 					select {
 					case updated := <-pvcAnnotationUpdated:
@@ -2773,7 +2780,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(Equal(updatedMemoryDump))
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should remove memory dump volume from vm volumes list when status is Dissociating", func() {
@@ -2792,7 +2799,7 @@ var _ = Describe("VirtualMachine", func() {
 				}).Return(vm, nil)
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Return(vm, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should dissociate memory dump request when status is Dissociating and not in vm volumes", func() {
@@ -2810,7 +2817,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(arg.(*virtv1.VirtualMachine).Status.MemoryDumpRequest).To(BeNil())
 				}).Return(nil, nil)
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should not setup vmi with memory dump if memory dump", func(phase virtv1.MemoryDumpPhase) {
@@ -2842,7 +2849,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStopped))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should set a Stopped status when VMI exists but stopped", func(phase virtv1.VirtualMachineInstancePhase, deletionTimestamp *metav1.Time) {
@@ -2868,7 +2875,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				shouldExpectVMIFinalizerRemoval(vmi)
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 
 				Entry("in Succeeded state", virtv1.Succeeded, nil),
@@ -2888,7 +2895,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStarting))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("Should set a Starting status when VMI is in a startup phase", func(phase virtv1.VirtualMachineInstancePhase) {
@@ -2904,7 +2911,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStarting))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 
 				Entry("VMI has no phase set", virtv1.VmPhaseUnset),
@@ -2941,7 +2948,7 @@ var _ = Describe("VirtualMachine", func() {
 						}).Return(vm, nil).Times(1)
 				}
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 
 				Entry("vm with runStrategy always and crash loop",
@@ -3068,7 +3075,7 @@ var _ = Describe("VirtualMachine", func() {
 						vmiInterface.EXPECT().Create(context.Background(), gomock.Any()).Return(vmi, nil)
 					}
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 					Entry("Started VM PendingPopulation", true, cdiv1.PendingPopulation, virtv1.VirtualMachineStatusWaitingForVolumeBinding),
 					Entry("Started VM WFFC", true, cdiv1.WaitForFirstConsumer, virtv1.VirtualMachineStatusWaitingForVolumeBinding),
@@ -3096,7 +3103,7 @@ var _ = Describe("VirtualMachine", func() {
 							Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
 						})
 
-						controller.Execute()
+						sanityExecute(vm)
 					},
 
 					Entry("DataVolume is in ImportScheduled phase", cdiv1.ImportScheduled),
@@ -3116,7 +3123,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusDataVolumeError))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 					Entry(
@@ -3154,7 +3161,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("Should set a Provisioning status when one DataVolume is ready and another isn't", func() {
@@ -3197,7 +3204,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusProvisioning))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 			})
 
@@ -3238,7 +3245,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusWaitingForVolumeBinding))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 					Entry("PersistentVolumeClaim is in Pending phase", k8sv1.ClaimPending),
@@ -3260,7 +3267,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusRunning))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should set a Paused status when VMI is running but is paused", func() {
@@ -3280,7 +3287,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusPaused))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should set a Stopping status when VMI has a deletion timestamp set", func(phase virtv1.VirtualMachineInstancePhase, condType virtv1.VirtualMachineInstanceConditionType) {
@@ -3303,7 +3310,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStopping))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 
 				Entry("when VMI is pending", virtv1.Pending, virtv1.VirtualMachineInstanceConditionType("")),
@@ -3336,7 +3343,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 					Entry("when VMI is pending", virtv1.Pending, virtv1.VirtualMachineInstanceConditionType("")),
@@ -3362,7 +3369,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				DescribeTable("when VMI does not exist", func(running bool) {
@@ -3378,7 +3385,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 					Entry("with running: true", true),
@@ -3402,7 +3409,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusMigrating))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			It("should set an Unknown status when VMI is in unknown phase", func() {
@@ -3418,7 +3425,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusUnknown))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			})
 
 			DescribeTable("should set a failure status in accordance to VMI condition",
@@ -3436,7 +3443,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(objVM.Status.PrintableStatus).To(Equal(status))
 					})
 
-					controller.Execute()
+					sanityExecute(vm)
 				},
 
 				Entry("FailedUnschedulable", virtv1.VirtualMachineStatusUnschedulable,
@@ -3474,7 +3481,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachinePrintableStatus(reason)))
 				})
 
-				controller.Execute()
+				sanityExecute(vm)
 			},
 				Entry("Reason: ErrImagePull", ErrImagePullReason),
 				Entry("Reason: ImagePullBackOff", ImagePullBackOffReason),
@@ -3629,7 +3636,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					revision, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), expectedRevisionName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -3673,7 +3680,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 				},
 					Entry("using v1alpha1 and VirtualMachineInstancetypeSpecRevision with APIVersion", func() []byte {
@@ -3806,7 +3813,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
 
@@ -3841,7 +3848,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					revision, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), expectedRevisionName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -3879,7 +3886,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 				})
 
@@ -3915,7 +3922,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeRevision.Name))
 
@@ -3939,7 +3946,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("got unexpected kind in InstancetypeMatcher"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -3962,7 +3969,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -3985,7 +3992,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4016,7 +4023,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("spec.template.spec.domain.cpu"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 				})
@@ -4047,7 +4054,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("found existing ControllerRevision with unexpected data"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4136,7 +4143,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					preferenceRevision, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), expectedPreferenceRevisionName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -4179,7 +4186,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 				},
 					Entry("using v1alpha1 and VirtualMachinePreferenceSpecRevision with APIVersion", func() []byte {
@@ -4324,7 +4331,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
 
@@ -4361,7 +4368,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					preferenceRevision, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), expectedPreferenceRevisionName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -4398,7 +4405,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 				})
 
@@ -4434,7 +4441,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceRevision.Name))
 
@@ -4458,7 +4465,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("got unexpected kind in PreferenceMatcher"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4481,7 +4488,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4504,7 +4511,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Reason).To(Equal("FailedCreate"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4538,7 +4545,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(cond.Message).To(ContainSubstring("found existing ControllerRevision with unexpected data"))
 					}).Return(vm, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvents(recorder, FailedCreateVirtualMachineReason)
 
@@ -4572,7 +4579,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferredAutoattachPodInterface and skip adding default network interface", func() {
@@ -4621,7 +4628,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferences to default volume disk", func() {
@@ -4675,7 +4682,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferences to AutoattachInputDevice attached input device", func() {
@@ -4707,7 +4714,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferences to preferredAutoattachInputDevice attached input device", func() {
@@ -4755,7 +4762,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 
 				It("should apply preferredAutoattachInputDevice and skip adding default input device", func() {
@@ -4800,7 +4807,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-					controller.Execute()
+					sanityExecute(vm)
 				})
 			})
 		})
@@ -4846,7 +4853,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-				controller.Execute()
+				sanityExecute(vm)
 
 			},
 			Entry("as bridge", "bridge"),
@@ -4869,7 +4876,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 		},
 			Entry("interfaces and networks are non-empty", []v1.Interface{{Name: "a"}}, []v1.Network{{Name: "b"}}),
@@ -4906,7 +4913,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 		})
 
@@ -4931,7 +4938,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1)
 
-			controller.Execute()
+			sanityExecute(vm)
 
 		},
 			Entry("add default input device when enabled in VirtualMachine", pointer.Bool(true), []v1.Input{}, &v1.Input{Name: "default-0"}),
@@ -5266,7 +5273,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 					}).Return(nil, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 				})
@@ -5300,7 +5307,7 @@ var _ = Describe("VirtualMachine", func() {
 						Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
 					}).Return(nil, nil)
 
-					controller.Execute()
+					sanityExecute(vm)
 
 					testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 				})


### PR DESCRIPTION
### What this PR does
Cherry-pick of https://github.com/kubevirt/kubevirt/pull/11265

Before this PR:
A cache is corrupted.

After this PR:
A cache is not corrupted ;)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

This is a suboptimal patch to be able to backport this for the latest releases.

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: VM controller doesn't corrupt its cache anymore
```

