### PR TITLE
[release-1.0] Collect VMI OS info from the Guest agent

### DIFF
--- a/pkg/monitoring/vmistats/collector_test.go
+++ b/pkg/monitoring/vmistats/collector_test.go
@@ -158,6 +158,12 @@ var _ = Describe("Utility functions", func() {
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
 						Phase: "Pending",
+						GuestOSInfo: k6tv1.VirtualMachineInstanceGuestOSInfo{
+							KernelRelease: "6.5.6-300.fc39.x86_64",
+							Machine:       "x86_64",
+							Name:          "Fedora Linux",
+							VersionID:     "39",
+						},
 					},
 				},
 				{
@@ -195,28 +201,40 @@ var _ = Describe("Utility functions", func() {
 			Expect(countMap).To(HaveLen(3))
 
 			running := vmiCountMetric{
-				Phase:        "running",
-				OS:           "centos8",
-				Workload:     "server",
-				Flavor:       "tiny",
-				InstanceType: "<none>",
-				Preference:   "<none>",
+				Phase:                "running",
+				OS:                   "centos8",
+				Workload:             "server",
+				Flavor:               "tiny",
+				GuestOSKernelRelease: "<none>",
+				GuestOSMachine:       "<none>",
+				GuestOSName:          "<none>",
+				GuestOSVersionID:     "<none>",
+				InstanceType:         "<none>",
+				Preference:           "<none>",
 			}
 			pending := vmiCountMetric{
-				Phase:        "pending",
-				OS:           "fedora33",
-				Workload:     "workstation",
-				Flavor:       "large",
-				InstanceType: "<none>",
-				Preference:   "<none>",
+				Phase:                "pending",
+				OS:                   "fedora33",
+				Workload:             "workstation",
+				Flavor:               "large",
+				InstanceType:         "<none>",
+				Preference:           "<none>",
+				GuestOSKernelRelease: "6.5.6-300.fc39.x86_64",
+				GuestOSMachine:       "x86_64",
+				GuestOSName:          "Fedora Linux",
+				GuestOSVersionID:     "39",
 			}
 			scheduling := vmiCountMetric{
-				Phase:        "scheduling",
-				OS:           "centos7",
-				Workload:     "server",
-				Flavor:       "medium",
-				InstanceType: "<none>",
-				Preference:   "<none>",
+				Phase:                "scheduling",
+				OS:                   "centos7",
+				Workload:             "server",
+				Flavor:               "medium",
+				GuestOSKernelRelease: "<none>",
+				GuestOSMachine:       "<none>",
+				GuestOSName:          "<none>",
+				GuestOSVersionID:     "<none>",
+				InstanceType:         "<none>",
+				Preference:           "<none>",
 			}
 			bogus := vmiCountMetric{
 				Phase: "bogus",
@@ -254,7 +272,7 @@ var _ = Describe("Utility functions", func() {
 			Expect(result).ToNot(BeNil())
 			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_phase_count"))
 			Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(1))
-			Expect(dto.Label).To(HaveLen(7))
+			Expect(dto.Label).To(HaveLen(11))
 			for _, pair := range dto.Label {
 				if pair.GetName() == "instance_type" {
 					Expect(pair.GetValue()).To(Equal(expected))
@@ -297,7 +315,7 @@ var _ = Describe("Utility functions", func() {
 			Expect(result).ToNot(BeNil())
 			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_phase_count"))
 			Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(1))
-			Expect(dto.Label).To(HaveLen(7))
+			Expect(dto.Label).To(HaveLen(11))
 			for _, pair := range dto.Label {
 				if pair.GetName() == "preference" {
 					Expect(pair.GetValue()).To(Equal(expected))

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//vendor/github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/prometheus/client_golang/api/prometheus/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 
 	corev1 "k8s.io/api/core/v1"
@@ -242,6 +243,25 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		})
 	})
 
+	Context("VM metrics that are based on the guest agent", func() {
+		It("should have kubevirt_vmi_phase_count correctly configured with guest OS labels", func() {
+			agentVMI := createAgentVMI()
+			Expect(agentVMI.Status.GuestOSInfo.KernelRelease).ToNot(BeEmpty())
+			Expect(agentVMI.Status.GuestOSInfo.Machine).ToNot(BeEmpty())
+			Expect(agentVMI.Status.GuestOSInfo.Name).ToNot(BeEmpty())
+			Expect(agentVMI.Status.GuestOSInfo.VersionID).ToNot(BeEmpty())
+
+			labels := map[string]string{
+				"guest_os_kernel_release": agentVMI.Status.GuestOSInfo.KernelRelease,
+				"guest_os_machine":        agentVMI.Status.GuestOSInfo.Machine,
+				"guest_os_name":           agentVMI.Status.GuestOSInfo.Name,
+				"guest_os_version_id":     agentVMI.Status.GuestOSInfo.VersionID,
+			}
+
+			waitForMetricValueWithLabels(virtClient, "kubevirt_vmi_phase_count", 1, labels)
+		})
+	})
+
 	Context("VM alerts", func() {
 		var scales *Scaling
 
@@ -301,3 +321,21 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		})
 	})
 })
+
+func createAgentVMI() *v1.VirtualMachineInstance {
+	virtClient := kubevirt.Client()
+	vmiAgentConnectedConditionMatcher := MatchFields(IgnoreExtras, Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})
+	vmi := tests.RunVMIAndExpectLaunch(libvmi.NewFedora(libvmi.WithMasqueradeNetworking()...), 180)
+
+	var err error
+	var agentVMI *v1.VirtualMachineInstance
+
+	By("VMI has the guest agent connected condition")
+	Eventually(func() []v1.VirtualMachineInstanceCondition {
+		agentVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return agentVMI.Status.Conditions
+	}, 240*time.Second, 1*time.Second).Should(ContainElement(vmiAgentConnectedConditionMatcher), "Should have agent connected condition")
+
+	return agentVMI
+}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/11283.

Required for implementing a fix for https://issues.redhat.com/browse/CNV-38482.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Collect VMI OS info from the Guest agent as `kubevirt_vmi_phase_count` metric labels
```