### PR TITLE
perfscale: Change v flag to verbose in load generator

### DIFF
--- a/hack/perfscale-tests.sh
+++ b/hack/perfscale-tests.sh
@@ -44,7 +44,7 @@ function get_timestamp() {
 
 function perftest() {
     _out/cmd/perfscale-load-generator/perfscale-load-generator \
-        -v 6 \
+        -verbose 6 \
         -delete \
         -workload ${PERFSCALE_WORKLOAD}
 }

--- a/tools/perfscale-load-generator/README.md
+++ b/tools/perfscale-load-generator/README.md
@@ -20,7 +20,7 @@ Deleting a workload requires an explicit request by the user.  Run the same comm
         absolute path to the kubeconfig file
   -master string
         kubernetes master url
-  -v int
+  -verbose int
         log level for V logs (default 2)
   -workload string
         path to the file containing the worload configuration (default "tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density.yaml")

--- a/tools/perfscale-load-generator/flags/flags.go
+++ b/tools/perfscale-load-generator/flags/flags.go
@@ -41,7 +41,7 @@ func init() {
 
 	flag.StringVar(&Kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&Kubemaster, "master", "", "kubernetes master url")
-	flag.IntVar(&Verbosity, "v", 2, "log level for V logs")
+	flag.IntVar(&Verbosity, "verbose", 2, "log level for V logs")
 	flag.StringVar(&WorkloadConfigFile, "workload", "tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density.yaml", "path to the file containing the worload configuration")
 	flag.BoolVar(&Run, "run", true, "Run a workload")
 	flag.BoolVar(&Delete, "delete", false, "Delete a workload")


### PR DESCRIPTION
### What this PR does

A panic occurs in the periodic performance lanes as the v flag is redefined[1]. Update the perfscale-load-generator flag to verbose rather than v to avoid this clash

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-performance-cluster-100-density-test/1760162626240778240#1:build-log.txt%3A2082
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
/cc @alaypatel07 @rthallisey @dhiller @xpivarc 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

