### PR TITLE
Fix kubevirt_vm_created_total being broken down by virt-api pod

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -75,8 +75,11 @@ The current available memory of the VM containers based on the rss. Type: Gauge.
 ### kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes
 The current available memory of the VM containers based on the working set. Type: Gauge.
 
+### kubevirt_vm_created_by_pod_total
+The total number of VMs created by namespace and virt-api pod, since install. Type: Counter.
+
 ### kubevirt_vm_created_total
-Amount of VMs created, broken down by namespace, since install. Type: Counter.
+The total number of VMs created by namespace, since install. Type: Counter.
 
 ### kubevirt_vm_error_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to error status. Type: Counter.

--- a/pkg/monitoring/metrics/virt-api/vm_metrics.go
+++ b/pkg/monitoring/metrics/virt-api/vm_metrics.go
@@ -31,8 +31,8 @@ var (
 
 	vmsCreatedCounter = operatormetrics.NewCounterVec(
 		operatormetrics.MetricOpts{
-			Name: "kubevirt_vm_created_total",
-			Help: "Amount of VMs created, broken down by namespace, since install.",
+			Name: "kubevirt_vm_created_by_pod_total",
+			Help: "The total number of VMs created by namespace and virt-api pod, since install.",
 		},
 		[]string{"namespace"},
 	)

--- a/pkg/monitoring/rules/recordingrules/vm.go
+++ b/pkg/monitoring/rules/recordingrules/vm.go
@@ -47,4 +47,12 @@ var vmRecordingRules = []operatorrules.RecordingRule{
 		MetricType: operatormetrics.GaugeType,
 		Expr:       intstr.FromString("sum by (namespace) (count by (name,namespace) (kubevirt_vm_error_status_last_transition_timestamp_seconds + kubevirt_vm_migrating_status_last_transition_timestamp_seconds + kubevirt_vm_non_running_status_last_transition_timestamp_seconds + kubevirt_vm_running_status_last_transition_timestamp_seconds + kubevirt_vm_starting_status_last_transition_timestamp_seconds))"),
 	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vm_created_total",
+			Help: "The total number of VMs created by namespace, since install.",
+		},
+		MetricType: operatormetrics.CounterType,
+		Expr:       intstr.FromString("sum by (namespace) (kubevirt_vm_created_by_pod_total)"),
+	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Since `kubevirt_vm_created_total` is exposed by all `virt-api` replicas with the total value of VMs created by that instance, the metric values on Prometheus were labeled by namespace but also by the original `virt-api` pod.

After this PR:

Since the need for `kubevirt_vm_created_total` was originally having a single metric with the total value of the VMs created, this PR renames the metric created by the `virt-api` pods, and creates a new recording rule based on that metric which contains the total value of VMs created broken down only by namespace.

jira-ticket: https://issues.redhat.com/browse/CNV-37015

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix kubevirt_vm_created_total being broken down by virt-api pod
```

/cc @enp0s3 @sradco 