### PR TITLE
network/tests: use NewGuestless instead of a complex vmi definition

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -52,7 +52,6 @@ go_library(
         "//tests:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//tests/console:go_default_library",
-        "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/events:go_default_library",
         "//tests/exec:go_default_library",


### PR DESCRIPTION
The removed code started with NewRandomVMI and made an effort to erase mostly everything there, rolling it down to something like what NewGuestless is providing.

The removed code also added a Cirros boot disk, but it is not clear why. The test does not expect the VM to boot at all.

I don't understand why we need this test at all, but I'm not addressing this now.

/sig code-quality

```release-note
NONE
```

