### PR TITLE
tests restore/storage/imageupload use libvmi.new

### DIFF
--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -10,6 +10,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libvmi"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -132,7 +133,10 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 
 			if startVM {
 				By("Start VM")
-				vmi := tests.NewRandomVMIWithDataVolume(targetName)
+				vmi := libvmi.New(
+					libvmi.WithDataVolume("disk0", targetName),
+					libvmi.WithResourceMemory("1Gi"),
+				)
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred())
 				defer func() {
@@ -269,7 +273,10 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 			Expect(err.Error()).To(ContainSubstring("make sure the PVC is Bound, or use force-bind flag"))
 
 			By("Start VM")
-			vmi := tests.NewRandomVMIWithDataVolume("target-dv")
+			vmi := libvmi.New(
+				libvmi.WithDataVolume("disk0", "target-dv"),
+				libvmi.WithResourceMemory("1Gi"),
+			)
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1834,8 +1834,11 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 						libdv.WithPVC(libdv.PVCWithStorageClass(snapshotStorageClass), libdv.PVCWithVolumeSize("1Gi")),
 					)
 
-					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-					tests.AddUserData(vmi, "cloud-init", bashHelloScript)
+					vmi := libvmi.New(
+						libvmi.WithDataVolume("disk0", dataVolume.Name),
+						libvmi.WithResourceMemory("1Gi"),
+						libvmi.WithCloudInitNoCloudUserData(bashHelloScript),
+					)
 					vm := libvmi.NewVirtualMachine(vmi)
 					libstorage.AddDataVolumeTemplate(vm, dataVolume)
 					return vm

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1127,9 +1127,6 @@ var _ = SIGDescribe("Storage", func() {
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				labelKey := "testshareablekey"
-				labels := map[string]string{
-					labelKey: "",
-				}
 
 				// give an affinity rule to ensure the vmi's get placed on the same node.
 				affinityRule := &k8sv1.Affinity{
@@ -1153,11 +1150,16 @@ var _ = SIGDescribe("Storage", func() {
 					},
 				}
 
-				vmi1 = tests.NewRandomVMIWithDataVolume(dv.Name)
-				vmi2 = tests.NewRandomVMIWithDataVolume(dv.Name)
-				vmi1.Labels = labels
-				vmi2.Labels = labels
-
+				vmi1 = libvmi.New(
+					libvmi.WithDataVolume("disk0", dv.Name),
+					libvmi.WithResourceMemory("1Gi"),
+					libvmi.WithLabel(labelKey, ""),
+				)
+				vmi2 = libvmi.New(
+					libvmi.WithDataVolume("disk0", dv.Name),
+					libvmi.WithResourceMemory("1Gi"),
+					libvmi.WithLabel(labelKey, ""),
+				)
 				vmi1.Spec.Affinity = affinityRule
 				vmi2.Spec.Affinity = affinityRule
 			})


### PR DESCRIPTION
### What this PR does
Before this PR:
The tests folder restore.go / storage.go / imageupload.go used a deprecated method NewRandomVMIWithDataVolume

After this PR:
They will use the libvmi methods for better readability

### Why we need it and why it was done in this way
This will improve readability and save code lines in the long term

### Special notes for your reviewer
Addition changed are required for other files in the tests folder and will be done in another PR


### Release note
```
NONE
```

