### PR TITLE
tests: Move get GetSupportedCPUModels to libnode

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
-        "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/util:go_default_library",

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -226,7 +226,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 			nodes := libnode.GetAllSchedulableNodes(virtClient)
 			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 			node := &nodes.Items[0]
-			supportedCPUs := tests.GetSupportedCPUModels(*nodes)
+			supportedCPUs := libnode.GetSupportedCPUModels(*nodes)
 			Expect(supportedCPUs).ToNot(BeEmpty(), "There should be some supported cpu models")
 
 			for key := range node.Labels {

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -409,3 +409,27 @@ func GetSupportedCPUFeatures(nodesList k8sv1.NodeList) []string {
 	}
 	return features
 }
+
+func GetSupportedCPUModels(nodeList k8sv1.NodeList) []string {
+	var cpuDenyList = map[string]bool{
+		"qemu64":     true,
+		"Opteron_G2": true,
+	}
+	cpuMap := make(map[string]bool)
+	for _, node := range nodeList.Items {
+		for key := range node.Labels {
+			if strings.Contains(key, services.NFD_CPU_MODEL_PREFIX) {
+				cpu := strings.TrimPrefix(key, services.NFD_CPU_MODEL_PREFIX)
+				if _, ok := cpuDenyList[cpu]; !ok {
+					cpuMap[cpu] = true
+				}
+			}
+		}
+	}
+
+	cpus := make([]string, 0)
+	for model := range cpuMap {
+		cpus = append(cpus, model)
+	}
+	return cpus
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -71,7 +71,6 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	kutil "kubevirt.io/kubevirt/pkg/util"
-	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	launcherApi "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 
@@ -98,30 +97,6 @@ const (
 	DiskWindowsSysprep     = "disk-windows-sysprep"
 	DiskCustomHostPath     = "disk-custom-host-path"
 )
-
-func GetSupportedCPUModels(nodeList k8sv1.NodeList) []string {
-	var cpuDenyList = map[string]bool{
-		"qemu64":     true,
-		"Opteron_G2": true,
-	}
-	cpuMap := make(map[string]bool)
-	for _, node := range nodeList.Items {
-		for key := range node.Labels {
-			if strings.Contains(key, services.NFD_CPU_MODEL_PREFIX) {
-				cpu := strings.TrimPrefix(key, services.NFD_CPU_MODEL_PREFIX)
-				if _, ok := cpuDenyList[cpu]; !ok {
-					cpuMap[cpu] = true
-				}
-			}
-		}
-	}
-
-	cpus := make([]string, 0)
-	for model := range cpuMap {
-		cpus = append(cpus, model)
-	}
-	return cpus
-}
 
 func CreateConfigMap(name, namespace string, data map[string]string) {
 	virtCli := kubevirt.Client()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -99,13 +99,13 @@ const (
 	DiskCustomHostPath     = "disk-custom-host-path"
 )
 
-func GetSupportedCPUModels(nodes k8sv1.NodeList) []string {
+func GetSupportedCPUModels(nodeList k8sv1.NodeList) []string {
 	var cpuDenyList = map[string]bool{
 		"qemu64":     true,
 		"Opteron_G2": true,
 	}
 	cpuMap := make(map[string]bool)
-	for _, node := range nodes.Items {
+	for _, node := range nodeList.Items {
 		for key := range node.Labels {
 			if strings.Contains(key, services.NFD_CPU_MODEL_PREFIX) {
 				cpu := strings.TrimPrefix(key, services.NFD_CPU_MODEL_PREFIX)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1764,7 +1764,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model defined", func() {
 			It("[test_id:1678]should report defined CPU model", func() {
-				supportedCPUs := tests.GetSupportedCPUModels(*nodes)
+				supportedCPUs := libnode.GetSupportedCPUModels(*nodes)
 				Expect(supportedCPUs).ToNot(BeEmpty())
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					Model: supportedCPUs[0],

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -894,7 +894,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				checks.SkipIfARM64(testsuite.Arch, "arm64 does not support cpu model")
 				nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-				supportedCpuModels = tests.GetSupportedCPUModels(*nodes)
+				supportedCpuModels = libnode.GetSupportedCPUModels(*nodes)
 				if len(supportedCpuModels) < 2 {
 					Skip("need at least 2 supported cpuModels for this test")
 				}
@@ -1003,7 +1003,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 				node = &nodes.Items[0]
-				supportedCPUs = tests.GetSupportedCPUModels(*nodes)
+				supportedCPUs = libnode.GetSupportedCPUModels(*nodes)
 				Expect(supportedCPUs).ToNot(BeEmpty(), "There should be some supported cpu models")
 
 				supportedCPU = supportedCPUs[0]


### PR DESCRIPTION
### What this PR does
This PR moves GetSupportedCPUModels to libnode where it is more relevant.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

