### PR TITLE
virt-api: Fix race condition on streamer unit-test

### DIFF
--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -64,6 +64,8 @@ go_test(
         "expand_test.go",
         "profiler_test.go",
         "rest_suite_test.go",
+        "streamer_norace_test.go",
+        "streamer_race_test.go",
         "streamer_test.go",
         "subresource_test.go",
     ],

--- a/pkg/virt-api/rest/streamer_norace_test.go
+++ b/pkg/virt-api/rest/streamer_norace_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package rest
+
+const raceDetectorEnabled = false

--- a/pkg/virt-api/rest/streamer_race_test.go
+++ b/pkg/virt-api/rest/streamer_race_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package rest
+
+const raceDetectorEnabled = true


### PR DESCRIPTION
Empty and close channels after each test run to avoid race condition.
Skip check test checking for closed write-only channels, as it is mutually exclusive with the `-race`-flag.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Running `make go-test` fails with race condition found.
After this PR:
Running `make go-test` passes.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #8765 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
Detecting if the `-race` flag is set via `runtime.debug`, however the `BuildInfo.Settings` was empty.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

