### PR TITLE
virtctl: improve usbredir as module

### DIFF
--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -20,6 +20,7 @@
 package usbredir
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -58,7 +59,7 @@ type usbredirCommand struct {
 	clientConfig clientcmd.ClientConfig
 }
 
-type ClientConnectFn func(device, address string) error
+type ClientConnectFn func(device, address string, stop chan struct{}) error
 
 type Client struct {
 	// To connect local USB device buffer to the remote VM using the websocket.
@@ -69,8 +70,11 @@ type Client struct {
 
 	listener *net.TCPListener
 
+	stopped bool
+
 	// channels
 	done   chan struct{}
+	stop   chan struct{}
 	stream chan error
 	local  chan error
 	remote chan error
@@ -82,6 +86,7 @@ func NewUSBRedirClient() *Client {
 	inReader, inWriter := io.Pipe()
 	outReader, outWriter := io.Pipe()
 	return &Client{
+		stop:          make(chan struct{}),
 		inputReader:   inReader,
 		inputWriter:   inWriter,
 		outputReader:  outReader,
@@ -90,17 +95,30 @@ func NewUSBRedirClient() *Client {
 	}
 }
 
+func (k *Client) Stop() {
+	k.stopped = true
+	k.stop <- struct{}{}
+}
+
 func (k *Client) WithRemoteVMIStream(usbredirStream kubecli.StreamInterface) *Client {
 	k.stream = make(chan error)
 
 	go func() {
 		defer k.outputWriter.Close()
-		k.stream <- usbredirStream.Stream(
-			kubecli.StreamOptions{
-				In:  k.inputReader,
-				Out: k.outputWriter,
-			},
-		)
+		errch := make(chan error)
+		go func() {
+			errch <- usbredirStream.Stream(
+				kubecli.StreamOptions{
+					In:  k.inputReader,
+					Out: k.outputWriter,
+				},
+			)
+		}()
+		select {
+		case <-k.stop:
+		case err := <-errch:
+			k.stream <- err
+		}
 	}()
 
 	return k
@@ -155,9 +173,10 @@ func (k *Client) ConnectRemote() {
 		}()
 
 		select {
+		case <-k.stop: // outside request to stop
 		case <-k.done: // Wait for local usbredir to complete
 		case err = <-stream: // Wait for remote connection to close
-			if err == nil {
+			if err == nil && !k.stopped {
 				// Remote connection closed, report this as error
 				err = fmt.Errorf("Remote connection has closed.")
 			}
@@ -168,7 +187,7 @@ func (k *Client) ConnectRemote() {
 	}()
 }
 
-func clientConnect(device, address string) error {
+func clientConnect(device, address string, stop chan struct{}) error {
 	bin := usbredirClient
 	args := []string{}
 	args = append(args, "--device", device, "--to", address)
@@ -177,13 +196,25 @@ func clientConnect(device, address string) error {
 	log.Log.Infof("args: '%v'", args)
 	log.Log.Infof("Executing commandline: '%s %v'", bin, args)
 
-	command := exec.Command(bin, args...)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		log.Log.Errorf("Failed to execute %v due %v, output: %v", bin, err, string(output))
-	} else {
+	ctx, cancelFn := context.WithCancel(context.Background())
+	command := exec.CommandContext(ctx, bin, args...)
+	done := make(chan error)
+	go func() {
+		output, err := command.CombinedOutput()
 		log.Log.V(2).Infof("%v output: %v", bin, string(output))
+		done <- err
+	}()
+
+	var err error
+	select {
+	case err = <-done:
+		if err != nil {
+			log.Log.Errorf("Failed to execute %v due %v", bin, err)
+		}
+	case <-stop:
+		// will stop with cancelFn()
 	}
+	cancelFn()
 	return err
 }
 
@@ -193,7 +224,7 @@ func (k *Client) ConnectLocal(device string) {
 	k.local = make(chan error)
 	go func() {
 		defer close(k.done)
-		k.local <- k.ClientConnect(device, address)
+		k.local <- k.ClientConnect(device, address, k.stop)
 	}()
 }
 
@@ -211,6 +242,7 @@ func (k *Client) Run() error {
 	case err = <-k.stream:
 	case err = <-k.local:
 	case err = <-k.remote:
+	case <-k.stop:
 	}
 	return err
 }

--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -150,7 +150,7 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 		streamResChan <- err
 	}()
 
-	port := ln.Addr().(*net.TCPAddr).Port
+	address := ln.Addr().String()
 
 	// execute local usbredir binary
 	usbredirExecResChan := make(chan error)
@@ -159,10 +159,9 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 
 		bin := usbredirClient
 		args := []string{}
-		port_arg := fmt.Sprintf("localhost:%v", port)
-		args = append(args, "--device", usbdeviceArg, "--to", port_arg)
+		args = append(args, "--device", usbdeviceArg, "--to", address)
 
-		log.Log.Infof("port_arg: '%s'", port_arg)
+		log.Log.Infof("hostaddr: '%s'", address)
 		log.Log.Infof("args: '%v'", args)
 		log.Log.Infof("Executing commandline: '%s %v'", bin, args)
 

--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -58,6 +58,163 @@ type usbredirCommand struct {
 	clientConfig clientcmd.ClientConfig
 }
 
+type ClientConnectFn func(device, address string) error
+
+type Client struct {
+	// To connect local USB device buffer to the remote VM using the websocket.
+	inputReader  *io.PipeReader
+	inputWriter  *io.PipeWriter
+	outputReader *io.PipeReader
+	outputWriter *io.PipeWriter
+
+	listener *net.TCPListener
+
+	// channels
+	done   chan struct{}
+	stream chan error
+	local  chan error
+	remote chan error
+
+	ClientConnect ClientConnectFn
+}
+
+func NewUSBRedirClient() *Client {
+	inReader, inWriter := io.Pipe()
+	outReader, outWriter := io.Pipe()
+	return &Client{
+		inputReader:   inReader,
+		inputWriter:   inWriter,
+		outputReader:  outReader,
+		outputWriter:  outWriter,
+		ClientConnect: clientConnect,
+	}
+}
+
+func (k *Client) WithRemoteVMIStream(usbredirStream kubecli.StreamInterface) *Client {
+	k.stream = make(chan error)
+
+	go func() {
+		defer k.outputWriter.Close()
+		k.stream <- usbredirStream.Stream(
+			kubecli.StreamOptions{
+				In:  k.inputReader,
+				Out: k.outputWriter,
+			},
+		)
+	}()
+
+	return k
+}
+
+func (k *Client) WithLocalTCPClient(address string) *Client {
+	lnAddr, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		log.Log.Errorf("Can't resolve the address: %s", err.Error())
+		return nil
+	}
+
+	// The local tcp server is used to proxy between remote websocket and local USB
+	k.listener, err = net.ListenTCP("tcp", lnAddr)
+	if err != nil {
+		log.Log.Errorf("Can't listen on unix socket: %s", err.Error())
+		return nil
+	}
+
+	return k
+}
+
+func (k *Client) ConnectRemote() {
+	// forward data to/from websocket after usbredir client connects.
+	k.done = make(chan struct{}, 1)
+	k.remote = make(chan error)
+	go func() {
+		defer k.inputWriter.Close()
+		start := time.Now()
+
+		usbredirConn, err := k.listener.Accept()
+		if err != nil {
+			log.Log.V(2).Infof("Failed to accept connection: %s", err.Error())
+			k.remote <- err
+			return
+		}
+		defer usbredirConn.Close()
+
+		log.Log.V(2).Infof("Connected to %s at %v", usbredirClient, time.Now().Sub(start))
+
+		stream := make(chan error)
+		// write to local usbredir from pipeOutReader
+		go func() {
+			_, err := io.Copy(usbredirConn, k.outputReader)
+			stream <- err
+		}()
+
+		// read from local usbredir towards pipeInWriter
+		go func() {
+			_, err := io.Copy(k.inputWriter, usbredirConn)
+			stream <- err
+		}()
+
+		select {
+		case <-k.done: // Wait for local usbredir to complete
+		case err = <-stream: // Wait for remote connection to close
+			if err == nil {
+				// Remote connection closed, report this as error
+				err = fmt.Errorf("Remote connection has closed.")
+			}
+		}
+
+		// Wait for local usbredir to complete
+		k.remote <- err
+	}()
+}
+
+func clientConnect(device, address string) error {
+	bin := usbredirClient
+	args := []string{}
+	args = append(args, "--device", device, "--to", address)
+
+	log.Log.Infof("port_arg: '%s'", address)
+	log.Log.Infof("args: '%v'", args)
+	log.Log.Infof("Executing commandline: '%s %v'", bin, args)
+
+	command := exec.Command(bin, args...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		log.Log.Errorf("Failed to execute %v due %v, output: %v", bin, err, string(output))
+	} else {
+		log.Log.V(2).Infof("%v output: %v", bin, string(output))
+	}
+	return err
+}
+
+func (k *Client) ConnectLocal(device string) {
+	// execute local usbredir binary
+	address := k.listener.Addr().String()
+	k.local = make(chan error)
+	go func() {
+		defer close(k.done)
+		k.local <- k.ClientConnect(device, address)
+	}()
+}
+
+func (k *Client) Run() error {
+	var err error
+
+	interrupt := make(chan os.Signal, 1)
+	go func() {
+		signal.Notify(interrupt, os.Interrupt)
+		<-interrupt
+	}()
+
+	select {
+	case <-interrupt:
+	case err = <-k.stream:
+	case err = <-k.local:
+	case err = <-k.remote:
+	}
+	return err
+}
+
 func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) error {
 	if _, err := exec.LookPath(usbredirClient); err != nil {
 		return fmt.Errorf("Error on finding %s in $PATH: %s", usbredirClient, err.Error())
@@ -82,116 +239,13 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 		return fmt.Errorf("Can't access VMI %s: %s", vmiArg, err.Error())
 	}
 
-	// We will connect the local USB device using a usbredir TCP client to the
-	// remote VM using the websocket.
-	pipeInReader, pipeInWriter := io.Pipe()
-	pipeOutReader, pipeOutWriter := io.Pipe()
+	usbredirClient := NewUSBRedirClient().
+		WithRemoteVMIStream(usbredirVMI).
+		WithLocalTCPClient("localhost:0")
 
-	// Configure in/out and start stream with websocket
-	k8ResChan := make(chan error)
-	go func() {
-		defer pipeOutWriter.Close()
-		k8ResChan <- usbredirVMI.Stream(kubecli.StreamOptions{
-			In:  pipeInReader,
-			Out: pipeOutWriter,
-		})
-	}()
-
-	lnAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:0"))
-	if err != nil {
-		return fmt.Errorf("Can't resolve the address: %s", err.Error())
-	}
-
-	// The local tcp server is used to proxy between remote websocket and local USB
-	ln, err := net.ListenTCP("tcp", lnAddr)
-	if err != nil {
-		return fmt.Errorf("Can't listen on unix socket: %s", err.Error())
-	}
-
-	// forward data to/from websocket after usbredir client connects.
-	usbredirDoneChan := make(chan struct{}, 1)
-	streamResChan := make(chan error)
-	go func() {
-		defer pipeInWriter.Close()
-		start := time.Now()
-
-		usbredirConn, err := ln.Accept()
-		if err != nil {
-			log.Log.V(2).Infof("Failed to accept connection: %s", err.Error())
-			streamResChan <- err
-			return
-		}
-		defer usbredirConn.Close()
-
-		log.Log.V(2).Infof("Connected to %s at %v", usbredirClient, time.Now().Sub(start))
-
-		streamStop := make(chan error)
-		// write to local usbredir from pipeOutReader
-		go func() {
-			_, err := io.Copy(usbredirConn, pipeOutReader)
-			streamStop <- err
-		}()
-
-		// read from local usbredir towards pipeInWriter
-		go func() {
-			_, err := io.Copy(pipeInWriter, usbredirConn)
-			streamStop <- err
-		}()
-
-		select {
-		case <-usbredirDoneChan: // Wait for local usbredir to complete
-		case err = <-streamStop: // Wait for remote connection to close
-			if err == nil {
-				// Remote connection closed, report this as error
-				err = fmt.Errorf("Remote connection has closed.")
-			}
-		}
-
-		streamResChan <- err
-	}()
-
-	address := ln.Addr().String()
-
-	// execute local usbredir binary
-	usbredirExecResChan := make(chan error)
-	go func() {
-		defer close(usbredirDoneChan)
-
-		bin := usbredirClient
-		args := []string{}
-		args = append(args, "--device", usbdeviceArg, "--to", address)
-
-		log.Log.Infof("hostaddr: '%s'", address)
-		log.Log.Infof("args: '%v'", args)
-		log.Log.Infof("Executing commandline: '%s %v'", bin, args)
-
-		command := exec.Command(bin, args...)
-		output, err := command.CombinedOutput()
-		if err != nil {
-			log.Log.Errorf("Failed to execut %v due %v, output: %v", bin, err, string(output))
-		} else {
-			log.Log.V(2).Infof("%v output: %v", bin, string(output))
-		}
-		usbredirExecResChan <- err
-	}()
-
-	interrupt := make(chan os.Signal, 1)
-	go func() {
-		signal.Notify(interrupt, os.Interrupt)
-		<-interrupt
-	}()
-
-	select {
-	case <-interrupt:
-	case err = <-k8ResChan:
-	case err = <-usbredirExecResChan:
-	case err = <-streamResChan:
-	}
-
-	if err != nil {
-		return fmt.Errorf("Error encountered: %s", err.Error())
-	}
-	return nil
+	usbredirClient.ConnectRemote()
+	usbredirClient.ConnectLocal(usbdeviceArg)
+	return usbredirClient.Run()
 }
 
 func usage() string {

--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -141,6 +141,10 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 		select {
 		case <-usbredirDoneChan: // Wait for local usbredir to complete
 		case err = <-streamStop: // Wait for remote connection to close
+			if err == nil {
+				// Remote connection closed, report this as error
+				err = fmt.Errorf("Remote connection has closed.")
+			}
 		}
 
 		streamResChan <- err

--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -175,16 +175,14 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 		usbredirExecResChan <- err
 	}()
 
-	sigStopChan := make(chan struct{}, 1)
+	interrupt := make(chan os.Signal, 1)
 	go func() {
-		defer close(sigStopChan)
-		interrupt := make(chan os.Signal, 1)
 		signal.Notify(interrupt, os.Interrupt)
 		<-interrupt
 	}()
 
 	select {
-	case <-sigStopChan:
+	case <-interrupt:
 	case err = <-k8ResChan:
 	case err = <-usbredirExecResChan:
 	case err = <-streamResChan:

--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -41,8 +41,8 @@ const usbredirClient = "usbredirect"
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "usbredir (vendor:product) (VMI)",
-		Short:   "Redirect a usb device to a virtual machine instance.",
+		Use:     "usbredir (vendor:product)|(bus-device) (VMI)",
+		Short:   "Redirect an USB device to a virtual machine instance.",
 		Example: usage(),
 		Args:    templates.ExactArgs("usb", 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -192,6 +192,14 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 }
 
 func usage() string {
-	return `  # Redirect a local USB device to the remote VMI:\n"
-  {{ProgramName}} usbredir vendor:product testvmi`
+	return `# Find the device you want to redirect (linux):
+	$ lsusb | grep Kingston
+	Bus 002 Device 003: ID 0951:1666 Kingston Technology DataTraveler 100 G3/G4/SE9 G2/50
+
+	# Redirect it with vendor:product to testvmi:
+    {{ProgramName}} usbredir 0951:1666 testvmi
+
+	# Redirect it with bus-device:
+    {{ProgramName}} usbredir 02-03 testvmi
+	`
 }

--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -111,7 +111,6 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 	// forward data to/from websocket after usbredir client connects.
 	usbredirDoneChan := make(chan struct{}, 1)
 	streamResChan := make(chan error)
-	streamStop := make(chan error)
 	go func() {
 		defer pipeInWriter.Close()
 		start := time.Now()
@@ -126,6 +125,7 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 
 		log.Log.V(2).Infof("Connected to %s at %v", usbredirClient, time.Now().Sub(start))
 
+		streamStop := make(chan error)
 		// write to local usbredir from pipeOutReader
 		go func() {
 			_, err := io.Copy(usbredirConn, pipeOutReader)
@@ -138,8 +138,11 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 			streamStop <- err
 		}()
 
-		// Wait for local usbredir to complete
-		<-usbredirDoneChan
+		select {
+		case <-usbredirDoneChan: // Wait for local usbredir to complete
+		case err = <-streamStop: // Wait for remote connection to close
+		}
+
 		streamResChan <- err
 	}()
 
@@ -179,7 +182,6 @@ func (usbredirCmd *usbredirCommand) Run(command *cobra.Command, args []string) e
 
 	select {
 	case <-sigStopChan:
-	case err = <-streamStop:
 	case err = <-k8ResChan:
 	case err = <-usbredirExecResChan:
 	case err = <-streamResChan:

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -168,6 +168,7 @@ go_test(
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virtctl/pause:go_default_library",
         "//pkg/virtctl/softreboot:go_default_library",
+        "//pkg/virtctl/usbredir:go_default_library",
         "//pkg/virtctl/vm:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core:go_default_library",

--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -20,8 +20,10 @@
 package tests_test
 
 import (
-	"io"
+	"net"
 	"time"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/usbredir"
 
 	"kubevirt.io/kubevirt/tests/decorators"
 
@@ -57,7 +59,6 @@ var helloMessageRemote = []byte{
 
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] USB Redirection", decorators.SigCompute, func() {
 
-	var err error
 	var virtClient kubecli.KubevirtClient
 	const enoughMemForSafeBiosEmulation = "32Mi"
 	BeforeEach(func() {
@@ -82,99 +83,138 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with usbredir support", func() {
 
 		var vmi *v1.VirtualMachineInstance
+
 		BeforeEach(func() {
+			// A VMI for each test to have fresh stack on server side
 			vmi = libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation), withClientPassthrough())
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 		})
 
-		Context("with an usbredir connection", func() {
-
-			usbredirConnect := func(connStop chan struct{}) {
-				pipeInReader, pipeInWriter := io.Pipe()
-				pipeOutReader, pipeOutWriter := io.Pipe()
-				defer pipeInReader.Close()
-				defer pipeOutReader.Close()
-
-				k8ResChan := make(chan error)
-				readStop := make(chan []byte)
-
-				By("Stablishing communication with usbredir socket from VMI")
-				go func() {
-					defer GinkgoRecover()
-					usbredirVMI, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).USBRedir(vmi.ObjectMeta.Name)
-					if err != nil {
-						k8ResChan <- err
-						return
-					}
-
-					k8ResChan <- usbredirVMI.Stream(kubecli.StreamOptions{
-						In:  pipeInReader,
-						Out: pipeOutWriter,
-					})
-				}()
-
-				By("Exchanging hello message between client and QEMU's usbredir")
-				go func() {
-					defer GinkgoRecover()
-					buf := make([]byte, 1024, 1024)
-
-					// write hello message to remote (VMI)
-					nw, err := pipeInWriter.Write(helloMessageLocal)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(nw).To(Equal(len(helloMessageLocal)))
-
-					// reading hello message from remote (VMI)
-					nr, err := pipeOutReader.Read(buf)
-					if err != nil && err != io.EOF {
-						Expect(err).ToNot(HaveOccurred())
-						return
-					}
-					if nr == 0 && err == io.EOF {
-						readStop <- []byte("")
-						return
-					}
-					readStop <- buf[0:nr]
-				}()
-
-				select {
-				case response := <-readStop:
-					By("Checking the response from QEMU's usbredir")
-					// Comparing the actual messages could be error prone due the fact that:
-					// 1. Part of the return value is a qemu release version, e.g: 5.2.0 (test would break with different release!)
-					// 2. Capabilities can change over time which means the message would be different then the one hardcoded, correct nonetheless.
-					// I'm keeping the helloMessageRemote to have a proof of working example that could also be used if needed.
-					Expect(response).ToNot(BeEmpty(), "response should not be empty")
-					Expect(response).To(HaveLen(len(helloMessageRemote)))
-				case err = <-k8ResChan:
-					Expect(err).ToNot(HaveOccurred())
-				case <-time.After(45 * time.Second):
-					Fail("Timout reached while waiting for valid response")
-				case <-connStop:
-					return
-				}
+		It("Should fail when limit is reached", func() {
+			stops := make([]chan struct{}, v1.UsbClientPassthroughMaxNumberOf+1)
+			errors := make([]chan error, v1.UsbClientPassthroughMaxNumberOf+1)
+			for i := 0; i <= v1.UsbClientPassthroughMaxNumberOf; i++ {
+				stops[i] = make(chan struct{})
+				errors[i] = make(chan error)
+				go runConnectGoroutine(virtClient, vmi, stops[i], errors[i])
+				// avoid too fast requests which might get denied by server (to avoid flakyness)
+				time.Sleep(100 * time.Millisecond)
 			}
 
-			It("Should work several times", func() {
-				for i := 0; i < 10; i++ {
-					usbredirConnect(nil)
+			for i := 0; i <= v1.UsbClientPassthroughMaxNumberOf; i++ {
+				select {
+				case err := <-errors[i]:
+					Expect(err).To(MatchError(ContainSubstring("websocket: bad handshake")))
+					Expect(i).To(Equal(v1.UsbClientPassthroughMaxNumberOf))
+				case <-time.After(time.Second):
+					stops[i] <- struct{}{}
+					Expect(i).ToNot(Equal(v1.UsbClientPassthroughMaxNumberOf))
 				}
-			})
+			}
+		})
 
-			It("Should work in parallel", func() {
-				connStop := make(chan struct{})
-				defer close(connStop)
-				for i := 0; i < v1.UsbClientPassthroughMaxNumberOf; i++ {
-					go func() {
-						defer GinkgoRecover()
-						usbredirConnect(connStop)
-					}()
+		It("Should work in parallel", func() {
+			stops := make([]chan struct{}, v1.UsbClientPassthroughMaxNumberOf)
+			errors := make([]chan error, v1.UsbClientPassthroughMaxNumberOf)
+			for i := 0; i < v1.UsbClientPassthroughMaxNumberOf; i++ {
+				stops[i] = make(chan struct{})
+				errors[i] = make(chan error)
+				go runConnectGoroutine(virtClient, vmi, stops[i], errors[i])
+				// avoid too fast requests which might get denied by server (to avoid flakyness)
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			for i := 0; i < v1.UsbClientPassthroughMaxNumberOf; i++ {
+				select {
+				case err := <-errors[i]:
+					Expect(err).ToNot(HaveOccurred())
+				case <-time.After(time.Second):
+					stops[i] <- struct{}{}
 				}
-				// Wait for connection, write and read of all above.
-				time.Sleep(5 * time.Second)
-			})
+			}
+		})
+
+		It("Should work several times", func() {
+			for i := 0; i < 4*v1.UsbClientPassthroughMaxNumberOf; i++ {
+				stop := make(chan struct{})
+				errch := make(chan error)
+				go runConnectGoroutine(virtClient, vmi, stop, errch)
+
+				select {
+				case err := <-errch:
+					Expect(err).ToNot(HaveOccurred())
+				case <-time.After(time.Second):
+					stop <- struct{}{}
+				}
+			}
 		})
 	})
 })
+
+func runConnectGoroutine(
+	virtClient kubecli.KubevirtClient,
+	vmi *v1.VirtualMachineInstance,
+	stop chan struct{},
+	errch chan error,
+) {
+	defer GinkgoRecover()
+	usbredirStream, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).USBRedir(vmi.ObjectMeta.Name)
+	if err != nil {
+		errch <- err
+		return
+	}
+	usbredirConnect(usbredirStream, stop)
+}
+
+func usbredirConnect(
+	usbredirStream kubecli.StreamInterface,
+	stop chan struct{},
+) {
+
+	usbredirClient := usbredir.NewUSBRedirClient().
+		WithRemoteVMIStream(usbredirStream).
+		WithLocalTCPClient("localhost:0")
+
+	usbredirClient.ClientConnect = func(device, address string, stop chan struct{}) error {
+		defer GinkgoRecover()
+
+		conn, err := net.Dial("tcp", address)
+		Expect(err).ToNot(HaveOccurred())
+		defer conn.Close()
+
+		buf := make([]byte, 1024, 1024)
+
+		// write hello message to remote (VMI)
+		nw, err := conn.Write([]byte(helloMessageLocal))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nw).To(Equal(len(helloMessageLocal)))
+
+		// reading hello message from remote (VMI)
+		nr, err := conn.Read(buf)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buf[0:nr]).ToNot(BeEmpty(), "response should not be empty")
+		Expect(buf[0:nr]).To(HaveLen(len(helloMessageRemote)))
+		<-stop
+		return err
+	}
+
+	usbredirClient.ConnectRemote()
+	usbredirClient.ConnectLocal("dead:beef")
+	run := make(chan error)
+	go func() {
+		run <- usbredirClient.Run()
+	}()
+	var err error
+	select {
+	case err = <-run:
+	case <-stop:
+		// stop requested, make the call
+		usbredirClient.Stop()
+		// now wait till Run() finishes
+		err = <-run
+	}
+	Expect(err).ToNot(HaveOccurred())
+}
 
 func withClientPassthrough() libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The `virctl usbredir` command was a big script that was hard to be re-used. The functional tests in `usbredir_test.go` were not testing virtctl's code at all, instead it was re-implementing the client logic without calling `usbredirect` binary.

After this PR:
The `virtctl usbredir` is broken down with a Client type with init, run and stop functions. The functional test makes usage of this.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
~~Fixes #~~

### Why we need it and why it was done in this way
~~The following tradeoffs were made:~~

~~The following alternatives were considered:~~

~~Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->~~

### Special notes for your reviewer
I'm interested in expanding a bit the virtctl/usbredir module to have a little bit more knowledge of usbredir protocol in a follow-up, in order to fetch details of devices being redirected by virtctl and expose that information to users. This PR is a somewhat 'cleaning the house' step before that.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

