### PR TITLE
net, admitter: Move network related admiter validations to the `network/admitter` package

### DIFF
--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "admit.go",
         "binding.go",
+        "netsource.go",
         "slirp.go",
         "validator.go",
     ],
@@ -24,6 +25,7 @@ go_test(
         "admit_suite_test.go",
         "admit_test.go",
         "binding_test.go",
+        "netsource_test.go",
         "slirp_test.go",
     ],
     deps = [

--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "admit.go",
         "slirp.go",
+        "validator.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/network/admitter",
     visibility = ["//visibility:public"],

--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "admit.go",
+        "binding.go",
         "slirp.go",
         "validator.go",
     ],
@@ -22,6 +23,7 @@ go_test(
     srcs = [
         "admit_suite_test.go",
         "admit_test.go",
+        "binding_test.go",
         "slirp_test.go",
     ],
     deps = [

--- a/pkg/network/admitter/admit.go
+++ b/pkg/network/admitter/admit.go
@@ -59,31 +59,6 @@ func validateInterfaceStateValue(field *k8sfield.Path, spec *v1.VirtualMachineIn
 	return causes
 }
 
-func validateInterfaceBinding(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
-	var causes []metav1.StatusCause
-	for idx, iface := range spec.Domain.Devices.Interfaces {
-		if iface.Binding != nil {
-			if hasInterfaceBindingMethod(iface) {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("logical %s interface cannot have both binding plugin and interface binding method", iface.Name),
-					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("binding").String(),
-				})
-			}
-		}
-	}
-	return causes
-}
-
-func hasInterfaceBindingMethod(iface v1.Interface) bool {
-	return iface.InterfaceBindingMethod.Bridge != nil ||
-		iface.InterfaceBindingMethod.Slirp != nil ||
-		iface.InterfaceBindingMethod.Masquerade != nil ||
-		iface.InterfaceBindingMethod.SRIOV != nil ||
-		iface.InterfaceBindingMethod.Macvtap != nil ||
-		iface.InterfaceBindingMethod.Passt != nil
-}
-
 func validateSinglePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	if countPodNetworks(spec.Networks) > 1 {
 		return []metav1.StatusCause{{

--- a/pkg/network/admitter/admit.go
+++ b/pkg/network/admitter/admit.go
@@ -58,24 +58,3 @@ func validateInterfaceStateValue(field *k8sfield.Path, spec *v1.VirtualMachineIn
 	}
 	return causes
 }
-
-func validateSinglePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
-	if countPodNetworks(spec.Networks) > 1 {
-		return []metav1.StatusCause{{
-			Type:    metav1.CauseTypeFieldValueDuplicate,
-			Message: fmt.Sprintf("more than one interface is connected to a pod network in %s", field.Child("interfaces").String()),
-			Field:   field.Child("interfaces").String(),
-		}}
-	}
-	return nil
-}
-
-func countPodNetworks(networks []v1.Network) int {
-	count := 0
-	for _, net := range networks {
-		if net.Pod != nil {
-			count++
-		}
-	}
-	return count
-}

--- a/pkg/network/admitter/admit.go
+++ b/pkg/network/admitter/admit.go
@@ -30,7 +30,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-func ValidateInterfaceStateValue(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+func validateInterfaceStateValue(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	for idx, iface := range spec.Domain.Devices.Interfaces {
 		if iface.State != "" && iface.State != v1.InterfaceStateAbsent {
@@ -59,7 +59,7 @@ func ValidateInterfaceStateValue(field *k8sfield.Path, spec *v1.VirtualMachineIn
 	return causes
 }
 
-func ValidateInterfaceBinding(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+func validateInterfaceBinding(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	for idx, iface := range spec.Domain.Devices.Interfaces {
 		if iface.Binding != nil {
@@ -84,7 +84,7 @@ func hasInterfaceBindingMethod(iface v1.Interface) bool {
 		iface.InterfaceBindingMethod.Passt != nil
 }
 
-func ValidateSinglePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+func validateSinglePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	if countPodNetworks(spec.Networks) > 1 {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueDuplicate,

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -94,42 +94,6 @@ var _ = Describe("Validating VMI network spec", func() {
 			}))
 	})
 
-	It("network interface has both binding plugin and interface binding method", func() {
-		vm := api.NewMinimalVMI("testvm")
-		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "foo",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-			Binding:                &v1.PluginBinding{Name: "boo"},
-		}}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
-		Expect(validator.Validate()).To(
-			ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
-				Message: "logical foo interface cannot have both binding plugin and interface binding method",
-				Field:   "fake.domain.devices.interfaces[0].binding",
-			}))
-	})
-
-	It("network interface has only plugin binding", func() {
-		vm := api.NewMinimalVMI("testvm")
-		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:    "foo",
-			Binding: &v1.PluginBinding{Name: "boo"},
-		}}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
-		Expect(validator.Validate()).To(BeEmpty())
-	})
-
-	It("network interface has only binding method", func() {
-		vm := api.NewMinimalVMI("testvm")
-		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "foo",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-		}}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
-		Expect(validator.Validate()).To(BeEmpty())
-	})
-
 	It("support only a single pod network", func() {
 		const net1Name = "default"
 		const net2Name = "default2"

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -93,18 +93,4 @@ var _ = Describe("Validating VMI network spec", func() {
 				Field:   "fake.domain.devices.interfaces[0].state",
 			}))
 	})
-
-	It("support only a single pod network", func() {
-		const net1Name = "default"
-		const net2Name = "default2"
-		vmi := v1.VirtualMachineInstance{}
-		vmi.Spec.Networks = []v1.Network{
-			{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-			{Name: net2Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-		}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubSlirpClusterConfigChecker{})
-		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
-	})
 })

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -42,7 +42,8 @@ var _ = Describe("Validating VMI network spec", func() {
 			State:                  value,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
 		}
-		Expect(admitter.ValidateInterfaceStateValue(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(BeEmpty())
 	},
 		Entry("is empty", v1.InterfaceState("")),
 		Entry("is absent when bridge binding is used", v1.InterfaceStateAbsent),
@@ -51,7 +52,8 @@ var _ = Describe("Validating VMI network spec", func() {
 	It("network interface state value is invalid", func() {
 		vm := api.NewMinimalVMI("testvm")
 		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "foo", State: v1.InterfaceState("foo")}}
-		Expect(admitter.ValidateInterfaceStateValue(k8sfield.NewPath("fake"), &vm.Spec)).To(
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
 				Message: "logical foo interface state value is unsupported: foo",
@@ -66,7 +68,8 @@ var _ = Describe("Validating VMI network spec", func() {
 			State:                  v1.InterfaceStateAbsent,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 		}}
-		Expect(admitter.ValidateInterfaceStateValue(k8sfield.NewPath("fake"), &vm.Spec)).To(
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
 				Message: "\"foo\" interface's state \"absent\" is supported only for bridge binding",
@@ -82,7 +85,8 @@ var _ = Describe("Validating VMI network spec", func() {
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 		}}
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
-		Expect(admitter.ValidateInterfaceStateValue(k8sfield.NewPath("fake"), &vm.Spec)).To(
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
 				Message: "\"foo\" interface's state \"absent\" is not supported on default networks",
@@ -97,7 +101,8 @@ var _ = Describe("Validating VMI network spec", func() {
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 			Binding:                &v1.PluginBinding{Name: "boo"},
 		}}
-		Expect(admitter.ValidateInterfaceBinding(k8sfield.NewPath("fake"), &vm.Spec)).To(
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
 				Message: "logical foo interface cannot have both binding plugin and interface binding method",
@@ -111,7 +116,8 @@ var _ = Describe("Validating VMI network spec", func() {
 			Name:    "foo",
 			Binding: &v1.PluginBinding{Name: "boo"},
 		}}
-		Expect(admitter.ValidateInterfaceBinding(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(BeEmpty())
 	})
 
 	It("network interface has only binding method", func() {
@@ -120,7 +126,8 @@ var _ = Describe("Validating VMI network spec", func() {
 			Name:                   "foo",
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 		}}
-		Expect(admitter.ValidateInterfaceBinding(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(BeEmpty())
 	})
 
 	It("support only a single pod network", func() {
@@ -131,7 +138,8 @@ var _ = Describe("Validating VMI network spec", func() {
 			{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
 			{Name: net2Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
 		}
-		causes := admitter.ValidateSinglePodNetwork(k8sfield.NewPath("fake"), &vmi.Spec)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubSlirpClusterConfigChecker{})
+		causes := validator.Validate()
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
 	})

--- a/pkg/network/admitter/binding.go
+++ b/pkg/network/admitter/binding.go
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitter
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func validateInterfaceBinding(fieldPath *field.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	for idx, iface := range spec.Domain.Devices.Interfaces {
+		if iface.Binding != nil {
+			if hasInterfaceBindingMethod(iface) {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("logical %s interface cannot have both binding plugin and interface binding method", iface.Name),
+					Field:   fieldPath.Child("domain", "devices", "interfaces").Index(idx).Child("binding").String(),
+				})
+			}
+		}
+	}
+	return causes
+}
+
+func hasInterfaceBindingMethod(iface v1.Interface) bool {
+	return iface.InterfaceBindingMethod.Bridge != nil ||
+		iface.InterfaceBindingMethod.Slirp != nil ||
+		iface.InterfaceBindingMethod.Masquerade != nil ||
+		iface.InterfaceBindingMethod.SRIOV != nil ||
+		iface.InterfaceBindingMethod.Macvtap != nil ||
+		iface.InterfaceBindingMethod.Passt != nil
+}

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitter_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	"kubevirt.io/client-go/api"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/admitter"
+)
+
+var _ = Describe("Validating network binding combinations", func() {
+
+	It("network interface has both binding plugin and interface binding method", func() {
+		vm := api.NewMinimalVMI("testvm")
+		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name:                   "foo",
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+			Binding:                &v1.PluginBinding{Name: "boo"},
+		}}
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(
+			ConsistOf(metav1.StatusCause{
+				Type:    "FieldValueInvalid",
+				Message: "logical foo interface cannot have both binding plugin and interface binding method",
+				Field:   "fake.domain.devices.interfaces[0].binding",
+			}))
+	})
+
+	It("network interface has only plugin binding", func() {
+		vm := api.NewMinimalVMI("testvm")
+		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name:    "foo",
+			Binding: &v1.PluginBinding{Name: "boo"},
+		}}
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(BeEmpty())
+	})
+
+	It("network interface has only binding method", func() {
+		vm := api.NewMinimalVMI("testvm")
+		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+			Name:                   "foo",
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+		}}
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubSlirpClusterConfigChecker{})
+		Expect(validator.Validate()).To(BeEmpty())
+	})
+})

--- a/pkg/network/admitter/netsource.go
+++ b/pkg/network/admitter/netsource.go
@@ -68,3 +68,16 @@ func validateSingleNetworkSource(field *k8sfield.Path, spec *v1.VirtualMachineIn
 	}
 	return causes
 }
+
+func validateMultusNetworkSource(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	for idx, net := range spec.Networks {
+		if net.Multus != nil && net.Multus.NetworkName == "" {
+			return []metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldValueRequired,
+				Message: "CNI delegating plugin must have a networkName",
+				Field:   field.Child("networks").Index(idx).String(),
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/network/admitter/netsource.go
+++ b/pkg/network/admitter/netsource.go
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitter
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func validateSinglePodNetwork(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	if countPodNetworks(spec.Networks) > 1 {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueDuplicate,
+			Message: fmt.Sprintf("more than one interface is connected to a pod network in %s", field.Child("interfaces").String()),
+			Field:   field.Child("interfaces").String(),
+		}}
+	}
+	return nil
+}
+
+func countPodNetworks(networks []v1.Network) int {
+	count := 0
+	for _, net := range networks {
+		if net.Pod != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func validateSingleNetworkSource(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	for idx, net := range spec.Networks {
+		if net.Pod == nil && net.Multus == nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueRequired,
+				Message: "should have a network type",
+				Field:   field.Child("networks").Index(idx).String(),
+			})
+		} else if net.Pod != nil && net.Multus != nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueRequired,
+				Message: "should have only one network type",
+				Field:   field.Child("networks").Index(idx).String(),
+			})
+		}
+	}
+	return causes
+}

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitter_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/admitter"
+)
+
+var _ = Describe("Validate network source", func() {
+
+	It("support only a single pod network", func() {
+		const net1Name = "default"
+		const net2Name = "default2"
+		vmi := v1.VirtualMachineInstance{}
+		vmi.Spec.Networks = []v1.Network{
+			{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+			{Name: net2Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+		}
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubSlirpClusterConfigChecker{})
+		causes := validator.Validate()
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
+	})
+
+	It("should reject when multiple types defined for a CNI network", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		spec.Networks = []v1.Network{
+			{
+				Name: "default",
+				NetworkSource: v1.NetworkSource{
+					Multus: &v1.MultusNetwork{NetworkName: "default1"},
+					Pod:    &v1.PodNetwork{},
+				},
+			},
+		}
+
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubSlirpClusterConfigChecker{})
+		causes := validator.Validate()
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Message).To(Equal("should have only one network type"))
+	})
+
+	It("when network source is not configured", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net1 := v1.Network{
+			NetworkSource: v1.NetworkSource{},
+			Name:          "testnet1",
+		}
+		iface1 := v1.Interface{Name: net1.Name}
+		spec.Networks = []v1.Network{net1}
+		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubSlirpClusterConfigChecker{})
+		causes := validator.Validate()
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Message).To(Equal("should have a network type"))
+	})
+})

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -79,4 +79,18 @@ var _ = Describe("Validate network source", func() {
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("should have a network type"))
 	})
+
+	It("should reject multus network source without networkName", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		spec.Networks = []v1.Network{{
+			Name:          "default",
+			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
+		}}
+
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubSlirpClusterConfigChecker{})
+		causes := validator.Validate()
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Message).To(Equal("CNI delegating plugin must have a networkName"))
+	})
 })

--- a/pkg/network/admitter/slirp.go
+++ b/pkg/network/admitter/slirp.go
@@ -32,7 +32,7 @@ type slirpClusterConfigChecker interface {
 	IsSlirpInterfaceEnabled() bool
 }
 
-func ValidateSlirpBinding(
+func validateSlirpBinding(
 	field *k8sfield.Path,
 	spec *v1.VirtualMachineInstanceSpec,
 	configChecker slirpClusterConfigChecker) (causes []metav1.StatusCause) {

--- a/pkg/network/admitter/slirp_test.go
+++ b/pkg/network/admitter/slirp_test.go
@@ -44,8 +44,8 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 		}}
 
-		config := stubSlirpClusterConfigChecker{}
-		causes := admitter.ValidateSlirpBinding(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubSlirpClusterConfigChecker{})
+		causes := validator.Validate()
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("Slirp interface is not enabled in kubevirt-config"))
 	})
@@ -64,7 +64,8 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 		}}
 
 		config := stubSlirpClusterConfigChecker{enabled: true}
-		causes := admitter.ValidateSlirpBinding(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		causes := validator.Validate()
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("Slirp interface only implemented with pod network"))
 	})
@@ -83,7 +84,8 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 		}}
 
 		config := stubSlirpClusterConfigChecker{enabled: true}
-		Expect(admitter.ValidateSlirpBinding(k8sfield.NewPath("fake"), &vmi.Spec, config)).To(BeEmpty())
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		Expect(validator.Validate()).To(BeEmpty())
 	})
 })
 

--- a/pkg/network/admitter/slirp_test.go
+++ b/pkg/network/admitter/slirp_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 		}}
 		vmi.Spec.Networks = []v1.Network{{
 			Name:          "default",
-			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
+			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}},
 		}}
 
 		config := stubSlirpClusterConfigChecker{enabled: true}

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitter
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
+)
+
+type clusterConfigChecker interface {
+	IsSlirpInterfaceEnabled() bool
+}
+
+type Validator struct {
+	field         *k8sfield.Path
+	vmiSpec       *v1.VirtualMachineInstanceSpec
+	configChecker clusterConfigChecker
+
+	networkByName map[string]v1.Network
+}
+
+func NewValidator(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, configChecker clusterConfigChecker) *Validator {
+	return &Validator{
+		field:         field,
+		vmiSpec:       vmiSpec,
+		configChecker: configChecker,
+		networkByName: netvmispec.IndexNetworkSpecByName(vmiSpec.Networks),
+	}
+}
+
+func (v Validator) Validate() []metav1.StatusCause {
+	var causes []metav1.StatusCause
+
+	causes = append(causes, validateSinglePodNetwork(v.field, v.vmiSpec)...)
+	causes = append(causes, validateInterfaceStateValue(v.field, v.vmiSpec)...)
+	causes = append(causes, validateInterfaceBinding(v.field, v.vmiSpec)...)
+	causes = append(causes, validateSlirpBinding(v.field, v.vmiSpec, v.configChecker)...)
+
+	return causes
+}

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -54,6 +54,7 @@ func (v Validator) Validate() []metav1.StatusCause {
 
 	causes = append(causes, validateSinglePodNetwork(v.field, v.vmiSpec)...)
 	causes = append(causes, validateSingleNetworkSource(v.field, v.vmiSpec)...)
+	causes = append(causes, validateMultusNetworkSource(v.field, v.vmiSpec)...)
 	causes = append(causes, validateInterfaceStateValue(v.field, v.vmiSpec)...)
 	causes = append(causes, validateInterfaceBinding(v.field, v.vmiSpec)...)
 	causes = append(causes, validateSlirpBinding(v.field, v.vmiSpec, v.configChecker)...)

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -53,6 +53,7 @@ func (v Validator) Validate() []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	causes = append(causes, validateSinglePodNetwork(v.field, v.vmiSpec)...)
+	causes = append(causes, validateSingleNetworkSource(v.field, v.vmiSpec)...)
 	causes = append(causes, validateInterfaceStateValue(v.field, v.vmiSpec)...)
 	causes = append(causes, validateInterfaceBinding(v.field, v.vmiSpec)...)
 	causes = append(causes, validateSlirpBinding(v.field, v.vmiSpec, v.configChecker)...)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/monitoring/metrics/virt-api:go_default_library",
         "//pkg/network/admitter:go_default_library",
         "//pkg/network/link:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/snapshot:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -926,8 +926,6 @@ func validateNetworks(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec,
 			}
 		}
 
-		causes = validateNetworkHasOnlyOneType(field, cniTypesCount, causes, idx)
-
 		if !networkNameExistsOrNotNeeded {
 			causes = appendStatusCauseForCNIPluginHasNoNetworkName(field, causes, idx)
 		}
@@ -943,23 +941,6 @@ func appendStatusCauseForCNIPluginHasNoNetworkName(field *k8sfield.Path, incomin
 		Message: "CNI delegating plugin must have a networkName",
 		Field:   field.Child("networks").Index(idx).String(),
 	})
-	return causes
-}
-
-func validateNetworkHasOnlyOneType(field *k8sfield.Path, cniTypesCount int, causes []metav1.StatusCause, idx int) []metav1.StatusCause {
-	if cniTypesCount == 0 {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueRequired,
-			Message: "should have a network type",
-			Field:   field.Child("networks").Index(idx).String(),
-		})
-	} else if cniTypesCount > 1 {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueRequired,
-			Message: "should have only one network type",
-			Field:   field.Child("networks").Index(idx).String(),
-		})
-	}
 	return causes
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -910,8 +910,6 @@ func validateNetworks(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec,
 	for idx, network := range spec.Networks {
 
 		cniTypesCount := 0
-		// network name not needed by default
-		networkNameExistsOrNotNeeded := true
 
 		if network.Pod != nil {
 			cniTypesCount++
@@ -920,28 +918,14 @@ func validateNetworks(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec,
 
 		if network.NetworkSource.Multus != nil {
 			cniTypesCount++
-			networkNameExistsOrNotNeeded = network.Multus.NetworkName != ""
 			if network.NetworkSource.Multus.Default {
 				multusDefaultCount++
 			}
 		}
 
-		if !networkNameExistsOrNotNeeded {
-			causes = appendStatusCauseForCNIPluginHasNoNetworkName(field, causes, idx)
-		}
-
 		networkNameMap[spec.Networks[idx].Name] = &spec.Networks[idx]
 	}
 	return podExists, multusDefaultCount, causes
-}
-
-func appendStatusCauseForCNIPluginHasNoNetworkName(field *k8sfield.Path, incomingCauses []metav1.StatusCause, idx int) (causes []metav1.StatusCause) {
-	causes = append(incomingCauses, metav1.StatusCause{
-		Type:    metav1.CauseTypeFieldValueRequired,
-		Message: "CNI delegating plugin must have a networkName",
-		Field:   field.Child("networks").Index(idx).String(),
-	})
-	return causes
 }
 
 func validateBootOrder(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, volumeNameMap map[string]*v1.Volume) (bootOrderMap map[uint]bool, causes []metav1.StatusCause) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -167,7 +167,8 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateSpecTopologySpreadConstraints(field, spec)...)
 	causes = append(causes, validateArchitecture(field, spec, config)...)
 
-	causes = append(causes, netadmitter.ValidateSinglePodNetwork(field, spec)...)
+	netValidator := netadmitter.NewValidator(field, spec, config)
+	causes = append(causes, netValidator.Validate()...)
 
 	bootOrderMap, newCauses := validateBootOrder(field, spec, volumeNameMap)
 	causes = append(causes, newCauses...)
@@ -181,7 +182,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		causes = appendStatusCauseForPodNetworkDefinedWithMultusDefaultNetworkDefined(field, causes)
 	}
 
-	causes = append(causes, netadmitter.ValidateSlirpBinding(field, spec, config)...)
 	networkInterfaceMap, newCauses, done := validateNetworksMatchInterfaces(field, spec, config, networkNameMap, bootOrderMap)
 	causes = append(causes, newCauses...)
 	if done {
@@ -189,8 +189,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	}
 
 	causes = append(causes, validateNetworksAssignedToInterfaces(field, spec, networkInterfaceMap)...)
-	causes = append(causes, netadmitter.ValidateInterfaceStateValue(field, spec)...)
-	causes = append(causes, netadmitter.ValidateInterfaceBinding(field, spec)...)
 
 	causes = append(causes, validateInputDevices(field, spec)...)
 	causes = append(causes, validateIOThreadsPolicy(field, spec)...)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1258,63 +1258,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
 			Expect(causes).To(BeEmpty())
 		})
-		It("should reject multiple multus networks with a multus default", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				*v1.DefaultBridgeNetworkInterface(),
-				*v1.DefaultBridgeNetworkInterface(),
-			}
-			vm.Spec.Domain.Devices.Interfaces[0].Name = "multus1"
-			vm.Spec.Domain.Devices.Interfaces[1].Name = "multus2"
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "multus1",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "multus-net1", Default: true},
-					},
-				},
-				{
-					Name: "multus2",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "multus-net2", Default: true},
-					},
-				},
-			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
-			Expect(causes[0].Field).To(Equal("fake.networks"))
-			Expect(causes[0].Message).To(Equal("Multus CNI should only have one default network"))
-		})
-		It("should reject pod network with a multus default", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				*v1.DefaultBridgeNetworkInterface(),
-				*v1.DefaultBridgeNetworkInterface(),
-			}
-			vm.Spec.Domain.Devices.Interfaces[1].Name = "multus1"
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "default",
-					NetworkSource: v1.NetworkSource{
-						Pod: &v1.PodNetwork{},
-					},
-				},
-				{
-					Name: "multus1",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "multus-net1", Default: true},
-					},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
-			Expect(causes[0].Field).To(Equal("fake.networks"))
-			Expect(causes[0].Message).To(Equal("Pod network cannot be defined when Multus default network is defined"))
-		})
 		It("should reject networks with a passt interface and passt feature gate disabled", func() {
 			vm := api.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1205,23 +1205,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
 			Expect(causes).To(BeEmpty())
 		})
-		It("should reject when multiple types defined for a CNI network", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "default",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "default1"},
-						Pod:    &v1.PodNetwork{},
-					},
-				},
-			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(Equal("fake.networks[0]"))
-		})
 		It("should allow multiple networks of same CNI type", func() {
 			vm := api.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
@@ -4789,33 +4773,6 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		spec.Networks = []v1.Network{net1, net2}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface1, iface2}
 		Expect(getNumberOfPodInterfaces(spec)).To(Equal(2))
-	})
-	It("when network source is not configured", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		net1 := v1.Network{
-			NetworkSource: v1.NetworkSource{},
-			Name:          "testnet1",
-		}
-		iface1 := v1.Interface{Name: net1.Name}
-		spec.Networks = []v1.Network{net1}
-		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-		Expect(causes).To(HaveLen(1))
-	})
-	It("should reject when more than one network source is configured", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		net1 := v1.Network{
-			NetworkSource: v1.NetworkSource{
-				Pod:    &v1.PodNetwork{},
-				Multus: &v1.MultusNetwork{NetworkName: "testnet1"},
-			},
-			Name: "testnet",
-		}
-		iface1 := v1.Interface{Name: net1.Name}
-		spec.Networks = []v1.Network{net1}
-		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-		Expect(causes).To(HaveLen(1))
 	})
 	It("should work when boot order is given to interfaces", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1768,25 +1768,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
 			Expect(causes).To(BeEmpty())
 		})
-		It("should reject specs with multiple pod interfaces", func() {
-			vm := api.NewMinimalVMI("testvm")
-			for i := 1; i < 3; i++ {
-				iface := v1.DefaultBridgeNetworkInterface()
-				net := v1.DefaultPodNetwork()
-
-				// make sure whatever the error we receive is not related to duplicate names
-				name := fmt.Sprintf("podnet%d", i)
-				iface.Name = name
-				net.Name = name
-
-				vm.Spec.Domain.Devices.Interfaces = append(vm.Spec.Domain.Devices.Interfaces, *iface)
-				vm.Spec.Networks = append(vm.Spec.Networks, *net)
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(Equal("fake.interfaces"))
-		})
 
 		It("should accept valid MAC address", func() {
 			vmi := api.NewMinimalVMI("testvm")

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1315,22 +1315,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes[0].Field).To(Equal("fake.networks"))
 			Expect(causes[0].Message).To(Equal("Pod network cannot be defined when Multus default network is defined"))
 		})
-		It("should reject multus network source without networkName", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "default",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{},
-					},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(Equal("fake.networks[0]"))
-		})
 		It("should reject networks with a passt interface and passt feature gate disabled", func() {
 			vm := api.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{


### PR DESCRIPTION
### What this PR does
Relocate & refactor network validation admitters to the `network/admitter` package.

These changes include placing the validation logic under the sig-network ownership, optimize and simplify validation code, removing duplicate tests, adding missing tests. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This is a continuation of #11511 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

