### PR TITLE
Use libvmi in disk related unit tests

### DIFF
--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/config/config-map_test.go
+++ b/pkg/config/config-map_test.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
@@ -53,20 +55,9 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	It("Should create a new config map iso disk", func() {
-		vmi := api.NewMinimalVMI("fake-vmi")
-		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-			Name: "configmap-volume",
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: k8sv1.LocalObjectReference{
-						Name: "test-config",
-					},
-				},
-			},
-		})
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-			Name: "configmap-volume",
-		})
+		vmi := libvmi.New(
+			libvmi.WithConfigMapDisk("test-config", "configmap-volume"),
+		)
 
 		err := CreateConfigMapDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/config/secret_test.go
+++ b/pkg/config/secret_test.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -52,18 +54,9 @@ var _ = Describe("Secret", func() {
 	})
 
 	It("Should create a new secret iso disk", func() {
-		vmi := api.NewMinimalVMI("fake-vmi")
-		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-			Name: "secret-volume",
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: "test-secret",
-				},
-			},
-		})
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-			Name: "secret-volume",
-		})
+		vmi := libvmi.New(
+			libvmi.WithSecretDisk("test-secret", "secret-volume"),
+		)
 
 		err := CreateSecretDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/config/service-account_test.go
+++ b/pkg/config/service-account_test.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -52,18 +54,9 @@ var _ = Describe("ServiceAccount", func() {
 	})
 
 	It("Should create a new service account iso disk", func() {
-		vmi := api.NewMinimalVMI("fake-vmi")
-		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-			Name: "serviceaccount-volume",
-			VolumeSource: v1.VolumeSource{
-				ServiceAccount: &v1.ServiceAccountVolumeSource{
-					ServiceAccountName: "testaccount",
-				},
-			},
-		})
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-			Name: "serviceaccount-volume",
-		})
+		vmi := libvmi.New(
+			libvmi.WithServiceAccountDisk("testaccount"),
+		)
 
 		err := CreateServiceAccountDisk(vmi, false)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What this PR does
This PR improves test readability by using libvmi which shortens the code and makes it more elegant.

Before this PR:
All vmis created for admitter unit tests were made with NewMinimalVMI() and disks are manually added.

After this PR:
Unit tests are using libvmi, adding disks elegantly and cleary.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

