### PR TITLE
Wait until backend storage PVC is ready before starting VMIs

### DIFF
--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -14,5 +14,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -126,6 +126,7 @@ go_test(
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/rest:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/export/export:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/storage/types:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -623,6 +623,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.vmInformer,
 		vca.kvPodInformer,
 		vca.persistentVolumeClaimInformer,
+		vca.storageClassInformer,
 		vca.vmiRecorder,
 		vca.clientSet,
 		vca.dataVolumeInformer,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -131,6 +131,7 @@ var _ = Describe("Application", func() {
 			vmInformer,
 			podInformer,
 			pvcInformer,
+			storageClassInformer,
 			recorder,
 			virtClient,
 			dataVolumeInformer,

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -85,9 +85,12 @@ const (
 	// FailedHandOverPodReason is added in an event and in a vmi controller condition
 	// when transferring the pod ownership from the controller to virt-hander fails.
 	FailedHandOverPodReason = "FailedHandOver"
-	// FailedBackendStorageCreateReason is added in an event when posting a dynamically
-	// generated dataVolume to the cluster fails.
+	// FailedBackendStorageCreateReason is added when the creation of the backend storage PVC fails.
 	FailedBackendStorageCreateReason = "FailedBackendStorageCreate"
+	// FailedBackendStorageProbeReason is added when probing the backend storage PVC fails.
+	FailedBackendStorageProbeReason = "FailedBackendStorageProbe"
+	// BackendStorageNotReadyReason is added when the backend storage PVC is pending.
+	BackendStorageNotReadyReason = "BackendStorageNotReady"
 	// SuccessfulHandOverPodReason is added in an event
 	// when the pod ownership transfer from the controller to virt-hander succeeds.
 	SuccessfulHandOverPodReason = "SuccessfulHandOver"
@@ -1177,17 +1180,14 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 		// do not return; just log the error
 	}
 
+	err := backendstorage.CreateIfNeeded(vmi, c.clusterConfig, c.clientset)
+	if err != nil {
+		return &syncErrorImpl{err, FailedBackendStorageCreateReason}
+	}
+
 	dataVolumesReady, isWaitForFirstConsumer, syncErr := c.handleSyncDataVolumes(vmi, dataVolumes)
 	if syncErr != nil {
 		return syncErr
-	}
-
-	err := backendstorage.CreateIfNeeded(vmi, c.clusterConfig, c.clientset)
-	if err != nil {
-		return &syncErrorImpl{
-			err:    err,
-			reason: FailedBackendStorageCreateReason,
-		}
 	}
 
 	if !podExists(pod) {
@@ -1205,6 +1205,17 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 		if !dataVolumesReady {
 			log.Log.V(3).Object(vmi).Infof("Delaying pod creation while DataVolume populates or while we wait for PVCs to appear.")
 			return nil
+		}
+
+		// Ensure the backend storage PVC is ready
+		var backendStorageReady bool
+		backendStorageReady, err = backendstorage.IsPVCReady(vmi, c.clientset)
+		if err != nil {
+			return &syncErrorImpl{err, FailedBackendStorageProbeReason}
+		}
+		if !backendStorageReady {
+			log.Log.V(3).Object(vmi).Infof("Delaying pod creation while backend storage populates.")
+			return &syncErrorImpl{fmt.Errorf("PVC pending"), BackendStorageNotReadyReason}
 		}
 
 		var templatePod *k8sv1.Pod

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/network/downwardapi"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/network"
 
@@ -191,6 +192,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			update, _ := action.(testing.UpdateAction)
 			return true, update.GetObject(), nil
 		})
+	}
+
+	shouldExpectVirtualMachinePendingState := func(vmi *virtv1.VirtualMachineInstance) {
+		vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
+			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Pending))
+			Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
+		}).Return(vmi, nil)
 	}
 
 	shouldExpectVirtualMachineSchedulingState := func(vmi *virtv1.VirtualMachineInstance) {
@@ -573,6 +582,28 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionFalse)
+			controller.Execute()
+		})
+
+		It("should not create a corresponding Pod on VMI creation when backend storage is pending", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+			vmi.Spec.Domain.Firmware = &virtv1.Firmware{
+				Bootloader: &virtv1.Bootloader{
+					EFI: &virtv1.EFI{
+						Persistent: pointer.Bool(true),
+					},
+				},
+			}
+
+			pvc := NewPvc(vmi.Namespace, backendstorage.PVCForVMI(vmi))
+			pvc.Status.Phase = k8sv1.ClaimPending
+			Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
+
+			addVirtualMachine(vmi)
+			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
+				return true, pvc, nil
+			})
+			shouldExpectVirtualMachinePendingState(vmi)
 			controller.Execute()
 		})
 	})


### PR DESCRIPTION
### What this PR does
Before this PR:
VMIs can encounter a (non-fatal) error while starting if the PVC is not ready.

After this PR:
VMIs will wait until the PVC is ready and not run into any error.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

