### PR TITLE
Adding our SIG release team to the Owners file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -136,8 +136,14 @@ aliases:
   # SIG Release
   # Owns the release process, including the schedule, and tools.
   #
-  sig-release-approvers: []
-  sig-release-reviewers: []
+  sig-release-approvers:
+    - acardace
+    - fossedihelm
+    - xpivarc
+  sig-release-reviewers:
+    - acardace
+    - fossedihelm
+    - xpivarc
 
   #
   # SIG Buildsystem


### PR DESCRIPTION
### What this PR does

Adding @acardace @fossedihelm and @xpivarc to our Owner file as part of our release team. 
This will enable them to be notified about PRs with the sig/release label.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

