### PR TITLE
Improve testability of virt-handler

### DIFF
--- a/pkg/monitoring/domainstats/collector.go
+++ b/pkg/monitoring/domainstats/collector.go
@@ -124,8 +124,9 @@ func newvmiSocketMapFromVMIs(vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap 
 	}
 
 	ret := make(vmiSocketMap)
+
 	for _, vmi := range vmis {
-		socketPath, err := cmdclient.FindSocketOnHost(vmi)
+		socketPath, err := cmdclient.NewDefaultSocketFinder().FindSocketOnHost(vmi)
 		if err != nil {
 			// nothing to scrape...
 			// this means there's no socket or the socket

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -260,8 +260,20 @@ func FindPodDirOnHost(vmi *v1.VirtualMachineInstance) (string, error) {
 	return "", fmt.Errorf("No command socketdir for vmi %s", vmi.UID)
 }
 
-// gets the cmd socket for a VMI
-func FindSocketOnHost(vmi *v1.VirtualMachineInstance) (string, error) {
+// SocketFinder represents an interface for finding sockets on the host.
+type SocketFinder interface {
+	FindSocketOnHost(vmi *v1.VirtualMachineInstance) (string, error)
+}
+
+// DefaultSocketFinder is an implementation of SocketFinder that performs the actual socket discovery
+type DefaultSocketFinder struct{}
+
+func NewDefaultSocketFinder() SocketFinder {
+	return &DefaultSocketFinder{}
+}
+
+// FindSocketOnHost finds the socket for the given VirtualMachineInstance.
+func (finder *DefaultSocketFinder) FindSocketOnHost(vmi *v1.VirtualMachineInstance) (string, error) {
 	if string(vmi.UID) != "" {
 		legacySockFile := string(vmi.UID) + "_sock"
 		legacySock := filepath.Join(LegacySocketsDirectory(), legacySockFile)

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Virt remote commands", func() {
 
 	Context("client", func() {
 		It("socket from UID", func() {
-			sock, err := FindSocketOnHost(vmi)
+			sock, err := NewDefaultSocketFinder().FindSocketOnHost(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sock).To(Equal(podSocketFile))
 
@@ -100,7 +100,7 @@ var _ = Describe("Virt remote commands", func() {
 			f, err := os.Create(filepath.Join(socketsDir, "1234_sock"))
 			Expect(err).ToNot(HaveOccurred())
 			f.Close()
-			sock, err = FindSocketOnHost(vmi)
+			sock, err = NewDefaultSocketFinder().FindSocketOnHost(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sock).To(Equal(filepath.Join(shareDir, "sockets", "1234_sock")))
 		})
@@ -120,7 +120,7 @@ var _ = Describe("Virt remote commands", func() {
 		})
 
 		It("Detect unresponsive socket", func() {
-			sock, err := FindSocketOnHost(vmi)
+			sock, err := NewDefaultSocketFinder().FindSocketOnHost(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			os.RemoveAll(sock)

--- a/pkg/virt-handler/cmd-client/generated_mock_client.go
+++ b/pkg/virt-handler/cmd-client/generated_mock_client.go
@@ -352,3 +352,35 @@ func (_m *MockLauncherClient) SyncVirtualMachineMemory(vmi *v1.VirtualMachineIns
 func (_mr *_MockLauncherClientRecorder) SyncVirtualMachineMemory(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SyncVirtualMachineMemory", arg0, arg1)
 }
+
+// Mock of SocketFinder interface
+type MockSocketFinder struct {
+	ctrl     *gomock.Controller
+	recorder *_MockSocketFinderRecorder
+}
+
+// Recorder for MockSocketFinder (not exported)
+type _MockSocketFinderRecorder struct {
+	mock *MockSocketFinder
+}
+
+func NewMockSocketFinder(ctrl *gomock.Controller) *MockSocketFinder {
+	mock := &MockSocketFinder{ctrl: ctrl}
+	mock.recorder = &_MockSocketFinderRecorder{mock}
+	return mock
+}
+
+func (_m *MockSocketFinder) EXPECT() *_MockSocketFinderRecorder {
+	return _m.recorder
+}
+
+func (_m *MockSocketFinder) FindSocketOnHost(vmi *v1.VirtualMachineInstance) (string, error) {
+	ret := _m.ctrl.Call(_m, "FindSocketOnHost", vmi)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockSocketFinderRecorder) FindSocketOnHost(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FindSocketOnHost", arg0)
+}

--- a/pkg/virt-handler/dmetrics-manager/dmetrics-manager.go
+++ b/pkg/virt-handler/dmetrics-manager/dmetrics-manager.go
@@ -107,8 +107,7 @@ func (m *DownwardMetricsManager) StartServer(vmi *v1.VirtualMachineInstance, pid
 	if _, alreadyStarted := m.stopServer[vmi.UID]; alreadyStarted {
 		return nil
 	}
-
-	launcherSocketPath, err := cmdclient.FindSocketOnHost(vmi)
+	launcherSocketPath, err := cmdclient.NewDefaultSocketFinder().FindSocketOnHost(vmi)
 	if err != nil {
 		return fmt.Errorf("failed to get the launcher socket for VMI [%s], error: %v", vmi.GetName(), err)
 	}

--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -70,7 +70,7 @@ func NewSocketBasedIsolationDetector(socketDir string) PodIsolationDetector {
 
 func (s *socketBasedIsolationDetector) Detect(vm *v1.VirtualMachineInstance) (IsolationResult, error) {
 	// Look up the socket of the virt-launcher Pod which was created for that VM, and extract the PID from it
-	socket, err := cmdclient.FindSocketOnHost(vm)
+	socket, err := cmdclient.NewDefaultSocketFinder().FindSocketOnHost(vm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-handler/rest/lifecycle.go
+++ b/pkg/virt-handler/rest/lifecycle.go
@@ -227,8 +227,7 @@ func (lh *LifecycleHandler) getVMILauncherClient(request *restful.Request, respo
 		response.WriteError(code, err)
 		return nil, nil, err
 	}
-
-	sockFile, err := cmdclient.FindSocketOnHost(vmi)
+	sockFile, err := cmdclient.NewDefaultSocketFinder().FindSocketOnHost(vmi)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error(failedDetectCmdClient)
 		response.WriteError(http.StatusInternalServerError, err)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2235,7 +2235,7 @@ func (d *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualM
 			// use cached socket if we previously established a connection
 			socketFile = clientInfo.SocketFile
 		} else {
-			socketFile, err = cmdclient.FindSocketOnHost(vmi)
+			socketFile, err = cmdclient.NewDefaultSocketFinder().FindSocketOnHost(vmi)
 			if err != nil {
 				// socket does not exist, but let's see if the pod is still there
 				if _, err = cmdclient.FindPodDirOnHost(vmi); err != nil {
@@ -2258,7 +2258,7 @@ func (d *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualM
 		}
 		d.launcherClients.Store(vmi.UID, clientInfo)
 		// attempt to find the socket if the established connection doesn't currently exist.
-		socketFile, err = cmdclient.FindSocketOnHost(vmi)
+		socketFile, err = cmdclient.NewDefaultSocketFinder().FindSocketOnHost(vmi)
 		// no socket file, no VMI, so it's unresponsive
 		if err != nil {
 			// socket does not exist, but let's see if the pod is still there
@@ -2293,7 +2293,7 @@ func (d *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInsta
 		return clientInfo.Client, nil
 	}
 
-	socketFile, err := cmdclient.FindSocketOnHost(vmi)
+	socketFile, err := cmdclient.NewDefaultSocketFinder().FindSocketOnHost(vmi)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Modified the findSocketOnHost() and Introduced the well defined interface to use stub for testing, improving and easing the testing.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR
Previous , we are using the `FindSocketOnHost`  for detecting a socket over which the communication between the handler and virt-launchers happen which represent the VMs.

After this PR
Introduced a well defined Interface covering all the usage of this function which would allow us to use stub for testing, improving and easing the testing.



<!-- (optional, in `fixes #<issue number>(, fixes #11572, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11572

### Why we need it and why it was done in this way
 - Allow for stub and improving for testing

Links to places where the discussion took place: <!--https://github.com/kubevirt/kubevirt/issues/11572 , ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

