### PR TITLE
Move functions from utils

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -184,8 +184,7 @@ func NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc string, acc
 		),
 	)
 
-	var err error
-	dv, err = virtCli.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+	dv, err := virtCli.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	libstorage.EventuallyDV(dv, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 	return libvmi.New(
@@ -195,24 +194,6 @@ func NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc string, acc
 		libvmi.WithResourceMemory("1Gi"),
 		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 	), dv
-}
-
-// NewRandomVirtualMachineInstanceWithFileDisk
-//
-// Deprecated: Use libvmi directly
-func NewRandomVirtualMachineInstanceWithFileDisk(imageUrl, namespace string, accessMode k8sv1.PersistentVolumeAccessMode) (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-	if !libstorage.HasCDI() {
-		Skip("Skip DataVolume tests when CDI is not present")
-	}
-	sc, foundSC := libstorage.GetRWOFileSystemStorageClass()
-	if accessMode == k8sv1.ReadWriteMany {
-		sc, foundSC = libstorage.GetRWXFileSystemStorageClass()
-	}
-	if !foundSC {
-		Skip("Skip test when Filesystem storage is not present")
-	}
-
-	return NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc, accessMode, k8sv1.PersistentVolumeFilesystem)
 }
 
 // NewRandomVirtualMachineInstanceWithBlockDisk


### PR DESCRIPTION
Move functions from util to the test file that uses them.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

