### PR TITLE
Rename rest client metrics to include kubevirt prefix

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -33,6 +33,15 @@ The number of VMs in the cluster by namespace. Type: Gauge.
 ### kubevirt_portforward_active_tunnels
 Amount of active portforward tunnels, broken down by namespace and vmi name. Type: Gauge.
 
+### kubevirt_rest_client_rate_limiter_duration_seconds
+Client side rate limiter latency in seconds. Broken down by verb and URL. Type: Histogram.
+
+### kubevirt_rest_client_request_latency_seconds
+Request latency in seconds. Broken down by verb and URL. Type: Histogram.
+
+### kubevirt_rest_client_requests_total
+Number of HTTP requests, partitioned by status code, method, and host. Type: Counter.
+
 ### kubevirt_usbredir_active_connections
 Amount of active USB redirection connections, broken down by namespace and vmi name. Type: Gauge.
 
@@ -269,15 +278,6 @@ Returns the labels of the persistent volume claims that are used for restoring v
 
 ### kubevirt_vnc_active_connections
 Amount of active VNC connections, broken down by namespace and vmi name. Type: Gauge.
-
-### rest_client_rate_limiter_duration_seconds
-Client side rate limiter latency in seconds. Broken down by verb and URL. Type: Histogram.
-
-### rest_client_request_latency_seconds
-Request latency in seconds. Broken down by verb and URL. Type: Histogram.
-
-### rest_client_requests_total
-Number of HTTP requests, partitioned by status code, method, and host. Type: Counter.
 
 ## Developing new metrics
 After developing new metrics or changing old ones, please run `make generate` to regenerate this document.

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -317,21 +317,21 @@ tests:
   # values : `0+100x15  0+100x5`  the same way because prometheus counters might reset
   - interval: 1m
     input_series:
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-controller-1", code="200"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-controller-1", code="200"}'
         values: '0+10x20'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-controller-1", code="400"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-controller-1", code="400"}'
         values: '0+100x15  0+100x5'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-operator-1", code="200"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-operator-1", code="200"}'
         values: '0+10x20'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-operator-1", code="400"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-operator-1", code="400"}'
         values: '0+100x15  0+100x5'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="200"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="200"}'
         values: '0+10x20'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="500"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="500"}'
         values: '0+100x15  0+100x5'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-api-1", code="200"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-api-1", code="200"}'
         values: '0+10x20'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-api-1", code="500"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-api-1", code="500"}'
         values: '0+100x15  0+100x5'
 
     alert_rule_test:
@@ -390,21 +390,21 @@ tests:
   # values : '0+5x90 0+5x10'  the same way because prometheus counters might reset
   - interval: 1m
     input_series:
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-controller-1", code="200"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-controller-1", code="200"}'
         values: '0+10x100'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-controller-1", code="400"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-controller-1", code="400"}'
         values: '0+5x90 0+5x10'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-operator-1", code="200"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-operator-1", code="200"}'
         values: '0+10x100'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-operator-1", code="400"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-operator-1", code="400"}'
         values: '0+5x90 0+5x10'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="200"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="200"}'
         values: '0+10x100'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="500"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="500"}'
         values: '0+5x90 0+5x10'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-api-1", code="200"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-api-1", code="200"}'
         values: '0+10x100'
-      - series: 'rest_client_requests_total{namespace="ci", pod="virt-api-1", code="500"}'
+      - series: 'kubevirt_rest_client_requests_total{namespace="ci", pod="virt-api-1", code="500"}'
         values: '0+5x90 0+5x10'
 
     alert_rule_test:

--- a/pkg/monitoring/metrics/common/client/rest_metrics.go
+++ b/pkg/monitoring/metrics/common/client/rest_metrics.go
@@ -34,7 +34,7 @@ var (
 	// "verb" and "url" labels. It is used for the rest client latency metrics.
 	requestLatency = operatormetrics.NewHistogramVec(
 		operatormetrics.MetricOpts{
-			Name: "rest_client_request_latency_seconds",
+			Name: "kubevirt_rest_client_request_latency_seconds",
 			Help: "Request latency in seconds. Broken down by verb and URL.",
 		},
 		prometheus.HistogramOpts{
@@ -50,7 +50,7 @@ var (
 
 	rateLimiterLatency = operatormetrics.NewHistogramVec(
 		operatormetrics.MetricOpts{
-			Name: "rest_client_rate_limiter_duration_seconds",
+			Name: "kubevirt_rest_client_rate_limiter_duration_seconds",
 			Help: "Client side rate limiter latency in seconds. Broken down by verb and URL.",
 		},
 		prometheus.HistogramOpts{
@@ -61,7 +61,7 @@ var (
 
 	requestResult = operatormetrics.NewCounterVec(
 		operatormetrics.MetricOpts{
-			Name: "rest_client_requests_total",
+			Name: "kubevirt_rest_client_requests_total",
 			Help: "Number of HTTP requests, partitioned by status code, method, and host.",
 		},
 		[]string{"code", "method", "host", "resource", "verb"},

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -79,7 +79,7 @@ func getRunbookURLTemplate() string {
 }
 
 func getErrorRatio(ns string, podName string, errorCodeRegex string, durationInMinutes int) string {
-	errorRatioQuery := "sum ( rate ( rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\",code=~\"%s\"} [%dm] ) )  /  sum ( rate ( rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\"} [%dm] ) )"
+	errorRatioQuery := "sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\",code=~\"%s\"} [%dm] ) )  /  sum ( rate ( kubevirt_rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\"} [%dm] ) )"
 	return fmt.Sprintf(errorRatioQuery, ns, podName, errorCodeRegex, durationInMinutes, ns, podName, durationInMinutes)
 }
 

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -74,12 +74,6 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			"kubevirt_vmi_migrations_in_running_phase":                           true,
 			"kubevirt_vmi_migration_succeeded":                                   true,
 			"kubevirt_vmi_migration_failed":                                      true,
-
-			// name do not follow the convention to be prefixed with 'kubevirt_'
-			// TODO: @machadovilaca - refactor the metric names
-			"rest_client_request_latency_seconds":       true,
-			"rest_client_rate_limiter_duration_seconds": true,
-			"rest_client_requests_total":                true,
 		}
 
 		It("should contain virt components metrics", func() {

--- a/tools/perfscale-audit/metric-client/metric-client.go
+++ b/tools/perfscale-audit/metric-client/metric-client.go
@@ -42,7 +42,7 @@ const (
 	vmiCreationTimePercentileQuery            = `histogram_quantile(0.%d, rate(kubevirt_vmi_phase_transition_time_from_creation_seconds_bucket{phase="Running"}[%ds] offset %ds))`
 	vmiDeletionToSucceededTimePercentileQuery = `histogram_quantile(0.%d, rate(kubevirt_vmi_phase_transition_time_from_deletion_seconds_bucket{phase="Succeeded"}[%ds] offset %ds))`
 	vmiDeletionToFailedTimePercentileQuery    = `histogram_quantile(0.%d, rate(kubevirt_vmi_phase_transition_time_from_deletion_seconds_bucket{phase="Failed"}[%ds] offset %ds))`
-	resourceRequestCountsByOperation          = `increase(rest_client_requests_total{pod=~"virt-controller.*|virt-handler.*|virt-operator.*|virt-api.*"}[%ds] offset %ds)`
+	resourceRequestCountsByOperation          = `increase(kubevirt_rest_client_requests_total{pod=~"virt-controller.*|virt-handler.*|virt-operator.*|virt-api.*"}[%ds] offset %ds)`
 )
 
 // Gauge - Using a Gauge doesn't require using an offset because it holds the accurate count

--- a/tools/prom-metrics-collector/metrics_collector.go
+++ b/tools/prom-metrics-collector/metrics_collector.go
@@ -33,10 +33,7 @@ import (
 // https://sdk.operatorframework.io/docs/best-practices/observability-best-practices/#metrics-guidelines
 // should be ignored.
 var excludedMetrics = map[string]struct{}{
-	"kubevirt_vmi_phase_count":                  {},
-	"rest_client_rate_limiter_duration_seconds": {},
-	"rest_client_request_latency_seconds":       {},
-	"rest_client_requests_total":                {},
+	"kubevirt_vmi_phase_count": {},
 }
 
 // Extract the name, help, and type from the metrics doc file


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Rest client metrics were not following naming conventions because they were not prefixed with `kubevirt_`

After this PR:

Those metrics are correctly named

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-40202

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rename rest client metrics to include kubevirt prefix
```

