### PR TITLE
bump-common-instancetypes: Allow RC releases to be sync'd

### DIFF
--- a/hack/bump-common-instancetypes.sh
+++ b/hack/bump-common-instancetypes.sh
@@ -8,13 +8,8 @@ source "$(dirname "$0")/config.sh"
 TARGET_BRANCH=${1:-"main"}
 
 function latest_version() {
-    if [[ $TARGET_BRANCH == "main" ]]; then
-        curl --fail -s "https://api.github.com/repos/kubevirt/common-instancetypes/releases/latest" |
-            jq -r '.tag_name'
-    else
-        curl --fail -s "https://api.github.com/repos/kubevirt/common-instancetypes/releases?per_page=100" |
-            jq -r '.[] | select(.target_commitish == '\""${TARGET_BRANCH}"\"') | .tag_name' | head -n1
-    fi
+    curl --fail -s "https://api.github.com/repos/kubevirt/common-instancetypes/releases?per_page=100" |
+        jq -r '.[] | select(.target_commitish == '\""${TARGET_BRANCH}"\"') | .tag_name' | head -n1
 }
 
 function checksum() {


### PR DESCRIPTION
/cc @0xFelix 
/area instancetype

### What this PR does

The releases/latest GitHub API doesn't include pre-releases however we'd like to sync these to the main branch of kubevirt/kubevirt for testing ahead of GA.

Before this PR:

RC releases of common-instancetypes were not sync'd.

After this PR:

RC releases of common-instancetypes are now sync'd.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

