### PR TITLE
Migration create mutator, tests: Avoid name collisions

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -41,12 +41,12 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 	It("Should mutate the VirtualMachineInstanceMigration object", func() {
 		migration := newMigration()
 
-		admissionReview, err := newAdmissionReview(migration)
+		admissionReview, err := newAdmissionReviewForVMIMCreation(migration)
 		Expect(err).ToNot(HaveOccurred())
 
 		mutator := &mutators.MigrationCreateMutator{}
 
-		expectedJSONPatch, err := expectedJSONPatch(
+		expectedJSONPatch, err := expectedJSONPatchForVMIMCreation(
 			expectedMigrationObjectMeta(migration.ObjectMeta, migration.Spec.VMIName),
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -72,7 +72,7 @@ func newMigration() *v1.VirtualMachineInstanceMigration {
 	}
 }
 
-func newAdmissionReview(migration *v1.VirtualMachineInstanceMigration) (*admissionv1.AdmissionReview, error) {
+func newAdmissionReviewForVMIMCreation(migration *v1.VirtualMachineInstanceMigration) (*admissionv1.AdmissionReview, error) {
 	migrationBytes, err := json.Marshal(migration)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func expectedMigrationObjectMeta(currentObjectMeta k8smetav1.ObjectMeta, vmiName
 	return expectedObjectMeta
 }
 
-func expectedJSONPatch(expectedObjectMeta k8smetav1.ObjectMeta) ([]byte, error) {
+func expectedJSONPatchForVMIMCreation(expectedObjectMeta k8smetav1.ObjectMeta) ([]byte, error) {
 	return patch.GeneratePatchPayload(
 		patch.PatchOperation{
 			Op:    patch.PatchReplaceOp,


### PR DESCRIPTION
PR #11561 introduced two new functions to the unit test file:
- newAdmissionReview
- expectedJSONPatch

Since:
1. Other mutators' tests will have similar functions
2. The tests share the same `mutators_test` package

add a suffix to differentiate them and avoid name collisions.

[1] https://github.com/kubevirt/kubevirt/pull/11561
[2] https://github.com/kubevirt/kubevirt/pull/11625

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

