### PR TITLE
logger: Add Verbosity() method

### DIFF
--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -238,6 +238,10 @@ func (l FilteredVerbosityLogger) Reason(err error) *FilteredVerbosityLogger {
 	return &l
 }
 
+func (l FilteredVerbosityLogger) Verbosity(level int) bool {
+	return l.filteredLogger.Verbosity(level)
+}
+
 func (l FilteredLogger) Object(obj LoggableObject) *FilteredLogger {
 
 	name := obj.GetObjectMeta().GetName()
@@ -293,6 +297,10 @@ func (l FilteredLogger) V(level int) *FilteredVerbosityLogger {
 	return &FilteredVerbosityLogger{
 		filteredLogger: l,
 	}
+}
+
+func (l FilteredLogger) Verbosity(level int) bool {
+	return l.currentVerbosityLevel >= level
 }
 
 func (l FilteredLogger) Reason(err error) *FilteredLogger {

--- a/staging/src/kubevirt.io/client-go/log/log_test.go
+++ b/staging/src/kubevirt.io/client-go/log/log_test.go
@@ -354,8 +354,18 @@ func TestLogVerbosity(t *testing.T) {
 	log := MakeLogger(MockLogger{})
 	log.SetLogLevel(INFO)
 	log.SetVerbosityLevel(2)
-	log.V(2).Log("msg", "test")
 
+	// Filtered Logger
+	assert(t, log.Verbosity(2), "Verbosity should match")
+	assert(t, log.Verbosity(1), "Actual verbosity is higher")
+	assert(t, !log.Verbosity(3), "Verbosity is lower")
+
+	// Filtered Verbosity Logger
+	assert(t, log.V(2).Verbosity(2), "Verbosity should match")
+	assert(t, log.V(2).Verbosity(1), "Actual verbosity is higher")
+	assert(t, !log.V(2).Verbosity(3), "Verbosity is lower")
+
+	log.V(2).Log("msg", "test")
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[4].(string) == "pos", "Logged line did not contain pos")
 	assert(t, strings.HasPrefix(logEntry[5].(string), "log_test.go"), "Logged line referenced wrong module")


### PR DESCRIPTION
This is similar to golang's glog.V() method which is useful to add conditional block of code (e.g: debug) when a high enough verbosity is set.

```go
  if log.Verbosity(5) {
      // do something you wouldn't otherwise
  }
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
No way to make conditional log related to verbosity.

After this PR:
We have a way to do it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Should help move forward with https://github.com/kubevirt/kubevirt/pull/11580 and related.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

