### PR TITLE
migration controller: add a secondary queue to keep the main one managable

### DIFF
--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch/descheduler:go_default_library",
+        "//pkg/virt-controller/watch/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1994,7 +1994,7 @@ func (c *Controller) outboundMigrationsOnNode(node string, runningMigrations []*
 	return sum, nil
 }
 
-// findRunningMigrations calcules how many migrations are running or in flight to be triggered to running
+// findRunningMigrations calculates how many migrations are running or in flight to be triggered to running
 // Migrations which are in running phase are added alongside with migrations which are still pending but
 // where we already see a target pod.
 func (c *Controller) findRunningMigrations() ([]*virtv1.VirtualMachineInstanceMigration, error) {

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -2277,7 +2277,23 @@ var _ = Describe("Migration watcher", func() {
 			testutils.ExpectEvent(recorder, virtcontroller.SuccessfulMigrationReason)
 			Expect(controller.pendingQueue.GetQueue()).To(BeEmpty())
 		})
+		It("should flush the pending queue when the main one is empty and only then", func() {
+			By("Adding 3 items to the pending queue")
+			controller.pendingQueue.Add("testns/testmig1")
+			controller.pendingQueue.Add("testns/testmig2")
+			controller.pendingQueue.Add("testns/testmig3")
 
+			By("Executing the controller and expecting an empty pending queue and 2 items left in the main queue")
+			controller.Execute()
+			Expect(controller.pendingQueue.GetQueue()).To(BeEmpty())
+			Expect(controller.Queue.Len()).To(Equal(2))
+
+			By("Adding 1 item to the pending queue, executing the controller and expecting no pending queue flush")
+			controller.pendingQueue.Add("testns/testmig4")
+			controller.Execute()
+			Expect(controller.pendingQueue.GetQueue()).To(HaveLen(1))
+			Expect(controller.Queue.Len()).To(Equal(1))
+		})
 	})
 })
 

--- a/pkg/virt-controller/watch/util/BUILD.bazel
+++ b/pkg/virt-controller/watch/util/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["util.go"],
+    srcs = [
+        "pendingqueue.go",
+        "util.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/util",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/virt-controller/watch/util/pendingqueue.go
+++ b/pkg/virt-controller/watch/util/pendingqueue.go
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Contributors
+ *
+ */
+
+package util
+
+import (
+	"sync"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+type PendingQueue struct {
+	queue     []string
+	queueLock *sync.Mutex
+}
+
+func NewPendingQueue() *PendingQueue {
+	return &PendingQueue{
+		queue:     []string{},
+		queueLock: &sync.Mutex{},
+	}
+}
+
+func (pq *PendingQueue) GetQueue() []string {
+	pq.queueLock.Lock()
+	defer pq.queueLock.Unlock()
+	return pq.queue
+}
+
+func (pq *PendingQueue) FlushTo(queue workqueue.TypedRateLimitingInterface[string]) {
+	pq.queueLock.Lock()
+	defer pq.queueLock.Unlock()
+	for _, key := range pq.queue {
+		queue.AddRateLimited(key)
+	}
+	pq.queue = []string{}
+}
+
+func (pq *PendingQueue) Add(item string) {
+	pq.queueLock.Lock()
+	defer pq.queueLock.Unlock()
+	pq.queue = append(pq.queue, item)
+}


### PR DESCRIPTION
### What this PR does
When starting a large number of migrations, most of them will stay pending for a long time. Since pending migrations keep consuming controller execution cycles to just get re-enqueued, there can be not enough cycles left for active migrations to move forward in time.

This PR introduces a second queue dedicated to the pending migrations. This second queue will only be consumed when the main one is empty. That's a bit harsh, and in extreme scenarios could lead to fewer than 5 migrations running in parallel, but it's better than spinlocking virt-controller doing pointless re-enqueues.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Large number of migrations started at the same time should be less of a problem now.
```

