### PR TITLE
[release-1.1] Manual backport of address incompatibility between IOThreads and unsupported buses

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -2492,14 +2492,14 @@ func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 				}
 			}
 
-			// Reject defining DedicatedIOThread to a disk with SATA bus since this configuration
+			// Reject defining DedicatedIOThread to a disk without VirtIO bus since this configuration
 			// is not supported in libvirt.
-			isIOThreadsWithSataBus := disk.DedicatedIOThread != nil && *disk.DedicatedIOThread &&
-				(disk.DiskDevice.Disk != nil) && (disk.DiskDevice.Disk.Bus == v1.DiskBusSATA)
-			if isIOThreadsWithSataBus {
+			isIOThreadsWithUnsupportedBus := disk.DedicatedIOThread != nil && *disk.DedicatedIOThread &&
+				bus != v1.DiskBusVirtio
+			if isIOThreadsWithUnsupportedBus {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueNotSupported,
-					Message: "IOThreads are not supported for disks on a SATA bus",
+					Message: fmt.Sprintf("IOThreads are not supported for disks on a %s bus", bus),
 					Field:   field.Child("domain", "devices", "disks").Index(idx).String(),
 				})
 			}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3284,7 +3284,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(BeEmpty())
 		})
 
-		It("Should reject disk with DedicatedIOThread and SATA bus", func() {
+		DescribeTable("Should reject disk with DedicatedIOThread and non-virtio bus", func(bus v1.DiskBus) {
 			vmi := api.NewMinimalVMI("testvmi")
 
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks,
@@ -3292,7 +3292,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Name:              "disk-with-dedicated-io-thread-and-sata",
 					DedicatedIOThread: pointer.Bool(true),
 					DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{
-						Bus: v1.DiskBusSATA,
+						Bus: bus,
 					}},
 				},
 				v1.Disk{
@@ -3315,9 +3315,13 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(HaveLen(1)) // Only first disk should fail
 			Expect(string(causes[0].Type)).To(Equal("FieldValueNotSupported"))
 			Expect(causes[0].Field).To(ContainSubstring("domain.devices.disks"))
-			Expect(causes[0].Message).To(Equal(fmt.Sprintf("IOThreads are not supported for disks on a SATA bus")))
+			Expect(causes[0].Message).To(Equal(fmt.Sprintf("IOThreads are not supported for disks on a %s bus", bus)))
 
-		})
+		},
+			Entry("SATA bus", v1.DiskBusSATA),
+			Entry("SCSI bus", v1.DiskBusSCSI),
+			Entry("USB bus", v1.DiskBusUSB),
+		)
 
 		Context("With block size", func() {
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -185,6 +185,14 @@ func verifyHotplugVolumes(newHotplugVolumeMap, oldHotplugVolumeMap map[string]v1
 					})
 
 				}
+				if disk.DedicatedIOThread != nil && *disk.DedicatedIOThread {
+					return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
+						{
+							Type:    metav1.CauseTypeFieldValueInvalid,
+							Message: fmt.Sprintf("hotplugged Disk %s can't use dedicated IOThread: scsi bus is unsupported.", k),
+						},
+					})
+				}
 			}
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -759,6 +759,13 @@ func validateDiskConfiguration(disk *v1.Disk, name string) []metav1.StatusCause 
 			Field:   k8sfield.NewPath("Status", "volumeRequests").String(),
 		}}
 	}
+	if disk.DedicatedIOThread != nil && *disk.DedicatedIOThread {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "IOThreads are not supported by scsi bus.",
+			Field:   k8sfield.NewPath("Status", "volumeRequests").String(),
+		}}
+	}
 
 	return nil
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -43,6 +43,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	k8sptr "k8s.io/utils/pointer"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
@@ -431,6 +432,28 @@ var _ = Describe("Validating VM Admitter", func() {
 			},
 		},
 			true),
+		Entry("with invalid request to add volume with dedicated IOThreads", []v1.VirtualMachineVolumeRequest{
+			{
+				AddVolumeOptions: &v1.AddVolumeOptions{
+					Name: "testDisk",
+					Disk: &v1.Disk{
+						Name: "testDisk",
+						DiskDevice: v1.DiskDevice{
+							Disk: &v1.DiskTarget{
+								Bus: "scsi",
+							},
+						},
+						DedicatedIOThread: k8sptr.Bool(true),
+					},
+					VolumeSource: &v1.HotplugVolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "diskTest",
+						}},
+					},
+				},
+			},
+		},
+			false),
 		Entry("with invalid request to add volume that conflicts with running vmi", []v1.VirtualMachineVolumeRequest{
 			{
 				AddVolumeOptions: &v1.AddVolumeOptions{

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1652,7 +1652,10 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 
 		if useIOThreads {
-			if _, ok := c.HotplugVolumes[disk.Name]; !ok {
+			bus := getBusFromDisk(disk)
+			switch bus {
+			// Only disks with virtio bus support IOThreads
+			case v1.DiskBusVirtio:
 				ioThreadId := defaultIOThread
 				dedicatedThread := false
 				if disk.DedicatedIOThread != nil {
@@ -1669,8 +1672,14 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 					currentAutoThread = (currentAutoThread % uint(autoThreads)) + 1
 				}
 				newDisk.Driver.IOThread = &ioThreadId
-			} else {
+
+			// We can find a workaround by adding IOThreads to the SCSI controller
+			case v1.DiskBusSCSI:
 				newDisk.Driver.IO = v1.IOThreads
+
+			default:
+				// TODO: if possible, find a workaround for SATA and USB buses.
+				log.Log.Infof("IOthreads not available for disk %s: Bus %s not supported", disk.Name, bus)
 			}
 		}
 
@@ -1727,20 +1736,16 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		return err
 	}
 
-	if isUSBNeeded(c, vmi) {
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
-			Type:  "usb",
-			Index: "0",
-			Model: "qemu-xhci",
-		})
-	} else {
-		// disable usb controller
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
-			Type:  "usb",
-			Index: "0",
-			Model: "none",
-		})
+	// Creating USB controller, disabled by default
+	usbController := api.Controller{
+		Type:  "usb",
+		Index: "0",
+		Model: "none",
 	}
+	if isUSBNeeded(c, vmi) {
+		usbController.Model = "qemu-xhci"
+	}
+	domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, usbController)
 
 	if needsSCSIController(vmi) {
 		scsiController := api.Controller{
@@ -2057,17 +2062,24 @@ func GetImageInfo(imagePath string) (*containerdisk.DiskInfo, error) {
 
 func needsSCSIController(vmi *v1.VirtualMachineInstance) bool {
 	for _, disk := range vmi.Spec.Domain.Devices.Disks {
-		if disk.LUN != nil && disk.LUN.Bus == "scsi" {
-			return true
-		}
-		if disk.Disk != nil && disk.Disk.Bus == "scsi" {
-			return true
-		}
-		if disk.CDRom != nil && disk.CDRom.Bus == "scsi" {
+		if getBusFromDisk(disk) == v1.DiskBusSCSI {
 			return true
 		}
 	}
 	return !vmi.Spec.Domain.Devices.DisableHotplug
+}
+
+func getBusFromDisk(disk v1.Disk) v1.DiskBus {
+	if disk.LUN != nil {
+		return disk.LUN.Bus
+	}
+	if disk.Disk != nil {
+		return disk.Disk.Bus
+	}
+	if disk.CDRom != nil {
+		return disk.CDRom.Bus
+	}
+	return ""
 }
 
 func getPrefixFromBus(bus v1.DiskBus) string {

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1917,6 +1917,97 @@ var _ = Describe("Converter", func() {
 			Entry("using an auto policy with 5 CPUs", v1.IOThreadsPolicyAuto, 5, 7, []int{7, 1, 2, 3, 4, 5, 6}),
 		)
 
+		It("Should not add IOThreads to non-virtio disks", func() {
+			dedicatedDiskName := "dedicated"
+			sharedDiskName := "shared"
+			incompatibleDiskName := "incompatible"
+			claimName := "claimName"
+			vmi := v1.VirtualMachineInstance{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name:      "testvmi",
+					Namespace: "default",
+					UID:       "1234",
+				},
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							Disks: []v1.Disk{
+								{
+									Name: dedicatedDiskName,
+									DiskDevice: v1.DiskDevice{
+										Disk: &v1.DiskTarget{
+											Bus: v1.VirtIO,
+										},
+									},
+									DedicatedIOThread: True(),
+								},
+								{
+									Name: sharedDiskName,
+									DiskDevice: v1.DiskDevice{
+										Disk: &v1.DiskTarget{
+											Bus: v1.VirtIO,
+										},
+									},
+									DedicatedIOThread: False(),
+								},
+								{
+									Name: incompatibleDiskName,
+									DiskDevice: v1.DiskDevice{
+										Disk: &v1.DiskTarget{
+											Bus: v1.DiskBusSATA,
+										},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: dedicatedDiskName,
+							VolumeSource: v1.VolumeSource{
+								Ephemeral: &v1.EphemeralVolumeSource{
+									PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+										ClaimName: claimName,
+									},
+								},
+							},
+						},
+						{
+							Name: sharedDiskName,
+							VolumeSource: v1.VolumeSource{
+								Ephemeral: &v1.EphemeralVolumeSource{
+									PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+										ClaimName: claimName,
+									},
+								},
+							},
+						},
+						{
+							Name: incompatibleDiskName,
+							VolumeSource: v1.VolumeSource{
+								Ephemeral: &v1.EphemeralVolumeSource{
+									PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+										ClaimName: claimName,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			domain := vmiToDomain(&vmi, &ConverterContext{AllowEmulation: true, EphemeraldiskCreator: EphemeralDiskImageCreator})
+			Expect(domain.Spec.IOThreads).ToNot(BeNil())
+			Expect(domain.Spec.IOThreads.IOThreads).To(Equal(uint(2)))
+			// Disk with dedicated IOThread (2)
+			Expect(domain.Spec.Devices.Disks[0].Driver.IOThread).ToNot(BeNil())
+			Expect(*domain.Spec.Devices.Disks[0].Driver.IOThread).To(Equal(uint(2)))
+			// Disk with shared IOThread
+			Expect(domain.Spec.Devices.Disks[1].Driver.IOThread).ToNot(BeNil())
+			Expect(*domain.Spec.Devices.Disks[1].Driver.IOThread).To(Equal(uint(1)))
+			// Disk incompatible with IOThreads
+			Expect(domain.Spec.Devices.Disks[2].Driver.IOThread).To(BeNil())
+		})
 	})
 
 	Context("virtio block multi-queue", func() {

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_ppc64le.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_ppc64le.xml.tmpl
@@ -52,26 +52,26 @@
     <disk device="cdrom" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
       <target bus="sata" dev="sda" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-cdrom_tray_unspecified"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/cdrom_tray_open/disk.img"></source>
       <target bus="sata" dev="sdb" tray="open"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <readonly></readonly>
       <alias name="ua-cdrom_tray_open"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/should_default_to_disk/disk.img"></source>
       <target bus="sata" dev="sdc"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-should_default_to_disk"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/libvirt/kubevirt-ephemeral-disk/ephemeral_pvc/disk.qcow2"></source>
       <target bus="sata" dev="sdd"></target>
-      <driver cache="none" error_policy="stop" name="qemu" type="qcow2" iothread="1" discard="unmap"></driver>
+      <driver cache="none" error_policy="stop" name="qemu" type="qcow2" discard="unmap"></driver>
       <alias name="ua-ephemeral_pvc"></alias>
       <backingStore type="file">
         <format type="raw"></format>
@@ -82,44 +82,44 @@
       <source file="/var/run/kubevirt-private/secret-disks/secret_test.iso"></source>
       <target bus="sata" dev="sde"></target>
       <serial>D23YZ9W6WA5DJ487</serial>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-secret_test"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/config-map-disks/configmap_test.iso"></source>
       <target bus="sata" dev="sdf"></target>
       <serial>CVLY623300HK240D</serial>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-configmap_test"></alias>
     </disk>
     <disk device="disk" type="block">
       <source dev="/dev/pvc_block_test" name="pvc_block_test"></source>
       <target bus="sata" dev="sdg"></target>
-      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-pvc_block_test"></alias>
     </disk>
     <disk device="disk" type="block">
       <source dev="/dev/dv_block_test" name="dv_block_test"></source>
       <target bus="sata" dev="sdh"></target>
-      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-dv_block_test"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
       <target bus="sata" dev="sdi"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-serviceaccount_test"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep.iso"></source>
       <target bus="sata" dev="sdj" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-sysprep"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep_secret.iso"></source>
       <target bus="sata" dev="sdk" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-sysprep_secret"></alias>
     </disk>
     <input type="tablet" bus="virtio" model="virtio">

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64.xml.tmpl
@@ -53,26 +53,26 @@
     <disk device="cdrom" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
       <target bus="sata" dev="sda" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-cdrom_tray_unspecified"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/cdrom_tray_open/disk.img"></source>
       <target bus="sata" dev="sdb" tray="open"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <readonly></readonly>
       <alias name="ua-cdrom_tray_open"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/should_default_to_disk/disk.img"></source>
       <target bus="sata" dev="sdc"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-should_default_to_disk"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/libvirt/kubevirt-ephemeral-disk/ephemeral_pvc/disk.qcow2"></source>
       <target bus="sata" dev="sdd"></target>
-      <driver cache="none" error_policy="stop" name="qemu" type="qcow2" iothread="1" discard="unmap"></driver>
+      <driver cache="none" error_policy="stop" name="qemu" type="qcow2" discard="unmap"></driver>
       <alias name="ua-ephemeral_pvc"></alias>
       <backingStore type="file">
         <format type="raw"></format>
@@ -83,44 +83,44 @@
       <source file="/var/run/kubevirt-private/secret-disks/secret_test.iso"></source>
       <target bus="sata" dev="sde"></target>
       <serial>D23YZ9W6WA5DJ487</serial>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-secret_test"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/config-map-disks/configmap_test.iso"></source>
       <target bus="sata" dev="sdf"></target>
       <serial>CVLY623300HK240D</serial>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-configmap_test"></alias>
     </disk>
     <disk device="disk" type="block">
       <source dev="/dev/pvc_block_test" name="pvc_block_test"></source>
       <target bus="sata" dev="sdg"></target>
-      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-pvc_block_test"></alias>
     </disk>
     <disk device="disk" type="block">
       <source dev="/dev/dv_block_test" name="dv_block_test"></source>
       <target bus="sata" dev="sdh"></target>
-      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-dv_block_test"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
       <target bus="sata" dev="sdi"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-serviceaccount_test"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep.iso"></source>
       <target bus="sata" dev="sdj" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-sysprep"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep_secret.iso"></source>
       <target bus="sata" dev="sdk" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-sysprep_secret"></alias>
     </disk>
     <input type="tablet" bus="virtio" model="virtio">

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64_root.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64_root.xml.tmpl
@@ -63,26 +63,26 @@
     <disk device="cdrom" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
       <target bus="sata" dev="sda" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-cdrom_tray_unspecified"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/cdrom_tray_open/disk.img"></source>
       <target bus="sata" dev="sdb" tray="open"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <readonly></readonly>
       <alias name="ua-cdrom_tray_open"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/should_default_to_disk/disk.img"></source>
       <target bus="sata" dev="sdc"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-should_default_to_disk"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/libvirt/kubevirt-ephemeral-disk/ephemeral_pvc/disk.qcow2"></source>
       <target bus="sata" dev="sdd"></target>
-      <driver cache="none" error_policy="stop" name="qemu" type="qcow2" iothread="1" discard="unmap"></driver>
+      <driver cache="none" error_policy="stop" name="qemu" type="qcow2" discard="unmap"></driver>
       <alias name="ua-ephemeral_pvc"></alias>
       <backingStore type="file">
         <format type="raw"></format>
@@ -93,44 +93,44 @@
       <source file="/var/run/kubevirt-private/secret-disks/secret_test.iso"></source>
       <target bus="sata" dev="sde"></target>
       <serial>D23YZ9W6WA5DJ487</serial>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-secret_test"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/config-map-disks/configmap_test.iso"></source>
       <target bus="sata" dev="sdf"></target>
       <serial>CVLY623300HK240D</serial>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-configmap_test"></alias>
     </disk>
     <disk device="disk" type="block">
       <source dev="/dev/pvc_block_test" name="pvc_block_test"></source>
       <target bus="sata" dev="sdg"></target>
-      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-pvc_block_test"></alias>
     </disk>
     <disk device="disk" type="block">
       <source dev="/dev/dv_block_test" name="dv_block_test"></source>
       <target bus="sata" dev="sdh"></target>
-      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-dv_block_test"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
       <target bus="sata" dev="sdi"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
+      <driver error_policy="stop" name="qemu" type="raw" discard="unmap"></driver>
       <alias name="ua-serviceaccount_test"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep.iso"></source>
       <target bus="sata" dev="sdj" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-sysprep"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep_secret.iso"></source>
       <target bus="sata" dev="sdk" tray="closed"></target>
-      <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
+      <driver error_policy="stop" name="qemu" type="raw"></driver>
       <alias name="ua-sysprep_secret"></alias>
     </disk>
     <input type="tablet" bus="virtio" model="virtio">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/11219

Libvirt only supports IOThreads in disks with virtio bus (see [this](https://github.com/libvirt/libvirt/blob/master/src/qemu/qemu_validate.c#L2703)). This behavior was unaddressed in Kubevirt and could lead to several unhandled cases, mainly, enabling dedicated IOThreads on a single, valid virtio disks would cause other non-virtio disks to error. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-34292
 
### Why we need it and why it was done in this way

This Pull Request introduces changes such as:

- Webhook rejection of disks with non-virtio bus explicitly setting dedicated IOThreads.

- Using dedicated IOThreads in a single disk would mean enabling them for all remaining ones independently of their bus type. Now, only virtio disks will use IO threads when another disk enables them.

- Improves handling of all SCSI disks with IOThreads, not only hotplugged volumes (see https://github.com/kubevirt/kubevirt/pull/6425).

While SCSI buses can still benefit from enabling a IOThread policy, USB and SATA have been left unhandled as their controllers don't support iothreads.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Improve handling of IOThreads with incompatible buses
```

