### PR TITLE
Allow to set memory limits when doing memory hotplug 

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -155,6 +155,7 @@ go_test(
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
+        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -150,7 +150,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateMemoryRequestsNegativeOrNull(field, spec)...)
 	causes = append(causes, validateMemoryLimitsNegativeOrNull(field, spec)...)
 	causes = append(causes, validateHugepagesMemoryRequests(field, spec)...)
-	causes = append(causes, validateGuestMemoryLimit(field, spec)...)
+	causes = append(causes, validateGuestMemoryLimit(field, spec, config)...)
 	causes = append(causes, validateEmulatedMachine(field, spec, config)...)
 	causes = append(causes, validateFirmwareSerial(field, spec)...)
 	causes = append(causes, validateCPURequestNotNegative(field, spec)...)
@@ -1378,7 +1378,11 @@ func validateEmulatedMachine(field *k8sfield.Path, spec *v1.VirtualMachineInstan
 	return causes
 }
 
-func validateGuestMemoryLimit(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) (causes []metav1.StatusCause) {
+func validateGuestMemoryLimit(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) (causes []metav1.StatusCause) {
+	if config.IsVMRolloutStrategyLiveUpdate() {
+		return
+	}
+
 	if spec.Domain.Memory != nil && spec.Domain.Memory.Guest != nil {
 		limits := spec.Domain.Resources.Limits.Memory().Value()
 		guest := spec.Domain.Memory.Guest.Value()

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -470,14 +470,6 @@ func validateLiveUpdateCPU(field *k8sfield.Path, domain *v1.DomainSpec) (causes 
 }
 
 func validateLiveUpdateMemory(field *k8sfield.Path, domain *v1.DomainSpec, architecture string) (causes []metav1.StatusCause) {
-	if hasMemoryLimits(&domain.Resources) {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("Configuration of Memory limits is not allowed when Memory live update is enabled"),
-			Field:   field.Child("template", "spec", "domain", "resources").String(),
-		})
-	}
-
 	if domain.CPU != nil &&
 		domain.CPU.Realtime != nil {
 		causes = append(causes, metav1.StatusCause{
@@ -818,9 +810,4 @@ func hasCPURequestsOrLimits(rr *v1.ResourceRequirements) bool {
 	}
 
 	return false
-}
-
-func hasMemoryLimits(rr *v1.ResourceRequirements) bool {
-	_, ok := rr.Limits[corev1.ResourceMemory]
-	return ok
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1928,14 +1928,6 @@ var _ = Describe("Validating VM Admitter", func() {
 				Expect(response.Allowed).To(BeFalse())
 				Expect(response.Result.Details.Causes).To(ContainElement(cause))
 			},
-				Entry("resource limits are configured", func(vm *v1.VirtualMachine) {
-					vm.Spec.Template.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-					vm.Spec.Template.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-				}, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Field:   "spec.template.spec.domain.resources",
-					Message: "Configuration of Memory limits is not allowed when Memory live update is enabled",
-				}),
 				Entry("hugepages is configured", func(vm *v1.VirtualMachine) {
 					vm.Spec.Template.Spec.Domain.Memory.Hugepages = &v1.Hugepages{
 						PageSize: "2Mi",

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3191,17 +3191,37 @@ func (c *VMController) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi
 		return nil
 	}
 
-	newMemoryReq := vm.Spec.Template.Spec.Domain.Memory.Guest.DeepCopy()
-	newMemoryReq.Sub(*vmi.Status.Memory.GuestCurrent)
-	newMemoryReq.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
+	memoryDelta := resource.NewQuantity(vm.Spec.Template.Spec.Domain.Memory.Guest.Value()-vmi.Status.Memory.GuestCurrent.Value(), resource.BinarySI)
 
-	guestTest := fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/memory/guest", "value": "%s"}`, vmi.Spec.Domain.Memory.Guest.String())
-	updateGuest := fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/memory/guest", "value": "%s"}`, vm.Spec.Template.Spec.Domain.Memory.Guest.String())
-	MemoryReqTest := fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/requests/memory", "value": "%s"}`, vmi.Spec.Domain.Resources.Requests.Memory().String())
-	updateMemoryReq := fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/resources/requests/memory", "value": "%s"}`, newMemoryReq.String())
-	patch := fmt.Sprintf(`[%s, %s, %s, %s]`, guestTest, updateGuest, MemoryReqTest, updateMemoryReq)
+	newMemoryReq := vmi.Spec.Domain.Resources.Requests.Memory().DeepCopy()
+	newMemoryReq.Add(*memoryDelta)
 
-	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &v1.PatchOptions{})
+	// checking if the new memory req are at least equal to the memory being requested in the handleMemoryHotplugRequest
+	// this is necessary as weirdness can arise after hot-unplugs as not all memory is guaranteed to be released when doing hot-unplug.
+	if newMemoryReq.Cmp(*vm.Spec.Template.Spec.Domain.Memory.Guest) == -1 {
+		newMemoryReq = *vm.Spec.Template.Spec.Domain.Memory.Guest
+		// adjusting memoryDelta too for the new limits computation (if required)
+		memoryDelta = resource.NewQuantity(vm.Spec.Template.Spec.Domain.Memory.Guest.Value()-newMemoryReq.Value(), resource.BinarySI)
+	}
+
+	patches := []string{
+		fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/memory/guest", "value": "%s"}`, vmi.Spec.Domain.Memory.Guest.String()),
+		fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/memory/guest", "value": "%s"}`, vm.Spec.Template.Spec.Domain.Memory.Guest.String()),
+		fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/requests/memory", "value": "%s"}`, vmi.Spec.Domain.Resources.Requests.Memory().String()),
+		fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/resources/requests/memory", "value": "%s"}`, newMemoryReq.String()),
+	}
+
+	if !vm.Spec.Template.Spec.Domain.Resources.Limits.Memory().IsZero() {
+		newMemoryLimit := vmi.Spec.Domain.Resources.Limits.Memory().DeepCopy()
+		newMemoryLimit.Add(*memoryDelta)
+
+		patches = append(patches, fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/limits/memory", "value": "%s"}`, vmi.Spec.Domain.Resources.Limits.Memory().String()))
+		patches = append(patches, fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/resources/limits/memory", "value": "%s"}`, newMemoryLimit.String()))
+	}
+
+	memoryPatch := controller.GeneratePatchBytes(patches)
+
+	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, memoryPatch, &v1.PatchOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5179,9 +5179,10 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(vmi.Spec.Domain.Memory.MaxGuest.Value()).To(Equal(guestMemory.Value() * int64(config.GetMaxHotplugRatio())))
 				})
 
-				It("should patch VMI when memory hotplug is requested", func() {
+				DescribeTable("should patch VMI when memory hotplug is requested", func(resources virtv1.ResourceRequirements) {
 					vm, _ := DefaultVirtualMachine(true)
 					newMemory := resource.MustParse("128Mi")
+					vm.Spec.Template.Spec.Domain.Resources = resources
 					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{
 						Guest:    &newMemory,
 						MaxGuest: &maxGuestFromSpec,
@@ -5190,11 +5191,7 @@ var _ = Describe("VirtualMachine", func() {
 					vmi := api.NewMinimalVMI(vm.Name)
 					guestMemory := resource.MustParse("64Mi")
 					vmi.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
-
-					memReqBuffer := resource.MustParse("100Mi")
-					memoryRequest := guestMemory.DeepCopy()
-					memoryRequest.Add(memReqBuffer)
-					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = memoryRequest
+					vmi.Spec.Domain.Resources = resources
 
 					vmi.Status.Memory = &virtv1.MemoryStatus{
 						GuestAtBoot:    &guestMemory,
@@ -5202,32 +5199,53 @@ var _ = Describe("VirtualMachine", func() {
 						GuestRequested: &guestMemory,
 					}
 
-					vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), &metav1.PatchOptions{}).Do(func(ctx context.Context, name, patchType, patch, opts interface{}, subs ...interface{}) {
-						originalVMIBytes, err := json.Marshal(vmi)
-						Expect(err).ToNot(HaveOccurred())
-						patchBytes := patch.([]byte)
+					vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), &metav1.PatchOptions{}).Do(
+						func(ctx context.Context, name, patchType, patch, opts interface{}, subs ...interface{},
+						) {
+							originalVMIBytes, err := json.Marshal(vmi)
+							Expect(err).ToNot(HaveOccurred())
+							patchBytes := patch.([]byte)
 
-						patchJSON, err := jsonpatch.DecodePatch(patchBytes)
-						Expect(err).ToNot(HaveOccurred())
-						newVMIBytes, err := patchJSON.Apply(originalVMIBytes)
-						Expect(err).ToNot(HaveOccurred())
+							patchJSON, err := jsonpatch.DecodePatch(patchBytes)
+							Expect(err).ToNot(HaveOccurred())
+							newVMIBytes, err := patchJSON.Apply(originalVMIBytes)
+							Expect(err).ToNot(HaveOccurred())
 
-						var newVMI *virtv1.VirtualMachineInstance
-						err = json.Unmarshal(newVMIBytes, &newVMI)
-						Expect(err).ToNot(HaveOccurred())
+							var newVMI *virtv1.VirtualMachineInstance
+							err = json.Unmarshal(newVMIBytes, &newVMI)
+							Expect(err).ToNot(HaveOccurred())
 
-						// this tests when memory request is not equal guest memory
-						expectedMemReq := vm.Spec.Template.Spec.Domain.Memory.Guest.DeepCopy()
-						expectedMemReq.Add(memReqBuffer)
+							Expect(newVMI.Spec.Domain.Memory.Guest.Value()).To(Equal(vm.Spec.Template.Spec.Domain.Memory.Guest.Value()))
 
-						Expect(newVMI.Spec.Domain.Memory.Guest.Value()).To(Equal(vm.Spec.Template.Spec.Domain.Memory.Guest.Value()))
-						Expect(newVMI.Spec.Domain.Resources.Requests.Memory().Value()).To(Equal(expectedMemReq.Value()))
+							if !resources.Requests.Memory().IsZero() {
+								expectedMemReq := resources.Requests.Memory().Value() + newMemory.Value() - guestMemory.Value()
+								Expect(newVMI.Spec.Domain.Resources.Requests.Memory().Value()).To(Equal(expectedMemReq))
+							}
 
-					})
+							if !resources.Limits.Memory().IsZero() {
+								expectedMemLimit := resources.Limits.Memory().Value() + newMemory.Value() - guestMemory.Value()
+								Expect(newVMI.Spec.Domain.Resources.Limits.Memory().Value()).To(Equal(expectedMemLimit))
+							}
+
+						})
 
 					err := controller.handleMemoryHotplugRequest(vm, vmi)
 					Expect(err).ToNot(HaveOccurred())
-				})
+				},
+					Entry("with memory request set", virtv1.ResourceRequirements{
+						Requests: k8sv1.ResourceList{
+							k8sv1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					}),
+					Entry("with memory request and limits set", virtv1.ResourceRequirements{
+						Requests: k8sv1.ResourceList{
+							k8sv1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						Limits: k8sv1.ResourceList{
+							k8sv1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					}),
+				)
 
 				It("should not patch VMI if memory hotplug is already in progress", func() {
 					vm, _ := DefaultVirtualMachine(true)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5160,15 +5160,6 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(*vmi.Spec.Domain.Memory.MaxGuest).To(Equal(maxGuestFromConfig))
 				})
 
-				It("should opt-out from memory live-update if liveUpdateFeatures is disabled in the VM spec", func() {
-					vm, _ := DefaultVirtualMachine(true)
-					guestMemory := resource.MustParse("0")
-					vm.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{Guest: &guestMemory}
-
-					vmi := controller.setupVMIFromVM(vm)
-					Expect(vmi.Spec.Domain.Memory.MaxGuest).To(BeNil())
-				})
-
 				It("should calculate maxGuest to be `MaxHotplugRatio` times the configured guest memory when no maxGuest is defined", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					guestMemory := resource.MustParse("64Mi")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
A VM with memory limits set could not hotplug memory.

After this PR:
A VM with memory limits set can hotplug memory.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow to hotplug memory for VMs with memory limits set
```

