### PR TITLE
Fix multiple pci devices in same iommu group

### DIFF
--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -243,7 +243,7 @@ func IsChanClosed(ch <-chan struct{}) bool {
 	return false
 }
 
-func formatVFIODeviceSpecs(devID string) []*v1beta1.DeviceSpec {
+func formatVFIODeviceSpecs(devID string, separator string) []*v1beta1.DeviceSpec {
 	// always add /dev/vfio/vfio device as well
 	devSpecs := make([]*v1beta1.DeviceSpec, 0)
 	devSpecs = append(devSpecs, &v1beta1.DeviceSpec{
@@ -251,8 +251,8 @@ func formatVFIODeviceSpecs(devID string) []*v1beta1.DeviceSpec {
 		ContainerPath: vfioMount,
 		Permissions:   "mrw",
 	})
-
-	vfioDevice := filepath.Join(vfioDevicePath, devID)
+	iommuGroup := strings.Split(devID, separator)[0]
+	vfioDevice := filepath.Join(vfioDevicePath, iommuGroup)
 	devSpecs = append(devSpecs, &v1beta1.DeviceSpec{
 		HostPath:      vfioDevice,
 		ContainerPath: vfioDevice,

--- a/pkg/virt-handler/device-manager/mediated_device.go
+++ b/pkg/virt-handler/device-manager/mediated_device.go
@@ -193,7 +193,7 @@ func (dpi *MediatedDevicePlugin) Allocate(_ context.Context, r *pluginapi.Alloca
 					return resp, fmt.Errorf("Failed to allocate resource %s", dpi.resourceName)
 				}
 
-				formattedVFIO := formatVFIODeviceSpecs(devID)
+				formattedVFIO := formatVFIODeviceSpecs(devID, deviceIDSeparator)
 				log.DefaultLogger().Infof("Allocate: formatted vfio: %v", formattedVFIO)
 				deviceSpecs = append(deviceSpecs, formattedVFIO...)
 			}


### PR DESCRIPTION
### What this PR does

Before this PR: 

When you have a node with multiple PCI devices with the same resourceName sharing the same IOMMU group,  kubernetes would not recognize these devices as different devices.

After this PR:

We are able to see and use the devices individually.

Fixes #7755 and #11412

### Why we need it and why it was done in this way

We noticed that the resource was not showing in the Capacity section when you describe the node that contains the resource on kubernetes, in this particular case we had a node with 4 nvidia.com/bridge resources and capacity was showing only 1.

We increased log levels in both the kubelet of the node and the virt-handler to be able to check if the device plugin was returning the correct number (4) in the ListAndWatch grpc.

And we were able to confirm it was with the logs below:

```virt-handler
{"component":"virt-handler","level":"info","msg":"Discovered PCIs 4 devices on the node for the resource: nvidia.com/bridge","pos":"device_controller.go:215"}
```

```kubelet
kubelet[1194276]: I0327 00:10:58.479376 1194276 client.go:91] "State pushed for device plugin" resource="nvidia.com/bridge" resourceCapacity=4
```

Then we looked into the kubelet internals to see where it was being dropped and found out that when it update the number of healthy devices [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/devicemanager/manager.go#L269) because the [healthyDevices](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/devicemanager/manager.go#L78) is a map from resourceName to a set of strings (deviceIds) then it was counting the 4 devices as the same device because kubevirt is using the IOMMU group as the device id in the pci_devices plugin [here](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-handler/device-manager/pci_device.go#L99).

The following tradeoffs were made: 

We considered fixing this initially by changing the [iommuToPci map](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-handler/device-manager/pci_device.go#L68) in the pci_devices plugin to because a map from IommuGroup to a slice of addresses in order to store multiple addresses for the same iommuGroup and we would be able to use the 4 devices as a single device in kubernetes and then we would call the resource nvidia.com/bridge4 to represent the fact that this is actually 4 bridges in the same IOMMU group, it looked more sane as it would respect the IOMMU isolation.

But it didn't work inside the VM, I believe it was because the Allocate grpc would generate a single device spec with multiple allocated device addresses [here](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-handler/device-manager/pci_device.go#L211), therefore the virt-launcher would understand it as a single resource anyways, in our practice it looks like it only considered the first address.

The following alternatives were considered:

Another alternative that was considered was using the pciAddress directly as the deviceID in the device plugin instead of the iommuGroup, but that creates an issue in the AllocateGrpc response as well, as it presuming that the deviceID is going to match the file path for the socket file on vfio.

This was achieved by 

The best option we saw was a mixed mapping where we use iommuGroup + separator + pciAddress as the device plugin id, such that we can use the deviceID differently depending on the device plugin grpc that is being processed.

Particularly we use it in two ways:

- By using the full form of the new deviceId we introduce the uniqueness required by kubernetes to recognize the different devices from the ListAndWatch grpc response.
- By extracting the iommuGroup from the deviceID received in the Allocate grpc request we are able to inject the correct number of environment variables in the response all pointing to the right vfio file path inside the container so the virt-launcher can mount the devices correctly.

### Special notes for your reviewer

I'm not a contributor of kubevirt. 

But I want to become one. I understand that this might not be an ideal first thing to work on, but since it was a huge  problem for us, we decided to work specifically on this issue and we were able to re-deploy the changes here which are working really well for our use case so far.
 
I opened this draft so you could see the solution, such that this can be potentially incorporated to the project. 

I understand there is a formal process for contributing as specified [here](https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md) where I would need to become compliant with  Developer Certificate Of Origin first, I will promptly do it in order to proceed implementing this change if you guys think it makes sense.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

