### PR TITLE
refactor: remove informers from controllers

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -284,9 +284,9 @@ func CurrentVMIPod(vmi *v1.VirtualMachineInstance, podIndexer cache.Indexer) (*k
 	return curPod, nil
 }
 
-func VMIActivePodsCount(vmi *v1.VirtualMachineInstance, vmiPodInformer cache.SharedIndexInformer) int {
+func VMIActivePodsCount(vmi *v1.VirtualMachineInstance, vmiPodIndexer cache.Indexer) int {
 
-	objs, err := vmiPodInformer.GetIndexer().ByIndex(cache.NamespaceIndex, vmi.Namespace)
+	objs, err := vmiPodIndexer.ByIndex(cache.NamespaceIndex, vmi.Namespace)
 	if err != nil {
 		return 0
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -393,8 +393,8 @@ func VMIHasHotplugMemory(vmi *v1.VirtualMachineInstance) bool {
 	return vmiHasCondition(vmi, v1.VirtualMachineInstanceMemoryChange)
 }
 
-func AttachmentPods(ownerPod *k8sv1.Pod, podInformer cache.SharedIndexInformer) ([]*k8sv1.Pod, error) {
-	objs, err := podInformer.GetIndexer().ByIndex(cache.NamespaceIndex, ownerPod.Namespace)
+func AttachmentPods(ownerPod *k8sv1.Pod, podIndexer cache.Indexer) ([]*k8sv1.Pod, error) {
+	objs, err := podIndexer.ByIndex(cache.NamespaceIndex, ownerPod.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -236,11 +236,11 @@ func ListDataVolumesFromTemplates(namespace string, dvTemplates []virtv1.DataVol
 	return dataVolumes, nil
 }
 
-func ListDataVolumesFromVolumes(namespace string, volumes []virtv1.Volume, dataVolumeStore cache.Store, pvcIndexer cache.Indexer) ([]*cdiv1.DataVolume, error) {
+func ListDataVolumesFromVolumes(namespace string, volumes []virtv1.Volume, dataVolumeStore cache.Store, pvcStore cache.Store) ([]*cdiv1.DataVolume, error) {
 	dataVolumes := []*cdiv1.DataVolume{}
 
 	for _, volume := range volumes {
-		dataVolumeName := getDataVolumeName(namespace, volume, pvcIndexer)
+		dataVolumeName := getDataVolumeName(namespace, volume, pvcStore)
 		if dataVolumeName == nil {
 			continue
 		}
@@ -258,9 +258,9 @@ func ListDataVolumesFromVolumes(namespace string, volumes []virtv1.Volume, dataV
 	return dataVolumes, nil
 }
 
-func getDataVolumeName(namespace string, volume virtv1.Volume, pvcIndexer cache.Indexer) *string {
+func getDataVolumeName(namespace string, volume virtv1.Volume, pvcStore cache.Store) *string {
 	if volume.VolumeSource.PersistentVolumeClaim != nil {
-		pvcInterface, pvcExists, _ := pvcIndexer.
+		pvcInterface, pvcExists, _ := pvcStore.
 			GetByKey(fmt.Sprintf("%s/%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName))
 		if pvcExists {
 			pvc := pvcInterface.(*v1.PersistentVolumeClaim)
@@ -275,14 +275,14 @@ func getDataVolumeName(namespace string, volume virtv1.Volume, pvcIndexer cache.
 	return nil
 }
 
-func DataVolumeByNameFunc(dataVolumeIndexer cache.Indexer, dataVolumes []*cdiv1.DataVolume) func(name string, namespace string) (*cdiv1.DataVolume, error) {
+func DataVolumeByNameFunc(dataVolumeStore cache.Store, dataVolumes []*cdiv1.DataVolume) func(name string, namespace string) (*cdiv1.DataVolume, error) {
 	return func(name, namespace string) (*cdiv1.DataVolume, error) {
 		for _, dataVolume := range dataVolumes {
 			if dataVolume.Name == name && dataVolume.Namespace == namespace {
 				return dataVolume, nil
 			}
 		}
-		dv, exists, _ := dataVolumeIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+		dv, exists, _ := dataVolumeStore.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
 		if !exists {
 			return nil, fmt.Errorf("unable to find datavolume %s/%s", namespace, name)
 		}

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -194,14 +194,14 @@ func HasUnboundPVC(namespace string, volumes []virtv1.Volume, pvcStore cache.Sto
 	return false
 }
 
-func VolumeReadyToAttachToNode(namespace string, volume virtv1.Volume, dataVolumes []*cdiv1.DataVolume, dataVolumeInformer, pvcInformer cache.SharedInformer) (bool, bool, error) {
+func VolumeReadyToAttachToNode(namespace string, volume virtv1.Volume, dataVolumes []*cdiv1.DataVolume, dataVolumeIndexer, pvcIndexer cache.Indexer) (bool, bool, error) {
 	name := PVCNameFromVirtVolume(&volume)
 
-	dataVolumeFunc := DataVolumeByNameFunc(dataVolumeInformer, dataVolumes)
+	dataVolumeFunc := DataVolumeByNameFunc(dataVolumeIndexer, dataVolumes)
 	wffc := false
 	ready := false
 	// err is always nil
-	pvcInterface, pvcExists, _ := pvcInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+	pvcInterface, pvcExists, _ := pvcIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
 	if pvcExists {
 		var err error
 		pvc := pvcInterface.(*k8sv1.PersistentVolumeClaim)

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -194,14 +194,14 @@ func HasUnboundPVC(namespace string, volumes []virtv1.Volume, pvcStore cache.Sto
 	return false
 }
 
-func VolumeReadyToAttachToNode(namespace string, volume virtv1.Volume, dataVolumes []*cdiv1.DataVolume, dataVolumeIndexer, pvcIndexer cache.Indexer) (bool, bool, error) {
+func VolumeReadyToAttachToNode(namespace string, volume virtv1.Volume, dataVolumes []*cdiv1.DataVolume, dataVolumeStore, pvcStore cache.Store) (bool, bool, error) {
 	name := PVCNameFromVirtVolume(&volume)
 
-	dataVolumeFunc := DataVolumeByNameFunc(dataVolumeIndexer, dataVolumes)
+	dataVolumeFunc := DataVolumeByNameFunc(dataVolumeStore, dataVolumes)
 	wffc := false
 	ready := false
 	// err is always nil
-	pvcInterface, pvcExists, _ := pvcIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+	pvcInterface, pvcExists, _ := pvcStore.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
 	if pvcExists {
 		var err error
 		pvc := pvcInterface.(*k8sv1.PersistentVolumeClaim)

--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -11,8 +11,8 @@ import (
 
 const CancelMigrationFailedVmiNotMigratingErr = "failed to cancel migration - vmi is not migrating"
 
-func ListUnfinishedMigrations(informer cache.SharedIndexInformer) []*v1.VirtualMachineInstanceMigration {
-	objs := informer.GetStore().List()
+func ListUnfinishedMigrations(indexer cache.Indexer) []*v1.VirtualMachineInstanceMigration {
+	objs := indexer.List()
 	migrations := []*v1.VirtualMachineInstanceMigration{}
 	for _, obj := range objs {
 		migration := obj.(*v1.VirtualMachineInstanceMigration)

--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -11,8 +11,8 @@ import (
 
 const CancelMigrationFailedVmiNotMigratingErr = "failed to cancel migration - vmi is not migrating"
 
-func ListUnfinishedMigrations(indexer cache.Indexer) []*v1.VirtualMachineInstanceMigration {
-	objs := indexer.List()
+func ListUnfinishedMigrations(store cache.Store) []*v1.VirtualMachineInstanceMigration {
+	objs := store.List()
 	migrations := []*v1.VirtualMachineInstanceMigration{}
 	for _, obj := range objs {
 		migration := obj.(*v1.VirtualMachineInstanceMigration)

--- a/pkg/util/pdbs/pdbs.go
+++ b/pkg/util/pdbs/pdbs.go
@@ -10,8 +10,8 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 )
 
-func PDBsForVMI(vmi *virtv1.VirtualMachineInstance, pdbInformer cache.SharedIndexInformer) ([]*policyv1.PodDisruptionBudget, error) {
-	pbds, err := pdbInformer.GetIndexer().ByIndex(cache.NamespaceIndex, vmi.Namespace)
+func PDBsForVMI(vmi *virtv1.VirtualMachineInstance, pdbIndexer cache.Indexer) ([]*policyv1.PodDisruptionBudget, error) {
+	pbds, err := pdbIndexer.ByIndex(cache.NamespaceIndex, vmi.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -389,7 +389,7 @@ func (c *DisruptionBudgetController) execute(key string) error {
 	}
 
 	// Only consider pdbs which belong to this vmi
-	pdbs, err := pdbs.PDBsForVMI(vmi, c.pdbInformer)
+	pdbs, err := pdbs.PDBsForVMI(vmi, c.pdbInformer.GetIndexer())
 	if err != nil {
 		log.DefaultLogger().Reason(err).Error("Failed to fetch pod disruption budgets for namespace from cache.")
 		// If the situation does not change there is no benefit in retrying
@@ -430,7 +430,7 @@ func (c *DisruptionBudgetController) isMigrationComplete(vmi *virtv1.VirtualMach
 		return false, nil
 	}
 
-	runningPods := controller.VMIActivePodsCount(vmi, c.podInformer)
+	runningPods := controller.VMIActivePodsCount(vmi, c.podInformer.GetIndexer())
 	return runningPods == 1, nil
 }
 

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -348,7 +348,7 @@ func (c *EvacuationController) execute(key string) error {
 		return fmt.Errorf("failed to list VMIs on node: %v", err)
 	}
 
-	migrations := migrationutils.ListUnfinishedMigrations(c.migrationInformer.GetIndexer())
+	migrations := migrationutils.ListUnfinishedMigrations(c.migrationInformer.GetStore())
 
 	return c.sync(node, vmis, migrations)
 }

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -348,7 +348,7 @@ func (c *EvacuationController) execute(key string) error {
 		return fmt.Errorf("failed to list VMIs on node: %v", err)
 	}
 
-	migrations := migrationutils.ListUnfinishedMigrations(c.migrationInformer)
+	migrations := migrationutils.ListUnfinishedMigrations(c.migrationInformer.GetIndexer())
 
 	return c.sync(node, vmis, migrations)
 }
@@ -522,7 +522,7 @@ func (c *EvacuationController) filterRunningNonMigratingVMIs(vmis []*virtv1.Virt
 			continue
 		}
 
-		if controller.VMIActivePodsCount(vmi, c.vmiPodInformer) > 1 {
+		if controller.VMIActivePodsCount(vmi, c.vmiPodInformer.GetIndexer()) > 1 {
 			// waiting on target/source pods from a previous migration to terminate
 			//
 			// We only want to create a migration when num pods == 1 or else we run the

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -92,22 +92,23 @@ const defaultCatchAllPendingTimeoutSeconds = int64(60 * 15)
 var migrationBackoffError = errors.New(MigrationBackoffReason)
 
 type MigrationController struct {
-	templateService         services.TemplateService
-	clientset               kubecli.KubevirtClient
-	Queue                   workqueue.RateLimitingInterface
-	vmiInformer             cache.SharedIndexInformer
-	podInformer             cache.SharedIndexInformer
-	migrationInformer       cache.SharedIndexInformer
-	nodeInformer            cache.SharedIndexInformer
-	pvcInformer             cache.SharedIndexInformer
-	pdbInformer             cache.SharedIndexInformer
-	migrationPolicyInformer cache.SharedIndexInformer
-	resourceQuotaInformer   cache.SharedIndexInformer
-	recorder                record.EventRecorder
-	podExpectations         *controller.UIDTrackingControllerExpectations
-	migrationStartLock      *sync.Mutex
-	clusterConfig           *virtconfig.ClusterConfig
-	statusUpdater           *status.MigrationStatusUpdater
+	templateService        services.TemplateService
+	clientset              kubecli.KubevirtClient
+	Queue                  workqueue.RateLimitingInterface
+	vmiIndexer             cache.Store
+	podIndexer             cache.Indexer
+	migrationIndexer       cache.Indexer
+	nodeIndexer            cache.Store
+	pvcIndexer             cache.Store
+	pdbIndexer             cache.Indexer
+	migrationPolicyIndexer cache.Store
+	resourceQuotaIndexer   cache.Indexer
+	recorder               record.EventRecorder
+	podExpectations        *controller.UIDTrackingControllerExpectations
+	migrationStartLock     *sync.Mutex
+	clusterConfig          *virtconfig.ClusterConfig
+	statusUpdater          *status.MigrationStatusUpdater
+	hasSynced              func() bool
 
 	// the set of cancelled migrations before being handed off to virt-handler.
 	// the map keys are migration keys
@@ -133,29 +134,33 @@ func NewMigrationController(templateService services.TemplateService,
 ) (*MigrationController, error) {
 
 	c := &MigrationController{
-		templateService:         templateService,
-		Queue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-migration"),
-		vmiInformer:             vmiInformer,
-		podInformer:             podInformer,
-		migrationInformer:       migrationInformer,
-		nodeInformer:            nodeInformer,
-		pvcInformer:             pvcInformer,
-		pdbInformer:             pdbInformer,
-		resourceQuotaInformer:   resourceQuotaInformer,
-		migrationPolicyInformer: migrationPolicyInformer,
-		recorder:                recorder,
-		clientset:               clientset,
-		podExpectations:         controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		migrationStartLock:      &sync.Mutex{},
-		clusterConfig:           clusterConfig,
-		statusUpdater:           status.NewMigrationStatusUpdater(clientset),
-		handOffMap:              make(map[string]struct{}),
+		templateService:        templateService,
+		Queue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-migration"),
+		vmiIndexer:             vmiInformer.GetIndexer(),
+		podIndexer:             podInformer.GetIndexer(),
+		migrationIndexer:       migrationInformer.GetIndexer(),
+		nodeIndexer:            nodeInformer.GetIndexer(),
+		pvcIndexer:             pvcInformer.GetIndexer(),
+		pdbIndexer:             pdbInformer.GetIndexer(),
+		resourceQuotaIndexer:   resourceQuotaInformer.GetIndexer(),
+		migrationPolicyIndexer: migrationPolicyInformer.GetIndexer(),
+		recorder:               recorder,
+		clientset:              clientset,
+		podExpectations:        controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		migrationStartLock:     &sync.Mutex{},
+		clusterConfig:          clusterConfig,
+		statusUpdater:          status.NewMigrationStatusUpdater(clientset),
+		handOffMap:             make(map[string]struct{}),
 
 		unschedulablePendingTimeoutSeconds: defaultUnschedulablePendingTimeoutSeconds,
 		catchAllPendingTimeoutSeconds:      defaultCatchAllPendingTimeoutSeconds,
 	}
 
-	_, err := c.vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	c.hasSynced = func() bool {
+		return vmiInformer.HasSynced() && podInformer.HasSynced() && migrationInformer.HasSynced() && pdbInformer.HasSynced() && resourceQuotaInformer.HasSynced()
+	}
+
+	_, err := vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addVMI,
 		DeleteFunc: c.deleteVMI,
 		UpdateFunc: c.updateVMI,
@@ -164,7 +169,7 @@ func NewMigrationController(templateService services.TemplateService,
 		return nil, err
 	}
 
-	_, err = c.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addPod,
 		DeleteFunc: c.deletePod,
 		UpdateFunc: c.updatePod,
@@ -173,7 +178,7 @@ func NewMigrationController(templateService services.TemplateService,
 		return nil, err
 	}
 
-	_, err = c.migrationInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = migrationInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addMigration,
 		DeleteFunc: c.deleteMigration,
 		UpdateFunc: c.updateMigration,
@@ -182,14 +187,14 @@ func NewMigrationController(templateService services.TemplateService,
 		return nil, err
 	}
 
-	_, err = c.pdbInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = pdbInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: c.updatePDB,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = c.resourceQuotaInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = resourceQuotaInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: c.updateResourceQuota,
 		DeleteFunc: c.deleteResourceQuota,
 	})
@@ -206,7 +211,7 @@ func (c *MigrationController) Run(threadiness int, stopCh <-chan struct{}) {
 	log.Log.Info("Starting migration controller.")
 
 	// Wait for cache sync before we start the pod controller
-	cache.WaitForCacheSync(stopCh, c.vmiInformer.HasSynced, c.podInformer.HasSynced, c.migrationInformer.HasSynced, c.pdbInformer.HasSynced, c.resourceQuotaInformer.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.hasSynced)
 	// Start the actual work
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
@@ -295,7 +300,7 @@ func (c *MigrationController) execute(key string) error {
 	var targetPods []*k8sv1.Pod
 
 	// Fetch the latest state from cache
-	obj, exists, err := c.migrationInformer.GetStore().GetByKey(key)
+	obj, exists, err := c.migrationIndexer.GetByKey(key)
 	if err != nil {
 		return err
 	}
@@ -319,7 +324,7 @@ func (c *MigrationController) execute(key string) error {
 		return err
 	}
 
-	vmiObj, vmiExists, err := c.vmiInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", migration.Namespace, migration.Spec.VMIName))
+	vmiObj, vmiExists, err := c.vmiIndexer.GetByKey(fmt.Sprintf("%s/%s", migration.Namespace, migration.Spec.VMIName))
 	if err != nil {
 		return err
 	}
@@ -383,7 +388,7 @@ func (c *MigrationController) canMigrateVMI(migration *virtv1.VirtualMachineInst
 	curMigrationUID := vmi.Status.MigrationState.MigrationUID
 
 	// check to see if the curMigrationUID still exists or is finalized
-	objs, err := c.migrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, migration.Namespace)
+	objs, err := c.migrationIndexer.ByIndex(cache.NamespaceIndex, migration.Namespace)
 
 	if err != nil {
 		return false, err
@@ -416,7 +421,7 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 	if podExists {
 		pod = pods[0]
 
-		if attachmentPods, err := controller.AttachmentPods(pod, c.podInformer.GetIndexer()); err != nil {
+		if attachmentPods, err := controller.AttachmentPods(pod, c.podIndexer); err != nil {
 			return fmt.Errorf(failedGetAttractionPodsFmt, err)
 		} else {
 			attachmentPodExists = len(attachmentPods) > 0
@@ -505,7 +510,7 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 	}
 
 	controller.SetVMIMigrationPhaseTransitionTimestamp(migration, migrationCopy)
-	controller.SetSourcePod(migrationCopy, vmi, c.podInformer.GetIndexer())
+	controller.SetSourcePod(migrationCopy, vmi, c.podIndexer)
 
 	if !equality.Semantic.DeepEqual(migration.Status, migrationCopy.Status) {
 		err := c.statusUpdater.UpdateStatus(migrationCopy)
@@ -889,7 +894,7 @@ func (c *MigrationController) handleTargetPodHandoff(migration *virtv1.VirtualMa
 	vmiCopy.ObjectMeta.Labels[virtv1.MigrationTargetNodeNameLabel] = pod.Spec.NodeName
 
 	if controller.VMIHasHotplugVolumes(vmiCopy) {
-		attachmentPods, err := controller.AttachmentPods(pod, c.podInformer.GetIndexer())
+		attachmentPods, err := controller.AttachmentPods(pod, c.podIndexer)
 		if err != nil {
 			return fmt.Errorf(failedGetAttractionPodsFmt, err)
 		}
@@ -994,7 +999,7 @@ func (c *MigrationController) handleTargetPodCreation(key string, migration *vir
 	if c.podExpectations.AllPendingCreations() > 0 {
 		c.Queue.AddAfter(key, 1*time.Second)
 		return nil
-	} else if controller.VMIActivePodsCount(vmi, c.podInformer) > 1 {
+	} else if controller.VMIActivePodsCount(vmi, c.podIndexer) > 1 {
 		log.Log.Object(migration).Infof("Waiting to schedule target pod for migration because there are already multiple pods running for vmi %s/%s", vmi.Namespace, vmi.Name)
 		c.Queue.AddAfter(key, 1*time.Second)
 		return nil
@@ -1033,7 +1038,7 @@ func (c *MigrationController) handleTargetPodCreation(key string, migration *vir
 	// should create the target pod
 	if vmi.IsRunning() {
 		if migrations.VMIMigratableOnEviction(c.clusterConfig, vmi) {
-			pdbs, err := pdbs.PDBsForVMI(vmi, c.pdbInformer)
+			pdbs, err := pdbs.PDBsForVMI(vmi, c.pdbIndexer)
 			if err != nil {
 				return err
 			}
@@ -1063,14 +1068,14 @@ func (c *MigrationController) handleTargetPodCreation(key string, migration *vir
 }
 
 func (c *MigrationController) createAttachmentPod(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) error {
-	sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
+	sourcePod, err := controller.CurrentVMIPod(vmi, c.podIndexer)
 	if err != nil {
 		return fmt.Errorf("failed to get current VMI pod: %v", err)
 	}
 
 	volumes := getHotplugVolumes(vmi, sourcePod)
 
-	volumeNamesPVCMap, err := storagetypes.VirtVolumesToPVCMap(volumes, c.pvcInformer.GetStore(), virtLauncherPod.Namespace)
+	volumeNamesPVCMap, err := storagetypes.VirtVolumesToPVCMap(volumes, c.pvcIndexer, virtLauncherPod.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get PVC map: %v", err)
 	}
@@ -1267,7 +1272,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 		}
 
 		if !targetPodExists {
-			sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
+			sourcePod, err := controller.CurrentVMIPod(vmi, c.podIndexer)
 			if err != nil {
 				log.Log.Reason(err).Error("Failed to fetch pods for namespace from cache.")
 				return err
@@ -1292,7 +1297,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 			return c.handleTargetPodCreation(key, migration, vmi, sourcePod)
 		} else if isPodReady(pod) {
 			if controller.VMIHasHotplugVolumes(vmi) {
-				attachmentPods, err := controller.AttachmentPods(pod, c.podInformer.GetIndexer())
+				attachmentPods, err := controller.AttachmentPods(pod, c.podIndexer)
 				if err != nil {
 					return fmt.Errorf(failedGetAttractionPodsFmt, err)
 				}
@@ -1389,7 +1394,7 @@ func (c *MigrationController) listMatchingTargetPods(migration *virtv1.VirtualMa
 		return nil, err
 	}
 
-	objs, err := c.podInformer.GetIndexer().ByIndex(cache.NamespaceIndex, migration.Namespace)
+	objs, err := c.podIndexer.ByIndex(cache.NamespaceIndex, migration.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1448,7 +1453,7 @@ func (c *MigrationController) resolveControllerRef(namespace string, controllerR
 	if controllerRef.Kind != virtv1.VirtualMachineInstanceMigrationGroupVersionKind.Kind {
 		return nil
 	}
-	migration, exists, err := c.migrationInformer.GetStore().GetByKey(namespace + "/" + controllerRef.Name)
+	migration, exists, err := c.migrationIndexer.GetByKey(namespace + "/" + controllerRef.Name)
 	if err != nil {
 		return nil
 	}
@@ -1536,7 +1541,7 @@ func (c *MigrationController) updatePod(old, cur interface{}) {
 func (c *MigrationController) updateResourceQuota(_, cur interface{}) {
 	curResourceQuota := cur.(*k8sv1.ResourceQuota)
 	log.Log.V(4).Object(curResourceQuota).Infof("ResourceQuota updated")
-	objs, _ := c.migrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, curResourceQuota.Namespace)
+	objs, _ := c.migrationIndexer.ByIndex(cache.NamespaceIndex, curResourceQuota.Namespace)
 	for _, obj := range objs {
 		migration := obj.(*virtv1.VirtualMachineInstanceMigration)
 		if migration.Status.Conditions == nil {
@@ -1556,7 +1561,7 @@ func (c *MigrationController) updateResourceQuota(_, cur interface{}) {
 func (c *MigrationController) deleteResourceQuota(obj interface{}) {
 	resourceQuota := obj.(*k8sv1.ResourceQuota)
 	log.Log.V(4).Object(resourceQuota).Infof("ResourceQuota deleted")
-	objs, _ := c.migrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, resourceQuota.Namespace)
+	objs, _ := c.migrationIndexer.ByIndex(cache.NamespaceIndex, resourceQuota.Namespace)
 	for _, obj := range objs {
 		migration := obj.(*virtv1.VirtualMachineInstanceMigration)
 		if migration.Status.Conditions == nil {
@@ -1619,7 +1624,7 @@ func (c *MigrationController) updatePDB(old, cur interface{}) {
 		return
 	}
 
-	objs, err := c.migrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, curPDB.Namespace)
+	objs, err := c.migrationIndexer.ByIndex(cache.NamespaceIndex, curPDB.Namespace)
 	if err != nil {
 		return
 	}
@@ -1691,7 +1696,7 @@ func (c *MigrationController) garbageCollectFinalizedMigrations(vmi *virtv1.Virt
 }
 
 func (c *MigrationController) filterMigrations(namespace string, filter func(*virtv1.VirtualMachineInstanceMigration) bool) ([]*virtv1.VirtualMachineInstanceMigration, error) {
-	objs, err := c.migrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	objs, err := c.migrationIndexer.ByIndex(cache.NamespaceIndex, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1800,7 +1805,7 @@ func (c *MigrationController) deleteVMI(obj interface{}) {
 func (c *MigrationController) outboundMigrationsOnNode(node string, runningMigrations []*virtv1.VirtualMachineInstanceMigration) (int, error) {
 	sum := 0
 	for _, migration := range runningMigrations {
-		if vmi, exists, _ := c.vmiInformer.GetStore().GetByKey(migration.Namespace + "/" + migration.Spec.VMIName); exists {
+		if vmi, exists, _ := c.vmiIndexer.GetByKey(migration.Namespace + "/" + migration.Spec.VMIName); exists {
 			if vmi.(*virtv1.VirtualMachineInstance).Status.NodeName == node {
 				sum = sum + 1
 			}
@@ -1815,14 +1820,14 @@ func (c *MigrationController) outboundMigrationsOnNode(node string, runningMigra
 func (c *MigrationController) findRunningMigrations() ([]*virtv1.VirtualMachineInstanceMigration, error) {
 
 	// Don't start new migrations if we wait for migration object updates because of new target pods
-	notFinishedMigrations := migrations.ListUnfinishedMigrations(c.migrationInformer)
+	notFinishedMigrations := migrations.ListUnfinishedMigrations(c.migrationIndexer)
 	var runningMigrations []*virtv1.VirtualMachineInstanceMigration
 	for _, migration := range notFinishedMigrations {
 		if migration.IsRunning() {
 			runningMigrations = append(runningMigrations, migration)
 			continue
 		}
-		vmi, exists, err := c.vmiInformer.GetStore().GetByKey(migration.Namespace + "/" + migration.Spec.VMIName)
+		vmi, exists, err := c.vmiIndexer.GetByKey(migration.Namespace + "/" + migration.Spec.VMIName)
 		if err != nil {
 			return nil, err
 		}
@@ -1841,7 +1846,7 @@ func (c *MigrationController) findRunningMigrations() ([]*virtv1.VirtualMachineI
 }
 
 func (c *MigrationController) getNodeForVMI(vmi *virtv1.VirtualMachineInstance) (*k8sv1.Node, error) {
-	obj, exists, err := c.nodeInformer.GetStore().GetByKey(vmi.Status.NodeName)
+	obj, exists, err := c.nodeIndexer.GetByKey(vmi.Status.NodeName)
 
 	if err != nil {
 		return nil, fmt.Errorf("cannot get nodes to migrate VMI with host-model CPU. error: %v", err)
@@ -1867,7 +1872,7 @@ func (c *MigrationController) alertIfHostModelIsUnschedulable(vmi *virtv1.Virtua
 		}
 	}
 
-	nodes := c.nodeInformer.GetStore().List()
+	nodes := c.nodeIndexer.List()
 	for _, nodeInterface := range nodes {
 		node := nodeInterface.(*k8sv1.Node)
 
@@ -1947,7 +1952,7 @@ func (c *MigrationController) matchMigrationPolicy(vmi *virtv1.VirtualMachineIns
 
 	// Fetch cluster policies
 	var policies []v1alpha1.MigrationPolicy
-	migrationInterfaceList := c.migrationPolicyInformer.GetStore().List()
+	migrationInterfaceList := c.migrationPolicyIndexer.List()
 	for _, obj := range migrationInterfaceList {
 		policy := obj.(*v1alpha1.MigrationPolicy)
 		policies = append(policies, *policy)

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -416,7 +416,7 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 	if podExists {
 		pod = pods[0]
 
-		if attachmentPods, err := controller.AttachmentPods(pod, c.podInformer); err != nil {
+		if attachmentPods, err := controller.AttachmentPods(pod, c.podInformer.GetIndexer()); err != nil {
 			return fmt.Errorf(failedGetAttractionPodsFmt, err)
 		} else {
 			attachmentPodExists = len(attachmentPods) > 0
@@ -889,7 +889,7 @@ func (c *MigrationController) handleTargetPodHandoff(migration *virtv1.VirtualMa
 	vmiCopy.ObjectMeta.Labels[virtv1.MigrationTargetNodeNameLabel] = pod.Spec.NodeName
 
 	if controller.VMIHasHotplugVolumes(vmiCopy) {
-		attachmentPods, err := controller.AttachmentPods(pod, c.podInformer)
+		attachmentPods, err := controller.AttachmentPods(pod, c.podInformer.GetIndexer())
 		if err != nil {
 			return fmt.Errorf(failedGetAttractionPodsFmt, err)
 		}
@@ -1292,7 +1292,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 			return c.handleTargetPodCreation(key, migration, vmi, sourcePod)
 		} else if isPodReady(pod) {
 			if controller.VMIHasHotplugVolumes(vmi) {
-				attachmentPods, err := controller.AttachmentPods(pod, c.podInformer)
+				attachmentPods, err := controller.AttachmentPods(pod, c.podInformer.GetIndexer())
 				if err != nil {
 					return fmt.Errorf(failedGetAttractionPodsFmt, err)
 				}

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -35,8 +35,8 @@ const (
 type NodeController struct {
 	clientset        kubecli.KubevirtClient
 	Queue            workqueue.RateLimitingInterface
-	nodeIndexer      cache.Store
-	vmiIndexer       cache.Store
+	nodeStore        cache.Store
+	vmiStore         cache.Store
 	recorder         record.EventRecorder
 	heartBeatTimeout time.Duration
 	recheckInterval  time.Duration
@@ -48,8 +48,8 @@ func NewNodeController(clientset kubecli.KubevirtClient, nodeInformer cache.Shar
 	c := &NodeController{
 		clientset:        clientset,
 		Queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-node"),
-		nodeIndexer:      nodeInformer.GetIndexer(),
-		vmiIndexer:       vmiInformer.GetIndexer(),
+		nodeStore:        nodeInformer.GetStore(),
+		vmiStore:         vmiInformer.GetStore(),
 		recorder:         recorder,
 		heartBeatTimeout: 5 * time.Minute,
 		recheckInterval:  1 * time.Minute,
@@ -164,7 +164,7 @@ func (c *NodeController) Execute() bool {
 func (c *NodeController) execute(key string) error {
 	logger := log.DefaultLogger()
 
-	obj, nodeExists, err := c.nodeIndexer.GetByKey(key)
+	obj, nodeExists, err := c.nodeStore.GetByKey(key)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -35,11 +35,12 @@ const (
 type NodeController struct {
 	clientset        kubecli.KubevirtClient
 	Queue            workqueue.RateLimitingInterface
-	nodeInformer     cache.SharedIndexInformer
-	vmiInformer      cache.SharedIndexInformer
+	nodeIndexer      cache.Store
+	vmiIndexer       cache.Store
 	recorder         record.EventRecorder
 	heartBeatTimeout time.Duration
 	recheckInterval  time.Duration
+	hasSynced        func() bool
 }
 
 // NewNodeController creates a new instance of the NodeController struct.
@@ -47,14 +48,18 @@ func NewNodeController(clientset kubecli.KubevirtClient, nodeInformer cache.Shar
 	c := &NodeController{
 		clientset:        clientset,
 		Queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-node"),
-		nodeInformer:     nodeInformer,
-		vmiInformer:      vmiInformer,
+		nodeIndexer:      nodeInformer.GetIndexer(),
+		vmiIndexer:       vmiInformer.GetIndexer(),
 		recorder:         recorder,
 		heartBeatTimeout: 5 * time.Minute,
 		recheckInterval:  1 * time.Minute,
 	}
 
-	_, err := c.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	c.hasSynced = func() bool {
+		return nodeInformer.HasSynced() && vmiInformer.HasSynced()
+	}
+
+	_, err := nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addNode,
 		DeleteFunc: c.deleteNode,
 		UpdateFunc: c.updateNode,
@@ -63,7 +68,7 @@ func NewNodeController(clientset kubecli.KubevirtClient, nodeInformer cache.Shar
 		return nil, err
 	}
 
-	_, err = c.vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addVirtualMachine,
 		DeleteFunc: func(_ interface{}) { /* nothing to do */ },
 		UpdateFunc: c.updateVirtualMachine,
@@ -119,7 +124,7 @@ func (c *NodeController) Run(threadiness int, stopCh <-chan struct{}) {
 	log.Log.Info("Starting node controller.")
 
 	// Wait for cache sync before we start the node controller
-	cache.WaitForCacheSync(stopCh, c.nodeInformer.HasSynced, c.vmiInformer.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.hasSynced)
 
 	// Start the actual work
 	for i := 0; i < threadiness; i++ {
@@ -159,7 +164,7 @@ func (c *NodeController) Execute() bool {
 func (c *NodeController) execute(key string) error {
 	logger := log.DefaultLogger()
 
-	obj, nodeExists, err := c.nodeInformer.GetStore().GetByKey(key)
+	obj, nodeExists, err := c.nodeIndexer.GetByKey(key)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -170,7 +170,7 @@ func NewVMIController(templateService services.TemplateService,
 	}
 
 	c.hasSynced = func() bool {
-		return vmiInformer.HasSynced() && vmInformer.HasSynced() && podInformer.HasSynced() && pvcInformer.HasSynced() && dataVolumeInformer.HasSynced() && cdiInformer.HasSynced()
+		return vmInformer.HasSynced() && vmiInformer.HasSynced() && podInformer.HasSynced() && dataVolumeInformer.HasSynced() && cdiConfigInformer.HasSynced() && cdiInformer.HasSynced() && pvcInformer.HasSynced()
 	}
 
 	_, err := vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -151,25 +151,29 @@ func NewVMIController(templateService services.TemplateService,
 ) (*VMIController, error) {
 
 	c := &VMIController{
-		templateService:    templateService,
-		Queue:              workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-vmi"),
-		vmiInformer:        vmiInformer,
-		vmInformer:         vmInformer,
-		podInformer:        podInformer,
-		pvcInformer:        pvcInformer,
-		recorder:           recorder,
-		clientset:          clientset,
-		podExpectations:    controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		vmiExpectations:    controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		dataVolumeInformer: dataVolumeInformer,
-		cdiInformer:        cdiInformer,
-		cdiConfigInformer:  cdiConfigInformer,
-		clusterConfig:      clusterConfig,
-		topologyHinter:     topologyHinter,
-		cidsMap:            newCIDsMap(),
+		templateService:   templateService,
+		Queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-vmi"),
+		vmiIndexer:        vmiInformer.GetIndexer(),
+		vmIndexer:         vmInformer.GetIndexer(),
+		podIndexer:        podInformer.GetIndexer(),
+		pvcIndexer:        pvcInformer.GetIndexer(),
+		recorder:          recorder,
+		clientset:         clientset,
+		podExpectations:   controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		vmiExpectations:   controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		dataVolumeIndexer: dataVolumeInformer.GetIndexer(),
+		cdiIndexer:        cdiInformer.GetIndexer(),
+		cdiConfigIndexer:  cdiConfigInformer.GetIndexer(),
+		clusterConfig:     clusterConfig,
+		topologyHinter:    topologyHinter,
+		cidsMap:           newCIDsMap(),
 	}
 
-	_, err := c.vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	c.hasSynced = func() bool {
+		return vmiInformer.HasSynced() && vmInformer.HasSynced() && podInformer.HasSynced() && pvcInformer.HasSynced() && dataVolumeInformer.HasSynced() && cdiInformer.HasSynced()
+	}
+
+	_, err := vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addVirtualMachineInstance,
 		DeleteFunc: c.deleteVirtualMachineInstance,
 		UpdateFunc: c.updateVirtualMachineInstance,
@@ -178,7 +182,7 @@ func NewVMIController(templateService services.TemplateService,
 		return nil, err
 	}
 
-	_, err = c.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addPod,
 		DeleteFunc: c.deletePod,
 		UpdateFunc: c.updatePod,
@@ -187,7 +191,7 @@ func NewVMIController(templateService services.TemplateService,
 		return nil, err
 	}
 
-	_, err = c.dataVolumeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = dataVolumeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addDataVolume,
 		DeleteFunc: c.deleteDataVolume,
 		UpdateFunc: c.updateDataVolume,
@@ -196,7 +200,7 @@ func NewVMIController(templateService services.TemplateService,
 		return nil, err
 	}
 
-	_, err = c.pvcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = pvcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addPVC,
 		UpdateFunc: c.updatePVC,
 	})
@@ -251,22 +255,23 @@ func (i informalSyncError) RequiresRequeue() bool {
 }
 
 type VMIController struct {
-	templateService    services.TemplateService
-	clientset          kubecli.KubevirtClient
-	Queue              workqueue.RateLimitingInterface
-	vmiInformer        cache.SharedIndexInformer
-	vmInformer         cache.SharedIndexInformer
-	podInformer        cache.SharedIndexInformer
-	pvcInformer        cache.SharedIndexInformer
-	topologyHinter     topology.Hinter
-	recorder           record.EventRecorder
-	podExpectations    *controller.UIDTrackingControllerExpectations
-	vmiExpectations    *controller.UIDTrackingControllerExpectations
-	dataVolumeInformer cache.SharedIndexInformer
-	cdiInformer        cache.SharedIndexInformer
-	cdiConfigInformer  cache.SharedIndexInformer
-	clusterConfig      *virtconfig.ClusterConfig
-	cidsMap            *cidsMap
+	templateService   services.TemplateService
+	clientset         kubecli.KubevirtClient
+	Queue             workqueue.RateLimitingInterface
+	vmiIndexer        cache.Indexer
+	vmIndexer         cache.Store
+	podIndexer        cache.Indexer
+	pvcIndexer        cache.Indexer
+	topologyHinter    topology.Hinter
+	recorder          record.EventRecorder
+	podExpectations   *controller.UIDTrackingControllerExpectations
+	vmiExpectations   *controller.UIDTrackingControllerExpectations
+	dataVolumeIndexer cache.Indexer
+	cdiIndexer        cache.Store
+	cdiConfigIndexer  cache.Store
+	clusterConfig     *virtconfig.ClusterConfig
+	cidsMap           *cidsMap
+	hasSynced         func() bool
 }
 
 func (c *VMIController) Run(threadiness int, stopCh <-chan struct{}) {
@@ -275,18 +280,11 @@ func (c *VMIController) Run(threadiness int, stopCh <-chan struct{}) {
 	log.Log.Info("Starting vmi controller.")
 
 	// Wait for cache sync before we start the pod controller
-	cache.WaitForCacheSync(stopCh,
-		c.vmInformer.HasSynced,
-		c.vmiInformer.HasSynced,
-		c.podInformer.HasSynced,
-		c.dataVolumeInformer.HasSynced,
-		c.cdiConfigInformer.HasSynced,
-		c.cdiInformer.HasSynced,
-		c.pvcInformer.HasSynced,
-	)
+	cache.WaitForCacheSync(stopCh, c.hasSynced)
+
 	// Sync the CIDs from exist VMIs
 	var vmis []*virtv1.VirtualMachineInstance
-	for _, obj := range c.vmiInformer.GetStore().List() {
+	for _, obj := range c.vmiIndexer.List() {
 		vmi := obj.(*virtv1.VirtualMachineInstance)
 		vmis = append(vmis, vmi)
 	}
@@ -333,7 +331,7 @@ func (c *VMIController) Execute() bool {
 func (c *VMIController) execute(key string) error {
 
 	// Fetch the latest Vm state from cache
-	obj, exists, err := c.vmiInformer.GetStore().GetByKey(key)
+	obj, exists, err := c.vmiIndexer.GetByKey(key)
 
 	if err != nil {
 		return err
@@ -374,14 +372,14 @@ func (c *VMIController) execute(key string) error {
 
 	// Only consider pods which belong to this vmi
 	// excluding unfinalized migration targets from this list.
-	pod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
+	pod, err := controller.CurrentVMIPod(vmi, c.podIndexer)
 	if err != nil {
 		logger.Reason(err).Error("Failed to fetch pods for namespace from cache.")
 		return err
 	}
 
 	// Get all dataVolumes associated with this vmi
-	dataVolumes, err := storagetypes.ListDataVolumesFromVolumes(vmi.Namespace, vmi.Spec.Volumes, c.dataVolumeInformer.GetStore(), c.pvcInformer)
+	dataVolumes, err := storagetypes.ListDataVolumesFromVolumes(vmi.Namespace, vmi.Spec.Volumes, c.dataVolumeIndexer, c.pvcIndexer)
 	if err != nil {
 		logger.Reason(err).Error("Failed to fetch dataVolumes for namespace from cache.")
 		return err
@@ -512,7 +510,7 @@ func (c *VMIController) hasOwnerVM(vmi *virtv1.VirtualMachineInstance) bool {
 		return false
 	}
 
-	obj, exists, _ := c.vmInformer.GetStore().GetByKey(vmi.Namespace + "/" + controllerRef.Name)
+	obj, exists, _ := c.vmIndexer.GetByKey(vmi.Namespace + "/" + controllerRef.Name)
 	if !exists {
 		return false
 	}
@@ -1141,7 +1139,7 @@ func podExists(pod *k8sv1.Pod) bool {
 
 func (c *VMIController) hotplugPodsReady(vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) (bool, syncError) {
 	if controller.VMIHasHotplugVolumes(vmi) {
-		hotplugAttachmentPods, err := controller.AttachmentPods(virtLauncherPod, c.podInformer)
+		hotplugAttachmentPods, err := controller.AttachmentPods(virtLauncherPod, c.podIndexer)
 		if err != nil {
 			return false, &syncErrorImpl{fmt.Errorf("failed to get attachment pods: %v", err), FailedHotplugSyncReason}
 		}
@@ -1263,7 +1261,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 		}
 
 		hotplugVolumes := getHotplugVolumes(vmi, pod)
-		hotplugAttachmentPods, err := controller.AttachmentPods(pod, c.podInformer)
+		hotplugAttachmentPods, err := controller.AttachmentPods(pod, c.podIndexer)
 		if err != nil {
 			return &syncErrorImpl{fmt.Errorf("failed to get attachment pods: %v", err), FailedHotplugSyncReason}
 		}
@@ -1303,7 +1301,7 @@ func (c *VMIController) handleSyncDataVolumes(vmi *virtv1.VirtualMachineInstance
 	for _, volume := range vmi.Spec.Volumes {
 		// Check both DVs and PVCs
 		if volume.VolumeSource.DataVolume != nil || volume.VolumeSource.PersistentVolumeClaim != nil {
-			volumeReady, volumeWffc, err := storagetypes.VolumeReadyToAttachToNode(vmi.Namespace, volume, dataVolumes, c.dataVolumeInformer, c.pvcInformer)
+			volumeReady, volumeWffc, err := storagetypes.VolumeReadyToAttachToNode(vmi.Namespace, volume, dataVolumes, c.dataVolumeIndexer, c.pvcIndexer)
 			if err != nil {
 				if _, ok := err.(storagetypes.PvcNotFoundError); ok {
 					// due to the eventually consistent nature of controllers, CDI or users may need some time to actually crate the PVC.
@@ -1605,7 +1603,7 @@ func (c *VMIController) enqueueVirtualMachine(obj interface{}) {
 func (c *VMIController) resolveControllerRef(namespace string, controllerRef *v1.OwnerReference) *virtv1.VirtualMachineInstance {
 	if controllerRef != nil && controllerRef.Kind == "Pod" {
 		// This could be an attachment pod, look up the pod, and check if it is owned by a VMI.
-		obj, exists, err := c.podInformer.GetIndexer().GetByKey(namespace + "/" + controllerRef.Name)
+		obj, exists, err := c.podIndexer.GetByKey(namespace + "/" + controllerRef.Name)
 		if err != nil {
 			return nil
 		}
@@ -1620,7 +1618,7 @@ func (c *VMIController) resolveControllerRef(namespace string, controllerRef *v1
 	if controllerRef == nil || controllerRef.Kind != virtv1.VirtualMachineInstanceGroupVersionKind.Kind {
 		return nil
 	}
-	vmi, exists, err := c.vmiInformer.GetStore().GetByKey(namespace + "/" + controllerRef.Name)
+	vmi, exists, err := c.vmiIndexer.GetByKey(namespace + "/" + controllerRef.Name)
 	if err != nil {
 		return nil
 	}
@@ -1640,7 +1638,7 @@ func (c *VMIController) listVMIsMatchingDV(namespace string, dvName string) ([]*
 	// TODO - refactor if/when dv/pvc do not have the same name
 	vmis := []*virtv1.VirtualMachineInstance{}
 	for _, indexName := range []string{"dv", "pvc"} {
-		objs, err := c.vmiInformer.GetIndexer().ByIndex(indexName, namespace+"/"+dvName)
+		objs, err := c.vmiIndexer.ByIndex(indexName, namespace+"/"+dvName)
 		if err != nil {
 			return nil, err
 		}
@@ -1702,7 +1700,7 @@ func (c *VMIController) deleteAllMatchingPods(vmi *virtv1.VirtualMachineInstance
 
 // listPodsFromNamespace takes a namespace and returns all Pods from the pod cache which run in this namespace
 func (c *VMIController) listPodsFromNamespace(namespace string) ([]*k8sv1.Pod, error) {
-	objs, err := c.podInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	objs, err := c.podIndexer.ByIndex(cache.NamespaceIndex, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1906,7 +1904,7 @@ func (c *VMIController) handleHotplugVolumes(hotplugVolumes []*virtv1.Volume, ho
 	// Find all ready volumes
 	for _, volume := range hotplugVolumes {
 		var err error
-		ready, wffc, err := storagetypes.VolumeReadyToAttachToNode(vmi.Namespace, *volume, dataVolumes, c.dataVolumeInformer, c.pvcInformer)
+		ready, wffc, err := storagetypes.VolumeReadyToAttachToNode(vmi.Namespace, *volume, dataVolumes, c.dataVolumeIndexer, c.pvcIndexer)
 		if err != nil {
 			return &syncErrorImpl{fmt.Errorf("Error determining volume status %v", err), PVCNotReadyReason}
 		}
@@ -2076,14 +2074,14 @@ func (c *VMIController) createAttachmentPodTemplate(vmi *virtv1.VirtualMachineIn
 	var pod *k8sv1.Pod
 	var err error
 
-	volumeNamesPVCMap, err := storagetypes.VirtVolumesToPVCMap(volumes, c.pvcInformer.GetStore(), virtlauncherPod.Namespace)
+	volumeNamesPVCMap, err := storagetypes.VirtVolumesToPVCMap(volumes, c.pvcIndexer, virtlauncherPod.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get PVC map: %v", err)
 	}
 	for volumeName, pvc := range volumeNamesPVCMap {
 		//Verify the PVC is ready to be used.
 		populated, err := cdiv1.IsSucceededOrPendingPopulation(pvc, func(name, namespace string) (*cdiv1.DataVolume, error) {
-			dv, exists, _ := c.dataVolumeInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+			dv, exists, _ := c.dataVolumeIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, name))
 			if !exists {
 				return nil, fmt.Errorf("unable to find datavolume %s/%s", namespace, name)
 			}
@@ -2110,7 +2108,7 @@ func (c *VMIController) createAttachmentPopulateTriggerPodTemplate(volume *virtv
 		return nil, errors.New("Unable to hotplug, claim not PVC or Datavolume")
 	}
 
-	pvc, exists, isBlock, err := storagetypes.IsPVCBlockFromStore(c.pvcInformer.GetStore(), virtlauncherPod.Namespace, claimName)
+	pvc, exists, isBlock, err := storagetypes.IsPVCBlockFromStore(c.pvcIndexer, virtlauncherPod.Namespace, claimName)
 	if err != nil {
 		return nil, err
 	}
@@ -2122,12 +2120,12 @@ func (c *VMIController) createAttachmentPopulateTriggerPodTemplate(volume *virtv
 }
 
 func (c *VMIController) deleteAllAttachmentPods(vmi *virtv1.VirtualMachineInstance) error {
-	virtlauncherPod, err := controller.CurrentVMIPod(vmi, c.podInformer.GetIndexer())
+	virtlauncherPod, err := controller.CurrentVMIPod(vmi, c.podIndexer)
 	if err != nil {
 		return err
 	}
 	if virtlauncherPod != nil {
-		attachmentPods, err := controller.AttachmentPods(virtlauncherPod, c.podInformer)
+		attachmentPods, err := controller.AttachmentPods(virtlauncherPod, c.podIndexer)
 		if err != nil {
 			return err
 		}
@@ -2156,7 +2154,7 @@ func (c *VMIController) deleteOrphanedAttachmentPods(vmi *virtv1.VirtualMachineI
 			continue
 		}
 
-		attachmentPods, err := controller.AttachmentPods(pod, c.podInformer)
+		attachmentPods, err := controller.AttachmentPods(pod, c.podIndexer)
 		if err != nil {
 			log.Log.Reason(err).Errorf("failed to get attachment pods %s: %v", controller.PodKey(pod), err)
 			// do not return; continue the cleanup...
@@ -2187,7 +2185,7 @@ func (c *VMIController) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, v
 		hotplugVolumesMap[volume.Name] = volume
 	}
 
-	attachmentPods, err := controller.AttachmentPods(virtlauncherPod, c.podInformer)
+	attachmentPods, err := controller.AttachmentPods(virtlauncherPod, c.podIndexer)
 	if err != nil {
 		return err
 	}
@@ -2245,7 +2243,7 @@ func (c *VMIController) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, v
 
 			pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
 
-			pvcInterface, pvcExists, _ := c.pvcInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", vmi.Namespace, pvcName))
+			pvcInterface, pvcExists, _ := c.pvcIndexer.GetByKey(fmt.Sprintf("%s/%s", vmi.Namespace, pvcName))
 			if pvcExists {
 				pvc := pvcInterface.(*k8sv1.PersistentVolumeClaim)
 				status.PersistentVolumeClaimInfo = &virtv1.PersistentVolumeClaimInfo{
@@ -2297,7 +2295,7 @@ func (c *VMIController) volumeReady(phase virtv1.VolumePhase) bool {
 
 func (c *VMIController) getFilesystemOverhead(pvc *k8sv1.PersistentVolumeClaim) (cdiv1.Percent, error) {
 	// To avoid conflicts, we only allow having one CDI instance
-	if cdiInstances := len(c.cdiInformer.GetStore().List()); cdiInstances != 1 {
+	if cdiInstances := len(c.cdiIndexer.List()); cdiInstances != 1 {
 		if cdiInstances > 1 {
 			log.Log.V(3).Object(pvc).Reason(storagetypes.ErrMultipleCdiInstances).Infof(storagetypes.FSOverheadMsg)
 		} else {
@@ -2306,7 +2304,7 @@ func (c *VMIController) getFilesystemOverhead(pvc *k8sv1.PersistentVolumeClaim) 
 		return storagetypes.DefaultFSOverhead, nil
 	}
 
-	cdiConfigInterface, cdiConfigExists, err := c.cdiConfigInformer.GetStore().GetByKey(storagetypes.ConfigName)
+	cdiConfigInterface, cdiConfigExists, err := c.cdiConfigIndexer.GetByKey(storagetypes.ConfigName)
 	if !cdiConfigExists || err != nil {
 		return "0", fmt.Errorf("Failed to find CDIConfig but CDI exists: %w", err)
 	}
@@ -2336,7 +2334,7 @@ func (c *VMIController) findAttachmentPodByVolumeName(volumeName string, attachm
 func (c *VMIController) getVolumePhaseMessageReason(volume *virtv1.Volume, namespace string) (virtv1.VolumePhase, string, string) {
 	claimName := storagetypes.PVCNameFromVirtVolume(volume)
 
-	pvcInterface, pvcExists, _ := c.pvcInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", namespace, claimName))
+	pvcInterface, pvcExists, _ := c.pvcIndexer.GetByKey(fmt.Sprintf("%s/%s", namespace, claimName))
 	if !pvcExists {
 		return virtv1.VolumePending, FailedPvcNotFoundReason, "Unable to determine PVC name"
 	}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -2649,7 +2649,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Expect(podInformer.GetIndexer().Add(attachmentPod)).To(Succeed())
 			}
 
-			res, err := kvcontroller.AttachmentPods(virtlauncherPod, podInformer)
+			res, err := kvcontroller.AttachmentPods(virtlauncherPod, podInformer.GetIndexer())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(HaveLen(podCount))
 		},

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -339,7 +339,7 @@ func (c *WorkloadUpdateController) getUpdateData(kv *virtv1.KubeVirt) *updateDat
 
 	lookup := make(map[string]bool)
 
-	migrations := migrationutils.ListUnfinishedMigrations(c.migrationInformer)
+	migrations := migrationutils.ListUnfinishedMigrations(c.migrationInformer.GetIndexer())
 
 	for _, migration := range migrations {
 		lookup[migration.Namespace+"/"+migration.Spec.VMIName] = true

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -339,7 +339,7 @@ func (c *WorkloadUpdateController) getUpdateData(kv *virtv1.KubeVirt) *updateDat
 
 	lookup := make(map[string]bool)
 
-	migrations := migrationutils.ListUnfinishedMigrations(c.migrationInformer.GetIndexer())
+	migrations := migrationutils.ListUnfinishedMigrations(c.migrationInformer.GetStore())
 
 	for _, migration := range migrations {
 		lookup[migration.Namespace+"/"+migration.Spec.VMIName] = true


### PR DESCRIPTION
### What this PR does

Remove informers from controllers:
- Get rid of informers in controllers struct and use indexers.
- Additional field in controllers `hasSynced` and lighten parameters `WaitForCacheSync` with this new field.

The updated controllers are:
- [x] VMIController
- [x] VMController (#11379)
- [x] MigrationController
- [x] NodeController
- [x] PoolController

Fixes #11570

### Why we need it and why it was done in this way

### Special notes for your reviewer

I'm Sylvain from KubeVirt contribfest at the kubecon.

Continued of PR #11379.

### Release note

```release-note
NONE
```
