### PR TITLE
migrations: add check for vmi equal to nil

### DIFF
--- a/pkg/util/migrations/BUILD.bazel
+++ b/pkg/util/migrations/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
@@ -35,6 +36,10 @@ func FilterRunningMigrations(migrations []*v1.VirtualMachineInstanceMigration) [
 
 // IsMigrating returns true if a given VMI is still migrating and false otherwise.
 func IsMigrating(vmi *v1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		log.Log.V(4).Infof("checking if VMI is migrating, but it is empty")
+		return false
+	}
 
 	now := v12.Now()
 


### PR DESCRIPTION
Add check if VMI is nil in `IsMigrating`. This function could be called in different places of the code where the vmi object can be empty and this causes a panic.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

