### PR TITLE
migration state: add source pod and failure reason

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20120,6 +20120,9 @@
       "description": "The source node that the VMI originated on",
       "type": "string"
      },
+     "sourcePod": {
+      "type": "string"
+     },
      "startTimestamp": {
       "description": "The time the migration action began",
       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20100,6 +20100,10 @@
       "description": "Indicates that the migration failed",
       "type": "boolean"
      },
+     "failureReason": {
+      "description": "Contains the reason why the migration failed",
+      "type": "string"
+     },
      "migrationConfiguration": {
       "description": "Migration configurations to apply",
       "$ref": "#/definitions/v1.MigrationConfiguration"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -346,6 +346,23 @@ func SetVMIMigrationPhaseTransitionTimestamp(oldVMIMigration *v1.VirtualMachineI
 	}
 }
 
+func SetSourcePod(migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, podInformer cache.SharedIndexInformer) {
+	if migration.Status.Phase != v1.MigrationPending {
+		return
+	}
+	sourcePod, err := CurrentVMIPod(vmi, podInformer)
+	if err != nil {
+		log.Log.Object(vmi).Reason(err).Warning("migration source pod not found")
+	}
+	if sourcePod != nil {
+		if migration.Status.MigrationState == nil {
+			migration.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{}
+		}
+		migration.Status.MigrationState.SourcePod = sourcePod.Name
+	}
+
+}
+
 func VMIHasHotplugVolumes(vmi *v1.VirtualMachineInstance) bool {
 	for _, volumeStatus := range vmi.Status.VolumeStatus {
 		if volumeStatus.HotplugVolume != nil {

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -444,6 +444,7 @@ var _ = Describe("Migration watcher", func() {
 			vmi.Status.SelinuxContext = "system_u:system_r:container_file_t:s0:c1,c2"
 			addVirtualMachineInstance(vmi)
 			podFeeder.Add(targetPod)
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectAttachmentPodCreation(vmi.UID, migration.UID)
 
 			controller.Execute()
@@ -633,6 +634,7 @@ var _ = Describe("Migration watcher", func() {
 					return vmiReturn, nil
 				})
 
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectPodCreation(vmi.UID, migration.UID, 1, 0, 0)
 			controller.Execute()
 			testutils.ExpectEvents(recorder, SuccessfulCreatePodReason)
@@ -643,6 +645,7 @@ var _ = Describe("Migration watcher", func() {
 
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectPodCreation(vmi.UID, migration.UID, 1, 0, 0)
 
 			controller.Execute()
@@ -661,6 +664,7 @@ var _ = Describe("Migration watcher", func() {
 
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
+			shouldExpectGenericMigrationUpdate()
 
 			controller.Execute()
 		})
@@ -693,6 +697,7 @@ var _ = Describe("Migration watcher", func() {
 				addVirtualMachineInstance(vmi)
 			}
 
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectPodCreation(vmi.UID, migration.UID, 1, 0, 0)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
@@ -715,6 +720,8 @@ var _ = Describe("Migration watcher", func() {
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
 			}
+
+			shouldExpectGenericMigrationUpdate()
 
 			controller.Execute()
 		})
@@ -749,6 +756,8 @@ var _ = Describe("Migration watcher", func() {
 				Expect(podInformer.GetStore().Add(pod)).To(Succeed())
 			}
 
+			shouldExpectGenericMigrationUpdate()
+
 			controller.Execute()
 		})
 
@@ -769,6 +778,7 @@ var _ = Describe("Migration watcher", func() {
 				addVirtualMachineInstance(vmi)
 			}
 
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectPodCreation(vmi.UID, migration.UID, 1, 0, 0)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
@@ -791,6 +801,7 @@ var _ = Describe("Migration watcher", func() {
 				addVirtualMachineInstance(vmi)
 			}
 
+			shouldExpectGenericMigrationUpdate()
 			controller.Execute()
 		})
 
@@ -845,6 +856,7 @@ var _ = Describe("Migration watcher", func() {
 
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectPodCreation(vmi.UID, migration.UID, 2, 1, 1)
 
 			controller.Execute()
@@ -1550,6 +1562,8 @@ var _ = Describe("Migration watcher", func() {
 			addVirtualMachineInstance(vmi)
 			addNode(node)
 
+			shouldExpectGenericMigrationUpdate()
+
 			expectPodToHaveProperNodeSelector := func(pod *k8sv1.Pod) {
 				podHasCpuModeLabelSelector := false
 				for key, _ := range pod.Spec.NodeSelector {
@@ -1589,6 +1603,7 @@ var _ = Describe("Migration watcher", func() {
 			addVirtualMachineInstance(vmi)
 			addPDB(pdb)
 
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectPDBPatch(vmi, migration)
 			controller.Execute()
 
@@ -1611,6 +1626,7 @@ var _ = Describe("Migration watcher", func() {
 			addVirtualMachineInstance(vmi)
 			addPDB(pdb)
 
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectPodCreation(vmi.UID, migration.UID, 1, 0, 0)
 
 			controller.Execute()
@@ -1631,6 +1647,7 @@ var _ = Describe("Migration watcher", func() {
 
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
+				shouldExpectGenericMigrationUpdate()
 				addPDB(pdb)
 
 				shouldExpectPDBPatch(vmi, migration)
@@ -2016,6 +2033,7 @@ var _ = Describe("Migration watcher", func() {
 
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectTargetPodWithSELinuxLevel("s0:c1,c2")
 
 			controller.Execute()
@@ -2034,6 +2052,7 @@ var _ = Describe("Migration watcher", func() {
 
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
+			shouldExpectGenericMigrationUpdate()
 			shouldExpectTargetPodWithSELinuxLevel("")
 
 			controller.Execute()

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1136,10 +1136,7 @@ func isPodFailed(pod *k8sv1.Pod) bool {
 }
 
 func podExists(pod *k8sv1.Pod) bool {
-	if pod != nil {
-		return true
-	}
-	return false
+	return pod != nil
 }
 
 func (c *VMIController) hotplugPodsReady(vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) (bool, syncError) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -594,7 +594,6 @@ func canUpdateToUnmounted(currentPhase v1.VolumePhase) bool {
 }
 
 func (d *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
-
 	if domain == nil ||
 		domain.Spec.Metadata.KubeVirt.Migration == nil ||
 		vmi.Status.MigrationState == nil ||
@@ -609,6 +608,7 @@ func (d *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMac
 
 	if vmi.Status.MigrationState.EndTimestamp == nil && migrationMetadata.EndTimestamp != nil {
 		if migrationMetadata.Failed {
+			vmi.Status.MigrationState.FailureReason = migrationMetadata.FailureReason
 			d.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("VirtualMachineInstance migration uid %s failed. reason:%s", string(migrationMetadata.UID), migrationMetadata.FailureReason))
 		}
 	}

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -12292,6 +12292,8 @@ var CRDsValidation map[string]string = map[string]string{
             sourceNode:
               description: The source node that the VMI originated on
               type: string
+            sourcePod:
+              type: string
             startTimestamp:
               description: The time the migration action began
               format: date-time
@@ -12689,6 +12691,8 @@ var CRDsValidation map[string]string = map[string]string{
               type: string
             sourceNode:
               description: The source node that the VMI originated on
+              type: string
+            sourcePod:
               type: string
             startTimestamp:
               description: The time the migration action began

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -12196,6 +12196,9 @@ var CRDsValidation map[string]string = map[string]string{
             failed:
               description: Indicates that the migration failed
               type: boolean
+            failureReason:
+              description: Contains the reason why the migration failed
+              type: string
             migrationConfiguration:
               description: Migration configurations to apply
               properties:
@@ -12596,6 +12599,9 @@ var CRDsValidation map[string]string = map[string]string{
             failed:
               description: Indicates that the migration failed
               type: boolean
+            failureReason:
+              description: Contains the reason why the migration failed
+              type: string
             migrationConfiguration:
               description: Migration configurations to apply
               properties:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -708,8 +708,11 @@ type VirtualMachineInstanceMigrationState struct {
 	TargetPod string `json:"targetPod,omitempty"`
 	// The UID of the target attachment pod for hotplug volumes
 	TargetAttachmentPodUID types.UID `json:"targetAttachmentPodUID,omitempty"`
+
 	// The source node that the VMI originated on
 	SourceNode string `json:"sourceNode,omitempty"`
+	SourcePod  string `json:"sourcePod,omitempty"`
+
 	// Indicates the migration completed
 	Completed bool `json:"completed,omitempty"`
 	// Indicates that the migration failed

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -721,6 +721,8 @@ type VirtualMachineInstanceMigrationState struct {
 	AbortRequested bool `json:"abortRequested,omitempty"`
 	// Indicates the final status of the live migration abortion
 	AbortStatus MigrationAbortStatus `json:"abortStatus,omitempty"`
+	// Contains the reason why the migration failed
+	FailureReason string `json:"failureReason,omitempty"`
 	// The VirtualMachineInstanceMigration object associated with this migration
 	MigrationUID types.UID `json:"migrationUid,omitempty"`
 	// Lets us know if the vmi is currently running pre or post copy migration

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -216,6 +216,7 @@ func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 		"failed":                         "Indicates that the migration failed",
 		"abortRequested":                 "Indicates that the migration has been requested to abort",
 		"abortStatus":                    "Indicates the final status of the live migration abortion",
+		"failureReason":                  "Contains the reason why the migration failed",
 		"migrationUid":                   "The VirtualMachineInstanceMigration object associated with this migration",
 		"mode":                           "Lets us know if the vmi is currently running pre or post copy migration",
 		"migrationPolicyName":            "Name of the migration policy. If string is empty, no policy is matched",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23547,6 +23547,12 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationState(ref comm
 							Format:      "",
 						},
 					},
+					"sourcePod": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"completed": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Indicates the migration completed",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23581,6 +23581,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationState(ref comm
 							Format:      "",
 						},
 					},
+					"failureReason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Contains the reason why the migration failed",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"migrationUid": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The VirtualMachineInstanceMigration object associated with this migration",

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -357,7 +357,7 @@ func CreateNodeAffinityRuleToMigrateFromSourceToTargetAndBack(sourceNode *k8sv1.
 		},
 	}, nil
 }
-func ConfirmVMIPostMigrationFailed(vmi *v1.VirtualMachineInstance, migrationUID string) {
+func ConfirmVMIPostMigrationFailed(vmi *v1.VirtualMachineInstance, migrationUID string) *v1.VirtualMachineInstance {
 	virtClient := kubevirt.Client()
 	By("Retrieving the VMI post migration")
 	vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
@@ -376,6 +376,8 @@ func ConfirmVMIPostMigrationFailed(vmi *v1.VirtualMachineInstance, migrationUID 
 
 	By("Verifying the VMI's is in the running state")
 	Expect(vmi.Status.Phase).To(Equal(v1.Running))
+
+	return vmi
 }
 
 func ConfirmVMIPostMigrationAborted(vmi *v1.VirtualMachineInstance, migrationUID string, timeout int) *v1.VirtualMachineInstance {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -316,10 +316,12 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 			// execute a migration, wait for finalized state
 			By("Starting the Migration for iteration")
+			sourcePod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			migration := libmigration.New(vmi.Name, vmi.Namespace)
 			migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 			By("Checking VMI, confirm migration state")
-			libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+			vmi = libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+			Expect(vmi.Status.MigrationState.SourcePod).To(Equal(sourcePod.Name))
 			confirmMigrationMode(vmi, mode)
 
 			By("Is agent connected after migration")

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1831,7 +1831,8 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					migrationUID := libmigration.RunMigrationAndExpectFailure(migration, 180)
 
 					// check VMI, confirm migration state
-					libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
+					vmi = libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
+					Expect(vmi.Status.MigrationState.FailureReason).To(ContainSubstring("has been aborted"))
 				})
 
 			})
@@ -1878,7 +1879,10 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				migrationUID := libmigration.RunMigrationAndExpectFailure(migration, 180)
 
 				// check VMI, confirm migration state
-				libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
+				vmi = libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
+				// Not sure how consistent the entire error is, so just making sure the failure happened in libvirt. Example string:
+				// Live migration failed error encountered during MigrateToURI3 libvirt api call: virError(Code=1, Domain=7, Message='internal error: client socket is closed'
+				Expect(vmi.Status.MigrationState.FailureReason).To(ContainSubstring("libvirt api call"))
 
 				By("Removing our migration killer pods")
 				for _, podName := range createdPods {
@@ -1935,7 +1939,8 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					migrationUID := libmigration.RunMigrationAndExpectFailure(migration, 180)
 
 					// check VMI, confirm migration state
-					libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
+					vmi = libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
+					Expect(vmi.Status.MigrationState.FailureReason).To(ContainSubstring("Failed migration to satisfy functional test condition"))
 
 					Eventually(func() error {
 						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
@@ -1973,7 +1978,8 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				migrationUID := libmigration.RunMigrationAndExpectFailure(migration, 180)
 
 				// check VMI, confirm migration state
-				libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
+				vmi = libmigration.ConfirmVMIPostMigrationFailed(vmi, migrationUID)
+				Expect(vmi.Status.MigrationState.FailureReason).To(ContainSubstring("Failed migration to satisfy functional test condition"))
 
 				Eventually(func() error {
 					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})


### PR DESCRIPTION
### What this PR does
Before this PR:
Migration state has no source pod and no failure reason

After this PR:
Migration state has a source pod and a failure reason

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
More information in the migration state of VMI / migration objects
```

