### PR TITLE
Improve time interval in Eventually in tests/

### DIFF
--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -820,7 +820,7 @@ func waitForSnapshotToBeReady(virtClient kubecli.KubevirtClient, snapshot *v1alp
 		updatedSnap, err := virtClient.VirtualMachineSnapshot(snapshot.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return updatedSnap.Status != nil && updatedSnap.Status.ReadyToUse != nil && *updatedSnap.Status.ReadyToUse
-	}, time.Duration(timeoutSec)*time.Second, 2).Should(BeTrue(), "Should be ready to use")
+	}).WithTimeout(time.Duration(timeoutSec)*time.Second).WithPolling(2*time.Second).Should(BeTrue(), "Should be ready to use")
 }
 
 func dryRunCreate(client *rest.RESTClient, resource, namespace string, obj interface{}, result runtime.Object) error {

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -174,7 +174,7 @@ func executeDeviceMapperOnNode(nodeName string, cmd []string) {
 	pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
-	Eventually(ThisPod(pod), 30).Should(HaveSucceeded())
+	Eventually(ThisPod(pod)).WithTimeout(30 * time.Second).Should(HaveSucceeded())
 }
 
 func CreateFaultyDisk(nodeName, deviceName string) {

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -195,7 +195,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 				Eventually(func() error {
 					migrationCreated, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
 					return err
-				}, libmigration.MigrationWaitTime, 1*time.Second).Should(Succeed(), "migration creation should succeed")
+				}).WithTimeout(libmigration.MigrationWaitTime*time.Second).WithPolling(1*time.Second).Should(Succeed(), "migration creation should succeed")
 				migration = migrationCreated
 
 				libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration)

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -219,7 +219,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			err := virtClient.CoreV1().Pods(helperPod.Namespace).Delete(context.Background(), helperPod.Name, k8smetav1.DeleteOptions{})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		}()
-		EventuallyWithOffset(1, ThisPod(helperPod), 30).Should(BeInPhase(k8sv1.PodRunning))
+		EventuallyWithOffset(1, ThisPod(helperPod)).WithTimeout(30 * time.Second).Should(BeInPhase(k8sv1.PodRunning))
 
 		execOnHelperPod := func(command string) (string, error) {
 			stdout, err := exec.ExecuteCommandOnPod(
@@ -356,7 +356,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			vmi := newSEVFedora(false, libvmi.WithSEVAttestation())
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisVMI(vmi), 60).Should(BeInPhase(v1.Scheduled))
+			Eventually(ThisVMI(vmi)).WithTimeout(60 * time.Second).Should(BeInPhase(v1.Scheduled))
 
 			By("Querying virsh nodesevinfo")
 			nodeSevInfo := tests.RunCommandOnVmiPod(vmi, []string{"virsh", "nodesevinfo"})
@@ -376,7 +376,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			sevSessionOptions, tikBase64, tekBase64 := prepareSession(virtClient, vmi.Status.NodeName, sevPlatformInfo.PDH)
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).SEVSetupSession(vmi.Name, sevSessionOptions)
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisVMI(vmi), 60).Should(And(BeRunning(), HaveConditionTrue(v1.VirtualMachineInstancePaused)))
+			Eventually(ThisVMI(vmi)).WithTimeout(60 * time.Second).Should(And(BeRunning(), HaveConditionTrue(v1.VirtualMachineInstancePaused)))
 
 			By("Querying virsh domlaunchsecinfo 1")
 			domLaunchSecInfo := tests.RunCommandOnVmiPod(vmi, []string{"virsh", "domlaunchsecinfo", "1"})

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -145,7 +145,7 @@ func SetDataVolumeGC(virtCli kubecli.KubevirtClient, ttlSec *int32) {
 		config, err := virtCli.CdiClient().CdiV1beta1().CDIConfigs().Get(context.TODO(), "config", v12.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return config.Spec.DataVolumeTTLSeconds
-	}, 10, time.Second).Should(Equal(ttlSec))
+	}).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(Equal(ttlSec))
 }
 
 func IsDataVolumeGC(virtCli kubecli.KubevirtClient) bool {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -791,7 +791,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				Eventually(func() error {
 					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
 					return err
-				}, 5, 1*time.Second).Should(Succeed(), "migration creation should succeed")
+				}).WithTimeout(5*time.Second).WithPolling(1*time.Second).Should(Succeed(), "migration creation should succeed")
 
 				By("Should receive warning event that target pod is currently unschedulable")
 				ctx, cancel := context.WithCancel(context.Background())
@@ -853,7 +853,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				Eventually(func() error {
 					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
 					return err
-				}, 5, 1*time.Second).Should(Succeed(), "migration creation should succeed")
+				}).WithTimeout(5*time.Second).WithPolling(1*time.Second).Should(Succeed(), "migration creation should succeed")
 
 				By("Migration should observe a timeout period before canceling pending target pod")
 				Consistently(func() error {
@@ -1839,7 +1839,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					phase := migration.Status.Phase
 					Expect(phase).NotTo(Equal(v1.MigrationSucceeded))
 					return phase
-				}, 120, 1*time.Second).Should(Equal(v1.MigrationPreparingTarget))
+				}).WithTimeout(120 * time.Second).WithPolling(1 * time.Second).Should(Equal(v1.MigrationPreparingTarget))
 
 				By("Killing the target pod and expecting failure")
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
@@ -1919,7 +1919,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					phase := migration.Status.Phase
 					Expect(phase).NotTo(Equal(v1.MigrationSucceeded))
 					return phase
-				}, 120, 1*time.Second).Should(Equal(v1.MigrationPreparingTarget))
+				}).WithTimeout(120 * time.Second).WithPolling(1 * time.Second).Should(Equal(v1.MigrationPreparingTarget))
 
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -2126,18 +2126,18 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 
 				By("Starting a Migration")
-				const timeout = 180
+				const timeout = 180 * time.Second
 				Eventually(func() error {
 					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
 					return err
-				}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
+				}).WithTimeout(timeout).WithPolling(1 * time.Second).ShouldNot(HaveOccurred())
 
 				By("Waiting until the Migration has UID")
 				Eventually(func() bool {
 					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return migration.UID != ""
-				}, timeout, 1*time.Second).Should(BeTrue())
+				}).WithTimeout(timeout).WithPolling(1 * time.Second).Should(BeTrue())
 
 				By("Cancelling migration")
 				libmigration.CancelMigration(migration, vmi.Name, with_virtctl)

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -291,13 +291,13 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 						runMigrationKillerPod(vmi.Status.NodeName)
 
 						By("Making sure that post-copy migration failed")
-						Eventually(matcher.ThisMigration(migration), 150, 1*time.Second).Should(BeInPhase(v1.MigrationFailed))
+						Eventually(matcher.ThisMigration(migration)).WithTimeout(150 * time.Second).WithPolling(1 * time.Second).Should(BeInPhase(v1.MigrationFailed))
 
 						By("Removing migration killer pods")
 						removeMigrationKillerPod()
 
 						By("Ensuring the VirtualMachineInstance is restarted")
-						Eventually(ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(matcher.BeRestarted(vmi.UID))
+						Eventually(ThisVMI(vmi)).WithTimeout(240 * time.Second).WithPolling(1 * time.Second).Should(matcher.BeRestarted(vmi.UID))
 					})
 				})
 			})

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -183,14 +183,14 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 			})
 
 			It("should keep connectivity after a migration", func() {
-				const containerCompletionWaitTime = 60
+				const containerCompletionWaitTime = 60 * time.Second
 				migration := libmigration.New(serverVMI.Name, serverVMI.GetNamespace())
 				_ = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
 				// In case of clientVMI and serverVMI running on the same node before migration, the serverVMI
 				// will be reachable only when the original launcher pod terminates.
 				Eventually(func() error {
 					return waitForPodCompleted(serverVMI.Namespace, serverVMIPodName)
-				}, containerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod: %s", serverVMIPodName))
+				}).WithTimeout(containerCompletionWaitTime).WithPolling(time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod: %s", serverVMIPodName))
 				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed(), "connectivity is expected *after* migrating the VMI")
 			})
 		})

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -195,7 +195,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					_, err := virtClient.CoreV1().Endpoints(testsuite.GetTestNamespace(nil)).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
 					return err
 				}
-				Eventually(getEndpoint, 60, 1).Should(BeNil())
+				Eventually(getEndpoint).WithTimeout(60 * time.Second).WithPolling(1 * time.Second).Should(BeNil())
 
 				endpoints, err := virtClient.CoreV1().Endpoints(testsuite.GetTestNamespace(nil)).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -253,7 +253,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					_, err := virtClient.CoreV1().Endpoints(testsuite.GetTestNamespace(nil)).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
 					return err
 				}
-				Eventually(getEndpoint, 60, 1).Should(BeNil())
+				Eventually(getEndpoint).WithTimeout(60 * time.Second).WithPolling(1 * time.Second).Should(BeNil())
 
 				endpoints, err := virtClient.CoreV1().Endpoints(testsuite.GetTestNamespace(nil)).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -222,7 +222,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return vmi.IsFinal()
-			}, 120, 1).Should(Not(BeTrue()))
+			}).WithTimeout(120 * time.Second).WithPolling(1 * time.Second).Should(Not(BeTrue()))
 		},
 			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv4", tcpProbe, corev1.IPv4Protocol),
 			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv6", tcpProbe, corev1.IPv6Protocol),
@@ -262,7 +262,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return vmi.IsFinal()
-			}, 120, 1).Should(BeTrue())
+			}).WithTimeout(120 * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
 		},
 			Entry("[test_id:1217][posneg:negative]with working TCP probe and no running server", tcpProbe, libvmifact.NewCirros),
 			Entry("[test_id:1218][posneg:negative]with working HTTP probe and no running server", httpProbe, libvmifact.NewCirros),

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -192,10 +192,10 @@ var istioTests = func(vmType VmType) {
 				libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 			})
 			It("All containers should complete in source virt-launcher pod after migration", func() {
-				const containerCompletionWaitTime = 60
+				const containerCompletionWaitTime = 60 * time.Second
 				Eventually(func() error {
 					return allContainersCompleted(sourcePodName)
-				}, containerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod"))
+				}).WithTimeout(containerCompletionWaitTime).WithPolling(time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod"))
 			})
 		})
 		Describe("SSH traffic", func() {

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
 
@@ -89,7 +90,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 					pod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Get(context.Background(), pod.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return pod.Status.Phase
-				}, 50, 5).Should(Equal(k8sv1.PodSucceeded))
+				}).WithTimeout(50 * time.Second).WithPolling(5 * time.Second).Should(Equal(k8sv1.PodSucceeded))
 
 				By("starting another VMI on the same node, to verify kubelet is running again")
 				newVMI := libvmifact.NewCirros()
@@ -98,7 +99,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 					newVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(newVMI)).Create(context.Background(), newVMI, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return nil
-				}, 100, 10).Should(Succeed(), "Should be able to start a new VM")
+				}).WithTimeout(100*time.Second).WithPolling(10*time.Second).Should(Succeed(), "Should be able to start a new VM")
 				libwait.WaitForSuccessfulVMIStart(newVMI)
 
 				By("checking if the VMI with bridged networking is still running, it will verify the CNI didn't cause the pod to be killed")

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -718,7 +718,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 						return nil
 					}
 					return updatedVmi.Status.Interfaces
-				}, 420*time.Second, 4).Should(HaveLen(4), "Should have interfaces in vmi status")
+				}).WithTimeout(420*time.Second).WithPolling(4*time.Second).Should(HaveLen(4), "Should have interfaces in vmi status")
 
 				updatedVmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, getOptions)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -804,7 +804,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 					}
 				}
 				return nil
-			}, 320, 1).Should(BeNil(), "All VMIs should delete automatically")
+			}).WithTimeout(320*time.Second).WithPolling(1*time.Second).Should(BeNil(), "All VMIs should delete automatically")
 
 		}
 
@@ -851,7 +851,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 					}
 				}
 				return nil
-			}, 500, 1).Should(BeNil(), "All VMIs should update via live migration")
+			}).WithTimeout(500*time.Second).WithPolling(1*time.Second).ShouldNot(HaveOccurred(), "All VMIs should update via live migration")
 
 			// this is put in an eventually loop because it's possible for the VMI to complete
 			// migrating and for the migration object to briefly lag behind in reporting
@@ -872,7 +872,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 					}
 				}
 				return nil
-			}, 10, 1).Should(BeNil(), "Expects only a single successful migration per workload update")
+			}).WithTimeout(10*time.Second).WithPolling(1*time.Second).ShouldNot(HaveOccurred(), "Expects only a single successful migration per workload update")
 		}
 
 		getVirtLauncherSha = func() string {
@@ -1908,7 +1908,7 @@ spec:
 				vmi := migratableVMIs[0]
 				migration, err := virtClient.VirtualMachineInstanceMigration(testsuite.GetTestNamespace(vmi)).Create(libmigration.New(vmi.Name, vmi.Namespace), &metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(ThisMigration(migration), 180).Should(HaveSucceeded())
+				Eventually(ThisMigration(migration)).WithTimeout(180 * time.Second).Should(HaveSucceeded())
 			}
 
 			By("Deleting migratable VMIs")

--- a/tests/pod_servers.go
+++ b/tests/pod_servers.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,7 +38,7 @@ func CreatePodAndWaitUntil(pod *corev1.Pod, phaseToWait corev1.PodPhase) *corev1
 		Expect(err).ToNot(HaveOccurred())
 		return pod.Status.Phase
 	}
-	Eventually(getStatus, 30, 1).Should(Equal(phaseToWait), "should reach %s phase", phaseToWait)
+	Eventually(getStatus).WithTimeout(30*time.Second).WithPolling(time.Second).Should(Equal(phaseToWait), "should reach %s phase", phaseToWait)
 	return pod
 }
 

--- a/tests/portforward_test.go
+++ b/tests/portforward_test.go
@@ -63,7 +63,7 @@ var _ = Describe("[sig-compute]PortForward", decorators.SigCompute, func() {
 				return err
 			}
 			return nil
-		}, 12*60*time.Second, 2).ShouldNot(HaveOccurred())
+		}).WithTimeout(12 * 60 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
 
 		inReader, in := io.Pipe()
 		var out bytes.Buffer

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -162,7 +162,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					&expect.BExp{R: "1"},
 				}, 10)
 				return err
-			}, 360).Should(BeNil())
+			}).WithTimeout(360 * time.Second).Should(BeNil())
 
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "sudo /sbin/resize-filesystem /dev/root /run/resize.rootfs /dev/console && echo $?\n"},
@@ -274,7 +274,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				// This will only work on storage with binding mode WaitForFirstConsumer,
 				if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-					Eventually(ThisDV(dataVolume), 40).Should(WaitForFirstConsumer())
+					Eventually(ThisDV(dataVolume)).WithTimeout(40 * time.Second).Should(WaitForFirstConsumer())
 				}
 				num := 2
 				By("Starting and stopping the VirtualMachineInstance a number of times")
@@ -366,7 +366,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Expect(err).ToNot(HaveOccurred())
 				// This will only work on storage with binding mode WaitForFirstConsumer,
 				if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-					Eventually(ThisDV(dataVolume), 40).Should(WaitForFirstConsumer())
+					Eventually(ThisDV(dataVolume)).WithTimeout(40 * time.Second).Should(WaitForFirstConsumer())
 				}
 				// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
 				// import and start
@@ -511,7 +511,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for DV to start crashing")
-				Eventually(ThisDVWith(vm.Namespace, dataVolume.Name), 60).Should(BeInPhase(cdiv1.ImportInProgress))
+				Eventually(ThisDVWith(vm.Namespace, dataVolume.Name)).WithTimeout(60 * time.Second).Should(BeInPhase(cdiv1.ImportInProgress))
 
 				By("Stop VM")
 				tests.StopVirtualMachineWithTimeout(vm, time.Second*30)
@@ -540,7 +540,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VMI to be created")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(100 * time.Second).Should(BeInPhase(v1.Pending))
 			})
 			It("[test_id:3190]should correctly handle eventually consistent DataVolumes", func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
@@ -591,7 +591,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(Or(BeInPhase(v1.Pending), BeInPhase(v1.Scheduling)))
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(100 * time.Second).Should(Or(BeInPhase(v1.Pending), BeInPhase(v1.Scheduling)))
 
 				By("Creating a service which makes the registry reachable")
 				_, err = virtClient.CoreV1().Services(vm.Namespace).Create(context.Background(), &k8sv1.Service{
@@ -609,7 +609,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				libstorage.EventuallyDV(dataVolume, 160, HaveSucceeded())
 
 				By("Waiting for VMI to be created")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Running))
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(100 * time.Second).Should(BeInPhase(v1.Running))
 			})
 		})
 	})
@@ -650,10 +650,10 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			libstorage.EventuallyDVWith(vm.Namespace, dataVolumeName, 100, And(HaveSucceeded(), BeOwned()))
 
 			By(verifyingPVCCreated)
-			Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+			Eventually(ThisPVCWith(vm.Namespace, pvcName)).WithTimeout(160 * time.Second).Should(Exist())
 
 			By(verifyingVMICreated)
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+			Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(160 * time.Second).Should(And(BeRunning(), BeOwned()))
 		})
 
 		It("[test_id:837]deleting VM with cascade=true should automatically delete DataVolumes and VMI owned by VM.", func() {
@@ -665,26 +665,26 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			libstorage.EventuallyDVWith(vm.Namespace, dataVolumeName, 100, And(HaveSucceeded(), BeOwned()))
 
 			By(verifyingPVCCreated)
-			Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+			Eventually(ThisPVCWith(vm.Namespace, pvcName)).WithTimeout(160 * time.Second).Should(Exist())
 
 			By(verifyingVMICreated)
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+			Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(160 * time.Second).Should(And(BeRunning(), BeOwned()))
 
 			By("Deleting VM with cascade=true")
 			_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for the VM to be deleted")
-			Eventually(ThisVM(vm), 100).Should(BeGone())
+			Eventually(ThisVM(vm)).WithTimeout(100 * time.Second).Should(BeGone())
 
 			By("Waiting for the VMI to be deleted")
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeGone())
+			Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(100 * time.Second).Should(BeGone())
 
 			By("Waiting for the DataVolume to be deleted")
-			Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(BeGone())
+			Eventually(ThisDVWith(vm.Namespace, dataVolumeName)).WithTimeout(100 * time.Second).Should(BeGone())
 
 			By("Waiting for the PVC to be deleted")
-			Eventually(ThisPVCWith(vm.Namespace, pvcName), 100).Should(BeGone())
+			Eventually(ThisPVCWith(vm.Namespace, pvcName)).WithTimeout(100 * time.Second).Should(BeGone())
 		})
 
 		It("[test_id:838]deleting VM with cascade=false should orphan DataVolumes and VMI owned by VM.", func() {
@@ -696,23 +696,23 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			libstorage.EventuallyDVWith(vm.Namespace, dataVolumeName, 100, And(HaveSucceeded(), BeOwned()))
 
 			By(verifyingPVCCreated)
-			Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+			Eventually(ThisPVCWith(vm.Namespace, pvcName)).WithTimeout(160 * time.Second).Should(Exist())
 
 			By(verifyingVMICreated)
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+			Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(160 * time.Second).Should(And(BeRunning(), BeOwned()))
 
 			By("Deleting VM with cascade=false")
 			_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for the VM to be deleted")
-			Eventually(ThisVM(vm), 100).Should(BeGone())
+			Eventually(ThisVM(vm)).WithTimeout(100 * time.Second).Should(BeGone())
 
 			By("Verifying DataVolume still exists with owner references removed")
 			libstorage.EventuallyDVWith(vm.Namespace, dataVolumeName, 100, And(HaveSucceeded(), Not(BeOwned())))
 
 			By("Verifying VMI still exists with owner references removed")
-			Consistently(ThisVMIWith(vm.Namespace, vm.Name), 60, 1).Should(And(BeRunning(), Not(BeOwned())))
+			Consistently(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(60 * time.Second).WithPolling(1 * time.Second).Should(And(BeRunning(), Not(BeOwned())))
 		})
 
 	})
@@ -777,7 +777,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Check for owner reference
-				Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(BeOwned())
+				Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name)).WithTimeout(100 * time.Second).Should(BeOwned())
 
 				// Delete the VM with orphan Propagation
 				orphanPolicy := metav1.DeletePropagationOrphan
@@ -785,7 +785,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					Delete(context.Background(), vm.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
 
 				// Wait for the owner reference to disappear
-				Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(Not(BeOwned()))
+				Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name)).WithTimeout(100 * time.Second).Should(Not(BeOwned()))
 			})
 		})
 	})
@@ -1007,7 +1007,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				}, 90*time.Second, 1*time.Second).Should(BeTrue())
 
 				// Check for owner reference
-				Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(BeOwned())
+				Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name)).WithTimeout(100 * time.Second).Should(BeOwned())
 
 				// We check the expected event
 				By("Expecting SourcePVCNotAvailabe event")

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2023,7 +2023,7 @@ var _ = SIGDescribe("Export", func() {
 			libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 		)
 		dv = createDataVolume(dv)
-		Eventually(ThisPVCWith(vm.Namespace, dv.Name), 160).Should(Exist())
+		Eventually(ThisPVCWith(vm.Namespace, dv.Name)).WithTimeout(160 * time.Second).Should(Exist())
 
 		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -729,7 +729,7 @@ func createExecutorPodWithPVC(podName string, pvc *k8sv1.PersistentVolumeClaim) 
 	}
 	pod = tests.RunPod(pod)
 
-	Eventually(matcher.ThisPod(pod), 120).Should(matcher.HaveConditionTrue(k8sv1.PodReady))
+	Eventually(matcher.ThisPod(pod)).WithTimeout(120 * time.Second).Should(matcher.HaveConditionTrue(k8sv1.PodReady))
 	pod, err = matcher.ThisPod(pod)()
 	Expect(err).ToNot(HaveOccurred())
 	return pod

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -338,7 +338,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				vm.Spec.Running = pointer.BoolPtr(true)
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(360 * time.Second).Should(BeInPhase(v1.Running))
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1605,7 +1605,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				By("Starting the VM and expecting it to run")
 				vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 360).Should(BeInPhase(v1.Running))
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name)).WithTimeout(360 * time.Second).Should(BeInPhase(v1.Running))
 
 				for _, dvt := range vm.Spec.DataVolumeTemplates {
 					waitDataVolumePopulated(vm.Namespace, dvt.Name)

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -550,7 +550,7 @@ var _ = SIGDescribe("Storage", func() {
 
 					err = virtClient.VirtualMachineInstance(obj.Namespace).Delete(context.Background(), obj.Name, metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					Eventually(ThisVMI(obj), 120).Should(BeGone())
+					Eventually(ThisVMI(obj)).WithTimeout(120 * time.Second).Should(BeGone())
 				}
 			})
 		})
@@ -597,7 +597,7 @@ var _ = SIGDescribe("Storage", func() {
 						if err != nil && !errors.IsNotFound(err) {
 							Expect(err).ToNot(HaveOccurred())
 						}
-						Eventually(ThisVMI(vmi), 30).Should(Or(BeGone(), BeInPhase(v1.Failed), BeInPhase(v1.Succeeded)))
+						Eventually(ThisVMI(vmi)).WithTimeout(30 * time.Second).Should(Or(BeGone(), BeInPhase(v1.Failed), BeInPhase(v1.Succeeded)))
 					}
 					if nodeName != "" {
 						tests.RemoveHostDiskImage(hostDiskDir, nodeName)

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -150,7 +150,7 @@ func waitForSchedulableNodesWithCPUManager(n int) {
 		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true," + v1.CPUManager + "=true"})
 		Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
 		return len(nodes.Items) == n
-	}, 360, 1*time.Second).Should(BeTrue())
+	}).WithTimeout(360 * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
 }
 
 func RestoreKubeVirtResource() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -453,7 +453,7 @@ func RunPodInNamespace(pod *k8sv1.Pod, namespace string) *k8sv1.Pod {
 	var err error
 	pod, err = virtClient.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(ThisPod(pod), 180).Should(BeInPhase(k8sv1.PodRunning))
+	Eventually(ThisPod(pod)).WithTimeout(180 * time.Second).Should(BeInPhase(k8sv1.PodRunning))
 
 	pod, err = ThisPod(pod)()
 	Expect(err).ToNot(HaveOccurred())
@@ -470,7 +470,7 @@ func RunPodAndExpectCompletion(pod *k8sv1.Pod) *k8sv1.Pod {
 	var err error
 	pod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(ThisPod(pod), 120).Should(BeInPhase(k8sv1.PodSucceeded))
+	Eventually(ThisPod(pod)).WithTimeout(120 * time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
 
 	pod, err = ThisPod(pod)()
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -50,8 +50,8 @@ import (
 )
 
 const (
-	DefaultStabilizationTimeoutInSeconds = 300
-	DefaultPollIntervalInSeconds         = 3
+	defaultStabilizationTimeout = 300 * time.Second
+	defaultPollInterval         = 3 * time.Second
 )
 
 const (
@@ -127,25 +127,19 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 			return true, nil
 		}
 
-		eventuallyWithTimeout := func(f func() (bool, error)) {
-			Eventually(f,
-				DefaultStabilizationTimeoutInSeconds, DefaultPollIntervalInSeconds,
-			).Should(BeTrue())
-		}
-
 		BeforeEach(func() {
 			nodeList = libnode.GetAllSchedulableNodes(virtCli).Items
 			for _, node := range nodeList {
 				libnode.SetNodeUnschedulable(node.Name, virtCli)
 			}
-			eventuallyWithTimeout(waitForDeploymentsToStabilize)
+			Eventually(waitForDeploymentsToStabilize).WithTimeout(defaultStabilizationTimeout).WithPolling(defaultPollInterval).Should(BeTrue())
 		})
 
 		AfterEach(func() {
 			for _, node := range nodeList {
 				libnode.SetNodeSchedulable(node.Name, virtCli)
 			}
-			eventuallyWithTimeout(waitForDeploymentsToStabilize)
+			Eventually(waitForDeploymentsToStabilize).WithTimeout(defaultStabilizationTimeout).WithPolling(defaultPollInterval).Should(BeTrue())
 		})
 
 		DescribeTable("evicting pods of control plane", func(podName string, isMultiReplica bool, msg string) {

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -314,7 +314,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			Expect(err).ToNot(HaveOccurred())
 			By("Waiting until the DataVolume is ready")
 			if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-				Eventually(ThisDV(dataVolume), 30).Should(WaitForFirstConsumer())
+				Eventually(ThisDV(dataVolume)).WithTimeout(30 * time.Second).Should(WaitForFirstConsumer())
 			}
 
 			virtiofsMountPath := fmt.Sprintf("/mnt/virtiofs_%s", dataVolume.Name)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1274,7 +1274,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					freshVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, getOptions)
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 					return freshVMI.Status.Conditions
-				}, 240*time.Second, 2).Should(
+				}).WithTimeout(240*time.Second).WithPolling(2*time.Second).Should(
 					ContainElement(
 						MatchFields(
 							IgnoreExtras,
@@ -1332,7 +1332,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				}, 400)).To(Succeed())
 
 				By("VMI has the guest agent connected condition")
-				Eventually(matcher.ThisVMI(agentVMI), 240*time.Second, 2).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
+				Eventually(matcher.ThisVMI(agentVMI)).WithTimeout(240 * time.Second).WithPolling(2 * time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
 			})
 
 			Context("[Serial]with cluster config changes", Serial, func() {
@@ -1384,7 +1384,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						return false
 					}
 					return updatedVmi.Status.GuestOSInfo.Name != ""
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in vmi status")
+				}).WithTimeout(240*time.Second).WithPolling(2*time.Second).Should(BeTrue(), "Should have guest OS Info in vmi status")
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
@@ -1407,7 +1407,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						guestInfo.OS.Name != "" &&
 						len(guestInfo.FSInfo.Filesystems) > 0
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in subresource")
+				}).WithTimeout(240*time.Second).WithPolling(2*time.Second).Should(BeTrue(), "Should have guest OS Info in subresource")
 			})
 
 			It("[test_id:4628]should not return the whole data when agent is not present", func() {
@@ -1429,7 +1429,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						return err.Error()
 					}
 					return ""
-				}, 240*time.Second, 2).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
+				}).WithTimeout(240*time.Second).WithPolling(2*time.Second).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
 			})
 
 			It("[test_id:4629]should return user list", func() {
@@ -1447,7 +1447,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 					return len(userList.Items) > 0 && userList.Items[0].UserName == "fedora"
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have fedora users")
+				}).WithTimeout(240*time.Second).WithPolling(2*time.Second).Should(BeTrue(), "Should have fedora users")
 			})
 
 			It("[test_id:4630]should return filesystem list", func() {
@@ -1464,7 +1464,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					return len(fsList.Items) > 0 && fsList.Items[0].DiskName != "" && fsList.Items[0].MountPoint != "" &&
 						len(fsList.Items[0].Disk) > 0 && fsList.Items[0].Disk[0].BusType != ""
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have some filesystem")
+				}).WithTimeout(240*time.Second).WithPolling(2*time.Second).Should(BeTrue(), "Should have some filesystem")
 			})
 
 		})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -528,7 +528,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					vmi, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI successfully")
 					return vmi.Status.Phase
-				}, 10, 1).Should(Equal(v1.Failed), "VMI should be failed")
+				}).WithTimeout(10*time.Second).WithPolling(1*time.Second).Should(Equal(v1.Failed), "VMI should be failed")
 			})
 		})
 
@@ -645,7 +645,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					data, err := logsQuery.DoRaw(context.Background())
 					Expect(err).ToNot(HaveOccurred(), "Should get logs")
 					return string(data)
-				}, 60, 1).Should(
+				}).WithTimeout(60*time.Second).WithPolling(1*time.Second).Should(
 					ContainSubstring(
 						fmt.Sprintf("device socket file for device %s was removed, kubelet probably restarted.", "kvm"),
 					), "Should log device plugin restart")
@@ -1041,7 +1041,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					currVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 					return currVMI.Status.Phase
-				}, 120, 0.5).Should(Equal(v1.Running), "VMI should be succeeded")
+				}).WithTimeout(120*time.Second).WithPolling(500*time.Millisecond).Should(Equal(v1.Running), "VMI should be succeeded")
 			})
 
 			It("[test_id:1640]the vmi with cpu.model that cannot match an nfd label on node should not be scheduled", func() {
@@ -1261,7 +1261,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					data, err := logsQuery.DoRaw(context.Background())
 					Expect(err).ToNot(HaveOccurred(), "Should get logs from virthandler")
 					return string(data)
-				}, 30, 0.5).Should(MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Running reason Unknown","name":"%s"`, vmi.GetObjectMeta().GetName()), "Should verify from logs that domain is running")
+				}).WithTimeout(30*time.Second).WithPolling(500*time.Millisecond).Should(MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Running reason Unknown","name":"%s"`, vmi.GetObjectMeta().GetName()), "Should verify from logs that domain is running")
 				// Check the VirtualMachineInstance Namespace
 				Expect(vmi.GetObjectMeta().GetNamespace()).To(Equal(namespace), "VMI should run in the right namespace")
 
@@ -1288,7 +1288,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					data, err := logsQuery.DoRaw(context.Background())
 					Expect(err).ToNot(HaveOccurred(), "Should get the virthandler logs")
 					return string(data)
-				}, 30, 0.5).Should(SatisfyAny(
+				}).WithTimeout(30*time.Second).WithPolling(500*time.Millisecond).Should(SatisfyAny(
 					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is marked for deletion","name":"%s"`, vmi.GetObjectMeta().GetName()),               // Domain was deleted by virt-handler
 					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Shutoff reason Destroyed","name":"%s"`, vmi.GetObjectMeta().GetName()), // Domain was destroyed because the launcher pod is gone
 				), "Logs should confirm pod deletion")
@@ -1347,7 +1347,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					podList, err := kubevirt.Client().CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), listOptions)
 					Expect(err).ToNot(HaveOccurred(), "Should list the pods")
 					return len(podList.Items)
-				}, 75, 0.5).Should(Equal(1), "There should be only one pod")
+				}).WithTimeout(75*time.Second).WithPolling(500*time.Millisecond).Should(Equal(1), "There should be only one pod")
 
 				Eventually(func() error {
 					podList, err := kubevirt.Client().CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), listOptions)
@@ -1358,7 +1358,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 						}
 					}
 					return fmt.Errorf("Associated pod for VirtualMachineInstance '%s' not found", vmi.Name)
-				}, 75, 0.5).Should(Succeed(), "Should find the VMI pod")
+				}).WithTimeout(75*time.Second).WithPolling(500*time.Millisecond).Should(Succeed(), "Should find the VMI pod")
 
 				getOptions := metav1.GetOptions{}
 				var newVMI *v1.VirtualMachineInstance
@@ -1545,7 +1545,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					pods, err := kubevirt.Client().CoreV1().Pods(vmi.Namespace).List(context.Background(), podSelector)
 					Expect(err).ToNot(HaveOccurred(), "Should list pods")
 					return len(pods.Items)
-				}, 75, 0.5).Should(Equal(0), "There should be no pods")
+				}).WithTimeout(75*time.Second).WithPolling(500*time.Millisecond).Should(Equal(0), "There should be no pods")
 
 			})
 		})
@@ -1575,7 +1575,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					currVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 					return currVMI.Status.Phase
-				}, gracePeriod+5, 0.5).Should(Equal(v1.Succeeded), "VMI should be succeeded")
+				}).WithTimeout(time.Duration(gracePeriod+5)*time.Second).WithPolling(500*time.Millisecond).Should(Equal(v1.Succeeded), "VMI should be succeeded")
 			},
 				Entry("[test_id:1653]with set grace period seconds", int64(10)),
 				Entry("[test_id:1654]with default grace period seconds", int64(-1)),
@@ -1621,7 +1621,9 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					data, err := logsQuery.DoRaw(context.Background())
 					Expect(err).ToNot(HaveOccurred(), "Should get the logs")
 					return string(data)
-				}, 30, 0.5).Should(ContainSubstring(fmt.Sprintf("Signaled graceful shutdown for %s", vmi.GetObjectMeta().GetName())), "Should log graceful shutdown")
+				}).WithTimeout(30*time.Second).
+					WithPolling(500*time.Millisecond).
+					Should(ContainSubstring(fmt.Sprintf("Signaled graceful shutdown for %s", vmi.GetObjectMeta().GetName())), "Should log graceful shutdown")
 
 				// Verify VirtualMachineInstance is killed after grace period expires
 				By("Checking that the VirtualMachineInstance does not exist after grace period")
@@ -1629,7 +1631,9 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					data, err := logsQuery.DoRaw(context.Background())
 					Expect(err).ToNot(HaveOccurred(), "Should get logs")
 					return string(data)
-				}, 30, 0.5).Should(ContainSubstring(fmt.Sprintf("Grace period expired, killing deleted VirtualMachineInstance %s", vmi.GetObjectMeta().GetName())), "Should log graceful kill")
+				}).WithTimeout(30*time.Second).
+					WithPolling(500*time.Millisecond).
+					Should(ContainSubstring(fmt.Sprintf("Grace period expired, killing deleted VirtualMachineInstance %s", vmi.GetObjectMeta().GetName())), "Should log graceful kill")
 			})
 		})
 	})
@@ -1657,7 +1661,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				failedVMI, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 				return failedVMI.Status.Phase
-			}, 10, 1).Should(Equal(v1.Failed), "VMI should be failed")
+			}).WithTimeout(10*time.Second).WithPolling(1*time.Second).Should(Equal(v1.Failed), "VMI should be failed")
 
 		})
 
@@ -1810,7 +1814,7 @@ func pkillHandler(virtCli kubecli.KubevirtClient, node string) error {
 		return podG.Status.Phase
 	}
 
-	Eventually(getStatus, 30, 0.5).Should(Equal(k8sv1.PodSucceeded), "Pod should end itself")
+	Eventually(getStatus).WithTimeout(30*time.Second).WithPolling(500*time.Millisecond).Should(Equal(k8sv1.PodSucceeded), "Pod should end itself")
 
 	return err
 }


### PR DESCRIPTION
### What this PR does
The gomega's `Eventually` and `Consistently` function API is ambiguous. The time interval parameters (timeout and polling) are both optional, and can get multiple values, such as integers or floating points as number of seconds, or `time.Duration`. This is very confusing.

This PR removes all these ambiguous parameters, replacing them with the explicit versions: the `WithTimeout()` and `WithPolling()` methods, that also only receives time.Duration values.

That make the usage in Eventually and Consistently more readable and explicit.

### Release note
```release-note
None
```

/sig code-quality
