### PR TITLE
tests/storage: remove newVMIWithEphemeralPVC()

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -434,7 +434,11 @@ var _ = SIGDescribe("Storage", func() {
 					} else {
 						pvName = tests.DiskAlpineHostPath
 					}
-					vmi = newVMIWithEphemeralPVC(pvName)
+
+					vmi = libvmi.New(
+						libvmi.WithResourceMemory("256Mi"),
+						libvmi.WithEphemeralPersistentVolumeClaim("disk0", pvName),
+					)
 
 					if storageEngine == "nfs" {
 						vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 120)
@@ -453,7 +457,11 @@ var _ = SIGDescribe("Storage", func() {
 
 			// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
 			It("[test_id:3137]should not persist data", func() {
-				vmi = newVMIWithEphemeralPVC(tests.DiskAlpineHostPath)
+				vmi = libvmi.New(
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithEphemeralPersistentVolumeClaim("disk0", tests.DiskAlpineHostPath),
+				)
 
 				By("Starting the VirtualMachineInstance")
 				var createdVMI *v1.VirtualMachineInstance
@@ -1083,10 +1091,12 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 			It("should generate the block backingstore disk within the domain", func() {
-				vmi = newVMIWithEphemeralPVC(dataVolume.Name)
+				vmi = libvmifact.NewGuestless(
+					libvmi.WithEphemeralPersistentVolumeClaim("disk0", dataVolume.Name),
+				)
 
 				By("Initializing the VM")
-				tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -1100,7 +1110,10 @@ var _ = SIGDescribe("Storage", func() {
 				Expect(disks[0].BackingStore.Source.Dev).To(Equal(converter.GetBlockDeviceVolumePath("disk0")))
 			})
 			It("should generate the pod with the volumeDevice", func() {
-				vmi = newVMIWithEphemeralPVC(dataVolume.Name)
+				vmi = libvmifact.NewGuestless(
+					libvmi.WithEphemeralPersistentVolumeClaim("disk0", dataVolume.Name),
+				)
+
 				By("Initializing the VM")
 
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
@@ -1413,31 +1426,6 @@ func createBlockDataVolume(virtClient kubecli.KubevirtClient) (*cdiv1.DataVolume
 	)
 
 	return virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-}
-
-func newVMIWithEphemeralPVC(claimName string) *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMI()
-
-	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-		Name: "disk0",
-		DiskDevice: v1.DiskDevice{
-			Disk: &v1.DiskTarget{
-				Bus: v1.DiskBusSATA,
-			},
-		},
-	})
-	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-		Name: "disk0",
-
-		VolumeSource: v1.VolumeSource{
-			Ephemeral: &v1.EphemeralVolumeSource{
-				PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-					ClaimName: claimName,
-				},
-			},
-		},
-	})
-	return vmi
 }
 
 func checkResultShellCommandOnVmi(vmi *v1.VirtualMachineInstance, cmd, output string, timeout int) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Remove `newVMIWithEphemeralPVC()` function in `tests/storage/storage.go`, and use `libvmi.New()` and `libvmifact.NewGuestless()` instead.
   


/sig code-quality

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

