### PR TITLE
Improve default handling of export resources in virtctl vmexport

### DIFF
--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -368,6 +368,7 @@ func (c *command) initVMExportInfo(vmeInfo *VMExportInfo) error {
 	vmeInfo.ShouldCreate = shouldCreate
 	vmeInfo.Insecure = insecure
 	vmeInfo.KeepVme = keepVme
+	vmeInfo.DeleteVme = deleteVme
 	vmeInfo.VolumeName = volumeName
 	vmeInfo.ServiceURL = serviceUrl
 	vmeInfo.OutputFormat = manifestOutputFormat
@@ -583,7 +584,7 @@ func downloadVolume(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMac
 // shouldDeleteVMExport decides wether we should retain or delete a VMExport after a download. If delete/retain are not explicitly specified,
 // the vmexport will be deleted when is created in the same instance as the download, retained otherwise.
 func shouldDeleteVMExport(vmeInfo *VMExportInfo) bool {
-	return vmeInfo.DeleteVme || (vmeInfo.ShouldCreate && !vmeInfo.KeepVme && !vmeInfo.ExportManifest)
+	return !vmeInfo.ExportManifest && (vmeInfo.DeleteVme || (vmeInfo.ShouldCreate && !vmeInfo.KeepVme))
 }
 
 func replaceUrlWithServiceUrl(manifestUrl string, vmeInfo *VMExportInfo) (string, error) {

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -257,6 +257,8 @@ func NewVirtualMachineExportCommand(clientConfig clientcmd.ClientConfig) *cobra.
 		},
 	}
 
+	shouldCreate = false
+
 	cmd.Flags().StringVar(&vm, "vm", "", "Sets VirtualMachine as vmexport kind and specifies the vm name.")
 	cmd.Flags().StringVar(&snapshot, "snapshot", "", "Sets VirtualMachineSnapshot as vmexport kind and specifies the snapshot name.")
 	cmd.Flags().StringVar(&pvc, "pvc", "", "Sets PersistentVolumeClaim as vmexport kind and specifies the PVC name.")

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -261,15 +261,17 @@ var _ = Describe("vmexport", func() {
 			Expect(err.Error()).Should(Equal("bad status: 500 Internal Server Error"))
 		})
 
-		It("Bad flag combination", func() {
+		DescribeTable("Bad flag combination", func(errString string, args ...string) {
 			testInit(http.StatusOK)
-			args := []string{virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), setflag(virtctlvmexport.VM_FLAG, "test2"), setflag(virtctlvmexport.SNAPSHOT_FLAG, "test3")}
 			args = append([]string{commandName}, args...)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(Equal("if any flags in the group [vm snapshot pvc] are set none of the others can be; [pvc snapshot vm] were all set"))
-		})
+			Expect(err.Error()).Should(Equal(errString))
+		},
+			Entry("Multiple target types", "if any flags in the group [vm snapshot pvc] are set none of the others can be; [pvc snapshot vm] were all set", virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), setflag(virtctlvmexport.VM_FLAG, "test2"), setflag(virtctlvmexport.SNAPSHOT_FLAG, "test3")),
+			Entry("Retain and delte vmexport", "if any flags in the group [keep-vme delete-vme] are set none of the others can be; [delete-vme keep-vme] were all set", virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.DELETE_FLAG, virtctlvmexport.KEEP_FLAG),
+		)
 
 		DescribeTable("Invalid arguments/flags", func(errString string, args ...string) {
 			testInit(http.StatusOK)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

The `virtctl vmexport download` command always deleted the vmexport resources after exiting. This behavior wasn't ideal since we could be potentially deleting resources created in advance. This behavior could be improved.

**After this PR:**

Now the command will delete vmexport resources by default when the `download` command creates them itself. However, the resources will be retained if they were created in advance.

A new, `--delete-vme` flag has been included to allow deleting the vmexport everytime the download exits. `--keep-vme` does the opposite, so we can retain the vmexport resource even when the command creates it. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://github.com/kubevirt/kubevirt/issues/11080

### Why we need it and why it was done in this way

Following several offline conversations we decided this was the best approach to handle vmexport resources. Another option would be to handle resources differently depending on whether the download succeeds or fails.

### Special notes for your reviewer

The change in behavior remains the same whether the download was successful or not. I think this is the appropriate behavior but feel free to argue otherwise if you think it's more appropriate always to delete the vmexport resource if a download fails.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve handling of export resources in virtctl vmexport
```

