### PR TITLE
Nominate myself as a sig-compute approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -106,6 +106,7 @@ aliases:
   #
   sig-compute-approvers:
     - jean-edouard
+    - iholder101
   sig-compute-reviewers:
     - victortoso
 


### PR DESCRIPTION
### What this PR does
Before this PR:
I a top-level approver, but not assigned to any SIGs.

After this PR:
I am assigned as a sig-compute approver.

### Why we need it and why it was done in this way
This is part of the process to refine SIGs and ownerships in Kubevirt.
Related to https://github.com/kubevirt/kubevirt/pull/11046 and https://github.com/kubevirt/kubevirt/pull/11355.
Also see below links for reference.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
- https://groups.google.com/g/kubevirt-dev/c/-5TLpOcRkco
- https://groups.google.com/g/kubevirt-dev/c/dXvwU6Pon7Y

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- ~[ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] ~Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)~
- [ ] ~Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)]~(https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [ ] ~Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [X] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

