### PR TITLE
Poc sig net testsuite

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -621,6 +621,17 @@ genrule(
 )
 
 genrule(
+    name = "build-functests-sig-net",
+    testonly = True,
+    srcs = [
+        "//tests/network:go_default_test",
+    ],
+    outs = ["functests-copier-sig-net"],
+    cmd = "echo '#!/bin/sh\n\ncp -f $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)
+
+genrule(
     name = "build-example-guest-agent",
     testonly = True,
     srcs = [

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ integ-test:
 functest: build-functests
 	hack/functests.sh
 
+functest-sig-net: build-functests
+	KUBEVIRT_TESTS=_out/tests/sig-net.test hack/functests.sh
+
 dump: bazel-build
 	hack/dump.sh
 
@@ -252,6 +255,7 @@ lint-metrics:
 	sync \
 	manifests \
 	functest \
+	functest-sig-net \
 	cluster-up \
 	cluster-down \
 	cluster-clean \

--- a/hack/bazel-build-functests.sh
+++ b/hack/bazel-build-functests.sh
@@ -60,6 +60,9 @@ bazel run \
     :build-functests -- ${TESTS_OUT_DIR}/tests.test
 bazel run \
     --config=${HOST_ARCHITECTURE} \
+    :build-functests-sig-net -- ${TESTS_OUT_DIR}/sig-net.test
+bazel run \
+    --config=${HOST_ARCHITECTURE} \
     :build-junit-merger -- ${TESTS_OUT_DIR}/junit-merger
 bazel run \
     --config=${HOST_ARCHITECTURE} \

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -25,6 +25,8 @@ KUBEVIRT_E2E_PARALLEL_NODES=${KUBEVIRT_E2E_PARALLEL_NODES:-3}
 KUBEVIRT_FUNC_TEST_GINKGO_ARGS=${FUNC_TEST_ARGS:-${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}}
 KUBEVIRT_FUNC_TEST_LABEL_FILTER=${FUNC_TEST_LABEL_FILTER:-${KUBEVIRT_FUNC_TEST_LABEL_FILTER}}
 
+KUBEVIRT_TESTS=${KUBEVIRT_TESTS:-_out/tests/tests.test}
+
 source hack/common.sh
 source hack/config.sh
 
@@ -66,7 +68,7 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
-    _out/tests/ginkgo -timeout=3h -r "$@" _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
+    _out/tests/ginkgo -timeout=3h -r "$@" ${KUBEVIRT_TESTS} -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
 }
 
 if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -8,7 +8,6 @@ go_library(
         "bindingplugin_passt.go",
         "bindingplugin_slirp.go",
         "dual_stack_cluster.go",
-        "expose.go",
         "framework.go",
         "hotplug.go",
         "hotplug_bridge.go",
@@ -89,9 +88,43 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "expose_test.go",
+        "network_suite_test.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":go_default_library",
+        "//pkg/libvmi:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
+        "//tests/clientcmd:go_default_library",
+        "//tests/console:go_default_library",
+        "//tests/decorators:go_default_library",
+        "//tests/exec:go_default_library",
+        "//tests/framework/kubevirt:go_default_library",
+        "//tests/libnet:go_default_library",
+        "//tests/libnet/cluster:go_default_library",
+        "//tests/libnet/job:go_default_library",
+        "//tests/libpod:go_default_library",
+        "//tests/libvmifact:go_default_library",
+        "//tests/testsuite:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/batch/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )

--- a/tests/network/expose_test.go
+++ b/tests/network/expose_test.go
@@ -1,4 +1,4 @@
-package network
+package network_test
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"kubevirt.io/kubevirt/tests/network"
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -82,7 +84,7 @@ func includesIpv4(ipFamily ipFamily) bool {
 	return ipFamily != ipv6
 }
 
-var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose", decorators.Expose, func() {
+var _ = network.SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose", decorators.Expose, func() {
 
 	var virtClient kubecli.KubevirtClient
 	var err error

--- a/tests/network/network_suite_test.go
+++ b/tests/network/network_suite_test.go
@@ -1,0 +1,13 @@
+package network_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Network Suite")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
PoC Adding new ginkgo tests suite for sig network tests

Current state of this PR is merely foo test to check the new test suite works and run only sig-network tests under tests/network.

The following topics should be considered:
- The original Ginkgo test suite have setup/teardown logic that responsible for the following topics (but not only):
    -  Creating namespace for tests, delete it when finished
    -  Cleanup between tests
    -  Change Kubevirt config for tests, rollback when finished
  The introduced test suite has no setup/teardown logic, thus tests are fails with "kubevirt-test-default namespace not found" error.
  The new test suite should using the exact same logic as the original tests suite for starters.
  We and revisit it later and introduced new practices. For example: move clean up responsibility the tests code instead of a global cleanup.
- Bazel build
    -  The `bazel-build-functest`  target build the all tests under /tests in advance and produce the `test.test` file,  wich `functest` target runs it later on.
    -  Along with the tests,  `bazel-build-functest` builds various binarys, its not clear what actually needed for sig-net or in general.
    - In case only sig-net tests should run it should build only those tests.
- Bazel genruls
    - This PR introduce new genrule to build sig-net tests only to make `bazel-build-functest` work and produce test file for sig-net tests only.
    - As follow up we should revisit the necessity of such genrule, maybe we can simplify the flow.
- Test on CI
    - Adjust automation/test to work with the new makefile target, or use the existing target and pass the sig-test file path as parameter.

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

