### PR TITLE
conformance: fix multi-arch image manifest issue

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -74,6 +74,10 @@ container_image(
 container_image(
     name = "conformance_image",
     testonly = True,
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
     base = ":conformance_image_base",
     directory = "/usr/bin",
     entrypoint = ["/usr/bin/conformance"],


### PR DESCRIPTION
Set up the architecture in the image manifest based on bazel architecture.
Otherwise, the architecture in the manifest of conformance would be same to the CPU arch of the build server.
Fixes #11702

### Release note
```release-note
None
```

