### PR TITLE
Create patchset type for patching operations

### DIFF
--- a/pkg/apimachinery/patch/BUILD.bazel
+++ b/pkg/apimachinery/patch/BUILD.bazel
@@ -1,8 +1,22 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["patch.go"],
     importpath = "kubevirt.io/kubevirt/pkg/apimachinery/patch",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "patch_suite_test.go",
+        "patch_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )

--- a/pkg/apimachinery/patch/patch_suite_test.go
+++ b/pkg/apimachinery/patch/patch_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package patch_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestPatch(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/apimachinery/patch/patch_test.go
+++ b/pkg/apimachinery/patch/patch_test.go
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package patch_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+)
+
+var _ = Describe("PatchSet", func() {
+
+	It("should generate correct patch remove operation", func() {
+		Expect(patch.New(patch.WithRemove("/abcd")).GeneratePayload()).To(Equal([]byte(
+			`[{"op":"remove","path":"/abcd"}]`)))
+	})
+
+	DescribeTable("should generate correct patch add operation", func(v interface{}, expected string) {
+		Expect(patch.New(patch.WithAdd("/abcd", v)).GeneratePayload()).To(Equal([]byte(
+			fmt.Sprintf(`[{"op":"add","path":"/abcd","value":%s}]`, expected),
+		)))
+	},
+		Entry("with value", "test", `"test"`),
+		Entry("with nil value", nil, `null`),
+	)
+
+	DescribeTable("should generate correct patch replace operation", func(v interface{}, expected string) {
+		Expect(patch.New(patch.WithReplace("/abcd", v)).GeneratePayload()).To(Equal([]byte(
+			fmt.Sprintf(`[{"op":"replace","path":"/abcd","value":%s}]`, expected),
+		)))
+	},
+		Entry("with value", "test", `"test"`),
+		Entry("with nil value", nil, `null`),
+	)
+
+	DescribeTable("should generate correct patch test operation", func(v interface{}, expected string) {
+		Expect(patch.New(patch.WithTest("/abcd", v)).GeneratePayload()).To(Equal([]byte(
+			fmt.Sprintf(`[{"op":"test","path":"/abcd","value":%s}]`, expected),
+		)))
+	},
+		Entry("with value", "test", `"test"`),
+		Entry("with nil value", nil, `null`),
+	)
+
+	It("should generate correct patch with a mix of operations", func() {
+		Expect(patch.New(patch.WithRemove("/abcd"),
+			patch.WithAdd("/abcd", "test"),
+			patch.WithReplace("/abcd", "test"),
+			patch.WithTest("/abcd", "test")).GeneratePayload()).To(Equal([]byte(
+			`[{"op":"remove","path":"/abcd"},{"op":"add","path":"/abcd","value":"test"},{"op":"replace","path":"/abcd","value":"test"},{"op":"test","path":"/abcd","value":"test"}]`,
+		)))
+	})
+
+	It("should generate an empty set of patches", func() {
+		patches := patch.New()
+		Expect(patches.IsEmpty()).To(BeTrue())
+	})
+})

--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -227,43 +227,26 @@ func (m *InstancetypeMethods) storePreferenceRevision(vm *virtv1.VirtualMachine)
 }
 
 func GenerateRevisionNamePatch(instancetypeRevision, preferenceRevision *appsv1.ControllerRevision) ([]byte, error) {
-	var patches []patch.PatchOperation
-
+	patchSet := patch.New()
 	if instancetypeRevision != nil {
-		patches = append(patches,
-			patch.PatchOperation{
-				Op:    patch.PatchTestOp,
-				Path:  "/spec/instancetype/revisionName",
-				Value: nil,
-			},
-			patch.PatchOperation{
-				Op:    patch.PatchAddOp,
-				Path:  "/spec/instancetype/revisionName",
-				Value: instancetypeRevision.Name,
-			},
+		patchSet.AddOption(
+			patch.WithTest("/spec/instancetype/revisionName", nil),
+			patch.WithAdd("/spec/instancetype/revisionName", instancetypeRevision.Name),
 		)
 	}
 
 	if preferenceRevision != nil {
-		patches = append(patches,
-			patch.PatchOperation{
-				Op:    patch.PatchTestOp,
-				Path:  "/spec/preference/revisionName",
-				Value: nil,
-			},
-			patch.PatchOperation{
-				Op:    patch.PatchAddOp,
-				Path:  "/spec/preference/revisionName",
-				Value: preferenceRevision.Name,
-			},
+		patchSet.AddOption(
+			patch.WithTest("/spec/preference/revisionName", nil),
+			patch.WithAdd("/spec/preference/revisionName", preferenceRevision.Name),
 		)
 	}
 
-	if len(patches) == 0 {
+	if patchSet.IsEmpty() {
 		return nil, nil
 	}
 
-	payload, err := patch.GeneratePatchPayload(patches...)
+	payload, err := patchSet.GeneratePayload()
 	if err != nil {
 		// This is a programmer's error and should not happen
 		return nil, fmt.Errorf("failed to generate patch payload: %w", err)

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -463,10 +463,15 @@ func (c *DisruptionBudgetController) deletePDB(key string, pdb *policyv1.PodDisr
 
 func (c *DisruptionBudgetController) shrinkPDB(vmi *virtv1.VirtualMachineInstance, pdb *policyv1.PodDisruptionBudget) error {
 	if pdb != nil && pdb.DeletionTimestamp == nil && pdb.Spec.MinAvailable != nil && pdb.Spec.MinAvailable.IntValue() != 1 {
-		patchOps := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/minAvailable", "value": 1 }, { "op": "remove", "path": "/metadata/labels/%s" }]`,
-			patch.EscapeJSONPointer(virtv1.MigrationNameLabel)))
-
-		_, err := c.clientset.PolicyV1().PodDisruptionBudgets(pdb.Namespace).Patch(context.Background(), pdb.Name, types.JSONPatchType, patchOps, v1.PatchOptions{})
+		patches := patch.New(
+			patch.WithReplace("/spec/minAvailable", 1),
+			patch.WithRemove(fmt.Sprintf("/metadata/labels/%s", patch.EscapeJSONPointer(virtv1.MigrationNameLabel))),
+		)
+		patchOps, err := patches.GeneratePayload()
+		if err != nil {
+			return err
+		}
+		_, err = c.clientset.PolicyV1().PodDisruptionBudgets(pdb.Namespace).Patch(context.Background(), pdb.Name, types.JSONPatchType, patchOps, v1.PatchOptions{})
 		if err != nil {
 			c.recorder.Eventf(vmi, corev1.EventTypeWarning, FailedUpdatePodDisruptionBudgetReason, "Error updating the PodDisruptionBudget %s: %v", pdb.Name, err)
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Several ways how to perform patch operations with a mixture of hardcoded strings and types.

After this PR:
Gradually introduce the patch package to replace hardcoded patch operations. This package and the PatchSet type tries to follow the same style as libvmi.
The https://github.com/kubevirt/kubevirt/pull/11211 can be used as reference to see which files and operations we can replace with this new type.
This PR only modifies a couple of files to give an example how the package can be used. More refactoring PRs will follow.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

