### PR TITLE
Remove redundant DeepCopy calls

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -306,7 +306,6 @@ func (c *VMController) execute(key string) error {
 	// this must be first step in execution. Writing the object
 	// when api version changes ensures our api stored version is updated.
 	if !controller.ObservedLatestApiVersionAnnotation(vm) {
-		vm := vm.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(vm)
 		_, err = c.clientset.VirtualMachine(vm.Namespace).Update(context.Background(), vm)
 
@@ -712,8 +711,7 @@ func (c *VMController) VMIAffinityPatch(vm *virtv1.VirtualMachine, vmi *virtv1.V
 	var ops []string
 
 	if vm.Spec.Template.Spec.Affinity != nil {
-		vmAffinity := vm.Spec.Template.Spec.Affinity.DeepCopy()
-		vmAffinityJson, err := json.Marshal(vmAffinity)
+		vmAffinityJson, err := json.Marshal(vm.Spec.Template.Spec.Affinity)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What this PR does
Removes redundant `DeepCopy` calls because we now have https://github.com/kubevirt/kubevirt/pull/11265 

Fixes #

### Why we need it and why it was done in this way

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

