### PR TITLE
Generated client: embed generated methods into KV interface

### DIFF
--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -191,7 +191,7 @@ func (u *updater) updateUnstructured(obj runtime.Object) (oldStatus interface{},
 		return oldObj.Status, newObj.Status, nil
 	case *v1.KubeVirt:
 		oldObj := obj.(*v1.KubeVirt)
-		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Update(oldObj)
+		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Update(context.Background(), oldObj, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -225,7 +225,7 @@ func (u *updater) updateStatusUnstructured(obj runtime.Object) (err error) {
 		_, err = u.cli.VirtualMachineInstanceMigration(a.GetNamespace()).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
 	case *v1.KubeVirt:
 		oldObj := obj.(*v1.KubeVirt)
-		_, err = u.cli.KubeVirt(a.GetNamespace()).UpdateStatus(oldObj)
+		_, err = u.cli.KubeVirt(a.GetNamespace()).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
 	case *clonev1alpha1.VirtualMachineClone:
 		oldObj := obj.(*clonev1alpha1.VirtualMachineClone)
 		_, err = u.cli.VirtualMachineClone(oldObj.Namespace).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})

--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -128,7 +128,7 @@ func (u *updater) patchUnstructured(obj runtime.Object, patchType types.PatchTyp
 		return oldObj.ResourceVersion, newObj.ResourceVersion, nil
 	case *v1.KubeVirt:
 		oldObj := obj.(*v1.KubeVirt)
-		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Patch(a.GetName(), patchType, data, patchOptions)
+		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Patch(context.Background(), a.GetName(), patchType, data, *patchOptions)
 		if err != nil {
 			return "", "", err
 		}
@@ -155,7 +155,7 @@ func (u *updater) patchStatusUnstructured(obj runtime.Object, patchType types.Pa
 		_, err = u.cli.VirtualMachine(a.GetNamespace()).PatchStatus(context.Background(), a.GetName(), patchType, data, *patchOptions)
 		return err
 	case *v1.KubeVirt:
-		_, err = u.cli.KubeVirt(a.GetNamespace()).PatchStatus(a.GetName(), patchType, data, patchOptions)
+		_, err = u.cli.KubeVirt(a.GetNamespace()).PatchStatus(context.Background(), a.GetName(), patchType, data, *patchOptions)
 		return err
 	default:
 		panic(unknownObj)

--- a/pkg/util/status/status_test.go
+++ b/pkg/util/status/status_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Status", func() {
 			It("should continuously use the /status subresource if no errors occur", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(2)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
@@ -50,8 +50,8 @@ var _ = Describe("Status", func() {
 			It("should fall back on a 404 error on the /status subresource to an ordinary update", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				kvInterface.EXPECT().Update(kv).Return(kv, nil).Times(2)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
@@ -59,10 +59,10 @@ var _ = Describe("Status", func() {
 			It("should fall back on a 404 error on the /status subresource to an ordinary update but keep in mind that objects may have disappeared", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				kvInterface.EXPECT().Update(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
 
@@ -71,18 +71,18 @@ var _ = Describe("Status", func() {
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
 				newKV := kv.DeepCopy()
 				newKV.Status.Phase = v1.KubeVirtPhaseDeleted
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				kvInterface.EXPECT().Update(kv).Return(newKV, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(newKV, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
 
 			It("should stick with /status if an arbitrary error occurs", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, fmt.Errorf("I am not 404")).Times(1)
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, fmt.Errorf("I am not 404")).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
@@ -152,7 +152,7 @@ var _ = Describe("Status", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				updater.updater.subresource = false
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().Update(kv).Return(kv, nil).Times(2)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
@@ -161,7 +161,7 @@ var _ = Describe("Status", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				updater.updater.subresource = false
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().Update(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(2)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(2)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 			})
@@ -170,7 +170,7 @@ var _ = Describe("Status", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				updater.updater.subresource = false
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().Update(kv).Return(kv, fmt.Errorf("I am not 404")).Times(2)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, fmt.Errorf("I am not 404")).Times(2)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 			})
@@ -181,10 +181,10 @@ var _ = Describe("Status", func() {
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
 				oldKV := kv.DeepCopy()
 				oldKV.Status.Phase = v1.KubeVirtPhaseDeploying
-				kvInterface.EXPECT().Update(kv).Return(oldKV, nil).Times(1)
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(oldKV, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
 		})
@@ -246,7 +246,7 @@ var _ = Describe("Status", func() {
 			By("checking the KubeVirt resource")
 			kvUpdater := NewKubeVirtStatusUpdater(virtClient)
 			kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-			kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(2)
+			kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 			Expect(kvUpdater.UpdateStatus(kv)).To(Succeed())
 			Expect(kvUpdater.UpdateStatus(kv)).To(Succeed())
 
@@ -275,7 +275,7 @@ var _ = Describe("Status", func() {
 			kvUpdater := NewKubeVirtStatusUpdater(virtClient)
 			kvUpdater.updater.subresource = false
 			kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-			kvInterface.EXPECT().Update(kv).Return(kv, nil).Times(2)
+			kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 			Expect(kvUpdater.UpdateStatus(kv)).To(Succeed())
 			Expect(kvUpdater.UpdateStatus(kv)).To(Succeed())
 

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Workload Updater", func() {
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
 
-			kubeVirtInterface.EXPECT().PatchStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) {
+			kubeVirtInterface.EXPECT().PatchStatus(context.Background(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) {
 				str := string(data)
 				Expect(str).To(Equal("[{ \"op\": \"test\", \"path\": \"/status/outdatedVirtualMachineInstanceWorkloads\", \"value\": 0}, { \"op\": \"replace\", \"path\": \"/status/outdatedVirtualMachineInstanceWorkloads\", \"value\": 100}]"))
 

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -764,7 +764,7 @@ func (c *KubeVirtController) execute(key string) error {
 			return err
 		}
 		patch := fmt.Sprintf(`[{"op": "replace", "path": "/metadata/finalizers", "value": %s}]`, string(finalizersJson))
-		_, err = c.clientset.KubeVirt(kvCopy.ObjectMeta.Namespace).Patch(kvCopy.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{})
+		_, err = c.clientset.KubeVirt(kvCopy.ObjectMeta.Namespace).Patch(context.Background(), kvCopy.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 		if err != nil {
 			logger.Reason(err).Errorf("Could not patch the KubeVirt finalizers.")
 			return err

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -709,7 +709,7 @@ func (c *KubeVirtController) execute(key string) error {
 	if !controller.ObservedLatestApiVersionAnnotation(kv) {
 		kv := kv.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(kv)
-		_, err = c.clientset.KubeVirt(kv.ObjectMeta.Namespace).Update(kv)
+		_, err = c.clientset.KubeVirt(kv.ObjectMeta.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 		if err != nil {
 			logger.Reason(err).Errorf("Could not update the KubeVirt resource.")
 		}

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -410,7 +410,7 @@ func (k *KubeVirtTestData) shouldExpectKubeVirtFinalizersPatch(times int) {
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdate(times int) {
-	update := k.kvInterface.EXPECT().Update(gomock.Any())
+	update := k.kvInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{})
 	update.Do(func(kv *v1.KubeVirt) {
 		k.kvInformer.GetStore().Update(kv)
 		update.Return(kv, nil)
@@ -418,16 +418,16 @@ func (k *KubeVirtTestData) shouldExpectKubeVirtUpdate(times int) {
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatus(times int) {
-	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
-	update.Do(func(kv *v1.KubeVirt) {
+	update := k.kvInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{})
+	update.Do(func(ctx context.Context, kv *v1.KubeVirt, options metav1.UpdateOptions) {
 		k.kvInformer.GetStore().Update(kv)
 		update.Return(kv, nil)
 	}).Times(times)
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusVersion(times int, config *util.KubeVirtDeploymentConfig) {
-	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
-	update.Do(func(kv *v1.KubeVirt) {
+	update := k.kvInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{})
+	update.Do(func(ctx context.Context, kv *v1.KubeVirt, options metav1.UpdateOptions) {
 
 		Expect(kv.Status.TargetKubeVirtVersion).To(Equal(config.GetKubeVirtVersion()))
 		Expect(kv.Status.ObservedKubeVirtVersion).To(Equal(config.GetKubeVirtVersion()))
@@ -437,8 +437,8 @@ func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusVersion(times int, co
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusFailureCondition(reason string) {
-	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
-	update.Do(func(kv *v1.KubeVirt) {
+	update := k.kvInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{})
+	update.Do(func(ctx context.Context, kv *v1.KubeVirt, options metav1.UpdateOptions) {
 		Expect(kv.Status.Conditions).To(HaveLen(1))
 		Expect(kv.Status.Conditions[0].Reason).To(Equal(reason))
 		k.kvInformer.GetStore().Update(kv)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -394,8 +394,8 @@ func extractFinalizers(data []byte) []string {
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtFinalizersPatch(times int) {
-	patch := k.kvInterface.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	patch.DoAndReturn(func(name string, pt types.PatchType, data []byte, opts *metav1.PatchOptions, _ ...string) (*v1.KubeVirt, error) {
+	patch := k.kvInterface.EXPECT().Patch(context.Background(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	patch.DoAndReturn(func(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, _ ...string) (*v1.KubeVirt, error) {
 		Expect(pt).To(Equal(types.JSONPatchType))
 		finalizers := extractFinalizers(data)
 		obj, exists, err := k.kvInformer.GetStore().GetByKey(NAMESPACE + "/" + name)

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
@@ -20,6 +20,7 @@
 package webhooks
 
 import (
+	"context"
 	"fmt"
 
 	"kubevirt.io/client-go/log"
@@ -58,7 +59,7 @@ func (k *kubeVirtCreateAdmitter) Admit(review *admissionv1.AdmissionReview) *adm
 	//TODO: Do we want semantic validation
 
 	// Best effort
-	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(&metav1.ListOptions{})
+	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return webhooks.ToAdmissionResponseError(err)
 	}

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter_test.go
@@ -1,6 +1,7 @@
 package webhooks
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/golang/mock/gomock"
@@ -33,7 +34,7 @@ var _ = Describe("Validating KubeVirtCreate Admitter", func() {
 				Name:      "Existing",
 			},
 		}
-		kvInterface.EXPECT().List(gomock.Any()).
+		kvInterface.EXPECT().List(context.Background(), gomock.Any()).
 			Return(&v1.KubeVirtList{Items: []v1.KubeVirt{alreadyExistingKv}}, nil).AnyTimes()
 
 		newKv := v1.KubeVirt{
@@ -59,7 +60,7 @@ var _ = Describe("Validating KubeVirtCreate Admitter", func() {
 	})
 
 	It("should allow creating new Kubevirt resource", func() {
-		kvInterface.EXPECT().List(gomock.Any()).
+		kvInterface.EXPECT().List(context.Background(), gomock.Any()).
 			Return(&v1.KubeVirtList{Items: []v1.KubeVirt{}}, nil).AnyTimes()
 
 		newKv := v1.KubeVirt{

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -36,7 +36,7 @@ func (k *KubeVirtDeletionAdmitter) Admit(review *admissionv1.AdmissionReview) *a
 	var kv *v1.KubeVirt
 	var err error
 	if review.Request.Name != "" {
-		kv, err = k.client.KubeVirt(review.Request.Namespace).Get(review.Request.Name, &metav1.GetOptions{})
+		kv, err = k.client.KubeVirt(review.Request.Namespace).Get(context.Background(), review.Request.Name, metav1.GetOptions{})
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -41,7 +41,7 @@ func (k *KubeVirtDeletionAdmitter) Admit(review *admissionv1.AdmissionReview) *a
 			return webhookutils.ToAdmissionResponseError(err)
 		}
 	} else {
-		list, err := k.client.KubeVirt(review.Request.Namespace).List(&metav1.ListOptions{})
+		list, err := k.client.KubeVirt(review.Request.Namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}

--- a/pkg/virt-operator/webhooks/webhook_test.go
+++ b/pkg/virt-operator/webhooks/webhook_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Webhook", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		kubeCli = kubecli.NewMockKubevirtClient(ctrl)
 		kvInterface = kubecli.NewMockKubeVirtInterface(ctrl)
-		kvInterface.EXPECT().Get("kubevirt", gomock.Any()).Return(kv, nil).AnyTimes()
+		kvInterface.EXPECT().Get(context.Background(), "kubevirt", gomock.Any()).Return(kv, nil).AnyTimes()
 		kvInterface.EXPECT().List(gomock.Any()).Return(&k6tv1.KubeVirtList{}, nil).AnyTimes()
 		admitter = &KubeVirtDeletionAdmitter{kubeCli}
 		kubeCli.EXPECT().KubeVirt("test").Return(kvInterface)

--- a/pkg/virt-operator/webhooks/webhook_test.go
+++ b/pkg/virt-operator/webhooks/webhook_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Webhook", func() {
 		kubeCli = kubecli.NewMockKubevirtClient(ctrl)
 		kvInterface = kubecli.NewMockKubeVirtInterface(ctrl)
 		kvInterface.EXPECT().Get(context.Background(), "kubevirt", gomock.Any()).Return(kv, nil).AnyTimes()
-		kvInterface.EXPECT().List(gomock.Any()).Return(&k6tv1.KubeVirtList{}, nil).AnyTimes()
+		kvInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.KubeVirtList{}, nil).AnyTimes()
 		admitter = &KubeVirtDeletionAdmitter{kubeCli}
 		kubeCli.EXPECT().KubeVirt("test").Return(kvInterface)
 

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -1,6 +1,7 @@
 package logverbosity
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -369,7 +370,7 @@ func (c *Command) RunE(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	kv, err := virtClient.KubeVirt(namespace).Get(name, &k8smetav1.GetOptions{})
+	kv, err := virtClient.KubeVirt(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -181,7 +181,7 @@ func getJSONNameByComponentName(componentName string) string {
 }
 
 func detectInstallNamespaceAndName(virtClient kubecli.KubevirtClient) (string, string, error) {
-	kvs, err := virtClient.KubeVirt(k8smetav1.NamespaceAll).List(&k8smetav1.ListOptions{})
+	kvs, err := virtClient.KubeVirt(k8smetav1.NamespaceAll).List(context.Background(), k8smetav1.ListOptions{})
 	if err != nil {
 		return "", "", fmt.Errorf("could not list KubeVirt CRs across all namespaces: %v", err)
 	}

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -410,7 +410,7 @@ func (c *Command) RunE(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		_, err = virtClient.KubeVirt(namespace).Patch(name, types.JSONPatchType, patchData, &k8smetav1.PatchOptions{})
+		_, err = virtClient.KubeVirt(namespace).Patch(context.Background(), name, types.JSONPatchType, patchData, k8smetav1.PatchOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -1,6 +1,7 @@
 package logverbosity_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -143,8 +144,8 @@ var _ = Describe("Log Verbosity", func() {
 			})
 
 			expectGetError := func() {
-				kvInterface.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(name string, _ any) (*v1.KubeVirt, error) {
+				kvInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, name string, _ any) (*v1.KubeVirt, error) {
 						Expect(name).To(Equal(kvs.Items[0].Name))
 						return nil, errors.New("Get error")
 					}).AnyTimes()
@@ -170,8 +171,8 @@ var _ = Describe("Log Verbosity", func() {
 		})
 
 		expectGetKv := func() {
-			kvInterface.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
-				func(name string, _ any) (*v1.KubeVirt, error) {
+			kvInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, name string, _ any) (*v1.KubeVirt, error) {
 					Expect(name).To(Equal(kvs.Items[0].Name))
 					return &kvs.Items[0], nil
 				}).AnyTimes()
@@ -393,7 +394,7 @@ func NewKubeVirtWithoutDeveloperConfiguration(namespace, name string) *v1.KubeVi
 
 func commonSetup(kvInterface *kubecli.MockKubeVirtInterface, kvs *v1.KubeVirtList) {
 	kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
-	kvInterface.EXPECT().Get(kvs.Items[0].Name, gomock.Any()).Return(&kvs.Items[0], nil).AnyTimes()
+	kvInterface.EXPECT().Get(context.Background(), kvs.Items[0].Name, gomock.Any()).Return(&kvs.Items[0], nil).AnyTimes()
 }
 
 func commonShowTest(output []uint, args ...string) {

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -87,8 +87,8 @@ var _ = Describe("Log Verbosity", func() {
 		kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(kvs.Items[0].Namespace).Return(kvInterface).AnyTimes() // Get & Patch
 		kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(k8smetav1.NamespaceAll).Return(kvInterface).AnyTimes() // List
 
-		kvInterface.EXPECT().Patch(gomock.Any(), types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-			func(name string, _ any, patchData []byte, _ any, _ ...any) (*v1.KubeVirt, error) {
+		kvInterface.EXPECT().Patch(context.Background(), gomock.Any(), types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, name string, _ any, patchData []byte, _ any, _ ...any) (*v1.KubeVirt, error) {
 				Expect(name).To(Equal(kvs.Items[0].Name))
 
 				patch, err := jsonpatch.DecodePatch(patchData)

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -123,8 +123,8 @@ var _ = Describe("Log Verbosity", func() {
 
 		Context("detectInstallNamespaceAndName has en error", func() {
 			expectListError := func() {
-				kvInterface.EXPECT().List(gomock.Any()).DoAndReturn(
-					func(_ any) (*v1.KubeVirt, error) {
+				kvInterface.EXPECT().List(context.Background(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, _ any) (*v1.KubeVirt, error) {
 						return nil, errors.New("List error")
 					}).AnyTimes()
 			}
@@ -140,7 +140,7 @@ var _ = Describe("Log Verbosity", func() {
 
 		Context("Get function has an error", func() {
 			BeforeEach(func() {
-				kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+				kvInterface.EXPECT().List(context.Background(), gomock.Any()).Return(kvs, nil).AnyTimes()
 			})
 
 			expectGetError := func() {
@@ -167,7 +167,7 @@ var _ = Describe("Log Verbosity", func() {
 			kvs = kubecli.NewKubeVirtList(*kv)
 
 			kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(kvs.Items[0].Namespace).Return(kvInterface).AnyTimes() // Get & Patch
-			kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+			kvInterface.EXPECT().List(context.Background(), gomock.Any()).Return(kvs, nil).AnyTimes()
 		})
 
 		expectGetKv := func() {
@@ -393,7 +393,7 @@ func NewKubeVirtWithoutDeveloperConfiguration(namespace, name string) *v1.KubeVi
 }
 
 func commonSetup(kvInterface *kubecli.MockKubeVirtInterface, kvs *v1.KubeVirtList) {
-	kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+	kvInterface.EXPECT().List(context.Background(), gomock.Any()).Return(kvs, nil).AnyTimes()
 	kvInterface.EXPECT().Get(context.Background(), kvs.Items[0].Name, gomock.Any()).Return(&kvs.Items[0], nil).AnyTimes()
 }
 

--- a/pkg/virtctl/configuration/configuration.go
+++ b/pkg/virtctl/configuration/configuration.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -52,7 +53,7 @@ func (c *command) run() error {
 		return fmt.Errorf("cannot obtain KubeVirt client: %v", err)
 	}
 
-	kvList, err := virtClient.KubeVirt(namespace).List(&metav1.ListOptions{})
+	kvList, err := virtClient.KubeVirt(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -2032,8 +2032,8 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []byte, patchOptions *v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {
-	_s := []interface{}{name, pt, data, patchOptions}
+func (_m *MockKubeVirtInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {
+	_s := []interface{}{ctx, name, pt, data, patchOptions}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -2043,8 +2043,8 @@ func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []b
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
-	_s := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
+func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
@@ -2059,15 +2059,15 @@ func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *v12.PatchOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "PatchStatus", name, pt, data, patchOptions)
+func (_m *MockKubeVirtInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions v12.PatchOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "PatchStatus", ctx, name, pt, data, patchOptions)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3)
+func (_mr *_MockKubeVirtInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3, arg4)
 }
 
 // Mock of ServerVersionInterface interface

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -2000,26 +2000,26 @@ func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
-func (_m *MockKubeVirtInterface) Create(instance *v120.KubeVirt) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Create", instance)
+func (_m *MockKubeVirtInterface) Create(ctx context.Context, instance *v120.KubeVirt, opts v12.CreateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, instance, opts)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Create(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0)
+func (_mr *_MockKubeVirtInterfaceRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Update(_param0 *v120.KubeVirt) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Update", _param0)
+func (_m *MockKubeVirtInterface) Update(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.UpdateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Update", ctx, kubeVirt, opts)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Update(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0)
+func (_mr *_MockKubeVirtInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) Delete(name string, options *v12.DeleteOptions) error {
@@ -2048,15 +2048,15 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockKubeVirtInterface) UpdateStatus(_param0 *v120.KubeVirt) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "UpdateStatus", _param0)
+func (_m *MockKubeVirtInterface) UpdateStatus(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.UpdateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, kubeVirt, opts)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0)
+func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *v12.PatchOptions) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1978,30 +1978,8 @@ func (_m *MockKubeVirtInterface) EXPECT() *_MockKubeVirtInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockKubeVirtInterface) Get(ctx context.Context, name string, options v12.GetOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
-	ret0, _ := ret[0].(*v120.KubeVirt)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
-}
-
-func (_m *MockKubeVirtInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.KubeVirtList, error) {
-	ret := _m.ctrl.Call(_m, "List", ctx, opts)
-	ret0, _ := ret[0].(*v120.KubeVirtList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
-}
-
-func (_m *MockKubeVirtInterface) Create(ctx context.Context, instance *v120.KubeVirt, opts v12.CreateOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Create", ctx, instance, opts)
+func (_m *MockKubeVirtInterface) Create(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.CreateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, kubeVirt, opts)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -2022,8 +2000,19 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
+func (_m *MockKubeVirtInterface) UpdateStatus(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.UpdateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, kubeVirt, opts)
+	ret0, _ := ret[0].(*v120.KubeVirt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
+}
+
+func (_m *MockKubeVirtInterface) Delete(ctx context.Context, name string, opts v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -2032,8 +2021,51 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {
-	_s := []interface{}{ctx, name, pt, data, patchOptions}
+func (_m *MockKubeVirtInterface) DeleteCollection(ctx context.Context, opts v12.DeleteOptions, listOpts v12.ListOptions) error {
+	ret := _m.ctrl.Call(_m, "DeleteCollection", ctx, opts, listOpts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) DeleteCollection(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCollection", arg0, arg1, arg2)
+}
+
+func (_m *MockKubeVirtInterface) Get(ctx context.Context, name string, opts v12.GetOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, opts)
+	ret0, _ := ret[0].(*v120.KubeVirt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
+}
+
+func (_m *MockKubeVirtInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.KubeVirtList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
+	ret0, _ := ret[0].(*v120.KubeVirtList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
+}
+
+func (_m *MockKubeVirtInterface) Watch(ctx context.Context, opts v12.ListOptions) (watch.Interface, error) {
+	ret := _m.ctrl.Call(_m, "Watch", ctx, opts)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) Watch(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Watch", arg0, arg1)
+}
+
+func (_m *MockKubeVirtInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {
+	_s := []interface{}{ctx, name, pt, data, opts}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -2046,17 +2078,6 @@ func (_m *MockKubeVirtInterface) Patch(ctx context.Context, name string, pt type
 func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
 	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
-}
-
-func (_m *MockKubeVirtInterface) UpdateStatus(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.UpdateOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, kubeVirt, opts)
-	ret0, _ := ret[0].(*v120.KubeVirt)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions v12.PatchOptions) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -2022,14 +2022,14 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Delete(name string, options *v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", name, options)
+func (_m *MockKubeVirtInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []byte, patchOptions *v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1978,15 +1978,15 @@ func (_m *MockKubeVirtInterface) EXPECT() *_MockKubeVirtInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockKubeVirtInterface) Get(name string, options *v12.GetOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Get", name, options)
+func (_m *MockKubeVirtInterface) Get(ctx context.Context, name string, options v12.GetOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) List(opts *v12.ListOptions) (*v120.KubeVirtList, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1989,15 +1989,15 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) List(opts *v12.ListOptions) (*v120.KubeVirtList, error) {
-	ret := _m.ctrl.Call(_m, "List", opts)
+func (_m *MockKubeVirtInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.KubeVirtList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
 	ret0, _ := ret[0].(*v120.KubeVirtList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
+func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
 func (_m *MockKubeVirtInterface) Create(instance *v120.KubeVirt) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -318,7 +318,7 @@ type KubeVirtInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
 	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
 	Update(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
-	Delete(name string, options *metav1.DeleteOptions) error
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
 	UpdateStatus(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
 	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.KubeVirt, err error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -316,7 +316,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 type KubeVirtInterface interface {
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
-	Create(instance *v1.KubeVirt) (*v1.KubeVirt, error)
+	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
 	Update(*v1.KubeVirt) (*v1.KubeVirt, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -315,7 +315,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 
 type KubeVirtInterface interface {
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
-	List(opts *metav1.ListOptions) (*v1.KubeVirtList, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
 	Create(instance *v1.KubeVirt) (*v1.KubeVirt, error)
 	Update(*v1.KubeVirt) (*v1.KubeVirt, error)
 	Delete(name string, options *metav1.DeleteOptions) error

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -317,10 +317,10 @@ type KubeVirtInterface interface {
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
 	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
-	Update(*v1.KubeVirt) (*v1.KubeVirt, error)
+	Update(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
-	UpdateStatus(*v1.KubeVirt) (*v1.KubeVirt, error)
+	UpdateStatus(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
 	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.KubeVirt, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -314,7 +314,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 }
 
 type KubeVirtInterface interface {
-	Get(name string, options *metav1.GetOptions) (*v1.KubeVirt, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
 	List(opts *metav1.ListOptions) (*v1.KubeVirtList, error)
 	Create(instance *v1.KubeVirt) (*v1.KubeVirt, error)
 	Update(*v1.KubeVirt) (*v1.KubeVirt, error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -319,9 +319,9 @@ type KubeVirtInterface interface {
 	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
 	Update(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
 	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
-	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
 	UpdateStatus(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
-	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.KubeVirt, err error)
+	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) (result *v1.KubeVirt, err error)
 }
 
 type ServerVersionInterface interface {

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -314,13 +314,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 }
 
 type KubeVirtInterface interface {
-	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
-	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
-	Update(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
-	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
-	UpdateStatus(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
+	kvcorev1.KubeVirtInterface
 	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) (result *v1.KubeVirt, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -55,14 +55,9 @@ func (o *kv) Create(kv *v1.KubeVirt) (*v1.KubeVirt, error) {
 }
 
 // Get the KubeVirt from the cluster by its name and namespace
-func (o *kv) Get(name string, options *k8smetav1.GetOptions) (*v1.KubeVirt, error) {
-	opts := k8smetav1.GetOptions{}
-	if options != nil {
-		opts = *options
-	}
-	newKv, err := o.KubeVirtInterface.Get(context.Background(), name, opts)
+func (o *kv) Get(ctx context.Context, name string, options k8smetav1.GetOptions) (*v1.KubeVirt, error) {
+	newKv, err := o.KubeVirtInterface.Get(ctx, name, options)
 	newKv.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
-
 	return newKv, err
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -47,10 +47,9 @@ type kv struct {
 }
 
 // Create new KubeVirt in the cluster to specified namespace
-func (o *kv) Create(kv *v1.KubeVirt) (*v1.KubeVirt, error) {
-	newKv, err := o.KubeVirtInterface.Create(context.Background(), kv, k8smetav1.CreateOptions{})
+func (o *kv) Create(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.CreateOptions) (*v1.KubeVirt, error) {
+	newKv, err := o.KubeVirtInterface.Create(ctx, kv, opts)
 	newKv.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
-
 	return newKv, err
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -61,10 +61,9 @@ func (o *kv) Get(ctx context.Context, name string, options k8smetav1.GetOptions)
 }
 
 // Update the KubeVirt instance in the cluster in given namespace
-func (o *kv) Update(kv *v1.KubeVirt) (*v1.KubeVirt, error) {
-	updatedKv, err := o.KubeVirtInterface.Update(context.Background(), kv, k8smetav1.UpdateOptions{})
+func (o *kv) Update(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateOptions) (*v1.KubeVirt, error) {
+	updatedKv, err := o.KubeVirtInterface.Update(ctx, kv, opts)
 	updatedKv.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
-
 	return updatedKv, err
 }
 
@@ -98,8 +97,8 @@ func (o *kv) PatchStatus(name string, pt types.PatchType, data []byte, patchOpti
 	return o.Patch(name, pt, data, patchOptions, "status")
 }
 
-func (o *kv) UpdateStatus(kv *v1.KubeVirt) (result *v1.KubeVirt, err error) {
-	result, err = o.KubeVirtInterface.UpdateStatus(context.Background(), kv, k8smetav1.UpdateOptions{})
+func (o *kv) UpdateStatus(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateOptions) (result *v1.KubeVirt, err error) {
+	result, err = o.KubeVirtInterface.UpdateStatus(ctx, kv, opts)
 	result.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -68,12 +68,8 @@ func (o *kv) Update(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateO
 }
 
 // Delete the defined KubeVirt in the cluster in defined namespace
-func (o *kv) Delete(name string, options *k8smetav1.DeleteOptions) error {
-	opts := k8smetav1.DeleteOptions{}
-	if options != nil {
-		opts = *options
-	}
-	return o.KubeVirtInterface.Delete(context.Background(), name, opts)
+func (o *kv) Delete(ctx context.Context, name string, options k8smetav1.DeleteOptions) error {
+	return o.KubeVirtInterface.Delete(ctx, name, options)
 }
 
 // List all KubeVirts in given namespace

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -79,16 +79,11 @@ func (o *kv) Delete(name string, options *k8smetav1.DeleteOptions) error {
 }
 
 // List all KubeVirts in given namespace
-func (o *kv) List(options *k8smetav1.ListOptions) (*v1.KubeVirtList, error) {
-	opts := k8smetav1.ListOptions{}
-	if options != nil {
-		opts = *options
-	}
-	newKvList, err := o.KubeVirtInterface.List(context.Background(), opts)
+func (o *kv) List(ctx context.Context, options k8smetav1.ListOptions) (*v1.KubeVirtList, error) {
+	newKvList, err := o.KubeVirtInterface.List(ctx, options)
 	for i := range newKvList.Items {
 		newKvList.Items[i].SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
 	}
-
 	return newKvList, err
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -81,16 +81,12 @@ func (o *kv) List(ctx context.Context, options k8smetav1.ListOptions) (*v1.KubeV
 	return newKvList, err
 }
 
-func (o *kv) Patch(name string, pt types.PatchType, data []byte, patchOptions *k8smetav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error) {
-	opts := k8smetav1.PatchOptions{}
-	if patchOptions != nil {
-		opts = *patchOptions
-	}
-	return o.KubeVirtInterface.Patch(context.Background(), name, pt, data, opts, subresources...)
+func (o *kv) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions k8smetav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error) {
+	return o.KubeVirtInterface.Patch(ctx, name, pt, data, patchOptions, subresources...)
 }
 
-func (o *kv) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *k8smetav1.PatchOptions) (result *v1.KubeVirt, err error) {
-	return o.Patch(name, pt, data, patchOptions, "status")
+func (o *kv) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions k8smetav1.PatchOptions) (result *v1.KubeVirt, err error) {
+	return o.Patch(ctx, name, pt, data, patchOptions, "status")
 }
 
 func (o *kv) UpdateStatus(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateOptions) (result *v1.KubeVirt, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err = client.KubeVirt(k8sv1.NamespaceDefault).Delete("testkubevirt", &k8smetav1.DeleteOptions{})
+		err = client.KubeVirt(k8sv1.NamespaceDefault).Delete(context.Background(), "testkubevirt", k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -156,8 +156,8 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
 
-		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Patch(kubevirt.Name, types.MergePatchType,
-			[]byte("{\"spec\":{\"imagePullPolicy\":something}}"), &k8smetav1.PatchOptions{})
+		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Patch(context.Background(), kubevirt.Name, types.MergePatchType,
+			[]byte("{\"spec\":{\"imagePullPolicy\":something}}"), k8smetav1.PatchOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("PUT", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
-		updatedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Update(kubevirt)
+		updatedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Update(context.Background(), kubevirt, k8smetav1.UpdateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewKubeVirtList(*kubevirt)),
 		))
-		fetchedKubeVirtList, err := client.KubeVirt(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
+		fetchedKubeVirtList, err := client.KubeVirt(k8sv1.NamespaceDefault).List(context.Background(), k8smetav1.ListOptions{})
 		apiVersion, kind := v1.KubeVirtGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -20,6 +20,7 @@
 package kubecli
 
 import (
+	"context"
 	"net/http"
 	"path"
 
@@ -53,7 +54,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
-		fetchedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Get("testkubevirt", &k8smetav1.GetOptions{})
+		fetchedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Get(context.Background(), "testkubevirt", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
@@ -71,7 +72,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testkubevirt")),
 		))
-		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Get("testkubevirt", &k8smetav1.GetOptions{})
+		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Get(context.Background(), "testkubevirt", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, kubevirt),
 		))
-		createdKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Create(kubevirt)
+		createdKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Create(context.Background(), kubevirt, k8smetav1.CreateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, de
 		close(stopCh)
 
 		retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			_, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(originalKV)
+			_, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(context.Background(), originalKV, metav1.UpdateOptions{})
 			return err
 		})
 
@@ -114,7 +114,7 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, de
 			},
 		}
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			_, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			_, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			return err
 		})
 	}

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -499,14 +499,14 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no KubeVirt CR was actually deleted")
-			_, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+			_, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("[test_id:7649]update a KubeVirt CR", func() {
 			By("Make a Dry-Run request to update a KubeVirt CR")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -519,7 +519,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.Labels["key"]).ToNot(Equal("42"))
 		})
@@ -531,7 +531,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.Labels["key"]).ToNot(Equal("42"))
 		})

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -495,7 +495,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 				DryRun:            []string{metav1.DryRunAll},
 				PropagationPolicy: &deletePolicy,
 			}
-			err = virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &opts)
+			err = virtClient.KubeVirt(kv.Namespace).Delete(context.Background(), kv.Name, opts)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no KubeVirt CR was actually deleted")

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -273,7 +273,7 @@ func patchWorkloadUpdateMethodAndRolloutStrategy(kvName string, virtClient kubec
 	data := []byte(fmt.Sprintf(`[%s, %s]`, data1, data2))
 
 	EventuallyWithOffset(1, func() error {
-		_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(kvName, types.JSONPatchType, data, &k8smetav1.PatchOptions{})
+		_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), kvName, types.JSONPatchType, data, k8smetav1.PatchOptions{})
 		return err
 	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 }

--- a/tests/hotplug/rolloutstrategy.go
+++ b/tests/hotplug/rolloutstrategy.go
@@ -49,7 +49,7 @@ var _ = Describe("[Serial][sig-compute]VM Rollout Strategy", decorators.SigCompu
 
 			kv := util2.GetCurrentKv(virtClient)
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(kv.Name, types.JSONPatchType, []byte(data), &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), kv.Name, types.JSONPatchType, []byte(data), metav1.PatchOptions{})
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		})

--- a/tests/libkvconfig/kvconfig.go
+++ b/tests/libkvconfig/kvconfig.go
@@ -20,6 +20,7 @@
 package libkvconfig
 
 import (
+	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,6 +53,6 @@ func patchKV(namespace, name string, patchOps []patch.PatchOperation) error {
 	if err != nil {
 		return err
 	}
-	_, err = kubevirt.Client().KubeVirt(namespace).Patch(name, types.JSONPatchType, patchData, &metav1.PatchOptions{})
+	_, err = kubevirt.Client().KubeVirt(namespace).Patch(context.Background(), name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 	return err
 }

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -123,7 +123,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 	Context("System Alerts", func() {
 		disableVirtHandler := func() *v1.KubeVirt {
 			originalKv := util.GetCurrentKv(virtClient)
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{
 				Patches: []v1.CustomizeComponentsPatch{
@@ -158,7 +158,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 
 		restoreVirtHandler := func(kv *v1.KubeVirt) {
 			originalKv := util.GetCurrentKv(virtClient)
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{}

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -137,7 +137,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			}
 
 			Eventually(func() error {
-				kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+				kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 				return err
 			}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
@@ -164,7 +164,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{}
 
 			Eventually(func() error {
-				kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+				kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 				return err
 			}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -201,7 +201,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 		createKv = func(newKv *v1.KubeVirt) {
 			Eventually(func() error {
-				_, err = virtClient.KubeVirt(newKv.Namespace).Create(newKv)
+				_, err = virtClient.KubeVirt(newKv.Namespace).Create(context.Background(), newKv, metav1.CreateOptions{})
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}
@@ -2219,7 +2219,7 @@ spec:
 			newKv.Name = "someother-kubevirt"
 
 			By("Creating another KubeVirt object")
-			_, err = virtClient.KubeVirt(newKv.Namespace).Create(newKv)
+			_, err = virtClient.KubeVirt(newKv.Namespace).Create(context.Background(), newKv, metav1.CreateOptions{})
 			Expect(err).To(MatchError(ContainSubstring("Kubevirt is already created")))
 		})
 
@@ -2734,7 +2734,7 @@ spec:
 			}
 			var one uint8 = 1
 			kv.Spec.Infra.Replicas = &one
-			kv, err = virtClient.KubeVirt(kv.Namespace).Create(kv)
+			kv, err = virtClient.KubeVirt(kv.Namespace).Create(context.Background(), kv, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the kv CR to get a finalizer")

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -258,7 +258,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		allPodsAreReady = func(kv *v1.KubeVirt) {
 			Eventually(func() error {
 
-				curKv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				curKv, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -310,7 +310,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 		waitForUpdateCondition = func(kv *v1.KubeVirt) {
 			Eventually(func() *v1.KubeVirt {
-				kv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				return kv
@@ -325,7 +325,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 		waitForKvWithTimeout = func(newKv *v1.KubeVirt, timeoutSeconds int) {
 			Eventually(func() error {
-				kv, err := virtClient.KubeVirt(newKv.Namespace).Get(newKv.Name, &metav1.GetOptions{})
+				kv, err := virtClient.KubeVirt(newKv.Namespace).Get(context.Background(), newKv.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -1381,7 +1381,7 @@ spec:
 			maxDevicesCommandArgument := fmt.Sprintf("--max-devices %d", newVirtualMachineInstancesPerNode)
 
 			By("Updating KubeVirt Object")
-			kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.Spec.Configuration.VirtualMachineInstancesPerNode).ToNot(Equal(&newVirtualMachineInstancesPerNode))
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = &newVirtualMachineInstancesPerNode
@@ -1396,7 +1396,7 @@ spec:
 			Eventually(fetchVirtHandlerCommand, 60*time.Second, 5*time.Second).Should(ContainSubstring(maxDevicesCommandArgument))
 
 			By("Deleting patch from KubeVirt object")
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = nil
@@ -1418,7 +1418,7 @@ spec:
 			annotationPatchKey := "applied-patch"
 
 			By("Updating KubeVirt Object")
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{
 				Patches: []v1.CustomizeComponentsPatch{
@@ -1452,7 +1452,7 @@ spec:
 			waitForKvWithTimeout(kv, 120)
 
 			By("Check that KubeVirt CR generation does not get updated when applying patch")
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.GetGeneration()).To(Equal(generation))
 
@@ -1515,7 +1515,7 @@ spec:
 		It("should not be present if not specified on the KubeVirt CR", func() {
 
 			By("Check that KubeVirt CR has empty imagePullSecrets")
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(kv.Spec.ImagePullSecrets).To(BeEmpty())
 
@@ -1559,7 +1559,7 @@ spec:
 			})
 
 			By("Updating KubeVirt Object")
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = imagePullSecrets
 			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
@@ -1581,7 +1581,7 @@ spec:
 			checkVirtLauncherPod(vmi)
 
 			By("Deleting imagePullSecrets from KubeVirt object")
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = []k8sv1.LocalObjectReference{}
 			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
@@ -1974,7 +1974,7 @@ spec:
 
 				By("setting the right uninstall strategy")
 				Eventually(func() error {
-					kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+					kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					kv.Spec.UninstallStrategy = v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
 					_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
@@ -2724,7 +2724,7 @@ spec:
 
 			By("waiting for the kv CR to be gone")
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				_, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				return err
 			}, 120*time.Second, 4*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 
@@ -2739,7 +2739,7 @@ spec:
 
 			By("waiting for the kv CR to get a finalizer")
 			Eventually(func() bool {
-				kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return len(kv.Finalizers) > 0
 			}, 120*time.Second, 4*time.Second).Should(BeTrue())
@@ -2747,7 +2747,7 @@ spec:
 			By("ensuring the CR generation is stable")
 			Expect(err).ToNot(HaveOccurred())
 			Consistently(func() int64 {
-				kv2, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv2, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return kv2.GetGeneration()
 			}, 30*time.Second, 2*time.Second).Should(Equal(kv.GetGeneration()))

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -382,7 +382,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 				"]")
 
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -391,7 +391,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		patchKvVersionAndRegistry = func(name string, version string, registry string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/imageTag", "value": "%s"},{ "op": "replace", "path": "/spec/imageRegistry", "value": "%s"}]`, version, registry))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -400,7 +400,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		patchKvVersion = func(name string, version string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "add", "path": "/spec/imageTag", "value": "%s"}]`, version))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -414,7 +414,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -428,7 +428,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
-			_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+			_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(errMsg))
 
@@ -479,7 +479,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -496,7 +496,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).Should(HaveOccurred())

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -641,7 +641,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 					if kv.DeletionTimestamp == nil {
 
 						By("deleting the kv object")
-						err := virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
+						err := virtClient.KubeVirt(kv.Namespace).Delete(context.Background(), kv.Name, metav1.DeleteOptions{})
 						if err != nil {
 							return err
 						}
@@ -1986,7 +1986,7 @@ spec:
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Deleting KubeVirt object")
-				err = virtClient.KubeVirt(originalKv.Namespace).Delete(originalKv.Name, &metav1.DeleteOptions{})
+				err = virtClient.KubeVirt(originalKv.Namespace).Delete(context.Background(), originalKv.Name, metav1.DeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("there are still Virtual Machine Instances present"))
 			})
@@ -2707,7 +2707,7 @@ spec:
 			}
 
 			By("deleting the kv CR")
-			err = virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
+			err = virtClient.KubeVirt(kv.Namespace).Delete(context.Background(), kv.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for virt-api and virt-controller to be gone")

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1386,7 +1386,7 @@ spec:
 			Expect(kv.Spec.Configuration.VirtualMachineInstancesPerNode).ToNot(Equal(&newVirtualMachineInstancesPerNode))
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = &newVirtualMachineInstancesPerNode
 
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -1400,7 +1400,7 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = nil
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -1431,7 +1431,7 @@ spec:
 				},
 			}
 
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			generation := kv.GetGeneration()
 
@@ -1458,7 +1458,7 @@ spec:
 
 			By("Deleting patch from KubeVirt object")
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{}
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			generation = kv.GetGeneration()
 
@@ -1562,7 +1562,7 @@ spec:
 			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = imagePullSecrets
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -1584,7 +1584,7 @@ spec:
 			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = []k8sv1.LocalObjectReference{}
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -1977,7 +1977,7 @@ spec:
 					kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					kv.Spec.UninstallStrategy = v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
-					_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
+					_, err = virtClient.KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 					return err
 				}, 60*time.Second, time.Second).ShouldNot(HaveOccurred())
 

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -686,7 +686,7 @@ func (r *KubernetesReporter) logConfigMaps(virtCli kubecli.KubevirtClient) {
 }
 
 func (r *KubernetesReporter) logKubeVirtCR(virtCli kubecli.KubevirtClient) {
-	kvs, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).List(&metav1.ListOptions{})
+	kvs, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to fetch kubevirts: %v\n", err)
 		return

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -26,7 +26,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 
 	setccs := func(ccs v12.CustomizeComponents) (oldcss v12.CustomizeComponents) {
 		originalKv := util.GetCurrentKv(virtClient)
-		kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &v1.GetOptions{})
+		kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, v1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		oldcss = kv.Spec.CustomizeComponents
 		kv.Spec.CustomizeComponents = ccs
@@ -40,7 +40,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 
 	restorescc := func(ccs v12.CustomizeComponents) {
 		originalKv := util.GetCurrentKv(virtClient)
-		kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &v1.GetOptions{})
+		kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, v1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		kv.Spec.CustomizeComponents = v12.CustomizeComponents{}
 

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -31,7 +31,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 		oldcss = kv.Spec.CustomizeComponents
 		kv.Spec.CustomizeComponents = ccs
 		EventuallyWithOffset(1, func() error {
-			_, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			_, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, v1.UpdateOptions{})
 			return err
 		}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
@@ -45,7 +45,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 		kv.Spec.CustomizeComponents = v12.CustomizeComponents{}
 
 		EventuallyWithOffset(1, func() error {
-			_, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			_, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, v1.UpdateOptions{})
 			return err
 		}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2060,7 +2060,7 @@ var _ = SIGDescribe("Export", func() {
 				return
 			}
 			kv.Spec.CertificateRotationStrategy = *beforeCertParams
-			_, err := virtClient.KubeVirt(kv.Namespace).Update(kv)
+			_, err := virtClient.KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -2076,7 +2076,7 @@ var _ = SIGDescribe("Export", func() {
 					RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
 				},
 			}
-			_, err := virtClient.KubeVirt(kv.Namespace).Update(kv)
+			_, err := virtClient.KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		}
 

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -162,7 +162,7 @@ func EnsureKubevirtReadyWithTimeout(timeout time.Duration) {
 			"virt-operator deployment is not ready")
 
 	Eventually(func() *v1.KubeVirt {
-		kv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+		kv, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return kv
 	}, timeout, 1*time.Second).Should(

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -133,7 +133,7 @@ func AdjustKubeVirtResource() {
 	data, err := json.Marshal(kv.Spec)
 	Expect(err).ToNot(HaveOccurred())
 	patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
-	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(kv.Name, types.JSONPatchType, []byte(patchData), &metav1.PatchOptions{})
+	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
 	util.PanicOnError(err)
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
 	if checks.HasFeature(virtconfig.CPUManager) {
@@ -159,7 +159,7 @@ func RestoreKubeVirtResource() {
 		data, err := json.Marshal(originalKV.Spec)
 		Expect(err).ToNot(HaveOccurred())
 		patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
-		_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(originalKV.Name, types.JSONPatchType, []byte(patchData), &metav1.PatchOptions{})
+		_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(context.Background(), originalKV.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
 		util.PanicOnError(err)
 	}
 }
@@ -198,7 +198,7 @@ func UpdateKubeVirtConfigValue(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
 	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, kv)
 	Expect(err).ToNot(HaveOccurred())
 
-	kv, err = virtClient.KubeVirt(kv.Namespace).Patch(kv.GetName(), types.MergePatchType, patch, &metav1.PatchOptions{})
+	kv, err = virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
 	return kv

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -338,7 +338,7 @@ func removeAllGroupVersionResourceFromNamespace(groupVersionResource schema.Grou
 
 func detectInstallNamespace() {
 	virtCli := kubevirt.Client()
-	kvs, err := virtCli.KubeVirt("").List(&metav1.ListOptions{})
+	kvs, err := virtCli.KubeVirt("").List(context.Background(), metav1.ListOptions{})
 	util.PanicOnError(err)
 	if len(kvs.Items) == 0 {
 		util.PanicOnError(fmt.Errorf("Could not detect a kubevirt installation"))

--- a/tests/util/util.go
+++ b/tests/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"time"
 
 	"github.com/onsi/gomega"
@@ -36,14 +37,14 @@ func GetKvList(virtClient kubecli.KubevirtClient) []k6sv1.KubeVirt {
 
 	gomega.Eventually(func() error {
 
-		kvListInstallNS, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).List(&k8smetav1.ListOptions{})
+		kvListInstallNS, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).List(context.Background(), k8smetav1.ListOptions{})
 
 		return err
 	}, 10*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 
 	gomega.Eventually(func() error {
 
-		kvListDefaultNS, err = virtClient.KubeVirt(NamespaceTestDefault).List(&k8smetav1.ListOptions{})
+		kvListDefaultNS, err = virtClient.KubeVirt(NamespaceTestDefault).List(context.Background(), k8smetav1.ListOptions{})
 
 		return err
 	}, 10*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -711,7 +711,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 						},
 					},
 				}
-				_, err = kubevirt.Client().KubeVirt(kv.Namespace).Update(kv)
+				_, err = kubevirt.Client().KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should update kubevirt infra placement")
 
 				Eventually(func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
We have our custom `kubevirtInterface` interface with the common `Get`, `Delete`, etc...
From https://github.com/kubevirt/kubevirt/pull/11297 the common methods implementation works as a wrapper with different signatures for the generated ones, redirecting the requests to them.

After this PR:
Convert using the generated client signatures instead of the custom one. The generated `kubevirtInterface`  is embedded into our custom one, also providing new `DeleteCollection` and `Watch` methods.
The changes inherited are:
- `Patch` and `PatchStatus` now use metav1.PatchOptions{} instead of *metav1.PatchOptions{}.
- `List` now uses metav1.ListOptions{} instead of *metav1.ListOptions{}.
- `Get` now uses metav1.GetOptions{} instead of *metav1.GetOptions{}.
- `Delete` now uses metav1.DeleteOptions{} instead of *metav1.DeleteOptions{}.
- `Create` now receives metav1.CreateOptions{} too.
- `Update` and `UpdateStatus` now receive metav1.UpdateOptions{} too.
- Added `DeleteCollection`, `Watch` methods.
- All the methods above take a  `Context` as first paramether.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
For an easier review process the commits was splitted in the following manner:
1. Align our custom common methods' signature to the generated one in the following order:
     - `Create` - introduced `CreateOptions` and introduced a `Context`
     - `Get` - used `GetOptions` instead of the pointer and introduced a `Context`
     - `List` - used `ListOptions` instead of the pointer and introduced a `Context`
     - `Update` - introduced `UpdateOptions` and introduced a `Context`
     - `Delete` - used `DeleteOptions` instead of the pointer and introduced a `Context`
     - `Patch` and `PatchStatus` - used `PatchOptions` instead of the pointer and introduced a `Context`
     - `UpdateStatus` - introduced `UpdateOptions` and introduced a `Context`
2. Embed the generated `kubevirtInterface` into the custom one.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] ~Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```