### PR TITLE
Fix: Set the end featurename with the conventional name with "Gate" word

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -41,31 +41,31 @@ const (
 	VirtIOFSGate          = "ExperimentalVirtiofsSupport"
 
 	DownwardMetricsFeatureGate = "DownwardMetrics"
-	Root                       = "Root"
-	ClusterProfiler            = "ClusterProfiler"
-	WorkloadEncryptionSEV      = "WorkloadEncryptionSEV"
+	RootGate                       = "Root"
+	ClusterProfilerGate            = "ClusterProfiler"
+	WorkloadEncryptionSEVGate      = "WorkloadEncryptionSEV"
 	// DockerSELinuxMCSWorkaround sets the SELinux level of all the non-compute virt-launcher containers to "s0".
-	DockerSELinuxMCSWorkaround = "DockerSELinuxMCSWorkaround"
+	DockerSELinuxMCSWorkaroundGate = "DockerSELinuxMCSWorkaround"
 	VSOCKGate                  = "VSOCK"
 	// DisableCustomSELinuxPolicy disables the installation of the custom SELinux policy for virt-launcher
-	DisableCustomSELinuxPolicy = "DisableCustomSELinuxPolicy"
+	DisableCustomSELinuxPolicyGate = "DisableCustomSELinuxPolicy"
 	// KubevirtSeccompProfile indicate that Kubevirt will install its custom profile and
 	// user can tell Kubevirt to use it
-	KubevirtSeccompProfile = "KubevirtSeccompProfile"
+	KubevirtSeccompProfileGate = "KubevirtSeccompProfile"
 	// DisableMediatedDevicesHandling disables the handling of mediated
 	// devices, its creation and deletion
-	DisableMediatedDevicesHandling = "DisableMDEVConfiguration"
+	DisableMediatedDevicesHandlingGate = "DisableMDEVConfiguration"
 	// HotplugNetworkIfacesGate enables the virtio network interface hotplug feature
 	HotplugNetworkIfacesGate = "HotplugNICs"
 	// PersistentReservation enables the use of the SCSI persistent reservation with the pr-helper daemon
-	PersistentReservation = "PersistentReservation"
+	PersistentReservationGate = "PersistentReservation"
 	// VMPersistentState enables persisting backend state files of VMs, such as the contents of the vTPM
-	VMPersistentState = "VMPersistentState"
-	Multiarchitecture = "MultiArchitecture"
+	VMPersistentStateGate = "VMPersistentState"
+	MultiarchitectureGate = "MultiArchitecture"
 	// VMLiveUpdateFeaturesGate allows updating certain VM fields, such as CPU sockets to enable hot-plug functionality.
 	VMLiveUpdateFeaturesGate = "VMLiveUpdateFeatures"
 	// When BochsDisplayForEFIGuests is enabled, EFI guests will be started with Bochs display instead of VGA
-	BochsDisplayForEFIGuests = "BochsDisplayForEFIGuests"
+	BochsDisplayForEFIGuestsGate = "BochsDisplayForEFIGuests"
 	// NetworkBindingPlugingsGate enables using a plugin to bind the pod and the VM network
 	NetworkBindingPlugingsGate = "NetworkBindingPlugins"
 	// AutoResourceLimitsGate enables automatic setting of vmi limits if there is a ResourceQuota with limits associated with the vmi namespace.
@@ -176,19 +176,19 @@ func (config *ClusterConfig) HostDevicesPassthroughEnabled() bool {
 }
 
 func (config *ClusterConfig) RootEnabled() bool {
-	return config.isFeatureGateEnabled(Root)
+	return config.isFeatureGateEnabled(RootGate)
 }
 
 func (config *ClusterConfig) ClusterProfilerEnabled() bool {
-	return config.isFeatureGateEnabled(ClusterProfiler)
+	return config.isFeatureGateEnabled(ClusterProfilerGate)
 }
 
 func (config *ClusterConfig) WorkloadEncryptionSEVEnabled() bool {
-	return config.isFeatureGateEnabled(WorkloadEncryptionSEV)
+	return config.isFeatureGateEnabled(WorkloadEncryptionSEVGate)
 }
 
 func (config *ClusterConfig) DockerSELinuxMCSWorkaroundEnabled() bool {
-	return config.isFeatureGateEnabled(DockerSELinuxMCSWorkaround)
+	return config.isFeatureGateEnabled(DockerSELinuxMCSWorkaroundGate)
 }
 
 func (config *ClusterConfig) VSOCKEnabled() bool {
@@ -196,15 +196,15 @@ func (config *ClusterConfig) VSOCKEnabled() bool {
 }
 
 func (config *ClusterConfig) CustomSELinuxPolicyDisabled() bool {
-	return config.isFeatureGateEnabled(DisableCustomSELinuxPolicy)
+	return config.isFeatureGateEnabled(DisableCustomSELinuxPolicyGate)
 }
 
 func (config *ClusterConfig) MediatedDevicesHandlingDisabled() bool {
-	return config.isFeatureGateEnabled(DisableMediatedDevicesHandling)
+	return config.isFeatureGateEnabled(DisableMediatedDevicesHandlingGate)
 }
 
 func (config *ClusterConfig) KubevirtSeccompProfileEnabled() bool {
-	return config.isFeatureGateEnabled(KubevirtSeccompProfile)
+	return config.isFeatureGateEnabled(KubevirtSeccompProfileGate)
 }
 
 func (config *ClusterConfig) HotplugNetworkInterfacesEnabled() bool {
@@ -212,15 +212,15 @@ func (config *ClusterConfig) HotplugNetworkInterfacesEnabled() bool {
 }
 
 func (config *ClusterConfig) PersistentReservationEnabled() bool {
-	return config.isFeatureGateEnabled(PersistentReservation)
+	return config.isFeatureGateEnabled(PersistentReservationGate)
 }
 
 func (config *ClusterConfig) VMPersistentStateEnabled() bool {
-	return config.isFeatureGateEnabled(VMPersistentState)
+	return config.isFeatureGateEnabled(VMPersistentStateGate)
 }
 
 func (config *ClusterConfig) MultiArchitectureEnabled() bool {
-	return config.isFeatureGateEnabled(Multiarchitecture)
+	return config.isFeatureGateEnabled(MultiarchitectureGate)
 }
 
 func (config *ClusterConfig) VMLiveUpdateFeaturesEnabled() bool {
@@ -228,7 +228,7 @@ func (config *ClusterConfig) VMLiveUpdateFeaturesEnabled() bool {
 }
 
 func (config *ClusterConfig) BochsDisplayForEFIGuestsEnabled() bool {
-	return config.isFeatureGateEnabled(BochsDisplayForEFIGuests)
+	return config.isFeatureGateEnabled(BochsDisplayForEFIGuestsGate)
 }
 
 func (config *ClusterConfig) NetworkBindingPlugingsEnabled() bool {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -27,7 +27,7 @@ import "kubevirt.io/kubevirt/pkg/virt-config/deprecation"
 
 const (
 	ExpandDisksGate       = "ExpandDisks"
-	CPUManager            = "CPUManager"
+	CPUManagerGate        = "CPUManager"
 	NUMAFeatureGate       = "NUMA"
 	IgnitionGate          = "ExperimentalIgnitionSupport"
 	HypervStrictCheckGate = "HypervStrictCheck"
@@ -104,7 +104,7 @@ func (config *ClusterConfig) ExpandDisksEnabled() bool {
 }
 
 func (config *ClusterConfig) CPUManagerEnabled() bool {
-	return config.isFeatureGateEnabled(CPUManager)
+	return config.isFeatureGateEnabled(CPUManagerGate)
 }
 
 func (config *ClusterConfig) NUMAEnabled() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: just change the typo to respect the "conventional name" with the Gate word in the end of each feature

After this PR: /

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made: just change the typo to respect the "conventional name" with the Gate word in the end of each feature

The following alternatives were considered: leave it like that

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->https://github.com/kubevirt/user-guide/pull/780

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ X ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ X ] PR: The PR description is expressive enough and will help future contributors
- [ X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ X ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ X ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ X ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ X ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

