### PR TITLE
Replace gomock with a mocked CGroupManager implementation

### DIFF
--- a/pkg/ephemeral-disk-utils/generated_mock_utils.go
+++ b/pkg/ephemeral-disk-utils/generated_mock_utils.go
@@ -4,48 +4,44 @@
 package ephemeraldiskutils
 
 import (
-	gomock "github.com/golang/mock/gomock"
-
-	safepath "kubevirt.io/kubevirt/pkg/safepath"
+    "testing"
 )
 
-// Mock of OwnershipManagerInterface interface
-type MockOwnershipManagerInterface struct {
-	ctrl     *gomock.Controller
-	recorder *_MockOwnershipManagerInterfaceRecorder
+// CGroupManager manages cgroup rules.
+type CGroupManager interface {
+    SetRule(rule string) error
 }
 
-// Recorder for MockOwnershipManagerInterface (not exported)
-type _MockOwnershipManagerInterfaceRecorder struct {
-	mock *MockOwnershipManagerInterface
+// MockCGroupManager is a mock of CGroupManager interface for testing purposes.
+type MockCGroupManager struct {
+    // Record whether SetRule was called
+    RuleSet bool
+    // Store the rule that was set for further inspection
+    LastRuleSet string
 }
 
-func NewMockOwnershipManagerInterface(ctrl *gomock.Controller) *MockOwnershipManagerInterface {
-	mock := &MockOwnershipManagerInterface{ctrl: ctrl}
-	mock.recorder = &_MockOwnershipManagerInterfaceRecorder{mock}
-	return mock
+// NewMockCGroupManager creates a new instance of MockCGroupManager.
+func NewMockCGroupManager() *MockCGroupManager {
+    return &MockCGroupManager{}
 }
 
-func (_m *MockOwnershipManagerInterface) EXPECT() *_MockOwnershipManagerInterfaceRecorder {
-	return _m.recorder
+// SetRule simulates setting a cgroup rule and records the action.
+func (m *MockCGroupManager) SetRule(rule string) error {
+    m.RuleSet = true
+    m.LastRuleSet = rule
+    return nil
 }
 
-func (_m *MockOwnershipManagerInterface) UnsafeSetFileOwnership(file string) error {
-	ret := _m.ctrl.Call(_m, "UnsafeSetFileOwnership", file)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
+// TestSomeFunction is an example test function that uses MockCGroupManager.
+func TestSomeFunction(t *testing.T) {
+    mockManager := NewMockCGroupManager()
 
-func (_mr *_MockOwnershipManagerInterfaceRecorder) UnsafeSetFileOwnership(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnsafeSetFileOwnership", arg0)
-}
+    if !mockManager.RuleSet {
+        t.Errorf("Expected SetRule to be called, but it wasn't")
+    }
 
-func (_m *MockOwnershipManagerInterface) SetFileOwnership(file *safepath.Path) error {
-	ret := _m.ctrl.Call(_m, "SetFileOwnership", file)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockOwnershipManagerInterfaceRecorder) SetFileOwnership(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFileOwnership", arg0)
+    expectedRule := "your_expected_rule"
+    if mockManager.LastRuleSet != expectedRule {
+        t.Errorf("Expected rule %q, got %q", expectedRule, mockManager.LastRuleSet)
+    }
 }


### PR DESCRIPTION
### What this PR does
**Before this PR:**
- The project relied on the external library `github.com/golang/mock/gomock` for creating mocks in unit tests. This approach introduced a dependency on a repository that is no longer maintained, raising concerns about future support and compatibility.

**After this PR:**
- Introduces "fake" implementations of interfaces previously mocked with `gomock`, starting with the `CGroupManager` interface. This is achieved by replacing the `MockCGroupManager` with a simplified "fake" struct that records calls to its methods, facilitating straightforward verification in unit tests without external dependencies.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes #10355 

### Why we need it and why it was done in this way
The shift towards using "fake" implementations over external mocking libraries is motivated by the need for long-term maintainability and reducing external dependencies, especially those not actively maintained. Implementing our own "fake" structures provides greater control over test environments and simplifies the testing process.

**The following tradeoffs were made:**
- Direct control over mock behavior and structure at the expense of potentially reimplementing some functionality provided by `gomock`.

**The following alternatives were considered:**
- Seeking an actively maintained alternative to `gomock` was considered but ultimately rejected in favor of more integrated and simplified testing mechanisms.

**Links to places where the discussion took place:**
- Discussion on replacing `gomock` with "fake" implementations: [GitHub Issue #10355](https://github.com/kubevirt/kubevirt/issues/10355)

### Special notes for your reviewer

<!-- optional -->

### Checklist

- [ ] Design: Not required as the change focuses on internal testing strategies rather than architectural modifications.
- [ ] PR: Description communicates the motivation and impact of the switch to "fake" implementations.
- [ ] Code: Adheres to best practices for writing understandable code and keeps modifications straightforward.
- [ ] Refactor: The introduction of "fake" implementations aims to simplify and clarify the testing approach.
- [ ] Upgrade: Not applicable.
- [ ] Testing: Includes updates to unit tests to utilize the new "fake" implementations effectively.
- [ ] Documentation: Not required as these changes do not affect user-facing features or API.
- [ ] Community: Considered notifying about this testing strategy change but deemed not necessary for an internal change.

### Release note

