### PR TITLE
tests,cloud-init: Move secret creation to package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ lint:
 	  tests/libnode/... \
 	  tests/libpod/... \
 	  tests/libvmifact/... \
+	  tests/libsecret/... \
 	  && \
 	  golangci-lint run --disable-all -E ginkgolinter --timeout 10m --verbose --no-config \
 	  ./pkg/... \

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -209,6 +209,7 @@ go_test(
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/libreplicaset:go_default_library",
+        "//tests/libsecret:go_default_library",
         "//tests/libssh:go_default_library",
         "//tests/libstorage:go_default_library",
         "//tests/libvmifact:go_default_library",

--- a/tests/libsecret/BUILD.bazel
+++ b/tests/libsecret/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["secret.go"],
+    importpath = "kubevirt.io/kubevirt/tests/libsecret",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/tests/libsecret/secret.go
+++ b/tests/libsecret/secret.go
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package libsecret
+
+import (
+	kubev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// New return Secret of Opaque type with "kubevirt.io/secret" label
+func New(name string, data map[string][]byte) *kubev1.Secret {
+	// secretLabel set this label to make the test suite namespace clean-up delete the secret on teardown
+	const secretLabel = "kubevirt.io/secret" // #nosec G101
+	return &kubev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				secretLabel: name,
+			},
+		},
+		Data: data,
+	}
+}

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -44,10 +44,10 @@ import (
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libpod"
+	"kubevirt.io/kubevirt/tests/libsecret"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
-	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -324,20 +324,10 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				// Store userdata as k8s secret
 				By("Creating a user-data secret")
-				secret := kubev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      secretID,
-						Namespace: vmi.Namespace,
-						Labels: map[string]string{
-							util.SecretLabel: secretID,
-						},
-					},
-					Type: "Opaque",
-					Data: map[string][]byte{
-						"userdata": []byte(userData), // The client encrypts the secret for us
-					},
-				}
-				_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+				secret := libsecret.New(secretID, map[string][]byte{
+					"userdata": []byte(userData),
+				})
+				_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				break
 			}
@@ -405,21 +395,10 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					// Store cloudinit data as k8s secret
 					By("Creating a secret with network data")
-					secret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      secretID,
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								util.SecretLabel: secretID,
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							// The client encrypts the secret for us
-							"networkdata": []byte(testNetworkData),
-						},
-					}
-					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+					secret := libsecret.New(secretID, map[string][]byte{
+						"networkdata": []byte(testNetworkData),
+					})
+					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					break
@@ -548,21 +527,11 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					// Store cloudinit data as k8s secret
 					By("Creating a secret with user and network data")
-					secret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      secretID,
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								util.SecretLabel: secretID,
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							// The client encrypts the secret for us
-							"networkdata": []byte(testNetworkData),
-						},
-					}
-					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+					secret := libsecret.New(secretID, map[string][]byte{
+						"networkdata": []byte(testNetworkData),
+					})
+
+					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					break
@@ -606,39 +575,19 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					// Store cloudinit data as k8s secret
 					By("Creating a secret with userdata")
-					uSecret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      uSecretID,
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								util.SecretLabel: uSecretID,
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							// The client encrypts the secret for us
-							userDataLabel: []byte(testUserData),
-						},
-					}
+					uSecret := libsecret.New(uSecretID, map[string][]byte{
+						userDataLabel: []byte(testUserData),
+					})
+
 					By("Creating a secret with network data")
-					nSecret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nSecretID,
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								util.SecretLabel: nSecretID,
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							// The client encrypts the secret for us
-							networkDataLabel: []byte(testNetworkData),
-						},
-					}
-					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &uSecret, metav1.CreateOptions{})
+					nSecret := libsecret.New(nSecretID, map[string][]byte{
+						networkDataLabel: []byte(testNetworkData),
+					})
+
+					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), uSecret, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					_, err = virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &nSecret, metav1.CreateOptions{})
+					_, err = virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), nSecret, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Move the secret definition code to new package 'tests/libsecret'

In follow up PR, other tests will change to use libsecret and remove "kubevirt.io/secret" from tests/utils/labels

**Before this PR:**
On cloud-init e2ev test suite, each test would define the same secret object but with different data.

**After this PR:**
Each test will use libsecret to define Secret objects 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

