### PR TITLE
BugFix ipv4/ipv6 typo.

### DIFF
--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -506,7 +506,7 @@ func hasIP4GlobalUnicast(iface nmstate.Interface) bool {
 }
 
 func hasIP6GlobalUnicast(iface nmstate.Interface) bool {
-	return hasIPGlobalUnicast(iface.IPv4)
+	return hasIPGlobalUnicast(iface.IPv6)
 }
 
 func hasIPGlobalUnicast(ip nmstate.IP) bool {


### PR DESCRIPTION
### What this PR does
Fix a typo!

Before this PR:
We experienced an error that pointed to using ipv6 when it was disabled. When looking into [pull/10921](https://github.com/kubevirt/kubevirt/pull/10921), it seemed that did not fix it fully for us. Looking further in the code I found this typo which resulted in a desired pod network without issues.

After this PR:
The VM started as expected.

### Why we need it and why it was done in this way

Fixes a typo.

