### PR TITLE
Add `igb` interface model

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17525,7 +17525,7 @@
       "$ref": "#/definitions/v1.InterfaceMasquerade"
      },
      "model": {
-      "description": "Interface model. One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.",
+      "description": "Interface model. One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.",
       "type": "string"
      },
      "name": {

--- a/pkg/network/admitter/netiface.go
+++ b/pkg/network/admitter/netiface.go
@@ -131,6 +131,7 @@ func validateInterfaceNameFormat(field *k8sfield.Path, idx int, iface v1.Interfa
 var validInterfaceModels = map[string]struct{}{
 	"e1000":    {},
 	"e1000e":   {},
+	"igb":      {},
 	"ne2k_pci": {},
 	"pcnet":    {},
 	"rtl8139":  {},

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5879,7 +5879,7 @@ var CRDsValidation map[string]string = map[string]string{
                               model:
                                 description: |-
                                   Interface model.
-                                  One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+                                  One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.
                                   Defaults to virtio.
                                   TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
                                 type: string
@@ -10721,7 +10721,7 @@ var CRDsValidation map[string]string = map[string]string{
                       model:
                         description: |-
                           Interface model.
-                          One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+                          One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.
                           Defaults to virtio.
                           TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
                         type: string
@@ -13732,7 +13732,7 @@ var CRDsValidation map[string]string = map[string]string{
                       model:
                         description: |-
                           Interface model.
-                          One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+                          One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.
                           Defaults to virtio.
                           TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
                         type: string
@@ -15968,7 +15968,7 @@ var CRDsValidation map[string]string = map[string]string{
                               model:
                                 description: |-
                                   Interface model.
-                                  One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+                                  One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.
                                   Defaults to virtio.
                                   TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
                                 type: string
@@ -20279,7 +20279,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       model:
                                         description: |-
                                           Interface model.
-                                          One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+                                          One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.
                                           Defaults to virtio.
                                           TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
                                         type: string
@@ -25255,7 +25255,7 @@ var CRDsValidation map[string]string = map[string]string{
                                           model:
                                             description: |-
                                               Interface model.
-                                              One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+                                              One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.
                                               Defaults to virtio.
                                               TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
                                             type: string

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -1241,7 +1241,7 @@ type Interface struct {
 	// Must match the Name of a Network.
 	Name string `json:"name"`
 	// Interface model.
-	// One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+	// One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.
 	// Defaults to virtio.
 	// TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
 	Model string `json:"model,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -668,7 +668,7 @@ func (I6300ESBWatchdog) SwaggerDoc() map[string]string {
 func (Interface) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"name":        "Logical name of the interface as well as a reference to the associated networks.\nMust match the Name of a Network.",
-		"model":       "Interface model.\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
+		"model":       "Interface model.\nOne of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
 		"binding":     "Binding specifies the binding plugin that will be used to connect the interface to the guest.\nIt provides an alternative to InterfaceBindingMethod.\nversion: 1alphav1",
 		"ports":       "List of ports to be forwarded to the virtual machine.",
 		"macAddress":  "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18552,7 +18552,7 @@ func schema_kubevirtio_api_core_v1_Interface(ref common.ReferenceCallback) commo
 					},
 					"model": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Interface model. One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.",
+							Description: "Interface model. One of: e1000, e1000e, igb, ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
### What this PR does
This adds the `igb` interface model as an option. 

Currently based on #11753 for the QEMU 8.2 as this is how I tested it to verify `igb` is actually working.

Tested with the following VM:
```yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: ubuntu
spec:
  running: false
  template:
    metadata:
      labels:
        kubevirt.io/size: medium
        kubevirt.io/domain: ubuntu
    spec:
      domain:
        cpu:
          cores: 2
        devices:
          disks:
            - name: containervolume
              disk:
                bus: virtio
            - name: cloudinitvolume
              disk:
                bus: virtio
          interfaces:
          - name: default
            model: igb
            bridge: {}
        resources:
          requests:
            memory: 1024M
      networks:
      - name: default
        pod: {}
      volumes:
        - name: containervolume
          containerDisk:
            image: tedezed/ubuntu-container-disk:22.0
        - name: cloudinitvolume
          cloudInitNoCloud:
            userData: |-
              #cloud-config
              bootcmd:
                - echo cloud-init=disabled > /etc/cloud/cloud-init.disabled
                - [ /bin/bash, -c, 'echo -e "demopass\ndemopass" | passwd root' ]
                - reboot
```

### Release note
```release-note
Adding support for the `igb` network interface model
```

