### PR TITLE
[release-1.0] test: Fix node taint test

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -65,11 +65,11 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 
 	k8sv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/retry"
 
@@ -487,108 +487,42 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, decorators.SigCo
 	Describe("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com][level:component]Taints and toleration", func() {
 
 		Context("CriticalAddonsOnly taint set on a node", func() {
-
-			var selectedNodeName string
+			var (
+				possiblyTaintedNodeName string
+				kubevirtPodsOnNode      []string
+				deploymentsOnNode       []types.NamespacedName
+			)
 
 			BeforeEach(func() {
-				selectedNodeName = ""
-			})
+				possiblyTaintedNodeName = ""
+				kubevirtPodsOnNode = nil
+				deploymentsOnNode = nil
 
-			AfterEach(func() {
-				if selectedNodeName != "" {
-					By("removing the taint from the tainted node")
-					selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					var taints []k8sv1.Taint
-					for _, taint := range selectedNode.Spec.Taints {
-						if taint.Key != "CriticalAddonsOnly" {
-							taints = append(taints, taint)
-						}
-					}
-					patchData, err := patch.GenerateTestReplacePatch("/spec/taints", selectedNode.Spec.Taints, taints)
-					Expect(err).NotTo(HaveOccurred())
-					selectedNode, err = virtClient.CoreV1().Nodes().Patch(context.Background(), selectedNode.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				}
-			})
-
-			It("[test_id:4134] kubevirt components on that node should not evict", func() {
-
-				By("finding all kubevirt pods")
 				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
 				Expect(err).ShouldNot(HaveOccurred(), "failed listing kubevirt pods")
 				Expect(pods.Items).ToNot(BeEmpty(), "no kubevirt pods found")
 
-				By("finding all schedulable nodes")
-				schedulableNodesList := libnode.GetAllSchedulableNodes(virtClient)
-				schedulableNodes := map[string]*k8sv1.Node{}
-				for _, node := range schedulableNodesList.Items {
-					schedulableNodes[node.Name] = node.DeepCopy()
-				}
-
-				By("selecting one compute only node that runs kubevirt components")
-				// control-plane nodes should never have the CriticalAddonsOnly taint because core components might not
-				// tolerate this taint because it is meant to be used on compute nodes only. If we set this taint
-				// on a control-plane node, we risk in breaking the test cluster.
-				for _, pod := range pods.Items {
-					node, ok := schedulableNodes[pod.Spec.NodeName]
-					if !ok {
-						// Pod is running on a non-schedulable node?
-						continue
-					}
-
-					if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
-						continue
-					}
-
-					selectedNodeName = node.Name
-					break
-				}
+				nodeName := getNodeWithOneOfPods(virtClient, pods.Items)
 
 				// It is possible to run this test on a cluster that simply does not have worker nodes.
 				// Since KubeVirt can't control that, the only correct action is to halt the test.
-				if selectedNodeName == "" {
-					Skip("Could nould determine a node to safely taint")
+				if nodeName == "" {
+					Skip("Could not determine a node to safely taint")
 				}
 
-				By("setting up a watch for terminated pods")
-				lw, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Watch(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				// in the test env, we also deploy non core-kubevirt apps
-				kvCoreApps := map[string]string{
-					"virt-handler":    "",
-					"virt-controller": "",
-					"virt-api":        "",
-					"virt-operator":   "",
-				}
+				podsOnNode, err := virtClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+				})
+				Expect(err).NotTo(HaveOccurred())
 
-				signalTerminatedPods := func(stopCn <-chan bool, eventsCn <-chan watch.Event, terminatedPodsCn chan<- bool) {
-					for {
-						select {
-						case <-stopCn:
-							return
-						case e := <-eventsCn:
-							pod, ok := e.Object.(*k8sv1.Pod)
-							Expect(ok).To(BeTrue())
-							if _, isCoreApp := kvCoreApps[pod.Name]; !isCoreApp {
-								continue
-							}
-							if pod.DeletionTimestamp != nil {
-								By(fmt.Sprintf("%s terminated", pod.Name))
-								terminatedPodsCn <- true
-								return
-							}
-						}
-					}
-				}
-				stopCn := make(chan bool, 1)
-				terminatedPodsCn := make(chan bool, 1)
-				go signalTerminatedPods(stopCn, lw.ResultChan(), terminatedPodsCn)
+				kubevirtPodsOnNode = filterKubevirtPods(podsOnNode.Items)
+				deploymentsOnNode = getDeploymentsForPods(virtClient, podsOnNode.Items)
 
 				By("tainting the selected node")
-				selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
+				selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
+
+				possiblyTaintedNodeName = nodeName
 
 				taints := append(selectedNode.Spec.Taints, k8sv1.Taint{
 					Key:    "CriticalAddonsOnly",
@@ -600,9 +534,74 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, decorators.SigCo
 				Expect(err).ToNot(HaveOccurred())
 				selectedNode, err = virtClient.CoreV1().Nodes().Patch(context.Background(), selectedNode.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
+			})
 
-				Consistently(terminatedPodsCn, 5*time.Second).ShouldNot(Receive(), "pods should not terminate")
-				stopCn <- true
+			AfterEach(func() {
+				if possiblyTaintedNodeName == "" {
+					return
+				}
+
+				By("removing the taint from the tainted node")
+				selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), possiblyTaintedNodeName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				var hasTaint bool
+				var otherTaints []k8sv1.Taint
+				for _, taint := range selectedNode.Spec.Taints {
+					if taint.Key == "CriticalAddonsOnly" {
+						hasTaint = true
+					} else {
+						otherTaints = append(otherTaints, taint)
+					}
+				}
+
+				if !hasTaint {
+					return
+				}
+
+				patchData, err := patch.GenerateTestReplacePatch("/spec/taints", selectedNode.Spec.Taints, otherTaints)
+				Expect(err).NotTo(HaveOccurred())
+				selectedNode, err = virtClient.CoreV1().Nodes().Patch(context.Background(), selectedNode.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Waiting until all affected deployments have at least 1 ready replica
+				checkedDeployments := map[types.NamespacedName]struct{}{}
+				Eventually(func(g Gomega) {
+					for _, namespacedName := range deploymentsOnNode {
+						if _, ok := checkedDeployments[namespacedName]; ok {
+							continue
+						}
+
+						deployment, err := virtClient.AppsV1().Deployments(namespacedName.Namespace).
+							Get(context.Background(), namespacedName.Name, metav1.GetOptions{})
+						if k8serrors.IsNotFound(err) {
+							checkedDeployments[namespacedName] = struct{}{}
+							continue
+						}
+						g.Expect(err).NotTo(HaveOccurred())
+
+						if deployment.DeletionTimestamp != nil || *deployment.Spec.Replicas == 0 {
+							checkedDeployments[namespacedName] = struct{}{}
+							continue
+						}
+						g.Expect(deployment.Status.ReadyReplicas).To(
+							BeNumerically(">=", 1),
+							fmt.Sprintf("Deployment %s is not ready", namespacedName.String()),
+						)
+						checkedDeployments[namespacedName] = struct{}{}
+					}
+				}, time.Minute, time.Second).Should(Succeed())
+			})
+
+			It("[test_id:4134] kubevirt components on that node should not evict", func() {
+				Consistently(func(g Gomega) {
+					for _, podName := range kubevirtPodsOnNode {
+						pod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), podName, metav1.GetOptions{})
+						g.Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error getting pod %s/%s", flags.KubeVirtInstallNamespace, podName))
+						g.Expect(pod.DeletionTimestamp).To(BeNil(), fmt.Sprintf("pod %s/%s is being deleted", flags.KubeVirtInstallNamespace, podName))
+						g.Expect(pod.Spec.NodeName).To(Equal(possiblyTaintedNodeName), fmt.Sprintf("pod %s/%s does not run on tainted node", flags.KubeVirtInstallNamespace, podName))
+					}
+				}, time.Second*10, time.Second).Should(Succeed())
 			})
 
 		})
@@ -2021,4 +2020,76 @@ func containsCrt(bundle []byte, containedCrt []byte) bool {
 		}
 	}
 	return attached
+}
+
+func getNodeWithOneOfPods(virtClient kubecli.KubevirtClient, pods []k8sv1.Pod) string {
+	schedulableNodesList := libnode.GetAllSchedulableNodes(virtClient)
+	schedulableNodes := map[string]*k8sv1.Node{}
+	for _, node := range schedulableNodesList.Items {
+		schedulableNodes[node.Name] = node.DeepCopy()
+	}
+
+	// control-plane nodes should never have the CriticalAddonsOnly taint because core components might not
+	// tolerate this taint because it is meant to be used on compute nodes only. If we set this taint
+	// on a control-plane node, we risk in breaking the test cluster.
+	for _, pod := range pods {
+		node, ok := schedulableNodes[pod.Spec.NodeName]
+		if !ok {
+			// Pod is running on a non-schedulable node?
+			continue
+		}
+
+		if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
+			continue
+		}
+
+		return node.Name
+	}
+	return ""
+}
+
+func filterKubevirtPods(pods []k8sv1.Pod) []string {
+	kubevirtPodPrefixes := []string{
+		"virt-handler",
+		"virt-controller",
+		"virt-api",
+		"virt-operator",
+	}
+
+	var result []string
+	for _, pod := range pods {
+		if pod.Namespace != flags.KubeVirtInstallNamespace {
+			continue
+		}
+		for _, prefix := range kubevirtPodPrefixes {
+			if strings.HasPrefix(pod.Name, prefix) {
+				result = append(result, pod.Name)
+				break
+			}
+		}
+	}
+	return result
+}
+
+func getDeploymentsForPods(virtClient kubecli.KubevirtClient, pods []k8sv1.Pod) []types.NamespacedName {
+	// Listing all deployments to find which ones belong to the pods.
+	allDeployments, err := virtClient.AppsV1().Deployments("").List(context.Background(), metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	var result []types.NamespacedName
+	for _, deployment := range allDeployments.Items {
+		selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, pod := range pods {
+			if selector.Matches(labels.Set(pod.Labels)) {
+				result = append(result, types.NamespacedName{
+					Namespace: deployment.Namespace,
+					Name:      deployment.Name,
+				})
+				break
+			}
+		}
+	}
+	return result
 }


### PR DESCRIPTION
This is a manual cherry-pick of: https://github.com/kubevirt/kubevirt/pull/11277

### What this PR does
Before this PR:
The test did not correctly check prefixes of pod names, so it always passed.
And after finishing, it left the cluster in an inconsistent state, so other tests could fail.

After this PR:
An `Eventually()` is used in `AfterEach()` to wait until all deployments that were running on the tainted node are ready again.


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

