### PR TITLE
Replace NewRandomVirtualMachineInstanceWithFileDisk inside vm_test.go

### DIFF
--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -41,6 +41,7 @@ const (
 const (
 	FedoraVolumeSize = "6Gi"
 	CirrosVolumeSize = "512Mi"
+	AlpineVolumeSize = "512Mi"
 	BlankVolumeSize  = "16Mi"
 )
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -197,24 +197,6 @@ func NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc string, acc
 	), dv
 }
 
-// NewRandomVirtualMachineInstanceWithFileDisk
-//
-// Deprecated: Use libvmi directly
-func NewRandomVirtualMachineInstanceWithFileDisk(imageUrl, namespace string, accessMode k8sv1.PersistentVolumeAccessMode) (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-	if !libstorage.HasCDI() {
-		Skip("Skip DataVolume tests when CDI is not present")
-	}
-	sc, foundSC := libstorage.GetRWOFileSystemStorageClass()
-	if accessMode == k8sv1.ReadWriteMany {
-		sc, foundSC = libstorage.GetRWXFileSystemStorageClass()
-	}
-	if !foundSC {
-		Skip("Skip test when Filesystem storage is not present")
-	}
-
-	return NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc, accessMode, k8sv1.PersistentVolumeFilesystem)
-}
-
 // NewRandomVirtualMachineInstanceWithBlockDisk
 //
 // Deprecated: Use libvmi directly


### PR DESCRIPTION
### What this PR does
Before this PR:
vm_test.go used a deprecated function named NewRandomVirtualMachineInstanceWithFileDisk

After this PR:
vm_test.go uses libvmi instead and NewRandomVirtualMachineInstanceWithFileDisk is removed


### Special notes for your reviewer
After this PR it would be easier to remove NewRandomVirtualMachineInstanceWithBlockDisk and later NewRandomVirtualMachineInstanceWithDisk

### Release note
```
NONE
```

