### PR TITLE
migration: Sync unpaused condition at target pod before migration finish

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "node.go",
         "pool.go",
         "replicaset.go",
+        "sync.go",
         "vm.go",
         "vmi.go",
         "vsock.go",


### PR DESCRIPTION
### What this PR does
Before this PR:
The virt-launcher pod has a readiness gate that depends on the vm
unpaused condition to be present, this condition is set when the VM is
running, but sometimes after proper live migration readiness gate takes
some time to see the condition so there are going to be some time where
target virt-launcher unpropertly marked as not ready.


After this PR:
This change create the target pod of live migration with unpaused
condition if the VM is not paused so readiness gate is fine before live
migration finish.

It also improve a little the pod status condition patching to not fail
when there is no "conditions" fiels yet at "status.

Fixes #https://issues.redhat.com/browse/CNV-38604


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

TODO:
- [ ] Add test to check unpause condition creation timestamp is older than live migration finish timestamp.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Sync unpaused condition at target pod before migration finish
```

