### PR TITLE
docs: added a command to resolve the build error #11549

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,6 +21,8 @@ Then build the manifests and images:
 make && make push && make manifests
 ```
 
+**Note:** If the `make && make push && make manifests` command gives an unexpected disconnect or Early EOF while fetching the repositories during the building of manifests and images, then adjusting the default timeout using `export PULLER_TIMEOUT=10000` will solve the issue. 
+
 Finally, push the manifests to your cluster:
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,10 @@ Then build the manifests and images:
 make && make push && make manifests
 ```
 
-**Note:** If the `make && make push && make manifests` command gives an unexpected disconnect or Early EOF while fetching the repositories during the building of manifests and images, then adjusting the default timeout using `export PULLER_TIMEOUT=10000` will solve the issue. 
+**Note:** If you see failures related to fetching some modules, try increasing bazel's timeout with:
+ ```bash
+ export PULLER_TIMEOUT=10000
+ ```
 
 Finally, push the manifests to your cluster:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
It resolves the Build command error while fetching the go container registry during the build process.
Before this PR:

After this PR: 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11549 

### Why we need it and why it was done in this way
The following tradeoffs were made: 

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... --> https://kubernetes.slack.com/archives/C0163DT0R8X/p1710856660625449

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
--> 
```release-note
"NONE"
```

