### PR TITLE
Fix exec.ExecuteCommandOnPod to not require virtclient as a parameter

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -36,21 +36,16 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
-	"kubevirt.io/client-go/kubecli"
-
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config", decorators.SigCompute, func() {
-
-	var virtClient kubecli.KubevirtClient
 
 	var CheckIsoVolumeSizes = func(vmi *v1.VirtualMachineInstance) {
 		pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -67,7 +62,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			}
 			if len(path) > 0 {
 				cmdCheck := []string{"stat", "--printf='%s'", path}
-				out, err := exec.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
+				out, err := exec.ExecuteCommandOnPod(pod, "compute", cmdCheck)
 				Expect(err).NotTo(HaveOccurred())
 				size, err := strconv.Atoi(strings.Trim(out, "'"))
 				Expect(err).NotTo(HaveOccurred())
@@ -75,10 +70,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			}
 		}
 	}
-
-	BeforeEach(func() {
-		virtClient = kubevirt.Client()
-	})
 
 	Context("With a ConfigMap defined", func() {
 
@@ -117,7 +108,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				By("Checking if ConfigMap has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				podOutput, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -211,7 +201,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				By("Checking if Secret has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(nil))
 				podOutput, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -284,7 +273,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			By("Checking if ServiceAccount has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			namespace, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"cat",
@@ -296,7 +284,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(namespace).To(Equal(testsuite.GetTestNamespace(vmi)))
 
 			token, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"tail", "-c", "20",
@@ -386,7 +373,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				By("Checking if ConfigMap has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				podOutputCfgMap, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -413,7 +399,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				By("Checking if Secret has also been attached to the same pod")
 				podOutputSecret, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -493,7 +478,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				By("Checking if Secret has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(nil))
 				podOutput1, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -504,7 +488,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(podOutput1).To(Equal(expectedPrivateKey), "Expected pod output of private key to match genereated one.")
 
 				podOutput2, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -554,7 +537,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			By("Checking if DownwardAPI has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(nil))
 			podOutput, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"grep", testLabelKey,

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -229,7 +229,6 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				writableImagePath := fmt.Sprintf("/var/run/kubevirt-ephemeral-disks/disk-data/%v/disk.qcow2", vmi.Spec.Domain.Devices.Disks[0].Name)
 
 				writableImageOctalMode, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					pod,
 					"compute",
 					[]string{"/usr/bin/bash", "-c", fmt.Sprintf("stat -c %%a %s", writableImagePath)},
@@ -240,7 +239,6 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(strings.Trim(writableImageOctalMode, "\n")).To(Equal("640"), "Octal Mode of writable Image should be 640")
 
 				readonlyImageOctalMode, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					pod,
 					"compute",
 					[]string{"/usr/bin/bash", "-c", "stat -c %a /var/run/kubevirt/container-disks/disk_0.img"},

--- a/tests/exec/BUILD.bazel
+++ b/tests/exec/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/framework/kubevirt:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",

--- a/tests/exec/execute.go
+++ b/tests/exec/execute.go
@@ -23,6 +23,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
@@ -30,8 +32,8 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-func ExecuteCommandOnPod(virtCli kubecli.KubevirtClient, pod *k8sv1.Pod, containerName string, command []string) (string, error) {
-	stdout, stderr, err := ExecuteCommandOnPodWithResults(virtCli, pod, containerName, command)
+func ExecuteCommandOnPod(pod *k8sv1.Pod, containerName string, command []string) (string, error) {
+	stdout, stderr, err := ExecuteCommandOnPodWithResults(pod, containerName, command)
 
 	if err != nil {
 		return "", fmt.Errorf("failed executing command on pod: %v: stderr %v: stdout: %v", err, stderr, stdout)
@@ -44,7 +46,7 @@ func ExecuteCommandOnPod(virtCli kubecli.KubevirtClient, pod *k8sv1.Pod, contain
 	return stdout, nil
 }
 
-func ExecuteCommandOnPodWithResults(virtCli kubecli.KubevirtClient, pod *k8sv1.Pod, containerName string, command []string) (stdout, stderr string, err error) {
+func ExecuteCommandOnPodWithResults(pod *k8sv1.Pod, containerName string, command []string) (stdout, stderr string, err error) {
 	var (
 		stdoutBuf bytes.Buffer
 		stderrBuf bytes.Buffer
@@ -54,12 +56,12 @@ func ExecuteCommandOnPodWithResults(virtCli kubecli.KubevirtClient, pod *k8sv1.P
 		Stderr: &stderrBuf,
 		Tty:    false,
 	}
-	err = ExecuteCommandOnPodWithOptions(virtCli, pod, containerName, command, options)
+	err = ExecuteCommandOnPodWithOptions(pod, containerName, command, options)
 	return stdoutBuf.String(), stderrBuf.String(), err
 }
 
-func ExecuteCommandOnPodWithOptions(virtCli kubecli.KubevirtClient, pod *k8sv1.Pod, containerName string, command []string, options remotecommand.StreamOptions) error {
-	req := virtCli.CoreV1().RESTClient().Post().
+func ExecuteCommandOnPodWithOptions(pod *k8sv1.Pod, containerName string, command []string, options remotecommand.StreamOptions) error {
+	req := kubevirt.Client().CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(pod.Name).
 		Namespace(pod.Namespace).

--- a/tests/guestlog/BUILD.bazel
+++ b/tests/guestlog/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
         "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -151,7 +151,7 @@ var _ = DescribeInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][leve
 		// We need a token from a service account that can view all namespaces in the cluster
 		By("extracting virt-operator sa token")
 		cmd := []string{"cat", "/var/run/secrets/kubernetes.io/serviceaccount/token"}
-		token, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, &op, "virt-operator", cmd)
+		token, stderr, err := exec.ExecuteCommandOnPodWithResults(&op, "virt-operator", cmd)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(remoteCmdErrPattern, strings.Join(cmd, " "), token, stderr, err))
 		Expect(token).ToNot(BeEmpty(), "virt-operator sa token returned empty")
 
@@ -170,7 +170,7 @@ var _ = DescribeInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][leve
 				vmi.Name,
 			)}
 
-		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, &op, "virt-operator", cmd)
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(&op, "virt-operator", cmd)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(remoteCmdErrPattern, strings.Join(cmd, " "), stdout, stderr, err))
 
 		// the Prometheus go-client does not export queryResult, and
@@ -339,7 +339,7 @@ var _ = DescribeInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][leve
 		Expect(err).ToNot(HaveOccurred())
 		for _, ep := range endpoint.Subsets[0].Addresses {
 			cmd := fmt.Sprintf("curl -L -k https://%s:8443/metrics", libnet.FormatIPForURL(ep.IP))
-			stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, "virt-handler", strings.Fields(cmd))
+			stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "virt-handler", strings.Fields(cmd))
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(remoteCmdErrPattern, cmd, stdout, stderr, err))
 			Expect(stdout).To(ContainSubstring("go_goroutines"))
 		}
@@ -616,7 +616,7 @@ func countReadyAndLeaderPods(pod *k8sv1.Pod, component string) (foundMetrics map
 		}
 
 		cmd := fmt.Sprintf("curl -L -k https://%s:8443/metrics", libnet.FormatIPForURL(ep.IP))
-		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, "virt-handler", strings.Fields(cmd))
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "virt-handler", strings.Fields(cmd))
 		if err != nil {
 			return nil, fmt.Errorf(remoteCmdErrPattern, cmd, stdout, stderr, err)
 		}

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -68,7 +68,7 @@ func ExecuteCommandInVirtHandlerPod(nodeName string, args []string) (stdout stri
 		return stdout, err
 	}
 
-	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, "virt-handler", args)
+	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "virt-handler", args)
 	if err != nil {
 		return stdout, fmt.Errorf("Failed excuting command=%v, error=%v, stdout=%s, stderr=%s", args, err, stdout, stderr)
 	}

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -222,7 +222,6 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 
 		execOnHelperPod := func(command string) (string, error) {
 			stdout, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				helperPod,
 				helperPod.Spec.Containers[0].Name,
 				[]string{tests.BinBash, "-c", command})

--- a/tests/libmonitoring/BUILD.bazel
+++ b/tests/libmonitoring/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
-        "//tests/framework/kubevirt:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",

--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -30,7 +30,6 @@ import (
 	execute "kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 )
 
 type AlertRequestResult struct {
@@ -395,7 +394,7 @@ func getPrometheusAlerts(virtClient kubecli.KubevirtClient) promv1.PrometheusRul
 
 func GetKubevirtVMMetrics(pod *k8sv1.Pod, ip string) string {
 	metricsURL := PrepareMetricsURL(ip, 8443)
-	stdout, _, err := execute.ExecuteCommandOnPodWithResults(kubevirt.Client(),
+	stdout, _, err := execute.ExecuteCommandOnPodWithResults(
 		pod,
 		"virt-handler",
 		[]string{

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -267,7 +267,6 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 			vmiPodRequestMemory := vmiPod.Spec.Containers[0].Resources.Requests.Memory().Value()
 			_, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"/usr/bin/bash", "-c", fmt.Sprintf("cat <( </dev/zero head -c %d) <(sleep 150) | tail", vmiPodRequestMemory)},

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -370,7 +370,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						launcher, err := libpod.GetPodByVirtualMachineInstance(tcpVM, tcpVM.GetNamespace())
 						Expect(err).ToNot(HaveOccurred())
 						ipv6NodeIP, err = resolveNodeIPAddrByFamily(
-							virtClient,
 							launcher,
 							node,
 							k8sv1.IPv6Protocol)
@@ -485,7 +484,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						launcher, err := libpod.GetPodByVirtualMachineInstance(udpVM, udpVM.GetNamespace())
 						Expect(err).ToNot(HaveOccurred())
 						ipv6NodeIP, err = resolveNodeIPAddrByFamily(
-							virtClient,
 							launcher,
 							node,
 							k8sv1.IPv6Protocol)
@@ -782,10 +780,9 @@ func getNodeHostname(nodeAddresses []k8sv1.NodeAddress) *string {
 	return nil
 }
 
-func resolveNodeIp(virtclient kubecli.KubevirtClient, pod *k8sv1.Pod, hostname string, ipFamily k8sv1.IPFamily) (string, error) {
+func resolveNodeIp(pod *k8sv1.Pod, hostname string, ipFamily k8sv1.IPFamily) (string, error) {
 	ahostsCmd := string("ahosts" + ipFamily[2:])
 	output, err := exec.ExecuteCommandOnPod(
-		virtclient,
 		pod,
 		"compute",
 		[]string{"getent", ahostsCmd, hostname})
@@ -803,10 +800,10 @@ func resolveNodeIp(virtclient kubecli.KubevirtClient, pod *k8sv1.Pod, hostname s
 	return "", fmt.Errorf("could not resolve an %s address from %s name", ipFamily, hostname)
 }
 
-func resolveNodeIPAddrByFamily(virtClient kubecli.KubevirtClient, sourcePod *k8sv1.Pod, node k8sv1.Node, ipFamily k8sv1.IPFamily) (string, error) {
+func resolveNodeIPAddrByFamily(sourcePod *k8sv1.Pod, node k8sv1.Node, ipFamily k8sv1.IPFamily) (string, error) {
 	hostname := getNodeHostname(node.Status.Addresses)
 	if hostname == nil {
 		return "", fmt.Errorf("could not get node hostname")
 	}
-	return resolveNodeIp(virtClient, sourcePod, *hostname, ipFamily)
+	return resolveNodeIp(sourcePod, *hostname, ipFamily)
 }

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -366,7 +366,6 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, testsuite.GetTestNamespace(vmiOne))
 				podInterfaceName := "e31d7ce2712-nic"
 				out, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					vmiPod,
 					"compute",
 					[]string{"sh", "-c", fmt.Sprintf("ip a show %s", podInterfaceName)},
@@ -477,7 +476,6 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, vmiOne.Namespace)
 				podInterfaceName := "72ad293a5c9-nic"
 				out, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					vmiPod,
 					"compute",
 					[]string{"sh", "-c", fmt.Sprintf("ip a show %s", podInterfaceName)},
@@ -529,7 +527,6 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				getPodInterfaceMtu := func(vmi *v1.VirtualMachineInstance) string {
 					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					output, err := exec.ExecuteCommandOnPod(
-						virtClient,
 						vmiPod,
 						"compute",
 						[]string{"cat", "/sys/class/net/pod72ad293a5c9/mtu"},

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -164,7 +164,6 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				for _, ifaceName := range []string{"k6t-eth0", "tap0"} {
 					By(fmt.Sprintf("checking %s MTU inside the pod", ifaceName))
 					output, err := exec.ExecuteCommandOnPod(
-						virtClient,
 						vmiPod,
 						"compute",
 						[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},
@@ -942,7 +941,6 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 			getMtu := func(pod *k8sv1.Pod, ifaceName string) int {
 				output, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					pod,
 					"compute",
 					[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -134,7 +134,6 @@ var _ = SIGDescribe("Slirp Networking", decorators.Networking, func() {
 
 			By("start the virtual machine with slirp interface")
 			output, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"cat", "/proc/net/tcp"},
@@ -145,7 +144,6 @@ var _ = SIGDescribe("Slirp Networking", decorators.Networking, func() {
 			Expect(strings.Contains(output, "0: 00000000:0050 00000000:0000 0A")).To(BeTrue())
 			By("return \"Hello World!\" when connecting to localhost on port 80")
 			output, err = exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"nc", "127.0.0.1", "80", "--recv-only"},
@@ -156,7 +154,6 @@ var _ = SIGDescribe("Slirp Networking", decorators.Networking, func() {
 
 			By("reject connecting to localhost and port different than 80")
 			output, err = exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[1].Name,
 				[]string{"curl", "127.0.0.1:9080"},

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -63,7 +63,7 @@ var _ = Describe("[sig-compute][Serial]NUMA", Serial, decorators.SigCompute, fun
 		By("Fetching the numa memory mapping")
 		handler, err := libnode.GetVirtHandlerPod(virtClient, cpuVMI.Status.NodeName)
 		Expect(err).ToNot(HaveOccurred())
-		pid := getQEMUPID(virtClient, handler, cpuVMI)
+		pid := getQEMUPID(handler, cpuVMI)
 
 		By("Checking if the pinned numa memory chunks match the VMI memory size")
 		scanner := bufio.NewScanner(strings.NewReader(getNUMAMapping(virtClient, handler, pid)))
@@ -109,12 +109,12 @@ var _ = Describe("[sig-compute][Serial]NUMA", Serial, decorators.SigCompute, fun
 
 })
 
-func getQEMUPID(virtClient kubecli.KubevirtClient, handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
+func getQEMUPID(handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
 	var stdout, stderr string
 	// Using `ps` here doesn't work reliably. Grepping /proc instead.
 	// The "[g]" prevents grep from finding its own process
 	Eventually(func() (err error) {
-		stdout, stderr, err = exec.ExecuteCommandOnPodWithResults(virtClient, handlerPod, "virt-handler",
+		stdout, stderr, err = exec.ExecuteCommandOnPodWithResults(handlerPod, "virt-handler",
 			[]string{
 				"/bin/bash",
 				"-c",
@@ -132,7 +132,7 @@ func getQEMUPID(virtClient kubecli.KubevirtClient, handlerPod *k8sv1.Pod, vmi *v
 }
 
 func getNUMAMapping(virtClient kubecli.KubevirtClient, pod *k8sv1.Pod, pid string) string {
-	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, "virt-handler",
+	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "virt-handler",
 		[]string{
 			"/bin/bash",
 			"-c",

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -90,7 +90,6 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			Expect(err).ToNot(HaveOccurred())
 			emulator = filepath.Base(emulator)
 			psOutput, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{tests.BinBash, "-c", "ps -LC " + emulator + " -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
@@ -103,7 +102,6 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			}
 			By("Validating that the memory lock limits are higher than the memory requested")
 			psOutput, err = exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{tests.BinBash, "-c", "grep 'locked memory' /proc/$(ps -C " + emulator + " -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
@@ -134,7 +132,6 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			Expect(err).ToNot(HaveOccurred())
 			emulator = filepath.Base(emulator)
 			psOutput, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{tests.BinBash, "-c", "ps -LC " + emulator + " -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
@@ -146,7 +143,6 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 
 			By("Validating the VCPU mask matches the scheduler profile for all cores")
 			psOutput, err = exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{tests.BinBash, "-c", "ps -TcC " + emulator + " |grep CPU |awk '{print $3\" \" $8}'"},

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -140,7 +140,6 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				qemuProcessSelinuxContext, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					pod,
 					"compute",
 					[]string{"/usr/bin/bash", "-c", fmt.Sprintf("ps -efZ | grep %s | awk '{print $1}'", emulator)},
@@ -217,7 +216,6 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 				pod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.NamespacePrivileged)
 				Expect(err).ToNot(HaveOccurred())
 				qemuProcessSelinuxContext, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					pod,
 					"compute",
 					[]string{"/usr/bin/bash", "-c", fmt.Sprintf("ps -efZ | grep %s | awk '{print $1}'", emulator)},
@@ -374,7 +372,7 @@ func runOnAllSchedulableNodes(virtClient kubecli.KubevirtClient, command []strin
 		if err != nil {
 			return err
 		}
-		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, components.VirtHandlerName, command)
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, components.VirtHandlerName, command)
 		if err != nil {
 			_, _ = GinkgoWriter.Write([]byte(stderr))
 			return err

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1148,7 +1148,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			var unused string
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(nil))
 			lsOutput, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{"ls", "-s", "/var/run/kubevirt-private/vmi-disks/disk0/disk.img"},

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -309,7 +309,7 @@ var _ = SIGDescribe("Export", func() {
 		if volumeMode == k8sv1.PersistentVolumeBlock {
 			fileName = blockVolumeMountPath
 		}
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Spec.Containers[0].Name, md5Command(fileName))
+		out, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, md5Command(fileName))
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		md5sum := strings.Split(out, " ")[0]
 		Expect(md5sum).To(HaveLen(32))
@@ -348,7 +348,7 @@ var _ = SIGDescribe("Export", func() {
 		if volumeMode == k8sv1.PersistentVolumeBlock {
 			fileAndPathName = blockVolumeMountPath
 		}
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
+		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		md5sum := strings.Split(out, " ")[0]
 		Expect(md5sum).To(HaveLen(32))
@@ -361,7 +361,7 @@ var _ = SIGDescribe("Export", func() {
 			"-d",
 			filepath.Join(dataPath, fileName),
 		}
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, downloadPod, downloadPod.Spec.Containers[0].Name, command)
+		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 
 		fileName = strings.Replace(fileName, ".gz", "", 1)
@@ -369,7 +369,7 @@ var _ = SIGDescribe("Export", func() {
 		if volumeMode == k8sv1.PersistentVolumeBlock {
 			fileAndPathName = blockVolumeMountPath
 		}
-		out, stderr, err = exec.ExecuteCommandOnPodWithResults(virtClient, downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
+		out, stderr, err = exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		md5sum := strings.Split(out, " ")[0]
 		Expect(md5sum).To(HaveLen(32))
@@ -388,14 +388,14 @@ var _ = SIGDescribe("Export", func() {
 			filepath.Join(dataPath),
 			"./" + extractedFileName,
 		}
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, downloadPod, downloadPod.Spec.Containers[0].Name, command)
+		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 
 		fileAndPathName := filepath.Join(dataPath, extractedFileName)
 		if volumeMode == k8sv1.PersistentVolumeBlock {
 			fileAndPathName = blockVolumeMountPath
 		}
-		out, stderr, err = exec.ExecuteCommandOnPodWithResults(virtClient, downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
+		out, stderr, err = exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, md5Command(fileAndPathName))
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		md5sum := strings.Split(out, " ")[0]
 		Expect(md5sum).To(HaveLen(32))
@@ -570,7 +570,7 @@ var _ = SIGDescribe("Export", func() {
 			fileAndPathName,
 		}
 		By(fmt.Sprintf("Downloading from URL: %s", downloadUrl))
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, downloadPod, downloadPod.Spec.Containers[0].Name, command)
+		out, stderr, err := exec.ExecuteCommandOnPodWithResults(downloadPod, downloadPod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 
 		verifyFunction(fileName, comparison, downloadPod, volumeMode)
@@ -737,7 +737,7 @@ var _ = SIGDescribe("Export", func() {
 			"-c",
 			"kill 1",
 		}
-		_, _, _ = exec.ExecuteCommandOnPodWithResults(virtClient, exporterPod, exporterPod.Spec.Containers[0].Name, command)
+		_, _, _ = exec.ExecuteCommandOnPodWithResults(exporterPod, exporterPod.Spec.Containers[0].Name, command)
 		By("Verifying the pod is killed and a new secret created")
 		Eventually(func() types.UID {
 			exporterPod = getExporterPod(vmExport)
@@ -1649,7 +1649,7 @@ var _ = SIGDescribe("Export", func() {
 			url,
 		}
 
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Spec.Containers[0].Name, command)
+		out, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		split := strings.Split(out, "\n---\n")
 		Expect(split).To(HaveLen(3))
@@ -1677,7 +1677,7 @@ var _ = SIGDescribe("Export", func() {
 			filepath.Join(caCertPath, caBundleKey),
 			url,
 		}
-		out, stderr, err = exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Spec.Containers[0].Name, command)
+		out, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		split = strings.Split(out, "\n---\n")
 		Expect(split).To(HaveLen(2))
@@ -1708,7 +1708,7 @@ var _ = SIGDescribe("Export", func() {
 			url,
 		}
 
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Spec.Containers[0].Name, command)
+		out, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		list := &k8sv1.List{}
 		err = json.Unmarshal([]byte(out), list)
@@ -1741,7 +1741,7 @@ var _ = SIGDescribe("Export", func() {
 			filepath.Join(caCertPath, caBundleKey),
 			url,
 		}
-		out, stderr, err = exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Spec.Containers[0].Name, command)
+		out, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		resSecret := &k8sv1.Secret{}
 		err = yaml.Unmarshal([]byte(out), resSecret)
@@ -1912,7 +1912,7 @@ var _ = SIGDescribe("Export", func() {
 			url,
 		}
 
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Spec.Containers[0].Name, command)
+		out, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		split := strings.Split(out, "\n---\n")
 		Expect(split).To(HaveLen(5))
@@ -1954,7 +1954,7 @@ var _ = SIGDescribe("Export", func() {
 			filepath.Join(caCertPath, caBundleKey),
 			url,
 		}
-		out, stderr, err = exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Spec.Containers[0].Name, command)
+		out, stderr, err = exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 		split = strings.Split(out, "\n---\n")
 		Expect(split).To(HaveLen(2))

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -55,7 +55,7 @@ var _ = SIGDescribe("[rfe_id:6364]Guestfs", func() {
 	execCommandLibguestfsPod := func(podName, namespace string, c []string) (string, string, error) {
 		pod, err := virtClient.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		return exec.ExecuteCommandOnPodWithResults(virtClient, pod, "libguestfs", c)
+		return exec.ExecuteCommandOnPodWithResults(pod, "libguestfs", c)
 	}
 
 	createPVCFilesystem := func(name, namespace string) {

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -67,7 +67,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pods.Items).ToNot(BeEmpty())
 
-		stderr, err := copyFromPod(virtClient, &pods.Items[0], "target", "/images/alpine/disk.img", imagePath)
+		stderr, err := copyFromPod(&pods.Items[0], "target", "/images/alpine/disk.img", imagePath)
 		log.DefaultLogger().Info(stderr)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -449,7 +449,7 @@ func createArchive(targetFile, tgtDir string, sourceFilesNames ...string) string
 	return tgtPath
 }
 
-func copyFromPod(virtCli kubecli.KubevirtClient, pod *k8sv1.Pod, containerName, sourceFile, targetFile string) (stderr string, err error) {
+func copyFromPod(pod *k8sv1.Pod, containerName, sourceFile, targetFile string) (stderr string, err error) {
 	var (
 		stderrBuf bytes.Buffer
 	)
@@ -468,6 +468,6 @@ func copyFromPod(virtCli kubecli.KubevirtClient, pod *k8sv1.Pod, containerName, 
 		Stderr: &stderrBuf,
 		Tty:    false,
 	}
-	err = execute.ExecuteCommandOnPodWithOptions(virtCli, pod, containerName, []string{"cat", sourceFile}, options)
+	err = execute.ExecuteCommandOnPodWithOptions(pod, containerName, []string{"cat", sourceFile}, options)
 	return stderrBuf.String(), err
 }

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -242,7 +242,6 @@ var _ = SIGDescribe("Memory dump", func() {
 	verifyMemoryDumpOutput := func(memoryDumpPVC *k8sv1.PersistentVolumeClaim, previousOutput string, shouldEqual bool) string {
 		executorPod := createExecutorPodWithPVC(verifierPodName, memoryDumpPVC)
 		lsOutput, err := exec.ExecuteCommandOnPod(
-			virtClient,
 			executorPod,
 			executorPod.Spec.Containers[0].Name,
 			[]string{"/bin/sh", "-c", fmt.Sprintf("ls -1 %s", libstorage.DefaultPvcMountPath)},
@@ -251,7 +250,6 @@ var _ = SIGDescribe("Memory dump", func() {
 		log.Log.Infof("%s", lsOutput)
 		Expect(err).ToNot(HaveOccurred())
 		wcOutput, err := exec.ExecuteCommandOnPod(
-			virtClient,
 			executorPod,
 			executorPod.Spec.Containers[0].Name,
 			[]string{"/bin/sh", "-c", fmt.Sprintf("ls -1 %s | wc -l", libstorage.DefaultPvcMountPath)},

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -72,7 +72,7 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 		pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), podName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, "targetcli", cmd)
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli", cmd)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("command='targetcli %v' stdout='%s' stderr='%s'", args, stdout, stderr))
 	}
 
@@ -93,7 +93,7 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 		// at the package installation. The targetcli utility relies on ctype python package that
 		// uses it to find shared library.
 		// To fix this issue, we run ldconfig before targetcli
-		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, "targetcli", []string{"ldconfig"})
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli", []string{"ldconfig"})
 		By(fmt.Sprintf("ldconfig: stdout: %v stderr: %v", stdout, stderr))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -122,7 +122,7 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 		pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), podName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, "targetcli",
+		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "targetcli",
 			[]string{"/bin/lsblk", "--scsi", "-o", "NAME,MODEL", "-p", "-n"})
 		Expect(err).ToNot(HaveOccurred(), stdout, stderr)
 		lines := strings.Split(stdout, "\n")

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -407,8 +407,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				for _, c := range strings.Split(command, ",") {
 					commandSlice = append(commandSlice, strings.Trim(c, "\" "))
 				}
-				virtClient := kubevirt.Client()
-				return exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Annotations[annoContainer], commandSlice)
+				return exec.ExecuteCommandOnPodWithResults(pod, pod.Annotations[annoContainer], commandSlice)
 			}
 
 			It("[test_id:6767]with volumes and guest agent available", func() {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -620,7 +620,6 @@ var _ = SIGDescribe("Storage", func() {
 						vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 						nodeName = vmiPod.Spec.NodeName
 						output, err := exec.ExecuteCommandOnPod(
-							virtClient,
 							vmiPod,
 							vmiPod.Spec.Containers[0].Name,
 							[]string{"find", hostdisk.GetMountedHostDiskDir(hostDiskName), "-name", diskName, "-size", "1G", "-o", "-size", "+1G"},
@@ -649,7 +648,6 @@ var _ = SIGDescribe("Storage", func() {
 						vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 						nodeName = vmiPod.Spec.NodeName
 						output, err := exec.ExecuteCommandOnPod(
-							virtClient,
 							vmiPod,
 							vmiPod.Spec.Containers[0].Name,
 							[]string{"find", hostdisk.GetMountedHostDiskDir("anotherdisk"), "-size", "1G", "-o", "-size", "+1G"},
@@ -659,7 +657,6 @@ var _ = SIGDescribe("Storage", func() {
 
 						By("Checking if disk.img has been created")
 						output, err = exec.ExecuteCommandOnPod(
-							virtClient,
 							vmiPod,
 							vmiPod.Spec.Containers[0].Name,
 							[]string{"find", hostdisk.GetMountedHostDiskDir(hostDiskName), "-size", "1G", "-o", "-size", "+1G"},
@@ -703,7 +700,6 @@ var _ = SIGDescribe("Storage", func() {
 						By("Checking if disk.img exists")
 						vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 						output, err := exec.ExecuteCommandOnPod(
-							virtClient,
 							vmiPod,
 							vmiPod.Spec.Containers[0].Name,
 							[]string{"find", hostdisk.GetMountedHostDiskDir(hostDiskName), "-name", diskName},
@@ -789,7 +785,6 @@ var _ = SIGDescribe("Storage", func() {
 						By("Checking if disk.img exists")
 						vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 						output, err := exec.ExecuteCommandOnPod(
-							virtClient,
 							vmiPod,
 							vmiPod.Spec.Containers[0].Name,
 							[]string{"find", "/var/run/kubevirt-private/vmi-disks/disk0/", "-name", diskImgName, "-size", "1G", "-o", "-size", "+1G"},
@@ -837,7 +832,7 @@ var _ = SIGDescribe("Storage", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Determining the size of the mounted directory")
-					diskSizeStr, _, err := exec.ExecuteCommandOnPodWithResults(virtClient, pod, pod.Spec.Containers[0].Name, []string{tests.BinBash, "-c", fmt.Sprintf("df %s | tail -n 1 | awk '{print $4}'", mountDir)})
+					diskSizeStr, _, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, []string{tests.BinBash, "-c", fmt.Sprintf("df %s | tail -n 1 | awk '{print $4}'", mountDir)})
 					Expect(err).ToNot(HaveOccurred())
 					diskSize, err = strconv.Atoi(strings.TrimSpace(diskSizeStr))
 					diskSize = diskSize * 1000 // byte to kilobyte

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -360,7 +360,6 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 			Eventually(func() error {
 				fmt.Printf("Running \"%s\" command via winrm-cli\n", command)
 				output, err = exec.ExecuteCommandOnPod(
-					virtClient,
 					winrmcliPod,
 					winrmcliPod.Spec.Containers[0].Name,
 					command,

--- a/tests/virtiofs/config.go
+++ b/tests/virtiofs/config.go
@@ -22,12 +22,8 @@ package virtiofs
 import (
 	"fmt"
 
-	"kubevirt.io/client-go/kubecli"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 
 	expect "github.com/google/goexpect"
@@ -45,10 +41,7 @@ import (
 )
 
 var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, func() {
-	var virtClient kubecli.KubevirtClient
-
 	BeforeEach(func() {
-		virtClient = kubevirt.Client()
 		checks.SkipTestIfNoFeatureGate(virtconfig.VirtIOFSGate)
 	})
 
@@ -86,7 +79,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			By("Checking if ConfigMap has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			podOutput, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				fmt.Sprintf("virtiofs-%s", configMapName),
 				[]string{"cat",
@@ -143,7 +135,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			By("Checking if Secret has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			podOutput, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				fmt.Sprintf("virtiofs-%s", secretName),
 				[]string{"cat",
@@ -185,7 +176,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			By("Checking if ServiceAccount has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			namespace, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				fmt.Sprintf("virtiofs-%s", serviceAccountVolumeName),
 				[]string{"cat",
@@ -196,7 +186,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			Expect(namespace).To(Equal(testsuite.GetTestNamespace(vmi)))
 
 			token, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				fmt.Sprintf("virtiofs-%s", serviceAccountVolumeName),
 				[]string{"tail", "-c", "20",
@@ -244,7 +233,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			By("Checking if DownwardAPI has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			podOutput, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				vmiPod,
 				fmt.Sprintf("virtiofs-%s", downwardAPIName),
 				[]string{"grep", testLabelKey,

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -125,7 +125,6 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", pvc1)
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			podVirtioFsFileExist, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
@@ -136,7 +135,6 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			virtioFsFileTestCmd = fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", pvc2)
 			pod = tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			podVirtioFsFileExist, err = exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
@@ -233,7 +231,6 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", pvcName)
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			podVirtioFsFileExist, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
@@ -345,7 +342,6 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", dataVolume.Name)
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 			podVirtioFsFileExist, err := exec.ExecuteCommandOnPod(
-				virtClient,
 				pod,
 				"compute",
 				[]string{tests.BinBash, "-c", virtioFsFileTestCmd},

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -124,7 +124,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		By(fmt.Sprintf("Checking cloud init ISO at '%s' is 4k-block fs compatible", path))
 		cmdCheck := []string{"stat", "--printf='%s'", path}
 
-		out, err := exec.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
+		out, err := exec.ExecuteCommandOnPod(pod, "compute", cmdCheck)
 		Expect(err).NotTo(HaveOccurred())
 		size, err := strconv.Atoi(strings.Trim(out, "'"))
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -97,7 +97,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 	getPodMemoryUsage := func(pod *kubev1.Pod) (output string, err error) {
 		output, err = exec.ExecuteCommandOnPod(
-			virtClient,
 			pod,
 			"compute",
 			[]string{"cat", cgroupV2MemoryUsagePath},
@@ -108,7 +107,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		}
 
 		output, err = exec.ExecuteCommandOnPod(
-			virtClient,
 			pod,
 			"compute",
 			[]string{"cat", cgroupV1MemoryUsagePath},
@@ -1069,7 +1067,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 				// Get a hugepages statistics from virt-launcher pod
 				output, err := exec.ExecuteCommandOnPod(
-					virtClient,
 					&pods.Items[0],
 					pods.Items[0].Spec.Containers[0].Name,
 					[]string{"cat", fmt.Sprintf("%s/nr_hugepages", hugepagesDir)},
@@ -1080,7 +1077,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				output, err = exec.ExecuteCommandOnPod(
-					virtClient,
 					&pods.Items[0],
 					pods.Items[0].Spec.Containers[0].Name,
 					[]string{"cat", fmt.Sprintf("%s/free_hugepages", hugepagesDir)},
@@ -1091,7 +1087,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				output, err = exec.ExecuteCommandOnPod(
-					virtClient,
 					&pods.Items[0],
 					pods.Items[0].Spec.Containers[0].Name,
 					[]string{"cat", fmt.Sprintf("%s/resv_hugepages", hugepagesDir)},
@@ -2743,9 +2738,8 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Expect(err).ToNot(HaveOccurred())
 				emulator = filepath.Base(emulator)
 
-				virtClient := kubevirt.Client()
 				pidCmd := []string{"pidof", emulator}
-				qemuPid, err := exec.ExecuteCommandOnPod(virtClient, readyPod, "compute", pidCmd)
+				qemuPid, err := exec.ExecuteCommandOnPod(readyPod, "compute", pidCmd)
 				// do not check for kvm-pit thread if qemu is not in use
 				if err != nil {
 					return
@@ -3253,7 +3247,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			var stdout, stderr string
 			errorMassageFormat := "failed after running the `ps` command with stdout:\n %v \n stderr:\n %v \n err: \n %v \n"
 			Eventually(func() error {
-				stdout, stderr, err = exec.ExecuteCommandOnPodWithResults(virtClient, &pods.Items[0], "compute",
+				stdout, stderr, err = exec.ExecuteCommandOnPodWithResults(&pods.Items[0], "compute",
 					[]string{
 						"ps",
 						"--no-header",
@@ -3413,10 +3407,7 @@ func getKvmPitMask(qemupid, nodeName string) (output string, err error) {
 }
 
 func listCgroupThreads(pod *k8sv1.Pod) (output string, err error) {
-	virtClient := kubevirt.Client()
-
 	output, err = exec.ExecuteCommandOnPod(
-		virtClient,
 		pod,
 		"compute",
 		[]string{"cat", "/sys/fs/cgroup/cpuset/tasks"},
@@ -3427,7 +3418,6 @@ func listCgroupThreads(pod *k8sv1.Pod) (output string, err error) {
 		return
 	}
 	output, err = exec.ExecuteCommandOnPod(
-		virtClient,
 		pod,
 		"compute",
 		[]string{"cat", "/sys/fs/cgroup/cgroup.threads"},
@@ -3436,11 +3426,8 @@ func listCgroupThreads(pod *k8sv1.Pod) (output string, err error) {
 }
 
 func getProcessName(pod *k8sv1.Pod, pid string) (output string, err error) {
-	virtClient := kubevirt.Client()
-
 	fPath := "/proc/" + pid + "/comm"
 	output, err = exec.ExecuteCommandOnPod(
-		virtClient,
 		pod,
 		"compute",
 		[]string{"cat", fPath},

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -620,7 +620,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				pod, err := libnode.GetVirtHandlerPod(kubevirt.Client(), nodeName)
 				Expect(err).ToNot(HaveOccurred())
 
-				_, _, err = exec.ExecuteCommandOnPodWithResults(kubevirt.Client(), pod,
+				_, _, err = exec.ExecuteCommandOnPodWithResults(pod,
 					"virt-handler",
 					[]string{
 						"rm",


### PR DESCRIPTION
We should fix `exec.ExecuteCommandOnPod` to not require `virtclient` as a parameter, since it's `kubevirt.Client()` in all cases.
This change will reduce imports and unnecessary var from many test files, which will improve code-quality.

Note: This pr was requested by @AlonaKaplan.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

