### PR TITLE
tests: fix flaky leader election test

### DIFF
--- a/tests/infrastructure/virt-controller-leader-election.go
+++ b/tests/infrastructure/virt-controller-leader-election.go
@@ -28,16 +28,13 @@ import (
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libwait"
 
-	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -56,34 +53,16 @@ var _ = DescribeInfra("Start a VirtualMachineInstance", func() {
 	})
 
 	Context("when the controller pod is not running and an election happens", func() {
-		It("[test_id:4642]should succeed afterwards", func() {
-			// This test needs at least 2 controller pods. Skip on single-replica.
-			checks.SkipIfSingleReplica(virtClient)
+		It("[test_id:4642]should elect a new controller pod", func() {
+			By("Deleting the virt-controller leader pod")
+			leaderPodName := libinfra.GetLeader()
+			Expect(virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(context.Background(), leaderPodName, metav1.DeleteOptions{})).To(Succeed())
 
-			newLeaderPod := libinfra.GetNewLeaderPod(virtClient)
-			Expect(newLeaderPod).NotTo(BeNil())
-
-			// TODO: It can be race condition when newly deployed pod receive leadership, in this case we will need
-			// to reduce Deployment replica before destroying the pod and to restore it after the test
-			By("Destroying the leading controller pod")
-			Eventually(func() string {
-				leaderPodName := libinfra.GetLeader()
-
-				Expect(virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(context.Background(), leaderPodName, metav1.DeleteOptions{})).To(Succeed())
-
-				Eventually(libinfra.GetLeader, 30*time.Second, 5*time.Second).ShouldNot(Equal(leaderPodName))
-
-				leaderPod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), libinfra.GetLeader(), metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				return leaderPod.Name
-			}, 90*time.Second, 5*time.Second).Should(Equal(newLeaderPod.Name))
-
-			Expect(matcher.ThisPod(newLeaderPod)()).To(matcher.HaveConditionTrue(k8sv1.PodReady))
-
-			vmi := libvmifact.NewAlpine()
+			By("Expecting a new leader to get elected")
+			Eventually(libinfra.GetLeader, 30*time.Second, 5*time.Second).ShouldNot(Equal(leaderPodName))
 
 			By("Starting a new VirtualMachineInstance")
+			vmi := libvmifact.NewAlpine()
 			obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Get()
 			Expect(err).ToNot(HaveOccurred())
 			vmiObj, ok := obj.(*v1.VirtualMachineInstance)


### PR DESCRIPTION
### What this PR does
Before this PR:
The leader election test removes the virt-controller leader pod expecting the second replica to become the new leader.
However, after deletion, a new virt-controller pod is instantly created, and has good chances of becoming the new leader.

After this PR:
We just expect a new leader to get elected, since the old one doesn't exist anymore.
We shouldn't care if the new leader is the other replica or a newly created pod.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following alternatives were considered:
Reducing the number of replicas in the virt-controller deployment as suggested by the TODO.
That however would still race against the pod deletion...

### Special notes for your reviewer
I realize this effectively remove the problematic part, but I don't think it makes much sense.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

