### PR TITLE
Remove utils' GetVmiPod() function and replace it with libpod functions

### DIFF
--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -106,7 +106,8 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			vmi = libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Ensuring the compute container has 200m CPU")
-			compute := libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
+			compute, err := libpod.LookupComputeContainerFromVmi(vmi)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqCpu := compute.Resources.Requests.Cpu().Value()
@@ -155,7 +156,9 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			}))
 
 			By("Ensuring the virt-launcher pod now has 400m CPU")
-			compute = libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
+			compute, err = libpod.LookupComputeContainerFromVmi(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqCpu = compute.Resources.Requests.Cpu().Value()
 			expCpu = resource.MustParse("400m")
@@ -205,7 +208,8 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			vmi = libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Ensuring the compute container has 2 CPU")
-			compute := libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
+			compute, err := libpod.LookupComputeContainerFromVmi(vmi)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqCpu := compute.Resources.Requests.Cpu().Value()
@@ -252,7 +256,8 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			}))
 
 			By("Ensuring the virt-launcher pod now has 4 CPU")
-			compute = libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
+			compute, err = libpod.LookupComputeContainerFromVmi(vmi)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqCpu = compute.Resources.Requests.Cpu().Value()

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -107,7 +107,8 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			migration.CreateMigrationPolicy(virtClient, migration.PreparePolicyAndVMIWithBandwidthLimitation(vmi, migrationBandwidthLimit))
 
 			By("Ensuring the compute container has at least 128Mi of memory")
-			compute := libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
+			compute, err := libpod.LookupComputeContainerFromVmi(vmi)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqMemory := compute.Resources.Requests.Memory().Value()
@@ -152,7 +153,8 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			}, 240*time.Second, time.Second).Should(BeNumerically(">", guest.Value()))
 
 			By("Ensuring the virt-launcher pod now has at least more than 256Mi of memory")
-			compute = libpod.LookupComputeContainer(tests.GetVmiPod(virtClient, vmi))
+			compute, err = libpod.LookupComputeContainerFromVmi(vmi)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(compute).NotTo(BeNil(), "failed to find compute container")
 			reqMemory = compute.Resources.Requests.Memory().Value()
 			Expect(reqMemory).To(BeNumerically(">=", maxGuest.Value()))

--- a/tests/libpod/container.go
+++ b/tests/libpod/container.go
@@ -22,6 +22,8 @@ package libpod
 import (
 	"fmt"
 
+	virtv1 "kubevirt.io/api/core/v1"
+
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -40,4 +42,17 @@ func LookupContainer(pod *v1.Pod, containerName string) *v1.Container {
 		}
 	}
 	panic(fmt.Errorf("could not find the %s container", containerName))
+}
+
+func LookupComputeContainerFromVmi(vmi *virtv1.VirtualMachineInstance) (*v1.Container, error) {
+	if vmi.Namespace == "" {
+		return nil, fmt.Errorf("vmi namespace is empty")
+	}
+
+	pod, err := GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return LookupComputeContainer(pod), nil
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -581,10 +581,13 @@ func GetVmiPod(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance
 // RunCommandOnVmiPod runs specified command on the virt-launcher pod
 func RunCommandOnVmiPod(vmi *v1.VirtualMachineInstance, command []string) string {
 	virtClient := kubevirt.Client()
-	vmiPod := GetVmiPod(virtClient, vmi)
+	pods, err := virtClient.CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), UnfinishedVMIPodSelector(vmi))
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, pods.Items).NotTo(BeEmpty())
+	vmiPod := pods.Items[0]
 
 	output, err := exec.ExecuteCommandOnPod(
-		vmiPod,
+		&vmiPod,
 		"compute",
 		command,
 	)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -569,15 +569,6 @@ func RemoveHostDiskImage(diskPath string, nodeName string) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func GetVmiPod(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
-	pods, err := virtClient.CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), UnfinishedVMIPodSelector(vmi))
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, pods.Items).NotTo(BeEmpty())
-	vmiPod := pods.Items[0]
-
-	return &vmiPod
-}
-
 // RunCommandOnVmiPod runs specified command on the virt-launcher pod
 func RunCommandOnVmiPod(vmi *v1.VirtualMachineInstance, command []string) string {
 	virtClient := kubevirt.Client()


### PR DESCRIPTION
### What this PR does
This PR removes utils' GetVmiPod() function and replace it with libpod functions.

/sig code-quality

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

