### PR TITLE
Replace NewRandomVMIWithEphemeralDiskAndUserdata with libvmifact

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting and stopping the same VirtualMachineInstance", func() {
 		Context("with ephemeral registry disk", func() {
 			It("[test_id:1463][Conformance] should success multiple times", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				vmi := libvmifact.NewCirros()
 				num := 2
 				for i := 0; i < num; i++ {
 					By("Starting the VirtualMachineInstance")
@@ -174,7 +174,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting from custom image location", func() {
 		Context("with disk at /custom-disk/downloaded", func() {
 			It("[test_id:1466]should boot normally", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirrosCustomLocation), "#!/bin/bash\necho 'hello'\n")
+				vmi := libvmifact.NewCirros()
 				for ind, volume := range vmi.Spec.Volumes {
 					if volume.ContainerDisk != nil {
 						vmi.Spec.Volumes[ind].ContainerDisk.Path = "/custom-disk/downloaded"

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -50,7 +50,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/testsuite"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -153,8 +152,9 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		resource := "virtualmachines"
 
 		newVM := func() *v1.VirtualMachine {
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
+			vmi := libvmifact.NewCirros(
+				libvmi.WithCloudInitNoCloudEncodedUserData("echo Hi\n"),
+			)
 			vm := libvmi.NewVirtualMachine(vmi)
 			return vm
 		}
@@ -543,8 +543,9 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		BeforeEach(func() {
 			tests.EnableFeatureGate(virtconfig.SnapshotGate)
 
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
+			vmi := libvmifact.NewCirros(
+				libvmi.WithCloudInitNoCloudEncodedUserData("echo Hi\n"),
+			)
 			vm := libvmi.NewVirtualMachine(vmi)
 			_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 			Expect(err).ToNot(HaveOccurred())
@@ -634,8 +635,9 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		BeforeEach(func() {
 			tests.EnableFeatureGate(virtconfig.SnapshotGate)
 
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
+			vmi := libvmifact.NewCirros(
+				libvmi.WithCloudInitNoCloudEncodedUserData("echo Hi\n"),
+			)
 			vm := libvmi.NewVirtualMachine(vmi)
 			_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -409,15 +409,6 @@ func GetFedoraToolsGuestAgentBlacklistUserData(commands string) string {
 `, commands)
 }
 
-// NewRandomVMIWithEphemeralDiskAndUserdata
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
-	AddUserData(vmi, "disk1", userData)
-	return vmi
-}
-
 // NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata
 //
 // Deprecated: Use libvmi directly

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -309,8 +309,9 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		It("[test_id:1618]should take user-data from k8s secret", func() {
 			userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "")
-
+			vmi := libvmifact.NewCirros(
+				libvmi.WithCloudInitNoCloudEncodedUserData(""),
+			)
 			idx := 0
 			for i, volume := range vmi.Spec.Volumes {
 				if volume.CloudInitNoCloud == nil {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2418,8 +2418,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			// ordering:
 			// use a small disk for the other ones
 			containerImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			// virtio - added by NewRandomVMIWithEphemeralDisk
-			vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, "echo hi!\n")
+			vmi := libvmifact.NewCirros(
+				libvmi.WithCloudInitNoCloudEncodedUserData("echo Hi\n"),
+			)
 			// sata
 			tests.AddEphemeralDisk(vmi, "disk2", v1.DiskBusSATA, containerImage)
 			// NOTE: we have one disk per bus, so we expect vda, sda


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR replaces the deprecated NewRandomVMIWithEphemeralDiskAndUserdata func with the libvmifact.NewCirros func.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

