### PR TITLE
vm_test: use a simpler smaller VMI

### DIFF
--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -85,6 +85,23 @@ func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	return New(alpineOpts...)
 }
 
+func NewGuestless(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	opts = append(
+		[]Option{WithResourceMemory(qemuMinimumMemory())},
+		opts...)
+	return New(opts...)
+}
+
+func qemuMinimumMemory() string {
+	if isARM64() {
+		// required to start qemu on ARM with UEFI firmware
+		// https://github.com/kubevirt/kubevirt/pull/11366#issuecomment-1970247448
+		const armMinimalBootableMemory = "128Mi"
+		return armMinimalBootableMemory
+	}
+	return "1Mi"
+}
+
 func cirrosMemory() string {
 	if isARM64() {
 		return "256Mi"

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1837,7 +1837,7 @@ status:
 		)
 
 		BeforeEach(func() {
-			vmi = tests.NewRandomVMI()
+			vmi = libvmi.NewGuestless()
 			vm = libvmi.NewVirtualMachine(vmi, libvmi.WithRunning())
 			Expect(vm.Finalizers).To(BeEmpty())
 			vm.Finalizers = append(vm.Finalizers, customFinalizer)


### PR DESCRIPTION
The tests that are affected by the modified `BeforeEach` do not make use of the guest. They can run just as well with much less memory.

/sig code-quality

```release-note
NONE
```

