### PR TITLE
tests: Make use of tests/libsecret

### DIFF
--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libnet/cloudinit:go_default_library",
+        "//tests/libsecret:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/libwait:go_default_library",
         "//tests/testsuite:go_default_library",
@@ -30,7 +31,6 @@ go_library(
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -27,23 +27,22 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/console"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
-	"kubevirt.io/kubevirt/tests/libvmifact"
-	"kubevirt.io/kubevirt/tests/testsuite"
-	"kubevirt.io/kubevirt/tests/util"
-
 	expect "github.com/google/goexpect"
 
-	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
+	"kubevirt.io/kubevirt/tests/libsecret"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 var _ = SIGDescribe("Guest Access Credentials", func() {
@@ -247,17 +246,8 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 	})
 })
 
-func createNewSecret(namespace string, secretID string, data map[string][]byte) {
-	secret := &kubev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: secretID,
-			Labels: map[string]string{
-				util.SecretLabel: secretID,
-			},
-		},
-		Type: "Opaque",
-		Data: data,
-	}
+func createNewSecret(namespace string, secretID string, data libsecret.DataBytes) {
+	secret := libsecret.New(secretID, data)
 	_, err := kubevirt.Client().CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 }

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/libregistry:go_default_library",
+        "//tests/libsecret:go_default_library",
         "//tests/libstorage:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/libwait:go_default_library",

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -74,6 +74,7 @@ import (
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libdv"
 	"kubevirt.io/kubevirt/tests/libpod"
+	"kubevirt.io/kubevirt/tests/libsecret"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/util"
@@ -232,15 +233,7 @@ var _ = SIGDescribe("Export", func() {
 
 	createExportTokenSecret := func(name, namespace string) *k8sv1.Secret {
 		var err error
-		secret := &k8sv1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      fmt.Sprintf("export-token-%s", name),
-			},
-			StringData: map[string]string{
-				"token": name,
-			},
-		}
+		secret := libsecret.New(fmt.Sprintf("export-token-%s", name), libsecret.DataString{"token": name})
 		token, err = virtClient.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return token
@@ -978,16 +971,7 @@ var _ = SIGDescribe("Export", func() {
 			if err != nil {
 				return "", err
 			}
-			secret := &k8sv1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: flags.KubeVirtInstallNamespace,
-				},
-				StringData: map[string]string{
-					tlsKey:  testKey,
-					tlsCert: testCert,
-				},
-			}
+			secret := libsecret.New(name, libsecret.DataString{tlsKey: testKey, tlsCert: testCert})
 			_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
 			if err != nil {
 				return "", err

--- a/tests/virtctl/BUILD.bazel
+++ b/tests/virtctl/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//tests/framework/cleanup:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libsecret:go_default_library",
         "//tests/libssh:go_default_library",
         "//tests/libstorage:go_default_library",
         "//tests/libvmifact:go_default_library",

--- a/tests/virtctl/credentials.go
+++ b/tests/virtctl/credentials.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -20,6 +19,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libsecret"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -91,22 +91,14 @@ var _ = Describe("[sig-compute][virtctl]credentials", func() {
 			))
 		})
 
-		keySecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: sshKeySecretName,
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: kubevirtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-					Kind:       kubevirtv1.VirtualMachineGroupVersionKind.Kind,
-					Name:       vm.Name,
-					UID:        vm.UID,
-					Controller: pointer.Bool(true),
-				}},
-			},
-			Data: map[string][]byte{
-				"key-file.pub": []byte(testKey1),
-			},
-		}
-
+		keySecret := libsecret.New(sshKeySecretName, libsecret.DataString{"key-file.pub": testKey1})
+		keySecret.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: kubevirtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+			Kind:       kubevirtv1.VirtualMachineGroupVersionKind.Kind,
+			Name:       vm.Name,
+			UID:        vm.UID,
+			Controller: pointer.Bool(true),
+		}}
 		keySecret, err = cli.CoreV1().Secrets(util.NamespaceTestDefault).Create(context.Background(), keySecret, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {
@@ -117,22 +109,14 @@ var _ = Describe("[sig-compute][virtctl]credentials", func() {
 			))
 		})
 
-		passwordSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: passwordSecretName,
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: kubevirtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-					Kind:       kubevirtv1.VirtualMachineGroupVersionKind.Kind,
-					Name:       vm.Name,
-					UID:        vm.UID,
-					Controller: pointer.Bool(true),
-				}},
-			},
-			Data: map[string][]byte{
-				userName: []byte("test-password"),
-			},
-		}
-
+		passwordSecret := libsecret.New(passwordSecretName, libsecret.DataString{userName: "test-password"})
+		passwordSecret.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: kubevirtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+			Kind:       kubevirtv1.VirtualMachineGroupVersionKind.Kind,
+			Name:       vm.Name,
+			UID:        vm.UID,
+			Controller: pointer.Bool(true),
+		}}
 		passwordSecret, err = cli.CoreV1().Secrets(util.NamespaceTestDefault).Create(context.Background(), passwordSecret, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -80,6 +80,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
+	"kubevirt.io/kubevirt/tests/libsecret"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -645,19 +646,8 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				vmi := libvmifact.NewAlpine()
 
 				By("Creating a secret with the binary ACPI SLIC table")
-				secret, err := virtClient.CoreV1().Secrets(testsuite.GetTestNamespace(vmi)).Create(
-					context.Background(),
-					&k8sv1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      secretWithSlicName,
-							Namespace: testsuite.GetTestNamespace(vmi),
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							"slic.bin": slicTable,
-						},
-					},
-					metav1.CreateOptions{})
+				secret := libsecret.New(secretWithSlicName, libsecret.DataBytes{"slic.bin": slicTable})
+				secret, err := virtClient.CoreV1().Secrets(testsuite.GetTestNamespace(vmi)).Create(context.Background(), secret, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(secret).ToNot(BeNil())
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -28,13 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/tests/decorators"
-
-	"kubevirt.io/kubevirt/tests/exec"
-	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/framework/matcher"
-
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -64,8 +57,14 @@ import (
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
+	"kubevirt.io/kubevirt/tests/libsecret"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -430,20 +429,8 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 					// Creat nonexistent secret, so that the VirtualMachineInstance can recover
 					By("Creating a user-data secret")
-					secret := k8sv1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "nonexistent",
-							Namespace: createdVMI.Namespace,
-							Labels: map[string]string{
-								util.SecretLabel: "nonexistent",
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							"userdata": []byte(userData64),
-						},
-					}
-					_, err = kubevirt.Client().CoreV1().Secrets(createdVMI.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+					secret := libsecret.New("nonexistent", libsecret.DataString{"userdata": userData64})
+					_, err = kubevirt.Client().CoreV1().Secrets(createdVMI.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should create secret successfully")
 
 					// Wait for the VirtualMachineInstance to be started, allow warning events to occur


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Change tests that involve defining simple Secret objects to use `tests/libsecret` package

Affected test suites:
- compute/credentials.go
- storage/export.go
- virtctl/credentials.go
- vmi_configuration_test.gp
- vmi_lifecycle_test.go

**Before this PR:**
E2E tests created the secret in-line, some added the `kubevirt.io/secret` label and some dont.

**After this PR:**
E2E tests create the secret object using libsecret, all tests use the same expected configuration.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The global test suite deletes cleanup that runs after each test delete secrets who has `kubevirt.io/secret` label.
It is not clear why this filtering is necessary, therefore we should revisit it and maybe remove the filtering so that all secrets in Kubevirt tests namespaces will get deleted by the global tests suite clean up.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

