### PR TITLE
cmd, cniplugins, passt-binding: Build the binary statically

### DIFF
--- a/cmd/cniplugins/passt-binding/cmd/BUILD.bazel
+++ b/cmd/cniplugins/passt-binding/cmd/BUILD.bazel
@@ -16,5 +16,6 @@ go_library(
 go_binary(
     name = "kubevirt-passt-binding",
     embed = [":go_default_library"],
+    static = "on",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### What this PR does

The custom CNI plugin that is used with the `passt` network binding plugin is distributed through the release assets.

In order to allow it to run on different platforms, build it statically to avoid shared library conflicts.

This change should resolve issues [1] reported by users when attempting to use the `passt` binding plugin.

[1] https://github.com/kubevirt/kubevirt/issues/11586

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11586

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Build the `passt`custom CNI binary statically, for the `passt` network binding plugin.
Resolves  https://github.com/kubevirt/kubevirt/issues/11586
```

