### PR TITLE
Add rule to collect issues with the pods

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,6 +24,9 @@ Indicates whether the Software Emulation is enabled in the configuration. Type: 
 ### kubevirt_console_active_connections
 Amount of active Console connections, broken down by namespace and vmi name. Type: Gauge.
 
+### kubevirt_memory_delta_from_requested_bytes
+The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator. Type: Gauge.
+
 ### kubevirt_nodes_with_kvm
 The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. Type: Gauge.
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/krolaw/dhcp4 v0.0.0-20180925202202-7cead472c414
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a
-	github.com/machadovilaca/operator-observability v0.0.14
+	github.com/machadovilaca/operator-observability v0.0.19
 	github.com/mdlayher/vsock v1.2.1
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyP
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a h1:cdX+oxWw1lJDS3EchP+7Oz1XbErk4r7ffVJu1b1MKgI=
 github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a/go.mod h1:qGj2agzgwQ27nYhP3xhLs+IBzE5+ALNUg8bDfMcwPqo=
-github.com/machadovilaca/operator-observability v0.0.14 h1:tS/GKvQRKvpD7pRauS1ulw0AN2V0j2mobg+mFWBt5LE=
-github.com/machadovilaca/operator-observability v0.0.14/go.mod h1:e4Z3VhOXb9InkmSh00JjqBBijE+iD+YMzynBpKB3+gE=
+github.com/machadovilaca/operator-observability v0.0.19 h1:v1rIrdaZ65iaUvKyBd2g29Aklwr0X9IsYukXTxTW6lo=
+github.com/machadovilaca/operator-observability v0.0.19/go.mod h1:e4Z3VhOXb9InkmSh00JjqBBijE+iD+YMzynBpKB3+gE=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/monitoring/rules/recordingrules/BUILD.bazel
+++ b/pkg/monitoring/rules/recordingrules/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "api.go",
         "nodes.go",
+        "operator.go",
         "recordingrules.go",
         "virt.go",
         "vm.go",

--- a/pkg/monitoring/rules/recordingrules/operator.go
+++ b/pkg/monitoring/rules/recordingrules/operator.go
@@ -1,0 +1,48 @@
+/*
+Copyright The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recordingrules
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var operatorRecordingRules = []operatorrules.RecordingRule{
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_memory_delta_from_requested_bytes",
+			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator.",
+			ConstLabels: map[string]string{
+				"reason": "memory_working_set",
+			},
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("topk by(container)(1,max by(container, namespace, node)(container_memory_working_set_bytes{container=~\"virt-controller|virt-api|virt-handler|virt-operator\"}  - on(pod) group_left(node) (kube_pod_container_resource_requests{ container=~\"virt-controller|virt-api|virt-handler|virt-operator\",resource=\"memory\"})))"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_memory_delta_from_requested_bytes",
+			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator.",
+			ConstLabels: map[string]string{
+				"reason": "memory_rss",
+			},
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("topk by(container)(1,max by(container, namespace, node)(container_memory_rss{container=~\"virt-controller|virt-api|virt-handler|virt-operator\"}  - on(pod) group_left(node) (kube_pod_container_resource_requests{ container=~\"virt-controller|virt-api|virt-handler|virt-operator\",resource=\"memory\"})))"),
+	},
+}

--- a/pkg/monitoring/rules/recordingrules/recordingrules.go
+++ b/pkg/monitoring/rules/recordingrules/recordingrules.go
@@ -6,6 +6,7 @@ func Register(namespace string) error {
 	return operatorrules.RegisterRecordingRules(
 		apiRecordingRules,
 		nodesRecordingRules,
+		operatorRecordingRules,
 		virtRecordingRules(namespace),
 		vmRecordingRules,
 		vmiRecordingRules,

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/prometheusrules.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/prometheusrules.go
@@ -62,6 +62,7 @@ func buildRecordingRulesRules() []promv1.Rule {
 		rules = append(rules, promv1.Rule{
 			Record: recordingRule.MetricsOpts.Name,
 			Expr:   recordingRule.Expr,
+			Labels: recordingRule.MetricsOpts.ConstLabels,
 		})
 	}
 

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
@@ -25,7 +25,8 @@ func newRegistry() operatorRegisterer {
 func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 	for _, recordingRuleList := range recordingRules {
 		for _, recordingRule := range recordingRuleList {
-			operatorRegistry.registeredRecordingRules[recordingRule.MetricsOpts.Name] = recordingRule
+			key := recordingRule.MetricsOpts.Name + ":" + recordingRule.Expr.String()
+			operatorRegistry.registeredRecordingRules[key] = recordingRule
 		}
 	}
 
@@ -51,7 +52,10 @@ func ListRecordingRules() []RecordingRule {
 	}
 
 	slices.SortFunc(rules, func(a, b RecordingRule) int {
-		return cmp.Compare(a.GetOpts().Name, b.GetOpts().Name)
+		aKey := a.GetOpts().Name + ":" + a.Expr.String()
+		bKey := b.GetOpts().Name + ":" + b.Expr.String()
+
+		return cmp.Compare(aKey, bKey)
 	})
 
 	return rules

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -241,7 +241,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a
 ## explicit; go 1.20
 github.com/kubevirt/monitoring/pkg/metrics/parser
-# github.com/machadovilaca/operator-observability v0.0.14
+# github.com/machadovilaca/operator-observability v0.0.19
 ## explicit; go 1.21
 github.com/machadovilaca/operator-observability/pkg/operatormetrics
 github.com/machadovilaca/operator-observability/pkg/operatorrules


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
We currently have rules that calculate the available memory for all pods per container.
After this PR:
This pr adds rule that calculate issues with the pods like the memory of the pod with the highest memory exception value by container based on working set/rss memory (in bytes).

For example, if the virt-api container has 2 pods, one of which has an exception rate of 1000 and the other has -2000: the rule will show 1000. 
The rules added is `kubevirt_memory_delta_from_requested_bytes` which includes both the working_set and rss memory minus the requested memory, see:
![Screenshot from 2024-03-31 21-48-41](https://github.com/kubevirt/kubevirt/assets/64130977/f7e81bcf-46d0-44bb-8aec-3b90d5917b16)

**cnv_abnormal added to hco repo, see pr: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2855

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
Jira-ticket: https://issues.redhat.com/browse/CNV-39598
### Why we need it and why it was done in this way
this pr is the next step after deprecating the KubeVirtComponentExceedsRequestedCPU and KubeVirtComponentExceedsRequestedMemory alerts: https://github.com/kubevirt/monitoring/pull/222.
we need it in order to still track memory exceeded issues and other issues in the future without making noise (like the alerts did)

### Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
The rules calculation discussed widely with cnv maintainers. 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
New memory statistics added named kubevirt_memory_delta_from_requested_bytes
```

