### PR TITLE
feature-gates: Retrospectively document CommonInstancetypesDeploymentGate as Beta from 1.2.0

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -73,6 +73,7 @@ const (
 
 	// Owner: @lyarwood
 	// Alpha: v1.1.0
+	// Beta:  v1.2.0
 	//
 	// CommonInstancetypesDeploymentGate enables the deployment of common-instancetypes by virt-operator
 	CommonInstancetypesDeploymentGate = "CommonInstancetypesDeploymentGate"


### PR DESCRIPTION
/sig api
/area instancetype
/cc @fabiand 
/cc @0xFelix 
/cc @EdDev 
/cc @alaypatel07

Apologies for the mass `/cc` here but I'd appreciate your thoughts on doing this retrospectively given it's purely a documentation change from alpha to beta at the moment.

### What this PR does

With the feature lifecycle discussion [1] heading towards consensus this change retrospectively moves the CommonInstancetypesDeploymentGate to Beta from 1.2.0 with an eye on moving to GA and removal of the FG by 1.4.0.

This is done retrospectively as the FG itself is now enabled by default by HCO with KubeVirt 1.2 and as such is already meeting the criteria of the beta phase defined by the feature lifecycle document.

As this is purely documentation the impact of this change is zero and just helps us move the process forward in the coming 1.3 and 1.4 releases.

[1] https://github.com/kubevirt/community/pull/251

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `CommonInstancetypesDeployment` feature and gate are retrospectively moved to Beta from the 1.2.0 release.
```

