### PR TITLE
e2e,compute: Add sig-compute-serial e2e target

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -84,6 +84,10 @@ elif [[ $TARGET =~ sig-compute-migrations ]]; then
   export KUBEVIRT_WITH_CNAO=true
   export KUBEVIRT_NUM_SECONDARY_NICS=1
   export KUBEVIRT_DEPLOY_NFS_CSI=true
+elif [[ $TARGET =~ sig-compute-serial ]]; then
+  export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-serial/}
+elif [[ $TARGET =~ sig-compute-parallel ]]; then
+  export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-parallel/}
 elif [[ $TARGET =~ sig-compute ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
 elif [[ $TARGET =~ sig-operator ]]; then
@@ -423,6 +427,13 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(sig-compute-realtime)'
   elif [[ $TARGET =~ sig-compute-migrations ]]; then
     label_filter='(sig-compute-migrations && !(GPU,VGPU))'
+  elif [[ $TARGET =~ sig-compute-serial ]]; then
+    export KUBEVIRT_E2E_PARALLEL=false
+    ginko_params="${ginko_params} --focus=\\[Serial\\]"
+    label_filter='((sig-compute) && !(GPU,VGPU,sig-compute-migrations))'
+  elif [[ $TARGET =~ sig-compute-parallel ]]; then
+    ginko_params="${ginko_params} --skip=\\[Serial\\]"
+    label_filter='(sig-compute && !(GPU,VGPU,sig-compute-migrations))'
   elif [[ $TARGET =~ sig-compute ]]; then
     label_filter='(sig-compute && !(GPU,VGPU,sig-compute-migrations))'
   elif [[ $TARGET =~ sig-monitoring ]]; then


### PR DESCRIPTION
### What this PR does

These new targets allow the splitting of the sig-compute presubmit lane
into a lane with the parallel tests and a separate lane with the serial
tests.

The sig-compute lane is by far the longest running lane - over 3.5 hours
on average[1]. Splitting this lane will give quicker CI feedback to contributors

[1] https://grafana.ci.kubevirt.io/d/gY4hNc5Iz/kubevirt-kubevirt-e2e-test-runtimes?orgId=1&viewPanel=2&from=now-90d&to=now

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
Mailing list: https://groups.google.com/g/kubevirt-dev/c/YhD-XNUeJJc

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

