### PR TITLE
refectory: fix misspelling

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19363,7 +19363,7 @@
     "type": "object",
     "properties": {
      "persistent": {
-      "description": "Persistent indicates the state of the TPM device should be kept accross reboots Defaults to false",
+      "description": "Persistent indicates the state of the TPM device should be kept across reboots. Defaults to false",
       "type": "boolean"
      }
     }

--- a/pkg/network/vmispec/infosource.go
+++ b/pkg/network/vmispec/infosource.go
@@ -8,13 +8,13 @@ const (
 	InfoSourceMultusStatus string = "multus-status"
 	InfoSourceDomainAndGA  string = InfoSourceDomain + ", " + InfoSourceGuestAgent
 
-	seperator = ", "
+	separator = ", "
 )
 
 func AddInfoSource(infoSourceData, name string) string {
 	var infoSources []string
 	if infoSourceData != "" {
-		infoSources = strings.Split(infoSourceData, seperator)
+		infoSources = strings.Split(infoSourceData, separator)
 	}
 	for _, infoSourceName := range infoSources {
 		if infoSourceName == name {
@@ -27,7 +27,7 @@ func AddInfoSource(infoSourceData, name string) string {
 
 func RemoveInfoSource(infoSourceData, name string) string {
 	var newInfoSources []string
-	infoSources := strings.Split(infoSourceData, seperator)
+	infoSources := strings.Split(infoSourceData, separator)
 	for _, infoSourceName := range infoSources {
 		if infoSourceName != name {
 			newInfoSources = append(newInfoSources, infoSourceName)
@@ -37,7 +37,7 @@ func RemoveInfoSource(infoSourceData, name string) string {
 }
 
 func ContainsInfoSource(infoSourceData, name string) bool {
-	infoSources := strings.Split(infoSourceData, seperator)
+	infoSources := strings.Split(infoSourceData, separator)
 	for _, infoSourceName := range infoSources {
 		if infoSourceName == name {
 			return true
@@ -47,5 +47,5 @@ func ContainsInfoSource(infoSourceData, name string) bool {
 }
 
 func NewInfoSource(names ...string) string {
-	return strings.Join(names, seperator)
+	return strings.Join(names, separator)
 }

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -109,7 +109,7 @@ const (
 
 	kvm = 107
 
-	// secretTokenLength is the lenght of the randomly generated token
+	// secretTokenLength is the length of the randomly generated token
 	secretTokenLength = 20
 	// secretTokenKey is the entry used to store the token in the virtualMachineExport secret
 	secretTokenKey = "token"
@@ -693,7 +693,7 @@ func (ctrl *VMExportController) createCertSecretManifest(vmExport *exportv1.Virt
 // handleVMExportToken checks if a secret has been specified for the current export object and, if not, creates one specific to it
 func (ctrl *VMExportController) handleVMExportToken(vmExport *exportv1.VirtualMachineExport) error {
 	// If a tokenSecretRef has been specified, we assume that the corresponding
-	// secret has already been created and managed appropiately by the user
+	// secret has already been created and managed appropriately by the user
 	if vmExport.Spec.TokenSecretRef != nil {
 		vmExport.Status.TokenSecretRef = vmExport.Spec.TokenSecretRef
 		return nil

--- a/pkg/util/os_helper.go
+++ b/pkg/util/os_helper.go
@@ -27,10 +27,10 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-// CloseIOAndCheckErr closes the file and check the returned error.
+// CloseIOAndCheckErr closes the file and checks the returned error.
 // If there was an error a log messages will be printed.
-// If a valid address (not nil) is passed in  err the function will also update the error
-// Note: to update the error the calling funtion need to use named returned variable (If called as defer function)
+// If a valid address (not nil) is passed in err the function will also update the error
+// Note: to update the error the calling function needs to use a named returned variable (If called as defer function)
 func CloseIOAndCheckErr(c io.Closer, err *error) {
 	if ferr := c.Close(); ferr != nil {
 		log.DefaultLogger().Reason(ferr).Error("Error when closing file")

--- a/pkg/util/trace/trace.go
+++ b/pkg/util/trace/trace.go
@@ -38,7 +38,7 @@ func (t *Tracer) StopTrace(key string) {
 	return
 }
 
-// A trace Step adds a new step with a specific message.
+// StepTrace adds a new trace step with a specific message.
 // Call StepTrace after an execution step to record how long it took.
 func (t *Tracer) StepTrace(key string, name string, field ...trace.Field) {
 	// Trace shouldn't be making noise unless the Trace is slow.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -196,7 +196,7 @@ func ResourceNameToEnvVar(prefix string, resourceName string) string {
 	return fmt.Sprintf("%s_%s", prefix, varName)
 }
 
-// Checks if kernel boot is defined in a valid way
+// HasKernelBootContainerImage checks if kernel boot is defined in a valid way
 func HasKernelBootContainerImage(vmi *v1.VirtualMachineInstance) bool {
 	if vmi == nil {
 		return false

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1338,7 +1338,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			Expect(response.StatusCode()).To(Equal(statusCode))
 		},
-			Entry("VM with a memory dump request without claim name with assocaited memory dump should succeed",
+			Entry("VM with a memory dump request without claim name with associated memory dump should succeed",
 				&v1.VirtualMachineMemoryDumpRequest{},
 				&v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: testPVCName,
@@ -1346,7 +1346,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				}, http.StatusAccepted),
 			Entry("VM with a memory dump request missing claim name without previous memory dump should fail",
 				&v1.VirtualMachineMemoryDumpRequest{}, nil, http.StatusBadRequest),
-			Entry("VM with a memory dump request with claim name different then assocaited memory dump should fail",
+			Entry("VM with a memory dump request with claim name different then associated memory dump should fail",
 				&v1.VirtualMachineMemoryDumpRequest{
 					ClaimName: "diffPVCName",
 				},

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -364,7 +364,7 @@ var _ = Describe("Evacuation", func() {
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
 
 			podSource.Add(newPod(vmi, "runningPod", v12.PodRunning, true))
-			podSource.Add(newPod(vmi, "succededPod", v12.PodSucceeded, true))
+			podSource.Add(newPod(vmi, "succeededPod", v12.PodSucceeded, true))
 			podSource.Add(newPod(vmi, "failedPod", v12.PodFailed, true))
 			podSource.Add(newPod(vmi, "notOwnedRunningPod", v12.PodRunning, false))
 			// pods do not cause the queue to get added to

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -2936,7 +2936,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("should not get any fs overhead if the PVC has volumeMode block", k8sv1.PersistentVolumeBlock, "default", cdiv1.Percent("0")),
 			Entry("should return global fs overhead if there's no storageClassName", k8sv1.PersistentVolumeFilesystem, "", cdiv1.Percent("0.5")),
 			Entry("should return global fs overhead if the storageClassName is invalid", k8sv1.PersistentVolumeFilesystem, "nonValid", cdiv1.Percent("0.5")),
-			Entry("should return the appropiate overhead when using a valid storageClassName", k8sv1.PersistentVolumeFilesystem, "default", cdiv1.Percent("0.8")),
+			Entry("should return the appropriate overhead when using a valid storageClassName", k8sv1.PersistentVolumeFilesystem, "default", cdiv1.Percent("0.8")),
 		)
 
 		It("Should properly create attachmentpod, if correct volume and disk are added", func() {

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -463,9 +463,9 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 		}
 	}
 
-	// Rather than enqueing based on VMI activity, we keep periodically poping the loop
+	// Rather than enqueuing based on VMI activity, we keep periodically popping the loop
 	// until all VMIs are updated. Watching all VMI activity is chatty for this controller
-	// when we don't need to be that efficent in how quickly the updates are being processed.
+	// when we don't need to be that efficient in how quickly the updates are being processed.
 	if len(data.evictOutdatedVMIs) != 0 || len(data.migratableOutdatedVMIs) != 0 {
 		c.queue.AddAfter(key, periodicReEnqueueIntervalSeconds)
 	}

--- a/pkg/virt-handler/heartbeat/ksm_test.go
+++ b/pkg/virt-handler/heartbeat/ksm_test.go
@@ -192,7 +192,7 @@ var _ = Describe("KSM", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, expectedLabelValue))
 		},
 			Entry("should add KSM label if the node labels match ksmConfiguration.nodeLabelSelector", map[string]string{"test_label": "true"}, "true"),
-			Entry("should not add KSM label if the node labels match ksmConfiguration.nodeLabelSelector", map[string]string{"no_macthing_label": "true"}, "false"),
+			Entry("should not add KSM label if the node labels match ksmConfiguration.nodeLabelSelector", map[string]string{"no_matching_label": "true"}, "false"),
 		)
 
 		DescribeTable("with memory pressure, should", func(initialKsmValue string, selectorOverride *metav1.LabelSelector,

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6059,8 +6059,7 @@ var CRDsValidation map[string]string = map[string]string{
                           properties:
                             persistent:
                               description: Persistent indicates the state of the TPM
-                                device should be kept accross reboots Defaults to
-                                false
+                                device should be kept across reboots Defaults to false
                               type: boolean
                           type: object
                         useVirtioTransitional:
@@ -8501,7 +8500,7 @@ var CRDsValidation map[string]string = map[string]string{
               properties:
                 persistent:
                   description: Persistent indicates the state of the TPM device should
-                    be kept accross reboots Defaults to false
+                    be kept across reboots Defaults to false
                   type: boolean
               type: object
             preferredUseVirtioTransitional:
@@ -10640,7 +10639,7 @@ var CRDsValidation map[string]string = map[string]string{
                   properties:
                     persistent:
                       description: Persistent indicates the state of the TPM device
-                        should be kept accross reboots Defaults to false
+                        should be kept across reboots Defaults to false
                       type: boolean
                   type: object
                 useVirtioTransitional:
@@ -13433,7 +13432,7 @@ var CRDsValidation map[string]string = map[string]string{
                   properties:
                     persistent:
                       description: Persistent indicates the state of the TPM device
-                        should be kept accross reboots Defaults to false
+                        should be kept across reboots Defaults to false
                       type: boolean
                   type: object
                 useVirtioTransitional:
@@ -15635,7 +15634,7 @@ var CRDsValidation map[string]string = map[string]string{
                           properties:
                             persistent:
                               description: Persistent indicates the state of the TPM
-                                device should be kept accross reboots Defaults to
+                                device should be kept across reboots Defaults to
                                 false
                               type: boolean
                           type: object
@@ -20022,7 +20021,7 @@ var CRDsValidation map[string]string = map[string]string{
                                   properties:
                                     persistent:
                                       description: Persistent indicates the state
-                                        of the TPM device should be kept accross reboots
+                                        of the TPM device should be kept across reboots
                                         Defaults to false
                                       type: boolean
                                   type: object
@@ -21853,7 +21852,7 @@ var CRDsValidation map[string]string = map[string]string{
               properties:
                 persistent:
                   description: Persistent indicates the state of the TPM device should
-                    be kept accross reboots Defaults to false
+                    be kept across reboots Defaults to false
                   type: boolean
               type: object
             preferredUseVirtioTransitional:
@@ -25191,7 +25190,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       properties:
                                         persistent:
                                           description: Persistent indicates the state
-                                            of the TPM device should be kept accross
+                                            of the TPM device should be kept across
                                             reboots Defaults to false
                                           type: boolean
                                       type: object

--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Guestfs shell", func() {
 			guestfs.SetDefaulAttacher()
 		})
 
-		It("Succesfully attach to PVC", func() {
+		It("Successfully attach to PVC", func() {
 			guestfs.SetClient(fakeCreateClientPVC)
 			cmd := virtctlcmd.NewRepeatableVirtctlCommand(commandName, pvcName)
 			Expect(cmd()).To(Succeed())

--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -78,7 +78,7 @@ type command struct {
 
 type memoryDumpCompleteFunc func(kubecli.KubevirtClient, string, string, time.Duration, time.Duration) (string, error)
 
-// WaitMemoryDumpCompleted is used to store the function to wait for the memory dump to be complete.
+// WaitMemoryDumpComplete is used to store the function to wait for the memory dump to be complete.
 // Useful for unit tests.
 var WaitMemoryDumpComplete memoryDumpCompleteFunc = waitForMemoryDump
 
@@ -240,7 +240,7 @@ func checkNoAssociatedMemoryDump(namespace, vmName string, virtClient kubecli.Ku
 
 func createPVCforMemoryDump(namespace, vmName, claimName string, virtClient kubecli.KubevirtClient) error {
 	// Before creating a new pvc check that there is not already
-	// assocaited memory dump pvc
+	// associated memory dump pvc
 	if err := checkNoAssociatedMemoryDump(namespace, vmName, virtClient); err != nil {
 		return err
 	}

--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -414,7 +414,7 @@ var _ = Describe("MemoryDump", func() {
 			Expect(cmd.Execute()).To(Succeed())
 		})
 
-		It("should call download memory dump and decompress succesfully", func() {
+		It("should call download memory dump and decompress successfully", func() {
 			vmexport.HandleHTTPRequest = func(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, downloadUrl string, insecure bool, exportURL string, headers map[string]string) (*http.Response, error) {
 				resp := http.Response{
 					StatusCode: http.StatusOK,
@@ -481,7 +481,7 @@ var _ = Describe("MemoryDump", func() {
 			Entry("with port-forward specifying default number on local port", []string{"memory-dump", "download", "testvm", outputFileFlag, "--port-forward", "--local-port", "0"}),
 		)
 
-		It("should fail download memory dump if not completed succesfully", func() {
+		It("should fail download memory dump if not completed successfully", func() {
 			memorydump.WaitMemoryDumpComplete = waitForMemoryDumpErr
 
 			commandAndArgs := []string{"memory-dump", "download", "testvm", outputFileFlag}

--- a/pkg/virtctl/portforward/portforward.go
+++ b/pkg/virtctl/portforward/portforward.go
@@ -226,7 +226,7 @@ func examples() string {
 
   # Note: {{ProgramName}} port-forward sends all traffic over the Kubernetes API Server. 
   # This means any traffic will add additional pressure to the control plane.
-  # For continous traffic intensive connections, consider using a dedicated Kubernetes Service.
+  # For continuous traffic intensive connections, consider using a dedicated Kubernetes Service.
 
   # Open an SSH connection using PortForward and ProxyCommand:
   ssh -o 'ProxyCommand={{ProgramName}} port-forward --stdio=true testvmi.mynamespace 22' user@testvmi.mynamespace

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -103,8 +103,8 @@ const (
 	exportTokenHeader = "x-kubevirt-export-token"
 	// secretTokenKey is the entry used to store the token in the virtualMachineExport secret
 	secretTokenKey = "token"
-	// secretTokenLenght is the lenght of the randomly generated token
-	secretTokenLenght = 20
+	// secretTokenLength is the length of the randomly generated token
+	secretTokenLength = 20
 
 	// ErrRequiredFlag serves as error message when a mandatory flag is missing
 	ErrRequiredFlag = "need to specify the '%s' flag when using '%s'"
@@ -333,7 +333,7 @@ func (c *command) run(args []string) error {
 func (c *command) parseExportArguments(args []string, vmeInfo *VMExportInfo) error {
 	funcName := strings.ToLower(args[0])
 
-	// Assign the appropiate vmexport function and make sure the used flags are compatible
+	// Assign the appropriate vmexport function and make sure the used flags are compatible
 	switch funcName {
 	case CREATE:
 		exportFunction = CreateVirtualMachineExport
@@ -466,7 +466,7 @@ func CreateVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExport
 		return err
 	}
 
-	printToOutput("VirtualMachineExport '%s/%s' created succesfully\n", vmeInfo.Namespace, vmeInfo.Name)
+	printToOutput("VirtualMachineExport '%s/%s' created successfully\n", vmeInfo.Namespace, vmeInfo.Name)
 	return nil
 }
 
@@ -480,7 +480,7 @@ func DeleteVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExport
 		return nil
 	}
 
-	printToOutput("VirtualMachineExport '%s/%s' deleted succesfully\n", vmeInfo.Namespace, vmeInfo.Name)
+	printToOutput("VirtualMachineExport '%s/%s' deleted successfully\n", vmeInfo.Namespace, vmeInfo.Name)
 	return nil
 }
 
@@ -597,7 +597,7 @@ func downloadVolume(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMac
 		return err
 	}
 
-	printToOutput("Download finished succesfully\n")
+	printToOutput("Download finished successfully\n")
 
 	return nil
 }
@@ -743,7 +743,7 @@ func waitForVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExpor
 // HandleHTTPRequestFunc function used to handle http requests
 type HandleHTTPRequestFunc func(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, downloadUrl string, insecure bool, exportURL string, headers map[string]string) (*http.Response, error)
 
-// instance of function used to handle http requests
+// HandleHTTPRequest is an instance of the function used to handle http requests
 var HandleHTTPRequest HandleHTTPRequestFunc = handleHTTPGetRequest
 
 // handleHTTPGetRequest generates the GET request with proper certificate handling
@@ -821,7 +821,7 @@ func copyFileWithProgressBar(output io.Writer, resp *http.Response, decompress b
 // getOrCreateTokenSecret obtains a token secret to be used along with the virtualMachineExport
 func getOrCreateTokenSecret(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport) (*k8sv1.Secret, error) {
 	// Securely randomize a 20 char string to be used as a token
-	token, err := util.GenerateSecureRandomString(secretTokenLenght)
+	token, err := util.GenerateSecureRandomString(secretTokenLength)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -308,7 +308,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		// Create tests
-		It("VirtualMachineExport is created succesfully", func() {
+		It("VirtualMachineExport is created successfully", func() {
 			utils.HandleVMExportCreate(vmExportClient, nil)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"))
 			err := cmd()
@@ -316,7 +316,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		// Delete tests
-		It("VirtualMachineExport is deleted succesfully", func() {
+		It("VirtualMachineExport is deleted successfully", func() {
 			utils.HandleVMExportDelete(vmExportClient, vmexportName)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DELETE, vmexportName)
 			err := cmd()
@@ -331,7 +331,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		// Download tests
-		It("Succesfully download from an already existing VirtualMachineExport", func() {
+		It("Successfully download from an already existing VirtualMachineExport", func() {
 			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -347,7 +347,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Succesfully create and download a VirtualMachineExport", func() {
+		It("Successfully create and download a VirtualMachineExport", func() {
 			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -363,7 +363,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Succesfully create and download a VirtualMachineExport with raw format", func() {
+		It("Successfully create and download a VirtualMachineExport with raw format", func() {
 			virtctlvmexport.HandleHTTPRequest = func(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, downloadUrl string, insecure bool, exportURL string, headers map[string]string) (*http.Response, error) {
 				resp := http.Response{
 					StatusCode: http.StatusOK,
@@ -399,7 +399,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Succesfully download a VirtualMachineExport without decompressing is url is already raw", func() {
+		It("Successfully download a VirtualMachineExport without decompressing is url is already raw", func() {
 			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -415,7 +415,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Succesfully download a VirtualMachineExport with just 'raw' links", func() {
+		It("Successfully download a VirtualMachineExport with just 'raw' links", func() {
 			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -465,7 +465,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Succesfully create VirtualMachineExport with TTL", func() {
+		It("Successfully create VirtualMachineExport with TTL", func() {
 			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -543,7 +543,7 @@ type SoundDevice struct {
 }
 
 type TPMDevice struct {
-	// Persistent indicates the state of the TPM device should be kept accross reboots
+	// Persistent indicates the state of the TPM device should be kept across reboots
 	// Defaults to false
 	Persistent *bool `json:"persistent,omitempty"`
 }

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -287,7 +287,7 @@ func (SoundDevice) SwaggerDoc() map[string]string {
 
 func (TPMDevice) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"persistent": "Persistent indicates the state of the TPM device should be kept accross reboots\nDefaults to false",
+		"persistent": "Persistent indicates the state of the TPM device should be kept across reboots\nDefaults to false",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -22198,7 +22198,7 @@ func schema_kubevirtio_api_core_v1_TPMDevice(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"persistent": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Persistent indicates the state of the TPM device should be kept accross reboots Defaults to false",
+							Description: "Persistent indicates the state of the TPM device should be kept across reboots Defaults to false",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -170,7 +170,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		Context("[Serial]without fsgroup support", Serial, func() {
 			size := "1Gi"
 
-			It("should succesfully start", func() {
+			It("should successfully start", func() {
 				// Create DV and alter permission of disk.img
 				sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
 				if !foundSC {
@@ -1007,7 +1007,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.NamespaceTestAlternative).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				// We check if the VM is succesfully created
+				// We check if the VM is successfully created
 				By("Creating VM")
 				Eventually(func() bool {
 					_, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)

--- a/tests/util/util.go
+++ b/tests/util/util.go
@@ -12,7 +12,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-// tests.NamespaceTestDefault is the default namespace, to test non-infrastructure related KubeVirt objects.
+// NamespaceTestDefault is the default namespace, to test non-infrastructure related KubeVirt objects.
 var NamespaceTestDefault = "kubevirt-test-default"
 
 func PanicOnError(err error) {

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -77,7 +77,7 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 		addDataToTPM := func(vmi *v1.VirtualMachineInstance) {
 			By("Storing a secret into the TPM")
 			// https://www.intel.com/content/www/us/en/developer/articles/code-sample/protecting-secret-data-and-keys-using-intel-platform-trust-technology.html
-			// Not sealing against a set of PCRs, out of scope here, but should work with a carefully selected set (at least PCR1 was seen changing accross reboots)
+			// Not sealing against a set of PCRs, out of scope here, but should work with a carefully selected set (at least PCR1 was seen changing across reboots)
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "tpm2_createprimary -Q --hierarchy=o --key-context=prim.ctx\n"},
 				&expect.BExp{R: console.PromptExpression},

--- a/tools/perfscale-load-generator/burst/burst.go
+++ b/tools/perfscale-load-generator/burst/burst.go
@@ -113,7 +113,7 @@ func (b *BurstJob) DeleteWorkloads() {
 	log.Log.V(2).Infof("Deleting %d objects for job %s", b.Workload.Count, jobUUID)
 	objUtil.DeleteNObjectsInNamespaces(b.virtClient, objType, config.GetListOpts(config.WorkloadUUIDLabel, jobUUID), b.Workload.Count)
 
-	// Wait all objects be Deleted. In the case of VMI, deleted means the succeded phase.
+	// Wait all objects be Deleted. In the case of VMI, deleted means the succeeded phase.
 	for objType, objWatcher := range b.watchers {
 		log.Log.Infof("Wait for obj(s) %s to be deleted", objType)
 		objWatcher.WaitDeletion(b.Workload.Timeout.Duration)

--- a/tools/perfscale-load-generator/steady-state/steady-state.go
+++ b/tools/perfscale-load-generator/steady-state/steady-state.go
@@ -148,7 +148,7 @@ func (b *SteadyStateJob) DeleteWorkloads(count int) {
 	log.Log.V(2).Infof("Deleting %d objects for job %s", count, jobUUID)
 	objUtil.DeleteNObjectsInNamespaces(b.virtClient, objType, config.GetListOpts(config.WorkloadUUIDLabel, jobUUID), count)
 
-	// Wait all objects be Deleted. In the case of VMI, deleted means the succeded phase.
+	// Wait all objects be Deleted. In the case of VMI, deleted means the succeeded phase.
 	for objType, objWatcher := range b.watchers {
 		log.Log.Infof("Wait for obj(s) %s to be deleted", objType)
 		objWatcher.WaitDeletion(b.Workload.Timeout.Duration)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
fix misspelling

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

