### PR TITLE
chore(fix): Reduces the downwardMetrics rate limit

### DIFF
--- a/pkg/downwardmetrics/virtio-serial/server.go
+++ b/pkg/downwardmetrics/virtio-serial/server.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	maxConnectAttempts   = 6
-	maxRequestsPerSecond = 5
+	maxRequestsPerSecond = 1
 	maxRequestsBurst     = 1 // must be >= 1, otherwise `rateLimiter.Wait()` will fail
 	invalidRequest       = "INVALID REQUEST\n\n"
 	emptyMetrics         = "<metrics><!-- host metrics not available --><!-- VM metrics not available --></metrics>"


### PR DESCRIPTION
### What this PR does
Before this PR:
The number of requests per second is set to 5, which causes an excessive resources consumption by the virt-handler if many VMs are running on the cluster and requesting the metrics.
After this PR:
 It reduces the number of requests per second that can be addressed to the downwardMetrics server to 1 to reduce the virt-handler resource consumption.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # [CNV-38661](https://issues.redhat.com/browse/CNV-38661)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Reduce the downwardMetrics server maximum number of request per second to 1.
```

