### PR TITLE
tests, k8s: Improve log collection logging

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -70,10 +70,10 @@ const (
 )
 
 type KubernetesReporter struct {
-	failureCount int
-	artifactsDir string
-	maxFails     int
-	alwaysReport bool
+	failureCount      int
+	artifactsDir      string
+	maxFails          int
+	programmaticFocus bool
 }
 
 type commands struct {
@@ -91,8 +91,8 @@ func NewKubernetesReporter(artifactsDir string, maxFailures int) *KubernetesRepo
 
 func (r *KubernetesReporter) ConfigurePerSpecReporting(report Report) {
 	// we want to emit k8s logs anyhow if we focus tests by i.e. FIt
-	r.alwaysReport = report.SuiteHasProgrammaticFocus
-	_, err := fmt.Fprintf(GinkgoWriter, "ConfigurePerSpecReporting r.alwaysReport = %t", r.alwaysReport)
+	r.programmaticFocus = report.SuiteHasProgrammaticFocus
+	_, err := fmt.Fprintf(GinkgoWriter, "ConfigurePerSpecReporting r.programmaticFocus = %t", r.programmaticFocus)
 	if err != nil {
 		GinkgoT().Error(err)
 	}
@@ -114,12 +114,12 @@ func (r *KubernetesReporter) Report(report types.Report) {
 
 func (r *KubernetesReporter) ReportSpec(specReport types.SpecReport) {
 	fmt.Fprintf(GinkgoWriter, "On failure, artifacts will be collected in %s/%d_*\n", r.artifactsDir, r.failureCount+1)
-	if !r.alwaysReport && r.failureCount > r.maxFails {
+	if !r.programmaticFocus && r.failureCount > r.maxFails {
 		return
 	}
 	if specReport.Failed() {
 		r.failureCount++
-	} else if !r.alwaysReport {
+	} else if !r.programmaticFocus {
 		return
 	}
 
@@ -127,7 +127,11 @@ func (r *KubernetesReporter) ReportSpec(specReport types.SpecReport) {
 	if r.artifactsDir == "" {
 		return
 	}
-	By("Collecting Logs for failed test")
+	reason := "due to failure"
+	if r.programmaticFocus {
+		reason = "due to use of programmatic focus container"
+	}
+	By(fmt.Sprintf("Collecting Logs %s", reason))
 	r.DumpTestNamespaces(specReport.RunTime)
 }
 


### PR DESCRIPTION
/cc @dhiller 

### What this PR does

Before this PR:

68ebda2ae7d20 started to always collect logs when focus containers are used by tests. While useful the step logging suggested that a failure had occurred even if the test passes and was confusing to the reader.

After this PR:

This change provides a useful reason for the log collection and also renames the associated KubernetesReporter attribute to make it clear what it actually relates to.

Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

