### PR TITLE
Introduce a generic thread-safe time-defined cache

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//tools/cache:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -456,22 +456,19 @@ func (l *Launcher) GetDomainStats(_ context.Context, _ *cmdv1.EmptyRequest) (*cm
 		},
 	}
 
-	list, err := l.domainManager.GetDomainStats()
+	stats, err := l.domainManager.GetDomainStats()
 	if err != nil {
 		response.Response.Success = false
 		response.Response.Message = getErrorMessage(err)
 		return response, nil
 	}
 
-	if len(list) > 0 {
-		if domainStats, err := json.Marshal(list[0]); err != nil {
-			log.Log.Reason(err).Errorf("Failed to marshal domain stats")
-			response.Response.Success = false
-			response.Response.Message = getErrorMessage(err)
-			return response, nil
-		} else {
-			response.DomainStats = string(domainStats)
-		}
+	if domainStats, err := json.Marshal(stats); err != nil {
+		log.Log.Reason(err).Errorf("Failed to marshal domain stats")
+		response.Response.Success = false
+		response.Response.Message = getErrorMessage(err)
+	} else {
+		response.DomainStats = string(domainStats)
 	}
 
 	return response, nil

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -210,21 +210,20 @@ var _ = Describe("Virt remote commands", func() {
 		})
 
 		It("should return domain stats", func() {
-			var list []*stats.DomainStats
 			dom := api.NewMinimalDomain("testvmstats1")
-			list = append(list, &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Name: dom.Spec.Name,
 				UUID: dom.Spec.UUID,
-			})
+			}
 
-			domainManager.EXPECT().GetDomainStats().Return(list, nil)
+			domainManager.EXPECT().GetDomainStats().Return(domainStats, nil)
 			domStats, exists, err := client.GetDomainStats()
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(exists).To(BeTrue())
 			Expect(domStats).ToNot(BeNil())
-			Expect(domStats.Name).To(Equal(list[0].Name))
-			Expect(domStats.UUID).To(Equal(list[0].UUID))
+			Expect(domStats.Name).To(Equal(domainStats.Name))
+			Expect(domStats.UUID).To(Equal(domainStats.UUID))
 		})
 
 		It("should return full user list", func() {

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -164,9 +164,9 @@ func (_mr *_MockDomainManagerRecorder) PrepareMigrationTarget(arg0, arg1, arg2 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrepareMigrationTarget", arg0, arg1, arg2)
 }
 
-func (_m *MockDomainManager) GetDomainStats() ([]*stats.DomainStats, error) {
+func (_m *MockDomainManager) GetDomainStats() (*stats.DomainStats, error) {
 	ret := _m.ctrl.Call(_m, "GetDomainStats")
-	ret0, _ := ret[0].([]*stats.DomainStats)
+	ret0, _ := ret[0].(*stats.DomainStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -41,6 +41,8 @@ import (
 	"sync"
 	"time"
 
+	virtcache "kubevirt.io/kubevirt/tools/cache"
+
 	"k8s.io/utils/pointer"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/generic"
@@ -122,7 +124,7 @@ type DomainManager interface {
 	ListAllDomains() ([]*api.Domain, error)
 	MigrateVMI(*v1.VirtualMachineInstance, *cmdclient.MigrationOptions) error
 	PrepareMigrationTarget(*v1.VirtualMachineInstance, bool, *cmdv1.VirtualMachineOptions) error
-	GetDomainStats() ([]*stats.DomainStats, error)
+	GetDomainStats() (*stats.DomainStats, error)
 	CancelVMIMigration(*v1.VirtualMachineInstance) error
 	GetGuestInfo() v1.VirtualMachineInstanceGuestAgentInfo
 	GetUsers() []v1.VirtualMachineInstanceGuestOSUser
@@ -169,7 +171,8 @@ type LibvirtDomainManager struct {
 	cancelSafetyUnfreezeChan chan struct{}
 	migrateInfoStats         *stats.DomainJobInfo
 
-	metadataCache *metadata.Cache
+	metadataCache    *metadata.Cache
+	domainStatsCache *virtcache.TimeDefinedCache[*stats.DomainStats]
 }
 
 type pausedVMIs struct {
@@ -221,6 +224,25 @@ func newLibvirtDomainManager(connection cli.Connection, virtShareDir, ephemeralD
 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
 	manager.memoryDumpInProgress = make(chan struct{}, maxConcurrentMemoryDumps)
 	manager.credManager = accesscredentials.NewManager(connection, &manager.domainModifyLock, metadataCache)
+
+	reCalcDomainStats := func() (*stats.DomainStats, error) {
+		list, err := manager.getDomainStats()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(list) == 0 {
+			return nil, nil
+		}
+
+		return list[0], nil
+	}
+
+	var err error
+	manager.domainStatsCache, err = virtcache.NewTimeDefinedCache(5*time.Second, true, reCalcDomainStats)
+	if err != nil {
+		return nil, err
+	}
 
 	return &manager, nil
 }
@@ -1893,7 +1915,11 @@ func (l *LibvirtDomainManager) GetQemuVersion() (string, error) {
 	return l.virConn.GetQemuVersion()
 }
 
-func (l *LibvirtDomainManager) GetDomainStats() ([]*stats.DomainStats, error) {
+func (l *LibvirtDomainManager) GetDomainStats() (*stats.DomainStats, error) {
+	return l.domainStatsCache.Get()
+}
+
+func (l *LibvirtDomainManager) getDomainStats() ([]*stats.DomainStats, error) {
 	statsTypes := libvirt.DOMAIN_STATS_BALLOON | libvirt.DOMAIN_STATS_CPU_TOTAL | libvirt.DOMAIN_STATS_VCPU | libvirt.DOMAIN_STATS_INTERFACE | libvirt.DOMAIN_STATS_BLOCK | libvirt.DOMAIN_STATS_DIRTYRATE
 	flags := libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2061,7 +2061,7 @@ var _ = Describe("Manager", func() {
 			domStats, err := manager.GetDomainStats()
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(domStats).To(HaveLen(1))
+			Expect(domStats).ToNot(BeNil())
 		})
 	})
 

--- a/tools/cache/BUILD.bazel
+++ b/tools/cache/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["time-defined-cache.go"],
+    importpath = "kubevirt.io/kubevirt/tools/cache",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "cache_suite_test.go",
+        "time-defined-cache_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/tools/cache/cache_suite_test.go
+++ b/tools/cache/cache_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package cache_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestPatch(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/tools/cache/time-defined-cache.go
+++ b/tools/cache/time-defined-cache.go
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type TimeDefinedCache[T any] struct {
+	minRefreshDuration time.Duration
+	lastRefresh        time.Time
+	savedValueSet      bool
+	savedValue         T
+	reCalcFunc         func() (T, error)
+	valueLock          *sync.RWMutex
+}
+
+// NewTimeDefinedCache creates a new cache that will refresh the value every minRefreshDuration. If the value is requested
+// before the minRefreshDuration has passed, the cached value will be returned. If minRefreshDuration is zero, the value will always be
+// recalculated.
+// In addition, a Set() can be used to explicitly set the value.
+// If useValueLock is set to true, the value will be locked when being set. If the cache won't be used concurrently, it's safe
+// to set this to false.
+func NewTimeDefinedCache[T any](minRefreshDuration time.Duration, useValueLock bool, reCalcFunc func() (T, error)) (*TimeDefinedCache[T], error) {
+	if reCalcFunc == nil {
+		return nil, fmt.Errorf("re-calculation function is not set")
+	}
+
+	t := &TimeDefinedCache[T]{
+		minRefreshDuration: minRefreshDuration,
+		reCalcFunc:         reCalcFunc,
+	}
+
+	if useValueLock {
+		t.valueLock = &sync.RWMutex{}
+	}
+
+	return t, nil
+}
+
+func (t *TimeDefinedCache[T]) Get() (T, error) {
+	if t.savedValueSet && t.minRefreshDuration.Nanoseconds() != 0 && time.Since(t.lastRefresh) <= t.minRefreshDuration {
+		if t.valueLock != nil {
+			t.valueLock.RLock()
+			defer t.valueLock.RUnlock()
+		}
+		return t.savedValue, nil
+	}
+
+	if t.valueLock != nil {
+		t.valueLock.Lock()
+		defer t.valueLock.Unlock()
+	}
+
+	value, err := t.reCalcFunc()
+	if err != nil {
+		return t.savedValue, err
+	}
+
+	t.setWithoutLock(value)
+
+	return t.savedValue, nil
+}
+
+func (t *TimeDefinedCache[T]) Set(value T) {
+	if t.valueLock != nil {
+		t.valueLock.Lock()
+		defer t.valueLock.Unlock()
+	}
+
+	t.setWithoutLock(value)
+}
+
+func (t *TimeDefinedCache[T]) setWithoutLock(value T) {
+	t.savedValue = value
+	t.savedValueSet = true
+	t.lastRefresh = time.Now()
+}

--- a/tools/cache/time-defined-cache_test.go
+++ b/tools/cache/time-defined-cache_test.go
@@ -1,0 +1,119 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package cache_test
+
+import (
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	virtcache "kubevirt.io/kubevirt/tools/cache"
+)
+
+var _ = Describe("time defined cache", func() {
+
+	getMockCalcFunc := func() func() (int, error) {
+		mockValue := 0
+		return func() (int, error) {
+			mockValue++
+			return mockValue, nil
+		}
+	}
+
+	DescribeTable("should get new or cached value according to refresh duration", func(refreshDurationPassed bool) {
+		minRefreshDuration := 123 * time.Second
+		if refreshDurationPassed {
+			minRefreshDuration = 0
+		}
+		cache, err := virtcache.NewTimeDefinedCache(minRefreshDuration, false, getMockCalcFunc())
+		Expect(err).ToNot(HaveOccurred())
+		value, err := cache.Get()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(value).To(Equal(1))
+
+		value, err = cache.Get()
+		Expect(err).ToNot(HaveOccurred())
+
+		if refreshDurationPassed {
+			Expect(value).To(Equal(2))
+		} else {
+			Expect(value).To(Equal(1))
+		}
+	},
+		Entry("should get the same value if the refresh duration has not passed", false),
+		Entry("should get a new value if the refresh duration has passed", true),
+	)
+
+	It("should return an error if the re-calculation function is not set", func() {
+		var dummyFunc func() (int, error)
+		dummyFunc = nil
+
+		_, err := virtcache.NewTimeDefinedCache(0, false, dummyFunc)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should not allow two threads to set value in parallel", func() {
+		stopChannel := make(chan struct{})
+		defer close(stopChannel)
+		firstCallMadeChannel := make(chan struct{})
+
+		recalcFunctionCalls := int64(0)
+
+		recalcFunc := func() (int, error) {
+			firstCallMadeChannel <- struct{}{}
+			atomic.AddInt64(&recalcFunctionCalls, 1)
+
+			ticker := time.NewTicker(1 * time.Second)
+			defer ticker.Stop()
+
+			select {
+			case <-ticker.C:
+				time.Sleep(100 * time.Millisecond)
+			case <-stopChannel:
+				break
+			}
+
+			return 1, nil
+		}
+
+		cache, err := virtcache.NewTimeDefinedCache(0, true, recalcFunc)
+		Expect(err).ToNot(HaveOccurred())
+
+		getValueFromCache := func() {
+			defer GinkgoRecover()
+			_, err = cache.Get()
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		for i := 0; i < 5; i++ {
+			go getValueFromCache()
+		}
+
+		// To ensure the first call is already made
+		<-firstCallMadeChannel
+
+		Consistently(func() {
+			Expect(recalcFunctionCalls).To(Equal(int64(1)), "value is being re-calculated, only one caller is expected")
+		}).WithPolling(250 * time.Millisecond).WithTimeout(1 * time.Second)
+	})
+
+})


### PR DESCRIPTION
### What this PR does
#### About the cache itself

This PR introduces a generic thread-safe and time-defined cache.

The main idea is that when the `Get()` method is called, the cache would either re-calculate the value or return the cached value according to the parameters passed to it during its creation.

This cache gets a few parameters:
* `minRefreshDuration`: If the value is requested before the minRefreshDuration has passed, the cached value will be returned. If minRefreshDuration is zero, the value will always be recalculated.
* `useValueLock`: which hurts performance a bit, but makes the cache thread-safe.
* `reCalcFunc`: a function to re-calculate the desired value.

The value can be also explicitly set with `Set()`.

#### Cache usage
This PR uses the cache for `GetDomainStats()`, and caches it for 5 seconds.
This is important since many GUI layers or external tooling call this function very often, sometimes many times a second for a single VM from different components. Without caching, we would re-calculate the stats again and again which increases load and compromises stability.

Before this PR:
UI layer that calls `GetDomainStats()` 20 times in one second would cause the domain stats to be re-calculated 20 times in one second.

After this PR:
A billion calls to `GetDomainStats()` would result in calculating the stats only once.

**Special notes for your reviewer**:
This was initially implemented in https://github.com/kubevirt/kubevirt/pull/10302. I've split it into a different PR since there was a broad acceptance of the cache itself. Now we'd be able to both have this cache in and the other PR would be easier to review and discuss.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

