### PR TITLE
[DO NOT REVIEW] [TEST] Remove NoSchedule taints for control-planes as well as masters

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -171,7 +171,7 @@ function _fix_node_labels() {
     master_nodes=$(_get_nodes | grep -i $MASTER_NODES_PATTERN | awk '{print $1}')
     for node in ${master_nodes[@]}; do
         # removing NoSchedule taint if is there
-        if _kubectl taint nodes $node node-role.kubernetes.io/master:NoSchedule-; then
+        if _kubectl taint nodes $node node-role.kubernetes.io/master:NoSchedule- || _kubectl taint nodes $node node-role.kubernetes.io/control-plane:NoSchedule-; then
             _kubectl label node $node kubevirt.io/schedulable=true
         fi
     done

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -51,7 +51,7 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 
 	injectOperatorMetadata(kv, &deployment.ObjectMeta, imageTag, imageRegistry, id, true)
 	injectOperatorMetadata(kv, &deployment.Spec.Template.ObjectMeta, imageTag, imageRegistry, id, false)
-	InjectPlacementMetadata(kv.Spec.Infra, &deployment.Spec.Template.Spec)
+	InjectPlacementMetadata(kv.Spec.Infra, &deployment.Spec.Template.Spec, RequireControlPlanePreferNonWorker)
 
 	if kv.Spec.Infra != nil && kv.Spec.Infra.Replicas != nil {
 		replicas := int32(*kv.Spec.Infra.Replicas)
@@ -276,7 +276,7 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 
 	injectOperatorMetadata(kv, &daemonSet.ObjectMeta, imageTag, imageRegistry, id, true)
 	injectOperatorMetadata(kv, &daemonSet.Spec.Template.ObjectMeta, imageTag, imageRegistry, id, false)
-	InjectPlacementMetadata(kv.Spec.Workloads, &daemonSet.Spec.Template.Spec)
+	InjectPlacementMetadata(kv.Spec.Workloads, &daemonSet.Spec.Template.Spec, AnyNode)
 
 	if daemonSet.GetName() == "virt-handler" {
 		setMaxDevices(r.kv, daemonSet)

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -900,14 +900,14 @@ var _ = Describe("Apply Apps", func() {
 		// Node Selectors
 		It("should succeed if componentConfig is nil", func() {
 			// if componentConfig is nil
-			InjectPlacementMetadata(nil, podSpec)
+			InjectPlacementMetadata(nil, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
 
 		It("should succeed if nodePlacement is nil", func() {
 			componentConfig.NodePlacement = nil
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
@@ -915,14 +915,14 @@ var _ = Describe("Apply Apps", func() {
 		It("should succeed if podSpec is nil", func() {
 			orig := componentConfig.DeepCopy()
 			orig.NodePlacement.NodeSelector = map[string]string{kubernetesOSLabel: kubernetesOSLinux}
-			InjectPlacementMetadata(componentConfig, nil)
+			InjectPlacementMetadata(componentConfig, nil, AnyNode)
 			Expect(equality.Semantic.DeepEqual(orig, componentConfig)).To(BeTrue())
 		})
 
 		It("should copy NodeSelectors when podSpec is empty", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
 			nodePlacement.NodeSelector["foo"] = "bar"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
@@ -933,7 +933,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.NodeSelector["foo"] = "bar"
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["existing"] = "value"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(3))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector["existing"]).To(Equal("value"))
@@ -945,7 +945,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.NodeSelector["foo"] = "bar"
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["foo"] = "from-podspec"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
@@ -953,14 +953,14 @@ var _ = Describe("Apply Apps", func() {
 
 		It("should set OS label if not defined", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
 
 		It("should favor NodeSelector OS label if present", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
 			nodePlacement.NodeSelector[kubernetesOSLabel] = "linux-custom"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal("linux-custom"))
 		})
@@ -968,7 +968,7 @@ var _ = Describe("Apply Apps", func() {
 		It("should favor podSpec OS label if present", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector[kubernetesOSLabel] = "linux-custom"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal("linux-custom"))
 		})
@@ -976,7 +976,7 @@ var _ = Describe("Apply Apps", func() {
 		It("should preserve NodeSelectors if nodePlacement has none", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["foo"] = "from-podspec"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
@@ -990,14 +990,14 @@ var _ = Describe("Apply Apps", func() {
 				Effect:   "NoSchedule",
 			}
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Tolerations).To(HaveLen(1))
 			Expect(podSpec.Tolerations[0].Key).To(Equal("test-taint"))
 		})
 
 		It("should preserve tolerations when nodePlacement is empty", func() {
 			podSpec.Tolerations = []corev1.Toleration{toleration}
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Tolerations).To(HaveLen(1))
 			Expect(podSpec.Tolerations[0].Key).To(Equal("test-taint"))
 		})
@@ -1005,13 +1005,13 @@ var _ = Describe("Apply Apps", func() {
 		It("should merge tolerations when both are defined", func() {
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
 			podSpec.Tolerations = []corev1.Toleration{toleration2}
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Tolerations).To(HaveLen(2))
 		})
 
 		It("It should copy NodePlacement if podSpec Affinity is empty", func() {
 			nodePlacement.Affinity = affinity
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(equality.Semantic.DeepEqual(nodePlacement.Affinity, podSpec.Affinity)).To(BeTrue())
 
 		})
@@ -1019,7 +1019,7 @@ var _ = Describe("Apply Apps", func() {
 		It("It should copy NodePlacement if Node, Pod and Anti affinities are empty", func() {
 			nodePlacement.Affinity = affinity
 			podSpec.Affinity = &corev1.Affinity{}
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(equality.Semantic.DeepEqual(nodePlacement.Affinity, podSpec.Affinity)).To(BeTrue())
 
 		})
@@ -1027,7 +1027,7 @@ var _ = Describe("Apply Apps", func() {
 		It("It should merge NodePlacement and podSpec affinity terms", func() {
 			nodePlacement.Affinity = affinity
 			podSpec.Affinity = affinity2
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(2))
 			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
 			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
@@ -1041,7 +1041,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
 		})
 
@@ -1049,7 +1049,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
@@ -1057,7 +1057,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
 			nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
@@ -1065,7 +1065,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
 			nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
@@ -1073,7 +1073,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 			nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
@@ -1081,7 +1081,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 			nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 	})

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -57,6 +57,13 @@ import (
 const Duration7d = time.Hour * 24 * 7
 const Duration1d = time.Hour * 24
 
+type DefaultInfraComponentsNodePlacement int
+
+const (
+	AnyNode DefaultInfraComponentsNodePlacement = iota
+	RequireControlPlanePreferNonWorker
+)
+
 const (
 	replaceSpecPatchTemplate     = `{ "op": "replace", "path": "/spec", "value": %s }`
 	replaceWebhooksValueTemplate = `{ "op": "replace", "path": "/webhooks", "value": %s }`
@@ -125,7 +132,7 @@ const (
 )
 
 // Merge all Tolerations, Affinity and NodeSelectos from NodePlacement into pod spec
-func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev1.PodSpec) {
+func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev1.PodSpec, nodePlacementOption DefaultInfraComponentsNodePlacement) {
 	if podSpec == nil {
 		podSpec = &corev1.PodSpec{}
 	}

--- a/pkg/virt-operator/resource/apply/reconcile_test.go
+++ b/pkg/virt-operator/resource/apply/reconcile_test.go
@@ -572,7 +572,13 @@ var _ = Describe("Apply", func() {
 
 					Expect(podSpec.Affinity).To(BeNil())
 				})
+
+				It("should not add requirement scheduling to control-plane nodes if the corresponding parameter is set to false", func() {
+					InjectPlacementMetadata(nil, podSpec, AnyNode)
+					Expect(podSpec.Affinity).To(BeNil())
+				})
 			})
+
 		})
 	})
 })

--- a/pkg/virt-operator/resource/apply/reconcile_test.go
+++ b/pkg/virt-operator/resource/apply/reconcile_test.go
@@ -336,14 +336,14 @@ var _ = Describe("Apply", func() {
 		// Node Selectors
 		It("should succeed if componentConfig is nil", func() {
 			// if componentConfig is nil
-			InjectPlacementMetadata(nil, podSpec)
+			InjectPlacementMetadata(nil, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
 
 		It("should succeed if nodePlacement is nil", func() {
 			componentConfig.NodePlacement = nil
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
@@ -351,14 +351,14 @@ var _ = Describe("Apply", func() {
 		It("should succeed if podSpec is nil", func() {
 			orig := componentConfig.DeepCopy()
 			orig.NodePlacement.NodeSelector = map[string]string{kubernetesOSLabel: kubernetesOSLinux}
-			InjectPlacementMetadata(componentConfig, nil)
+			InjectPlacementMetadata(componentConfig, nil, AnyNode)
 			Expect(equality.Semantic.DeepEqual(orig, componentConfig)).To(BeTrue())
 		})
 
 		It("should copy NodeSelectors when podSpec is empty", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
 			nodePlacement.NodeSelector["foo"] = "bar"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
@@ -369,7 +369,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.NodeSelector["foo"] = "bar"
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["existing"] = "value"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(3))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector["existing"]).To(Equal("value"))
@@ -381,7 +381,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.NodeSelector["foo"] = "bar"
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["foo"] = "from-podspec"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
@@ -389,14 +389,14 @@ var _ = Describe("Apply", func() {
 
 		It("should set OS label if not defined", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
 
 		It("should favor NodeSelector OS label if present", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
 			nodePlacement.NodeSelector[kubernetesOSLabel] = "linux-custom"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal("linux-custom"))
 		})
@@ -404,7 +404,7 @@ var _ = Describe("Apply", func() {
 		It("should favor podSpec OS label if present", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector[kubernetesOSLabel] = "linux-custom"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal("linux-custom"))
 		})
@@ -412,7 +412,7 @@ var _ = Describe("Apply", func() {
 		It("should preserve NodeSelectors if nodePlacement has none", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["foo"] = "from-podspec"
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
@@ -426,14 +426,14 @@ var _ = Describe("Apply", func() {
 				Effect:   "NoSchedule",
 			}
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Tolerations).To(HaveLen(1))
 			Expect(podSpec.Tolerations[0].Key).To(Equal("test-taint"))
 		})
 
 		It("should preserve tolerations when nodePlacement is empty", func() {
 			podSpec.Tolerations = []corev1.Toleration{toleration}
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Tolerations).To(HaveLen(1))
 			Expect(podSpec.Tolerations[0].Key).To(Equal("test-taint"))
 		})
@@ -441,13 +441,13 @@ var _ = Describe("Apply", func() {
 		It("should merge tolerations when both are defined", func() {
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
 			podSpec.Tolerations = []corev1.Toleration{toleration2}
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Tolerations).To(HaveLen(2))
 		})
 
 		It("It should copy NodePlacement if podSpec Affinity is empty", func() {
 			nodePlacement.Affinity = affinity
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(equality.Semantic.DeepEqual(nodePlacement.Affinity, podSpec.Affinity)).To(BeTrue())
 
 		})
@@ -455,7 +455,7 @@ var _ = Describe("Apply", func() {
 		It("It should copy NodePlacement if Node, Pod and Anti affinities are empty", func() {
 			nodePlacement.Affinity = affinity
 			podSpec.Affinity = &corev1.Affinity{}
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(equality.Semantic.DeepEqual(nodePlacement.Affinity, podSpec.Affinity)).To(BeTrue())
 
 		})
@@ -463,7 +463,7 @@ var _ = Describe("Apply", func() {
 		It("It should merge NodePlacement and podSpec affinity terms", func() {
 			nodePlacement.Affinity = affinity
 			podSpec.Affinity = affinity2
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(2))
 			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
 			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
@@ -477,7 +477,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
 		})
 
@@ -485,7 +485,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
@@ -493,7 +493,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
 			nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
@@ -501,7 +501,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
 			nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
@@ -509,7 +509,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 			nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
@@ -517,7 +517,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity = &corev1.Affinity{}
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 			nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-			InjectPlacementMetadata(componentConfig, podSpec)
+			InjectPlacementMetadata(componentConfig, podSpec, AnyNode)
 			Expect(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 	})

--- a/pkg/virt-operator/resource/apply/reconcile_test.go
+++ b/pkg/virt-operator/resource/apply/reconcile_test.go
@@ -560,6 +560,19 @@ var _ = Describe("Apply", func() {
 				Entry("nil component config", nil),
 				Entry("nil node placement", &v1.ComponentConfig{}),
 			)
+
+			Context("should not add requirement scheduling to control-plane nodes", func() {
+				It("if the user already provided a node placement", func() {
+					componentConfig = &v1.ComponentConfig{
+						NodePlacement: &v1.NodePlacement{
+							Tolerations: []corev1.Toleration{},
+						},
+					}
+					InjectPlacementMetadata(componentConfig, podSpec, RequireControlPlanePreferNonWorker)
+
+					Expect(podSpec.Affinity).To(BeNil())
+				})
+			})
 		})
 	})
 })

--- a/pkg/virt-operator/strategy_job.go
+++ b/pkg/virt-operator/strategy_job.go
@@ -98,7 +98,7 @@ func (c *KubeVirtController) generateInstallStrategyJob(infraPlacement *v1.Compo
 		},
 	}
 
-	apply.InjectPlacementMetadata(infraPlacement, &job.Spec.Template.Spec)
+	apply.InjectPlacementMetadata(infraPlacement, &job.Spec.Template.Spec, apply.RequireControlPlanePreferNonWorker)
 	env := job.Spec.Template.Spec.Containers[0].Env
 	extraEnv := util.NewEnvVarMap(config.GetExtraEnv())
 	job.Spec.Template.Spec.Containers[0].Env = append(env, *extraEnv...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

