### PR TITLE
fix(ksm): set ksm-enabled label to true independently from node pressure

### DIFF
--- a/pkg/virt-handler/heartbeat/ksm.go
+++ b/pkg/virt-handler/heartbeat/ksm.go
@@ -248,60 +248,54 @@ func getIntParam(node *v1.Node, param string, defaultValue, lowerBound, upperBou
 // will set the outcome value to the n.KSM struct
 // If the node labels match the selector terms, the ksm will be enabled.
 // Empty Selector will enable ksm for every node
-func handleKSM(node *v1.Node, clusterConfig *virtconfig.ClusterConfig) (bool, bool) {
-	available, running := loadKSM()
+func handleKSM(node *v1.Node, clusterConfig *virtconfig.ClusterConfig) (ksmLabelValue, ksmEnabledByUs bool) {
+	available, enabled := loadKSM()
 	if !available {
-		return running, false
+		return false, false
 	}
 
 	ksmConfig := clusterConfig.GetKSMConfiguration()
 	if ksmConfig == nil {
-		if disableKSM(node, running) {
-			return false, false
-		} else {
-			return running, false
+		if enabled {
+			disableKSM(node)
 		}
+
+		return false, false
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(ksmConfig.NodeLabelSelector)
 	if err != nil {
 		log.DefaultLogger().Errorf("An error occurred while converting the ksm selector: %s", err)
-		return running, false
+		return false, false
 	}
 
 	if !selector.Matches(labels.Set(node.ObjectMeta.Labels)) {
-		if disableKSM(node, running) {
-			return false, false
-		} else {
-			return running, false
+		if enabled {
+			disableKSM(node)
 		}
+
+		return false, false
 	}
-	ksm, err := calculateNewRunSleepAndPages(node, running)
+	ksm, err := calculateNewRunSleepAndPages(node, enabled)
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("An error occurred while calculating the new KSM values")
-		return running, false
+		return true, false
 	}
 
 	err = writeKsmValuesToFiles(ksm)
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("An error occurred while writing the new KSM values")
-		return running, false
+		return true, false
 	}
 
-	return ksm.running, ksm.running
+	return true, ksm.running
 }
 
-func disableKSM(node *v1.Node, enabled bool) bool {
-	if enabled {
-		if value, found := node.GetAnnotations()[kubevirtv1.KSMHandlerManagedAnnotation]; found && value == "true" {
-			err := os.WriteFile(ksmRunPath, []byte("0\n"), 0644)
-			if err != nil {
-				log.DefaultLogger().Errorf("Unable to write ksm: %s", err.Error())
-				return false
-			}
-			return true
+func disableKSM(node *v1.Node) {
+	if value, found := node.GetAnnotations()[kubevirtv1.KSMHandlerManagedAnnotation]; found && value == "true" {
+		err := os.WriteFile(ksmRunPath, []byte("0\n"), 0644)
+		if err != nil {
+			log.DefaultLogger().Errorf("Unable to write ksm: %s", err.Error())
 		}
 	}
-
-	return false
 }

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -969,7 +969,7 @@ const (
 	// SEVESLabel marks the node as capable of running workloads with SEV-ES
 	SEVESLabel string = "kubevirt.io/sev-es"
 
-	// KSMEnabledLabel marks the node as KSM enabled
+	// KSMEnabledLabel marks the node as KSM-handling enabled
 	KSMEnabledLabel string = "kubevirt.io/ksm-enabled"
 
 	// KSMHandlerManagedAnnotation is an annotation used to mark the nodes where the virt-handler has enabled the ksm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Currently, KubeVirt adds the `kubevirt.io/ksm-enabled` label to those nodes that match the labelSelector defined in kvConfiguration. The value of that label will be true only if that node is under pressure, false otherwise.

After this PR:
This is wrong since we need to provide users the information that a particular node is configured to use ksm, so that it can be used to schedule vms there.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
jira-ticket: https://issues.redhat.com/browse/CNV-38568

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix(ksm): set the `kubevirt.io/ksm-enabled` node label to true if the ksm is managed by KubeVirt, instead of reflect the actual ksm value.
```