### PR TITLE
tests, utils: Move functions from tests utils and tighten test/utils lines limit 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ format:
 fmt: format
 
 lint:
-	if [ $$(wc -l < tests/utils.go) -gt 2027 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
+	if [ $$(wc -l < tests/utils.go) -gt 1401 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 	hack/dockerized "golangci-lint run --timeout 20m --verbose \
 	  pkg/instancetype/... \
 	  pkg/network/namescheme/... \

--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -70,3 +70,12 @@ func ContainerDiskFromRegistryFor(registry string, name ContainerDisk) string {
 	}
 	panic(fmt.Sprintf("Unsupported registry disk %s", name))
 }
+
+func ContainerDiskSizeBySourceURL(url string) string {
+	if url == DataVolumeImportUrlForContainerDisk(ContainerDiskFedoraTestTooling) ||
+		url == DataVolumeImportUrlForContainerDisk(ContainerDiskFedoraRealtime) {
+		return FedoraVolumeSize
+	}
+
+	return CirrosVolumeSize
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Move functions from the tests utils to where they belong.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

