### PR TITLE
tests: Use libvmi instead of 'NewRandomVMIWithEphemeralDiskAndUserdataNetworkData'

### DIFF
--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -59,6 +59,7 @@ func WithCloudInitNoCloudNetworkData(data string) Option {
 
 		volume := getVolume(vmi, cloudInitDiskName)
 		volume.CloudInitNoCloud.NetworkData = data
+		volume.CloudInitNoCloud.NetworkDataBase64 = ""
 		volume.CloudInitNoCloud.NetworkDataSecretRef = nil
 	}
 }

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -22,6 +22,8 @@ package libvmi
 import (
 	"encoding/base64"
 
+	k8scorev1 "k8s.io/api/core/v1"
+
 	v1 "kubevirt.io/api/core/v1"
 )
 
@@ -57,6 +59,7 @@ func WithCloudInitNoCloudNetworkData(data string) Option {
 
 		volume := getVolume(vmi, cloudInitDiskName)
 		volume.CloudInitNoCloud.NetworkData = data
+		volume.CloudInitNoCloud.NetworkDataSecretRef = nil
 	}
 }
 
@@ -68,6 +71,19 @@ func WithCloudInitNoCloudEncodedNetworkData(networkData string) Option {
 		volume := getVolume(vmi, cloudInitDiskName)
 		volume.CloudInitNoCloud.NetworkDataBase64 = base64.StdEncoding.EncodeToString([]byte(networkData))
 		volume.CloudInitNoCloud.NetworkData = ""
+		volume.CloudInitNoCloud.NetworkDataSecretRef = nil
+	}
+}
+
+// WithCloudInitNoCloudNetworkDataSecretName adds cloud-init no-cloud network data from secret.
+func WithCloudInitNoCloudNetworkDataSecretName(secretName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		volume.CloudInitNoCloud.NetworkDataSecretRef = &k8scorev1.LocalObjectReference{Name: secretName}
+		volume.CloudInitNoCloud.NetworkData = ""
+		volume.CloudInitNoCloud.NetworkDataBase64 = ""
 	}
 }
 

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -60,6 +60,17 @@ func WithCloudInitNoCloudNetworkData(data string) Option {
 	}
 }
 
+// WithCloudInitNoCloudEncodedNetworkData adds cloud-init no-cloud base64 encoded network data.
+func WithCloudInitNoCloudEncodedNetworkData(networkData string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		volume.CloudInitNoCloud.NetworkDataBase64 = base64.StdEncoding.EncodeToString([]byte(networkData))
+		volume.CloudInitNoCloud.NetworkData = ""
+	}
+}
+
 // WithCloudInitConfigDriveUserData adds cloud-init config-drive user data.
 func WithCloudInitConfigDriveUserData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -409,15 +409,6 @@ func NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(containerImage string, 
 	return vmi
 }
 
-// NewRandomVMIWithEphemeralDiskAndUserdataNetworkData
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(containerImage, userData, networkData string, b64encode bool) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
-	AddCloudInitNoCloudData(vmi, "disk1", userData, networkData, b64encode)
-	return vmi
-}
-
 // NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData
 //
 // Deprecated: Use libvmi directly

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -349,8 +349,11 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		Context("with cloudInitNoCloud networkData", func() {
 			It("[test_id:3181]should have cloud-init network-config with NetworkData source", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
+				vmi := libvmifact.NewCirros(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithCloudInitNoCloudNetworkData(testNetworkData),
+				)
 				vmi = LaunchVMI(vmi)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
@@ -364,8 +367,11 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			})
 			It("[test_id:3182]should have cloud-init network-config with NetworkDataBase64 source", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
+				vmi := libvmifact.NewCirros(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithCloudInitNoCloudEncodedNetworkData(testNetworkData),
+				)
 				vmi = LaunchVMI(vmi)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
@@ -379,8 +385,11 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			})
 			It("[test_id:3183]should have cloud-init network-config from k8s secret", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
+				vmi := libvmifact.NewCirros(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithCloudInitNoCloudUserData(""),
+				)
 
 				idx := 0
 				for i, volume := range vmi.Spec.Volumes {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Use libvmi directly at the caller instead of `NewRandomVMIWithEphemeralDiskAndUserdataNetworkData`.

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- Since LaunchVMI() returned value is not used, the VMI instance in the
test context never get updated with the namespace causing failures.
It worked because 'NewRandomVMIWithEphemeralDiskAndUserdataNetworkData'
set the VMI with a namespace, so the instance in the test context had
the namespace.
To address this assign the the returned value from LaunchVMI().

- Regarding the test 'should have cloud-init network-config from k8s secret':
NewCirros() set cloudInit by default (to prevent it to hang at boot time).
Since the test asserts cloud-init user-data (and encoded use-data) is empty,
override cloudinit user-data that is set by NewCirros() as before these commit
changes.
Since cloud-init network-data is set the guest doesn't hang at boot time.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

