### PR TITLE
add device plugin interface

### DIFF
--- a/pkg/virt-handler/device-manager/BUILD.bazel
+++ b/pkg/virt-handler/device-manager/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "common.go",
         "device_controller.go",
+        "device_plugin_base.go",
         "generated_mock_common.go",
         "generic_device.go",
         "mediated_device.go",

--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -1,6 +1,7 @@
 package device_manager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -16,6 +17,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
 )
 
 type FakePlugin struct {
@@ -36,6 +38,18 @@ func (fp *FakePlugin) GetDeviceName() string {
 
 func (fp *FakePlugin) GetInitialized() bool {
 	return true
+}
+
+func (fp *FakePlugin) PreStartContainer(context.Context, *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
+	return &pluginapi.PreStartContainerResponse{}, nil
+}
+
+func (fp *FakePlugin) ListAndWatch(*pluginapi.Empty, pluginapi.DevicePlugin_ListAndWatchServer) error {
+	return nil
+}
+
+func (fp *FakePlugin) Allocate(context.Context, *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
+	return &pluginapi.AllocateResponse{}, nil
 }
 
 func NewFakePlugin(name string, path string) *FakePlugin {

--- a/pkg/virt-handler/device-manager/device_plugin_base.go
+++ b/pkg/virt-handler/device-manager/device_plugin_base.go
@@ -1,0 +1,235 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package device_manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"google.golang.org/grpc"
+	"kubevirt.io/client-go/log"
+
+	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
+)
+
+type DevicePluginBase struct {
+	devs         []*pluginapi.Device
+	server       *grpc.Server
+	socketPath   string
+	stop         <-chan struct{}
+	health       chan deviceHealth
+	resourceName string
+	done         chan struct{}
+	initialized  bool
+	lock         *sync.Mutex
+	deregistered chan struct{}
+	devicePath   string
+	deviceRoot   string
+	deviceName   string
+}
+
+func (dpi *DevicePluginBase) GetDeviceName() string {
+	return dpi.resourceName
+}
+
+func (dpi *DevicePluginBase) ListAndWatch(_ *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
+	s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
+
+	done := false
+	for {
+		select {
+		case devHealth := <-dpi.health:
+			for _, dev := range dpi.devs {
+				if devHealth.DevId == dev.ID {
+					dev.Health = devHealth.Health
+				}
+			}
+			s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
+		case <-dpi.stop:
+			done = true
+		case <-dpi.done:
+			done = true
+		}
+		if done {
+			break
+		}
+	}
+	emptyList := []*pluginapi.Device{}
+	if err := s.Send(&pluginapi.ListAndWatchResponse{Devices: emptyList}); err != nil {
+		log.DefaultLogger().Reason(err).Infof("%s device plugin failed to deregister", dpi.resourceName)
+	}
+	close(dpi.deregistered)
+	return nil
+}
+
+func (dpi *DevicePluginBase) healthCheck() error {
+	logger := log.DefaultLogger()
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to creating a fsnotify watcher: %v", err)
+	}
+	defer watcher.Close()
+
+	// This way we don't have to mount /dev from the node
+	devicePath := filepath.Join(dpi.deviceRoot, dpi.devicePath)
+
+	// Start watching the files before we check for their existence to avoid races
+	dirName := filepath.Dir(devicePath)
+
+	if err = watcher.Add(dirName); err != nil {
+		return fmt.Errorf("failed to add the device root path to the watcher: %v", err)
+	}
+
+	if _, err = os.Stat(devicePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("could not stat the device: %v", err)
+		}
+		logger.Warningf("device '%s' is not present, the device plugin can't expose it.", dpi.devicePath)
+		dpi.health <- deviceHealth{Health: pluginapi.Unhealthy}
+	}
+	logger.Infof("device '%s' is present.", dpi.devicePath)
+
+	dirName = filepath.Dir(dpi.socketPath)
+
+	if err = watcher.Add(dirName); err != nil {
+		return fmt.Errorf("failed to add the device-plugin kubelet path to the watcher: %v", err)
+	}
+
+	if _, err = os.Stat(dpi.socketPath); err != nil {
+		return fmt.Errorf("failed to stat the device-plugin socket: %v", err)
+	}
+
+	for {
+		select {
+		case <-dpi.stop:
+			return nil
+		case err := <-watcher.Errors:
+			logger.Reason(err).Errorf("error watching devices and device plugin directory")
+		case event := <-watcher.Events:
+			logger.V(4).Infof("health Event: %v", event)
+			if event.Name == devicePath {
+				// Health in this case is if the device path actually exists
+				if event.Op == fsnotify.Create {
+					logger.Infof("monitored device %s appeared", dpi.deviceName)
+					dpi.health <- deviceHealth{Health: pluginapi.Healthy}
+				} else if (event.Op == fsnotify.Remove) || (event.Op == fsnotify.Rename) {
+					logger.Infof("monitored device %s disappeared", dpi.deviceName)
+					dpi.health <- deviceHealth{Health: pluginapi.Unhealthy}
+				}
+			} else if event.Name == dpi.socketPath && event.Op == fsnotify.Remove {
+				logger.Infof("device socket file for device %s was removed, kubelet probably restarted.", dpi.deviceName)
+				return nil
+			}
+		}
+	}
+}
+
+func (dpi *DevicePluginBase) PreStartContainer(_ context.Context, _ *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
+	res := &pluginapi.PreStartContainerResponse{}
+	return res, nil
+}
+
+func (dpi *DevicePluginBase) GetDevicePluginOptions(_ context.Context, _ *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
+	options := &pluginapi.DevicePluginOptions{
+		PreStartRequired: false,
+	}
+	return options, nil
+}
+
+func (dpi *DevicePluginBase) Allocate(ctx context.Context, r *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
+	log.DefaultLogger().Infof("Generic Allocate: resourceName: %s", dpi.deviceName)
+	log.DefaultLogger().Infof("Generic Allocate: request: %v", r.ContainerRequests)
+	response := pluginapi.AllocateResponse{}
+	containerResponse := new(pluginapi.ContainerAllocateResponse)
+
+	dev := new(pluginapi.DeviceSpec)
+	dev.HostPath = dpi.devicePath
+	dev.ContainerPath = dpi.devicePath
+	containerResponse.Devices = []*pluginapi.DeviceSpec{dev}
+
+	response.ContainerResponses = []*pluginapi.ContainerAllocateResponse{containerResponse}
+
+	return &response, nil
+}
+
+func (dpi *DevicePluginBase) stopDevicePlugin() error {
+	defer func() {
+		if !IsChanClosed(dpi.done) {
+			close(dpi.done)
+		}
+	}()
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	select {
+	case <-dpi.deregistered:
+	case <-ticker.C:
+	}
+
+	dpi.server.Stop()
+	dpi.setInitialized(false)
+	return dpi.cleanup()
+}
+
+func (dpi *DevicePluginBase) cleanup() error {
+	if err := os.Remove(dpi.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (dpi *DevicePluginBase) GetInitialized() bool {
+	dpi.lock.Lock()
+	defer dpi.lock.Unlock()
+	return dpi.initialized
+}
+
+func (dpi *DevicePluginBase) setInitialized(initialized bool) {
+	dpi.lock.Lock()
+	dpi.initialized = initialized
+	dpi.lock.Unlock()
+}
+
+func (dpi *DevicePluginBase) register() error {
+	conn, err := gRPCConnect(pluginapi.KubeletSocket, connectionTimeout)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client := pluginapi.NewRegistrationClient(conn)
+	reqt := &pluginapi.RegisterRequest{
+		Version:      pluginapi.Version,
+		Endpoint:     path.Base(dpi.socketPath),
+		ResourceName: dpi.resourceName,
+	}
+
+	_, err = client.Register(context.Background(), reqt)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/virt-handler/device-manager/generic_device.go
+++ b/pkg/virt-handler/device-manager/generic_device.go
@@ -46,7 +46,10 @@ const (
 )
 
 type Device interface {
-	Start(stop <-chan struct{}) (err error)
+	Start(stop <-chan struct{}) error
+	ListAndWatch(*pluginapi.Empty, pluginapi.DevicePlugin_ListAndWatchServer) error
+	PreStartContainer(context.Context, *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error)
+	Allocate(context.Context, *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error)
 	GetDeviceName() string
 	GetInitialized() bool
 }

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -25,11 +25,9 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"google.golang.org/grpc"
@@ -56,68 +54,13 @@ type PCIDevice struct {
 }
 
 type PCIDevicePlugin struct {
-	devs          []*pluginapi.Device
-	server        *grpc.Server
-	socketPath    string
-	stop          <-chan struct{}
-	health        chan deviceHealth
-	devicePath    string
-	resourceName  string
-	done          chan struct{}
-	deviceRoot    string
+	*DevicePluginBase
 	iommuToPCIMap map[string]string
-	initialized   bool
-	lock          *sync.Mutex
-	deregistered  chan struct{}
 }
 
-func NewPCIDevicePlugin(pciDevices []*PCIDevice, resourceName string) *PCIDevicePlugin {
-	serverSock := SocketPath(strings.Replace(resourceName, "/", "-", -1))
-	iommuToPCIMap := make(map[string]string)
-
-	initHandler()
-
-	devs := constructDPIdevices(pciDevices, iommuToPCIMap)
-	dpi := &PCIDevicePlugin{
-		devs:          devs,
-		socketPath:    serverSock,
-		resourceName:  resourceName,
-		devicePath:    vfioDevicePath,
-		deviceRoot:    util.HostRootMount,
-		iommuToPCIMap: iommuToPCIMap,
-		health:        make(chan deviceHealth),
-		initialized:   false,
-		lock:          &sync.Mutex{},
-	}
-	return dpi
-}
-
-func constructDPIdevices(pciDevices []*PCIDevice, iommuToPCIMap map[string]string) (devs []*pluginapi.Device) {
-	for _, pciDevice := range pciDevices {
-		iommuToPCIMap[pciDevice.iommuGroup] = pciDevice.pciAddress
-		dpiDev := &pluginapi.Device{
-			ID:     string(pciDevice.iommuGroup),
-			Health: pluginapi.Healthy,
-		}
-		if pciDevice.numaNode >= 0 {
-			numaInfo := &pluginapi.NUMANode{
-				ID: int64(pciDevice.numaNode),
-			}
-			dpiDev.Topology = &pluginapi.TopologyInfo{
-				Nodes: []*pluginapi.NUMANode{numaInfo},
-			}
-		}
-		devs = append(devs, dpiDev)
-	}
-	return
-}
-
-// Start starts the device plugin
 func (dpi *PCIDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	logger := log.DefaultLogger()
 	dpi.stop = stop
-	dpi.done = make(chan struct{})
-	dpi.deregistered = make(chan struct{})
 
 	err = dpi.cleanup()
 	if err != nil {
@@ -161,36 +104,50 @@ func (dpi *PCIDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	return err
 }
 
-func (dpi *PCIDevicePlugin) ListAndWatch(_ *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
-	s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
+func NewPCIDevicePlugin(pciDevices []*PCIDevice, resourceName string) *PCIDevicePlugin {
+	serverSock := SocketPath(strings.Replace(resourceName, "/", "-", -1))
+	iommuToPCIMap := make(map[string]string)
 
-	done := false
-	for {
-		select {
-		case devHealth := <-dpi.health:
-			for _, dev := range dpi.devs {
-				if devHealth.DevId == dev.ID {
-					dev.Health = devHealth.Health
-				}
+	initHandler()
+
+	devs := constructDPIdevices(pciDevices, iommuToPCIMap)
+
+	dpi := &PCIDevicePlugin{
+		DevicePluginBase: &DevicePluginBase{
+			devs:         devs,
+			initialized:  false,
+			lock:         &sync.Mutex{},
+			socketPath:   serverSock,
+			devicePath:   vfioDevicePath,
+			resourceName: resourceName,
+			deviceRoot:   util.HostRootMount,
+			health:       make(chan deviceHealth),
+			done:         make(chan struct{}),
+			deregistered: make(chan struct{}),
+		},
+		iommuToPCIMap: iommuToPCIMap,
+	}
+	return dpi
+}
+
+func constructDPIdevices(pciDevices []*PCIDevice, iommuToPCIMap map[string]string) (devs []*pluginapi.Device) {
+	for _, pciDevice := range pciDevices {
+		iommuToPCIMap[pciDevice.iommuGroup] = pciDevice.pciAddress
+		dpiDev := &pluginapi.Device{
+			ID:     string(pciDevice.iommuGroup),
+			Health: pluginapi.Healthy,
+		}
+		if pciDevice.numaNode >= 0 {
+			numaInfo := &pluginapi.NUMANode{
+				ID: int64(pciDevice.numaNode),
 			}
-			s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
-		case <-dpi.stop:
-			done = true
-		case <-dpi.done:
-			done = true
+			dpiDev.Topology = &pluginapi.TopologyInfo{
+				Nodes: []*pluginapi.NUMANode{numaInfo},
+			}
 		}
-		if done {
-			break
-		}
+		devs = append(devs, dpiDev)
 	}
-	// Send empty list to increase the chance that the kubelet acts fast on stopped device plugins
-	// There exists no explicit way to deregister devices
-	emptyList := []*pluginapi.Device{}
-	if err := s.Send(&pluginapi.ListAndWatchResponse{Devices: emptyList}); err != nil {
-		log.DefaultLogger().Reason(err).Infof("%s device plugin failed to deregister", dpi.resourceName)
-	}
-	close(dpi.deregistered)
-	return nil
+	return
 }
 
 func (dpi *PCIDevicePlugin) Allocate(_ context.Context, r *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
@@ -298,73 +255,6 @@ func (dpi *PCIDevicePlugin) healthCheck() error {
 	}
 }
 
-func (dpi *PCIDevicePlugin) GetDeviceName() string {
-	return dpi.resourceName
-}
-
-// Stop stops the gRPC server
-func (dpi *PCIDevicePlugin) stopDevicePlugin() error {
-	defer func() {
-		if !IsChanClosed(dpi.done) {
-			close(dpi.done)
-		}
-	}()
-
-	// Give the device plugin one second to properly deregister
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-	select {
-	case <-dpi.deregistered:
-	case <-ticker.C:
-	}
-
-	dpi.server.Stop()
-	dpi.setInitialized(false)
-	return dpi.cleanup()
-}
-
-// Register registers the device plugin for the given resourceName with Kubelet.
-func (dpi *PCIDevicePlugin) register() error {
-	conn, err := gRPCConnect(pluginapi.KubeletSocket, connectionTimeout)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	client := pluginapi.NewRegistrationClient(conn)
-	reqt := &pluginapi.RegisterRequest{
-		Version:      pluginapi.Version,
-		Endpoint:     path.Base(dpi.socketPath),
-		ResourceName: dpi.resourceName,
-	}
-
-	_, err = client.Register(context.Background(), reqt)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (dpi *PCIDevicePlugin) cleanup() error {
-	if err := os.Remove(dpi.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-
-	return nil
-}
-
-func (dpi *PCIDevicePlugin) GetDevicePluginOptions(_ context.Context, _ *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
-	options := &pluginapi.DevicePluginOptions{
-		PreStartRequired: false,
-	}
-	return options, nil
-}
-
-func (dpi *PCIDevicePlugin) PreStartContainer(_ context.Context, _ *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
-	res := &pluginapi.PreStartContainerResponse{}
-	return res, nil
-}
-
 func discoverPermittedHostPCIDevices(supportedPCIDeviceMap map[string]string) map[string][]*PCIDevice {
 	initHandler()
 
@@ -404,16 +294,4 @@ func discoverPermittedHostPCIDevices(supportedPCIDeviceMap map[string]string) ma
 		log.DefaultLogger().Reason(err).Errorf("failed to discover host devices")
 	}
 	return pciDevicesMap
-}
-
-func (dpi *PCIDevicePlugin) GetInitialized() bool {
-	dpi.lock.Lock()
-	defer dpi.lock.Unlock()
-	return dpi.initialized
-}
-
-func (dpi *PCIDevicePlugin) setInitialized(initialized bool) {
-	dpi.lock.Lock()
-	dpi.initialized = initialized
-	dpi.lock.Unlock()
 }

--- a/pkg/virt-handler/device-manager/socket_device_test.go
+++ b/pkg/virt-handler/device-manager/socket_device_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Socket device", func() {
 		fileObj.Close()
 		dpi = NewSocketDevicePlugin("test", workDir, "fake-test.sock", 1)
 		dpi.server = grpc.NewServer([]grpc.ServerOption{}...)
-		dpi.pluginSocketPath = filepath.Join(workDir, "kubevirt-test.sock")
+		dpi.socketPath = filepath.Join(workDir, "kubevirt-test.sock")
 		dpi.done = make(chan struct{})
 		stop = make(chan struct{})
 		dpi.stop = stop
@@ -42,7 +42,7 @@ var _ = Describe("Socket device", func() {
 	})
 
 	It("Should stop if the device plugin socket file is deleted", func() {
-		os.OpenFile(dpi.pluginSocketPath, os.O_RDONLY|os.O_CREATE, 0666)
+		os.OpenFile(dpi.socketPath, os.O_RDONLY|os.O_CREATE, 0666)
 		errChan := make(chan error, 1)
 		go func(errChan chan error) {
 			errChan <- dpi.healthCheck()
@@ -50,13 +50,13 @@ var _ = Describe("Socket device", func() {
 		Consistently(func() string {
 			return dpi.devs[0].Health
 		}, 2*time.Second, 500*time.Millisecond).Should(Equal(pluginapi.Healthy))
-		Expect(os.Remove(dpi.pluginSocketPath)).To(Succeed())
+		Expect(os.Remove(dpi.socketPath)).To(Succeed())
 
 		Expect(<-errChan).ToNot(HaveOccurred())
 	})
 
 	It("Should monitor health of device node", func() {
-		os.OpenFile(dpi.pluginSocketPath, os.O_RDONLY|os.O_CREATE, 0666)
+		os.OpenFile(dpi.socketPath, os.O_RDONLY|os.O_CREATE, 0666)
 
 		go dpi.healthCheck()
 		Expect(dpi.devs[0].Health).To(Equal(pluginapi.Healthy))

--- a/pkg/virt-handler/device-manager/usb_device.go
+++ b/pkg/virt-handler/device-manager/usb_device.go
@@ -22,7 +22,6 @@ package device_manager
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -71,18 +70,10 @@ func (dev *USBDevice) GetID() string {
 
 // The actual plugin
 type USBDevicePlugin struct {
-	socketPath   string
-	stop         <-chan struct{}
-	update       chan struct{}
-	done         chan struct{}
-	deregistered chan struct{}
-	server       *grpc.Server
-	resourceName string
-	devices      []*PluginDevices
-	logger       *log.FilteredLogger
-
-	initialized bool
-	lock        *sync.Mutex
+	*DevicePluginBase
+	update  chan struct{}
+	devices []*PluginDevices
+	logger  *log.FilteredLogger
 }
 
 type PluginDevices struct {
@@ -97,6 +88,51 @@ func newPluginDevices(resourceName string, index int, usbdevs []*USBDevice) *Plu
 		isHealthy: true,
 		Devices:   usbdevs,
 	}
+}
+
+func (plugin *USBDevicePlugin) Start(stop <-chan struct{}) error {
+	plugin.stop = stop
+
+	err := plugin.cleanup()
+	if err != nil {
+		return fmt.Errorf("error on cleanup: %v", err)
+	}
+
+	sock, err := net.Listen("unix", plugin.socketPath)
+	if err != nil {
+		return fmt.Errorf("error creating GRPC server socket: %v", err)
+	}
+
+	plugin.server = grpc.NewServer([]grpc.ServerOption{}...)
+	defer plugin.stopDevicePlugin()
+
+	pluginapi.RegisterDevicePluginServer(plugin.server, plugin)
+
+	errChan := make(chan error, 2)
+
+	go func() {
+		errChan <- plugin.server.Serve(sock)
+	}()
+
+	err = waitForGRPCServer(plugin.socketPath, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("error starting the GRPC server: %v", err)
+	}
+
+	err = plugin.register()
+	if err != nil {
+		return fmt.Errorf("error registering with device plugin manager: %v", err)
+	}
+
+	go func() {
+		errChan <- plugin.healthCheck()
+	}()
+
+	plugin.setInitialized(true)
+	plugin.logger.Infof("%s device plugin started", plugin.resourceName)
+	err = <-errChan
+
+	return err
 }
 
 func (pd *PluginDevices) toKubeVirtDevicePlugin() *pluginapi.Device {
@@ -187,53 +223,6 @@ func (plugin *USBDevicePlugin) stopDevicePlugin() error {
 	return plugin.cleanup()
 }
 
-func (plugin *USBDevicePlugin) Start(stop <-chan struct{}) error {
-	plugin.stop = stop
-	plugin.done = make(chan struct{})
-	plugin.deregistered = make(chan struct{})
-
-	err := plugin.cleanup()
-	if err != nil {
-		return fmt.Errorf("error on cleanup: %v", err)
-	}
-
-	sock, err := net.Listen("unix", plugin.socketPath)
-	if err != nil {
-		return fmt.Errorf("error creating GRPC server socket: %v", err)
-	}
-
-	plugin.server = grpc.NewServer([]grpc.ServerOption{}...)
-	defer plugin.stopDevicePlugin()
-
-	pluginapi.RegisterDevicePluginServer(plugin.server, plugin)
-
-	errChan := make(chan error, 2)
-
-	go func() {
-		errChan <- plugin.server.Serve(sock)
-	}()
-
-	err = waitForGRPCServer(plugin.socketPath, 5*time.Second)
-	if err != nil {
-		return fmt.Errorf("error starting the GRPC server: %v", err)
-	}
-
-	err = plugin.register()
-	if err != nil {
-		return fmt.Errorf("error registering with device plugin manager: %v", err)
-	}
-
-	go func() {
-		errChan <- plugin.healthCheck()
-	}()
-
-	plugin.setInitialized(true)
-	plugin.logger.Infof("%s device plugin started", plugin.resourceName)
-	err = <-errChan
-
-	return err
-}
-
 func (plugin *USBDevicePlugin) healthCheck() error {
 	monitoredDevices := make(map[string]string)
 	watcher, err := fsnotify.NewWatcher()
@@ -295,14 +284,6 @@ func (plugin *USBDevicePlugin) healthCheck() error {
 	}
 }
 
-func (plugin *USBDevicePlugin) cleanup() error {
-	err := os.Remove(plugin.socketPath)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	return nil
-}
-
 func (plugin *USBDevicePlugin) register() error {
 	conn, err := grpc.Dial(pluginapi.KubeletSocket,
 		grpc.WithInsecure(),
@@ -329,12 +310,6 @@ func (plugin *USBDevicePlugin) register() error {
 		return err
 	}
 	return nil
-}
-
-func (plugin *USBDevicePlugin) GetDevicePluginOptions(ctx context.Context, _ *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
-	return &pluginapi.DevicePluginOptions{
-		PreStartRequired: false,
-	}, nil
 }
 
 // Interface to expose Devices: IDs, health and Topology
@@ -423,10 +398,6 @@ func (plugin *USBDevicePlugin) Allocate(_ context.Context, allocRequest *plugina
 	}
 
 	return allocResponse, nil
-}
-
-func (plugin *USBDevicePlugin) PreStartContainer(context.Context, *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
-	return &pluginapi.PreStartContainerResponse{}, nil
 }
 
 func parseSysUeventFile(path string) *USBDevice {
@@ -633,12 +604,18 @@ func NewUSBDevicePlugin(resourceName string, pluginDevices []*PluginDevices) *US
 		resourceID = s[1]
 	}
 	resourceID = fmt.Sprintf("usb-%s", resourceID)
-	return &USBDevicePlugin{
-		socketPath:   SocketPath(resourceID),
-		resourceName: resourceName,
-		devices:      pluginDevices,
-		logger:       log.Log.With("subcomponent", resourceID),
-		initialized:  false,
-		lock:         &sync.Mutex{},
+	usb := &USBDevicePlugin{
+		DevicePluginBase: &DevicePluginBase{
+			socketPath:   SocketPath(resourceID),
+			resourceName: resourceName,
+			initialized:  false,
+			lock:         &sync.Mutex{},
+			health:       make(chan deviceHealth),
+			done:         make(chan struct{}),
+			deregistered: make(chan struct{}),
+		},
+		devices: pluginDevices,
+		logger:  log.Log.With("subcomponent", resourceID),
 	}
+	return usb
 }


### PR DESCRIPTION
### What this PR does
Before this PR:

All methods on plugins are implemented without a common interface to unify testing

After this PR:
 Define the `DevicePlugin` interface to group methods

Fixes:
https://github.com/kubevirt/kubevirt/issues/11293#event-11910506102

### Why we need it and why it was done in this way
The following tradeoffs were made:

Other common shared methods are found in device plugins such as `cleanup`, `register`.. etc.
However I propose the interface to be as minimal as can be as to not make it difficult to implement on adding a new plugin. extra guidance on if any of these methods are needed in the interface may be required from the project maintainers .

Also there exists an interface called `Device` that implements the same thing in `kubevirt/pkg/virt-handler/device-manager/generic_device.go`. However its unclear whether its required to extend this interface as a part of this PR or create a new one. as this interface is already used in the code

### Release note

```release-note
Refactor device plugins to use a base plugin and define a common interface
```