### PR TITLE
fix: close files

### DIFF
--- a/tools/junit-merger/junit-merger.go
+++ b/tools/junit-merger/junit-merger.go
@@ -51,6 +51,20 @@ func main() {
 	}
 }
 
+func xmlDecode(file string) (reporters.JUnitTestSuite, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return reporters.JUnitTestSuite{}, fmt.Errorf("failed to open file %s: %v", file, err)
+	}
+	defer f.Close()
+	suite := reporters.JUnitTestSuite{}
+	err = xml.NewDecoder(f).Decode(&suite)
+	if err != nil {
+		return reporters.JUnitTestSuite{}, fmt.Errorf("failed to decode suite %s: %v", file, err)
+	}
+	return suite, nil
+}
+
 func loadJUnitFiles(fileGlobs []string) (suites []reporters.JUnitTestSuite, err error) {
 	for _, fileglob := range fileGlobs {
 		files, err := filepath.Glob(fileglob)
@@ -58,14 +72,9 @@ func loadJUnitFiles(fileGlobs []string) (suites []reporters.JUnitTestSuite, err 
 			return nil, err
 		}
 		for _, file := range files {
-			f, err := os.Open(file)
+			suite, err := xmlDecode(file)
 			if err != nil {
-				return nil, fmt.Errorf("failed to open file %s: %v", file, err)
-			}
-			suite := reporters.JUnitTestSuite{}
-			err = xml.NewDecoder(f).Decode(&suite)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode suite %s: %v", file, err)
+				return nil, err
 			}
 			suites = append(suites, suite)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

