### PR TITLE
tests/operator: Avoid usage of complex tests.NewRandomVMI

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1520,7 +1520,7 @@ spec:
 			checkVirtComponents(nil)
 
 			By("Starting a VMI")
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New(libvmi.WithResourceMemory("1Mi"))
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 			Expect(err).NotTo(HaveOccurred())
 			libwait.WaitForSuccessfulVMIStart(vmi)
@@ -1569,7 +1569,7 @@ spec:
 			checkVirtComponents(imagePullSecrets)
 
 			By("Starting a VMI")
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New(libvmi.WithResourceMemory("1Mi"))
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 			Expect(err).NotTo(HaveOccurred())
 			libwait.WaitForSuccessfulVMIStart(vmi)


### PR DESCRIPTION
libvmi.New(libvmi.WithResourceMemory("1Mi")) is simpler and smaller, yet just as good for these tests that do not need a guest at all.

```release-note
NONE
```

/sig code-quality
