### PR TITLE
chore: Remove use of fmt.Println from tests

### DIFF
--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -189,9 +189,6 @@ var _ = Describe("CloudInit", func() {
 				}
 				buf, err := json.MarshalIndent(metadataStruct, "", "  ")
 				Expect(err).ToNot(HaveOccurred())
-				fmt.Println("expected: ", string(buf))
-				fmt.Println("exmapleJsob: ", exampleJSONParsed)
-
 				Expect(string(buf)).To(Equal(exampleJSONParsed))
 			})
 			It("should match the generated nocloud metadata", func() {

--- a/pkg/emptydisk/emptydisk_test.go
+++ b/pkg/emptydisk/emptydisk_test.go
@@ -1,7 +1,6 @@
 package emptydisk
 
 import (
-	"fmt"
 	"os"
 	"path"
 
@@ -89,7 +88,6 @@ var _ = Describe("EmptyDisk", func() {
 })
 
 func fakeCreatorFunc(filePath string, _ string) error {
-	fmt.Println(filePath)
 	f, err := os.Create(filePath)
 	if err != nil {
 		return err

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1371,8 +1371,6 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			} else {
 				Expect(err).ToNot(HaveOccurred())
 			}
-
-			fmt.Println(patch)
 			Expect(patch).To(Equal(expectedPatch))
 		},
 			Entry("add memory dump request with no existing request",

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -2651,7 +2651,6 @@ var _ = Describe("VirtualMachine", func() {
 				test := `{ "op": "test", "path": "/spec/volumes", "value": [{"name":"testPVC","memoryDump":{"claimName":"testPVC","hotpluggable":true}}]}`
 				update := `{ "op": "replace", "path": "/spec/volumes", "value": []}`
 				patch := fmt.Sprintf("[%s, %s]", test, update)
-				fmt.Println(patch)
 
 				vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 			}

--- a/tests/hotplug/affinity.go
+++ b/tests/hotplug/affinity.go
@@ -95,7 +95,6 @@ var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.S
 			}
 			patchData1Str := fmt.Sprintf(`[ {"op":"%s","path":"/spec/template/spec/affinity"%s} ]`, op, value)
 			patchData1 := []byte(patchData1Str)
-			fmt.Println("patchData1: ", string(patchData1))
 			_, err = virtClient.VirtualMachine(vmNamespace).Patch(context.Background(), vmName, types.JSONPatchType, patchData1, &k8smetav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		}


### PR DESCRIPTION
/sig code-quality

### What this PR does

Before this PR:

`fmt.Println` was used during various tests to dump state to stdout making the actual test output cluttered and hard to read.

After this PR:

Use of `fmt.Println` removed from various tests where it makes sense.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

