### PR TITLE
vnc_test: place err variable more locally

### DIFF
--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -60,11 +60,11 @@ import (
 
 var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VNC", decorators.SigCompute, func() {
 
-	var err error
 	var vmi *v1.VirtualMachineInstance
 
 	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		BeforeEach(func() {
+			var err error
 			vmi = libvmi.New(libvmi.WithResourceMemory("1Mi"))
 			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -72,7 +72,6 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 		})
 
 		Context("with VNC connection", func() {
-
 			vncConnect := func() {
 				pipeInReader, _ := io.Pipe()
 				pipeOutReader, pipeOutWriter := io.Pipe()
@@ -120,7 +119,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 					// communicate.
 					By("Checking the response from VNC server")
 					Expect(response).To(Equal("RFB 003.008\n"))
-				case err = <-k8ResChan:
+				case err := <-k8ResChan:
 					Expect(err).ToNot(HaveOccurred())
 				case <-time.After(45 * time.Second):
 					Fail("Timout reached while waiting for valid VNC server response")

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -54,6 +54,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
@@ -67,9 +68,10 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 		BeforeEach(func() {
 			virtClient = kubevirt.Client()
 
-			vmi = tests.NewRandomVMI()
-			Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Error()).To(Succeed())
-			libwait.WaitForSuccessfulVMIStart(vmi)
+			vmi = libvmi.New(libvmi.WithResourceMemory("1Mi"))
+			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+			Expect(err).ToNot(HaveOccurred())
+			vmi = libwait.WaitForSuccessfulVMIStart(vmi)
 		})
 
 		Context("with VNC connection", func() {

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -61,15 +61,12 @@ import (
 var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VNC", decorators.SigCompute, func() {
 
 	var err error
-	var virtClient kubecli.KubevirtClient
 	var vmi *v1.VirtualMachineInstance
 
 	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		BeforeEach(func() {
-			virtClient = kubevirt.Client()
-
 			vmi = libvmi.New(libvmi.WithResourceMemory("1Mi"))
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+			vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 			Expect(err).ToNot(HaveOccurred())
 			vmi = libwait.WaitForSuccessfulVMIStart(vmi)
 		})
@@ -87,7 +84,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 
 				go func() {
 					defer GinkgoRecover()
-					vnc, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
+					vnc, err := kubevirt.Client().VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
 					if err != nil {
 						k8ResChan <- err
 						return


### PR DESCRIPTION
Variables with a too-wide scope may have unexpected side-effects, particularly when multiple lambda closures are defined and used.
Let us define an err variable closer to its needed context.

Requested by @xpivarc on https://github.com/kubevirt/kubevirt/pull/11302#discussion_r1500332243

```release-note
NONE
```

