### PR TITLE
Fix and deprecate `emulatedMachines` and `ovmfPath`

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17809,6 +17809,7 @@
       "$ref": "#/definitions/v1.DeveloperConfiguration"
      },
      "emulatedMachines": {
+      "description": "Deprecated. Use architectureConfiguration instead.",
       "type": "array",
       "items": {
        "type": "string",
@@ -17867,6 +17868,7 @@
       }
      },
      "ovmfPath": {
+      "description": "Deprecated. Use architectureConfiguration instead.",
       "type": "string"
      },
      "permittedHostDevices": {

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -354,6 +354,7 @@ spec:
                         type: boolean
                     type: object
                   emulatedMachines:
+                    description: Deprecated. Use architectureConfiguration instead.
                     items:
                       type: string
                     type: array
@@ -666,6 +667,7 @@ spec:
                       type: boolean
                     type: object
                   ovmfPath:
+                    description: Deprecated. Use architectureConfiguration instead.
                     type: string
                   permittedHostDevices:
                     description: PermittedHostDevices holds information about devices
@@ -3446,6 +3448,7 @@ spec:
                         type: boolean
                     type: object
                   emulatedMachines:
+                    description: Deprecated. Use architectureConfiguration instead.
                     items:
                       type: string
                     type: array
@@ -3758,6 +3761,7 @@ spec:
                       type: boolean
                     type: object
                   ovmfPath:
+                    description: Deprecated. Use architectureConfiguration instead.
                     type: string
                   permittedHostDevices:
                     description: PermittedHostDevices holds information about devices

--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -176,7 +176,6 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 		Product:      SmbiosConfigDefaultProduct,
 	}
 	supportedQEMUGuestAgentVersions := strings.Split(strings.TrimRight(SupportedGuestAgentVersions, ","), ",")
-	DefaultOVMFPath, _, emulatedMachinesDefault := getCPUArchSpecificDefault(cpuArch)
 	defaultDiskVerification := &v1.DiskVerification{
 		MemoryLimit: resource.NewScaledQuantity(DefaultDiskVerificationMemoryLimitMBytes, resource.Mega),
 	}
@@ -212,8 +211,7 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 			AllowAutoConverge:                 &allowAutoConverge,
 			AllowPostCopy:                     &allowPostCopy,
 		},
-		CPURequest:       &cpuRequestDefault,
-		EmulatedMachines: emulatedMachinesDefault,
+		CPURequest: &cpuRequestDefault,
 		NetworkConfiguration: &v1.NetworkConfiguration{
 			NetworkInterface:                  defaultNetworkInterface,
 			PermitSlirpInterface:              pointer.P(DefaultPermitSlirpInterface),
@@ -222,7 +220,6 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 		SMBIOSConfig:                SmbiosDefaultConfig,
 		SELinuxLauncherType:         DefaultSELinuxLauncherType,
 		SupportedGuestAgentVersions: supportedQEMUGuestAgentVersions,
-		OVMFPath:                    DefaultOVMFPath,
 		MemBalloonStatsPeriod:       &defaultMemBalloonStatsPeriod,
 		APIConfiguration: &v1.ReloadableComponentConfiguration{
 			RestClient: &v1.RESTClientConfiguration{RateLimiter: &v1.RateLimiter{TokenBucketRateLimiter: &v1.TokenBucketRateLimiter{

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -155,6 +155,11 @@ func (c *ClusterConfig) GetMemoryOvercommit() int {
 }
 
 func (c *ClusterConfig) GetEmulatedMachines(arch string) []string {
+	oldEmulatedMachines := c.GetConfig().EmulatedMachines
+	if oldEmulatedMachines != nil {
+		return oldEmulatedMachines
+	}
+
 	switch arch {
 	case "arm64":
 		return c.GetConfig().ArchitectureConfiguration.Arm64.EmulatedMachines
@@ -244,6 +249,11 @@ func (c *ClusterConfig) GetSupportedAgentVersions() []string {
 }
 
 func (c *ClusterConfig) GetOVMFPath(arch string) string {
+	oldOvmfPath := c.GetConfig().OVMFPath
+	if oldOvmfPath != "" {
+		return oldOvmfPath
+	}
+
 	switch arch {
 	case "arm64":
 		return c.GetConfig().ArchitectureConfiguration.Arm64.OVMFPath

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -958,6 +958,7 @@ var CRDsValidation map[string]string = map[string]string{
                   type: boolean
               type: object
             emulatedMachines:
+              description: Deprecated. Use architectureConfiguration instead.
               items:
                 type: string
               type: array
@@ -1264,6 +1265,7 @@ var CRDsValidation map[string]string = map[string]string{
                 type: boolean
               type: object
             ovmfPath:
+              description: Deprecated. Use architectureConfiguration instead.
               type: string
             permittedHostDevices:
               description: PermittedHostDevices holds information about devices allowed

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2372,17 +2372,19 @@ type KubeVirtConfiguration struct {
 	CPUModel               string                  `json:"cpuModel,omitempty"`
 	CPURequest             *resource.Quantity      `json:"cpuRequest,omitempty"`
 	DeveloperConfiguration *DeveloperConfiguration `json:"developerConfiguration,omitempty"`
+	// Deprecated. Use architectureConfiguration instead.
 	EmulatedMachines       []string                `json:"emulatedMachines,omitempty"`
 	ImagePullPolicy        k8sv1.PullPolicy        `json:"imagePullPolicy,omitempty"`
 	MigrationConfiguration *MigrationConfiguration `json:"migrations,omitempty"`
 	// Deprecated. Use architectureConfiguration instead.
-	MachineType               string                `json:"machineType,omitempty"`
-	NetworkConfiguration      *NetworkConfiguration `json:"network,omitempty"`
-	OVMFPath                  string                `json:"ovmfPath,omitempty"`
-	SELinuxLauncherType       string                `json:"selinuxLauncherType,omitempty"`
-	DefaultRuntimeClass       string                `json:"defaultRuntimeClass,omitempty"`
-	SMBIOSConfig              *SMBiosConfiguration  `json:"smbios,omitempty"`
-	ArchitectureConfiguration *ArchConfiguration    `json:"architectureConfiguration,omitempty"`
+	MachineType          string                `json:"machineType,omitempty"`
+	NetworkConfiguration *NetworkConfiguration `json:"network,omitempty"`
+	// Deprecated. Use architectureConfiguration instead.
+	OVMFPath                  string               `json:"ovmfPath,omitempty"`
+	SELinuxLauncherType       string               `json:"selinuxLauncherType,omitempty"`
+	DefaultRuntimeClass       string               `json:"defaultRuntimeClass,omitempty"`
+	SMBIOSConfig              *SMBiosConfiguration `json:"smbios,omitempty"`
+	ArchitectureConfiguration *ArchConfiguration   `json:"architectureConfiguration,omitempty"`
 	// EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be
 	// migrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific
 	// field is set it overrides the cluster level one.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -729,7 +729,9 @@ func (ReloadableComponentConfiguration) SwaggerDoc() map[string]string {
 func (KubeVirtConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                                   "KubeVirtConfiguration holds all kubevirt configurations",
+		"emulatedMachines":                   "Deprecated. Use architectureConfiguration instead.",
 		"machineType":                        "Deprecated. Use architectureConfiguration instead.",
+		"ovmfPath":                           "Deprecated. Use architectureConfiguration instead.",
 		"evictionStrategy":                   "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be\nmigrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific\nfield is set it overrides the cluster level one.",
 		"additionalGuestMemoryOverheadRatio": "AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure\noverhead. This is useful, since the calculation of this overhead is not accurate and cannot\nbe entirely known in advance. The ratio that is being set determines by which factor to increase\nthe overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised\nby node pressures, but would mean that fewer VMs could be scheduled to a node.\nIf not set, the default is 1.",
 		"supportContainerResources":          "+listType=map\n+listMapKey=type\nSupportContainerResources specifies the resource requirements for various types of supporting containers such as container disks/virtiofs/sidecars and hotplug attachment pods. If omitted a sensible default will be supplied.",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19126,7 +19126,8 @@ func schema_kubevirtio_api_core_v1_KubeVirtConfiguration(ref common.ReferenceCal
 					},
 					"emulatedMachines": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "Deprecated. Use architectureConfiguration instead.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -19165,8 +19166,9 @@ func schema_kubevirtio_api_core_v1_KubeVirtConfiguration(ref common.ReferenceCal
 					},
 					"ovmfPath": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Deprecated. Use architectureConfiguration instead.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"selinuxLauncherType": {


### PR DESCRIPTION
`spec.config.emulatedMachines` and `spec.config.ovmfPath` got obsoleted by https://github.com/kubevirt/kubevirt/pull/8293 but they still exist and should therefore be honored if set to not break compatibility.

The fields are now also marked as deprecated so that they can be removed in the future.

### What this PR does
Before this PR:
Setting `spec.config.emulatedMachines` and `spec.config.ovmfPath` doesn't work.

After this PR:
Setting `spec.config.emulatedMachines` and `spec.config.ovmfPath` works.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

