### PR TITLE
bump-common-instancetypes: Add support for stable branch releases

### DIFF
--- a/hack/bump-common-instancetypes.sh
+++ b/hack/bump-common-instancetypes.sh
@@ -2,15 +2,19 @@
 
 set -ex
 
-source $(dirname "$0")/common.sh
-source $(dirname "$0")/config.sh
+source "$(dirname "$0")/common.sh"
+source "$(dirname "$0")/config.sh"
+
+TARGET_BRANCH=${1:-"main"}
 
 function latest_version() {
-    local org="$1"
-    local repo="$2"
-
-    curl --fail -s "https://api.github.com/repos/${org}/${repo}/releases/latest" |
-        jq -r '.tag_name'
+    if [[ $TARGET_BRANCH == "main" ]]; then
+        curl --fail -s "https://api.github.com/repos/kubevirt/common-instancetypes/releases/latest" |
+            jq -r '.tag_name'
+    else
+        curl --fail -s "https://api.github.com/repos/kubevirt/common-instancetypes/releases?per_page=100" |
+            jq -r '.[] | select(.target_commitish == '\""${TARGET_BRANCH}"\"') | .tag_name' | head -n1
+    fi
 }
 
 function checksum() {
@@ -21,7 +25,7 @@ function checksum() {
         grep "${file}" | cut -d " " -f 1
 }
 
-version=$(latest_version "kubevirt" "common-instancetypes")
+version=$(latest_version)
 instancetypes_checksum=$(checksum "${version}" "common-clusterinstancetypes-bundle-${version}.yaml")
 preferences_checksum=$(checksum "${version}" "common-clusterpreferences-bundle-${version}.yaml")
 


### PR DESCRIPTION
/area instancetype
/cc 0xFelix

### What this PR does
Before this PR:

`bump-common-instancetypes` would sync `kubevirt` with the latest release of `common-instancetypes`.

After this PR:

`bump-common-instancetypes` continues to sync `kubevirt` with the latest release of `common-instancetypes` by default but can also sync with a stable branch if one is provided as an argument.

Partial Fix# https://github.com/kubevirt/common-instancetypes/issues/162

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

