### PR TITLE
sidecars, net-passt-binding: Add the device to the portForward config

### DIFF
--- a/cmd/sidecars/network-passt-binding/domain/configurator.go
+++ b/cmd/sidecars/network-passt-binding/domain/configurator.go
@@ -192,5 +192,9 @@ func (p PasstNetworkConfigurator) generatePortForward() []domainschema.Interface
 		portsFwd = append(portsFwd, domainschema.InterfacePortForward{Proto: protoUDP, Ranges: udpPortsRange})
 	}
 
+	for idx := range portsFwd {
+		portsFwd[idx].Dev = namescheme.PrimaryPodInterfaceName
+	}
+
 	return portsFwd
 }

--- a/cmd/sidecars/network-passt-binding/domain/configurator_test.go
+++ b/cmd/sidecars/network-passt-binding/domain/configurator_test.go
@@ -86,7 +86,7 @@ var _ = Describe("pod network configurator", func() {
 					Type:        "user",
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp", Dev: "eth0"}, {Proto: "udp", Dev: "eth0"}},
 					Model:       &domainschema.Model{Type: "virtio-non-transitional"},
 				},
 			),
@@ -98,7 +98,7 @@ var _ = Describe("pod network configurator", func() {
 					Type:        "user",
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp", Dev: "eth0"}, {Proto: "udp", Dev: "eth0"}},
 					Model:       &domainschema.Model{Type: "virtio-non-transitional"},
 					Address:     &domainschema.Address{Type: "pci", Domain: "0x0000", Bus: "0x02", Slot: "0x02", Function: "0x0"},
 				},
@@ -111,7 +111,7 @@ var _ = Describe("pod network configurator", func() {
 					Type:        "user",
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp", Dev: "eth0"}, {Proto: "udp", Dev: "eth0"}},
 					Model:       &domainschema.Model{Type: "virtio-non-transitional"},
 					MAC:         &domainschema.MAC{MAC: "02:02:02:02:02:02"},
 				},
@@ -124,7 +124,7 @@ var _ = Describe("pod network configurator", func() {
 					Type:        "user",
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp", Dev: "eth0"}, {Proto: "udp", Dev: "eth0"}},
 					Model:       &domainschema.Model{Type: "virtio-non-transitional"},
 					ACPI:        &domainschema.ACPI{Index: uint(2)},
 				},
@@ -138,7 +138,7 @@ var _ = Describe("pod network configurator", func() {
 					Type:        "user",
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp", Dev: "eth0"}, {Proto: "udp", Dev: "eth0"}},
 					Model:       &domainschema.Model{Type: "e1000"},
 				},
 			),
@@ -155,6 +155,7 @@ var _ = Describe("pod network configurator", func() {
 					PortForward: []domainschema.InterfacePortForward{
 						{
 							Proto: "tcp",
+							Dev:   "eth0",
 							Ranges: []domainschema.InterfacePortForwardRange{
 								{Start: 1}, {Start: 4},
 							},
@@ -175,6 +176,7 @@ var _ = Describe("pod network configurator", func() {
 					PortForward: []domainschema.InterfacePortForward{
 						{
 							Proto: "udp",
+							Dev:   "eth0",
 							Ranges: []domainschema.InterfacePortForwardRange{
 								{Start: 2}, {Start: 3},
 							},
@@ -195,12 +197,14 @@ var _ = Describe("pod network configurator", func() {
 					PortForward: []domainschema.InterfacePortForward{
 						{
 							Proto: "tcp",
+							Dev:   "eth0",
 							Ranges: []domainschema.InterfacePortForwardRange{
 								{Start: 1}, {Start: 4},
 							},
 						},
 						{
 							Proto: "udp",
+							Dev:   "eth0",
 							Ranges: []domainschema.InterfacePortForwardRange{
 								{Start: 2}, {Start: 3},
 							},
@@ -229,7 +233,7 @@ var _ = Describe("pod network configurator", func() {
 					Type:        "user",
 					Source:      domainschema.InterfaceSource{Device: "eth0"},
 					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp", Dev: "eth0"}, {Proto: "udp", Dev: "eth0"}},
 					Model:       &domainschema.Model{Type: "virtio-transitional"},
 				},
 			),
@@ -242,7 +246,7 @@ var _ = Describe("pod network configurator", func() {
 					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
 					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
 					PortForward: []domainschema.InterfacePortForward{
-						{Proto: "tcp", Ranges: []domainschema.InterfacePortForwardRange{
+						{Proto: "tcp", Dev: "eth0", Ranges: []domainschema.InterfacePortForwardRange{
 							{Start: 15000, Exclude: "yes"}, {Start: 15001, Exclude: "yes"},
 							{Start: 15004, Exclude: "yes"}, {Start: 15006, Exclude: "yes"},
 							{Start: 15008, Exclude: "yes"}, {Start: 15009, Exclude: "yes"},
@@ -268,7 +272,7 @@ var _ = Describe("pod network configurator", func() {
 				Type:        "user",
 				Source:      domainschema.InterfaceSource{Device: "eth0"},
 				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp", Dev: "eth0"}, {Proto: "udp", Dev: "eth0"}},
 				Model:       &domainschema.Model{Type: "virtio-non-transitional"},
 			}
 
@@ -294,7 +298,7 @@ var _ = Describe("pod network configurator", func() {
 				Type:        "user",
 				Source:      domainschema.InterfaceSource{Device: "eth0"},
 				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp", Dev: "eth0"}, {Proto: "udp", Dev: "eth0"}},
 				Model:       &domainschema.Model{Type: "virtio-non-transitional"},
 			}
 


### PR DESCRIPTION
### What this PR does

When configuring a passt interface in the domain, the `portForward` section can include a specific device on which the forward rules apply.

This change explicitly sets the device to assure the port forward rules are relevant to the traffic passing through that interface.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

