### PR TITLE
VMClone create mutator: Refactor unit tests

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -89,5 +89,5 @@ func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request) {
 }
 
 func ServeClones(resp http.ResponseWriter, req *http.Request) {
-	serve(resp, req, &mutators.CloneCreateMutator{})
+	serve(resp, req, mutators.NewCloneCreateMutator())
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/webhooks:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-        "//tests/util:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
@@ -33,6 +33,7 @@ import (
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 )
 
@@ -108,13 +109,16 @@ func generateTargetName(sourceName string, targetSuffix string) string {
 }
 
 func generateDefaultTarget(cloneSpec *clonev1alpha1.VirtualMachineCloneSpec, targetSuffix string) (target *k8sv1.TypedLocalObjectReference) {
-	const defaultTargetKind = "VirtualMachine"
+	const (
+		virtualMachineAPIGroup = "kubevirt.io"
+		virtualMachineKind     = "VirtualMachine"
+	)
 
 	source := cloneSpec.Source
 
 	target = &k8sv1.TypedLocalObjectReference{
-		APIGroup: source.APIGroup,
-		Kind:     defaultTargetKind,
+		APIGroup: pointer.P(virtualMachineAPIGroup),
+		Kind:     virtualMachineKind,
 		Name:     generateTargetName(source.Name, targetSuffix),
 	}
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -1,23 +1,28 @@
-package mutators
+package mutators_test
 
 import (
 	"encoding/json"
 
-	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
-
-	"kubevirt.io/kubevirt/tests/util"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	k8sv1 "k8s.io/api/core/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"k8s.io/utils/pointer"
 
 	"kubevirt.io/api/clone"
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
+
 	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/util"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/mutating-webhook/mutators"
 )
 
 var _ = Describe("Clone mutating webhook", func() {
@@ -73,7 +78,7 @@ func createCloneAdmissionReview(vmClone *clonev1alpha1.VirtualMachineClone) *adm
 
 func mutate(vmClone *clonev1alpha1.VirtualMachineClone) *clonev1alpha1.VirtualMachineCloneSpec {
 	ar := createCloneAdmissionReview(vmClone)
-	mutator := CloneCreateMutator{}
+	mutator := mutators.CloneCreateMutator{}
 
 	resp := mutator.Mutate(ar)
 	Expect(resp.Allowed).Should(BeTrue())

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -23,27 +23,23 @@ import (
 var _ = Describe("Clone mutating webhook", func() {
 	const testSourceVirtualMachineName = "test-source-vm"
 
-	It("Target should be auto generated if missing", func() {
-		vmClone := newVirtualMachineClone(
-			withVirtualMachineSource(testSourceVirtualMachineName),
-		)
-
+	DescribeTable("should mutate the spec", func(vmClone *clonev1alpha1.VirtualMachineClone) {
 		cloneSpec := mutate(vmClone)
 		Expect(cloneSpec.Target).ShouldNot(BeNil())
 		Expect(cloneSpec.Target.Name).ShouldNot(BeEmpty())
-	})
-
-	It("Target name should be auto generated if missing", func() {
-		vmClone := newVirtualMachineClone(
-			withVirtualMachineSource(testSourceVirtualMachineName),
-			withVirtualMachineTarget(""),
-		)
-
-		cloneSpec := mutate(vmClone)
-		Expect(cloneSpec.Target).ShouldNot(BeNil())
-		Expect(cloneSpec.Target.Name).ShouldNot(BeEmpty())
-	})
-
+	},
+		Entry("When the source is a VirtualMachine and the target is nil",
+			newVirtualMachineClone(
+				withVirtualMachineSource(testSourceVirtualMachineName),
+			),
+		),
+		Entry("When the source is a VirtualMachine and the target name is empty",
+			newVirtualMachineClone(
+				withVirtualMachineSource(testSourceVirtualMachineName),
+				withVirtualMachineTarget(""),
+			),
+		),
+	)
 })
 
 type option func(vmClone *clonev1alpha1.VirtualMachineClone)

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -22,7 +22,10 @@ import (
 )
 
 var _ = Describe("Clone mutating webhook", func() {
-	const testSourceVirtualMachineName = "test-source-vm"
+	const (
+		testSourceVirtualMachineName         = "test-source-vm"
+		testSourceVirtualMachineSnapshotName = "test-snapshot"
+	)
 
 	DescribeTable("should mutate the spec", func(vmClone *clonev1alpha1.VirtualMachineClone) {
 		admissionReview, err := newAdmissionReviewForVMCloneCreation(vmClone)
@@ -60,6 +63,17 @@ var _ = Describe("Clone mutating webhook", func() {
 				withVirtualMachineTarget(""),
 			),
 		),
+		Entry("when source is a VirtualMachineSnapshot and target is nil",
+			newVirtualMachineClone(
+				withVirtualMachineSnapshotSource(testSourceVirtualMachineSnapshotName),
+			),
+		),
+		Entry("when source is a VirtualMachineSnapshot and target name is missing",
+			newVirtualMachineClone(
+				withVirtualMachineSnapshotSource(testSourceVirtualMachineSnapshotName),
+				withVirtualMachineTarget(""),
+			),
+		),
 	)
 })
 
@@ -83,6 +97,9 @@ func newVirtualMachineClone(options ...option) *clonev1alpha1.VirtualMachineClon
 const (
 	virtualMachineAPIGroup = "kubevirt.io"
 	virtualMachineKind     = "VirtualMachine"
+
+	virtualMachineSnapshotAPIGroup = "snapshot.kubevirt.io"
+	virtualMachineSnapshotKind     = "VirtualMachineSnapshot"
 )
 
 func withVirtualMachineSource(virtualMachineName string) option {
@@ -91,6 +108,16 @@ func withVirtualMachineSource(virtualMachineName string) option {
 			APIGroup: pointer.P(virtualMachineAPIGroup),
 			Kind:     virtualMachineKind,
 			Name:     virtualMachineName,
+		}
+	}
+}
+
+func withVirtualMachineSnapshotSource(virtualMachineSnapshotName string) option {
+	return func(vmClone *clonev1alpha1.VirtualMachineClone) {
+		vmClone.Spec.Source = &k8sv1.TypedLocalObjectReference{
+			APIGroup: pointer.P(virtualMachineSnapshotAPIGroup),
+			Kind:     virtualMachineSnapshotKind,
+			Name:     virtualMachineSnapshotName,
 		}
 	}
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -26,25 +26,27 @@ import (
 )
 
 var _ = Describe("Clone mutating webhook", func() {
-
-	var vmClone *clonev1alpha1.VirtualMachineClone
-
-	BeforeEach(func() {
-		vmClone = kubecli.NewMinimalCloneWithNS("testclone", util.NamespaceTestDefault)
+	It("Target should be auto generated if missing", func() {
+		vmClone := kubecli.NewMinimalCloneWithNS("testclone", util.NamespaceTestDefault)
 		vmClone.Spec.Source = &k8sv1.TypedLocalObjectReference{
 			APIGroup: pointer.String(clone.GroupName),
 			Kind:     "VirtualMachine",
 			Name:     "test-source-vm",
 		}
-	})
 
-	It("Target should be auto generated if missing", func() {
 		cloneSpec := mutate(vmClone)
 		Expect(cloneSpec.Target).ShouldNot(BeNil())
 		Expect(cloneSpec.Target.Name).ShouldNot(BeEmpty())
 	})
 
 	It("Target name should be auto generated if missing", func() {
+		vmClone := kubecli.NewMinimalCloneWithNS("testclone", util.NamespaceTestDefault)
+		vmClone.Spec.Source = &k8sv1.TypedLocalObjectReference{
+			APIGroup: pointer.String(clone.GroupName),
+			Kind:     "VirtualMachine",
+			Name:     "test-source-vm",
+		}
+
 		vmClone.Spec.Target = &k8sv1.TypedLocalObjectReference{
 			APIGroup: pointer.String(clone.GroupName),
 			Kind:     "VirtualMachine",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:
Tests were united into a table.
The actual AdmissionResponse object is tested against an expected AdmissionResponse object.
The mutator sets the correct APIGroup when the source is a `VirutalMachineSnapshot` object.
Tests were added to cover scenarios when the source it a `VirutalMachineSnapshot` object.
External dependencies were removed.
Tests were moved to the `mutators_test` package.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Since this PR is already quite big, follow-up PR(s) should:
1. Make the JSON patch more precise.
2. Handle the case when the mutator has nothing to do.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
None
```

