### PR TITLE
Vm controller fix update and status update

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3082,13 +3082,15 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		}
 
 		if syncErr == nil {
-			if !equality.Semantic.DeepEqual(vm, vmCopy) {
+			if !equality.Semantic.DeepEqual(vm.Spec, vmCopy.Spec) || !equality.Semantic.DeepEqual(vm.ObjectMeta, vmCopy.ObjectMeta) {
 				updatedVm, err := c.clientset.VirtualMachine(vmCopy.Namespace).Update(context.Background(), vmCopy)
 				if err != nil {
 					syncErr = &syncErrorImpl{fmt.Errorf("Error encountered when trying to update vm according to add volume and/or memory dump requests: %v", err), FailedUpdateErrorReason}
 				} else {
 					vm = updatedVm
 				}
+			} else {
+				vm = vmCopy
 			}
 		}
 	}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -303,8 +303,8 @@ func (c *VMController) execute(key string) error {
 		c.expectations.DeleteExpectations(key)
 		return nil
 	}
-	vm := obj.(*virtv1.VirtualMachine)
-	vm = vm.DeepCopy()
+	originalVM := obj.(*virtv1.VirtualMachine)
+	vm := originalVM.DeepCopy()
 
 	logger := log.Log.Object(vm)
 
@@ -387,7 +387,7 @@ func (c *VMController) execute(key string) error {
 		logger.Reason(syncErr).Error("Reconciling the VirtualMachine failed.")
 	}
 
-	err = c.updateStatus(vm, vmi, syncErr, logger)
+	err = c.updateStatus(vm, originalVM, vmi, syncErr, logger)
 	if err != nil {
 		logger.Reason(err).Error("Updating the VirtualMachine status failed.")
 		return err
@@ -2388,11 +2388,9 @@ func (c *VMController) syncGenerationInfo(vm *virtv1.VirtualMachine, vmi *virtv1
 	return nil
 }
 
-func (c *VMController) updateStatus(vmOrig *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, syncErr syncError, logger *log.FilteredLogger) error {
+func (c *VMController) updateStatus(vm, vmOrig *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, syncErr syncError, logger *log.FilteredLogger) error {
 	key := controller.VirtualMachineKey(vmOrig)
 	defer virtControllerVMWorkQueueTracer.StepTrace(key, "updateStatus", trace.Field{Key: "VM Name", Value: vmOrig.Name})
-
-	vm := vmOrig.DeepCopy()
 
 	created := vmi != nil
 	vm.Status.Created = created

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -476,8 +476,7 @@ var _ = Describe("VirtualMachine", func() {
 			})
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				// vol request shouldn't be cleared until update status observes the new volume change
-				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
+				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
 			}).Return(vm, nil)
 
 			sanityExecute(vm)
@@ -486,6 +485,292 @@ var _ = Describe("VirtualMachine", func() {
 			Entry("that is running", true),
 			Entry("that is not running", false),
 		)
+
+		Context("add volume request", func() {
+			It("should not be cleared when hotplug fails on Running VM", func() {
+				By("Running VM")
+				vm, vmi := DefaultVirtualMachine(true)
+				vm.Status.Created = true
+				vm.Status.Ready = true
+				vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+					{
+						AddVolumeOptions: &virtv1.AddVolumeOptions{
+							Name:         "vol1",
+							Disk:         &virtv1.Disk{},
+							VolumeSource: &virtv1.HotplugVolumeSource{},
+						},
+					},
+				}
+
+				addVirtualMachine(vm)
+				markAsReady(vmi)
+				vmiFeeder.Add(vmi)
+
+				By("Simulate a failure in hotplug")
+				vmiInterface.EXPECT().AddVolume(context.Background(), vmi.ObjectMeta.Name, vm.Status.VolumeRequests[0].AddVolumeOptions).Return(fmt.Errorf("error"))
+
+				By("Expecting to not clear volume requests")
+				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
+					Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1),
+						"Volume request should stay, otherwise hotplug will not retry",
+					)
+				}).Return(vm, nil)
+
+				By("Not expecting to see a status update")
+				sanityExecute(vm)
+			})
+
+			It("should not be cleared when VM update fails on Running VM", func() {
+				By("Running VM")
+				vm, vmi := DefaultVirtualMachine(true)
+				vm.Status.Created = true
+				vm.Status.Ready = true
+				vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+					{
+						AddVolumeOptions: &virtv1.AddVolumeOptions{
+							Name:         "vol1",
+							Disk:         &virtv1.Disk{},
+							VolumeSource: &virtv1.HotplugVolumeSource{},
+						},
+					},
+				}
+
+				addVirtualMachine(vm)
+
+				markAsReady(vmi)
+				vmiFeeder.Add(vmi)
+				By("Simulate hotplug")
+				vmiInterface.EXPECT().AddVolume(context.Background(), vmi.ObjectMeta.Name, vm.Status.VolumeRequests[0].AddVolumeOptions).Return(nil)
+
+				By("Simulate update failure")
+				vmInterface.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("conflict"))
+				By("Expecting Volume request not to be cleared")
+				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
+					Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1),
+						"Volume request should stay, otherwise hotplug will not retry",
+					)
+				}).Return(vm, nil)
+
+				sanityExecute(vm)
+			})
+
+			It("should be cleared when hotplug on Stopped VM", func() {
+				By("Stopped VM")
+				vm, _ := DefaultVirtualMachine(false)
+				vm.Status.Created = false
+				vm.Status.Ready = false
+				vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+					{
+						AddVolumeOptions: &virtv1.AddVolumeOptions{
+							Name:         "vol1",
+							Disk:         &virtv1.Disk{},
+							VolumeSource: &virtv1.HotplugVolumeSource{},
+						},
+					},
+				}
+
+				addVirtualMachine(vm)
+
+				By("Expecting Volume to be added to VM")
+				vmInterface.EXPECT().Update(context.Background(), gomock.Any()).DoAndReturn(func(ctx context.Context, vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine, error) {
+					Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal("vol1"))
+					return vm, nil
+				})
+
+				By("Expecting Volume request to be cleared")
+				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, vm *virtv1.VirtualMachine) {
+					Expect(vm.Status.VolumeRequests).To(BeEmpty(),
+						"Volume request should stay, otherwise hotplug will not retry",
+					)
+				}).Return(nil, nil)
+
+				sanityExecute(vm)
+			})
+
+			It("should not be cleared when hotplug fails on Stopped VM", func() {
+				By("Stopped VM")
+				vm, _ := DefaultVirtualMachine(false)
+				vm.Status.Created = false
+				vm.Status.Ready = false
+				vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+					{
+						AddVolumeOptions: &virtv1.AddVolumeOptions{
+							Name:         "vol1",
+							Disk:         &virtv1.Disk{},
+							VolumeSource: &virtv1.HotplugVolumeSource{},
+						},
+					},
+				}
+
+				addVirtualMachine(vm)
+
+				By("Simulate a conflict on Update")
+				vmInterface.EXPECT().Update(context.Background(), gomock.Any()).DoAndReturn(func(ctx context.Context, vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine, error) {
+					Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal("vol1"))
+					return nil, fmt.Errorf("conflict")
+				})
+
+				By("Expecting Volume request to not be cleared")
+				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, vm *virtv1.VirtualMachine) {
+					Expect(vm.Status.VolumeRequests).To(HaveLen(1),
+						"Volume request should stay, otherwise hotplug will not retry",
+					)
+				}).Return(nil, nil)
+
+				sanityExecute(vm)
+			})
+		})
+
+		Context("remove volume request", func() {
+			It("should not be cleared when hotplug fails on Running VM", func() {
+				By("Running VM with a disk and matching volume")
+				vm, vmi := DefaultVirtualMachine(true)
+				vm.Status.Created = true
+				vm.Status.Ready = true
+				volume := virtv1.Volume{
+					Name: "vol1",
+					VolumeSource: virtv1.VolumeSource{
+						ContainerDisk: &virtv1.ContainerDiskSource{
+							Image: "random",
+						},
+					},
+				}
+				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, volume)
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, volume)
+
+				disk := virtv1.Disk{
+					Name: "vol1",
+					DiskDevice: virtv1.DiskDevice{
+						Disk: &virtv1.DiskTarget{},
+					},
+				}
+				vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, disk)
+				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
+
+				vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+					{
+						RemoveVolumeOptions: &virtv1.RemoveVolumeOptions{
+							Name: "vol1",
+						},
+					},
+				}
+
+				addVirtualMachine(vm)
+
+				markAsReady(vmi)
+				vmiFeeder.Add(vmi)
+				By("Simulate a un-hotplug failure")
+				vmiInterface.EXPECT().RemoveVolume(context.Background(), vmi.ObjectMeta.Name, vm.Status.VolumeRequests[0].RemoveVolumeOptions).Return(fmt.Errorf("error"))
+
+				By("Expecting Volume request to not be cleared")
+				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
+					Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1),
+						"Volume request should stay, otherwise hotplug will not retry",
+					)
+				}).Return(vm, nil)
+
+				sanityExecute(vm)
+			})
+
+			It("should be cleared when hotplug on Stopped VM", func() {
+				By("Stopped VM with a disk and matching volume")
+				vm, _ := DefaultVirtualMachine(false)
+				vm.Status.Created = false
+				vm.Status.Ready = false
+
+				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes,
+					virtv1.Volume{
+						Name: "vol1",
+						VolumeSource: virtv1.VolumeSource{
+							ContainerDisk: &virtv1.ContainerDiskSource{
+								Image: "random",
+							},
+						},
+					},
+				)
+				vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks,
+					virtv1.Disk{
+						Name: "vol1",
+						DiskDevice: virtv1.DiskDevice{
+							Disk: &virtv1.DiskTarget{},
+						},
+					},
+				)
+				vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+					{
+						RemoveVolumeOptions: &virtv1.RemoveVolumeOptions{
+							Name: "vol1",
+						},
+					},
+				}
+
+				addVirtualMachine(vm)
+
+				By("Expect the volume to be cleared")
+				vmInterface.EXPECT().Update(context.Background(), gomock.Any()).DoAndReturn(func(ctx context.Context, vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine, error) {
+					Expect(vm.Spec.Template.Spec.Volumes).To(BeEmpty())
+					return vm, nil
+				})
+
+				By("Expect the volume request to be cleared")
+				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, vm *virtv1.VirtualMachine) {
+					Expect(vm.Status.VolumeRequests).To(BeEmpty(),
+						"Volume request should stay, otherwise hotplug will not retry",
+					)
+				}).Return(nil, nil)
+
+				sanityExecute(vm)
+			})
+
+			It("should not be cleared when hotplug fails on Stopped VM", func() {
+				By("Stopped VM with a disk and matching volume")
+				vm, _ := DefaultVirtualMachine(false)
+				vm.Status.Created = false
+				vm.Status.Ready = false
+				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes,
+					virtv1.Volume{
+						Name: "vol1",
+						VolumeSource: virtv1.VolumeSource{
+							ContainerDisk: &virtv1.ContainerDiskSource{
+								Image: "random",
+							},
+						},
+					},
+				)
+				vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks,
+					virtv1.Disk{
+						Name: "vol1",
+						DiskDevice: virtv1.DiskDevice{
+							Disk: &virtv1.DiskTarget{},
+						},
+					},
+				)
+				vm.Status.VolumeRequests = []virtv1.VirtualMachineVolumeRequest{
+					{
+						RemoveVolumeOptions: &virtv1.RemoveVolumeOptions{
+							Name: "vol1",
+						},
+					},
+				}
+
+				addVirtualMachine(vm)
+
+				By("Simulate a conflict on VM update")
+				vmInterface.EXPECT().Update(context.Background(), gomock.Any()).DoAndReturn(func(ctx context.Context, vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine, error) {
+					Expect(vm.Spec.Template.Spec.Volumes).To(BeEmpty())
+					return nil, fmt.Errorf("conflict")
+				})
+
+				By("Expecting a Volume request to not be cleared")
+				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, vm *virtv1.VirtualMachine) {
+					Expect(vm.Status.VolumeRequests).To(HaveLen(1),
+						"Volume request should stay, otherwise hotplug will not retry",
+					)
+				}).Return(nil, nil)
+
+				sanityExecute(vm)
+			})
+		})
 
 		DescribeTable("should unhotplug a vm", func(isRunning bool) {
 			vm, vmi := DefaultVirtualMachine(isRunning)
@@ -526,8 +811,7 @@ var _ = Describe("VirtualMachine", func() {
 			})
 
 			vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Do(func(ctx context.Context, arg interface{}) {
-				// vol request shouldn't be cleared until update status observes the new volume change occured
-				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
+				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(BeEmpty())
 			}).Return(vm, nil)
 
 			sanityExecute(vm)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -3077,6 +3077,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmi.Status.Phase = virtv1.Running
 					vmiFeeder.Add(vmi)
 				}
+				vmiInterface.EXPECT().Create(gomock.Any(), gomock.Any()).AnyTimes()
 
 				vmInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any()).Times(1).Do(func(ctx context.Context, obj interface{}) {
 					objVM := obj.(*virtv1.VirtualMachine)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5857,11 +5857,6 @@ var _ = Describe("VirtualMachine", func() {
 
 			expectVMUpdate := func() {
 				vmInterface.EXPECT().Update(context.Background(), gomock.Any()).DoAndReturn(func(ctx context.Context, vm *virtv1.VirtualMachine) (interface{}, error) {
-					for _, condition := range vm.Status.Conditions {
-						if condition.Type == virtv1.VirtualMachineRestartRequired {
-							restartRequired = condition.Status == k8sv1.ConditionTrue
-						}
-					}
 					return vm, nil
 				}).AnyTimes()
 			}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -4047,6 +4047,7 @@ func now() *metav1.Time {
 }
 
 func markAsReady(vmi *virtv1.VirtualMachineInstance) {
+	vmi.Status.Phase = "Running"
 	kvcontroller.NewVirtualMachineInstanceConditionManager().AddPodCondition(vmi, &k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 }
 


### PR DESCRIPTION
### What this PR does
The controller was not adjusted to `/status` subresource changes. This means we were trying to use `Update` even if the change was in `Status` and would be ultimately ignored. 
Some of the changes (to the `Status`) to `vm` inside the `sync` were also ignored because we never passed the `vm` into `updateStatus` func. This is now fixed.

On top of these functional fixes, the last 2 commits address a few issues in unit tests and fixes false positive tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way

### Special notes for your reviewer

<!-- optional -->

### Release note

```release-note
NONE
```

/hold based on https://github.com/kubevirt/kubevirt/pull/11322
