### PR TITLE
virt-api, admitter: Refactor & move network validation admitters to the network package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ lint:
 	hack/dockerized "golangci-lint run --timeout 20m --verbose \
 	  pkg/instancetype/... \
 	  pkg/libvmi/... \
+	  pkg/network/admitter/... \
 	  pkg/network/namescheme/... \
 	  pkg/network/domainspec/... \
 	  pkg/network/sriov/... \

--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -15,11 +15,15 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["admit_test.go"],
+    srcs = [
+        "admit_suite_test.go",
+        "admit_test.go",
+    ],
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -2,11 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["admit.go"],
+    srcs = [
+        "admit.go",
+        "slirp.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/network/admitter",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/network/vmispec:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
@@ -18,9 +22,13 @@ go_test(
     srcs = [
         "admit_suite_test.go",
         "admit_test.go",
+        "slirp_test.go",
     ],
     deps = [
         ":go_default_library",
+        "//pkg/pointer:go_default_library",
+        "//pkg/testutils:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/network/vmispec:go_default_library",
-        "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
@@ -26,9 +25,6 @@ go_test(
     ],
     deps = [
         ":go_default_library",
-        "//pkg/pointer:go_default_library",
-        "//pkg/testutils:go_default_library",
-        "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/network/admitter/admit.go
+++ b/pkg/network/admitter/admit.go
@@ -83,3 +83,24 @@ func hasInterfaceBindingMethod(iface v1.Interface) bool {
 		iface.InterfaceBindingMethod.Macvtap != nil ||
 		iface.InterfaceBindingMethod.Passt != nil
 }
+
+func ValidateSinglePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	if countPodNetworks(spec.Networks) > 1 {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueDuplicate,
+			Message: fmt.Sprintf("more than one interface is connected to a pod network in %s", field.Child("interfaces").String()),
+			Field:   field.Child("interfaces").String(),
+		}}
+	}
+	return nil
+}
+
+func countPodNetworks(networks []v1.Network) int {
+	count := 0
+	for _, net := range networks {
+		if net.Pod != nil {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/network/admitter/admit_suite_test.go
+++ b/pkg/network/admitter/admit_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitter_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestAdmitter(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -122,4 +122,17 @@ var _ = Describe("Validating VMI network spec", func() {
 		}}
 		Expect(admitter.ValidateInterfaceBinding(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
 	})
+
+	It("support only a single pod network", func() {
+		const net1Name = "default"
+		const net2Name = "default2"
+		vmi := v1.VirtualMachineInstance{}
+		vmi.Spec.Networks = []v1.Network{
+			{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+			{Name: net2Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+		}
+		causes := admitter.ValidateSinglePodNetwork(k8sfield.NewPath("fake"), &vmi.Spec)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
+	})
 })

--- a/pkg/network/admitter/slirp.go
+++ b/pkg/network/admitter/slirp.go
@@ -30,7 +30,10 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-func ValidateSlirpBinding(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) (causes []metav1.StatusCause) {
+func ValidateSlirpBinding(
+	field *k8sfield.Path,
+	spec *v1.VirtualMachineInstanceSpec,
+	config *virtconfig.ClusterConfig) (causes []metav1.StatusCause) {
 	for idx, ifaceSpec := range spec.Domain.Devices.Interfaces {
 		if ifaceSpec.Slirp == nil {
 			continue

--- a/pkg/network/admitter/slirp.go
+++ b/pkg/network/admitter/slirp.go
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitter
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func ValidateSlirpBinding(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) (causes []metav1.StatusCause) {
+	for idx, ifaceSpec := range spec.Domain.Devices.Interfaces {
+		if ifaceSpec.Slirp == nil {
+			continue
+		}
+		net := vmispec.LookupNetworkByName(spec.Networks, ifaceSpec.Name)
+		if net == nil {
+			continue
+		}
+
+		if net.Pod == nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "Slirp interface only implemented with pod network",
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		} else if !config.IsSlirpInterfaceEnabled() {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "Slirp interface is not enabled in kubevirt-config",
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		}
+	}
+	return causes
+}

--- a/pkg/network/admitter/slirp_test.go
+++ b/pkg/network/admitter/slirp_test.go
@@ -1,0 +1,103 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitter_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
+	"kubevirt.io/kubevirt/pkg/network/admitter"
+)
+
+var _ = Describe("Validate interface with SLIRP binding", func() {
+	It("should be rejected if not enabled in the Kubevirt CR", func() {
+		vmi := v1.VirtualMachineInstance{}
+		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name: "default",
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{
+				Slirp: &v1.InterfaceSlirp{},
+			},
+		}}
+		vmi.Spec.Networks = []v1.Network{{
+			Name:          "default",
+			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+		}}
+
+		config, _, _ := testutils.NewFakeClusterConfigUsingKV(&v1.KubeVirt{})
+
+		causes := admitter.ValidateSlirpBinding(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Message).To(Equal("Slirp interface is not enabled in kubevirt-config"))
+	})
+
+	It("should be rejected without a pod network", func() {
+		vmi := v1.VirtualMachineInstance{}
+		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name: "default",
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{
+				Slirp: &v1.InterfaceSlirp{},
+			},
+		}}
+		vmi.Spec.Networks = []v1.Network{{
+			Name:          "default",
+			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
+		}}
+
+		config := newFakeClusterConfigWithSlirpEnabled()
+		causes := admitter.ValidateSlirpBinding(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Message).To(Equal("Slirp interface only implemented with pod network"))
+	})
+
+	It("should be accepted with a pod network when SLIRP is enabled in the Kubevirt CR", func() {
+		vmi := v1.VirtualMachineInstance{}
+		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name: "default",
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{
+				Slirp: &v1.InterfaceSlirp{},
+			},
+		}}
+		vmi.Spec.Networks = []v1.Network{{
+			Name:          "default",
+			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+		}}
+
+		config := newFakeClusterConfigWithSlirpEnabled()
+		Expect(admitter.ValidateSlirpBinding(k8sfield.NewPath("fake"), &vmi.Spec, config)).To(BeEmpty())
+	})
+})
+
+func newFakeClusterConfigWithSlirpEnabled() *virtconfig.ClusterConfig {
+	var kv v1.KubeVirt
+	kv.Spec.Configuration.NetworkConfiguration = &v1.NetworkConfiguration{
+		PermitSlirpInterface: pointer.P(true),
+	}
+	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(&kv)
+	testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &kv)
+	return config
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -167,7 +167,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateSpecTopologySpreadConstraints(field, spec)...)
 	causes = append(causes, validateArchitecture(field, spec, config)...)
 
-	causes = append(causes, validateSinglePodNetwork(field, spec)...)
+	causes = append(causes, netadmitter.ValidateSinglePodNetwork(field, spec)...)
 
 	bootOrderMap, newCauses := validateBootOrder(field, spec, volumeNameMap)
 	causes = append(causes, newCauses...)
@@ -222,17 +222,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateDownwardMetrics(field, spec, config)...)
 
 	return causes
-}
-
-func validateSinglePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
-	if getNumberOfPodInterfaces(spec) > 1 {
-		return []metav1.StatusCause{{
-			Type:    metav1.CauseTypeFieldValueDuplicate,
-			Message: fmt.Sprintf("more than one interface is connected to a pod network in %s", field.Child("interfaces").String()),
-			Field:   field.Child("interfaces").String(),
-		}}
-	}
-	return nil
 }
 
 func validateDownwardMetrics(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1354,45 +1354,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[0]"))
 		})
-		It("should reject networks with a multus network source and slirp interface", func() {
-			enableSlirpInterface()
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name: "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					Slirp: &v1.InterfaceSlirp{},
-				}}}
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "default",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "default"},
-					},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(1))
-		})
-		It("should accept networks with a pod network source and slirp interface", func() {
-			enableSlirpInterface()
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name: "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					Slirp: &v1.InterfaceSlirp{},
-				}}}
-
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name:          "default",
-					NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(BeEmpty())
-		})
 		It("should reject networks with a passt interface and passt feature gate disabled", func() {
 			vm := api.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1059,17 +1059,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
 		})
-		It("should accept network lists with more than one element", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
-				{Name: "default2", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
-			vm.Spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-				{Name: "default2", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			// if this is processed correctly, it should result an error only about duplicate pod network configuration
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
-		})
 
 		It("should accept valid interface models", func() {
 			vmi := api.NewMinimalVMI("testvm")


### PR DESCRIPTION
### What this PR does

Validation admitters related to network spec are moved under the network package in order to decouple them from the other admitters and allow the sig-network to properly own them.

In addition, work on simplifying the validation code and its tests has been included in this effort.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

