### PR TITLE
BugFix: Refined CPU Validation per Libvirt Guidelines

### DIFF
--- a/cmd/virt-launcher/node-labeller/node-labeller.sh
+++ b/cmd/virt-launcher/node-labeller/node-labeller.sh
@@ -36,8 +36,6 @@ virtqemud -d
 
 virsh domcapabilities --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE > /var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml
 
-cp -r /usr/share/libvirt/cpu_map /var/lib/kubevirt-node-labeller
-
 # hypervisor-cpu-baseline command only works on x86
 if [ "$ARCH" == "x86_64" ]; then
    virsh domcapabilities --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE | virsh hypervisor-cpu-baseline --features /dev/stdin --machine $MACHINE --arch $ARCH --virttype $VIRTTYPE > /var/lib/kubevirt-node-labeller/supported_features.xml

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -22,7 +22,6 @@
 package nodelabeller
 
 import (
-	"path"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,12 +34,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/testutils"
 	util "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
-)
-
-var features = []string{"apic", "clflush", "cmov"}
-
-const (
-	x86PenrynXml = "x86_Penryn.xml"
 )
 
 var _ = Describe("Node-labeller config", func() {
@@ -72,32 +65,11 @@ var _ = Describe("Node-labeller config", func() {
 		}
 	})
 
-	It("should return correct cpu file path", func() {
-		p := getPathCPUFeatures(nlController.volumePath, x86PenrynXml)
-		correctPath := path.Join(nlController.volumePath, "cpu_map", x86PenrynXml)
-		Expect(p).To(Equal(correctPath), "cpu file path is not the same")
-	})
-
-	It("should load cpu features", func() {
-		fileName := x86PenrynXml
-		f, err := nlController.loadFeatures(fileName)
-		Expect(err).ToNot(HaveOccurred())
-		for _, val := range features {
-			if _, ok := f[val]; !ok {
-				Expect(ok).To(BeFalse(), "expect feature")
-			}
-		}
-
-	})
-
 	It("should return correct cpu models, features and tsc freqnency", func() {
 		err := nlController.loadDomCapabilities()
 		Expect(err).ToNot(HaveOccurred())
 
 		err = nlController.loadHostSupportedFeatures()
-		Expect(err).ToNot(HaveOccurred())
-
-		err = nlController.loadCPUInfo()
 		Expect(err).ToNot(HaveOccurred())
 
 		err = nlController.loadHostCapabilities()
@@ -119,9 +91,6 @@ var _ = Describe("Node-labeller config", func() {
 	It("No cpu model is usable", func() {
 		nlController.domCapabilitiesFileName = "virsh_domcapabilities_nothing_usable.xml"
 		err := nlController.loadDomCapabilities()
-		Expect(err).ToNot(HaveOccurred())
-
-		err = nlController.loadCPUInfo()
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(nlController.loadHostSupportedFeatures()).To(Succeed())

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Node-labeller config", func() {
 		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
-		Expect(cpuModels).To(HaveLen(5), "number of models must match")
+		Expect(cpuModels).To(HaveLen(4), "number of models must match")
 
 		Expect(cpuFeatures).To(HaveLen(4), "number of features must match")
 		counter, err := nlController.capabilities.GetTSCCounter()

--- a/pkg/virt-handler/node-labeller/model.go
+++ b/pkg/virt-handler/node-labeller/model.go
@@ -30,12 +30,6 @@ type hostCPUModel struct {
 	requiredFeatures cpuFeatures
 }
 
-// hostCapabilities holds informations which provides libvirt,
-// so we don't have to call libvirt at every request
-type cpuInfo struct {
-	usableModels map[string]cpuFeatures
-}
-
 // HostDomCapabilities represents structure for parsing output of virsh capabilities
 type HostDomCapabilities struct {
 	CPU CPU              `xml:"cpu"`

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -162,17 +162,6 @@ var _ = Describe("Node-labeller ", func() {
 		))
 	})
 
-	It("should not add usable cpu model labels if some features are not suported (svm)", func() {
-		res := nlController.execute()
-		Expect(res).To(BeTrue())
-
-		node := retrieveNode(kubeClient)
-		Expect(node.Labels).ToNot(SatisfyAny(
-			HaveKey(v1.CPUModelLabel+"Opteron_G2"),
-			HaveKey(v1.SupportedHostModelMigrationCPU+"Opteron_G2"),
-		))
-	})
-
 	It("should remove not found cpu model and migration model", func() {
 		node := retrieveNode(kubeClient)
 		node.Labels[v1.CPUModelLabel+"Cascadelake-Server"] = "true"

--- a/pkg/virt-handler/node-labeller/util/util.go
+++ b/pkg/virt-handler/node-labeller/util/util.go
@@ -42,6 +42,8 @@ var DefaultObsoleteCPUModels = map[string]bool{
 	"qemu32":     true,
 	"kvm64":      true,
 	"kvm32":      true,
+	"Opteron_G1": true,
+	"Opteron_G2": true,
 }
 
 var DefaultArchitecturePrefix = map[string]string{

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1830,13 +1830,34 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 
 		// Set VM CPU features
+		existingFeatures := make(map[string]struct{})
 		if vmi.Spec.Domain.CPU.Features != nil {
 			for _, feature := range vmi.Spec.Domain.CPU.Features {
+				existingFeatures[feature.Name] = struct{}{}
 				domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
 					Name:   feature.Name,
 					Policy: feature.Policy,
 				})
 			}
+		}
+
+		/*
+						Libvirt validation fails when a CPU model is usable
+						by QEMU but lacks features listed in
+						`/usr/share/libvirt/cpu_map/[CPU Model].xml` on a node
+						To avoid the validation error mentioned above we can disable
+						deprecated features in the `/usr/share/libvirt/cpu_map/[CPU Model].xml` files.
+						Examples of validation error:
+			    		https://bugzilla.redhat.com/show_bug.cgi?id=2122283 - resolve by obsolete Opteron_G2
+						https://gitlab.com/libvirt/libvirt/-/issues/304 - resolve by disabling mpx which is deprecated
+						Issue in Libvirt: https://gitlab.com/libvirt/libvirt/-/issues/608
+						once the issue is resolved we can remove mpx disablement
+		*/
+		if _, exists := existingFeatures["mpx"]; !exists && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
+			domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
+				Name:   "mpx",
+				Policy: "disable",
+			})
 		}
 
 		// Adjust guest vcpu config. Currently will handle vCPUs to pCPUs pinning


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Refined CPU Validation per Libvirt Guidelines

**Issue:**
Libvirt validation fails when a CPU model is usable
by QEMU but lacks features listed in
`/usr/share/libvirt/cpu_map/[CPU Model].xml` on a node.

**Resolution:**
Nodes are now labeled with a CPU model only if all
features listed in the corresponding `cpu_map` XML file
are present and the model is usable by QEMU.
This prevents validation issues caused by missing features.

**Libvirt's Recommendation:**
Libvirt advises against using its internal data files for
feature validation.
As recommended, we're exploring the use only Libvirt's API
to identify usable CPU models, avoiding direct `cpu_map`
file dependency.

**New Approach:**
To avoid the validation error mentioned above we will disable
some of the features in the `/usr/share/libvirt/cpu_map/[CPU Model].xml` files:

- obsolete Opteron_G2 to avoid:
https://bugzilla.redhat.com/show_bug.cgi?id=2122283
- disable mpx for Skylake, Cascadelake, and Icelake to avoid:
https://gitlab.com/libvirt/libvirt/-/issues/304

These features are disabled only if not explicitly required by the user,
allowing broader CPU model support when svm or mpx features are absent.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
**Fixes #**
mark Opteron_G2 CPU model as obselete.
Cascadelake, Icelake and Skylake are not supporetd when mpx features is absent.

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

