### PR TITLE
libvmi: introduce NewGuestless

### DIFF
--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -85,6 +85,23 @@ func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	return New(alpineOpts...)
 }
 
+func NewGuestless(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	opts = append(
+		[]Option{WithResourceMemory(qemuMinimumMemory())},
+		opts...)
+	return New(opts...)
+}
+
+func qemuMinimumMemory() string {
+	if isARM64() {
+		// required to start qemu on ARM with UEFI firmware
+		// https://github.com/kubevirt/kubevirt/pull/11366#issuecomment-1970247448
+		const armMinimalBootableMemory = "128Mi"
+		return armMinimalBootableMemory
+	}
+	return "1Mi"
+}
+
 func cirrosMemory() string {
 	if isARM64() {
 		return "256Mi"


### PR DESCRIPTION
`libvmi.NewGuestless` would be useful by many tests that just want to define a VMI, but do not care about running a guest operating system inside it. The memory of such VMI can be much smaller (and thus, less demanding on our CI).

This has been discussed in https://github.com/kubevirt/kubevirt/pull/11366
I propose it here to allow quicker review by @EdDev .

sig code-quality

```release-note
NONE
```

