### PR TITLE
Migration create mutator: Refactor unit test

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
@@ -60,11 +60,6 @@ func (mutator *MigrationCreateMutator) Mutate(ar *admissionv1.AdmissionReview) *
 	patchBytes, err := patch.GeneratePatchPayload(
 		patch.PatchOperation{
 			Op:    patch.PatchReplaceOp,
-			Path:  "/spec",
-			Value: migration.Spec,
-		},
-		patch.PatchOperation{
-			Op:    patch.PatchReplaceOp,
 			Path:  "/metadata",
 			Value: migration.ObjectMeta,
 		},

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -72,14 +72,7 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 	}
 
 	BeforeEach(func() {
-		migration = &v1.VirtualMachineInstanceMigration{
-			ObjectMeta: k8smetav1.ObjectMeta{
-				Labels: map[string]string{"test": "test"},
-			},
-			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "testVmi",
-			},
-		}
+		migration = newMigration()
 	})
 
 	It("should verify migration spec", func() {
@@ -98,3 +91,14 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 		Expect(migrationMeta.Labels[v1.MigrationSelectorLabel]).To(Equal(migration.Spec.VMIName))
 	})
 })
+
+func newMigration() *v1.VirtualMachineInstanceMigration {
+	return &v1.VirtualMachineInstanceMigration{
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Labels: map[string]string{"test": "test"},
+		},
+		Spec: v1.VirtualMachineInstanceMigrationSpec{
+			VMIName: "testVmi",
+		},
+	}
+}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -47,19 +47,16 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 		resp := mutator.Mutate(ar)
 		Expect(resp.Allowed).To(BeTrue())
 
-		migrationSpec := &v1.VirtualMachineInstanceMigrationSpec{}
 		migrationMeta := &k8smetav1.ObjectMeta{}
 		patchOps := []patch.PatchOperation{
-			{Value: migrationSpec},
 			{Value: migrationMeta},
 		}
+
 		err = json.Unmarshal(resp.Patch, &patchOps)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(patchOps).NotTo(BeEmpty())
 
-		Expect(migrationSpec.VMIName).To(Equal("testVmi"))
 		Expect(migrationMeta.Finalizers).To(ContainElement(v1.VirtualMachineInstanceMigrationFinalizer))
-
 		Expect(migrationMeta.Labels).ToNot(BeNil())
 		Expect(migrationMeta.Labels[v1.MigrationSelectorLabel]).To(Equal(migration.Spec.VMIName))
 	})

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -17,20 +17,23 @@
  *
  */
 
-package mutators
+package mutators_test
 
 import (
 	"encoding/json"
 
-	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	admissionv1 "k8s.io/api/admission/v1"
+
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/mutating-webhook/mutators"
 )
 
 var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
@@ -50,7 +53,7 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 		}
 
 		By("Mutating the Migration")
-		mutator := &MigrationCreateMutator{}
+		mutator := &mutators.MigrationCreateMutator{}
 		resp := mutator.Mutate(ar)
 		Expect(resp.Allowed).To(BeTrue())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The Migration create mutator's tests ran three times - once for each `It` clause.
The Migration create mutator was replacing the migration object's spec for no apparent reason.

After this PR:
The Migration create mutator's test run once, is shorter and more explicit.
The Migration create mutator is no longer replacing the migration object's spec.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

