### PR TITLE
Fix alerts duration to be triggered

### DIFF
--- a/pkg/monitoring/rules/alerts/virt-operator.go
+++ b/pkg/monitoring/rules/alerts/virt-operator.go
@@ -74,7 +74,7 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		{
 			Alert: "LowReadyVirtOperatorsCount",
 			Expr:  intstr.FromString("kubevirt_virt_operator_ready <  kubevirt_virt_operator_up"),
-			For:   ptr.To(promv1.Duration("60m")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				"summary": "Some virt-operators are running but not ready.",
 			},
@@ -98,7 +98,7 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		{
 			Alert: "NoLeadingVirtOperator",
 			Expr:  intstr.FromString("kubevirt_virt_operator_leading == 0"),
-			For:   ptr.To(promv1.Duration("60m")),
+			For:   ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				"summary": "No leading virt-operator was detected for the last 10 min.",
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
During the alerts refactoring made by https://github.com/kubevirt/kubevirt/pull/10700, `NoLeadingVirtOperator` and `LowReadyVirtOperatorsCount` alerts duration to be triggered was accidentally changed from `10m` to `60m`. This PR fixes it.

Fixes https://issues.redhat.com/browse/CNV-39295

/cc @machadovilaca @sradco 
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

