### PR TITLE
Fix monitoring e2e failures due to missing CRBs

### DIFF
--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -87,6 +87,12 @@ var (
 		restErrorsHighAlert:  "VirtOperatorRESTErrorsHigh",
 		lowCountAlert:        "LowVirtOperatorCount",
 	}
+
+	crbs = []string{
+		"kubevirt-operator",
+		"kubevirt-controller",
+		"kubevirt-handler",
+	}
 )
 
 var _ = Describe("[Serial][sig-monitoring]Component Monitoring", Serial, decorators.SigMonitoring, func() {
@@ -167,13 +173,16 @@ var _ = Describe("[Serial][sig-monitoring]Component Monitoring", Serial, decorat
 	})
 
 	Context("Errors metrics", func() {
-		var crb *rbacv1.ClusterRoleBinding
+		var crbs_backup []*rbacv1.ClusterRoleBinding
 
 		BeforeEach(func() {
 			virtClient = kubevirt.Client()
 
-			crb, err = virtClient.RbacV1().ClusterRoleBindings().Get(context.Background(), "kubevirt-operator", metav1.GetOptions{})
-			util.PanicOnError(err)
+			for _, crb := range crbs {
+				crb, err := virtClient.RbacV1().ClusterRoleBindings().Get(context.Background(), crb, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				crbs_backup = append(crbs_backup, crb.DeepCopy())
+			}
 
 			increaseRateLimit()
 
@@ -184,13 +193,16 @@ var _ = Describe("[Serial][sig-monitoring]Component Monitoring", Serial, decorat
 		})
 
 		AfterEach(func() {
-			crb.Annotations = nil
-			crb.ObjectMeta.ResourceVersion = ""
-			crb.ObjectMeta.UID = ""
-			_, err = virtClient.RbacV1().ClusterRoleBindings().Create(context.Background(), crb, metav1.CreateOptions{})
-			if !errors.IsAlreadyExists(err) {
-				util.PanicOnError(err)
+			for _, crb := range crbs_backup {
+				crb.Annotations = nil
+				crb.ObjectMeta.ResourceVersion = ""
+				crb.ObjectMeta.UID = ""
+				_, err = virtClient.RbacV1().ClusterRoleBindings().Create(context.Background(), crb, metav1.CreateOptions{})
+				if !errors.IsAlreadyExists(err) {
+					util.PanicOnError(err)
+				}
 			}
+
 			scales.RestoreAllScales()
 
 			time.Sleep(10 * time.Second)
@@ -212,7 +224,7 @@ var _ = Describe("[Serial][sig-monitoring]Component Monitoring", Serial, decorat
 
 		It("VirtOperatorRESTErrorsBurst and VirtOperatorRESTErrorsHigh should be triggered when requests to virt-operator are failing", func() {
 			scales.RestoreScale(virtOperator.deploymentName)
-			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), crb.Name, metav1.DeleteOptions{})
+			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-operator", metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func(g Gomega) {

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -198,8 +198,10 @@ func UpdateKubeVirtConfigValue(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
 	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, kv)
 	Expect(err).ToNot(HaveOccurred())
 
-	kv, err = virtClient.KubeVirt(kv.Namespace).Patch(kv.GetName(), types.MergePatchType, patch, &metav1.PatchOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Eventually(func() error {
+		_, err = virtClient.KubeVirt(kv.Namespace).Patch(kv.GetName(), types.MergePatchType, patch, &metav1.PatchOptions{})
+		return err
+	}, 30*time.Second, 1*time.Second).Should(BeNil())
 
-	return kv
+	return util.GetCurrentKv(virtClient)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

e2e monitoring tests flakiness due to outdated configs
because some times pods don't have necessary permissions to access resources

After this PR:

no longer failing

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

