### PR TITLE
annotations: Remove unneeded const

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -77,8 +77,6 @@ const debugLogs = "debugLogs"
 const logVerbosity = "logVerbosity"
 const virtiofsDebugLogs = "virtiofsdDebugLogs"
 
-const MultusNetworksAnnotation = "k8s.v1.cni.cncf.io/networks"
-
 const qemuTimeoutJitterRange = 120
 
 const (
@@ -1331,7 +1329,7 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 		return nil, err
 	}
 	if multusAnnotation != "" {
-		annotationsSet[MultusNetworksAnnotation] = multusAnnotation
+		annotationsSet[networkv1.NetworkAttachmentAnnot] = multusAnnotation
 	}
 
 	if multusDefaultNetwork := lookupMultusDefaultNetworkName(vmi.Spec.Networks); multusDefaultNetwork != "" {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -994,7 +994,7 @@ var _ = Describe("Template", func() {
 
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
-				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
+				value, ok := pod.Annotations[networkv1.NetworkAttachmentAnnot]
 				Expect(ok).To(BeTrue())
 				expectedIfaces := "[" +
 					"{\"name\":\"default\",\"namespace\":\"default\",\"interface\":\"pod37a8eec1ce1\"}," +
@@ -1036,7 +1036,7 @@ var _ = Describe("Template", func() {
 				value, ok := pod.Annotations["v1.multus-cni.io/default-network"]
 				Expect(ok).To(BeTrue())
 				Expect(value).To(Equal("default"))
-				value, ok = pod.Annotations["k8s.v1.cni.cncf.io/networks"]
+				value, ok = pod.Annotations[networkv1.NetworkAttachmentAnnot]
 				Expect(ok).To(BeTrue())
 				Expect(value).To(Equal("[{\"name\":\"test1\",\"namespace\":\"default\",\"interface\":\"pod1b4f0e98519\"}]"))
 			})
@@ -1079,7 +1079,7 @@ var _ = Describe("Template", func() {
 
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
-				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
+				value, ok := pod.Annotations[networkv1.NetworkAttachmentAnnot]
 				Expect(ok).To(BeTrue())
 				expectedIfaces := "[" +
 					"{\"name\":\"default\",\"namespace\":\"default\",\"interface\":\"pod37a8eec1ce1\"}," +
@@ -1127,7 +1127,7 @@ var _ = Describe("Template", func() {
 					targetPod, err := svc.RenderMigrationManifest(vmi, sourcePod)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(targetPod.Annotations[MultusNetworksAnnotation]).To(MatchJSON(expectedTargetPodMultusNetworksAnnotation[MultusNetworksAnnotation]))
+					Expect(targetPod.Annotations[networkv1.NetworkAttachmentAnnot]).To(MatchJSON(expectedTargetPodMultusNetworksAnnotation[networkv1.NetworkAttachmentAnnot]))
 				},
 				Entry("when the migration source Multus network-status annotation has ordinal naming",
 					map[string]string{
@@ -1138,7 +1138,7 @@ var _ = Describe("Template", func() {
 						]`,
 					},
 					map[string]string{
-						MultusNetworksAnnotation: `[
+						networkv1.NetworkAttachmentAnnot: `[
 							{"interface":"net1", "name":"test1", "namespace":"default"},
 							{"interface":"net2", "name":"test1", "namespace":"other-namespace"}
 						]`,
@@ -1152,7 +1152,7 @@ var _ = Describe("Template", func() {
 						]`,
 					},
 					map[string]string{
-						MultusNetworksAnnotation: `[
+						networkv1.NetworkAttachmentAnnot: `[
 							{"interface":"pod16477688c0e", "name":"test1", "namespace":"default"},
 							{"interface":"podb1f51a511f1", "name":"test1", "namespace":"other-namespace"}
 						]`,

--- a/pkg/virt-operator/resource/generate/components/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/openshift/api/route/v1:go_default_library",
         "//vendor/github.com/openshift/api/security/v1:go_default_library",
         "//vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
@@ -67,7 +69,7 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 			podTemplateSpec.ObjectMeta.Annotations = make(map[string]string)
 		}
 		// Join the pod to the migration network and name the corresponding interface "migration0"
-		podTemplateSpec.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks"] = *migrationNetwork + "@" + virtv1.MigrationInterfaceName
+		podTemplateSpec.ObjectMeta.Annotations[networkv1.NetworkAttachmentAnnot] = *migrationNetwork + "@" + virtv1.MigrationInterfaceName
 	}
 
 	daemonset := &appsv1.DaemonSet{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
`"k8s.v1.cni.cncf.io/networks"` belongs to and already defined in existing package:
`network-attachment-definition-client`.
Use it from that one instead adding our const / hardcoded values.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

