### PR TITLE
test(fix): virtiofs multiple PVCs tests

### DIFF
--- a/tests/libstorage/storageclass.go
+++ b/tests/libstorage/storageclass.go
@@ -253,6 +253,19 @@ func GetBlockStorageClass(accessMode k8sv1.PersistentVolumeAccessMode) (string, 
 	return sc, foundSC
 }
 
+// GetAvailableRWFileSystemStorageClass returns any RWX or RWO access mode filesystem storage class available, i.e,
+// If the available filesystem storage classes only support RWO access mode, it returns that SC or vice versa.
+// This method to get a filesystem storage class is recommended when the access mode is not relevant for the purpose of
+// the test.
+func GetAvailableRWFileSystemStorageClass() (string, bool) {
+	sc, foundSC := GetRWXFileSystemStorageClass()
+	if !foundSC {
+		sc, foundSC = GetRWOFileSystemStorageClass()
+	}
+
+	return sc, foundSC
+}
+
 // GetNoVolumeSnapshotStorageClass goes over all the existing storage classes
 // and returns one which doesnt have volume snapshot ability
 // if the preference storage class exists and is without snapshot

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -76,7 +76,8 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 		pvc1 := "pvc-1"
 		pvc2 := "pvc-2"
 		createPVC := func(namespace, name string) {
-			sc, _ := libstorage.GetRWXFileSystemStorageClass()
+			sc, foundSC := libstorage.GetAvailableRWFileSystemStorageClass()
+			Expect(foundSC).To(BeTrue(), "Unable to get a FileSystem Storage Class")
 			pvc := libstorage.NewPVC(name, "1Gi", sc)
 			_, err = virtClient.CoreV1().PersistentVolumeClaims(namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What this PR does
Before this PR:
Virtiofs tests using multiple PVCs ask for a storage class supporting access mode `ReadWriteMany`. For the purpose of these tests, it is not required any specific access mode and, if this storage class is not found, the PVC requested through this non-existent storage class gets stuck in `Pending` state causing the test to fail.

After this PR:
It changes the requested storage class to any available one, regardless of the access mode. Moreover, this will ensure the test will work in the majority of scenarios.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

