### PR TITLE
refactor(e2e): use `libvmi` instead of `NewRandomVMIWithDataVolume`

### DIFF
--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -43,27 +43,6 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-func AddDataVolumeDisk(vmi *v13.VirtualMachineInstance, diskName, dataVolumeName string) *v13.VirtualMachineInstance {
-	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v13.Disk{
-		Name: diskName,
-		DiskDevice: v13.DiskDevice{
-			Disk: &v13.DiskTarget{
-				Bus: v13.DiskBusVirtio,
-			},
-		},
-	})
-	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v13.Volume{
-		Name: diskName,
-		VolumeSource: v13.VolumeSource{
-			DataVolume: &v13.DataVolumeSource{
-				Name: dataVolumeName,
-			},
-		},
-	})
-
-	return vmi
-}
-
 func AddDataVolumeTemplate(vm *v13.VirtualMachine, dataVolume *v1beta1.DataVolume) {
 	dvt := &v13.DataVolumeTemplateSpec{}
 

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1072,7 +1072,12 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 
-				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+				vmi := libvmi.New(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithDataVolume("disk0", dataVolume.Name),
+					libvmi.WithResourceMemory("1Gi"),
+				)
 
 				dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -1373,7 +1378,12 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				Entry("[test_id:8610] with DataVolume", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the DataVolume
-					return tests.NewRandomVMIWithDataVolume(dv.Name)
+					return libvmi.New(
+						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithDataVolume("disk0", dv.Name),
+						libvmi.WithResourceMemory("1Gi"),
+					)
 				}, console.LoginToAlpine),
 
 				Entry("[test_id:8611] with CD + CloudInit + SA + ConfigMap + Secret + DownwardAPI + Kernel Boot", func() *v1.VirtualMachineInstance {
@@ -1458,7 +1468,12 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				Entry("with DataVolume", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(testsuite.NamespacePrivileged, size)
 					// Use the DataVolume
-					return tests.NewRandomVMIWithDataVolume(dv.Name)
+					return libvmi.New(
+						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithDataVolume("disk0", dv.Name),
+						libvmi.WithResourceMemory("1Gi"),
+					)
 				}, console.LoginToAlpine),
 
 				Entry("with CD + CloudInit + SA + ConfigMap + Secret + DownwardAPI + Kernel Boot", func() *v1.VirtualMachineInstance {
@@ -2190,8 +2205,13 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				libstorage.EventuallyDV(dv, 600, HaveSucceeded())
-				vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
-				tests.AddUserData(vmi, "disk1", "#!/bin/bash\n echo hello\n")
+				vmi := libvmi.New(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithDataVolume("disk0", dv.Name),
+					libvmi.WithResourceMemory("1Gi"),
+					libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\n echo hello\n"),
+				)
 				return vmi
 			}
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1835,10 +1835,17 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 						libdv.WithPVC(libdv.PVCWithStorageClass(snapshotStorageClass), libdv.PVCWithVolumeSize("1Gi")),
 					)
 
-					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-					tests.AddUserData(vmi, "cloud-init", bashHelloScript)
-					vm := libvmi.NewVirtualMachine(vmi)
-					libstorage.AddDataVolumeTemplate(vm, dataVolume)
+					vm := libvmi.NewVirtualMachine(
+						libvmi.New(
+							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithNetwork(v1.DefaultPodNetwork()),
+							libvmi.WithDataVolume("disk0", dataVolume.Name),
+							libvmi.WithResourceMemory("1Gi"),
+							libvmi.WithCloudInitNoCloudEncodedUserData(bashHelloScript),
+							libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+						),
+						libvmi.WithDataVolumeTemplate(dataVolume),
+					)
 					return vm
 				}
 

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1130,9 +1130,6 @@ var _ = SIGDescribe("Storage", func() {
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				labelKey := "testshareablekey"
-				labels := map[string]string{
-					labelKey: "",
-				}
 
 				// give an affinity rule to ensure the vmi's get placed on the same node.
 				affinityRule := &k8sv1.Affinity{
@@ -1155,11 +1152,20 @@ var _ = SIGDescribe("Storage", func() {
 						},
 					},
 				}
-
-				vmi1 = tests.NewRandomVMIWithDataVolume(dv.Name)
-				vmi2 = tests.NewRandomVMIWithDataVolume(dv.Name)
-				vmi1.Labels = labels
-				vmi2.Labels = labels
+				vmi1 = libvmi.New(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithDataVolume("disk0", dv.Name),
+					libvmi.WithResourceMemory("1Gi"),
+					libvmi.WithLabel(labelKey, ""),
+				)
+				vmi2 = libvmi.New(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithDataVolume("disk0", dv.Name),
+					libvmi.WithResourceMemory("1Gi"),
+					libvmi.WithLabel(labelKey, ""),
+				)
 
 				vmi1.Spec.Affinity = affinityRule
 				vmi2.Spec.Affinity = affinityRule

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -352,14 +352,13 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 //
 // Deprecated: Use libvmi directly
 func NewRandomVMIWithDataVolume(dataVolumeName string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMI()
-
-	diskName := "disk0"
-
-	vmi = libstorage.AddDataVolumeDisk(vmi, diskName, dataVolumeName)
-
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
-	return vmi
+	return libvmi.New(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithDataVolume("disk0", dataVolumeName),
+		libvmi.WithResourceMemory("1Gi"),
+		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+	)
 }
 
 // NewRandomVMWithEphemeralDisk

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -285,7 +285,13 @@ func NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc string, acc
 	dv, err = virtCli.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	libstorage.EventuallyDV(dv, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer), BeInPhase(cdiv1.PendingPopulation)))
-	return NewRandomVMIWithDataVolume(dv.Name), dv
+	return libvmi.New(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithDataVolume("disk0", dv.Name),
+		libvmi.WithResourceMemory("1Gi"),
+		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+	), dv
 }
 
 // NewRandomVirtualMachineInstanceWithFileDisk
@@ -348,19 +354,6 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 	return vmi
 }
 
-// NewRandomVMIWithDataVolume
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithDataVolume(dataVolumeName string) *v1.VirtualMachineInstance {
-	return libvmi.New(
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithDataVolume("disk0", dataVolumeName),
-		libvmi.WithResourceMemory("1Gi"),
-		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-	)
-}
-
 // NewRandomVMWithEphemeralDisk
 //
 // Deprecated: Use libvmi directly
@@ -384,7 +377,13 @@ func NewRandomVMWithDataVolumeWithRegistryImport(imageUrl, namespace, storageCla
 		),
 	)
 
-	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
+	vmi := libvmi.New(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithDataVolume("disk0", dataVolume.Name),
+		libvmi.WithResourceMemory("1Gi"),
+		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+	)
 	vm := libvmi.NewVirtualMachine(vmi)
 
 	libstorage.AddDataVolumeTemplate(vm, dataVolume)
@@ -405,7 +404,13 @@ func NewRandomVMWithDataVolume(imageUrl string, namespace string) (*v1.VirtualMa
 		libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 	)
 
-	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
+	vmi := libvmi.New(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithDataVolume("disk0", dataVolume.Name),
+		libvmi.WithResourceMemory("1Gi"),
+		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+	)
 	vm := libvmi.NewVirtualMachine(vmi)
 
 	libstorage.AddDataVolumeTemplate(vm, dataVolume)
@@ -420,11 +425,18 @@ func NewRandomVMWithDataVolumeAndUserDataInStorageClass(imageUrl, namespace, use
 		libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullNode),
 		libdv.WithPVC(libdv.PVCWithStorageClass(storageClass), libdv.PVCWithVolumeSize(dvSizeBySourceURL(imageUrl))),
 	)
-	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
-	AddUserData(vmi, "cloud-init", userData)
-	vm := libvmi.NewVirtualMachine(vmi)
+	vm := libvmi.NewVirtualMachine(
+		libvmi.New(
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithDataVolume("disk0", dataVolume.Name),
+			libvmi.WithResourceMemory("1Gi"),
+			libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+			libvmi.WithCloudInitNoCloudEncodedUserData(userData),
+		),
+		libvmi.WithDataVolumeTemplate(dataVolume),
+	)
 
-	libstorage.AddDataVolumeTemplate(vm, dataVolume)
 	return vm
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
`tests/utils.go` file contains several utility functions that can be considered duplicated.
This is because the same result can be achieved with the already present libvmi/etc options.

After this PR:
This PR aims to drop the `NewRandomVMIWithDataVolume` wrapper function,
replacing its occurrences with:
```
vmi := libvmi.New(
	libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
	libvmi.WithNetwork(v1.DefaultPodNetwork()),
	libvmi.WithDataVolume("disk0", dataVolume.Name),
	libvmi.WithResourceMemory("1Gi"),
)
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->
During the conversion, some other improvements have been made, in the vision of using `libvmi.Option`.
In particular:
- `tests.AddUserData(vmi, ...)` --> `libvmi.WithCloudInitNoCloudEncodedUserData(...),`
- `libstorage.AddDataVolumeTemplate(vm, dataVolume)` --> `libvmi.WithDataVolumeTemplate(dataVolume))`
- `addDataVolumeDisk(vm, "blankdisk", blankDv.Name)` --> `libvmi.WithDataVolume("blankdisk", blankDv.Name)`
- `vm.Spec.Running = pointer.Bool(true)` --> `libvmi.WithRunning()`
- `vmi.ObjectMeta.Annotations = renderSidecar()` --> `libvmi.WithAnnotation("hooks.kubevirt.io/hookSidecars", hookSidecarsValue),...`
- `vmi1.Spec.Affinity = affinityRule --> `libvmi.WithNodeAffinityForLabel(labelKey, ""),`
- `vmi1.Labels = labels` --> `libvmi.WithLabel(labelKey, ""),`
					

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [ ] ~Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

