### PR TITLE
virt-controller: fix panic when VM udate fails

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3056,9 +3056,11 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 
 		if syncErr == nil {
 			if !equality.Semantic.DeepEqual(vm, vmCopy) {
-				vm, err = c.clientset.VirtualMachine(vmCopy.Namespace).Update(context.Background(), vmCopy)
+				updatedVm, err := c.clientset.VirtualMachine(vmCopy.Namespace).Update(context.Background(), vmCopy)
 				if err != nil {
 					syncErr = &syncErrorImpl{fmt.Errorf("Error encountered when trying to update vm according to add volume and/or memory dump requests: %v", err), FailedUpdateErrorReason}
+				} else {
+					vm = updatedVm
 				}
 			}
 		}


### PR DESCRIPTION
### What this PR does
A failed update returns a nil for the VM. This
commit fixes a potential panic.

Fixes #10811

### Why we need it and why it was done in this way

### Special notes for your reviewer
### Release note

```release-note
Bug-fix: Fix nil panic if VM update fails
```

