### PR TITLE
Cleanup owner aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -99,23 +99,7 @@ aliases:
   sig-api-reviewers: []
 
   #
-  # SIG Controllers
-  # Owns the knowledge about excellent controllers in kubevirt.
-  #
-  sig-controllers-approvers: []
-  sig-controllers-reviewers: []
-
-  #
-  # SIG Live Migration
-  # Owns the orchestration of live migrations, besides this keeping
-  # other teams honest to make sure that their features work well
-  # with Live Migration.
-  #
-  sig-live-migration-approvers: []
-  sig-live-migration-reviewers: []
-
-  #
-  # SIG Node
+  # SIG Compute
   # Owns everything which is taking place on a node, for example
   # (but not limited to) groups, SELinux, node labels, …
   #

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -102,10 +102,11 @@ aliases:
   # SIG Compute
   # Owns everything which is taking place on a node, for example
   # (but not limited to) groups, SELinux, node labels, …
+  # And everything on the cluster level such as RBAC, controller, …
   #
-  sig-node-approvers:
+  sig-compute-approvers:
     - jean-edouard
-  sig-node-reviewers:
+  sig-compute-reviewers:
     - victortoso
 
   #

--- a/pkg/handler-launcher-com/OWNERS
+++ b/pkg/handler-launcher-com/OWNERS
@@ -1,9 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-  - sig-node-reviewers
+  - sig-compute-reviewers
 approvers:
-  - sig-node-approvers
+  - sig-compute-approvers
 labels:
   - area/virt-handler
   - area/virt-launcher
-  - sig/node
+  - sig/compute

--- a/pkg/virt-handler/OWNERS
+++ b/pkg/virt-handler/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-  - sig-node-reviewers
+  - sig-compute-reviewers
 approvers:
-  - sig-node-approvers
+  - sig-compute-approvers
 labels:
   - area/virt-handler
-  - sig/node
+  - sig/compute


### PR DESCRIPTION
### What this PR does
Before this PR: We had more but empty and unusued sigs

After this PR: We have less - but used and staffed - sigs

### Why we need it and why it was done in this way
The following tradeoffs were made: Keep the current lis of sigs, but this would require staffing and defining ownership, which is tricky, thus we realign on sig-compute for now

The following alternatives were considered: Keep sigs, but this would require more work to define ownership and update code, htis is too much work that we do not want right now

Links to places where the discussion took place: i.e. https://groups.google.com/g/kubevirt-dev/c/dXvwU6Pon7Y

### Special notes for your reviewer

The decision about sig-node and sig-cluster/scheduling can take place separataely, but should not block this PR.
This PR reflects reality.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

