### PR TITLE
Allows pci devices to share the same iommu group.

### DIFF
--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -65,7 +65,7 @@ type PCIDevicePlugin struct {
 	resourceName  string
 	done          chan struct{}
 	deviceRoot    string
-	iommuToPCIMap map[string]string
+	iommuToPCIMap map[string][]string
 	initialized   bool
 	lock          *sync.Mutex
 	deregistered  chan struct{}
@@ -73,7 +73,7 @@ type PCIDevicePlugin struct {
 
 func NewPCIDevicePlugin(pciDevices []*PCIDevice, resourceName string) *PCIDevicePlugin {
 	serverSock := SocketPath(strings.Replace(resourceName, "/", "-", -1))
-	iommuToPCIMap := make(map[string]string)
+	iommuToPCIMap := make(map[string][]string)
 
 	initHandler()
 
@@ -92,9 +92,9 @@ func NewPCIDevicePlugin(pciDevices []*PCIDevice, resourceName string) *PCIDevice
 	return dpi
 }
 
-func constructDPIdevices(pciDevices []*PCIDevice, iommuToPCIMap map[string]string) (devs []*pluginapi.Device) {
+func constructDPIdevices(pciDevices []*PCIDevice, iommuToPCIMap map[string][]string) (devs []*pluginapi.Device) {
 	for _, pciDevice := range pciDevices {
-		iommuToPCIMap[pciDevice.iommuGroup] = pciDevice.pciAddress
+		iommuToPCIMap[pciDevice.iommuGroup] = append(iommuToPCIMap[pciDevice.iommuGroup], pciDevice.pciAddress)
 		dpiDev := &pluginapi.Device{
 			ID:     string(pciDevice.iommuGroup),
 			Health: pluginapi.Healthy,
@@ -203,11 +203,11 @@ func (dpi *PCIDevicePlugin) Allocate(_ context.Context, r *pluginapi.AllocateReq
 		deviceSpecs := make([]*pluginapi.DeviceSpec, 0)
 		for _, devID := range request.DevicesIDs {
 			// translate device's iommu group to its pci address
-			devPCIAddress, exist := dpi.iommuToPCIMap[devID]
+			devPCIAddresses, exist := dpi.iommuToPCIMap[devID]
 			if !exist {
 				continue
 			}
-			allocatedDevices = append(allocatedDevices, devPCIAddress)
+			allocatedDevices = append(allocatedDevices, devPCIAddresses...)
 			deviceSpecs = append(deviceSpecs, formatVFIODeviceSpecs(devID)...)
 		}
 		containerResponse.Devices = deviceSpecs

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -95,7 +95,7 @@ pciHostDevices:
 	})
 
 	It("Should validate DPI devices", func() {
-		iommuToPCIMap := make(map[string]string)
+		iommuToPCIMap := make(map[string][]string)
 		supportedPCIDeviceMap := make(map[string]string)
 		for _, pciDev := range fakePermittedHostDevices.PciHostDevices {
 			// do not add a device plugin for this resource if it's being provided via an external device plugin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR does some experimentation on having the mapping between devices and iommu groups being one to many instead of one to one and will be used to check if that solves the issues with not being able to register multiple identical devices sharing iommu group in the device plugin.

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

