### PR TITLE
tests, net, slirp: Remove most of the slirp tests

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -52,7 +52,6 @@ go_library(
         "//tests:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//tests/console:go_default_library",
-        "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/events:go_default_library",
         "//tests/exec:go_default_library",

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -25,27 +25,23 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-
-	"kubevirt.io/kubevirt/tests/exec"
-	"kubevirt.io/kubevirt/tests/testsuite"
-	"kubevirt.io/kubevirt/tests/util"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/testsuite"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -58,167 +54,117 @@ var _ = SIGDescribe("Slirp Networking", decorators.Networking, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
-	var currentConfiguration v1.KubeVirtConfiguration
 	var container k8sv1.Container
-
-	setSlirpEnabled := func(enable bool) {
-		if currentConfiguration.NetworkConfiguration == nil {
-			currentConfiguration.NetworkConfiguration = &v1.NetworkConfiguration{}
-		}
-
-		currentConfiguration.NetworkConfiguration.PermitSlirpInterface = pointer.BoolPtr(enable)
-		kv := tests.UpdateKubeVirtConfigValueAndWait(currentConfiguration)
-		currentConfiguration = kv.Spec.Configuration
-	}
-
-	setDefaultNetworkInterface := func(iface string) {
-		if currentConfiguration.NetworkConfiguration == nil {
-			currentConfiguration.NetworkConfiguration = &v1.NetworkConfiguration{}
-		}
-
-		currentConfiguration.NetworkConfiguration.NetworkInterface = iface
-		kv := tests.UpdateKubeVirtConfigValueAndWait(currentConfiguration)
-		currentConfiguration = kv.Spec.Configuration
-	}
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 
 		libnet.SkipWhenClusterNotSupportIpv4()
-
-		kv := util.GetCurrentKv(virtClient)
-		currentConfiguration = kv.Spec.Configuration
 	})
 
-	Context("slirp is not the default interface", func() {
-		var (
-			genericVmi  *v1.VirtualMachineInstance
-			deadbeafVmi *v1.VirtualMachineInstance
-			ports       []v1.Port
+	var (
+		genericVmi  *v1.VirtualMachineInstance
+		deadbeafVmi *v1.VirtualMachineInstance
+		ports       []v1.Port
+	)
+
+	BeforeEach(func() {
+		ports = []v1.Port{{Name: "http", Port: 80}}
+		genericVmi = libvmi.NewCirros(
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithInterface(
+				libvmi.InterfaceDeviceWithSlirpBinding(v1.DefaultPodNetwork().Name, ports...)))
+		deadbeafVmi = libvmi.NewCirros(
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithInterface(
+				libvmi.InterfaceDeviceWithSlirpBinding(v1.DefaultPodNetwork().Name, ports...)))
+		deadbeafVmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de:ad:00:00:be:af"
+	})
+
+	DescribeTable("should be able to", func(vmiRef **v1.VirtualMachineInstance) {
+		vmi := *vmiRef
+		vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		libwait.WaitForSuccessfulVMIStart(vmi,
+			libwait.WithFailOnWarnings(false),
+			libwait.WithTimeout(180),
 		)
+		tests.GenerateHelloWorldServer(vmi, 80, "tcp", console.LoginToCirros, true)
 
-		BeforeEach(func() {
-			ports = []v1.Port{{Name: "http", Port: 80}}
-			genericVmi = libvmi.NewCirros(
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(
-					libvmi.InterfaceDeviceWithSlirpBinding(v1.DefaultPodNetwork().Name, ports...)))
-			deadbeafVmi = libvmi.NewCirros(
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(
-					libvmi.InterfaceDeviceWithSlirpBinding(v1.DefaultPodNetwork().Name, ports...)))
-			deadbeafVmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de:ad:00:00:be:af"
-		})
+		By("have containerPort in the pod manifest")
+		vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+		Expect(err).NotTo(HaveOccurred())
 
-		DescribeTable("should be able to", func(vmiRef **v1.VirtualMachineInstance) {
-			vmi := *vmiRef
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitForSuccessfulVMIStart(vmi,
-				libwait.WithFailOnWarnings(false),
-				libwait.WithTimeout(180),
-			)
-			tests.GenerateHelloWorldServer(vmi, 80, "tcp", console.LoginToCirros, true)
-
-			By("have containerPort in the pod manifest")
-			vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(err).NotTo(HaveOccurred())
-
-			for _, containerSpec := range vmiPod.Spec.Containers {
-				if containerSpec.Name == "compute" {
-					container = containerSpec
-					break
-				}
+		for _, containerSpec := range vmiPod.Spec.Containers {
+			if containerSpec.Name == "compute" {
+				container = containerSpec
+				break
 			}
-			Expect(container.Name).ToNot(Equal(""))
-			Expect(container.Ports).ToNot(BeNil())
-			Expect(container.Ports[0].Name).To(Equal("http"))
-			Expect(container.Ports[0].Protocol).To(Equal(k8sv1.Protocol("TCP")))
-			Expect(container.Ports[0].ContainerPort).To(Equal(int32(80)))
+		}
+		Expect(container.Name).ToNot(Equal(""))
+		Expect(container.Ports).ToNot(BeNil())
+		Expect(container.Ports[0].Name).To(Equal("http"))
+		Expect(container.Ports[0].Protocol).To(Equal(k8sv1.Protocol("TCP")))
+		Expect(container.Ports[0].ContainerPort).To(Equal(int32(80)))
 
-			By("start the virtual machine with slirp interface")
-			output, err := exec.ExecuteCommandOnPod(
-				vmiPod,
-				vmiPod.Spec.Containers[0].Name,
-				[]string{"cat", "/proc/net/tcp"},
-			)
-			log.Log.Infof("%v", output)
-			Expect(err).ToNot(HaveOccurred())
-			// :0050 is port 80, 0A is listening
-			Expect(strings.Contains(output, "0: 00000000:0050 00000000:0000 0A")).To(BeTrue())
-			By("return \"Hello World!\" when connecting to localhost on port 80")
-			output, err = exec.ExecuteCommandOnPod(
-				vmiPod,
-				vmiPod.Spec.Containers[0].Name,
-				[]string{"nc", "127.0.0.1", "80", "--recv-only"},
-			)
-			log.Log.Infof("%v", output)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(strings.Contains(output, "Hello World!")).To(BeTrue())
-
-			By("reject connecting to localhost and port different than 80")
-			output, err = exec.ExecuteCommandOnPod(
-				vmiPod,
-				vmiPod.Spec.Containers[1].Name,
-				[]string{"curl", "127.0.0.1:9080"},
-			)
-			log.Log.Infof("%v", output)
-			Expect(err).To(HaveOccurred())
-		},
-			Entry("VirtualMachineInstance with slirp interface", &genericVmi),
-			Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),
+		By("start the virtual machine with slirp interface")
+		output, err := exec.ExecuteCommandOnPod(
+			vmiPod,
+			vmiPod.Spec.Containers[0].Name,
+			[]string{"cat", "/proc/net/tcp"},
 		)
-
-		DescribeTable("[outside_connectivity]should be able to communicate with the outside world", func(vmiRef **v1.VirtualMachineInstance) {
-			vmi := *vmiRef
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			vmi = libwait.WaitForSuccessfulVMIStart(vmi,
-				libwait.WithFailOnWarnings(false),
-				libwait.WithTimeout(180),
-			)
-			Expect(console.LoginToCirros(vmi)).To(Succeed())
-
-			dns := "google.com"
-			if flags.ConnectivityCheckDNS != "" {
-				dns = flags.ConnectivityCheckDNS
-			}
-
-			Eventually(func() error {
-				return console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: fmt.Sprintf("curl -o /dev/null -s -w \"%%{http_code}\\n\" -k https://%s\n", dns)},
-					&expect.BExp{R: "301"},
-				}, 60)
-			}, 180*time.Second, time.Second).Should(Succeed(), "Failed to establish a successful connection to the outside network")
-		},
-			Entry("VirtualMachineInstance with slirp interface", &genericVmi),
-			Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),
+		log.Log.Infof("%v", output)
+		Expect(err).ToNot(HaveOccurred())
+		// :0050 is port 80, 0A is listening
+		Expect(strings.Contains(output, "0: 00000000:0050 00000000:0000 0A")).To(BeTrue())
+		By("return \"Hello World!\" when connecting to localhost on port 80")
+		output, err = exec.ExecuteCommandOnPod(
+			vmiPod,
+			vmiPod.Spec.Containers[0].Name,
+			[]string{"nc", "127.0.0.1", "80", "--recv-only"},
 		)
-	})
+		log.Log.Infof("%v", output)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Contains(output, "Hello World!")).To(BeTrue())
 
-	Context("[Serial]slirp is the default interface", Serial, func() {
-		BeforeEach(func() {
-			setSlirpEnabled(false)
-			setDefaultNetworkInterface("slirp")
-		})
-		AfterEach(func() {
-			setSlirpEnabled(true)
-			setDefaultNetworkInterface("bridge")
-		})
-		It("should reject VMIs with default interface slirp when it's not permitted", func() {
-			var t int64 = 0
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.TerminationGracePeriodSeconds = &t
-			// Reset memory, devices and networks
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-			vmi.Spec.Domain.Devices = v1.Devices{}
-			vmi.Spec.Networks = nil
-			tests.AddEphemeralDisk(vmi, "disk0", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
+		By("reject connecting to localhost and port different than 80")
+		output, err = exec.ExecuteCommandOnPod(
+			vmiPod,
+			vmiPod.Spec.Containers[1].Name,
+			[]string{"curl", "127.0.0.1:9080"},
+		)
+		log.Log.Infof("%v", output)
+		Expect(err).To(HaveOccurred())
+	},
+		Entry("VirtualMachineInstance with slirp interface", &genericVmi),
+		Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),
+	)
 
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).To(HaveOccurred())
-		})
-	})
+	DescribeTable("[outside_connectivity]should be able to communicate with the outside world", func(vmiRef **v1.VirtualMachineInstance) {
+		vmi := *vmiRef
+		vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		vmi = libwait.WaitForSuccessfulVMIStart(vmi,
+			libwait.WithFailOnWarnings(false),
+			libwait.WithTimeout(180),
+		)
+		Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+		dns := "google.com"
+		if flags.ConnectivityCheckDNS != "" {
+			dns = flags.ConnectivityCheckDNS
+		}
+
+		Eventually(func() error {
+			return console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: fmt.Sprintf("curl -o /dev/null -s -w \"%%{http_code}\\n\" -k https://%s\n", dns)},
+				&expect.BExp{R: "301"},
+			}, 60)
+		}, 180*time.Second, time.Second).Should(Succeed(), "Failed to establish a successful connection to the outside network")
+	},
+		Entry("VirtualMachineInstance with slirp interface", &genericVmi),
+		Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),
+	)
 })


### PR DESCRIPTION
### What this PR does

Remove most of the SLIRP e2e tests and leave a single one running.

As a follow up, two changes should be considered:
- Use directly the binding plugin API instead of the core API.
- Check real connectivity and not just the configuration (e.g. use a job
that sends HTTP req to the VM).


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

