### PR TITLE
[code-clean] Use Go 1.21 `maps` package to clone and copy maps

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 
@@ -1048,11 +1049,7 @@ func applyNodeSelector(field *k8sfield.Path, instancetypeSpec *instancetypev1bet
 		return Conflicts{field.Child("nodeSelector")}
 	}
 
-	// TODO: This should be eventually moved to `maps` package (https://pkg.go.dev/maps@master).
-	vmiSpec.NodeSelector = make(map[string]string, len(instancetypeSpec.NodeSelector))
-	for k, v := range instancetypeSpec.NodeSelector {
-		vmiSpec.NodeSelector[k] = v
-	}
+	vmiSpec.NodeSelector = maps.Clone(instancetypeSpec.NodeSelector)
 
 	return nil
 }

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -33,8 +34,8 @@ func NewNodeSelectorRenderer(
 		podNodeSelectors[k8sv1.LabelArchStable] = strings.ToLower(architecture)
 	}
 
-	copySelectors(clusterWideConfNodeSelectors, podNodeSelectors)
-	copySelectors(vmiNodeSelectors, podNodeSelectors)
+	maps.Copy(podNodeSelectors, clusterWideConfNodeSelectors)
+	maps.Copy(podNodeSelectors, vmiNodeSelectors)
 
 	nodeSelectorRenderer := &NodeSelectorRenderer{podNodeSelectors: podNodeSelectors}
 	for _, opt := range opts {
@@ -48,7 +49,7 @@ func (nsr *NodeSelectorRenderer) Render() map[string]string {
 		nsr.enableSelectorLabel(v1.CPUManager)
 	}
 	if nsr.hyperv {
-		copySelectors(hypervNodeSelectors(nsr.vmiFeatures), nsr.podNodeSelectors)
+		maps.Copy(nsr.podNodeSelectors, hypervNodeSelectors(nsr.vmiFeatures))
 	}
 	if nsr.cpuModelLabel != "" && nsr.cpuModelLabel != cpuModelLabel(v1.CPUModeHostModel) && nsr.cpuModelLabel != cpuModelLabel(v1.CPUModeHostPassthrough) {
 		nsr.enableSelectorLabel(nsr.cpuModelLabel)
@@ -75,12 +76,6 @@ func (nsr *NodeSelectorRenderer) isManualTSCFrequencyRequired() bool {
 func WithDedicatedCPU() NodeSelectorRendererOption {
 	return func(renderer *NodeSelectorRenderer) {
 		renderer.hasDedicatedCPU = true
-	}
-}
-
-func copySelectors(src map[string]string, dst map[string]string) {
-	for k, v := range src {
-		dst[k] = v
 	}
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -22,6 +22,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -1316,9 +1317,7 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 	annotationsSet := map[string]string{
 		v1.DomainAnnotation: vmi.GetObjectMeta().GetName(),
 	}
-	for k, v := range filterVMIAnnotationsForPod(vmi.Annotations) {
-		annotationsSet[k] = v
-	}
+	maps.Copy(annotationsSet, filterVMIAnnotationsForPod(vmi.Annotations))
 
 	annotationsSet[podcmd.DefaultContainerAnnotationName] = "compute"
 

--- a/pkg/virt-controller/watch/pool.go
+++ b/pkg/virt-controller/watch/pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -389,14 +390,6 @@ func (c *PoolController) resolveControllerRef(namespace string, controllerRef *m
 	return pool.(*poolv1.VirtualMachinePool)
 }
 
-func mapCopy(src map[string]string) map[string]string {
-	dst := map[string]string{}
-	for k, v := range src {
-		dst[k] = v
-	}
-	return dst
-}
-
 // listControllerFromNamespace takes a namespace and returns all Pools from the Pool cache which run in this namespace
 func (c *PoolController) listControllerFromNamespace(namespace string) ([]*poolv1.VirtualMachinePool, error) {
 	objs, err := c.poolInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
@@ -764,8 +757,8 @@ func (c *PoolController) scaleOut(pool *poolv1.VirtualMachinePool, count int) er
 
 			vm := virtv1.NewVMReferenceFromNameWithNS(pool.Namespace, name)
 
-			vm.Labels = mapCopy(pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels)
-			vm.Annotations = mapCopy(pool.Spec.VirtualMachineTemplate.ObjectMeta.Annotations)
+			vm.Labels = maps.Clone(pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels)
+			vm.Annotations = maps.Clone(pool.Spec.VirtualMachineTemplate.ObjectMeta.Annotations)
 			vm.Spec = *indexVMSpec(pool.Spec.VirtualMachineTemplate.Spec.DeepCopy(), index)
 			vm = injectPoolRevisionLabelsIntoVM(vm, revisionName)
 
@@ -846,8 +839,8 @@ func (c *PoolController) opportunisticUpdate(pool *poolv1.VirtualMachinePool, vm
 
 			vmCopy := vm.DeepCopy()
 
-			vmCopy.Labels = mapCopy(pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels)
-			vmCopy.Annotations = mapCopy(pool.Spec.VirtualMachineTemplate.ObjectMeta.Annotations)
+			vmCopy.Labels = maps.Clone(pool.Spec.VirtualMachineTemplate.ObjectMeta.Labels)
+			vmCopy.Annotations = maps.Clone(pool.Spec.VirtualMachineTemplate.ObjectMeta.Annotations)
 			vmCopy.Spec = *indexVMSpec(pool.Spec.VirtualMachineTemplate.Spec.DeepCopy(), index)
 			vmCopy = injectPoolRevisionLabelsIntoVM(vmCopy, revisionName)
 

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -344,7 +345,7 @@ var _ = Describe("Pool", func() {
 			vmi.Spec = vm.Spec.Template.Spec
 			vmi.Name = vm.Name
 			vmi.Namespace = vm.Namespace
-			vmi.Labels = mapCopy(vm.Spec.Template.ObjectMeta.Labels)
+			vmi.Labels = maps.Clone(vm.Spec.Template.ObjectMeta.Labels)
 			vmi.OwnerReferences = []metav1.OwnerReference{{
 				APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
 				Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"math/rand"
 	"strconv"
@@ -694,11 +695,11 @@ func (c *VMController) VMNodeSelectorPatch(vm *virtv1.VirtualMachine, vmi *virtv
 	var ops []string
 
 	if vm.Spec.Template.Spec.NodeSelector != nil {
-		vmNodeSelector := make(map[string]string)
-		// copy the node selector map
-		for k, v := range vm.Spec.Template.Spec.NodeSelector {
-			vmNodeSelector[k] = v
+		vmNodeSelector := maps.Clone(vm.Spec.Template.Spec.NodeSelector)
+		if vmNodeSelector == nil {
+			vmNodeSelector = make(map[string]string)
 		}
+
 		vmNodeSelectorJson, err := json.Marshal(vmNodeSelector)
 		if err != nil {
 			return err


### PR DESCRIPTION
In this PR I'm starting to use new Go's `maps` package that's presented in Go 1.21.
This package leverages generics in order to provide official functions to clone, copy, delete and check equality, and more.

### What this PR does
Before this PR:
We manually copy and clone maps with code that is duplicated throughout the repo.

After this PR:
Duplicated private functions are deleted and official functions from the `maps` package are being used.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- ~[ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- ~[ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- ~[ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- ~[ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


/sig code-quality
