### PR TITLE
Hash HostName value on DownwardMetrics

### DIFF
--- a/pkg/monitoring/domainstats/downwardmetrics/BUILD.bazel
+++ b/pkg/monitoring/domainstats/downwardmetrics/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/downwardmetrics/vhostmd/api:go_default_library",
         "//pkg/downwardmetrics/vhostmd/metrics:go_default_library",
         "//pkg/monitoring/domainstats:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
@@ -29,10 +30,12 @@ go_test(
     srcs = [
         "downwardmetrics_suite_test.go",
         "hostmetrics_test.go",
+        "scraper_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/monitoring/domainstats/downwardmetrics/scraper.go
+++ b/pkg/monitoring/domainstats/downwardmetrics/scraper.go
@@ -15,6 +15,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd/api"
 	metricspkg "kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd/metrics"
 	vms "kubevirt.io/kubevirt/pkg/monitoring/domainstats"
+	"kubevirt.io/kubevirt/pkg/util"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
@@ -146,9 +147,12 @@ type Collector struct {
 }
 
 func NewReporter(nodeName string) *DownwardMetricsReporter {
+	// Let's return a hash of the host name to avoid exposing the real host name to an
+	// untrusted VM. The metrics `HostName` value is used as an uuid of the node (to
+	// detect changes), and is not used to do dns queries.
 	return &DownwardMetricsReporter{
 		staticHostInfo: &StaticHostMetrics{
-			HostName:             nodeName,
+			HostName:             util.HashString(nodeName),
 			HostSystemInfo:       "linux",
 			VirtualizationVendor: "kubevirt.io",
 		},

--- a/pkg/monitoring/domainstats/downwardmetrics/scraper_test.go
+++ b/pkg/monitoring/domainstats/downwardmetrics/scraper_test.go
@@ -1,0 +1,35 @@
+package downwardmetrics
+
+import (
+	"kubevirt.io/kubevirt/pkg/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Reporter", func() {
+	It("should return a hash of the node's host name", func() {
+		// A dummy domain that doesn't exist
+		nodeName := "node.example.invalid"
+		hashedNodeName := util.HashString(nodeName)
+
+		reporter := NewReporter(nodeName)
+		Expect(reporter.staticHostInfo.HostName).ToNot(Equal(nodeName))
+		Expect(reporter.staticHostInfo.HostName).To(Equal(hashedNodeName))
+	})
+
+	It("should return a 'HostName' string not longer than the maximum allowed", func() {
+		// The metrics `HostName` value is used as an uuid of the node (to detect changes),
+		// and is not used to do dns queries. So, we don't care about the maximum length of
+		// 63 chars of each label (i.e., a fqdn is a dot-separated list of labels), let's
+		// just check the total hostname length to be lees than 253 characters
+		// (the effective maximum length of a DNS name), in case the client has reserved
+		// that space as maximum.
+
+		// A dummy domain that doesn't exist
+		nodeName := "node.example.invalid"
+		reporter := NewReporter(nodeName)
+
+		Expect(len(reporter.staticHostInfo.HostName)).To(BeNumerically("<=", 253))
+	})
+})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -302,4 +304,10 @@ func GenerateKubeVirtGroupVersionKind(obj runtime.Object) (runtime.Object, error
 	objCopy.GetObjectKind().SetGroupVersionKind(gvks[0])
 
 	return objCopy, nil
+}
+
+// HashString returns a sha256 string representation of the input string
+func HashString(s string) string {
+	hashedStrBin := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(hashedStrBin[:])
 }

--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/tests/infrastructure/downward-metrics.go
+++ b/tests/infrastructure/downward-metrics.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/tests/libinfra"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -65,7 +66,7 @@ var _ = DescribeInfra("downwardMetrics", func() {
 			Expect(err).ToNot(HaveOccurred())
 			return libinfra.GetTimeFromMetrics(metrics)
 		}, 10*time.Second, 1*time.Second).ShouldNot(Equal(timestamp))
-		Expect(libinfra.GetHostnameFromMetrics(metrics)).To(Equal(vmi.Status.NodeName))
+		Expect(libinfra.GetHostnameFromMetrics(metrics)).To(Equal(util.HashString(vmi.Status.NodeName)))
 
 	},
 		Entry("[test_id:6535]using a disk", libvmi.WithDownwardMetricsVolume("vhostmd"), libinfra.GetDownwardMetricsDisk),

--- a/tests/migration/BUILD.bazel
+++ b/tests/migration/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	kvutil "kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 
@@ -501,7 +502,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("checking that the new nodename is reflected in the downward metrics")
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(libinfra.GetHostnameFromMetrics(metrics)).To(Equal(vmi.Status.NodeName))
+				Expect(libinfra.GetHostnameFromMetrics(metrics)).To(Equal(kvutil.HashString(vmi.Status.NodeName)))
 
 			},
 				Entry("[test_id:6971]disk", libvmi.WithDownwardMetricsVolume("vhostmd"), libinfra.GetDownwardMetricsDisk),


### PR DESCRIPTION
### What this PR does
A concern was raised about the possibility of exposing the host name to an untrusted VM via downward metrics. Let's return a hashed HostName value to avoid exposing the real host name to the VM.

The HostName value is used by SAP as an uuid of the node (to detect changes), and is not used to do dns queries.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The DonwardMetrics returns a hashed HostName value to avoid exposing the real host name to an untrusted VM
```

