### PR TITLE
wip: Fix double call to hook's onDefineDomain

### DIFF
--- a/pkg/hooks/BUILD.bazel
+++ b/pkg/hooks/BUILD.bazel
@@ -16,11 +16,11 @@ go_library(
         "//pkg/hooks/v1alpha2:go_default_library",
         "//pkg/hooks/v1alpha3:go_default_library",
         "//pkg/util/net/grpc:go_default_library",
-        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )
 

--- a/pkg/hooks/generated_mock_manager.go
+++ b/pkg/hooks/generated_mock_manager.go
@@ -8,9 +8,9 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "kubevirt.io/api/core/v1"
+	libvirtxml "libvirt.org/go/libvirtxml"
 
 	cloud_init "kubevirt.io/kubevirt/pkg/cloud-init"
-	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 // Mock of Manager interface
@@ -44,7 +44,7 @@ func (_mr *_MockManagerRecorder) Collect(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Collect", arg0, arg1)
 }
 
-func (_m *MockManager) OnDefineDomain(_param0 *api.DomainSpec, _param1 *v1.VirtualMachineInstance) (string, error) {
+func (_m *MockManager) OnDefineDomain(_param0 *libvirtxml.Domain, _param1 *v1.VirtualMachineInstance) (string, error) {
 	ret := _m.ctrl.Call(_m, "OnDefineDomain", _param0, _param1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)

--- a/pkg/hooks/manager.go
+++ b/pkg/hooks/manager.go
@@ -33,6 +33,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+	"libvirt.org/go/libvirtxml"
 
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
@@ -40,7 +41,6 @@ import (
 	hooksV1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
 	hooksV1alpha3 "kubevirt.io/kubevirt/pkg/hooks/v1alpha3"
 	grpcutil "kubevirt.io/kubevirt/pkg/util/net/grpc"
-	virtwrapApi "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 //go:generate mockgen -source $GOFILE -package=$GOPACKAGE -destination=generated_mock_$GOFILE
@@ -59,7 +59,7 @@ var once sync.Once
 type (
 	Manager interface {
 		Collect(uint, time.Duration) error
-		OnDefineDomain(*virtwrapApi.DomainSpec, *v1.VirtualMachineInstance) (string, error)
+		OnDefineDomain(*libvirtxml.Domain, *v1.VirtualMachineInstance) (string, error)
 		PreCloudInitIso(*v1.VirtualMachineInstance, *cloudinit.CloudInitData) (*cloudinit.CloudInitData, error)
 		Shutdown() error
 	}
@@ -197,7 +197,7 @@ func sortCallbacksPerHookPoint(callbacksPerHookPoint map[string][]*callBackClien
 	}
 }
 
-func (m *hookManager) OnDefineDomain(domainSpec *virtwrapApi.DomainSpec, vmi *v1.VirtualMachineInstance) (string, error) {
+func (m *hookManager) OnDefineDomain(domainSpec *libvirtxml.Domain, vmi *v1.VirtualMachineInstance) (string, error) {
 	domainSpecXML, err := xml.MarshalIndent(domainSpec, "", "\t")
 	if err != nil {
 		return "", fmt.Errorf("Failed to marshal domain spec: %v", domainSpec)

--- a/pkg/virt-launcher/virtwrap/libvirtxml/convert.go
+++ b/pkg/virt-launcher/virtwrap/libvirtxml/convert.go
@@ -20,6 +20,8 @@
 package libvirtxml
 
 import (
+	"encoding/xml"
+	"fmt"
 	"strconv"
 
 	"libvirt.org/go/libvirtxml"
@@ -302,4 +304,34 @@ func ConvertKubeVirtFeaturesToDomainFeatureList(features *api.Features) *libvirt
 	f.KVM = ConverKubeVirtFeatureKVMToDomainFeatureKVM(features.KVM)
 	return f
 
+}
+
+func ConvertKubeVirtDomainSpecToDomain(apiDomainSpec *api.DomainSpec) (*libvirtxml.Domain, error) {
+	if apiDomainSpec == nil {
+		return nil, fmt.Errorf("can't convert: apiDomainSpec is nil")
+	}
+
+	bytes, err := xml.Marshal(&apiDomainSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	var libvirtDomain libvirtxml.Domain
+	err = xml.Unmarshal(bytes, &libvirtDomain)
+	return &libvirtDomain, err
+}
+
+func ConvertDomainToKubeVirtDomainSpec(libvirtDomain *libvirtxml.Domain) (*api.DomainSpec, error) {
+	if libvirtDomain == nil {
+		return nil, fmt.Errorf("can't convert: libvirtDomain is nil")
+	}
+
+	bytes, err := xml.Marshal(libvirtDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	var apiDomainSpec api.DomainSpec
+	err = xml.Unmarshal(bytes, &apiDomainSpec)
+	return &apiDomainSpec, err
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -32,7 +32,6 @@ import (
 
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
-	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/net/ip"
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
@@ -158,7 +157,7 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 		return fmt.Errorf("conversion failed: %v", err)
 	}
 
-	dom, err := l.preStartHook(vmi, domain, true, options)
+	_, err = l.preStartHook(vmi, domain, true, options)
 	if err != nil {
 		return fmt.Errorf("pre-start pod-setup failed: %v", err)
 	}
@@ -175,11 +174,11 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 	// TODO this should probably a OnPrepareMigration hook or something.
 	// Right now we need to call OnDefineDomain, so that additional setup, which might be done
 	// by the hook can also be done for the new target pod
-	hooksManager := hooks.GetManager()
+	/*FIXME:hooksManager := hooks.GetManager()
 	_, err = hooksManager.OnDefineDomain(&dom.Spec, vmi)
 	if err != nil {
 		return fmt.Errorf("executing custom preStart hooks failed: %v", err)
-	}
+	}*/
 
 	if shouldBlockMigrationTargetPreparation(vmi) {
 		return fmt.Errorf("Blocking preparation of migration target in order to satisfy a functional test condition")

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1239,11 +1239,11 @@ func (l *LibvirtDomainManager) lookupOrCreateVirDomain(
 		return nil, err
 	}
 
-	setDomainFn := func(v *v1.VirtualMachineInstance, s *api.DomainSpec) (cli.VirDomain, error) {
-		return l.setDomainSpecWithHooks(v, s)
+	setDomainFn := func(v *v1.VirtualMachineInstance, s *api.DomainSpec) (cli.VirDomain, *api.DomainSpec, error) {
+		return util.SetDomainSpecStrWithHooks(l.virConn, v, s)
 	}
 
-	if dom, err = withNetworkIfacesResources(vmi, &domain.Spec, setDomainFn); err != nil {
+	if dom, _, err = withNetworkIfacesResources(vmi, &domain.Spec, setDomainFn); err != nil {
 		return nil, err
 	}
 
@@ -1883,10 +1883,6 @@ func (l *LibvirtDomainManager) ListAllDomains() ([]*api.Domain, error) {
 	}
 
 	return list, nil
-}
-
-func (l *LibvirtDomainManager) setDomainSpecWithHooks(vmi *v1.VirtualMachineInstance, origSpec *api.DomainSpec) (cli.VirDomain, error) {
-	return util.SetDomainSpecStrWithHooks(l.virConn, vmi, origSpec)
 }
 
 func (l *LibvirtDomainManager) GetQemuVersion() (string, error) {

--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -172,12 +172,14 @@ func indexedDomainInterfaces(domain *api.Domain) map[string]api.Interface {
 	return domainInterfaces
 }
 
+type SetDomainFunc func(*v1.VirtualMachineInstance, *api.DomainSpec) (cli.VirDomain, error)
+
 // withNetworkIfacesResources adds network interfaces as placeholders to the domain spec
 // to trigger the addition of the dependent resources/devices (e.g. PCI controllers).
 // As its last step, it reads the generated configuration and removes the network interfaces
 // so none will be created with the domain creation.
 // The dependent devices are left in the configuration, to allow future hotplug.
-func withNetworkIfacesResources(vmi *v1.VirtualMachineInstance, domainSpec *api.DomainSpec, f func(v *v1.VirtualMachineInstance, s *api.DomainSpec) (cli.VirDomain, error)) (cli.VirDomain, error) {
+func withNetworkIfacesResources(vmi *v1.VirtualMachineInstance, domainSpec *api.DomainSpec, f SetDomainFunc) (cli.VirDomain, error) {
 	domainSpecWithIfacesResource := appendPlaceholderInterfacesToTheDomain(vmi, domainSpec)
 	dom, err := f(vmi, domainSpecWithIfacesResource)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -172,27 +172,27 @@ func indexedDomainInterfaces(domain *api.Domain) map[string]api.Interface {
 	return domainInterfaces
 }
 
-type SetDomainFunc func(*v1.VirtualMachineInstance, *api.DomainSpec) (cli.VirDomain, error)
+type SetDomainFunc func(*v1.VirtualMachineInstance, *api.DomainSpec) (cli.VirDomain, *api.DomainSpec, error)
 
 // withNetworkIfacesResources adds network interfaces as placeholders to the domain spec
 // to trigger the addition of the dependent resources/devices (e.g. PCI controllers).
 // As its last step, it reads the generated configuration and removes the network interfaces
 // so none will be created with the domain creation.
 // The dependent devices are left in the configuration, to allow future hotplug.
-func withNetworkIfacesResources(vmi *v1.VirtualMachineInstance, domainSpec *api.DomainSpec, f SetDomainFunc) (cli.VirDomain, error) {
+func withNetworkIfacesResources(vmi *v1.VirtualMachineInstance, domainSpec *api.DomainSpec, f SetDomainFunc) (cli.VirDomain, *api.DomainSpec, error) {
 	domainSpecWithIfacesResource := appendPlaceholderInterfacesToTheDomain(vmi, domainSpec)
 	dom, err := f(vmi, domainSpecWithIfacesResource)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if len(domainSpec.Devices.Interfaces) == len(domainSpecWithIfacesResource.Devices.Interfaces) {
-		return dom, nil
+		return dom, domainSpec, nil
 	}
 
 	domainSpecWithoutIfacePlaceholders, err := util.GetDomainSpecWithFlags(dom, libvirt.DOMAIN_XML_INACTIVE)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	domainSpecWithoutIfacePlaceholders.Devices.Interfaces = domainSpec.Devices.Interfaces
 	// Only the devices are taken into account because some parameters are not assured to be returned when

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -22,6 +22,7 @@ import (
 	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"libvirt.org/go/libvirt"
+	"libvirt.org/go/libvirtxml"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 
@@ -139,7 +140,11 @@ func SetDomainSpecStr(virConn cli.Connection, vmi *v1.VirtualMachineInstance, wa
 	return dom, nil
 }
 
-func SetDomainSpecStrWithHooks(virConn cli.Connection, vmi *v1.VirtualMachineInstance, wantedSpec *api.DomainSpec) (cli.VirDomain, *api.DomainSpec, error) {
+func SetDomainSpecStrWithHooks(
+	virConn cli.Connection,
+	vmi *v1.VirtualMachineInstance,
+	wantedSpec *libvirtxml.Domain,
+) (cli.VirDomain, *libvirtxml.Domain, error) {
 	hooksManager := getHookManager()
 	domainSpec, err := hooksManager.OnDefineDomain(wantedSpec, vmi)
 	if err != nil {
@@ -147,11 +152,10 @@ func SetDomainSpecStrWithHooks(virConn cli.Connection, vmi *v1.VirtualMachineIns
 	}
 
 	// update wantedSpec to reflect changes made to domain spec by hooks
-	domainSpecObj := &api.DomainSpec{}
+	domainSpecObj := &libvirtxml.Domain{}
 	if err = xml.Unmarshal([]byte(domainSpec), domainSpecObj); err != nil {
 		return nil, nil, err
 	}
-	domainSpecObj.DeepCopyInto(wantedSpec)
 
 	dom, err := SetDomainSpecStr(virConn, vmi, domainSpec)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Sidecar hook OnDefineDomain is being called twice since https://github.com/kubevirt/kubevirt/commit/637be26ef415dbe77a003e3eef1e094b0ed456b3 and it does with the updated XML from the first call, which is bad as  `schema.go` might not recognize all the fields set by the Sidecar.

After this PR:
Sidecar hook is only called once.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11276

### Why we need it and why it was done in this way
The following tradeoffs were made:
There are more than one possible solution, I'm opening the PR to discuss it with @EdDev 

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

It is a must that we call the OnDefineDomain only once to avoid breaking user's scripts. Quoting also my comment in the original issue for clarity:

"
I think I found the reason, it was introduced in https://github.com/kubevirt/kubevirt/commit/637be26ef415dbe77a003e3eef1e094b0ed456b3 with the function [withNetworkIfacesResources()](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/nichotplug.go#L180), it end up calling twice the [SetDomainSpecStrWithHooks()](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/util/libvirt_helper.go#L142). Note that in the SetDomainSpecStrWithHooks, we do a DeepCopyInto() the wantedSpec, making the second call have partial data from the first call because the wantedSpec does not have all the libvirt fields. This is something we are talking and tracking with https://github.com/kubevirt/kubevirt/issues/10844

Many thanks for raising this bug, its there for sometime already (since v1.0.0)
"

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

