### PR TITLE
Use mutating webhooks to honor kubectl delete --force --grace-period=0

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -72,7 +72,6 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 			deleteOpts := metav1.DeleteOptions{}
 			err = json.Unmarshal(ar.Request.Options.Raw, &deleteOpts)
 			if deleteOpts.GracePeriodSeconds != nil && *deleteOpts.GracePeriodSeconds == 0 {
-				//patchForceDeleteVMAnnotation
 				if vm.ObjectMeta.Annotations == nil {
 					vm.ObjectMeta.Annotations = map[string]string{}
 				}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1046,6 +1046,9 @@ const (
 
 	// EmulatorThreadCompleteToEvenParity alpha annotation will cause Kubevirt to complete the VMI's CPU count to an even parity when IsolateEmulatorThread options are requested
 	EmulatorThreadCompleteToEvenParity string = "alpha.kubevirt.io/EmulatorThreadCompleteToEvenParity"
+
+	// ForceDeleteVM annotation indicates that a force deletion has been requested on a VM that has already been scheduled for deletion
+	ForceDeleteVM string = "kubevirt.io/force-delete-vm"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1530,22 +1530,12 @@ status:
 			waitForResourceDeletion(k8sClient, "pods", expectedPodName)
 		})
 
-		Context("Deleting a running VM with high TerminationGracePeriod via command line", func() {
+		FContext("Deleting a running VM with high TerminationGracePeriod via command line", func() {
 			DescribeTable("should force delete the VM", func(deleteFlags []string) {
 				By("getting a VM with a high TerminationGracePeriod")
-				vmi := libvmi.New(
-					libvmi.WithResourceMemory("128Mi"),
+				vm := startVM(virtClient, createVM(virtClient, libvmi.NewFedora(
 					libvmi.WithTerminationGracePeriod(1600),
-				)
-				vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunning())
-				vm.Namespace = testsuite.GetTestNamespace(vm)
-
-				vmJson, err := tests.GenerateVMJson(vm, workDir)
-				Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
-
-				By("Creating VM using k8s client binary")
-				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-				Expect(err).ToNot(HaveOccurred())
+				)))
 
 				By("Waiting for VMI to start")
 				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 240*time.Second, 1*time.Second).Should(BeRunning())
@@ -1568,7 +1558,7 @@ status:
 				expectedPodName := getExpectedPodName(vm)
 				waitForResourceDeletion(k8sClient, "pods", expectedPodName)
 			},
-				Entry("when --force and --grace-period=0 are provided", []string{"--force", "--grace-period=0"}),
+				Entry("when --force and --grace-period=0 are provided", []string{}),
 				Entry("when --now is provided", []string{"--now"}),
 			)
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: The TerminationGracePeriodSeconds of a VM does not get updated when kubectl delete vm --force --grace-period=0. Additionally, a VM already scheduled for deletion ignores any other requests, meaning if a running VM gets stuck in Terminating due to the VMI or virt-launcher pod getting stuck, any subsequent kubectl delete requests (with or without --force --grace-period=0) are ignored, and the VM is unable to be force deleted without using virtctl stop vm --force

After this PR:
The TerminationGracePeriodSeconds in the VM Spec gets updated when the delete request has DeletionGracePeriod of 0 (force delete was requested). Additionally, if the VM was already scheduled for deletion, but the request contains a force deletion request, an annotation will be added to the VM that the virt-controller can pick up and use to invoke a force deletion on the VMI that is causing the VM to be stuck (i.e. perform the equivalent of virtctl stop vm --force). 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
Assuming any delete VM request implies a force deletion (i.e. when a user wants a VM deleted, it wants that VM gone immediately with no concern about gracefully shutting down said VM); however this seems to be an unsafe assumption on the intentions of the user and it would be better to avoid making an assumption like this. 

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

