### PR TITLE
feature-gates: cleanup deprecation warning message

### DIFF
--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -28,9 +28,13 @@ import (
 type State string
 
 const (
-	GA           = "General Availability" // By default, GAed feature gates are considered enabled and no-op.
-	Deprecated   = "Deprecated"           // The feature is going to be discontinued next release
-	Discontinued = "Discontinued"
+	// By default, GAed feature gates are considered enabled and no-op.
+	GA = "General Availability"
+	// The feature is going to be discontinued next release
+	Deprecated     = "Deprecated"
+	Discontinued   = "Discontinued"
+	WarningPattern = "feature gate %s is deprecated (feature state is %q), therefore it can be safely removed and is redundant. " +
+		"For more info, please look at: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md"
 )
 
 const (
@@ -56,16 +60,15 @@ var featureGates = [...]FeatureGate{
 	{Name: NonRoot, State: GA},
 	{Name: PSA, State: GA},
 	{Name: CPUNodeDiscoveryGate, State: GA},
-	{Name: PasstGate, State: Deprecated, Message: passtDeprecationMessage, VmiSpecUsed: passtApiUsed},
-	{Name: MacvtapGate, State: Deprecated, Message: macvtapDeprecationMessage, VmiSpecUsed: macvtapApiUsed},
+	{Name: PasstGate, State: Deprecated, Message: PasstDeprecationMessage, VmiSpecUsed: passtApiUsed},
+	{Name: MacvtapGate, State: Deprecated, Message: MacvtapDeprecationMessage, VmiSpecUsed: macvtapApiUsed},
 }
 
 func init() {
 	for i, fg := range featureGates {
 		if fg.Message == "" {
-			const warningPattern = "feature gate %s is deprecated, therefore it can be safely removed and is redundant. " +
-				"For more info, please look at: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md"
-			featureGates[i].Message = fmt.Sprintf(warningPattern, fg.Name)
+
+			featureGates[i].Message = fmt.Sprintf(WarningPattern, fg.Name, fg.State)
 		}
 	}
 }

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -38,12 +38,12 @@ const (
 )
 
 const (
-	LiveMigrationGate      = "LiveMigration"      // Deprecated
-	SRIOVLiveMigrationGate = "SRIOVLiveMigration" // Deprecated
-	CPUNodeDiscoveryGate   = "CPUNodeDiscovery"   // Deprecated
+	LiveMigrationGate      = "LiveMigration"      // GA
+	SRIOVLiveMigrationGate = "SRIOVLiveMigration" // GA
+	NonRoot                = "NonRoot"            // GA
+	PSA                    = "PSA"                // GA
+	CPUNodeDiscoveryGate   = "CPUNodeDiscovery"   // GA
 	PasstGate              = "Passt"              // Deprecated
-	NonRoot                = "NonRoot"            // Deprecated
-	PSA                    = "PSA"                // Deprecated
 	MacvtapGate            = "Macvtap"            // Deprecated
 )
 

--- a/pkg/virt-config/deprecation/macvtap.go
+++ b/pkg/virt-config/deprecation/macvtap.go
@@ -23,7 +23,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-const macvtapDeprecationMessage = "Macvtap network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives."
+const MacvtapDeprecationMessage = "Macvtap network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives."
 
 func macvtapApiUsed(spec *v1.VirtualMachineInstanceSpec) bool {
 	for _, net := range spec.Domain.Devices.Interfaces {

--- a/pkg/virt-config/deprecation/passt.go
+++ b/pkg/virt-config/deprecation/passt.go
@@ -25,7 +25,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util"
 )
 
-const passtDeprecationMessage = "Passt network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives."
+const PasstDeprecationMessage = "Passt network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives."
 
 func passtApiUsed(spec *v1.VirtualMachineInstanceSpec) bool {
 	return util.IsPasstVMI(spec)

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -305,8 +305,13 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				},
 			}))
 		},
-			Entry("with Passt", deprecation.PasstGate, "Passt network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives."),
-			Entry("with SRIOVLiveMigrationGate", deprecation.SRIOVLiveMigrationGate, "feature gate SRIOVLiveMigration is deprecated, therefore it can be safely removed and is redundant. For more info, please look at: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md"),
+			Entry("with LiveMigration", deprecation.LiveMigrationGate, fmt.Sprintf(deprecation.WarningPattern, deprecation.LiveMigrationGate, deprecation.GA)),
+			Entry("with SRIOVLiveMigration", deprecation.SRIOVLiveMigrationGate, fmt.Sprintf(deprecation.WarningPattern, deprecation.SRIOVLiveMigrationGate, deprecation.GA)),
+			Entry("with NonRoot", deprecation.NonRoot, fmt.Sprintf(deprecation.WarningPattern, deprecation.NonRoot, deprecation.GA)),
+			Entry("with PSA", deprecation.PSA, fmt.Sprintf(deprecation.WarningPattern, deprecation.PSA, deprecation.GA)),
+			Entry("with CPUNodeDiscoveryGate", deprecation.CPUNodeDiscoveryGate, fmt.Sprintf(deprecation.WarningPattern, deprecation.CPUNodeDiscoveryGate, deprecation.GA)),
+			Entry("with Passt", deprecation.PasstGate, deprecation.PasstDeprecationMessage),
+			Entry("with MacvtapGate", deprecation.MacvtapGate, deprecation.MacvtapDeprecationMessage),
 		)
 	})
 })


### PR DESCRIPTION
/cc ormergi

### What this PR does
Before this PR:

The warning message emitted when each deprecated feature gate is enabled made no reference to the underlying state of the feature and may be confusing to the reader. For example, the `LiveMigration` feature gate is deprecated but the feature itself is GA.

After this PR:

The feature state is now included within the warning message message.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

