### PR TITLE
VMClone create mutator: Don't mutate when there is no need

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
@@ -43,10 +43,10 @@ type CloneCreateMutator struct {
 
 func NewCloneCreateMutator() *CloneCreateMutator {
 	const randomSuffixLength = 5
-	return NewCloneMutatorWithTargetSuffix(rand.String(randomSuffixLength))
+	return NewCloneCreateMutatorWithTargetSuffix(rand.String(randomSuffixLength))
 }
 
-func NewCloneMutatorWithTargetSuffix(targetSuffix string) *CloneCreateMutator {
+func NewCloneCreateMutatorWithTargetSuffix(targetSuffix string) *CloneCreateMutator {
 	return &CloneCreateMutator{
 		targetSuffix: targetSuffix,
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -75,6 +75,26 @@ var _ = Describe("Clone mutating webhook", func() {
 			),
 		),
 	)
+
+	It("should not mutate the spec when the target is fully set", func() {
+		const testTargetName = "my-vm"
+
+		vmClone := newVirtualMachineClone(
+			withVirtualMachineSource(testSourceVirtualMachineName),
+			withVirtualMachineTarget(testTargetName),
+		)
+
+		admissionReview, err := newAdmissionReviewForVMCloneCreation(vmClone)
+		Expect(err).ToNot(HaveOccurred())
+
+		mutator := mutators.NewCloneCreateMutator()
+
+		Expect(mutator.Mutate(admissionReview)).To(Equal(
+			&admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		))
+	})
 })
 
 type option func(vmClone *clonev1alpha1.VirtualMachineClone)

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Clone mutating webhook", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		const expectedTargetSuffix = "12345"
-		mutator := mutators.NewCloneMutatorWithTargetSuffix(expectedTargetSuffix)
+		mutator := mutators.NewCloneCreateMutatorWithTargetSuffix(expectedTargetSuffix)
 
 		expectedVirtualMachineCloneSpec := vmClone.Spec.DeepCopy()
 		expectedVirtualMachineCloneSpec.Target = &k8sv1.TypedLocalObjectReference{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Currently, the VMClone create mutator creates a JSON patch to replace the admitted object's spec even when there is no need to replace it (spec.target is fully set).

After this PR:
VMClone create mutator does not add a JSON patch to the AdmissionResponse in case there is no need to mutate the object.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

