### PR TITLE
inline CreateConfigMap into the places where it is used

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -34,6 +34,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"golang.org/x/crypto/ssh"
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
@@ -95,7 +96,11 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					"option2": "value2",
 					"option3": "value3",
 				}
-				tests.CreateConfigMap(configMapName, testsuite.GetTestNamespace(nil), data)
+				_, err := kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(nil)).Create(context.Background(), &k8sv1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+					Data:       data,
+				}, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			AfterEach(func() {
@@ -152,7 +157,12 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			BeforeEach(func() {
 				for i := 0; i < configMapsCnt; i++ {
 					name := "configmap-" + uuid.NewString()
-					tests.CreateConfigMap(name, testsuite.GetTestNamespace(nil), map[string]string{"option": "value"})
+					_, err := kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(nil)).Create(context.Background(), &k8sv1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: name},
+						Data:       map[string]string{"option": "value"},
+					}, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
 					configMaps = append(configMaps, name)
 				}
 			})
@@ -356,7 +366,11 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					"password": "redhat",
 				}
 
-				tests.CreateConfigMap(configMapName, testsuite.GetTestNamespace(nil), configData)
+				_, err := kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(nil)).Create(context.Background(), &k8sv1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+					Data:       configData,
+				}, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
 
 				tests.CreateSecret(secretName, testsuite.GetTestNamespace(nil), secretData)
 			})

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -129,7 +129,12 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			"config1": "value1",
 			"config2": "value2",
 		}
-		tests.CreateConfigMap(name, namespace, data)
+		_, err := kubevirt.Client().CoreV1().ConfigMaps(namespace).Create(context.Background(), &k8sv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Data:       data,
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
 		return name
 	}
 
@@ -1884,7 +1889,12 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					"password": "community",
 				}
 
-				tests.CreateConfigMap(configMapName, testsuite.GetTestNamespace(nil), config_data)
+				_, err := kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(nil)).Create(context.Background(), &k8sv1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+					Data:       config_data,
+				}, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
 				tests.CreateSecret(secretName, testsuite.GetTestNamespace(nil), secret_data)
 				vmi := libvmifact.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -716,7 +716,12 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 					"password": "community",
 				}
 
-				tests.CreateConfigMap(configMapName, testsuite.GetTestNamespace(nil), config_data)
+				_, err := kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(nil)).Create(context.Background(), &k8sv1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+					Data:       config_data,
+				}, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
 				tests.CreateSecret(secretName, testsuite.GetTestNamespace(nil), secret_data)
 				vmi := libvmifact.NewCirros(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -317,7 +317,12 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 		answerFileWithKey := insertProductKeyToAnswerFileTemplate(answerFileTemplate)
 		windowsVMI = tests.NewRandomVMI()
 		windowsVMI.Spec = getWindowsSysprepVMISpec()
-		tests.CreateConfigMap("sysprepautounattend", windowsVMI.Namespace, map[string]string{"Autounattend.xml": answerFileWithKey, "Unattend.xml": answerFileWithKey})
+		_, err := kubevirt.Client().CoreV1().ConfigMaps(windowsVMI.Namespace).Create(context.Background(), &k8sv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "sysprepautounattend"},
+			Data:       map[string]string{"Autounattend.xml": answerFileWithKey, "Unattend.xml": answerFileWithKey},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
 		addExplicitPodNetworkInterface(windowsVMI)
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -95,18 +95,6 @@ const (
 	DiskCustomHostPath     = "disk-custom-host-path"
 )
 
-func CreateConfigMap(name, namespace string, data map[string]string) {
-	virtCli := kubevirt.Client()
-	_, err := virtCli.CoreV1().ConfigMaps(namespace).Create(context.Background(), &k8sv1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Data:       data,
-	}, metav1.CreateOptions{})
-
-	if !errors.IsAlreadyExists(err) {
-		util2.PanicOnError(err)
-	}
-}
-
 func CreateSecret(name, namespace string, data map[string]string) {
 	virtCli := kubevirt.Client()
 

--- a/tests/virtiofs/config.go
+++ b/tests/virtiofs/config.go
@@ -20,6 +20,7 @@
 package virtiofs
 
 import (
+	"context"
 	"fmt"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
@@ -27,11 +28,14 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
 	expect "github.com/google/goexpect"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -64,7 +68,11 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 				"option2": "value2",
 				"option3": "value3",
 			}
-			tests.CreateConfigMap(configMapName, testsuite.GetTestNamespace(nil), data)
+			_, err := kubevirt.Client().CoreV1().ConfigMaps(testsuite.GetTestNamespace(nil)).Create(context.Background(), &k8sv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+				Data:       data,
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Should be the mounted virtiofs layout the same for a pod and vmi", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
### Description
Inlined ```CreateConfigMap``` present in `tests/utils.go`  into the places where it is used .
### What this PR does
Before this PR:

The functions `CreateConfigMap` in `tests/utils.go` doesnot look so useful because these function being called again and again in various file.

After this PR:

 This function is removed from `tests/utils.go` and inlined into the place where they are used.


<!-- (optional, in `fixes #11436(, fixes #11436, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11436

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- https://github.com/kubevirt/kubevirt/issues/11436 ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

