### PR TITLE
Replace deprecated functions and packages

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
@@ -868,8 +868,8 @@ func (ctrl *VMExportController) createExporterPodManifest(vmExport *exportv1.Vir
 	podManifest.Labels = map[string]string{exportServiceLabel: vmExport.Name}
 	podManifest.Annotations = map[string]string{annCertParams: scp}
 	podManifest.Spec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot:   pointer.Bool(true),
-		FSGroup:        pointer.Int64Ptr(kvm),
+		RunAsNonRoot:   ptr.To(true),
+		FSGroup:        ptr.To(int64(kvm)),
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 	for i, pvc := range pvcs {

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -45,7 +45,7 @@ import (
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	framework "k8s.io/client-go/tools/cache/testing"
@@ -534,7 +534,7 @@ var _ = Describe("Export controller", func() {
 				Namespace: testNamespace,
 			},
 			Status: &snapshotv1.VirtualMachineSnapshotStatus{
-				ReadyToUse: pointer.BoolPtr(false),
+				ReadyToUse: ptr.To(false),
 			},
 		}
 		syncCaches(stop)
@@ -590,7 +590,7 @@ var _ = Describe("Export controller", func() {
 						APIVersion: virtv1.GroupVersion.String(),
 						Kind:       "VirtualMachine",
 						Name:       testVmName,
-						Controller: pointer.BoolPtr(true),
+						Controller: ptr.To(true),
 					},
 				},
 			},
@@ -627,7 +627,7 @@ var _ = Describe("Export controller", func() {
 						APIVersion: virtv1.GroupVersion.String(),
 						Kind:       "VirtualMachine",
 						Name:       testVmName,
-						Controller: pointer.BoolPtr(true),
+						Controller: ptr.To(true),
 					},
 				},
 			},
@@ -830,7 +830,7 @@ var _ = Describe("Export controller", func() {
 				Namespace: testNamespace,
 			},
 			Spec: k8sv1.PersistentVolumeClaimSpec{
-				VolumeMode: (*k8sv1.PersistentVolumeMode)(pointer.StringPtr(string(k8sv1.PersistentVolumeBlock))),
+				VolumeMode: (*k8sv1.PersistentVolumeMode)(ptr.To(string(k8sv1.PersistentVolumeBlock))),
 			},
 		}
 		testVMExport := populateExportFunc()
@@ -1495,7 +1495,7 @@ func createPVCVMExport() *exportv1.VirtualMachineExport {
 				Kind:     "PersistentVolumeClaim",
 				Name:     testPVCName,
 			},
-			TokenSecretRef: pointer.StringPtr("token"),
+			TokenSecretRef: ptr.To("token"),
 		},
 	}
 }
@@ -1530,7 +1530,7 @@ func createSnapshotVMExport() *exportv1.VirtualMachineExport {
 				Kind:     "VirtualMachineSnapshot",
 				Name:     testVmsnapshotName,
 			},
-			TokenSecretRef: pointer.StringPtr("token"),
+			TokenSecretRef: ptr.To("token"),
 		},
 	}
 }
@@ -1549,7 +1549,7 @@ func createVMVMExport() *exportv1.VirtualMachineExport {
 				Kind:     "VirtualMachine",
 				Name:     testVmName,
 			},
-			TokenSecretRef: pointer.StringPtr("token"),
+			TokenSecretRef: ptr.To("token"),
 		},
 	}
 }

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
@@ -220,7 +220,7 @@ func (ctrl *VMExportController) updateVMExportVMStatus(vmExport *exportv1.Virtua
 	var requeue time.Duration
 
 	vmExportCopy := vmExport.DeepCopy()
-	vmExportCopy.Status.VirtualMachineName = pointer.StringPtr(vmExport.Spec.Source.Name)
+	vmExportCopy.Status.VirtualMachineName = ptr.To(vmExport.Spec.Source.Name)
 	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes, getVolumeName); err != nil {
 		return requeue, err
 	}

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	exportv1 "kubevirt.io/api/export/v1alpha1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
@@ -171,8 +171,8 @@ func (ctrl *VMExportController) getOrCreatePVCFromSnapshot(vmExport *exportv1.Vi
 			Kind:               exportGVK.Kind,
 			Name:               vmExport.Name,
 			UID:                vmExport.UID,
-			Controller:         pointer.BoolPtr(true),
-			BlockOwnerDeletion: pointer.BoolPtr(true),
+			Controller:         ptr.To(true),
+			BlockOwnerDeletion: ptr.To(true),
 		},
 	})
 
@@ -185,7 +185,7 @@ func (ctrl *VMExportController) getOrCreatePVCFromSnapshot(vmExport *exportv1.Vi
 
 func (ctrl *VMExportController) updateVMExporVMSnapshotStatus(vmExport *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, sourceVolumes *sourceVolumes) (time.Duration, error) {
 	vmExportCopy := vmExport.DeepCopy()
-	vmExportCopy.Status.VirtualMachineName = pointer.StringPtr(ctrl.getVmNameFromVmSnapshot(vmExport))
+	vmExportCopy.Status.VirtualMachineName = ptr.To(ctrl.getVmNameFromVmSnapshot(vmExport))
 
 	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes, getSnapshotVolumeName); err != nil {
 		return 0, err

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
@@ -240,8 +240,8 @@ var _ = Describe("VMSnapshot source", func() {
 			},
 			Spec: snapshotv1.VirtualMachineSnapshotSpec{},
 			Status: &snapshotv1.VirtualMachineSnapshotStatus{
-				VirtualMachineSnapshotContentName: pointer.StringPtr("snapshot-content"),
-				ReadyToUse:                        pointer.BoolPtr(ready),
+				VirtualMachineSnapshotContentName: ptr.To("snapshot-content"),
+				ReadyToUse:                        ptr.To(ready),
 			},
 		}
 	}
@@ -266,7 +266,7 @@ var _ = Describe("VMSnapshot source", func() {
 								},
 							},
 						},
-						VolumeSnapshotName: pointer.StringPtr(testVolumesnapshotName),
+						VolumeSnapshotName: ptr.To(testVolumesnapshotName),
 					},
 				},
 				Source: snapshotv1.SourceSpec{
@@ -292,7 +292,7 @@ var _ = Describe("VMSnapshot source", func() {
 				VolumeSnapshotStatus: []snapshotv1.VolumeSnapshotStatus{
 					{
 						VolumeSnapshotName: testVolumesnapshotName,
-						ReadyToUse:         pointer.BoolPtr(true),
+						ReadyToUse:         ptr.To(true),
 					},
 				},
 			},
@@ -359,7 +359,7 @@ var _ = Describe("VMSnapshot source", func() {
 					},
 				},
 				DataSource: &k8sv1.TypedLocalObjectReference{
-					APIGroup: pointer.StringPtr(vsv1.GroupName),
+					APIGroup: ptr.To(vsv1.GroupName),
 					Kind:     "VolumeSnapshot",
 					Name:     testVolumesnapshotName,
 				},
@@ -474,7 +474,7 @@ var _ = Describe("VMSnapshot source", func() {
 			Expect(pvc.Spec.Resources.Requests).ToNot(BeEmpty())
 			Expect(pvc.Spec.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
 			Expect(pvc.Spec.DataSource).To(Equal(&k8sv1.TypedLocalObjectReference{
-				APIGroup: pointer.StringPtr(vsv1.GroupName),
+				APIGroup: ptr.To(vsv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     testVolumesnapshotName,
 			}))
@@ -485,8 +485,8 @@ var _ = Describe("VMSnapshot source", func() {
 				Kind:               "VirtualMachineExport",
 				Name:               testVMExport.Name,
 				UID:                testVMExport.UID,
-				Controller:         pointer.BoolPtr(true),
-				BlockOwnerDeletion: pointer.BoolPtr(true),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}))
 			return true, pvc, nil
 		})
@@ -566,7 +566,7 @@ var _ = Describe("VMSnapshot source", func() {
 			Expect(pvc.Spec.Resources.Requests).ToNot(BeEmpty())
 			Expect(pvc.Spec.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
 			Expect(pvc.Spec.DataSource).To(Equal(&k8sv1.TypedLocalObjectReference{
-				APIGroup: pointer.StringPtr(vsv1.GroupName),
+				APIGroup: ptr.To(vsv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     testVolumesnapshotName,
 			}))
@@ -577,8 +577,8 @@ var _ = Describe("VMSnapshot source", func() {
 				Kind:               "VirtualMachineExport",
 				Name:               testVMExport.Name,
 				UID:                testVMExport.UID,
-				Controller:         pointer.BoolPtr(true),
-				BlockOwnerDeletion: pointer.BoolPtr(true),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}))
 			Expect(pvc.GetAnnotations()).ToNot(BeEmpty())
 			Expect(pvc.GetAnnotations()[annContentType]).To(BeEquivalentTo(cdiv1.DataVolumeKubeVirt))
@@ -617,7 +617,7 @@ var _ = Describe("VMSnapshot source", func() {
 			Expect(pvc.Spec.Resources.Requests).ToNot(BeEmpty())
 			Expect(pvc.Spec.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
 			Expect(pvc.Spec.DataSource).To(Equal(&k8sv1.TypedLocalObjectReference{
-				APIGroup: pointer.StringPtr(vsv1.GroupName),
+				APIGroup: ptr.To(vsv1.GroupName),
 				Kind:     "VolumeSnapshot",
 				Name:     testVolumesnapshotName,
 			}))
@@ -628,8 +628,8 @@ var _ = Describe("VMSnapshot source", func() {
 				Kind:               "VirtualMachineExport",
 				Name:               testVMExport.Name,
 				UID:                testVMExport.UID,
-				Controller:         pointer.BoolPtr(true),
-				BlockOwnerDeletion: pointer.BoolPtr(true),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}))
 			Expect(pvc.GetAnnotations()[annContentType]).To(BeEmpty())
 			return true, pvc, nil

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
@@ -834,7 +834,7 @@ var _ = Describe("Restore controller", func() {
 					}
 
 					Expect(vmRestore.Status.Restores).To(HaveLen(1))
-					vmRestore.Status.Restores[0].DataVolumeName = pointer.String(restoreDVName(vmRestore, vmRestore.Status.Restores[0].VolumeName))
+					vmRestore.Status.Restores[0].DataVolumeName = ptr.To(restoreDVName(vmRestore, vmRestore.Status.Restores[0].VolumeName))
 					expectPVCUpdates(k8sClient, vmRestore)
 
 					By("Making sure right VM update occurs")
@@ -886,8 +886,8 @@ var _ = Describe("Restore controller", func() {
 							Kind:               "VirtualMachine",
 							Name:               newVM.Name,
 							UID:                newVM.UID,
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
 						},
 					}
 

--- a/pkg/util/net/grpc/grpc.go
+++ b/pkg/util/net/grpc/grpc.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"kubevirt.io/client-go/log"
 
@@ -34,6 +35,7 @@ import (
 
 const (
 	CONNECT_TIMEOUT_SECONDS = 2
+	unixProtocol            = "unix"
 )
 
 func DialSocket(socketPath string) (*grpc.ClientConn, error) {
@@ -41,25 +43,25 @@ func DialSocket(socketPath string) (*grpc.ClientConn, error) {
 }
 
 func DialSocketWithTimeout(socketPath string, timeout int) (*grpc.ClientConn, error) {
+	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, unixProtocol, addr)
+	}
 
 	options := []grpc.DialOption{
 		grpc.WithAuthority("localhost"),
-		grpc.WithInsecure(),
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
-		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(dialer),
 		grpc.WithBlock(), // dial sync in order to catch errors early
 	}
 
+	ctxTimeout := time.Duration(timeout+CONNECT_TIMEOUT_SECONDS) * time.Second
 	if timeout > 0 {
-		options = append(options,
-			grpc.WithTimeout(time.Duration(timeout+CONNECT_TIMEOUT_SECONDS)*time.Second),
-		)
+		ctxTimeout = time.Duration(timeout) * time.Second
 	}
 
 	// Combined with the Block option, this context controls how long to wait for establishing the connection.
 	// The dial timeout used above, controls the overall duration of the connection (including RCP calls).
-	ctx, cancel := context.WithTimeout(context.Background(), CONNECT_TIMEOUT_SECONDS*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
 	return grpc.DialContext(ctx, socketPath, options...)

--- a/pkg/util/net/grpc/grpc.go
+++ b/pkg/util/net/grpc/grpc.go
@@ -43,14 +43,13 @@ func DialSocket(socketPath string) (*grpc.ClientConn, error) {
 }
 
 func DialSocketWithTimeout(socketPath string, timeout int) (*grpc.ClientConn, error) {
-	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
-		return (&net.Dialer{}).DialContext(ctx, unixProtocol, addr)
-	}
 
 	options := []grpc.DialOption{
 		grpc.WithAuthority("localhost"),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialer),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, unixProtocol, addr)
+		}),
 		grpc.WithBlock(), // dial sync in order to catch errors early
 	}
 

--- a/pkg/util/net/grpc/grpc.go
+++ b/pkg/util/net/grpc/grpc.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	CONNECT_TIMEOUT_SECONDS = 2
-	unixProtocol            = "unix"
+	defaultTimeSeconds = 2
+	unixProtocol       = "unix"
 )
 
 func DialSocket(socketPath string) (*grpc.ClientConn, error) {
@@ -53,7 +53,7 @@ func DialSocketWithTimeout(socketPath string, timeout int) (*grpc.ClientConn, er
 		grpc.WithBlock(), // dial sync in order to catch errors early
 	}
 
-	ctxTimeout := time.Duration(timeout+CONNECT_TIMEOUT_SECONDS) * time.Second
+	ctxTimeout := time.Duration(timeout+defaultTimeSeconds) * time.Second
 	if timeout > 0 {
 		ctxTimeout = time.Duration(timeout) * time.Second
 	}

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/pkg/util/status"
 
@@ -444,7 +444,7 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 				return
 			}
 			// set terminationGracePeriod to 1 (which is the shorted safe restart period) and delete the VMI pod to trigger a swift restart.
-			err = app.virtCli.CoreV1().Pods(namespace).Delete(context.Background(), vmiPodname, k8smetav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(1)})
+			err = app.virtCli.CoreV1().Pods(namespace).Delete(context.Background(), vmiPodname, k8smetav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(1))})
 			if err != nil {
 				if !errors.IsNotFound(err) {
 					writeError(errors.NewInternalError(err), response)

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
@@ -102,7 +102,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 	var vmiClient *kubecli.MockVirtualMachineInstanceInterface
 	var migrateClient *kubecli.MockVirtualMachineInstanceMigrationInterface
 
-	gracePeriodZero := pointer.Int64(0)
+	gracePeriodZero := ptr.To(int64(0))
 
 	kv := &v1.KubeVirt{
 		ObjectMeta: k8smetav1.ObjectMeta{
@@ -450,7 +450,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 				vm := v1.VirtualMachine{
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(NotRunning),
+						Running: ptr.To(NotRunning),
 					},
 				}
 
@@ -470,7 +470,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				bytesRepresentation, _ := json.Marshal(restartOptions)
 				request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
 
-				vm := newVirtualMachineWithRunning(pointer.Bool(Running))
+				vm := newVirtualMachineWithRunning(ptr.To(Running))
 				vmi := v1.VirtualMachineInstance{
 					Spec: v1.VirtualMachineInstanceSpec{},
 				}
@@ -527,7 +527,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				bytesRepresentation, _ := json.Marshal(body)
 				request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
 
-				vm := newVirtualMachineWithRunning(pointer.Bool(Running))
+				vm := newVirtualMachineWithRunning(ptr.To(Running))
 				vmi := v1.VirtualMachineInstance{
 					Spec: v1.VirtualMachineInstanceSpec{},
 				}
@@ -553,7 +553,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				request.PathParameters()["name"] = testVMName
 				request.PathParameters()["namespace"] = k8smetav1.NamespaceDefault
 
-				vm := newVirtualMachineWithRunning(pointer.Bool(Running))
+				vm := newVirtualMachineWithRunning(ptr.To(Running))
 
 				vmi := v1.VirtualMachineInstance{
 					Spec: v1.VirtualMachineInstanceSpec{},
@@ -574,7 +574,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				request.PathParameters()["name"] = testVMName
 				request.PathParameters()["namespace"] = k8smetav1.NamespaceDefault
 
-				vm := newVirtualMachineWithRunning(pointer.Bool(Running))
+				vm := newVirtualMachineWithRunning(ptr.To(Running))
 				vmi := newVirtualMachineInstanceInPhase(v1.Running)
 
 				vmClient.EXPECT().Get(context.Background(), vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil)
@@ -596,7 +596,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				bytesRepresentation, _ := json.Marshal(stopOptions)
 				request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
 
-				vm := newVirtualMachineWithRunning(pointer.Bool(Running))
+				vm := newVirtualMachineWithRunning(ptr.To(Running))
 
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: k8smetav1.ObjectMeta{
@@ -1639,11 +1639,11 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				Expect(response.StatusCode()).To(Equal(http.StatusAccepted))
 			}
 		},
-			Entry("fail with nil graceperiod", pointer.Int64(int64(1800)), nil, true),
-			Entry("fail with equal graceperiod", pointer.Int64(int64(1800)), pointer.Int64(int64(1800)), true),
-			Entry("fail with greater graceperiod", pointer.Int64(int64(1800)), pointer.Int64(int64(2400)), true),
-			Entry("not fail with non-nil graceperiod and nil termination graceperiod", nil, pointer.Int64(int64(1800)), false),
-			Entry("not fail with shorter graceperiod and non-nil termination graceperiod", pointer.Int64(int64(1800)), pointer.Int64(int64(800)), false),
+			Entry("fail with nil graceperiod", ptr.To(int64(1800)), nil, true),
+			Entry("fail with equal graceperiod", ptr.To(int64(1800)), ptr.To(int64(1800)), true),
+			Entry("fail with greater graceperiod", ptr.To(int64(1800)), ptr.To(int64(2400)), true),
+			Entry("not fail with non-nil graceperiod and nil termination graceperiod", nil, ptr.To(int64(1800)), false),
+			Entry("not fail with shorter graceperiod and non-nil termination graceperiod", ptr.To(int64(1800)), ptr.To(int64(800)), false),
 		)
 
 		DescribeTable("should not fail on VM with RunStrategy", func(runStrategy v1.VirtualMachineRunStrategy) {
@@ -2175,7 +2175,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 					Namespace: k8smetav1.NamespaceDefault,
 				},
 				Spec: v1.VirtualMachineSpec{
-					Running:  pointer.Bool(NotRunning),
+					Running:  ptr.To(NotRunning),
 					Template: &v1.VirtualMachineInstanceTemplateSpec{},
 				},
 			}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -13,7 +13,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/api/clone"
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
@@ -27,7 +27,7 @@ var _ = Describe("Clone mutating webhook", func() {
 	BeforeEach(func() {
 		vmClone = kubecli.NewMinimalCloneWithNS("testclone", util.NamespaceTestDefault)
 		vmClone.Spec.Source = &k8sv1.TypedLocalObjectReference{
-			APIGroup: pointer.String(clone.GroupName),
+			APIGroup: ptr.To(clone.GroupName),
 			Kind:     "VirtualMachine",
 			Name:     "test-source-vm",
 		}
@@ -41,7 +41,7 @@ var _ = Describe("Clone mutating webhook", func() {
 
 	It("Target name should be auto generated if missing", func() {
 		vmClone.Spec.Target = &k8sv1.TypedLocalObjectReference{
-			APIGroup: pointer.String(clone.GroupName),
+			APIGroup: ptr.To(clone.GroupName),
 			Kind:     "VirtualMachine",
 			Name:     "",
 		}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	rt "runtime"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -673,7 +673,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				SyNICTimer: &v1.SyNICTimer{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -713,13 +713,13 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				Relaxed: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				Runtime: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				Reset: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -728,13 +728,13 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 		hyperv := v1.FeatureHyperv{
 			Relaxed: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 			Runtime: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 			Reset: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 		}
 
@@ -752,10 +752,10 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				Relaxed: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				SyNICTimer: &v1.SyNICTimer{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -764,16 +764,16 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 		hyperv := v1.FeatureHyperv{
 			Relaxed: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 			VPIndex: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 			SyNIC: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 			SyNICTimer: &v1.SyNICTimer{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 		}
 
@@ -791,14 +791,14 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				VPIndex: &v1.FeatureState{
-					Enabled: pointer.Bool(false),
+					Enabled: ptr.To(false),
 				},
 				// should enable SyNIC
 				SyNICTimer: &v1.SyNICTimer{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				EVMCS: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -810,19 +810,19 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 		hyperv := v1.FeatureHyperv{
 			VPIndex: &v1.FeatureState{
-				Enabled: pointer.Bool(false),
+				Enabled: ptr.To(false),
 			},
 			SyNIC: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 			SyNICTimer: &v1.SyNICTimer{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 			EVMCS: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 			VAPIC: &v1.FeatureState{
-				Enabled: pointer.Bool(true),
+				Enabled: ptr.To(true),
 			},
 		}
 
@@ -949,13 +949,13 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Entry("if hyperV doesn't contain EVMCS", api.NewMinimalVMI("testvmi"),
 			&v1.FeatureHyperv{
 				Relaxed: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			}, nil),
 
 		Entry("if EVMCS is explicitly false ", api.NewMinimalVMI("testvmi"),
 			&v1.FeatureHyperv{
-				EVMCS: &v1.FeatureState{Enabled: pointer.BoolPtr(false)},
+				EVMCS: &v1.FeatureState{Enabled: ptr.To(false)},
 			},
 			nil,
 		),
@@ -969,7 +969,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 		Entry("if EVMCS is explicitly true ", api.NewMinimalVMI("testvmi"),
 			&v1.FeatureHyperv{
-				EVMCS: &v1.FeatureState{Enabled: pointer.BoolPtr(true)},
+				EVMCS: &v1.FeatureState{Enabled: ptr.To(true)},
 			}, &v1.CPU{
 				Features: cpuFeatures,
 			}),
@@ -1145,7 +1145,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			&v1.LaunchSecurity{
 				SEV: &v1.SEV{
 					Policy: &v1.SEVPolicy{
-						EncryptedState: pointer.Bool(true),
+						EncryptedState: ptr.To(true),
 					},
 				},
 			}),
@@ -1182,7 +1182,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			&v1.LaunchSecurity{
 				SEV: &v1.SEV{
 					Policy: &v1.SEVPolicy{
-						EncryptedState: pointer.Bool(false),
+						EncryptedState: ptr.To(false),
 					},
 				},
 			}),
@@ -1196,7 +1196,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			&v1.LaunchSecurity{
 				SEV: &v1.SEV{
 					Policy: &v1.SEVPolicy{
-						EncryptedState: pointer.Bool(true),
+						EncryptedState: ptr.To(true),
 					},
 				},
 			}),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/api/migrations"
 
@@ -60,7 +60,7 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 		),
 
 		Entry("negative CompletionTimeoutPerGiB",
-			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: pointer.Int64Ptr(-1)},
+			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: ptr.To(int64(-1))},
 		),
 	)
 
@@ -77,11 +77,11 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 		),
 
 		Entry("greater than zero CompletionTimeoutPerGiB",
-			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: pointer.Int64Ptr(1)},
+			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: ptr.To(int64(1))},
 		),
 
 		Entry("zero CompletionTimeoutPerGiB",
-			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: pointer.Int64Ptr(0)},
+			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: ptr.To(int64(0))},
 		),
 
 		Entry("zero BandwidthPerMigration",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/api/clone"
 	clonev1lpha1 "kubevirt.io/api/clone/v1alpha1"
@@ -175,7 +175,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 					Namespace: util.NamespaceTestDefault,
 				},
 				Status: &v1alpha1.VirtualMachineSnapshotStatus{
-					VirtualMachineSnapshotContentName: pointer.String("snapshot-contents"),
+					VirtualMachineSnapshotContentName: ptr.To("snapshot-contents"),
 				},
 			}
 			return true, snapshot, nil
@@ -190,7 +190,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 
 			contents := &v1alpha1.VirtualMachineSnapshotContent{
 				Spec: v1alpha1.VirtualMachineSnapshotContentSpec{
-					VirtualMachineSnapshotName: pointer.String("test-vm"),
+					VirtualMachineSnapshotName: ptr.To("test-vm"),
 					Source: v1alpha1.SourceSpec{
 						VirtualMachine: &v1alpha1.VirtualMachine{
 							Spec: vm.Spec,
@@ -234,7 +234,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		}),
 		Entry("Source with empty APIGroup", func() *k8sv1.TypedLocalObjectReference {
 			source := newValidObjReference()
-			source.APIGroup = pointer.String("")
+			source.APIGroup = ptr.To("")
 			return source
 		}),
 		Entry("Source with bad kind", func() *k8sv1.TypedLocalObjectReference {
@@ -335,7 +335,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			kubevirtClient.Fake.PrependReactor("get", "virtualmachinesnapshotcontents", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				contents := &v1alpha1.VirtualMachineSnapshotContent{
 					Spec: v1alpha1.VirtualMachineSnapshotContentSpec{
-						VirtualMachineSnapshotName: pointer.String("test-vm"),
+						VirtualMachineSnapshotName: ptr.To("test-vm"),
 						Source: v1alpha1.SourceSpec{
 							VirtualMachine: &v1alpha1.VirtualMachine{
 								Spec: vm.Spec,
@@ -443,7 +443,7 @@ func newValidClone() *clonev1lpha1.VirtualMachineClone {
 
 func newValidObjReference() *k8sv1.TypedLocalObjectReference {
 	return &k8sv1.TypedLocalObjectReference{
-		APIGroup: pointer.String(core.GroupName),
+		APIGroup: ptr.To(core.GroupName),
 		Kind:     virtualMachineKind,
 		Name:     "clone-source-vm",
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -85,14 +85,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	enableSlirpInterface := func() {
 		kvConfig := kv.DeepCopy()
 		kvConfig.Spec.Configuration.NetworkConfiguration = &v1.NetworkConfiguration{
-			PermitSlirpInterface: pointer.Bool(true),
+			PermitSlirpInterface: ptr.To(true),
 		}
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
 	}
 	disableBridgeOnPodNetwork := func() {
 		kvConfig := kv.DeepCopy()
 		kvConfig.Spec.Configuration.NetworkConfiguration = &v1.NetworkConfiguration{
-			PermitBridgeInterfaceOnPodNetwork: pointer.Bool(false),
+			PermitBridgeInterfaceOnPodNetwork: ptr.To(false),
 		}
 
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
@@ -155,7 +155,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		vmi.Spec.Domain.Clock = &v1.Clock{
 			ClockOffset: v1.ClockOffset{
 				UTC: &v1.ClockOffsetUTC{
-					OffsetSeconds: pointer.Int(5),
+					OffsetSeconds: ptr.To(5),
 				},
 			},
 		}
@@ -1964,7 +1964,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		It("should allow BlockMultiQueue with CPU settings", func() {
 			vmi := api.NewMinimalVMI("testvm")
-			vmi.Spec.Domain.Devices.BlockMultiQueue = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.BlockMultiQueue = ptr.To(true)
 			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{}
 			vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("5")
 
@@ -1974,7 +1974,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		It("should ignore CPU settings for explicitly rejected BlockMultiQueue", func() {
 			vmi := api.NewMinimalVMI("testvm")
-			vmi.Spec.Domain.Devices.BlockMultiQueue = pointer.Bool(false)
+			vmi.Spec.Domain.Devices.BlockMultiQueue = ptr.To(false)
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty())
@@ -3150,21 +3150,21 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks,
 				v1.Disk{
 					Name:              "disk-with-dedicated-io-thread-and-sata",
-					DedicatedIOThread: pointer.Bool(true),
+					DedicatedIOThread: ptr.To(true),
 					DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{
 						Bus: v1.DiskBusSATA,
 					}},
 				},
 				v1.Disk{
 					Name:              "disk-with-dedicated-io-thread-and-virtio",
-					DedicatedIOThread: pointer.Bool(true),
+					DedicatedIOThread: ptr.To(true),
 					DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{
 						Bus: v1.DiskBusVirtio,
 					}},
 				},
 				v1.Disk{
 					Name:              "disk-without-dedicated-io-thread-and-with-sata",
-					DedicatedIOThread: pointer.Bool(false),
+					DedicatedIOThread: ptr.To(false),
 					DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{
 						Bus: v1.DiskBusSATA,
 					}},
@@ -3251,7 +3251,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Name: "blockdisk",
 					BlockSize: &v1.BlockSize{
 						MatchVolume: &v1.FeatureState{
-							Enabled: pointer.Bool(true),
+							Enabled: ptr.To(true),
 						},
 					},
 				})
@@ -3271,7 +3271,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 							Physical: 1234,
 						},
 						MatchVolume: &v1.FeatureState{
-							Enabled: pointer.Bool(true),
+							Enabled: ptr.To(true),
 						},
 					},
 				})
@@ -3292,7 +3292,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 							Physical: 4096,
 						},
 						MatchVolume: &v1.FeatureState{
-							Enabled: pointer.Bool(false),
+							Enabled: ptr.To(false),
 						},
 					},
 				})
@@ -3564,7 +3564,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			vmi.Spec.Domain.Features = &v1.Features{
 				SMM: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			}
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
@@ -3598,7 +3598,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{
-						SecureBoot: pointer.Bool(false),
+						SecureBoot: ptr.To(false),
 					},
 				},
 			}
@@ -3613,7 +3613,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			vmi.Spec.Domain.Features = &v1.Features{
 				SMM: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			}
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
@@ -3678,7 +3678,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{
-						SecureBoot: pointer.Bool(true),
+						SecureBoot: ptr.To(true),
 					},
 				},
 			}
@@ -3766,7 +3766,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{
-						SecureBoot: pointer.Bool(false),
+						SecureBoot: ptr.To(false),
 					},
 				},
 			}
@@ -3803,10 +3803,10 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		It("should reject when SecureBoot is enabled", func() {
 			vmi.Spec.Domain.Features = &v1.Features{
 				SMM: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			}
-			vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.Bool(true)
+			vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = ptr.To(true)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("SEV does not work along with SecureBoot"))
@@ -3854,7 +3854,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Expect(causes).To(BeEmpty())
 			})
 			It("should accept vmi with vsocks defined", func() {
-				vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+				vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				Expect(causes).To(BeEmpty())
 			})
@@ -3862,7 +3862,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		Context("feature gate disabled", func() {
 			It("should reject when the feature gate is disabled", func() {
 				disableFeatureGates()
-				vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+				vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", virtconfig.VSOCKGate)))
@@ -4661,14 +4661,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	Context("with VM persistent state defined", func() {
 		var vmi *v1.VirtualMachineInstance
 		addPersistentTPM := func() {
-			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.BoolPtr(true)}
+			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: ptr.To(true)}
 		}
 		addPersistentEFI := func() {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{
-						Persistent: pointer.BoolPtr(true),
-						SecureBoot: pointer.BoolPtr(false),
+						Persistent: ptr.To(true),
+						SecureBoot: ptr.To(false),
 					},
 				},
 			}
@@ -4990,13 +4990,13 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				Relaxed: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				Runtime: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				Reset: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -5010,7 +5010,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				EVMCS: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -5035,7 +5035,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				EVMCS: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -5051,10 +5051,10 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				EVMCS: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				VAPIC: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -5078,10 +5078,10 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				EVMCS: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				VAPIC: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -5105,10 +5105,10 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				EVMCS: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				VAPIC: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -5122,13 +5122,13 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				Relaxed: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				SyNIC: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				SyNICTimer: &v1.SyNICTimer{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}
@@ -5142,16 +5142,16 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		vmi.Spec.Domain.Features = &v1.Features{
 			Hyperv: &v1.FeatureHyperv{
 				Relaxed: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				VPIndex: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				SyNIC: &v1.FeatureState{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 				SyNICTimer: &v1.SyNICTimer{
-					Enabled: pointer.Bool(true),
+					Enabled: ptr.To(true),
 				},
 			},
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -274,7 +274,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 						Domain: v1.DomainSpec{
 							Devices: v1.Devices{
 								TPM: &v1.TPMDevice{
-									Persistent: pointer.BoolPtr(true),
+									Persistent: ptr.To(true),
 								},
 							},
 						},

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -192,7 +192,7 @@ func securityContext(userId int64, privileged bool, requiredCapabilities *k8sv1.
 
 	if isNonRoot {
 		context.RunAsGroup = &userId
-		context.AllowPrivilegeEscalation = pointer.Bool(false)
+		context.AllowPrivilegeEscalation = ptr.To(false)
 	}
 
 	return context

--- a/pkg/virt-controller/services/serialconsolelog.go
+++ b/pkg/virt-controller/services/serialconsolelog.go
@@ -3,7 +3,7 @@ package services
 import (
 	"fmt"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -35,9 +35,9 @@ func generateSerialConsoleLogContainer(vmi *v1.VirtualMachineInstance, image str
 			},
 			Resources: resources,
 			SecurityContext: &k8sv1.SecurityContext{
-				RunAsUser:                pointer.Int64(util.NonRootUID),
-				RunAsNonRoot:             pointer.Bool(true),
-				AllowPrivilegeEscalation: pointer.Bool(false),
+				RunAsUser:                ptr.To(int64(util.NonRootUID)),
+				RunAsNonRoot:             ptr.To(true),
+				AllowPrivilegeEscalation: ptr.To(false),
 				Capabilities: &k8sv1.Capabilities{
 					Drop: []k8sv1.Capability{"ALL"},
 				},

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
@@ -302,7 +302,7 @@ func computePodSecurityContext(vmi *v1.VirtualMachineInstance, seccomp *k8sv1.Se
 		nonRootUser := int64(util.NonRootUID)
 		psc.RunAsUser = &nonRootUser
 		psc.RunAsGroup = &nonRootUser
-		psc.RunAsNonRoot = pointer.Bool(true)
+		psc.RunAsNonRoot = ptr.To(true)
 		psc.FSGroup = &nonRootUser
 	} else {
 		rootUser := int64(util.RootUser)
@@ -485,7 +485,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			volumeSource := k8sv1.VolumeSource{
 				ConfigMap: &k8sv1.ConfigMapVolumeSource{
 					LocalObjectReference: k8sv1.LocalObjectReference{Name: cm.Name},
-					DefaultMode:          pointer.Int32(0755),
+					DefaultMode:          ptr.To(int32(0755)),
 				},
 			}
 			vol := k8sv1.Volume{
@@ -863,8 +863,8 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 					Command:   command,
 					Resources: hotplugContainerResourceRequirementsForVMI(vmi, t.clusterConfig),
 					SecurityContext: &k8sv1.SecurityContext{
-						AllowPrivilegeEscalation: pointer.Bool(false),
-						RunAsNonRoot:             pointer.Bool(true),
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsNonRoot:             ptr.To(true),
 						RunAsUser:                &runUser,
 						SeccompProfile: &k8sv1.SeccompProfile{
 							Type: k8sv1.SeccompProfileTypeRuntimeDefault,
@@ -1006,8 +1006,8 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 					Command:   command,
 					Resources: hotplugContainerResourceRequirementsForVMI(vmi, t.clusterConfig),
 					SecurityContext: &k8sv1.SecurityContext{
-						AllowPrivilegeEscalation: pointer.Bool(false),
-						RunAsNonRoot:             pointer.Bool(true),
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsNonRoot:             ptr.To(true),
 						RunAsUser:                &runUser,
 						SeccompProfile: &k8sv1.SeccompProfile{
 							Type: k8sv1.SeccompProfileTypeRuntimeDefault,
@@ -1115,7 +1115,7 @@ func (t *templateService) RenderExporterManifest(vmExport *exportv1.VirtualMachi
 						},
 					},
 					SecurityContext: &k8sv1.SecurityContext{
-						AllowPrivilegeEscalation: pointer.Bool(false),
+						AllowPrivilegeEscalation: ptr.To(false),
 						Capabilities:             &k8sv1.Capabilities{Drop: []k8sv1.Capability{"ALL"}},
 					},
 					Resources: vmExportContainerResourceRequirements(t.clusterConfig),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
@@ -218,14 +218,14 @@ var _ = Describe("Template", func() {
 		It("should set seccomp profile when configured", func() {
 			expectedProfile := &k8sv1.SeccompProfile{
 				Type:             k8sv1.SeccompProfileTypeLocalhost,
-				LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
+				LocalhostProfile: ptr.To("kubevirt/kubevirt.json"),
 			}
 			_, kvInformer, svc = configFactory(defaultArch)
 			kvConfig := kv.DeepCopy()
 			kvConfig.Spec.Configuration.SeccompConfiguration = &v1.SeccompConfiguration{
 				VirtualMachineInstanceProfile: &v1.VirtualMachineInstanceProfile{
 					CustomProfile: &v1.CustomProfile{
-						LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
+						LocalhostProfile: ptr.To("kubevirt/kubevirt.json"),
 					},
 				},
 			}
@@ -1434,19 +1434,19 @@ var _ = Describe("Template", func() {
 							Features: &v1.Features{
 								Hyperv: &v1.FeatureHyperv{
 									SyNIC: &v1.FeatureState{
-										Enabled: pointer.BoolPtr(true),
+										Enabled: ptr.To(true),
 									},
 									SyNICTimer: &v1.SyNICTimer{
-										Enabled: pointer.BoolPtr(true),
+										Enabled: ptr.To(true),
 									},
 									Frequencies: &v1.FeatureState{
-										Enabled: pointer.BoolPtr(true),
+										Enabled: ptr.To(true),
 									},
 									IPI: &v1.FeatureState{
-										Enabled: pointer.BoolPtr(true),
+										Enabled: ptr.To(true),
 									},
 									EVMCS: &v1.FeatureState{
-										Enabled: pointer.BoolPtr(EVMCSEnabled),
+										Enabled: ptr.To(EVMCSEnabled),
 									},
 								},
 							},
@@ -1515,7 +1515,7 @@ var _ = Describe("Template", func() {
 
 			Context("TSC frequency label", func() {
 				var noHints, validHints *v1.TopologyHints
-				validHints = &v1.TopologyHints{TSCFrequency: pointer.Int64(123123)}
+				validHints = &v1.TopologyHints{TSCFrequency: ptr.To(int64(123123))}
 
 				setVmWithTscRequirementType := func(vmi *v1.VirtualMachineInstance, tscRequirementType topology.TscFrequencyRequirementType) {
 					switch tscRequirementType {
@@ -1533,7 +1533,7 @@ var _ = Describe("Template", func() {
 						vmi.Spec.Domain.Features = &v1.Features{
 							Hyperv: &v1.FeatureHyperv{
 								Reenlightenment: &v1.FeatureState{
-									Enabled: pointer.Bool(true),
+									Enabled: ptr.To(true),
 								},
 							},
 						}
@@ -2126,11 +2126,11 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
 				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 335),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", pointer.Bool(true), 335),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", pointer.Bool(false), 318),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", ptr.To(true), 335),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", ptr.To(false), 318),
 				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 469),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", pointer.Bool(true), 469),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", pointer.Bool(false), 453),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", ptr.To(true), 469),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", ptr.To(false), 453),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -3886,7 +3886,7 @@ var _ = Describe("Template", func() {
 			}, &k8sv1.PodSecurityContext{
 				RunAsUser:    &nonRootUser,
 				RunAsGroup:   &nonRootUser,
-				RunAsNonRoot: pointer.Bool(true),
+				RunAsNonRoot: ptr.To(true),
 				FSGroup:      &nonRootUser,
 			}),
 			Entry("on a passt vmi", func() *v1.VirtualMachineInstance {
@@ -3902,7 +3902,7 @@ var _ = Describe("Template", func() {
 			}, &k8sv1.PodSecurityContext{
 				RunAsUser:    &nonRootUser,
 				RunAsGroup:   &nonRootUser,
-				RunAsNonRoot: pointer.Bool(true),
+				RunAsNonRoot: ptr.To(true),
 				FSGroup:      &nonRootUser,
 			}),
 			Entry("on a virtiofs vmi", func() *v1.VirtualMachineInstance {
@@ -3916,7 +3916,7 @@ var _ = Describe("Template", func() {
 			}, &k8sv1.PodSecurityContext{
 				RunAsUser:    &nonRootUser,
 				RunAsGroup:   &nonRootUser,
-				RunAsNonRoot: pointer.Bool(true),
+				RunAsNonRoot: ptr.To(true),
 				FSGroup:      &nonRootUser,
 			}),
 		)
@@ -3933,8 +3933,8 @@ var _ = Describe("Template", func() {
 
 			runUser := int64(util.NonRootUID)
 			Expect(*pod.Spec.Containers[0].SecurityContext).To(Equal(k8sv1.SecurityContext{
-				AllowPrivilegeEscalation: pointer.Bool(false),
-				RunAsNonRoot:             pointer.Bool(true),
+				AllowPrivilegeEscalation: ptr.To(false),
+				RunAsNonRoot:             ptr.To(true),
 				RunAsUser:                &runUser,
 				SeccompProfile: &k8sv1.SeccompProfile{
 					Type: k8sv1.SeccompProfileTypeRuntimeDefault,
@@ -4047,8 +4047,8 @@ var _ = Describe("Template", func() {
 
 			runUser := int64(util.NonRootUID)
 			Expect(*pod.Spec.Containers[0].SecurityContext).To(Equal(k8sv1.SecurityContext{
-				AllowPrivilegeEscalation: pointer.Bool(false),
-				RunAsNonRoot:             pointer.Bool(true),
+				AllowPrivilegeEscalation: ptr.To(false),
+				RunAsNonRoot:             ptr.To(true),
 				RunAsUser:                &runUser,
 				SeccompProfile: &k8sv1.SeccompProfile{
 					Type: k8sv1.SeccompProfileTypeRuntimeDefault,
@@ -4271,7 +4271,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				originalOverhead := GetMemoryOverhead(vmi, config.GetClusterCPUArch(), nil)
-				actualOverheadWithHeadroom := GetMemoryOverhead(vmi, config.GetClusterCPUArch(), pointer.String(ratioStr))
+				actualOverheadWithHeadroom := GetMemoryOverhead(vmi, config.GetClusterCPUArch(), ptr.To(ratioStr))
 				expectedOverheadWithHeadroom := multiplyMemory(originalOverhead, ratio)
 
 				const errFmt = "overhead without headroom: %s, ratio: %s, actual overhead with headroom: %s, expected overhead with headroom: %s"
@@ -4319,7 +4319,7 @@ var _ = Describe("Template", func() {
 						VolumeSource: k8sv1.VolumeSource{
 							ConfigMap: &k8sv1.ConfigMapVolumeSource{
 								LocalObjectReference: k8sv1.LocalObjectReference{Name: "test-cm"},
-								DefaultMode:          pointer.Int32(0755),
+								DefaultMode:          ptr.To(int32(0755)),
 							},
 						},
 					}))
@@ -4480,7 +4480,7 @@ var _ = Describe("Template", func() {
 	Context("with VSOCK enabled", func() {
 		It("should add VSOCK device to resources", func() {
 			vmi := api.NewMinimalVMI("fake-vmi")
-			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 
 			pod, err := svc.RenderLaunchManifest(vmi)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -5,7 +5,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/config"
@@ -126,8 +126,8 @@ func securityContextVirtioFS(profile securityProfile) *k8sv1.SecurityContext {
 	return &k8sv1.SecurityContext{
 		RunAsUser:                credential,
 		RunAsGroup:               credential,
-		RunAsNonRoot:             pointer.Bool(isRestricted(profile)),
-		AllowPrivilegeEscalation: pointer.Bool(isPrivileged(profile)),
+		RunAsNonRoot:             ptr.To(isRestricted(profile)),
+		AllowPrivilegeEscalation: ptr.To(isPrivileged(profile)),
 		Capabilities:             virtiofsCapabilities(profile),
 	}
 }

--- a/pkg/virt-controller/watch/clone/clone.go
+++ b/pkg/virt-controller/watch/clone/clone.go
@@ -31,7 +31,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -293,7 +293,7 @@ func (ctrl *VMCloneController) updateStatus(origClone *clonev1alpha1.VirtualMach
 	}
 	if isInPhase(vmClone, clonev1alpha1.SnapshotInProgress) {
 		if snapshotName := syncInfo.snapshotName; snapshotName != "" {
-			vmClone.Status.SnapshotName = pointer.String(snapshotName)
+			vmClone.Status.SnapshotName = ptr.To(snapshotName)
 		}
 
 		if syncInfo.snapshotReady {
@@ -302,7 +302,7 @@ func (ctrl *VMCloneController) updateStatus(origClone *clonev1alpha1.VirtualMach
 	}
 	if isInPhase(vmClone, clonev1alpha1.RestoreInProgress) {
 		if restoreName := syncInfo.restoreName; restoreName != "" {
-			vmClone.Status.RestoreName = pointer.String(restoreName)
+			vmClone.Status.RestoreName = ptr.To(restoreName)
 		}
 
 		if syncInfo.restoreReady {
@@ -311,7 +311,7 @@ func (ctrl *VMCloneController) updateStatus(origClone *clonev1alpha1.VirtualMach
 	}
 	if isInPhase(vmClone, clonev1alpha1.CreatingTargetVM) {
 		if targetVMName := syncInfo.targetVMName; targetVMName != "" {
-			vmClone.Status.TargetName = pointer.String(targetVMName)
+			vmClone.Status.TargetName = ptr.To(targetVMName)
 		}
 
 		if syncInfo.targetVMCreated {

--- a/pkg/virt-controller/watch/clone/util.go
+++ b/pkg/virt-controller/watch/clone/util.go
@@ -5,7 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -89,7 +89,7 @@ func generateSnapshot(vmClone *clonev1alpha1.VirtualMachineClone, sourceVM *v1.V
 			Source: corev1.TypedLocalObjectReference{
 				Kind:     vmKind,
 				Name:     sourceVM.Name,
-				APIGroup: pointer.String(kubevirtApiGroup),
+				APIGroup: ptr.To(kubevirtApiGroup),
 			},
 		},
 	}
@@ -123,8 +123,8 @@ func getCloneOwnerReference(cloneName string, cloneUID types.UID) metav1.OwnerRe
 		Kind:               clonev1alpha1.VirtualMachineCloneKind.Kind,
 		Name:               cloneName,
 		UID:                cloneUID,
-		Controller:         pointer.Bool(true),
-		BlockOwnerDeletion: pointer.Bool(true),
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
 	}
 }
 

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -31,7 +31,7 @@ import (
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
 
@@ -1777,7 +1777,7 @@ var _ = Describe("Migration watcher", func() {
 			testutils.ExpectEvent(recorder, SuccessfulHandOverPodReason)
 		},
 			Entry("allow auto coverage",
-				func(p *migrationsv1.MigrationPolicySpec) { p.AllowAutoConverge = pointer.BoolPtr(true) },
+				func(p *migrationsv1.MigrationPolicySpec) { p.AllowAutoConverge = ptr.To(true) },
 				func(c *virtv1.MigrationConfiguration) {
 					Expect(c.AllowAutoConverge).ToNot(BeNil())
 					Expect(*c.AllowAutoConverge).To(BeTrue())
@@ -1785,7 +1785,7 @@ var _ = Describe("Migration watcher", func() {
 				true,
 			),
 			Entry("deny auto coverage",
-				func(p *migrationsv1.MigrationPolicySpec) { p.AllowAutoConverge = pointer.BoolPtr(false) },
+				func(p *migrationsv1.MigrationPolicySpec) { p.AllowAutoConverge = ptr.To(false) },
 				func(c *virtv1.MigrationConfiguration) {
 					Expect(c.AllowAutoConverge).ToNot(BeNil())
 					Expect(*c.AllowAutoConverge).To(BeFalse())
@@ -1809,7 +1809,7 @@ var _ = Describe("Migration watcher", func() {
 				true,
 			),
 			Entry("deny post copy",
-				func(p *migrationsv1.MigrationPolicySpec) { p.AllowPostCopy = pointer.BoolPtr(false) },
+				func(p *migrationsv1.MigrationPolicySpec) { p.AllowPostCopy = ptr.To(false) },
 				func(c *virtv1.MigrationConfiguration) {
 					Expect(c.AllowPostCopy).ToNot(BeNil())
 					Expect(*c.AllowPostCopy).To(BeFalse())
@@ -2025,7 +2025,7 @@ var _ = Describe("Migration watcher", func() {
 		It("should not be forced to the SELinux level of the source if the CR option is set to false", func() {
 			initController(&virtv1.KubeVirtConfiguration{
 				MigrationConfiguration: &virtv1.MigrationConfiguration{
-					MatchSELinuxLevelOnMigration: pointer.BoolPtr(false),
+					MatchSELinuxLevelOnMigration: ptr.To(false),
 				},
 			})
 			vmi := newVirtualMachine("testvmi", virtv1.Running)

--- a/pkg/virt-controller/watch/pool.go
+++ b/pkg/virt-controller/watch/pool.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"k8s.io/utils/trace"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -598,7 +598,7 @@ func calculateNewVMNames(count int, baseName string, namespace string, vmStore c
 }
 
 func poolOwnerRef(pool *poolv1.VirtualMachinePool) metav1.OwnerReference {
-	t := pointer.BoolPtr(true)
+	t := ptr.To(true)
 	gvk := schema.GroupVersionKind{Group: poolv1.SchemeGroupVersion.Group, Version: poolv1.SchemeGroupVersion.Version, Kind: poolv1.VirtualMachinePoolKind}
 	return metav1.OwnerReference{
 		APIVersion:         gvk.GroupVersion().String(),

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
@@ -41,7 +41,7 @@ func (t *topologyHinter) TopologyHintsForVMI(vmi *k6tv1.VirtualMachineInstance) 
 		return nil, requirement, fmt.Errorf("failed to determine the lowest tsc frequency on the cluster: %v", err)
 	}
 
-	hints = &k6tv1.TopologyHints{TSCFrequency: pointer.Int64Ptr(freq)}
+	hints = &k6tv1.TopologyHints{TSCFrequency: ptr.To(int64(freq))}
 	return
 }
 

--- a/pkg/virt-controller/watch/topology/hinter_test.go
+++ b/pkg/virt-controller/watch/topology/hinter_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -55,7 +55,7 @@ var _ = Describe("Hinter", func() {
 		g.Expect(GetTscFrequencyRequirement(vmi).Type).ToNot(g.Equal(NotRequired))
 		g.Expect(hinter.TopologyHintsForVMI(vmi)).To(g.Equal(
 			&virtv1.TopologyHints{
-				TSCFrequency: pointer.Int64Ptr(12),
+				TSCFrequency: ptr.To(int64(12)),
 			},
 		))
 	})

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -3,7 +3,7 @@ package topology_test
 import (
 	"fmt"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -87,7 +87,7 @@ var _ = Describe("TSC", func() {
 
 		newVmi := func(options ...libvmi.Option) *v1.VirtualMachineInstance {
 			vmi := libvmi.New(options...)
-			vmi.Status.TopologyHints = &v1.TopologyHints{TSCFrequency: pointer.Int64(12345)}
+			vmi.Status.TopologyHints = &v1.TopologyHints{TSCFrequency: ptr.To(int64(12345))}
 
 			return vmi
 		}
@@ -104,7 +104,7 @@ var _ = Describe("TSC", func() {
 			vmi := newVmi()
 			vmi.Spec.Domain.Features = &v1.Features{
 				Hyperv: &v1.FeatureHyperv{
-					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+					Reenlightenment: &v1.FeatureState{Enabled: ptr.To(true)},
 				},
 			}
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -4131,7 +4131,7 @@ var _ = Describe("VirtualMachine", func() {
 				BeforeEach(func() {
 					preferenceSpec := instancetypev1beta1.VirtualMachinePreferenceSpec{
 						Firmware: &instancetypev1beta1.FirmwarePreferences{
-							PreferredUseEfi: pointer.Bool(true),
+							PreferredUseEfi: ptr.To(true),
 						},
 						Devices: &instancetypev1beta1.DevicePreferences{
 							PreferredDiskBus:        virtv1.DiskBusVirtio,
@@ -4253,7 +4253,7 @@ var _ = Describe("VirtualMachine", func() {
 					Entry("using v1alpha1 and VirtualMachinePreferenceSpecRevision with APIVersion", func() []byte {
 						v1alpha1preferenceSpec := instancetypev1alpha1.VirtualMachinePreferenceSpec{
 							Firmware: &instancetypev1alpha1.FirmwarePreferences{
-								PreferredUseEfi: pointer.Bool(true),
+								PreferredUseEfi: ptr.To(true),
 							},
 							Devices: &instancetypev1alpha1.DevicePreferences{
 								PreferredDiskBus:        virtv1.DiskBusVirtio,
@@ -4278,7 +4278,7 @@ var _ = Describe("VirtualMachine", func() {
 					Entry("using v1alpha1 and VirtualMachinePreferenceSpecRevision without APIVersion", func() []byte {
 						v1alpha1preferenceSpec := instancetypev1alpha1.VirtualMachinePreferenceSpec{
 							Firmware: &instancetypev1alpha1.FirmwarePreferences{
-								PreferredUseEfi: pointer.Bool(true),
+								PreferredUseEfi: ptr.To(true),
 							},
 							Devices: &instancetypev1alpha1.DevicePreferences{
 								PreferredDiskBus:        virtv1.DiskBusVirtio,
@@ -4311,7 +4311,7 @@ var _ = Describe("VirtualMachine", func() {
 							},
 							Spec: instancetypev1alpha1.VirtualMachinePreferenceSpec{
 								Firmware: &instancetypev1alpha1.FirmwarePreferences{
-									PreferredUseEfi: pointer.Bool(true),
+									PreferredUseEfi: ptr.To(true),
 								},
 								Devices: &instancetypev1alpha1.DevicePreferences{
 									PreferredDiskBus:        virtv1.DiskBusVirtio,
@@ -4337,7 +4337,7 @@ var _ = Describe("VirtualMachine", func() {
 							},
 							Spec: instancetypev1alpha2.VirtualMachinePreferenceSpec{
 								Firmware: &instancetypev1alpha2.FirmwarePreferences{
-									PreferredUseEfi: pointer.Bool(true),
+									PreferredUseEfi: ptr.To(true),
 								},
 								Devices: &instancetypev1alpha2.DevicePreferences{
 									PreferredDiskBus:        virtv1.DiskBusVirtio,
@@ -4575,7 +4575,7 @@ var _ = Describe("VirtualMachine", func() {
 				It("should reject if an existing ControllerRevision is found with unexpected VirtualMachinePreferenceSpec data", func() {
 					unexpectedPreference := preference.DeepCopy()
 					unexpectedPreference.Spec.Firmware = &instancetypev1beta1.FirmwarePreferences{
-						PreferredUseBios: pointer.Bool(true),
+						PreferredUseBios: ptr.To(true),
 					}
 
 					preferenceRevision, err := instancetype.CreateControllerRevision(vm, unexpectedPreference)
@@ -4648,7 +4648,7 @@ var _ = Describe("VirtualMachine", func() {
 						},
 						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 							Devices: &instancetypev1beta1.DevicePreferences{
-								PreferredAutoattachPodInterface: pointer.Bool(false),
+								PreferredAutoattachPodInterface: ptr.To(false),
 							},
 						},
 					}
@@ -4747,7 +4747,7 @@ var _ = Describe("VirtualMachine", func() {
 						Kind: instancetypeapi.SingularPreferenceResourceName,
 					}
 
-					vm.Spec.Template.Spec.Domain.Devices.AutoattachInputDevice = pointer.Bool(true)
+					vm.Spec.Template.Spec.Domain.Devices.AutoattachInputDevice = ptr.To(true)
 
 					expectedPreferenceRevision, err := instancetype.CreateControllerRevision(vm, preference)
 					Expect(err).ToNot(HaveOccurred())
@@ -4783,7 +4783,7 @@ var _ = Describe("VirtualMachine", func() {
 						},
 						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 							Devices: &instancetypev1beta1.DevicePreferences{
-								PreferredAutoattachInputDevice: pointer.Bool(true),
+								PreferredAutoattachInputDevice: ptr.To(true),
 								PreferredInputBus:              virtv1.InputBusVirtio,
 								PreferredInputType:             virtv1.InputTypeTablet,
 							},
@@ -4831,7 +4831,7 @@ var _ = Describe("VirtualMachine", func() {
 						},
 						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 							Devices: &instancetypev1beta1.DevicePreferences{
-								PreferredAutoattachInputDevice: pointer.Bool(false),
+								PreferredAutoattachInputDevice: ptr.To(false),
 							},
 						},
 					}
@@ -4996,10 +4996,10 @@ var _ = Describe("VirtualMachine", func() {
 			sanityExecute(vm)
 
 		},
-			Entry("add default input device when enabled in VirtualMachine", pointer.Bool(true), []v1.Input{}, &v1.Input{Name: "default-0"}),
-			Entry("not add default input device when disabled by VirtualMachine", pointer.Bool(false), []v1.Input{}, nil),
+			Entry("add default input device when enabled in VirtualMachine", ptr.To(true), []v1.Input{}, &v1.Input{Name: "default-0"}),
+			Entry("not add default input device when disabled by VirtualMachine", ptr.To(false), []v1.Input{}, nil),
 			Entry("not add default input device by default", nil, []v1.Input{}, nil),
-			Entry("not add default input device when devices already present in VirtualMachine", pointer.Bool(true), []v1.Input{{Name: "existing-0"}}, &v1.Input{Name: "existing-0"}),
+			Entry("not add default input device when devices already present in VirtualMachine", ptr.To(true), []v1.Input{{Name: "existing-0"}}, &v1.Input{Name: "existing-0"}),
 		)
 
 		Context("Live update features", func() {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -31,7 +31,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -275,7 +275,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		kubevirtFakeConfig := &virtv1.KubeVirtConfiguration{
 			DeveloperConfiguration: &virtv1.DeveloperConfiguration{
-				MinimumClusterTSCFrequency: pointer.Int64(12345),
+				MinimumClusterTSCFrequency: ptr.To(int64(12345)),
 			},
 		}
 
@@ -3236,7 +3236,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Spec.Architecture = "amd64"
 			vmi.Spec.Domain.Features = &v1.Features{
 				Hyperv: &v1.FeatureHyperv{
-					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+					Reenlightenment: &v1.FeatureState{Enabled: ptr.To(true)},
 				},
 			}
 
@@ -3340,7 +3340,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.GuestNotRunningReason)
 			vmi.Status.Phase = virtv1.Scheduling
-			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			addVirtualMachine(vmi)
@@ -3357,7 +3357,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("should recycle the CID when the pods are deleted", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 			Expect(controller.cidsMap.Allocate(vmi)).To(Succeed())
 			vmi.Status.Phase = virtv1.Succeeded
 			addVirtualMachine(vmi)

--- a/pkg/virt-handler/migration-proxy/migration-proxy_test.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy_test.go
@@ -28,7 +28,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -209,8 +209,8 @@ var _ = Describe("MigrationProxy", func() {
 					}
 				}
 			},
-				Entry("with TLS enabled", &v1.MigrationConfiguration{DisableTLS: pointer.BoolPtr(false)}),
-				Entry("with TLS disabled", &v1.MigrationConfiguration{DisableTLS: pointer.BoolPtr(true)}),
+				Entry("with TLS enabled", &v1.MigrationConfiguration{DisableTLS: ptr.To(false)}),
+				Entry("with TLS disabled", &v1.MigrationConfiguration{DisableTLS: ptr.To(true)}),
 			)
 
 			DescribeTable("by ensuring no new listeners can be created after shutdown", func(migrationConfig *v1.MigrationConfiguration) {
@@ -255,8 +255,8 @@ var _ = Describe("MigrationProxy", func() {
 				Expect(err.Error()).To(Equal("unable to process new migration connections during virt-handler shutdown"))
 
 			},
-				Entry("with TLS enabled", &v1.MigrationConfiguration{DisableTLS: pointer.BoolPtr(false)}),
-				Entry("with TLS disabled", &v1.MigrationConfiguration{DisableTLS: pointer.BoolPtr(true)}),
+				Entry("with TLS enabled", &v1.MigrationConfiguration{DisableTLS: ptr.To(false)}),
+				Entry("with TLS disabled", &v1.MigrationConfiguration{DisableTLS: ptr.To(true)}),
 			)
 		})
 	})

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -32,7 +32,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
@@ -1281,8 +1281,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 						vmi.Spec.Volumes[0].Name: uint32(1234),
 					},
 					KernelBootChecksum: container_disk.KernelBootChecksum{
-						Kernel: pointer.Uint32(33),
-						Initrd: pointer.Uint32(35),
+						Kernel: ptr.To(uint32(33)),
+						Initrd: ptr.To(uint32(35)),
 					},
 				}
 
@@ -2892,14 +2892,14 @@ var _ = Describe("VirtualMachineInstance", func() {
 				}
 			},
 				Entry("CDROM", getCDRomDisk(nil), getContainerDiskVolume(), v1.LiveMigration),
-				Entry("CDROM with read-only=true", getCDRomDisk(pointer.BoolPtr(true)), getContainerDiskVolume(), v1.LiveMigration),
-				Entry("CDROM with read-only=false", getCDRomDisk(pointer.BoolPtr(false)), getContainerDiskVolume(), v1.BlockMigration),
+				Entry("CDROM with read-only=true", getCDRomDisk(ptr.To(true)), getContainerDiskVolume(), v1.LiveMigration),
+				Entry("CDROM with read-only=false", getCDRomDisk(ptr.To(false)), getContainerDiskVolume(), v1.BlockMigration),
 			)
 		})
 
 		It("HyperV reenlightenment shouldn't be migratable when tsc frequency is missing", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
-			vmi.Spec.Domain.Features = &v1.Features{Hyperv: &v1.FeatureHyperv{Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)}}}
+			vmi.Spec.Domain.Features = &v1.Features{Hyperv: &v1.FeatureHyperv{Reenlightenment: &v1.FeatureState{Enabled: ptr.To(true)}}}
 			vmi.Status.TopologyHints = nil
 
 			cond, _ := controller.calculateLiveMigrationCondition(vmi)

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
@@ -1316,7 +1316,7 @@ var _ = Describe("Converter", func() {
 			func(useVirtioTransitional bool) {
 				cid := uint32(100)
 				vmi.Status.VSOCKCID = &cid
-				vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+				vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 				c.UseVirtioTransitional = useVirtioTransitional
 				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
 				Expect(domainSpec.Devices.VSOCK).ToNot(BeNil())
@@ -2459,7 +2459,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{
-						SecureBoot: pointer.BoolPtr(false),
+						SecureBoot: ptr.To(false),
 					},
 				},
 			}
@@ -2734,7 +2734,7 @@ var _ = Describe("Converter", func() {
 			vmi = kvapi.NewMinimalVMI("testvmi")
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
-			vmi.Spec.Domain.Devices.AutoattachMemBalloon = pointer.BoolPtr(true)
+			vmi.Spec.Domain.Devices.AutoattachMemBalloon = ptr.To(true)
 			nonVirtioIface := v1.Interface{Name: "red", Model: "e1000"}
 			secondaryNetwork := v1.Network{Name: "red"}
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
@@ -2748,13 +2748,13 @@ var _ = Describe("Converter", func() {
 			}
 			vmi.Spec.Domain.Features = &v1.Features{
 				SMM: &v1.FeatureState{
-					Enabled: pointer.BoolPtr(false),
+					Enabled: ptr.To(false),
 				},
 			}
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{
-						SecureBoot: pointer.BoolPtr(false),
+						SecureBoot: ptr.To(false),
 					},
 				},
 			}
@@ -2778,7 +2778,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{
 				SEV: &v1.SEV{
 					Policy: &v1.SEVPolicy{
-						EncryptedState: pointer.Bool(true),
+						EncryptedState: ptr.To(true),
 					},
 				},
 			}
@@ -2846,7 +2846,7 @@ var _ = Describe("Converter", func() {
 		BeforeEach(func() {
 			vmi = kvapi.NewMinimalVMI("testvmi")
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			vmi.Status.TopologyHints = &v1.TopologyHints{TSCFrequency: pointer.Int64(fakeFrequency)}
+			vmi.Status.TopologyHints = &v1.TopologyHints{TSCFrequency: ptr.To(int64(fakeFrequency))}
 			c = &ConverterContext{
 				AllowEmulation: true,
 			}
@@ -2883,7 +2883,7 @@ var _ = Describe("Converter", func() {
 			It("hyperV reenlightenment", func() {
 				vmi.Spec.Domain.Features = &v1.Features{
 					Hyperv: &v1.FeatureHyperv{
-						Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+						Reenlightenment: &v1.FeatureState{Enabled: ptr.To(true)},
 					},
 				}
 

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
@@ -7,12 +7,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"kubevirt.io/client-go/log"
 
 	v1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -21,13 +18,6 @@ import (
 type factoryFunc func(requestedToplogy *api.CPUTopology, nodeTopology *v1.Topology, cpuSet []int) VCPUPool
 
 var _ = Describe("VCPU pinning", func() {
-
-	BeforeEach(func() {
-		seed := time.Now().UnixNano()
-		rand.Seed(seed)
-		log.DefaultLogger().Infof("using seed %v for cpu pinning tests", seed)
-	})
-
 	for _, factory := range []factoryFunc{NewRelaxedCPUPool, NewStrictCPUPool} {
 		generatePositiveCPUPinningTests(
 			defaultArgs().HostThreadsPerCore(1).CellCount(1).VCPUCores(12).VCPUThreadsPerCore(1).CPUPoolFactory(factory),

--- a/pkg/virt-launcher/virtwrap/launchsecurity/sev_test.go
+++ b/pkg/virt-launcher/virtwrap/launchsecurity/sev_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -43,12 +43,12 @@ var _ = Describe("LaunchSecurity: AMD Secure Encrypted Virtualization (SEV)", fu
 			Expect(launchsecurity.SEVPolicyToBits(&policy)).To(Equal(launchsecurity.SEVPolicyNoDebug))
 
 			policy = v1.SEVPolicy{
-				EncryptedState: pointer.Bool(false),
+				EncryptedState: ptr.To(false),
 			}
 			Expect(launchsecurity.SEVPolicyToBits(&policy)).To(Equal(launchsecurity.SEVPolicyNoDebug))
 
 			policy = v1.SEVPolicy{
-				EncryptedState: pointer.Bool(true),
+				EncryptedState: ptr.To(true),
 			}
 			Expect(launchsecurity.SEVPolicyToBits(&policy)).ToNot(Equal(launchsecurity.SEVPolicyNoDebug))
 			Expect(launchsecurity.SEVPolicyToBits(&policy) & launchsecurity.SEVPolicyNoDebug).To(Equal(launchsecurity.SEVPolicyNoDebug))
@@ -58,9 +58,9 @@ var _ = Describe("LaunchSecurity: AMD Secure Encrypted Virtualization (SEV)", fu
 			Expect(field).ToNot(BeNil())
 			*field = nil
 			Expect(launchsecurity.SEVPolicyToBits(&policy)).To(Equal(launchsecurity.SEVPolicyNoDebug))
-			*field = pointer.Bool(true)
+			*field = ptr.To(true)
 			Expect(launchsecurity.SEVPolicyToBits(&policy)).To(Equal(launchsecurity.SEVPolicyNoDebug | expectedBit))
-			*field = pointer.Bool(false)
+			*field = ptr.To(false)
 			Expect(launchsecurity.SEVPolicyToBits(&policy)).To(Equal(launchsecurity.SEVPolicyNoDebug))
 		},
 			Entry("EncryptedState", launchsecurity.SEVPolicyEncryptedState, &policy.EncryptedState),

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -41,7 +41,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/generic"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/gpu"
@@ -1675,7 +1675,7 @@ func (l *LibvirtDomainManager) SoftRebootVMI(vmi *v1.VirtualMachineInstance) err
 
 func (l *LibvirtDomainManager) MarkGracefulShutdownVMI() {
 	l.metadataCache.GracePeriod.WithSafeBlock(func(gracePeriodMetadata *api.GracePeriodMetadata, _ bool) {
-		gracePeriodMetadata.MarkedForGracefulShutdown = pointer.Bool(true)
+		gracePeriodMetadata.MarkedForGracefulShutdown = ptr.To(true)
 	})
 	log.Log.V(4).Infof("Marked for graceful shutdown in metadata: %s", l.metadataCache.GracePeriod.String())
 }

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -37,7 +37,7 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
@@ -1420,7 +1420,7 @@ var _ = Describe("Manager", func() {
 			manager.MarkGracefulShutdownVMI()
 
 			gracePeriod, _ := metadataCache.GracePeriod.Load()
-			Expect(gracePeriod.MarkedForGracefulShutdown).To(Equal(pointer.Bool(true)))
+			Expect(gracePeriod.MarkedForGracefulShutdown).To(Equal(ptr.To(true)))
 		})
 
 		It("Should signal graceful shutdown after marked for shutdown", func() {

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -9,14 +9,14 @@ import (
 	"runtime"
 	"strings"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -276,16 +276,16 @@ var _ = Describe("LibvirtHelper", func() {
 	Context("getLibvirtLogFilters()", func() {
 
 		DescribeTable("should return customLogFilters if defined and not empty with", func(libvirtLogVerbosityEnvVar *string, libvirtDebugLogsEnvVarDefined bool) {
-			customLogFilters := pointer.String("3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access")
+			customLogFilters := ptr.To("3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access")
 
 			logFilters, enableDebugLogs := getLibvirtLogFilters(customLogFilters, libvirtLogVerbosityEnvVar, libvirtDebugLogsEnvVarDefined)
 			Expect(enableDebugLogs).To(BeTrue())
 			Expect(logFilters).To(Equal(*customLogFilters))
 		},
 			Entry("libvirtLogVerbosityEnvVar not defined, libvirtDebugLogsEnvVarDefined false", nil, false),
-			Entry("libvirtLogVerbosityEnvVar defined, libvirtDebugLogsEnvVarDefined false", pointer.String("2"), false),
+			Entry("libvirtLogVerbosityEnvVar defined, libvirtDebugLogsEnvVarDefined false", ptr.To("2"), false),
 			Entry("libvirtLogVerbosityEnvVar not defined, libvirtDebugLogsEnvVarDefined true", nil, true),
-			Entry("libvirtLogVerbosityEnvVar defined, libvirtDebugLogsEnvVarDefined true", pointer.String("1"), true),
+			Entry("libvirtLogVerbosityEnvVar defined, libvirtDebugLogsEnvVarDefined true", ptr.To("1"), true),
 		)
 
 		Context("with customLogFilters not defined", func() {
@@ -296,8 +296,8 @@ var _ = Describe("LibvirtHelper", func() {
 				_, enableDebugLogs := getLibvirtLogFilters(nil, libvirtLogVerbosityEnvVar, true)
 				Expect(enableDebugLogs).To(BeTrue())
 			},
-				Entry("libvirtLogVerbosityEnvVar defined to 8", pointer.String("8")),
-				Entry("libvirtLogVerbosityEnvVar defined to 3", pointer.String("3")),
+				Entry("libvirtLogVerbosityEnvVar defined to 8", ptr.To("8")),
+				Entry("libvirtLogVerbosityEnvVar defined to 3", ptr.To("3")),
 				Entry("libvirtLogVerbosityEnvVar is not defined", nil),
 			)
 
@@ -305,15 +305,15 @@ var _ = Describe("LibvirtHelper", func() {
 
 				var libvirtLogVerbosityEnvVar *string
 				if libvirtLogVerbosity != nil {
-					libvirtLogVerbosityEnvVar = pointer.String(fmt.Sprintf("%d", *libvirtLogVerbosity))
+					libvirtLogVerbosityEnvVar = ptr.To(fmt.Sprintf("%d", *libvirtLogVerbosity))
 				}
 
 				_, enableDebugLogs := getLibvirtLogFilters(nil, libvirtLogVerbosityEnvVar, false)
 				Expect(enableDebugLogs).To(Equal(expectedEnableDebugLogs))
 			},
-				Entry("be disabled when libvirt log verbosity is below threshold", pointer.Int(verbosityThreshold-1), false),
-				Entry("be disabled when libvirt log verbosity is equal to threshold", pointer.Int(verbosityThreshold), true),
-				Entry("be enabled when libvirt log verbosity is above threshold", pointer.Int(verbosityThreshold+1), true),
+				Entry("be disabled when libvirt log verbosity is below threshold", ptr.To(verbosityThreshold-1), false),
+				Entry("be disabled when libvirt log verbosity is equal to threshold", ptr.To(verbosityThreshold), true),
+				Entry("be enabled when libvirt log verbosity is above threshold", ptr.To(verbosityThreshold+1), true),
 				Entry("be disabled when libvirt log verbosity is not defined", nil, false),
 			)
 

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -61,7 +61,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	apiinstancetype "kubevirt.io/api/instancetype"
@@ -1743,7 +1743,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{
 					Phase:              v1.KubeVirtPhaseDeleted,
-					ObservedGeneration: pointer.Int64Ptr(1),
+					ObservedGeneration: ptr.To(int64(1)),
 				},
 			}
 			// Add kubevirt deployment and mark everything as ready
@@ -1813,7 +1813,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				Status: v1.KubeVirtStatus{
 					Phase:              v1.KubeVirtPhaseDeployed,
 					OperatorVersion:    version.Get().String(),
-					ObservedGeneration: pointer.Int64Ptr(1),
+					ObservedGeneration: ptr.To(int64(1)),
 				},
 			}
 
@@ -1855,7 +1855,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				Status: v1.KubeVirtStatus{
 					Phase:              v1.KubeVirtPhaseDeployed,
 					OperatorVersion:    version.Get().String(),
-					ObservedGeneration: pointer.Int64Ptr(1),
+					ObservedGeneration: ptr.To(int64(1)),
 				},
 			}
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
@@ -2015,7 +2015,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				Status: v1.KubeVirtStatus{
 					Phase:              v1.KubeVirtPhaseDeployed,
 					OperatorVersion:    version.Get().String(),
-					ObservedGeneration: pointer.Int64Ptr(1),
+					ObservedGeneration: ptr.To(int64(1)),
 				},
 			}
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
@@ -2078,7 +2078,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				Status: v1.KubeVirtStatus{
 					Phase:              v1.KubeVirtPhaseDeployed,
 					OperatorVersion:    version.Get().String(),
-					ObservedGeneration: pointer.Int64Ptr(1),
+					ObservedGeneration: ptr.To(int64(1)),
 				},
 			}
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -65,7 +65,7 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 		if err != nil {
 			log.Log.Object(deployment).Warningf(err.Error())
 		} else {
-			deployment.Spec.Replicas = pointer.Int32(replicas)
+			deployment.Spec.Replicas = ptr.To(int32(replicas))
 		}
 	}
 

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -36,7 +36,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
@@ -228,14 +228,14 @@ func NewPresetCrd() (*extv1.CustomResourceDefinition, error) {
 				Served:             true,
 				Storage:            false,
 				Deprecated:         true,
-				DeprecationWarning: pointer.String("kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2."),
+				DeprecationWarning: ptr.To("kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2."),
 			},
 			{
 				Name:               "v1alpha3",
 				Served:             true,
 				Storage:            true,
 				Deprecated:         true,
-				DeprecationWarning: pointer.String("kubevirt.io/v1alpha3 VirtualMachineInstancePresets is now deprecated and will be removed in v2."),
+				DeprecationWarning: ptr.To("kubevirt.io/v1alpha3 VirtualMachineInstancePresets is now deprecated and will be removed in v2."),
 			},
 		},
 		Scope: "Namespaced",
@@ -628,13 +628,13 @@ func NewVirtualMachineInstancetypeCrd() (*extv1.CustomResourceDefinition, error)
 			Served:             true,
 			Storage:            false,
 			Deprecated:         true,
-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha1 VirtualMachineInstancetypes is now deprecated and will be removed in v1."),
+			DeprecationWarning: ptr.To("instancetype.kubevirt.io/v1alpha1 VirtualMachineInstancetypes is now deprecated and will be removed in v1."),
 		}, {
 			Name:               instancetypev1alpha2.SchemeGroupVersion.Version,
 			Served:             true,
 			Storage:            false,
 			Deprecated:         true,
-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha2 VirtualMachineInstancetypes is now deprecated and will be removed in v1."),
+			DeprecationWarning: ptr.To("instancetype.kubevirt.io/v1alpha2 VirtualMachineInstancetypes is now deprecated and will be removed in v1."),
 		}, {
 			Name:    instancetypev1beta1.SchemeGroupVersion.Version,
 			Served:  true,
@@ -669,13 +669,13 @@ func NewVirtualMachineClusterInstancetypeCrd() (*extv1.CustomResourceDefinition,
 			Served:             true,
 			Storage:            false,
 			Deprecated:         true,
-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha1 VirtualMachineClusterInstanceTypes is now deprecated and will be removed in v1."),
+			DeprecationWarning: ptr.To("instancetype.kubevirt.io/v1alpha1 VirtualMachineClusterInstanceTypes is now deprecated and will be removed in v1."),
 		}, {
 			Name:               instancetypev1alpha2.SchemeGroupVersion.Version,
 			Served:             true,
 			Storage:            false,
 			Deprecated:         true,
-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha2 VirtualMachineClusterInstanceTypes is now deprecated and will be removed in v1."),
+			DeprecationWarning: ptr.To("instancetype.kubevirt.io/v1alpha2 VirtualMachineClusterInstanceTypes is now deprecated and will be removed in v1."),
 		}, {
 			Name:    instancetypev1beta1.SchemeGroupVersion.Version,
 			Served:  true,
@@ -711,13 +711,13 @@ func NewVirtualMachinePreferenceCrd() (*extv1.CustomResourceDefinition, error) {
 			Served:             true,
 			Storage:            false,
 			Deprecated:         true,
-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha1 VirtualMachinePreferences is now deprecated and will be removed in v1."),
+			DeprecationWarning: ptr.To("instancetype.kubevirt.io/v1alpha1 VirtualMachinePreferences is now deprecated and will be removed in v1."),
 		}, {
 			Name:               instancetypev1alpha2.SchemeGroupVersion.Version,
 			Served:             true,
 			Storage:            false,
 			Deprecated:         true,
-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha2 VirtualMachinePreferences is now deprecated and will be removed in v1."),
+			DeprecationWarning: ptr.To("instancetype.kubevirt.io/v1alpha2 VirtualMachinePreferences is now deprecated and will be removed in v1."),
 		}, {
 			Name:    instancetypev1beta1.SchemeGroupVersion.Version,
 			Served:  true,
@@ -752,13 +752,13 @@ func NewVirtualMachineClusterPreferenceCrd() (*extv1.CustomResourceDefinition, e
 			Served:             true,
 			Storage:            false,
 			Deprecated:         true,
-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha1 VirtualMachineClusterPreferences is now deprecated and will be removed in v1."),
+			DeprecationWarning: ptr.To("instancetype.kubevirt.io/v1alpha1 VirtualMachineClusterPreferences is now deprecated and will be removed in v1."),
 		}, {
 			Name:               instancetypev1alpha2.SchemeGroupVersion.Version,
 			Served:             true,
 			Storage:            false,
 			Deprecated:         true,
-			DeprecationWarning: pointer.String("instancetype.kubevirt.io/v1alpha2 VirtualMachineClusterPreferences is now deprecated and will be removed in v1."),
+			DeprecationWarning: ptr.To("instancetype.kubevirt.io/v1alpha2 VirtualMachineClusterPreferences is now deprecated and will be removed in v1."),
 		}, {
 			Name:    instancetypev1beta1.SchemeGroupVersion.Version,
 			Served:  true,

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	virtv1 "kubevirt.io/api/core/v1"
 
@@ -42,8 +42,8 @@ func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:  pointer.Int64(util.RootUser),
-			Privileged: pointer.Bool(true),
+			RunAsUser:  ptr.To(int64(util.RootUser)),
+			Privileged: ptr.To(true),
 		},
 	}
 }
@@ -123,7 +123,7 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 				"node-labeller.sh",
 			},
 			SecurityContext: &corev1.SecurityContext{
-				Privileged: pointer.Bool(true),
+				Privileged: ptr.To(true),
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -193,7 +193,7 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 		},
 	}
 	container.SecurityContext = &corev1.SecurityContext{
-		Privileged: pointer.Bool(true),
+		Privileged: ptr.To(true),
 		SELinuxOptions: &corev1.SELinuxOptions{
 			Level: "s0",
 		},

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -261,7 +261,7 @@ func newBaseDeployment(deploymentName, imageName, namespace, repository, version
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(2),
+			Replicas: ptr.To(int32(2)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					kubevirtLabelKey: deploymentName,
@@ -327,7 +327,7 @@ func NewApiServerDeployment(namespace, repository, imagePrefix, version, product
 	pod := &deployment.Spec.Template.Spec
 	pod.ServiceAccountName = ApiServiceAccountName
 	pod.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot:   pointer.Bool(true),
+		RunAsNonRoot:   ptr.To(true),
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 
@@ -379,7 +379,7 @@ func NewApiServerDeployment(namespace, repository, imagePrefix, version, product
 	}
 
 	container.SecurityContext = &corev1.SecurityContext{
-		AllowPrivilegeEscalation: pointer.Bool(false),
+		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
@@ -408,7 +408,7 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 	pod := &deployment.Spec.Template.Spec
 	pod.ServiceAccountName = ControllerServiceAccountName
 	pod.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot:   pointer.Bool(true),
+		RunAsNonRoot:   ptr.To(true),
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 
@@ -476,7 +476,7 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 	}
 
 	container.SecurityContext = &corev1.SecurityContext{
-		AllowPrivilegeEscalation: pointer.Bool(false),
+		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
@@ -510,7 +510,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(2),
+			Replicas: ptr.To(int32(2)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					virtv1.AppLabel: VirtOperatorName,
@@ -597,7 +597,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: pointer.Bool(false),
+								AllowPrivilegeEscalation: ptr.To(false),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
@@ -606,7 +606,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 						},
 					},
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot:   pointer.Bool(true),
+						RunAsNonRoot:   ptr.To(true),
 						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 				},
@@ -646,7 +646,7 @@ func NewExportProxyDeployment(namespace, repository, imagePrefix, version, produ
 	pod := &deployment.Spec.Template.Spec
 	pod.ServiceAccountName = ExportProxyServiceAccountName
 	pod.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot: pointer.Bool(true),
+		RunAsNonRoot: ptr.To(true),
 	}
 
 	const shortName = "exportproxy"

--- a/pkg/virt-operator/resource/generate/components/webhooks.go
+++ b/pkg/virt-operator/resource/generate/components/webhooks.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/api/clone"
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
@@ -157,7 +157,7 @@ func NewOpertorValidatingWebhookConfiguration(operatorNamespace string) *admissi
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: operatorNamespace,
 						Name:      VirtOperatorServiceName,
-						Path:      pointer.String(KubeVirtCreateValidatePath),
+						Path:      ptr.To(KubeVirtCreateValidatePath),
 					},
 				},
 			},
@@ -281,7 +281,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: installNamespace,
 						Name:      VirtApiServiceName,
-						Path:      pointer.String(VMCloneCreateMutatePath),
+						Path:      ptr.To(VMCloneCreateMutatePath),
 					},
 				},
 			},

--- a/pkg/virt-operator/resource/generate/csv/csv.go
+++ b/pkg/virt-operator/resource/generate/csv/csv.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/coreos/go-semver/semver"
 	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -191,7 +191,7 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 	imageVersion := components.AddVersionSeparatorPrefix(data.OperatorImageVersion)
 
 	if data.Replicas > 0 && *deployment.Spec.Replicas != int32(data.Replicas) {
-		deployment.Spec.Replicas = pointer.Int32(int32(data.Replicas))
+		deployment.Spec.Replicas = ptr.To(int32(data.Replicas))
 	}
 
 	clusterRules := rbac.NewOperatorClusterRole().Rules

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -34,7 +34,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -378,7 +378,7 @@ func validateInfraPlacement(namespace string, placementConfig *v1.NodePlacement,
 			Name: deploymentName,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32Ptr(1),
+			Replicas: ptr.To(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					mockLabel: "",

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -62,7 +62,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			VirtualMachineInstanceProfile: &v1.VirtualMachineInstanceProfile{
 				CustomProfile: &v1.CustomProfile{
 					RuntimeDefaultProfile: true,
-					LocalhostProfile:      pointer.String("somethingNotImportant"),
+					LocalhostProfile:      ptr.To("somethingNotImportant"),
 				},
 			},
 		}, []string{vmProfileField.Child("customProfile", "runtimeDefaultProfile").String(), vmProfileField.Child("customProfile", "localhostProfile").String()}),

--- a/pkg/virtctl/credentials/add-key/add-key.go
+++ b/pkg/virtctl/credentials/add-key/add-key.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -208,7 +208,7 @@ func newSecretWithKey(vm *v1.VirtualMachine, sshKey string) *core.Secret {
 				Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 				Name:       vm.Name,
 				UID:        vm.UID,
-				Controller: pointer.Bool(true),
+				Controller: ptr.To(true),
 			}},
 		},
 		Data: map[string][]byte{

--- a/pkg/virtctl/credentials/add-key/add-key_test.go
+++ b/pkg/virtctl/credentials/add-key/add-key_test.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"kubevirt.io/api/core"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
@@ -90,7 +90,7 @@ var _ = Describe("Credentials add-ssh-key", func() {
 					Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 					Name:       vm.Name,
 					UID:        vm.UID,
-					Controller: pointer.Bool(true),
+					Controller: ptr.To(true),
 				}},
 			},
 		}
@@ -314,7 +314,7 @@ var _ = Describe("Credentials add-ssh-key", func() {
 					Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 					Name:       vm.Name,
 					UID:        vm.UID,
-					Controller: pointer.Bool(true),
+					Controller: ptr.To(true),
 				}},
 			},
 		}

--- a/pkg/virtctl/credentials/remove-key/remove-key_test.go
+++ b/pkg/virtctl/credentials/remove-key/remove-key_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"kubevirt.io/api/core"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
@@ -91,7 +91,7 @@ var _ = Describe("Credentials", func() {
 					Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 					Name:       vm.Name,
 					UID:        vm.UID,
-					Controller: pointer.Bool(true),
+					Controller: ptr.To(true),
 				}},
 			},
 			Data: map[string][]byte{
@@ -261,7 +261,7 @@ var _ = Describe("Credentials", func() {
 					Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 					Name:       vm.Name,
 					UID:        vm.UID,
-					Controller: pointer.Bool(true),
+					Controller: ptr.To(true),
 				}},
 			},
 			Data: map[string][]byte{

--- a/pkg/virtctl/credentials/set-password/set-password_test.go
+++ b/pkg/virtctl/credentials/set-password/set-password_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -68,7 +68,7 @@ var _ = Describe("Credentials set-password", func() {
 					Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 					Name:       vm.Name,
 					UID:        vm.UID,
-					Controller: pointer.Bool(true),
+					Controller: ptr.To(true),
 				}},
 			},
 		}
@@ -178,7 +178,7 @@ var _ = Describe("Credentials set-password", func() {
 					Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 					Name:       vm.Name,
 					UID:        vm.UID,
-					Controller: pointer.Bool(true),
+					Controller: ptr.To(true),
 				}},
 			},
 		}

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -22,7 +22,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 	"kubevirt.io/kubevirt/pkg/virtctl/utils"
@@ -470,7 +470,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 		},
 	}
 	securityContext := &corev1.PodSecurityContext{
-		RunAsNonRoot: pointer.Bool(!root),
+		RunAsNonRoot: ptr.To(!root),
 		RunAsUser:    u,
 		RunAsGroup:   g,
 		FSGroup:      f,
@@ -605,7 +605,7 @@ func createAttacher(client *K8sClient, p *corev1.Pod, command string) error {
 	resChan := make(chan error)
 
 	go func() {
-		resChan <- exec.Stream(remotecommand.StreamOptions{
+		resChan <- exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
 			Stdin:  stdinReader,
 			Stdout: stdoutWriter,
 			Stderr: stdoutWriter,

--- a/pkg/virtctl/utils/utils.go
+++ b/pkg/virtctl/utils/utils.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/signal"
 
-	"golang.org/x/crypto/ssh/terminal"
+	terminal "golang.org/x/term"
 )
 
 // AttachConsole attaches stdin and stdout to the console

--- a/pkg/virtctl/vm/start_test.go
+++ b/pkg/virtctl/vm/start_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -55,7 +55,7 @@ var _ = Describe("Start command", func() {
 
 	It("with dry-run parameter should not start VM", func() {
 		vm := kubecli.NewMinimalVM(vmName)
-		vm.Spec.Running = pointer.Bool(false)
+		vm.Spec.Running = ptr.To(false)
 
 		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).Times(1)
 		vmInterface.EXPECT().Start(context.Background(), vm.Name, &v1.StartOptions{DryRun: []string{k8smetav1.DryRunAll}}).Return(nil).Times(1)
@@ -80,7 +80,7 @@ var _ = Describe("Start command", func() {
 
 		It("with spec:running:true", func() {
 			vm := kubecli.NewMinimalVM(vmName)
-			vm.Spec.Running = pointer.Bool(false)
+			vm.Spec.Running = ptr.To(false)
 
 			kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).Times(1)
 			vmInterface.EXPECT().Start(context.Background(), vm.Name, &v1.StartOptions{Paused: false, DryRun: nil}).Return(nil).Times(1)

--- a/pkg/virtctl/vm/stop_test.go
+++ b/pkg/virtctl/vm/stop_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -55,7 +55,7 @@ var _ = Describe("Stop command", func() {
 
 	It("with dry-run parameter should not stop VM", func() {
 		vm := kubecli.NewMinimalVM(vmName)
-		vm.Spec.Running = pointer.Bool(true)
+		vm.Spec.Running = ptr.To(true)
 
 		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).Times(1)
 		vmInterface.EXPECT().Stop(context.Background(), vm.Name, &v1.StopOptions{DryRun: []string{k8smetav1.DryRunAll}}).Return(nil).Times(1)
@@ -103,12 +103,12 @@ var _ = Describe("Stop command", func() {
 			"stop", vmName),
 		Entry("with spec:running:false",
 			func(vm *v1.VirtualMachine) {
-				vm.Spec.Running = pointer.Bool(true)
+				vm.Spec.Running = ptr.To(true)
 			},
 			"stop", vmName),
 		Entry("with spec:running:false when it's false already",
 			func(vm *v1.VirtualMachine) {
-				vm.Spec.Running = pointer.Bool(false)
+				vm.Spec.Running = ptr.To(false)
 			},
 			"stop", vmName),
 	)

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -23,7 +23,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -83,7 +83,7 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 			},
 			Spec: v1alpha1.VirtualMachineSnapshotSpec{
 				Source: k8sv1.TypedLocalObjectReference{
-					APIGroup: pointer.String(vmAPIGroup),
+					APIGroup: ptr.To(vmAPIGroup),
 					Kind:     "VirtualMachine",
 					Name:     vm.Name,
 				},
@@ -138,7 +138,7 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 		vmClone := kubecli.NewMinimalCloneWithNS("testclone", sourceVM.Namespace)
 
 		cloneSourceRef := &k8sv1.TypedLocalObjectReference{
-			APIGroup: pointer.String(vmAPIGroup),
+			APIGroup: ptr.To(vmAPIGroup),
 			Kind:     "VirtualMachine",
 			Name:     sourceVM.Name,
 		}
@@ -156,13 +156,13 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 		vmClone := kubecli.NewMinimalCloneWithNS("testclone", snapshot.Namespace)
 
 		cloneSourceRef := &k8sv1.TypedLocalObjectReference{
-			APIGroup: pointer.String(virtsnapshot.GroupName),
+			APIGroup: ptr.To(virtsnapshot.GroupName),
 			Kind:     "VirtualMachineSnapshot",
 			Name:     snapshot.Name,
 		}
 
 		cloneTargetRef := &k8sv1.TypedLocalObjectReference{
-			APIGroup: pointer.String(vmAPIGroup),
+			APIGroup: ptr.To(vmAPIGroup),
 			Kind:     "VirtualMachine",
 			Name:     targetVMName,
 		}
@@ -468,7 +468,7 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 					)
 
 					vmClone = generateCloneFromVM()
-					vmClone.Spec.NewSMBiosSerial = pointer.String(targetSerial)
+					vmClone.Spec.NewSMBiosSerial = ptr.To(targetSerial)
 
 					createCloneAndWaitForFinish(vmClone)
 
@@ -531,7 +531,7 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 					storageClass,
 					k8sv1.ReadWriteOnce,
 				)
-				vm.Spec.Running = pointer.Bool(running)
+				vm.Spec.Running = ptr.To(running)
 
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/exec/execute.go
+++ b/tests/exec/execute.go
@@ -21,6 +21,7 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -85,5 +86,5 @@ func ExecuteCommandOnPodWithOptions(virtCli kubecli.KubevirtClient, pod *k8sv1.P
 		return err
 	}
 
-	return executor.Stream(options)
+	return executor.StreamWithContext(context.TODO(), options)
 }

--- a/tests/framework/storage/nfs.go
+++ b/tests/framework/storage/nfs.go
@@ -6,7 +6,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -55,7 +55,7 @@ func renderNFSServer(generateName string, hostPath string) *k8sv1.Pod {
 					ImagePullPolicy: k8sv1.PullIfNotPresent,
 					Resources:       resources,
 					SecurityContext: &k8sv1.SecurityContext{
-						Privileged: pointer.BoolPtr(true),
+						Privileged: ptr.To(true),
 					},
 					VolumeMounts: []k8sv1.VolumeMount{
 						{

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -29,7 +29,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -63,7 +63,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 				vmi.Spec.Domain.Features.Hyperv = &v1.FeatureHyperv{}
 			}
 
-			vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
+			vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: ptr.To(true)}
 		}
 
 		vmiWithReEnlightenment := func() *v1.VirtualMachineInstance {
@@ -284,9 +284,9 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 			}
 
 		},
-			Entry("hyperv and cpu features should be auto filled when EVMCS is enabled", decorators.VMX, &v1.FeatureState{Enabled: pointer.BoolPtr(true)}),
+			Entry("hyperv and cpu features should be auto filled when EVMCS is enabled", decorators.VMX, &v1.FeatureState{Enabled: ptr.To(true)}),
 			Entry("EVMCS should be enabled when vmi.Spec.Domain.Features.Hyperv.EVMCS is set but the EVMCS.Enabled field is nil ", decorators.VMX, &v1.FeatureState{Enabled: nil}),
-			Entry("Verify that features aren't applied when enabled is false", &v1.FeatureState{Enabled: pointer.BoolPtr(false)}),
+			Entry("Verify that features aren't applied when enabled is false", &v1.FeatureState{Enabled: ptr.To(false)}),
 		)
 	})
 })

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -315,18 +315,18 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			preference.Spec.Features = &instancetypev1beta1.FeaturePreferences{
 				PreferredHyperv: &v1.FeatureHyperv{
 					VAPIC: &v1.FeatureState{
-						Enabled: pointer.Bool(true),
+						Enabled: ptr.To(true),
 					},
 					Relaxed: &v1.FeatureState{
-						Enabled: pointer.Bool(true),
+						Enabled: ptr.To(true),
 					},
 				},
 			}
 			preference.Spec.Firmware = &instancetypev1beta1.FirmwarePreferences{
-				PreferredUseBios: pointer.Bool(true),
+				PreferredUseBios: ptr.To(true),
 			}
-			preference.Spec.PreferredTerminationGracePeriodSeconds = pointer.Int64(15)
-			preference.Spec.PreferredSubdomain = pointer.String("non-existent-subdomain")
+			preference.Spec.PreferredTerminationGracePeriodSeconds = ptr.To(int64(15))
+			preference.Spec.PreferredSubdomain = ptr.To("non-existent-subdomain")
 			preference.Spec.Annotations = map[string]string{
 				"preferred-annotation-1": "1",
 				"preferred-annotation-2": "use-vm-value",
@@ -1201,7 +1201,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Domain: v1.DomainSpec{},
 						},
 					},
-					Running: pointer.Bool(false),
+					Running: ptr.To(false),
 				},
 			}
 		})
@@ -1419,7 +1419,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vmi := libvmi.NewCirros()
 
 			clusterInstancetype := newVirtualMachineClusterInstancetype(vmi)
-			clusterInstancetype.Spec.CPU.DedicatedCPUPlacement = pointer.Bool(true)
+			clusterInstancetype.Spec.CPU.DedicatedCPUPlacement = ptr.To(true)
 			clusterInstancetype, err := virtClient.VirtualMachineClusterInstancetype().
 				Create(context.Background(), clusterInstancetype, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -1849,7 +1849,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Instancetype: &v1.InstancetypeMatcher{
 							Kind: "VirtualMachineInstancetype",
 						},
@@ -1892,7 +1892,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Instancetype: &v1.InstancetypeMatcher{
 							Kind: "VirtualMachineInstancetype",
 						},
@@ -1926,7 +1926,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1966,7 +1966,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2003,7 +2003,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2037,7 +2037,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2077,7 +2077,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2114,7 +2114,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2176,7 +2176,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Instancetype: &v1.InstancetypeMatcher{
 							Kind: "VirtualMachineInstancetype",
 						},
@@ -2220,7 +2220,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Instancetype: &v1.InstancetypeMatcher{
 							Kind: "VirtualMachineInstancetype",
 						},
@@ -2255,7 +2255,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2296,7 +2296,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2337,7 +2337,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2378,7 +2378,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2416,7 +2416,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.Bool(false),
+						Running: ptr.To(false),
 						Preference: &v1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -34,7 +34,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -161,8 +161,8 @@ func executeDeviceMapperOnNode(nodeName string, cmd []string) {
 					Image:   image,
 					Command: cmd,
 					SecurityContext: &k8sv1.SecurityContext{
-						Privileged: pointer.BoolPtr(true),
-						RunAsUser:  pointer.Int64Ptr(0),
+						Privileged: ptr.To(true),
+						RunAsUser:  ptr.To(int64(0)),
 					},
 				},
 			},

--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -75,10 +75,10 @@ func RenderPodWithPVC(name string, cmd []string, args []string, pvc *k8sv1.Persi
 						Capabilities: &k8sv1.Capabilities{
 							Drop: []k8sv1.Capability{"ALL"},
 						},
-						Privileged:               pointer.Bool(false),
+						Privileged:               ptr.To(false),
 						RunAsUser:                &nonRootUser,
-						RunAsNonRoot:             pointer.Bool(true),
-						AllowPrivilegeEscalation: pointer.Bool(false),
+						RunAsNonRoot:             ptr.To(true),
+						AllowPrivilegeEscalation: ptr.To(false),
 						SeccompProfile: &k8sv1.SeccompProfile{
 							Type: k8sv1.SeccompProfileTypeRuntimeDefault,
 						},

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -80,7 +80,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -245,7 +245,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			assertConnectivityToService := func(msg string) {
 				By(msg)
 				tcpJob := job.NewHelloWorldJobTCP(fmt.Sprintf("%s.%s", hostname, subdomain), strconv.FormatInt(int64(port), 10))
-				tcpJob.Spec.BackoffLimit = pointer.Int32(3)
+				tcpJob.Spec.BackoffLimit = ptr.To(int32(3))
 				tcpJob, err := virtClient.BatchV1().Jobs(vmi.Namespace).Create(context.Background(), tcpJob, k8smetav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1486,7 +1486,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			Context("[Serial] with TLS disabled", Serial, func() {
 				It("[test_id:6976] should be successfully migrated", func() {
 					cfg := getCurrentKvConfig(virtClient)
-					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
+					cfg.MigrationConfiguration.DisableTLS = ptr.To(true)
 					tests.UpdateKubeVirtConfigValueAndWait(cfg)
 
 					vmi := libvmi.NewAlpineWithTestTooling(
@@ -1510,7 +1510,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				It("[test_id:6977]should not secure migrations with TLS", func() {
 					cfg := getCurrentKvConfig(virtClient)
 					cfg.MigrationConfiguration.BandwidthPerMigration = resource.NewQuantity(1, resource.BinarySI)
-					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
+					cfg.MigrationConfiguration.DisableTLS = ptr.To(true)
 					tests.UpdateKubeVirtConfigValueAndWait(cfg)
 					vmi := tests.NewRandomFedoraVMI()
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
@@ -1801,8 +1801,8 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				BeforeEach(func() {
 					cfg := getCurrentKvConfig(virtClient)
 					cfg.MigrationConfiguration = &v1.MigrationConfiguration{
-						ProgressTimeout:         pointer.Int64(5),
-						CompletionTimeoutPerGiB: pointer.Int64(5),
+						ProgressTimeout:         ptr.To(int64(5)),
+						CompletionTimeoutPerGiB: ptr.To(int64(5)),
 						BandwidthPerMigration:   resource.NewQuantity(1, resource.BinarySI),
 					}
 					tests.UpdateKubeVirtConfigValueAndWait(cfg)
@@ -2684,7 +2684,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			DescribeTable("migration policy", func(defineMigrationPolicy bool) {
 				By("Updating config to allow auto converge")
 				config := getCurrentKvConfig(virtClient)
-				config.MigrationConfiguration.AllowAutoConverge = pointer.BoolPtr(true)
+				config.MigrationConfiguration.AllowAutoConverge = ptr.To(true)
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
@@ -2693,7 +2693,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				if defineMigrationPolicy {
 					By("Creating a migration policy that overrides cluster policy")
 					policy := GeneratePolicyAndAlignVMI(vmi)
-					policy.Spec.AllowAutoConverge = pointer.BoolPtr(false)
+					policy.Spec.AllowAutoConverge = ptr.To(false)
 
 					_, err := virtClient.MigrationPolicy().Create(context.Background(), policy, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -3355,7 +3355,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi := libvmi.NewWindows()
 				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
 				vmi.Spec.Volumes = []v1.Volume{}
-				vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
+				vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: ptr.To(true)}
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 				expectTopologyHintsToBeSet(vmi)

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -47,7 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netutils "k8s.io/utils/net"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	kvutil "kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/tests/util"
@@ -124,7 +124,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			currentConfiguration.NetworkConfiguration = &v1.NetworkConfiguration{}
 		}
 
-		currentConfiguration.NetworkConfiguration.PermitBridgeInterfaceOnPodNetwork = pointer.BoolPtr(enable)
+		currentConfiguration.NetworkConfiguration.PermitBridgeInterfaceOnPodNetwork = ptr.To(enable)
 		kv := tests.UpdateKubeVirtConfigValueAndWait(currentConfiguration)
 		currentConfiguration = kv.Spec.Configuration
 	}

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -64,7 +64,7 @@ var _ = SIGDescribe("Slirp Networking", decorators.Networking, func() {
 			currentConfiguration.NetworkConfiguration = &v1.NetworkConfiguration{}
 		}
 
-		currentConfiguration.NetworkConfiguration.PermitSlirpInterface = pointer.BoolPtr(enable)
+		currentConfiguration.NetworkConfiguration.PermitSlirpInterface = ptr.To(enable)
 		kv := tests.UpdateKubeVirtConfigValueAndWait(currentConfiguration)
 		currentConfiguration = kv.Spec.Configuration
 	}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -58,7 +58,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/api/instancetype/v1beta1"
@@ -2120,7 +2120,7 @@ spec:
 			kv := copyOriginalKv()
 			kv.Name = "kubevirt-alt-install"
 			kv.Spec.Configuration.NetworkConfiguration = &v1.NetworkConfiguration{
-				PermitBridgeInterfaceOnPodNetwork: pointer.BoolPtr(true),
+				PermitBridgeInterfaceOnPodNetwork: ptr.To(true),
 			}
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
 
@@ -2863,7 +2863,7 @@ spec:
 
 				vmProfile := &v1.VirtualMachineInstanceProfile{
 					CustomProfile: &v1.CustomProfile{
-						LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
+						LocalhostProfile: ptr.To("kubevirt/kubevirt.json"),
 					},
 				}
 				if !enable {
@@ -2958,10 +2958,10 @@ spec:
 				Entry("default should not set profile", nil, nil),
 				Entry("custom should use localhost", &v1.VirtualMachineInstanceProfile{
 					CustomProfile: &v1.CustomProfile{
-						LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
+						LocalhostProfile: ptr.To("kubevirt/kubevirt.json"),
 					},
 				},
-					&k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeLocalhost, LocalhostProfile: pointer.String("kubevirt/kubevirt.json")}),
+					&k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeLocalhost, LocalhostProfile: ptr.To("kubevirt/kubevirt.json")}),
 			)
 		})
 	})

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -41,7 +41,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -836,7 +836,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 						},
 					},
 				}
-				vm.Spec.DataVolumeTemplates[0].Spec.PVC.StorageClassName = pointer.String(storageClass)
+				vm.Spec.DataVolumeTemplates[0].Spec.PVC.StorageClassName = ptr.To(storageClass)
 				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, saVol)
 				vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{Name: volumeName})
 			})
@@ -1125,8 +1125,8 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			vm = tests.StopVirtualMachine(vm)
 		},
-			Entry("[test_id:8567]GC is enabled", pointer.Int32(0), pointer.Int32(0), ""),
-			Entry("[test_id:8571]GC is disabled, and after VM creation, GC is enabled and DV is annotated", pointer.Int32(-1), pointer.Int32(0), "true"),
+			Entry("[test_id:8567]GC is enabled", ptr.To(int32(0)), ptr.To(int32(0)), ""),
+			Entry("[test_id:8571]GC is disabled, and after VM creation, GC is enabled and DV is annotated", ptr.To(int32(-1)), ptr.To(int32(0)), "true"),
 		)
 	})
 

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -52,7 +52,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	routev1 "github.com/openshift/api/route/v1"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -315,7 +315,7 @@ var _ = SIGDescribe("Export", func() {
 		Expect(md5sum).To(HaveLen(32))
 
 		err = virtClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{
-			GracePeriodSeconds: pointer.Int64(0),
+			GracePeriodSeconds: ptr.To(int64(0)),
 		})
 		Expect(err).ToNot(HaveOccurred())
 		return pvc, md5sum
@@ -638,7 +638,7 @@ var _ = SIGDescribe("Export", func() {
 				Namespace: namespace,
 			},
 			Spec: exportv1.VirtualMachineExportSpec{
-				TokenSecretRef: pointer.String(token.Name),
+				TokenSecretRef: ptr.To(token.Name),
 				Source: k8sv1.TypedLocalObjectReference{
 					APIGroup: &apiGroup,
 					Kind:     "VirtualMachineSnapshot",
@@ -1001,7 +1001,7 @@ var _ = SIGDescribe("Export", func() {
 					Namespace: flags.KubeVirtInstallNamespace,
 				},
 				Spec: networkingv1.IngressSpec{
-					IngressClassName: pointer.String("ingress-class-name"),
+					IngressClassName: ptr.To("ingress-class-name"),
 					DefaultBackend: &networkingv1.IngressBackend{
 						Service: &networkingv1.IngressServiceBackend{
 							Name: "virt-exportproxy",
@@ -1167,7 +1167,7 @@ var _ = SIGDescribe("Export", func() {
 			if err != nil {
 				return err
 			}
-			vm.Spec.Running = pointer.Bool(false)
+			vm.Spec.Running = ptr.To(false)
 			vm, err = virtClient.VirtualMachine(vmNamespace).Update(context.Background(), vm)
 			return err
 		}, 15*time.Second, time.Second).Should(BeNil())
@@ -1185,7 +1185,7 @@ var _ = SIGDescribe("Export", func() {
 		Eventually(func() error {
 			vm, err = virtClient.VirtualMachine(vmNamespace).Get(context.Background(), vmName, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			vm.Spec.Running = pointer.Bool(true)
+			vm.Spec.Running = ptr.To(true)
 			vm, err = virtClient.VirtualMachine(vmNamespace).Update(context.Background(), vm)
 			return err
 		}, 15*time.Second, time.Second).Should(Succeed())
@@ -1440,7 +1440,7 @@ var _ = SIGDescribe("Export", func() {
 			testsuite.GetTestNamespace(nil),
 			sc,
 			k8sv1.ReadWriteOnce)
-		vm.Spec.Running = pointer.Bool(true)
+		vm.Spec.Running = ptr.To(true)
 		vm = createVM(vm)
 		Eventually(func() virtv1.VirtualMachineInstancePhase {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
@@ -1768,7 +1768,7 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when Filesystem storage is not present")
 		}
 		vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce)
-		vm.Spec.Running = pointer.Bool(true)
+		vm.Spec.Running = ptr.To(true)
 		vm = createVM(vm)
 		Expect(vm).ToNot(BeNil())
 		vm = stopVM(vm)
@@ -1803,7 +1803,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce)
-		vm.Spec.Running = pointer.Bool(true)
+		vm.Spec.Running = ptr.To(true)
 		vm = createVM(vm)
 		Expect(vm).ToNot(BeNil())
 		vm = stopVM(vm)
@@ -1871,7 +1871,7 @@ var _ = SIGDescribe("Export", func() {
 		tests.AddUserData(vmi, "cloud-init", bashHelloScript)
 		vm := libvmi.NewVirtualMachine(vmi)
 		addDataVolumeDisk(vm, "blankdisk", blankDv.Name)
-		vm.Spec.Running = pointer.Bool(true)
+		vm.Spec.Running = ptr.To(true)
 		vm.Spec.Instancetype = &virtv1.InstancetypeMatcher{
 			Name: clusterInstancetype.Name,
 		}
@@ -1935,13 +1935,13 @@ var _ = SIGDescribe("Export", func() {
 		err = yaml.Unmarshal([]byte(split[2]), diskDV)
 		Expect(err).ToNot(HaveOccurred())
 		diskDV.Name = fmt.Sprintf("%s-clone", diskDV.Name)
-		diskDV.Spec.PVC.StorageClassName = pointer.String(sc)
+		diskDV.Spec.PVC.StorageClassName = ptr.To(sc)
 		Expect(diskDV.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage]).To(BeEquivalentTo(resource.MustParse(cd.CirrosVolumeSize)))
 		blankDv = &cdiv1.DataVolume{}
 		err = yaml.Unmarshal([]byte(split[3]), blankDv)
 		Expect(err).ToNot(HaveOccurred())
 		blankDv.Name = fmt.Sprintf("%s-clone", blankDv.Name)
-		blankDv.Spec.PVC.StorageClassName = pointer.String(sc)
+		blankDv.Spec.PVC.StorageClassName = ptr.To(sc)
 		Expect(blankDv.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage]).To(BeEquivalentTo(resource.MustParse(cd.BlankVolumeSize)))
 
 		By("Getting token secret header")
@@ -2171,7 +2171,7 @@ var _ = SIGDescribe("Export", func() {
 				testsuite.GetTestNamespace(nil),
 				sc,
 				k8sv1.ReadWriteOnce)
-			vm.Spec.Running = pointer.Bool(true)
+			vm.Spec.Running = ptr.To(true)
 			vm = createVM(vm)
 			Eventually(func() virtv1.VirtualMachineInstancePhase {
 				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
@@ -2340,7 +2340,7 @@ var _ = SIGDescribe("Export", func() {
 					testsuite.GetTestNamespace(nil),
 					sc,
 					k8sv1.ReadWriteOnce)
-				vm.Spec.Running = pointer.Bool(true)
+				vm.Spec.Running = ptr.To(true)
 				vm = createVM(vm)
 				Eventually(func() virtv1.VirtualMachineInstancePhase {
 					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
@@ -2485,7 +2485,7 @@ var _ = SIGDescribe("Export", func() {
 					testsuite.GetTestNamespace(nil),
 					sc,
 					k8sv1.ReadWriteOnce)
-				vm.Spec.Running = pointer.Bool(true)
+				vm.Spec.Running = ptr.To(true)
 				vm = createVM(vm)
 				Eventually(func() virtv1.VirtualMachineInstancePhase {
 					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -31,7 +31,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -1380,7 +1380,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			Expect(podName).ToNot(BeEmpty())
 			foreGround := metav1.DeletePropagationForeground
 			err := virtClient.CoreV1().Pods(vmi.Namespace).Delete(context.Background(), podName, metav1.DeleteOptions{
-				GracePeriodSeconds: pointer.Int64(0),
+				GracePeriodSeconds: ptr.To(int64(0)),
 				PropagationPolicy:  &foreGround,
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -1481,7 +1481,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			vm.Spec.Template.Spec.Domain.Resources.Limits = corev1.ResourceList{}
 			vm.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceMemory] = *memLimitQuantity
 			vm.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceCPU] = *cpuLimitQuantity
-			vm.Spec.Running = pointer.Bool(true)
+			vm.Spec.Running = ptr.To(true)
 			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	"kubevirt.io/api/core"
@@ -1054,7 +1054,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				By("Creating VM clone")
 				vmClone := kubecli.NewMinimalCloneWithNS("testclone", testsuite.GetTestNamespace(nil))
 				cloneSourceRef := &corev1.TypedLocalObjectReference{
-					APIGroup: pointer.String(groupName),
+					APIGroup: ptr.To(groupName),
 					Kind:     "VirtualMachine",
 					Name:     sourceVMName,
 				}

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 
@@ -1385,8 +1385,8 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					Expect(found).To(BeTrue())
 				}
 			},
-				Entry("[test_id:4611] without DV garbage collection", pointer.Int32(-1)),
-				Entry("[test_id:8668] with DV garbage collection", pointer.Int32(0)),
+				Entry("[test_id:4611] without DV garbage collection", ptr.To(int32(-1))),
+				Entry("[test_id:8668] with DV garbage collection", ptr.To(int32(0))),
 			)
 		})
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -579,7 +579,7 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 			BeforeEach(func() {
 				preference = newVirtualMachinePreference()
 				preference.Spec.Devices = &instancetypev1beta1.DevicePreferences{
-					PreferredAutoattachGraphicsDevice: pointer.Bool(true),
+					PreferredAutoattachGraphicsDevice: ptr.To(true),
 				}
 				preference, err = virtCli.VirtualMachinePreference(testsuite.GetTestNamespace(preference)).
 					Create(context.Background(), preference, metav1.CreateOptions{})
@@ -591,7 +591,7 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 
 				clusterPreference = newVirtualMachineClusterPreference()
 				clusterPreference.Spec.Devices = &instancetypev1beta1.DevicePreferences{
-					PreferredAutoattachGraphicsDevice: pointer.Bool(true),
+					PreferredAutoattachGraphicsDevice: ptr.To(true),
 				}
 				clusterPreference, err = virtCli.VirtualMachineClusterPreference().
 					Create(context.Background(), clusterPreference, metav1.CreateOptions{})

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -38,7 +38,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -105,8 +105,8 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			kv := util.GetCurrentKv(virtClient)
 			oldMigrationConfiguration := kv.Spec.Configuration.MigrationConfiguration
 			kv.Spec.Configuration.MigrationConfiguration = &virtv1.MigrationConfiguration{
-				AllowPostCopy:           pointer.BoolPtr(true),
-				CompletionTimeoutPerGiB: pointer.Int64Ptr(1),
+				AllowPostCopy:           ptr.To(true),
+				CompletionTimeoutPerGiB: ptr.To(int64(1)),
 			}
 			tests.UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -386,13 +386,13 @@ func winRMCliPod() *k8sv1.Pod {
 					Command: []string{"sleep"},
 					Args:    []string{"3600"},
 					SecurityContext: &k8sv1.SecurityContext{
-						AllowPrivilegeEscalation: pointer.Bool(false),
+						AllowPrivilegeEscalation: ptr.To(false),
 						Capabilities:             &k8sv1.Capabilities{Drop: []k8sv1.Capability{"ALL"}},
 					},
 				},
 			},
 			SecurityContext: &k8sv1.PodSecurityContext{
-				RunAsNonRoot:   pointer.Bool(true),
+				RunAsNonRoot:   ptr.To(true),
 				RunAsUser:      &user,
 				SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault},
 			},

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -103,7 +103,6 @@ func SynchronizedBeforeTestSetup() []byte {
 func BeforeTestSuiteSetup(_ []byte) {
 
 	worker := GinkgoParallelProcess()
-	rand.Seed(int64(worker))
 	log.InitializeLogging("tests")
 	log.Log.SetIOWriter(GinkgoWriter)
 	var err error

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -103,6 +103,7 @@ func SynchronizedBeforeTestSetup() []byte {
 func BeforeTestSuiteSetup(_ []byte) {
 
 	worker := GinkgoParallelProcess()
+	rand.Seed(int64(worker))
 	log.InitializeLogging("tests")
 	log.Log.SetIOWriter(GinkgoWriter)
 	var err error

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -36,7 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -88,7 +88,7 @@ func AdjustKubeVirtResource() {
 	kv.Spec.Configuration.SeccompConfiguration = &v1.SeccompConfiguration{
 		VirtualMachineInstanceProfile: &v1.VirtualMachineInstanceProfile{
 			CustomProfile: &v1.CustomProfile{
-				LocalhostProfile: pointer.String("kubevirt/kubevirt.json"),
+				LocalhostProfile: ptr.To("kubevirt/kubevirt.json"),
 			},
 		},
 	}

--- a/tests/virtctl/credentials.go
+++ b/tests/virtctl/credentials.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -97,7 +97,7 @@ var _ = Describe("[sig-compute][virtctl]credentials", func() {
 					Kind:       kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 					Name:       vm.Name,
 					UID:        vm.UID,
-					Controller: pointer.Bool(true),
+					Controller: ptr.To(true),
 				}},
 			},
 			Data: map[string][]byte{
@@ -123,7 +123,7 @@ var _ = Describe("[sig-compute][virtctl]credentials", func() {
 					Kind:       kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 					Name:       vm.Name,
 					UID:        vm.UID,
-					Controller: pointer.Bool(true),
+					Controller: ptr.To(true),
 				}},
 			},
 			Data: map[string][]byte{

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -127,14 +127,14 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 			if withTPM {
 				By("with persistent TPM enabled")
 				vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{
-					Persistent: pointer.BoolPtr(true),
+					Persistent: ptr.To(true),
 				}
 			}
 			if withEFI {
 				By("with persistent EFI enabled")
 				vmi.Spec.Domain.Firmware = &v1.Firmware{
 					Bootloader: &v1.Bootloader{
-						EFI: &v1.EFI{SecureBoot: pointer.BoolPtr(false), Persistent: pointer.BoolPtr(true)},
+						EFI: &v1.EFI{SecureBoot: ptr.To(false), Persistent: ptr.To(true)},
 					},
 				}
 			}
@@ -183,7 +183,7 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 			By("Creating a VMI with persistent TPM enabled")
 			vmi := tests.NewRandomFedoraVMI()
 			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{
-				Persistent: pointer.BoolPtr(true),
+				Persistent: ptr.To(true),
 			}
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -47,7 +47,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -670,7 +669,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			// Registry URL scheme validated in CDI
 			vm := tests.NewRandomVMWithDataVolumeWithRegistryImport("docker://no.such/image",
 				testsuite.GetTestNamespace(nil), storageClassName, k8sv1.ReadWriteOnce)
-			vm.Spec.Running = pointer.BoolPtr(true)
+			vm.Spec.Running = ptr.To(true)
 			_, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -34,7 +34,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -72,7 +72,7 @@ var _ = Describe("[sig-compute]MultiQueue", decorators.SigCompute, func() {
 			)
 			cpuReq := resource.MustParse(fmt.Sprintf("%d", numCpus))
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = cpuReq
-			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = ptr.To(true)
 
 			vmi.Spec.Domain.Devices.Interfaces[0].Model = interfaceModel
 
@@ -97,7 +97,7 @@ var _ = Describe("[sig-compute]MultiQueue", decorators.SigCompute, func() {
 				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
 			)
 
-			vmi.Spec.Domain.Devices.BlockMultiQueue = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.BlockMultiQueue = ptr.To(true)
 			cpuReq := resource.MustParse(fmt.Sprintf("%d", numCpus))
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = cpuReq
 
@@ -138,7 +138,7 @@ var _ = Describe("[sig-compute]MultiQueue", decorators.SigCompute, func() {
 			vmi := libvmi.NewCirros()
 
 			vmi.Spec.Domain.CPU = &v1.CPU{Cores: 1, Sockets: 1, Threads: 1}
-			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = ptr.To(true)
 
 			By("Creating and starting the VMI")
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -35,7 +35,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/tests/libssh"
@@ -68,7 +68,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			By("Creating a VMI with VSOCK enabled")
 			vmi := tests.NewRandomFedoraVMI()
 			vmi.Spec.Domain.Devices.UseVirtioTransitional = &useVirtioTransitional
-			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(vmi.Status.VSOCKCID).NotTo(BeNil())
 
@@ -125,7 +125,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		It("should retain the CID for migration target", func() {
 			By("Creating a VMI with VSOCK enabled")
 			vmi := tests.NewRandomFedoraVMI()
-			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+			vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(vmi.Status.VSOCKCID).NotTo(BeNil())
 
@@ -140,7 +140,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			By("Creating a new VMI with VSOCK enabled on the same node")
 			node := vmi.Status.NodeName
 			vmi2 := tests.NewRandomFedoraVMI()
-			vmi2.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+			vmi2.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 			vmi2.Spec.Affinity = affinity(node)
 			vmi2 = tests.RunVMIAndExpectLaunch(vmi2, 60)
 			Expect(vmi2.Status.VSOCKCID).NotTo(BeNil())
@@ -179,7 +179,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithCloudInitNoCloudUserData(userData),
 		)
-		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+		vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 
 		By("Logging in as root")
@@ -205,7 +205,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		stopChan := make(chan error)
 		go func() {
 			defer GinkgoRecover()
-			vsock, err := virtClient.VirtualMachineInstance(vmi.Namespace).VSOCK(vmi.Name, &v1.VSOCKOptions{TargetPort: uint32(1234), UseTLS: pointer.Bool(useTLS)})
+			vsock, err := virtClient.VirtualMachineInstance(vmi.Namespace).VSOCK(vmi.Name, &v1.VSOCKOptions{TargetPort: uint32(1234), UseTLS: ptr.To(useTLS)})
 			if err != nil {
 				stopChan <- err
 				return
@@ -244,7 +244,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 
 		By("Creating a VMI with VSOCK enabled")
 		vmi := tests.NewRandomFedoraVMI()
-		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+		vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 
 		By("Connect to the guest on invalide port")
@@ -257,7 +257,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 
 		By("Creating a VMI with VSOCK enabled")
 		vmi := tests.NewRandomFedoraVMI()
-		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+		vmi.Spec.Domain.Devices.AutoattachVSOCK = ptr.To(true)
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 
 		By("Connect to the guest on the unused port")

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
@@ -1413,7 +1413,7 @@ func GetVirtualMachinePreferenceWindows() *instancetypev1beta1.VirtualMachinePre
 			Clock: &instancetypev1beta1.ClockPreferences{
 				PreferredClockOffset: &v1.ClockOffset{UTC: &v1.ClockOffsetUTC{}},
 				PreferredTimer: &v1.Timer{
-					HPET:   &v1.HPETTimer{Enabled: pointer.Bool(false)},
+					HPET:   &v1.HPETTimer{Enabled: ptr.To(false)},
 					PIT:    &v1.PITTimer{TickPolicy: v1.PITTickPolicyDelay},
 					RTC:    &v1.RTCTimer{TickPolicy: v1.RTCTickPolicyCatchup},
 					Hyperv: &v1.HypervTimer{},
@@ -1435,8 +1435,8 @@ func GetVirtualMachinePreferenceWindows() *instancetypev1beta1.VirtualMachinePre
 				PreferredSmm: &v1.FeatureState{},
 			},
 			Firmware: &instancetypev1beta1.FirmwarePreferences{
-				PreferredUseEfi:        pointer.Bool(true),
-				PreferredUseSecureBoot: pointer.Bool(true),
+				PreferredUseEfi:        ptr.To(true),
+				PreferredUseSecureBoot: ptr.To(true),
 			},
 		},
 	}
@@ -1501,7 +1501,7 @@ func GetVmWindowsInstancetypeComputeLargePreferencesWindows() *v1.VirtualMachine
 	addPVCDisk(&vm.Spec.Template.Spec, "disk-windows", "", "pvcdisk")
 
 	// Copy the same remaining defaults as the vmi-windows example
-	vm.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(0)
+	vm.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(0))
 	vm.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{
 		UUID: types.UID(windowsFirmware),
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Replaces the following deprecated function calls -
grpc.WithInsecure() -> grpc.WithTransportCredentials
grpc.WithDialer -> grpc.WithContextDialer
exec.Stream -> exec.StreamWithContext

Replaces the following deprecated packages -
"k8s.io/utils/pointer" ->  "k8s.io/utils/ptr"
"github.com/go-kit/kit/log" -> "github.com/go-kit/log

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Related to #11316 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

