### PR TITLE
[time-defined cache] [follow-up]: Use a regular Mutex over RWMutex to lock the entire Get() function

### DIFF
--- a/tools/cache/BUILD.bazel
+++ b/tools/cache/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["time-defined-cache.go"],
     importpath = "kubevirt.io/kubevirt/tools/cache",
     visibility = ["//visibility:public"],
+    deps = ["//pkg/pointer:go_default_library"],
 )
 
 go_test(

--- a/tools/cache/time-defined-cache.go
+++ b/tools/cache/time-defined-cache.go
@@ -30,7 +30,7 @@ import (
 type TimeDefinedCache[T any] struct {
 	minRefreshDuration time.Duration
 	lastRefresh        *time.Time
-	savedValue         T
+	value              T
 	reCalcFunc         func() (T, error)
 	valueLock          *sync.Mutex
 }
@@ -65,17 +65,17 @@ func (t *TimeDefinedCache[T]) Get() (T, error) {
 	}
 
 	if t.lastRefresh != nil && t.minRefreshDuration.Nanoseconds() != 0 && time.Since(*t.lastRefresh) <= t.minRefreshDuration {
-		return t.savedValue, nil
+		return t.value, nil
 	}
 
 	value, err := t.reCalcFunc()
 	if err != nil {
-		return t.savedValue, err
+		return t.value, err
 	}
 
 	t.setWithoutLock(value)
 
-	return t.savedValue, nil
+	return t.value, nil
 }
 
 func (t *TimeDefinedCache[T]) Set(value T) {
@@ -88,7 +88,7 @@ func (t *TimeDefinedCache[T]) Set(value T) {
 }
 
 func (t *TimeDefinedCache[T]) setWithoutLock(value T) {
-	t.savedValue = value
+	t.value = value
 
 	if t.lastRefresh == nil || t.minRefreshDuration.Nanoseconds() != 0 {
 		t.lastRefresh = k6tpointer.P(time.Now())


### PR DESCRIPTION
### What this PR does
A quick follow-up to https://github.com/kubevirt/kubevirt/pull/11634.
Specifically, addresses @vasiliy-ul feedback in [this comment](https://github.com/kubevirt/kubevirt/pull/11634#discussion_r1555314830).

Before this PR:
The following can occur before this commit:
* thread 1 calls Get(), sees value is not set yet.
* thread 2 calls Get(), sees value is not set yet.
* thread 1 captures the write lock
* thread 2 waits on the write lock
* thread 1 calculates value and sets it, releases lock
* thread 2 catches lock, calculates value and sets it

After this PR:
Get() is being locked in its entirety and give up on using RWMutex. Not only that the behavior would be more correct, but it would also be more performant as it avoids redandunt re-calculations.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
