### PR TITLE
tests, vmi_lifecycle: set the startup timeout

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -80,6 +80,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 	var allowEmulation *bool
 
 	const fakeLibvirtLogFilters = "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"
+	const startupTimeout = 45
 
 	AfterEach(func() {
 		// Not every test causes virt-handler to restart, but a few different contexts do.
@@ -124,12 +125,12 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:1620]should start it", func() {
-			tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), 30)
+			tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), startupTimeout)
 		})
 
 		It("[test_id:6095]should start in paused state if start strategy set to paused", func() {
 			vmi := libvmi.NewAlpine(libvmi.WithStartStrategy(v1.StartStrategyPaused))
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 			By("Unpausing VMI")
@@ -139,7 +140,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:1621]should attach virt-launcher to it", func() {
-			vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), 30)
+			vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), startupTimeout)
 
 			By("Getting virt-launcher logs")
 			logs := func() string { return getVirtLauncherLogs(kubevirt.Client(), vmi) }
@@ -152,7 +153,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		It("[test_id:3195]should carry annotations to pod", func() {
 			vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(
 				libvmi.WithAnnotation("testannotation", "annotation from vmi")),
-				30)
+				startupTimeout)
 
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(pod).NotTo(BeNil())
@@ -164,7 +165,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			vmi = tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(
 				libvmi.WithAnnotation("kubevirt.io/test", "test"),
 				libvmi.WithAnnotation("kubernetes.io/test", "test")),
-				30)
+				startupTimeout)
 
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(pod).NotTo(BeNil())
@@ -175,7 +176,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 		It("Should prevent eviction when EvictionStratgy: External", func() {
 			vmi := libvmi.NewAlpine(libvmi.WithEvictionStrategy(v1.EvictionStrategyExternal))
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(pod).ToNot(BeNil())
@@ -202,7 +203,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:1622]should log libvirtd logs", func() {
-			vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), 30)
+			vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), startupTimeout)
 
 			By("Getting virt-launcher logs")
 			logs := func() string { return getVirtLauncherLogs(kubevirt.Client(), vmi) }
@@ -227,7 +228,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			}
 			vmi := libvmi.New(options...)
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 			By("Getting virt-launcher logs")
 			logs := func() string { return getVirtLauncherLogs(kubevirt.Client(), vmi) }
@@ -352,7 +353,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi = addBootOrderToDisk(vmi, "disk0", &alpineBootOrder)
 				vmi = addBootOrderToDisk(vmi, "disk2", &cirrosBootOrder)
 				By("starting VMI")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 2*startupTimeout)
 
 				By("Checking console text")
 				err = console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -802,7 +803,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			It("[test_id:1635]the vmi with tolerations should be scheduled", func() {
 				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi.Spec.Tolerations = []k8sv1.Toleration{{Key: "test", Value: "123"}}
-				tests.RunVMIAndExpectLaunch(vmi, 30)
+				tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 			})
 
 			It("[test_id:1636]the vmi without tolerations should not be scheduled", func() {
@@ -833,7 +834,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 			It("[test_id:1637]the vmi with node affinity and no conflicts should be scheduled", func() {
 				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 				Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "Updated VMI name run on the same node")
@@ -842,7 +843,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 			It("[test_id:1638]the vmi with node affinity and anti-pod affinity should not be scheduled", func() {
 				vmi := libvmi.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 				Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "VMI should run on the same node")
@@ -914,7 +915,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				tests.UpdateKubeVirtConfigValueAndWait(*config)
 
 				vmi := libvmi.NewCirros()
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 				Expect(curVMI.Spec.Domain.CPU.Model).To(Equal(defaultCPUModel), "Expected default CPU model")
@@ -930,7 +931,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Model: vmiCPUModel,
 				}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
@@ -940,7 +941,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 			It("[sig-compute][test_id:3201]should set cpu model to default when vmi does not have it set and default cpu model is not set", func() {
 				vmi := libvmi.NewCirros()
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
@@ -1029,7 +1030,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					Cores: 1,
 					Model: supportedCPU,
 				}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				By("Verifying VirtualMachineInstance's status is Succeeded")
 				Eventually(func() v1.VirtualMachineInstancePhase {
@@ -1091,7 +1092,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 						},
 					},
 				}
-				tests.RunVMIAndExpectLaunch(vmi, 30)
+				tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 			})
 
 			It("[test_id:3203]the vmi with cpu.features that cannot match nfd labels on a node should not be scheduled", func() {
@@ -1415,7 +1416,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:1646]should request a KVM and TUN device", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), 30)
+				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), startupTimeout)
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(pod).NotTo(BeNil())
 
@@ -1436,7 +1437,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:1647]should not enable emulation in virt-launcher", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), 30)
+				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), startupTimeout)
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(pod).NotTo(BeNil())
 
@@ -1492,7 +1493,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance's Pod", func() {
 		It("[test_id:1650]should result in the VirtualMachineInstance moving to a finalized state", func() {
 			By("Creating the VirtualMachineInstance")
-			vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), 30)
+			vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), startupTimeout)
 
 			By("Verifying VirtualMachineInstance's pod is active")
 			pods, err := kubevirt.Client().CoreV1().Pods(vmi.Namespace).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
@@ -1524,7 +1525,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			It("[test_id:1651]should result in pod being terminated", func() {
 
 				By("Creating the VirtualMachineInstance")
-				vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), 30)
+				vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), startupTimeout)
 
 				podSelector := tests.UnfinishedVMIPodSelector(vmi)
 				By("Verifying VirtualMachineInstance's pod is active")
@@ -1600,7 +1601,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
 
 				By("Creating the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
 				By("Deleting the VirtualMachineInstance")


### PR DESCRIPTION
The startup time on Arm64 platform is over 30 seconds, so set the startup timeout to 45 seconds
https://github.com/kubevirt/project-infra/issues/3262

cc: @dhiller @brianmcarey @xpivarc 

```release-note
NONE
```

