### PR TITLE
Eviction admitter: Deny when triggering VMI evacuation

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -73,6 +73,8 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 			// As with the previous case, it is up to the user to issue a retry.
 			return denied(fmt.Sprintf("kubevirt failed marking the vmi for eviction: %s", err.Error()))
 		}
+
+		return denied(fmt.Sprintf("Eviction triggered evacuation of VMI \"%s/%s\"", vmi.Namespace, vmi.Name))
 	}
 
 	// We can let the request go through because the pod is protected by a PDB if the VMI wants to be live-migrated on

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -83,17 +83,20 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 func (admitter *PodEvictionAdmitter) markVMI(vmiNamespace, vmiName, nodeName string, dryRun bool) error {
 	data := fmt.Sprintf(`[{ "op": "add", "path": "/status/evacuationNodeName", "value": "%s" }]`, nodeName)
 
-	var err error
-	if !dryRun {
-		_, err = admitter.
-			VirtClient.
-			VirtualMachineInstance(vmiNamespace).
-			Patch(context.Background(),
-				vmiName,
-				types.JSONPatchType,
-				[]byte(data),
-				metav1.PatchOptions{})
+	var patchOptions metav1.PatchOptions
+	if dryRun {
+		patchOptions.DryRun = []string{metav1.DryRunAll}
 	}
+
+	_, err := admitter.
+		VirtClient.
+		VirtualMachineInstance(vmiNamespace).
+		Patch(context.Background(),
+			vmiName,
+			types.JSONPatchType,
+			[]byte(data),
+			patchOptions,
+		)
 
 	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
When the criteria for VMI evacuation are met (see  https://github.com/kubevirt/kubevirt/pull/11286):
1. The eviction admitter marks the VMI for evacuation.
2. The eviction admitter approves the eviction request.
3. kube-api [denies](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/#how-api-initiated-eviction-works) the eviction request because the virt-launcher is protected by a PDB.

When a [descheduler](https://github.com/kubernetes-sigs/descheduler) tries to evict a virt-launcher pod owned by a VMI that could be evacuated, it receives a denial for the eviction request and cannot understand that a VMI evacuation was triggered in the background.

After this PR:
When a VMI is marked for evacuation the eviction request is denied with a spacial message.
This is done in order to:
1. Signal the descheduler that an evacuation was triggered although the eviction was denied.
2. Use the existing K8s eviction API

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
This PR implements the first stage of https://github.com/kubevirt/community/pull/258

### Special notes for your reviewer
~~Depends on PR https://github.com/kubevirt/kubevirt/pull/11380, please skip the first ten commits.~~
Only the last commit changes behavior, other commits are small refactoring.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

