### PR TITLE
VMI controller - move unit tests to fake client (VirtualMachineInstanceInterface)

### DIFF
--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -78,7 +78,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var config *virtconfig.ClusterConfig
 
 	var ctrl *gomock.Controller
-	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
 	var vmiSource *framework.FakeControllerSource
 	var vmSource *framework.FakeControllerSource
 	var podSource *framework.FakeControllerSource
@@ -255,7 +254,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		stop = make(chan struct{})
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
-		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClientset = kubevirtfake.NewSimpleClientset()
 
 		vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, kvcontroller.GetVMIInformerIndexers())

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -48,7 +48,6 @@ import (
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
-	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
@@ -3044,7 +3043,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "existing",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: v1.DiskBusVirtio,
+						Bus: virtv1.DiskBusVirtio,
 					},
 				},
 			})
@@ -3052,7 +3051,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "hotplug",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: v1.DiskBusSATA,
+						Bus: virtv1.DiskBusSATA,
 					},
 				},
 			})
@@ -3127,7 +3126,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "existing",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: v1.DiskBusVirtio,
+						Bus: virtv1.DiskBusVirtio,
 					},
 				},
 			})
@@ -3294,7 +3293,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		getVmiWithInvTsc := func() *virtv1.VirtualMachineInstance {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Spec.Architecture = "amd64"
-			vmi.Spec.Domain.CPU = &v1.CPU{
+			vmi.Spec.Domain.CPU = &virtv1.CPU{
 				Features: []virtv1.CPUFeature{
 					{
 						Name:   "invtsc",
@@ -3309,9 +3308,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		getVmiWithReenlightenment := func() *virtv1.VirtualMachineInstance {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Spec.Architecture = "amd64"
-			vmi.Spec.Domain.Features = &v1.Features{
-				Hyperv: &v1.FeatureHyperv{
-					Reenlightenment: &v1.FeatureState{Enabled: pointer.P(true)},
+			vmi.Spec.Domain.Features = &virtv1.Features{
+				Hyperv: &virtv1.FeatureHyperv{
+					Reenlightenment: &virtv1.FeatureState{Enabled: pointer.P(true)},
 				},
 			}
 
@@ -3342,7 +3341,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			Context("HyperV reenlightenment is enabled", func() {
-				var vmi *v1.VirtualMachineInstance
+				var vmi *virtv1.VirtualMachineInstance
 
 				BeforeEach(func() {
 					vmi = getVmiWithReenlightenment()
@@ -3503,7 +3502,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				prependInjectPodPatch(pod)
 			})
 
-			DescribeTable("update pods network annotation with", func(networks []v1.Network, interfaces []v1.Interface, matchers ...gomegaTypes.GomegaMatcher) {
+			DescribeTable("update pods network annotation with", func(networks []virtv1.Network, interfaces []virtv1.Interface, matchers ...gomegaTypes.GomegaMatcher) {
 				vmi.Spec.Networks = networks
 				vmi.Spec.Domain.Devices.Interfaces = interfaces
 				Expect(controller.updateMultusAnnotation(
@@ -3513,25 +3512,25 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				}
 			},
 				Entry("a single interface",
-					[]v1.Network{{
+					[]virtv1.Network{{
 						Name:          "iface1",
-						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net1"}},
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "net1"}},
 					}},
-					[]v1.Interface{{
+					[]virtv1.Interface{{
 						Name: "iface1",
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
 						`[{"name":"net1","namespace":"default","interface":"pod7e0055a6880"}]`)),
 				Entry("multiple interfaces",
-					[]v1.Network{{
+					[]virtv1.Network{{
 						Name:          "iface1",
-						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net1"}},
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "net1"}},
 					}, {
 						Name:          "iface2",
-						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net1"}},
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "net1"}},
 					}},
-					[]v1.Interface{{
+					[]virtv1.Interface{{
 						Name:       "iface1",
 						MacAddress: "mac1",
 					}, {
@@ -3545,17 +3544,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			DescribeTable("the subject interface name, in the pod networks annotation, should be in similar form as other interfaces",
 				func(testPodNetworkStatus []networkv1.NetworkStatus, expectedMultusNetworksAnnotation string) {
 					vmi = api.NewMinimalVMI(vmName)
-					vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+					vmi.Spec.Domain.Devices.Interfaces = []virtv1.Interface{{
 						Name:                   "red",
-						InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}, {
+						InterfaceBindingMethod: virtv1.InterfaceBindingMethod{Bridge: &virtv1.InterfaceBridge{}}}, {
 						Name:                   "blue",
-						InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+						InterfaceBindingMethod: virtv1.InterfaceBindingMethod{Bridge: &virtv1.InterfaceBridge{}}}}
 
-					vmi.Spec.Networks = []v1.Network{{
+					vmi.Spec.Networks = []virtv1.Network{{
 						Name:          "red",
-						NetworkSource: v1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "red-net"}}}, {
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "red-net"}}}, {
 						Name:          "blue",
-						NetworkSource: v1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "blue-net"}}}}
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "blue-net"}}}}
 
 					pod, err := NewPodForVirtualMachineWithMultusAnnotations(vmi, k8sv1.PodRunning, config, testPodNetworkStatus...)
 					Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -50,6 +50,7 @@ import (
 
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
+	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -90,6 +91,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var mockQueue *testutils.MockWorkQueue
 	var podFeeder *testutils.PodFeeder
 	var virtClient *kubecli.MockKubevirtClient
+	var virtClientset *kubevirtfake.Clientset
 	var kubeClient *fake.Clientset
 	var networkClient *fakenetworkclient.Clientset
 	var pvcInformer cache.SharedIndexInformer
@@ -274,6 +276,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		virtClientset = kubevirtfake.NewSimpleClientset()
 
 		vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, kvcontroller.GetVMIInformerIndexers())
 		vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachine{}, kvcontroller.GetVirtualMachineInformerIndexers())
@@ -317,19 +320,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		dataVolumeFeeder = testutils.NewDataVolumeFeeder(mockQueue, dataVolumeSource)
 
 		// Set up mock client
-		virtClient.EXPECT().VirtualMachineInstance(k8sv1.NamespaceDefault).Return(vmiInterface).AnyTimes()
+		virtClient.EXPECT().VirtualMachineInstance(k8sv1.NamespaceDefault).Return(
+			virtClientset.KubevirtV1().VirtualMachineInstances(k8sv1.NamespaceDefault),
+		).AnyTimes()
 		kubeClient = fake.NewSimpleClientset()
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 		networkClient = fakenetworkclient.NewSimpleClientset()
 		virtClient.EXPECT().NetworkClient().Return(networkClient).AnyTimes()
 
-		// Make sure that all unexpected calls to kubeClient will fail
-		kubeClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-			Expect(action).To(BeNil())
-			return true, nil, nil
-		})
 		syncCaches(stop)
 	})
+
 	AfterEach(func() {
 		close(stop)
 		// Ensure that we add checks for expected events to every test

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -26,28 +26,16 @@ import (
 	"strings"
 	"time"
 
-	storagev1 "k8s.io/api/storage/v1"
-
-	"kubevirt.io/kubevirt/pkg/network/downwardapi"
-
-	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
-
-	"kubevirt.io/kubevirt/pkg/virt-controller/network"
-
-	"kubevirt.io/kubevirt/pkg/network/vmispec"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-
-	"kubevirt.io/kubevirt/pkg/pointer"
-
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/mock/gomock"
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegaTypes "github.com/onsi/gomega/types"
+
 	k8sv1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -69,8 +57,14 @@ import (
 
 	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/network/deviceinfo"
+	"kubevirt.io/kubevirt/pkg/network/downwardapi"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+	"kubevirt.io/kubevirt/pkg/pointer"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-controller/network"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 )

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -37,7 +37,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -89,7 +88,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var controller *VMIController
 	var recorder *record.FakeRecorder
 	var mockQueue *testutils.MockWorkQueue
-	var podFeeder *testutils.PodFeeder
 	var virtClient *kubecli.MockKubevirtClient
 	var virtClientset *kubevirtfake.Clientset
 	var kubeClient *fake.Clientset
@@ -100,11 +98,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var nsInformer cache.SharedIndexInformer
 	var kvInformer cache.SharedIndexInformer
 
-	var dataVolumeSource *framework.FakeControllerSource
 	var dataVolumeInformer cache.SharedIndexInformer
 	var cdiInformer cache.SharedIndexInformer
 	var cdiConfigInformer cache.SharedIndexInformer
-	var dataVolumeFeeder *testutils.DataVolumeFeeder
 	var qemuGid int64 = 107
 
 	shouldExpectMatchingPodCreation := func(uid types.UID, matchers ...gomegaTypes.GomegaMatcher) {
@@ -281,7 +277,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, kvcontroller.GetVMIInformerIndexers())
 		vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachine{}, kvcontroller.GetVirtualMachineInformerIndexers())
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
-		dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
+		dataVolumeInformer, _ = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 
@@ -316,8 +312,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		// Wrap our workqueue to have a way to detect when we are done processing updates
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
 		controller.Queue = mockQueue
-		podFeeder = testutils.NewPodFeeder(mockQueue, podSource)
-		dataVolumeFeeder = testutils.NewDataVolumeFeeder(mockQueue, dataVolumeSource)
 
 		// Set up mock client
 		virtClient.EXPECT().VirtualMachineInstance(k8sv1.NamespaceDefault).Return(
@@ -377,14 +371,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dvPVC := NewPvc(vmi.Namespace, "test1")
-			// we are mocking a successful DataVolume. we expect the PVC to
-			// be available in the store if DV is successful.
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
-
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 
 			addVirtualMachine(vmi)
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolumePVC(dvPVC)
+			addDataVolume(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
 			shouldExpectPodCreation(vmi.UID)
 
@@ -404,12 +395,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
-			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
-			// be in available but in the Pending state.
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
-
+			addDataVolumePVC(dvPVC)
 			addVirtualMachine(vmi)
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolume(dataVolume)
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElements(
 					MatchFields(IgnoreExtras, Fields{"Type": BeEquivalentTo(virtv1.VirtualMachineInstanceProvisioning)}),
@@ -427,12 +415,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 					return ""
 				},
-				Equal("/bin/bash -c echo bound PVCs"))
+				Equal("/bin/bash -c echo bound PVCs"),
+			)
 			shouldExpectMatchingPodCreation(vmi.UID, IsPodWithoutVmPayload)
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				Fail("here")
-				return true, dvPVC, nil
-			})
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
@@ -456,14 +441,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
-			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
-			// be in available but in the Pending state.
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
 
-			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addDataVolumePVC(dvPVC)
 			addActivePods(vmi, pod.UID, "")
-			dataVolumeFeeder.Add(dataVolume)
+			addVirtualMachine(vmi)
+			addPod(pod)
+			addDataVolume(dataVolume)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Pending))
@@ -473,9 +456,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						Status: k8sv1.ConditionTrue,
 					}))
 			}).Return(vmi, nil)
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				return true, dvPVC, nil
-			})
+
 			controller.Execute()
 		})
 
@@ -494,20 +475,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
-			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
-			// be in available
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
-
+			addDataVolumePVC(dvPVC)
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolume(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
 			shouldExpectPodDeletion(pod)
 
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				return true, dvPVC, nil
-			})
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 		})
@@ -561,16 +536,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
 
 				addVirtualMachine(vmi)
-				podFeeder.Add(pod)
+				addPod(pod)
+				addDataVolumePVC(dvPVC)
 				addActivePods(vmi, pod.UID, "")
-				dataVolumeFeeder.Add(dataVolume)
+				addDataVolume(dataVolume)
 
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(expectedPhase))
 				}).Return(vmi, nil)
-				kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-					return true, dvPVC, nil
-				})
 
 				controller.Execute()
 			},
@@ -596,10 +569,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Pending)
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
 
 			addVirtualMachine(vmi)
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolumePVC(dvPVC)
+			addDataVolume(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionFalse)
 			controller.Execute()
 		})
@@ -631,11 +604,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pvc := NewPvc(vmi.Namespace, backendstorage.PVCForVMI(vmi))
 				pvc.Status.Phase = k8sv1.ClaimPending
 				pvc.Spec.StorageClassName = pointer.P("testsc123")
-				Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
+				addDataVolumePVC(pvc)
 
-				kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-					return true, pvc, nil
-				})
 				shouldExpectVirtualMachinePendingState(vmi)
 				controller.Execute()
 			},
@@ -654,11 +624,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pvc := NewPvc(vmi.Namespace, backendstorage.PVCForVMI(vmi))
 				pvc.Status.Phase = k8sv1.ClaimPending
 				pvc.Spec.StorageClassName = pointer.P("testsc456")
-				Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
+				addDataVolumePVC(pvc)
 
-				kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-					return true, pvc, nil
-				})
 				shouldExpectPodCreation(vmi.UID)
 
 				controller.Execute()
@@ -684,14 +651,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
-			// we are mocking a successful DataVolume. we expect the PVC to
-			// be available in the store if DV is successful.
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
-
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 
 			addVirtualMachine(vmi)
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolumePVC(dvPVC)
+			addDataVolume(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
 			shouldExpectPodCreation(vmi.UID)
 
@@ -709,14 +673,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
-			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
-			// be in available but in the Pending state.
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
-
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
 			addVirtualMachine(vmi)
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolumePVC(dvPVC)
+			addDataVolume(dataVolume)
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
 					Fields{"Type": Equal(virtv1.VirtualMachineInstanceProvisioning)})))
@@ -755,16 +716,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
-			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
-			// be in available but in the Pending state.
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
-
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addDataVolumePVC(dvPVC)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolume(dataVolume)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Pending))
@@ -794,19 +752,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimBound
-			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
-			// be in available
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
-
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addDataVolumePVC(dvPVC)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolume(dataVolume)
 			shouldExpectPodDeletion(pod)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				return true, dvPVC, nil
-			})
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
@@ -822,14 +774,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
-			// we are mocking a successful DataVolume. we expect the PVC to
-			// be available in the store if DV is successful.
-			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
-
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Pending)
 
 			addVirtualMachine(vmi)
-			dataVolumeFeeder.Add(dataVolume)
+			addDataVolumePVC(dvPVC)
+			addDataVolume(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionFalse)
 
 			controller.Execute()
@@ -844,9 +793,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			pvc := NewPvc(vmi.Namespace, "test1")
-			Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
 
 			addVirtualMachine(vmi)
+			addDataVolumePVC(pvc)
 			shouldExpectPodCreation(vmi.UID)
 
 			controller.Execute()
@@ -868,9 +817,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.Phase = virtv1.Running
 			vmi = addDefaultNetwork(vmi, defaultNetworkName)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
-			addActivePods(vmi, pod.UID, "")
 			pod.Annotations[networkv1.NetworkStatusAnnot] = `
 			[
 			{
@@ -884,6 +830,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			"dns": {}
 			}
 			]`
+			addVirtualMachine(vmi)
+			addPod(pod)
+			addActivePods(vmi, pod.UID, "")
 
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(vmi, nil)
 			controller.Execute()
@@ -898,9 +847,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi = addSRIOVNetwork(vmi, sriovNetworkName, netAttachDefName)
 			vmi = addDefaultNetworkStatus(vmi, sriovNetworkName)
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
-			addActivePods(vmi, pod.UID, "")
 			pod.Annotations[networkv1.NetworkStatusAnnot] = `
 			[
 			{
@@ -926,6 +872,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			}
 			]`
+			addVirtualMachine(vmi)
+			addPod(pod)
+			addActivePods(vmi, pod.UID, "")
 
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(vmi, nil)
 			prependInjectPodPatch(pod)
@@ -976,8 +925,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod2.UID, "")
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
-			podFeeder.Add(pod2)
+			addPod(pod)
+			addPod(pod2)
 
 			deletionCount := 0
 			shouldExpectMultiplePodDeletions(pod, &deletionCount)
@@ -1013,7 +962,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			shouldExpectPodDeletion(pod)
@@ -1025,7 +974,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			modifiedPod := pod.DeepCopy()
 			modifiedPod.DeletionTimestamp = now()
 
-			podFeeder.Modify(modifiedPod)
+			mockQueue.ExpectAdds(1)
+			podSource.Modify(modifiedPod)
+			mockQueue.Wait()
 
 			shouldExpectVirtualMachineFailedState(vmi)
 
@@ -1039,7 +990,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			controller.Execute()
@@ -1056,6 +1007,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			controller.Execute()
 		})
+
 		It("should set an error condition if creating the pod fails", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
@@ -1180,7 +1132,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Expect(controller.Queue.Len()).To(Equal(0))
 				// When the PVC appears, we will automatically be retriggered, it is not an error condition
 				Expect(mockQueue.GetRateLimitedEnqueueCount()).To(BeZero())
-				addVirtualMachine(vmi)
+				mockQueue.ExpectAdds(1)
+				vmiSource.Add(vmi)
+				mockQueue.Wait()
 
 				// make sure that during next iteration we do not add the same condition again
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, vmi *virtv1.VirtualMachineInstance, options metav1.UpdateOptions) {
@@ -1219,7 +1173,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			setReadyCondition(vmi, k8sv1.ConditionFalse, unreadyReason)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			shouldExpectVirtualMachineSchedulingState(vmi)
@@ -1254,7 +1208,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				})
 
 				addVirtualMachine(vmi)
-				podFeeder.Add(pod)
+				addPod(pod)
 
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduling))
@@ -1287,7 +1241,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				})
 
 				addVirtualMachine(vmi)
-				podFeeder.Add(pod)
+				addPod(pod)
 
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).ToNot(ContainElement(MatchFields(IgnoreExtras,
@@ -1336,7 +1290,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod.Status.ContainerStatuses = containerStatus
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			if containerStatus[0].Ready {
 				addActivePods(vmi, pod.UID, "")
 			}
@@ -1364,7 +1318,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod.Status.ContainerStatuses = containerStatus
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			controller.Execute()
@@ -1419,8 +1373,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 			})
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
-			podFeeder.Add(attachmentPod)
+			addPod(pod)
+			addPod(attachmentPod)
 
 			switch expectedPhase {
 			case virtv1.Scheduled:
@@ -1467,9 +1421,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			failedTargetPod2.Spec.NodeName = "someothernode"
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(failedTargetPod)
-			podFeeder.Add(pod)
-			podFeeder.Add(failedTargetPod2)
+			addPod(failedTargetPod)
+			addPod(pod)
+			addPod(failedTargetPod2)
 
 			selectedPod, err := kvcontroller.CurrentVMIPod(vmi, podInformer.GetIndexer())
 			Expect(err).ToNot(HaveOccurred())
@@ -1489,7 +1443,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
@@ -1524,7 +1478,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
@@ -1569,7 +1523,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			shouldExpectVirtualMachineHandover(vmi)
 
@@ -1583,13 +1537,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod.Status.QOSClass = k8sv1.PodQOSGuaranteed
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(*arg.(*virtv1.VirtualMachineInstance).Status.QOSClass).To(Equal(k8sv1.PodQOSGuaranteed))
 			}).Return(vmi, nil)
 
 			controller.Execute()
+
 		})
 		It("should update the virtual machine to scheduled if pod is ready, triggered by pod change", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
@@ -1598,14 +1553,16 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodPending)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			controller.Execute()
 
 			pod = NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
-			podFeeder.Modify(pod)
+			mockQueue.ExpectAdds(1)
+			podSource.Modify(pod)
+			mockQueue.Wait()
 
 			shouldExpectVirtualMachineHandover(vmi)
 
@@ -1618,12 +1575,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.Phase = virtv1.Scheduling
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			controller.Execute()
 
-			podFeeder.Delete(pod)
+			mockQueue.ExpectAdds(1)
+			podSource.Delete(pod)
+			mockQueue.Wait()
 
 			shouldExpectVirtualMachineFailedState(vmi)
 
@@ -1637,7 +1596,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.Phase = virtv1.Scheduling
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			shouldExpectVirtualMachineFailedState(vmi)
 
@@ -1729,7 +1688,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			setReadyCondition(vmi, k8sv1.ConditionFalse, unreadyReason)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			controller.Execute()
@@ -1755,7 +1714,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 			addActivePods(vmi, pod.UID, "")
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			vmiPatch := `[{ "op": "add", "path": "/status/launcherContainerImageVersion", "value": "madeup" }, { "op": "add", "path": "/metadata/labels", "value": {"kubevirt.io/outdatedLauncherImage":""} }]`
 
@@ -1789,7 +1748,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 			addActivePods(vmi, pod.UID, "")
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			patch := `[{ "op": "add", "path": "/status/launcherContainerImageVersion", "value": "a" }, { "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io/outdatedLauncherImage":""} }, { "op": "replace", "path": "/metadata/labels", "value": {} }]`
 
@@ -1807,7 +1766,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 			addActivePods(vmi, pod.UID, "")
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			patch := `[{ "op": "test", "path": "/status/conditions", "value": null }, { "op": "replace", "path": "/status/conditions", "value": [{"type":"Ready","status":"True","lastProbeTime":null,"lastTransitionTime":null}] }]`
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}).Return(vmi, nil)
@@ -1825,7 +1784,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 			addActivePods(vmi, pod.UID, "")
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).DoAndReturn(func(ctx context.Context, _ string, _ interface{}, patchBytes []byte, options interface{}, _ ...string) (*virtv1.VirtualMachineInstance, error) {
 				patch, err := jsonpatch.DecodePatch(patchBytes)
@@ -1856,7 +1815,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod.Spec.NodeName = "someHost"
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			patch := `[{ "op": "test", "path": "/status/activePods", "value": {} }, { "op": "replace", "path": "/status/activePods", "value": {"someUID":"someHost"} }]`
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}).Return(vmi, nil)
@@ -1872,10 +1831,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				virtv1.VirtualMachineInstanceCondition{Type: virtv1.VirtualMachineInstanceSynchronized, Status: k8sv1.ConditionFalse})
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
+			addActivePods(vmi, pod.UID, "")
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
-			addActivePods(vmi, pod.UID, "")
+			addPod(pod)
 
 			controller.Execute()
 		})
@@ -1902,7 +1861,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod := NewPodForVirtualMachine(vmi, phase)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			shouldExpectVirtualMachineFailedState(vmi)
 
@@ -1927,7 +1886,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
@@ -1968,7 +1927,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}}
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
@@ -1991,7 +1950,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod.Annotations[virtv1.MigrationTransportUnixAnnotation] = "true"
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
@@ -2021,7 +1980,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 				addVirtualMachine(vmi)
 				addActivePods(vmi, pod.UID, "")
-				podFeeder.Add(pod)
+				addPod(pod)
 
 				vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(vmi, nil)
 
@@ -2106,9 +2065,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				})
 			}
 
-			addVirtualMachine(vmi)
 			addActivePods(vmi, pod.UID, "")
-			podFeeder.Add(pod)
+			addVirtualMachine(vmi)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(vmi, nil)
 			kubeClient.Fake.PrependReactor("patch", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
@@ -2139,9 +2098,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				})
 			}
 
-			addVirtualMachine(vmi)
 			addActivePods(vmi, pod.UID, "")
-			podFeeder.Add(pod)
+			addVirtualMachine(vmi)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(vmi, nil)
 			kubeClient.Fake.PrependReactor("patch", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
@@ -2176,10 +2135,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				}
 
 				pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
+				addActivePods(vmi, pod.UID, "")
 
 				addVirtualMachine(vmi)
-				podFeeder.Add(pod)
-				addActivePods(vmi, pod.UID, "")
+				addPod(pod)
 
 				vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Do(func(ctx context.Context, name, patchType, patch, opts interface{}, subs ...interface{}) {
 					originalVMIBytes, err := json.Marshal(vmi)
@@ -2245,7 +2204,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			attachmentPod := NewPodForVirtlauncher(pod, "hp-test", "abcd", k8sv1.PodRunning)
 			controllerRef := kvcontroller.GetControllerOf(attachmentPod)
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			result := controller.resolveControllerRef(k8sv1.NamespaceDefault, controllerRef)
 			Expect(equality.Semantic.DeepEqual(result, vmi)).To(BeTrue(), "result: %v, should equal %v", result, vmi)
@@ -2262,7 +2221,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
+			addPod(virtlauncherPod)
 			err := controller.deleteAllAttachmentPods(vmi)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -2274,10 +2233,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			attachmentPod2 := NewPodForVirtlauncher(virtlauncherPod, "pod2", "abcd", k8sv1.PodRunning)
 			attachmentPod3 := NewPodForVirtlauncher(virtlauncherPod, "pod3", "abcd", k8sv1.PodRunning)
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
-			podFeeder.Add(attachmentPod1)
-			podFeeder.Add(attachmentPod2)
-			podFeeder.Add(attachmentPod3)
+			addPod(virtlauncherPod)
+			addPod(attachmentPod1)
+			addPod(attachmentPod2)
+			addPod(attachmentPod3)
 			shouldExpectPodDeletion(attachmentPod3)
 			shouldExpectPodDeletion(attachmentPod1)
 			shouldExpectPodDeletion(attachmentPod2)
@@ -2292,7 +2251,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
+			addPod(virtlauncherPod)
 			invalidVolume := &virtv1.Volume{
 				Name: "fake",
 				VolumeSource: virtv1.VolumeSource{
@@ -2305,13 +2264,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 
 		It("CreateAttachmentPodTemplate should return error if volume has PVC that doesn't exist", func() {
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				return true, nil, k8serrors.NewNotFound(k8sv1.Resource("persistentvolumeclaim"), "noclaim")
-			})
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
+			addPod(virtlauncherPod)
 			nopvcVolume := &virtv1.Volume{
 				Name: "nopvc",
 				VolumeSource: virtv1.VolumeSource{
@@ -2328,17 +2284,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 
 		It("CreateAttachmentPodTemplate should return nil pod if only one DV exists and owning PVC doesn't exist", func() {
-			kubeClient.Fake.PrependReactor("get", "datavolumes", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				return true, nil, k8serrors.NewNotFound(k8sv1.Resource("datavolumes"), "test-dv")
-			})
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimPending)
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				return true, pvc, nil
-			})
+
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
+			addPod(virtlauncherPod)
+			addDataVolumePVC(pvc)
 			volume := &virtv1.Volume{
 				Name: "test-pvc-volume",
 				VolumeSource: virtv1.VolumeSource{
@@ -2361,7 +2313,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimPending)
-			Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
+			addDataVolumePVC(pvc)
 			dv := &cdiv1.DataVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dv",
@@ -2371,9 +2323,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Phase: cdiv1.Pending,
 				},
 			}
-			Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
+			addDataVolume(dv)
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
+			addPod(virtlauncherPod)
 			volume := &virtv1.Volume{
 				Name: "test-pvc-volume",
 				VolumeSource: virtv1.VolumeSource{
@@ -2403,7 +2355,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimBound)
-			Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
+			addDataVolumePVC(pvc)
 			dv := &cdiv1.DataVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dv",
@@ -2413,9 +2365,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Phase: cdiv1.Pending,
 				},
 			}
-			Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
+			addDataVolume(dv)
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
+			addPod(virtlauncherPod)
 			volume := &virtv1.Volume{
 				Name: "test-pvc-volume",
 				VolumeSource: virtv1.VolumeSource{
@@ -2439,7 +2391,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.SelinuxContext = "system_u:system_r:container_file_t:s0:c1,c2"
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimBound)
-			Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
+			addDataVolumePVC(pvc)
 			dv := &cdiv1.DataVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dv",
@@ -2449,9 +2401,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Phase: cdiv1.Succeeded,
 				},
 			}
-			Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
+			addDataVolume(dv)
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
+			addPod(virtlauncherPod)
 			volume := &virtv1.Volume{
 				Name: "test-pvc-volume",
 				VolumeSource: virtv1.VolumeSource{
@@ -2637,9 +2589,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		preparePVC := func(indexes ...int) {
 			for _, index := range indexes {
 				pvc := NewHotplugPVC(fmt.Sprintf("claim%d", index), k8sv1.NamespaceDefault, k8sv1.ClaimBound)
-				kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-					return true, pvc, nil
-				})
 				dv := &cdiv1.DataVolume{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("claim%d", index),
@@ -2649,8 +2598,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						Phase: cdiv1.Succeeded,
 					},
 				}
-				Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
-				Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
+
+				addDataVolume(dv)
+				addDataVolumePVC(pvc)
 			}
 		}
 
@@ -2671,7 +2621,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				})
 			}
 			addVirtualMachine(vmi)
-			podFeeder.Add(virtlauncherPod)
+			addPod(virtlauncherPod)
 			if createPodReaction != nil {
 				createPodReaction(virtlauncherPod, pvcIndexes...)
 			}
@@ -3080,7 +3030,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name:   "existing",
 				Target: "",
 			})
-			vmi.Status.ActivePods["virt-launch-uid"] = ""
+			addActivePods(vmi, "virt-launch-uid", "")
 			vmi.Status.SelinuxContext = "system_u:system_r:container_file_t:s0:c1,c2"
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
@@ -3111,14 +3061,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					},
 				},
 			})
-			Expect(pvcInformer.GetIndexer().Add(existingPVC)).To(Succeed())
-			Expect(pvcInformer.GetIndexer().Add(hpPVC)).To(Succeed())
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				return true, existingPVC, nil
-			})
-			shouldExpectHotplugPod()
+			addDataVolumePVC(existingPVC)
+			addDataVolumePVC(hpPVC)
 			addVirtualMachine(vmi)
-			Expect(podInformer.GetIndexer().Add(virtlauncherPod)).To(Succeed())
+			addPod(virtlauncherPod)
+
+			shouldExpectHotplugPod()
 			//Modify by adding a new hotplugged disk
 			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":"","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"}},{"name":"hotplug","target":"","phase":"Bound","reason":"PVCNotReady","message":"PVC is in phase Bound","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"},"hotplugVolume":{}}] }]`
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}).Return(vmi, nil)
@@ -3163,7 +3111,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					AttachPodUID:  "abcd",
 				},
 			})
-			vmi.Status.ActivePods["virt-launch-uid"] = ""
+			addActivePods(vmi, "virt-launch-uid", "")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			existingPVC := &k8sv1.PersistentVolumeClaim{
@@ -3200,15 +3148,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{},
 				},
 			})
-			Expect(podInformer.GetIndexer().Add(hpPod)).To(Succeed())
-			Expect(pvcInformer.GetIndexer().Add(existingPVC)).To(Succeed())
-			Expect(pvcInformer.GetIndexer().Add(hpPVC)).To(Succeed())
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				return true, existingPVC, nil
-			})
-			shouldExpectPodDeletion(hpPod)
+			addDataVolumePVC(existingPVC)
+			addDataVolumePVC(hpPVC)
 			addVirtualMachine(vmi)
-			Expect(podInformer.GetIndexer().Add(virtlauncherPod)).To(Succeed())
+			addPod(virtlauncherPod)
+			addPod(hpPod)
+
+			shouldExpectPodDeletion(hpPod)
 			//Modify by adding a new hotplugged disk
 			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":"","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"}},{"name":"hotplug","target":"","phase":"Detaching","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }]`
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}).Return(vmi, nil)
@@ -3437,7 +3383,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			addVirtualMachine(vmi)
-			podFeeder.Add(pod)
+			addPod(pod)
 
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg *virtv1.VirtualMachineInstance, options metav1.UpdateOptions) {
 				Expect(arg.Status.Phase).To(Equal(virtv1.Scheduled))
@@ -3723,9 +3669,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				dvPVC3 := NewPvc(vmi.Namespace, "test3")
 				// we are mocking a successful DataVolume. we expect the PVC to
 				// be available in the store if DV is successful.
-				Expect(pvcInformer.GetIndexer().Add(dvPVC1)).To(Succeed())
-				Expect(pvcInformer.GetIndexer().Add(dvPVC2)).To(Succeed())
-				Expect(pvcInformer.GetIndexer().Add(dvPVC3)).To(Succeed())
+				addDataVolumePVC(dvPVC1)
+				addDataVolumePVC(dvPVC2)
+				addDataVolumePVC(dvPVC3)
 
 				dataVolume1 := NewDv(vmi.Namespace, "test1", cdiv1.Unknown)
 				dataVolume2 := NewDv(vmi.Namespace, "test2", cdiv1.Unknown)
@@ -3741,9 +3687,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				}
 
 				addVirtualMachine(vmi)
-				dataVolumeFeeder.Add(dataVolume1)
-				dataVolumeFeeder.Add(dataVolume2)
-				dataVolumeFeeder.Add(dataVolume3)
+				addDataVolume(dataVolume1)
+				addDataVolume(dataVolume2)
+				addDataVolume(dataVolume3)
 				shouldExpectVirtualMachineDataVolumesReadyConditionWithMessage(vmi, expectedStatus, expectedMessage)
 				shouldExpectPodCreation(vmi.UID)
 

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3259,16 +3259,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		}
 
 		Context("needs to be set when", func() {
-
-			runController := func(vmi *virtv1.VirtualMachineInstance) {
-				addVirtualMachine(vmi)
-				controller.Execute()
-				expectMatchingPodCreation(vmi)
-			}
-
 			It("invtsc feature exists", func() {
 				vmi := getVmiWithInvTsc()
-				runController(vmi)
+				addVirtualMachine(vmi)
+				controller.Execute()
 				expectTopologyHintsDefined(vmi, BeTrue())
 			})
 
@@ -3281,7 +3275,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 				When("TSC frequency is exposed", func() {
 					It("topology hints need to be set", func() {
-						runController(vmi)
+						addVirtualMachine(vmi)
+						controller.Execute()
 						expectTopologyHintsDefined(vmi, BeTrue())
 					})
 				})
@@ -3297,9 +3292,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					It("topology hints don't need to be set and VMI needs to be non-migratable", func() {
 						unexposeTscFrequency(topology.RequiredForMigration)
 						// Make sure no update occurs
-						runController(vmi)
-						expectMatchingPodCreation(vmi)
+						addVirtualMachine(vmi)
+						controller.Execute()
 						expectTopologyHintsDefined(vmi, BeFalse())
+						expectMatchingPodCreation(vmi)
 						testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 					})
 				})
@@ -3310,32 +3306,31 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		Context("pod creation", func() {
 
-			runController := func(vmi *virtv1.VirtualMachineInstance) {
-				addVirtualMachine(vmi)
-				controller.Execute()
-			}
-
 			It("does not need to happen if tsc requiredment is of type RequiredForBoot", func() {
 				vmi := getVmiWithInvTsc()
 				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.RequiredForBoot))
 
-				runController(vmi)
+				addVirtualMachine(vmi)
+				controller.Execute()
 				expectTopologyHintsDefined(vmi, BeTrue())
 			})
 
 			It("does not need to happen if tsc requiredment is of type RequiredForMigration", func() {
 				vmi := getVmiWithReenlightenment()
 				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.RequiredForMigration))
+				addVirtualMachine(vmi)
 
-				runController(vmi)
+				controller.Execute()
 				expectTopologyHintsDefined(vmi, BeTrue())
 			})
 
 			It("does not need to happen if tsc requiredment is of type NotRequired", func() {
 				vmi := NewPendingVirtualMachine("testvmi")
 				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.NotRequired))
+				addVirtualMachine(vmi)
 
-				runController(vmi)
+				controller.Execute()
+
 				testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 				expectMatchingPodCreation(vmi)
 			})

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -111,7 +111,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var cdiConfigInformer cache.SharedIndexInformer
 	var dataVolumeFeeder *testutils.DataVolumeFeeder
 	var qemuGid int64 = 107
-	controllerOf := true
 
 	shouldExpectMatchingPodCreation := func(uid types.UID, matchers ...gomegaTypes.GomegaMatcher) {
 		// Expect pod creation
@@ -391,7 +390,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
@@ -443,7 +442,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
@@ -482,7 +481,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
 			// be in available
 			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
@@ -545,7 +544,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				})
 
 				dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
-				dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+				dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 				dvPVC.Status.Phase = k8sv1.ClaimBound
 				Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
 
@@ -583,7 +582,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Pending)
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
 
@@ -672,7 +671,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			// we are mocking a successful DataVolume. we expect the PVC to
 			// be available in the store if DV is successful.
 			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
@@ -696,7 +695,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
@@ -742,7 +741,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "test1",
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
@@ -781,7 +780,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimBound
 			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
 			// be in available
@@ -809,7 +808,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a successful DataVolume. we expect the PVC to
 			// be available in the store if DV is successful.
@@ -2775,7 +2774,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		makeVolumeStatusesForUpdateWithMessage := func(podName, podUID string, phase virtv1.VolumePhase, message, reason string, indexes ...int) []virtv1.VolumeStatus {
 			res := make([]virtv1.VolumeStatus, 0)
 			for _, index := range indexes {
-				fsOverhead := storagetypes.DefaultFSOverhead
 				res = append(res, virtv1.VolumeStatus{
 					Name: fmt.Sprintf("volume%d", index),
 					HotplugVolume: &virtv1.HotplugVolumeStatus{
@@ -2789,7 +2787,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						AccessModes: []k8sv1.PersistentVolumeAccessMode{
 							k8sv1.ReadOnlyMany,
 						},
-						FilesystemOverhead: &fsOverhead,
+						FilesystemOverhead: pointer.P(storagetypes.DefaultFSOverhead),
 					},
 				})
 			}
@@ -2818,9 +2816,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.VolumeStatus = oldStatus
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			attachmentPods := makePodWithVirtlauncher(virtlauncherPod, podIndexes...)
-			now := metav1.Now()
+
 			for _, pod := range attachmentPods {
-				pod.DeletionTimestamp = &now
+				pod.DeletionTimestamp = now()
 				Expect(podInformer.GetIndexer().Add(pod)).To(Succeed())
 			}
 			for _, pvcIndex := range pvcIndexes {
@@ -4059,7 +4057,6 @@ func NewPodForVirtualMachineWithMultusAnnotations(vmi *virtv1.VirtualMachineInst
 }
 
 func NewHotplugPVC(name, namespace string, phase k8sv1.PersistentVolumeClaimPhase) *k8sv1.PersistentVolumeClaim {
-	t := true
 	return &k8sv1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -4069,7 +4066,7 @@ func NewHotplugPVC(name, namespace string, phase k8sv1.PersistentVolumeClaimPhas
 					APIVersion: "v1alpha1",
 					Kind:       "DataVolume",
 					Name:       name,
-					Controller: &t,
+					Controller: pointer.P(true),
 				},
 			},
 		},
@@ -4085,7 +4082,6 @@ func NewHotplugPVC(name, namespace string, phase k8sv1.PersistentVolumeClaimPhas
 }
 
 func NewPodForVirtlauncher(virtlauncher *k8sv1.Pod, name, uid string, phase k8sv1.PodPhase) *k8sv1.Pod {
-	t := true
 	return &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -4096,7 +4092,7 @@ func NewPodForVirtlauncher(virtlauncher *k8sv1.Pod, name, uid string, phase k8sv
 					Name:       virtlauncher.Name,
 					Kind:       "Pod",
 					APIVersion: "v1",
-					Controller: &t,
+					Controller: pointer.P(true),
 					UID:        virtlauncher.UID,
 				},
 			},

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -978,6 +978,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 
 			controller.Execute()
+			Expect(virtClientset.Actions()).To(HaveLen(1))
+			Expect(virtClientset.Actions()[0].GetVerb()).To(Equal("create"))
+			Expect(virtClientset.Actions()[0].GetResource().Resource).To(Equal("virtualmachineinstances"))
+			Expect(kubeClient.Actions()).To(BeEmpty())
 		})
 
 		It("should set an error condition if creating the pod fails", func() {
@@ -1270,6 +1274,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 
 			controller.Execute()
+			expectVMIBeInPhase(vmi.Namespace, vmi.Name, virtv1.Scheduling)
+			expectVMIWithMatcherConditions(vmi.Namespace, vmi.Name, ContainElement(MatchFields(IgnoreExtras,
+				Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady), "Status": Equal(k8sv1.ConditionFalse), "Reason": Equal(virtv1.GuestNotRunningReason)})))
+			expectVMITimestamp(vmi.Namespace, vmi.Name, BeEmpty())
 		},
 			Entry("with not ready infra container and not ready compute container",
 				[]k8sv1.ContainerStatus{{Name: "compute", Ready: false}, {Name: "kubevirt-infra", Ready: false}},
@@ -1617,6 +1625,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 
 			controller.Execute()
+			Expect(virtClientset.Actions()).To(HaveLen(1))
+			Expect(virtClientset.Actions()[0].GetVerb()).To(Equal("create"))
+			Expect(virtClientset.Actions()[0].GetResource().Resource).To(Equal("virtualmachineinstances"))
+			Expect(kubeClient.Actions()).To(HaveLen(1))
+			Expect(kubeClient.Actions()[0].GetVerb()).To(Equal("create"))
+			Expect(kubeClient.Actions()[0].GetResource().Resource).To(Equal("pods"))
 		},
 			Entry("and in running state", k8sv1.PodRunning),
 			Entry("and in unknown state", k8sv1.PodUnknown),
@@ -1880,9 +1894,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		Context("should update pod labels", func() {
 
 			type testData struct {
-				vmiLabels     map[string]string
-				podLabels     map[string]string
-				expectedPatch string
+				vmiLabels      map[string]string
+				podLabels      map[string]string
+				expectedPatch  bool
+				expectedLabels map[string]string
 			}
 			DescribeTable("when VMI dynamic label set changes", func(td *testData) {
 				vmi := NewPendingVirtualMachine("testvmi")
@@ -1899,20 +1914,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				addActivePods(vmi, pod.UID, "")
 				addPod(pod)
 
-				vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(vmi, nil)
-
-				patch := ""
-				kubeClient.Fake.PrependReactor("patch", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-					p, _ := action.(testing.PatchAction)
-					patch = string(p.GetPatch())
-					return true, nil, nil
-				})
-
 				key := kvcontroller.VirtualMachineInstanceKey(vmi)
 				err := controller.execute(key)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(patch).To(Equal(td.expectedPatch))
+				updatedPod, err := kubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedPod.Labels).To(BeEquivalentTo(td.expectedLabels))
+				if td.expectedPatch {
+					Expect(kubeClient.Actions()).To(HaveLen(3)) // 0: create, 1: patch, 2: get
+					Expect(kubeClient.Actions()[1].GetVerb()).To(Equal("patch"))
+				} else {
+					Expect(kubeClient.Actions()).To(HaveLen(2)) // 0: create, 1: get
+				}
 			},
 				Entry("when VMI and pod labels differ",
 					&testData{
@@ -1922,7 +1936,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						podLabels: map[string]string{
 							virtv1.NodeNameLabel: "node1",
 						},
-						expectedPatch: `[{ "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234","kubevirt.io/nodeName":"node1"} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234","kubevirt.io/nodeName":"node2"} }]`,
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+							virtv1.NodeNameLabel:     "node2",
+						},
+						expectedPatch: true,
 					},
 				),
 				Entry("when VMI and pod label are the same",
@@ -1933,7 +1952,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						podLabels: map[string]string{
 							virtv1.NodeNameLabel: "node1",
 						},
-						expectedPatch: "",
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+							virtv1.NodeNameLabel:     "node1",
+						},
+						expectedPatch: false,
 					},
 				),
 				Entry("when POD label doesn't exist",
@@ -1942,15 +1966,24 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						vmiLabels: map[string]string{
 							virtv1.NodeNameLabel: "node1",
 						},
-						podLabels:     map[string]string{},
-						expectedPatch: `[{ "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234"} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234","kubevirt.io/nodeName":"node1"} }]`,
+						podLabels: map[string]string{},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+							virtv1.NodeNameLabel:     "node1",
+						},
+						expectedPatch: true,
 					},
 				),
 				Entry("when neither POD or VMI label exists",
 					&testData{
-						vmiLabels:     map[string]string{},
-						podLabels:     map[string]string{},
-						expectedPatch: "",
+						vmiLabels: map[string]string{},
+						podLabels: map[string]string{},
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedPatch: false,
 					},
 				),
 				Entry("when POD label exists and VMI does not",
@@ -1959,7 +1992,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						podLabels: map[string]string{
 							virtv1.OutdatedLauncherImageLabel: "",
 						},
-						expectedPatch: `[{ "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234","kubevirt.io/outdatedLauncherImage":""} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io":"virt-launcher","kubevirt.io/created-by":"1234"} }]`,
+						expectedLabels: map[string]string{
+							"kubevirt.io":            "virt-launcher",
+							"kubevirt.io/created-by": "1234",
+						},
+						expectedPatch: true,
 					},
 				),
 			)

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -341,6 +341,24 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		mockQueue.ExpectAdds(1)
 		vmiSource.Add(vmi)
 		mockQueue.Wait()
+		_, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	addPod := func(pod *k8sv1.Pod) {
+		Expect(podInformer.GetIndexer().Add(pod)).To(Succeed())
+		_, err := kubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	addDataVolumePVC := func(dvPVC *k8sv1.PersistentVolumeClaim) {
+		Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
+		_, err := kubeClient.CoreV1().PersistentVolumeClaims(dvPVC.Namespace).Create(context.Background(), dvPVC, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	addDataVolume := func(dv *cdiv1.DataVolume) {
+		Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
 	}
 
 	Context("On valid VirtualMachineInstance given with DataVolume source", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Use fake client instead of mocking in order to simulate real behavior.

The PR is exposing and fixing few tests: 
- [vmi ctrl: fix pod annotation patch tests](https://github.com/kubevirt/kubevirt/pull/11751/commits/c4819ab6466eeac5026c52f82603e87f82b8c7d0)
- [fix(vmi ctrl): remove empty activepods and volumestatus](https://github.com/kubevirt/kubevirt/pull/11751/commits/699c126a54ddbc3b99c8d9fc1f2fd04950a65421)
- [vmi ctrl: fix vmi status hotplug disk tests](https://github.com/kubevirt/kubevirt/pull/11751/commits/9cf28da2c16cb0634e2220309de4bd195923dda9)
- [vmi ctrl: fix invtsc and hyperv tests](https://github.com/kubevirt/kubevirt/pull/11751/commits/f3f4bf50117d45d06c7ca0329fbeb0c91c33db0f)

This PR also improved some tests:
- [fix(vmi ctrl): improve some tests](https://github.com/kubevirt/kubevirt/pull/11751/commits/4aae60e650a07d2c78920a8dc505081f5b14297d)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
Lower the bar for unit tests, eliminate false positives. The fake is standard for testing.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
