### PR TITLE
Vm controller remove Informers 

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -246,13 +246,13 @@ func ApplyVolumeRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request
 	return vmiSpec
 }
 
-func CurrentVMIPod(vmi *v1.VirtualMachineInstance, podInformer cache.SharedIndexInformer) (*k8sv1.Pod, error) {
+func CurrentVMIPod(vmi *v1.VirtualMachineInstance, podIndexer cache.Indexer) (*k8sv1.Pod, error) {
 
 	// current pod is the most recent pod created on the current VMI node
 	// OR the most recent pod created if no VMI node is set.
 
 	// Get all pods from the namespace
-	objs, err := podInformer.GetIndexer().ByIndex(cache.NamespaceIndex, vmi.Namespace)
+	objs, err := podIndexer.ByIndex(cache.NamespaceIndex, vmi.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -346,11 +346,11 @@ func SetVMIMigrationPhaseTransitionTimestamp(oldVMIMigration *v1.VirtualMachineI
 	}
 }
 
-func SetSourcePod(migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, podInformer cache.SharedIndexInformer) {
+func SetSourcePod(migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, podIndexer cache.Indexer) {
 	if migration.Status.Phase != v1.MigrationPending {
 		return
 	}
-	sourcePod, err := CurrentVMIPod(vmi, podInformer)
+	sourcePod, err := CurrentVMIPod(vmi, podIndexer)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Warning("migration source pod not found")
 	}

--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -145,9 +145,9 @@ func GenerateDataVolumeFromTemplate(clientset kubecli.KubevirtClient, dataVolume
 	return newDataVolume, nil
 }
 
-func GetDataVolumeFromCache(namespace, name string, dataVolumeInformer cache.SharedInformer) (*cdiv1.DataVolume, error) {
+func GetDataVolumeFromCache(namespace, name string, dataVolumeStore cache.Store) (*cdiv1.DataVolume, error) {
 	key := controller.NamespacedKey(namespace, name)
-	obj, exists, err := dataVolumeInformer.GetStore().GetByKey(key)
+	obj, exists, err := dataVolumeStore.GetByKey(key)
 
 	if err != nil {
 		return nil, fmt.Errorf("error fetching DataVolume %s: %v", key, err)
@@ -164,13 +164,13 @@ func GetDataVolumeFromCache(namespace, name string, dataVolumeInformer cache.Sha
 	return dv, nil
 }
 
-func HasDataVolumeErrors(namespace string, volumes []virtv1.Volume, dataVolumeInformer cache.SharedInformer) error {
+func HasDataVolumeErrors(namespace string, volumes []virtv1.Volume, dataVolumeStore cache.Store) error {
 	for _, volume := range volumes {
 		if volume.DataVolume == nil {
 			continue
 		}
 
-		dv, err := GetDataVolumeFromCache(namespace, volume.DataVolume.Name, dataVolumeInformer)
+		dv, err := GetDataVolumeFromCache(namespace, volume.DataVolume.Name, dataVolumeStore)
 		if err != nil {
 			log.Log.Errorf("Error fetching DataVolume %s: %v", volume.DataVolume.Name, err)
 			continue
@@ -195,13 +195,13 @@ func HasDataVolumeErrors(namespace string, volumes []virtv1.Volume, dataVolumeIn
 	return nil
 }
 
-func HasDataVolumeProvisioning(namespace string, volumes []virtv1.Volume, dataVolumeInformer cache.SharedInformer) bool {
+func HasDataVolumeProvisioning(namespace string, volumes []virtv1.Volume, dataVolumeStore cache.Store) bool {
 	for _, volume := range volumes {
 		if volume.DataVolume == nil {
 			continue
 		}
 
-		dv, err := GetDataVolumeFromCache(namespace, volume.DataVolume.Name, dataVolumeInformer)
+		dv, err := GetDataVolumeFromCache(namespace, volume.DataVolume.Name, dataVolumeStore)
 		if err != nil {
 			log.Log.Errorf("Error fetching DataVolume %s while determining virtual machine status: %v", volume.DataVolume.Name, err)
 			continue
@@ -221,12 +221,12 @@ func HasDataVolumeProvisioning(namespace string, volumes []virtv1.Volume, dataVo
 	return false
 }
 
-func ListDataVolumesFromTemplates(namespace string, dvTemplates []virtv1.DataVolumeTemplateSpec, dataVolumeInformer cache.SharedInformer) ([]*cdiv1.DataVolume, error) {
+func ListDataVolumesFromTemplates(namespace string, dvTemplates []virtv1.DataVolumeTemplateSpec, dataVolumeStore cache.Store) ([]*cdiv1.DataVolume, error) {
 	dataVolumes := []*cdiv1.DataVolume{}
 
 	for _, template := range dvTemplates {
 		// get DataVolume from cache for each templated dataVolume
-		dv, err := GetDataVolumeFromCache(namespace, template.Name, dataVolumeInformer)
+		dv, err := GetDataVolumeFromCache(namespace, template.Name, dataVolumeStore)
 		if err != nil {
 			return dataVolumes, err
 		} else if dv == nil {
@@ -238,7 +238,7 @@ func ListDataVolumesFromTemplates(namespace string, dvTemplates []virtv1.DataVol
 	return dataVolumes, nil
 }
 
-func ListDataVolumesFromVolumes(namespace string, volumes []virtv1.Volume, dataVolumeInformer cache.SharedInformer, pvcInformer cache.SharedInformer) ([]*cdiv1.DataVolume, error) {
+func ListDataVolumesFromVolumes(namespace string, volumes []virtv1.Volume, dataVolumeStore cache.Store, pvcInformer cache.SharedInformer) ([]*cdiv1.DataVolume, error) {
 	dataVolumes := []*cdiv1.DataVolume{}
 
 	for _, volume := range volumes {
@@ -247,7 +247,7 @@ func ListDataVolumesFromVolumes(namespace string, volumes []virtv1.Volume, dataV
 			continue
 		}
 
-		dv, err := GetDataVolumeFromCache(namespace, *dataVolumeName, dataVolumeInformer)
+		dv, err := GetDataVolumeFromCache(namespace, *dataVolumeName, dataVolumeStore)
 		if err != nil {
 			return dataVolumes, err
 		} else if dv == nil {

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -142,9 +142,9 @@ func VirtVolumesToPVCMap(volumes []*virtv1.Volume, pvcStore cache.Store, namespa
 	return volumeNamesPVCMap, nil
 }
 
-func GetPersistentVolumeClaimFromCache(namespace, name string, pvcInformer cache.SharedInformer) (*k8sv1.PersistentVolumeClaim, error) {
+func GetPersistentVolumeClaimFromCache(namespace, name string, pvcStore cache.Store) (*k8sv1.PersistentVolumeClaim, error) {
 	key := controller.NamespacedKey(namespace, name)
-	obj, exists, err := pvcInformer.GetStore().GetByKey(key)
+	obj, exists, err := pvcStore.GetByKey(key)
 
 	if err != nil {
 		return nil, fmt.Errorf("error fetching PersistentVolumeClaim %s: %v", key, err)
@@ -161,14 +161,14 @@ func GetPersistentVolumeClaimFromCache(namespace, name string, pvcInformer cache
 	return pvc, nil
 }
 
-func HasUnboundPVC(namespace string, volumes []virtv1.Volume, pvcInformer cache.SharedInformer) bool {
+func HasUnboundPVC(namespace string, volumes []virtv1.Volume, pvcStore cache.Store) bool {
 	for _, volume := range volumes {
 		claimName := PVCNameFromVirtVolume(&volume)
 		if claimName == "" {
 			continue
 		}
 
-		pvc, err := GetPersistentVolumeClaimFromCache(namespace, claimName, pvcInformer)
+		pvc, err := GetPersistentVolumeClaimFromCache(namespace, claimName, pvcStore)
 		if err != nil {
 			log.Log.Errorf("Error fetching PersistentVolumeClaim %s while determining virtual machine status: %v", claimName, err)
 			continue

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -505,7 +505,7 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 	}
 
 	controller.SetVMIMigrationPhaseTransitionTimestamp(migration, migrationCopy)
-	controller.SetSourcePod(migrationCopy, vmi, c.podInformer)
+	controller.SetSourcePod(migrationCopy, vmi, c.podInformer.GetIndexer())
 
 	if !equality.Semantic.DeepEqual(migration.Status, migrationCopy.Status) {
 		err := c.statusUpdater.UpdateStatus(migrationCopy)
@@ -1063,7 +1063,7 @@ func (c *MigrationController) handleTargetPodCreation(key string, migration *vir
 }
 
 func (c *MigrationController) createAttachmentPod(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) error {
-	sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer)
+	sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
 	if err != nil {
 		return fmt.Errorf("failed to get current VMI pod: %v", err)
 	}
@@ -1267,7 +1267,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 		}
 
 		if !targetPodExists {
-			sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer)
+			sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
 			if err != nil {
 				log.Log.Reason(err).Error("Failed to fetch pods for namespace from cache.")
 				return err

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -154,12 +154,12 @@ func NewVMController(vmiInformer cache.SharedIndexInformer,
 	}
 
 	c.hasSynced = func() bool {
-		return c.vmiInformer.HasSynced() && c.vmInformer.HasSynced() &&
-			c.dataVolumeInformer.HasSynced() && c.dataSourceInformer.HasSynced() &&
-			c.pvcInformer.HasSynced() && c.crInformer.HasSynced() && c.podInformer.HasSynced()
+		return vmiInformer.HasSynced() && vmInformer.HasSynced() &&
+			dataVolumeInformer.HasSynced() && dataSourceInformer.HasSynced() &&
+			pvcInformer.HasSynced() && crInformer.HasSynced() && podInformer.HasSynced()
 	}
 
-	_, err := c.vmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := vmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addVirtualMachine,
 		DeleteFunc: c.deleteVirtualMachine,
 		UpdateFunc: c.updateVirtualMachine,
@@ -168,7 +168,7 @@ func NewVMController(vmiInformer cache.SharedIndexInformer,
 		return nil, err
 	}
 
-	_, err = c.vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addVirtualMachineInstance,
 		DeleteFunc: c.deleteVirtualMachineInstance,
 		UpdateFunc: c.updateVirtualMachineInstance,
@@ -177,7 +177,7 @@ func NewVMController(vmiInformer cache.SharedIndexInformer,
 		return nil, err
 	}
 
-	_, err = c.dataVolumeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = dataVolumeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addDataVolume,
 		DeleteFunc: c.deleteDataVolume,
 		UpdateFunc: c.updateDataVolume,

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -374,14 +374,14 @@ func (c *VMIController) execute(key string) error {
 
 	// Only consider pods which belong to this vmi
 	// excluding unfinalized migration targets from this list.
-	pod, err := controller.CurrentVMIPod(vmi, c.podInformer)
+	pod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
 	if err != nil {
 		logger.Reason(err).Error("Failed to fetch pods for namespace from cache.")
 		return err
 	}
 
 	// Get all dataVolumes associated with this vmi
-	dataVolumes, err := storagetypes.ListDataVolumesFromVolumes(vmi.Namespace, vmi.Spec.Volumes, c.dataVolumeInformer, c.pvcInformer)
+	dataVolumes, err := storagetypes.ListDataVolumesFromVolumes(vmi.Namespace, vmi.Spec.Volumes, c.dataVolumeInformer.GetStore(), c.pvcInformer)
 	if err != nil {
 		logger.Reason(err).Error("Failed to fetch dataVolumes for namespace from cache.")
 		return err
@@ -2122,7 +2122,7 @@ func (c *VMIController) createAttachmentPopulateTriggerPodTemplate(volume *virtv
 }
 
 func (c *VMIController) deleteAllAttachmentPods(vmi *virtv1.VirtualMachineInstance) error {
-	virtlauncherPod, err := controller.CurrentVMIPod(vmi, c.podInformer)
+	virtlauncherPod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1377,7 +1377,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 			podFeeder.Add(failedTargetPod2)
 
-			selectedPod, err := kvcontroller.CurrentVMIPod(vmi, podInformer)
+			selectedPod, err := kvcontroller.CurrentVMIPod(vmi, podInformer.GetIndexer())
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(selectedPod.UID).To(Equal(pod.UID))

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -557,7 +557,7 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 		go func(vmi *virtv1.VirtualMachineInstance) {
 			defer wg.Done()
 
-			pod, err := controller.CurrentVMIPod(vmi, c.podInformer)
+			pod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
 			if err != nil {
 
 				log.Log.Object(vmi).Reason(err).Errorf("Failed to detect active pod for vmi during workload update")


### PR DESCRIPTION
### What this PR does
Removes the usage of Informers in the VM controller as what we really need is `cache.Store` or `cache.Indexer`. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way

### Special notes for your reviewer
The last commit mentions the simplification of unit tests. The problem is that we are using informers in the tests even when we most likely don't need them. This creates a problem because the `framework.FakeControllerSource` is not reflecting the changes synchronously. Meaning, an `.Add` will not be reflected in the underlying `cache.Store` right away and we always need to assert the existence if we don't want flaky behavior. Converting the controller to use `cache.Store` allows us to also switch the unit tests to directly use the store, removing the need for synchronization.

Note: We can also directly use the `cache.Store` of the informers today.



<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

