### PR TITLE
Introduce the update volume strategy field

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20903,6 +20903,10 @@
      "template": {
       "description": "Template is the direct specification of VirtualMachineInstance",
       "$ref": "#/definitions/v1.VirtualMachineInstanceTemplateSpec"
+     },
+     "updateVolumesStrategy": {
+      "description": "UpdateVolumesStrategy is the strategy to apply on volumes updates",
+      "type": "string"
      }
     }
    },

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -454,6 +454,14 @@ func validateLiveUpdateFeatures(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 		causes = append(causes, validateLiveUpdateMemory(field, &spec.Template.Spec.Domain, spec.Template.Spec.Architecture)...)
 	}
 
+	if spec.UpdateVolumesStrategy != nil && !config.VolumesUpdateStrategyEnabled() {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s feature gate is not enabled in kubevirt-config", virtconfig.VolumesUpdateStrategy),
+			Field:   "updateVolumesStrategy",
+		})
+	}
+
 	return causes
 }
 

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -78,6 +78,9 @@ const (
 	CommonInstancetypesDeploymentGate = "CommonInstancetypesDeploymentGate"
 	// AlignCPUsGate allows emulator thread to assign two extra CPUs if needed to complete even parity.
 	AlignCPUsGate = "AlignCPUs"
+
+	// VolumesUpdateStrategy enables to specify the strategy on the volume updates.
+	VolumesUpdateStrategy = "VolumesUpdateStrategy"
 )
 
 func (config *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
@@ -245,4 +248,8 @@ func (config *ClusterConfig) CommonInstancetypesDeploymentEnabled() bool {
 
 func (config *ClusterConfig) AlignCPUsEnabled() bool {
 	return config.isFeatureGateEnabled(AlignCPUsGate)
+}
+
+func (config *ClusterConfig) VolumesUpdateStrategyEnabled() bool {
+	return config.isFeatureGateEnabled(VolumesUpdateStrategy)
 }

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7501,6 +7501,9 @@ var CRDsValidation map[string]string = map[string]string{
               - domain
               type: object
           type: object
+        updateVolumesStrategy:
+          description: UpdateVolumesStrategy is the strategy to apply on volumes updates
+          type: string
       required:
       - template
       type: object
@@ -21588,6 +21591,10 @@ var CRDsValidation map[string]string = map[string]string{
                       - domain
                       type: object
                   type: object
+                updateVolumesStrategy:
+                  description: UpdateVolumesStrategy is the strategy to apply on volumes
+                    updates
+                  type: string
               required:
               - template
               type: object
@@ -26826,6 +26833,10 @@ var CRDsValidation map[string]string = map[string]string{
                           - domain
                           type: object
                       type: object
+                    updateVolumesStrategy:
+                      description: UpdateVolumesStrategy is the strategy to apply
+                        on volumes updates
+                      type: string
                   required:
                   - template
                   type: object

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -5772,6 +5772,11 @@ func (in *VirtualMachineSpec) DeepCopyInto(out *VirtualMachineSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.UpdateVolumesStrategy != nil {
+		in, out := &in.UpdateVolumesStrategy, &out.UpdateVolumesStrategy
+		*out = new(UpdateVolumesStrategy)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1477,6 +1477,12 @@ const (
 	RunStrategyOnce VirtualMachineRunStrategy = "Once"
 )
 
+type UpdateVolumesStrategy string
+
+const (
+	UpdateVolumesStrategyReplacement UpdateVolumesStrategy = "Replacement"
+)
+
 // VirtualMachineSpec describes how the proper VirtualMachine
 // should look like
 type VirtualMachineSpec struct {
@@ -1500,6 +1506,9 @@ type VirtualMachineSpec struct {
 	// dataVolumeTemplates is a list of dataVolumes that the VirtualMachineInstance template can reference.
 	// DataVolumes in this list are dynamically created for the VirtualMachine and are tied to the VirtualMachine's life-cycle.
 	DataVolumeTemplates []DataVolumeTemplateSpec `json:"dataVolumeTemplates,omitempty"`
+
+	// UpdateVolumesStrategy is the strategy to apply on volumes updates
+	UpdateVolumesStrategy *UpdateVolumesStrategy `json:"updateVolumesStrategy,omitempty"`
 }
 
 // StateChangeRequestType represents the existing state change requests that are possible

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -358,13 +358,14 @@ func (VirtualMachineList) SwaggerDoc() map[string]string {
 
 func (VirtualMachineSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                    "VirtualMachineSpec describes how the proper VirtualMachine\nshould look like",
-		"running":             "Running controls whether the associatied VirtualMachineInstance is created or not\nMutually exclusive with RunStrategy",
-		"runStrategy":         "Running state indicates the requested running state of the VirtualMachineInstance\nmutually exclusive with Running",
-		"instancetype":        "InstancetypeMatcher references a instancetype that is used to fill fields in Template",
-		"preference":          "PreferenceMatcher references a set of preference that is used to fill fields in Template",
-		"template":            "Template is the direct specification of VirtualMachineInstance",
-		"dataVolumeTemplates": "dataVolumeTemplates is a list of dataVolumes that the VirtualMachineInstance template can reference.\nDataVolumes in this list are dynamically created for the VirtualMachine and are tied to the VirtualMachine's life-cycle.",
+		"":                      "VirtualMachineSpec describes how the proper VirtualMachine\nshould look like",
+		"running":               "Running controls whether the associatied VirtualMachineInstance is created or not\nMutually exclusive with RunStrategy",
+		"runStrategy":           "Running state indicates the requested running state of the VirtualMachineInstance\nmutually exclusive with Running",
+		"instancetype":          "InstancetypeMatcher references a instancetype that is used to fill fields in Template",
+		"preference":            "PreferenceMatcher references a set of preference that is used to fill fields in Template",
+		"template":              "Template is the direct specification of VirtualMachineInstance",
+		"dataVolumeTemplates":   "dataVolumeTemplates is a list of dataVolumes that the VirtualMachineInstance template can reference.\nDataVolumes in this list are dynamically created for the VirtualMachine and are tied to the VirtualMachine's life-cycle.",
+		"updateVolumesStrategy": "UpdateVolumesStrategy is the strategy to apply on volumes updates",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -24887,6 +24887,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineSpec(ref common.ReferenceCallba
 							},
 						},
 					},
+					"updateVolumesStrategy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UpdateVolumesStrategy is the strategy to apply on volumes updates",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"template"},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
No support for the update volume strategy

After this PR:
This PR introduces the updateVolumeStrategy described in [update-volume-strategy proposal](https://github.com/kubevirt/community/blob/main/design-proposals/volume-update-strategy.md). 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer
This change prepares the virt-controller to support the volume update. It is a preparation for the [volume migration](https://github.com/kubevirt/kubevirt/pull/11533) and the migration update volume strategy.
Both volume migration and hotplug will also update the volume set of the VM, and we need to be able to distinguish the type of update that the user wants. This is the role of the new field `updateVolumeStrategy`.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the updateVolumeStrategy field
```

