### PR TITLE
migration: Check pod ready condition too

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1097,8 +1097,14 @@ func isPodReady(pod *k8sv1.Pod) bool {
 			return false
 		}
 	}
-
-	return pod.Status.Phase == k8sv1.PodRunning
+	podReadyConditionIsTrue := false
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == k8sv1.PodReady && condition.Status == k8sv1.ConditionTrue {
+			podReadyConditionIsTrue = true
+			break
+		}
+	}
+	return pod.Status.Phase == k8sv1.PodRunning && podReadyConditionIsTrue
 }
 
 func isPodDownOrGoingDown(pod *k8sv1.Pod) bool {


### PR DESCRIPTION
### What this PR does
Before this PR:
The live migration process wait for target pod readiness to close the source pod, it checks the container statuses and the pod phase to be running.

Sometimes the pod status is like the following:

```yaml
status:
    phase: Running                                                                conditions:
    - lastProbeTime: null
      lastTransitionTime: "2024-02-21T09:00:02Z"
      status: "True"
      type: Initialized
    - lastProbeTime: null
      lastTransitionTime: "2024-02-21T08:59:40Z"
      message: corresponding condition of pod readiness gate "kubevirt.io/virtual-machine-unpaused"
        does not exist.
      reason: ReadinessGatesNotReady
      status: "False"
      type: Ready
    - lastProbeTime: null
      lastTransitionTime: "2024-02-21T09:00:09Z"
      status: "True"
      type: ContainersReady
    - lastProbeTime: null
      lastTransitionTime: "2024-02-21T08:59:40Z"
      status: "True"
      type: PodScheduled
    - lastProbeTime: "2024-02-21T09:00:29Z"
      lastTransitionTime: "2024-02-21T09:00:29Z"
      message: the virtual machine is not paused
      reason: NotPaused
      status: "True"
      type: kubevirt.io/virtual-machine-unpaused
```

This means that Phase == Running but conditions.Ready == False.

At ovn-kubernetes CNI it means that the endpoint slices of a service exposing the a service will be set to not ready and the ovs/ovn network infra related to them will be deleted disconnecting the VM.

This change checks also the pod ready conditions to be sure that endpoint slices readiness are aligned with successful live migraiton.


After this PR:
The live migration target pod will be always true after successful live migration.

Fixes #https://issues.redhat.com/browse/CNV-38604

### Why we need it and why it was done in this way
The following tradeoffs were made:
It will wait a little more before continue with live migration and deleting the source pod on some scenarios

The following alternatives were considered: N/A

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Wait for pod ready condition to continue with live migration and close source pod.
```

