### PR TITLE
linter: Introduce a stricter formatter `gofumpt`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,8 @@ linters-settings:
     dot-import-whitelist:
       - "github.com/onsi/ginkgo/v2"
       - "github.com/onsi/gomega"
+  gofumpt:
+    extra-rules: true
 
 linters:
   disable-all: true
@@ -77,6 +79,7 @@ linters:
     - gocritic
     - gocyclo
     - gofmt
+    - gofumpt
     - goheader
     - goimports
     - gomnd

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,9 @@ lint-metrics:
 	./hack/prom-metric-linter/metric_name_linter.sh --operator-name="kubevirt" --sub-operator-name="kubevirt" --metrics-file=metrics.json
 	rm metrics.json
 
+gofumpt:
+	./hack/dockerized "hack/gofumpt.sh"
+
 .PHONY: \
 	build-verify \
 	conformance \

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -113,6 +113,7 @@ RUN set -x && \
 
 RUN set -x && \
     source /etc/profile.d/gimme.sh && \
+    go install -v mvdan.cc/gofumpt@v0.6.0 && \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOROOT)"/bin $GOLANGCI_LINT_VERSION
 
 RUN pip3 install --upgrade operator-courier==${OPERATOR_COURIER_VERSION}

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,7 +12,7 @@ fi
 
 fail_if_cri_bin_missing
 
-KUBEVIRT_BUILDER_IMAGE=${KUBEVIRT_BUILDER_IMAGE:-"quay.io/kubevirt/builder:2404291250-fb615eec4"}
+KUBEVIRT_BUILDER_IMAGE=${KUBEVIRT_BUILDER_IMAGE:-"quay.io/kubevirt/builder:2405080831-68cc76753"}
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/hack/gofumpt.sh
+++ b/hack/gofumpt.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2024 Red Hat, Inc.
+#
+
+set -e
+
+coveredpaths="\
+  pkg/instancetype \
+  pkg/libvmi \
+  pkg/network/admitter \
+  pkg/network/namescheme \
+  pkg/network/domainspec \
+  pkg/network/deviceinfo \
+  tests/console \
+  tests/libnet \
+  tests/libnode \
+  tests/libconfigmap \
+  tests/libpod \
+  tests/libvmifact \
+  tests/libsecret \
+  ${NULL}"
+
+gofumpt -l -w -extra ${coveredpaths}

--- a/pkg/instancetype/compatibility_test.go
+++ b/pkg/instancetype/compatibility_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 var _ = Describe("compatibility", func() {
-
 	generateUnknownObjectControllerRevision := func() *appsv1.ControllerRevision {
 		unknownObject := snapshotv1alpha1.VirtualMachineSnapshot{
 			TypeMeta: metav1.TypeMeta{

--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -303,7 +303,7 @@ func (m *InstancetypeMethods) StoreControllerRevisions(vm *virtv1.VirtualMachine
 	return nil
 }
 
-func CompareRevisions(revisionA *appsv1.ControllerRevision, revisionB *appsv1.ControllerRevision, isPreference bool) (bool, error) {
+func CompareRevisions(revisionA, revisionB *appsv1.ControllerRevision, isPreference bool) (bool, error) {
 	if err := decodeControllerRevision(revisionA, isPreference); err != nil {
 		return false, err
 	}

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -39,9 +39,11 @@ import (
 	instancetypeclientv1beta1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/instancetype/v1beta1"
 )
 
-const resourceUID types.UID = "9160e5de-2540-476a-86d9-af0081aee68a"
-const resourceGeneration int64 = 1
-const nonExistingResourceName = "non-existing-resource"
+const (
+	resourceUID             types.UID = "9160e5de-2540-476a-86d9-af0081aee68a"
+	resourceGeneration      int64     = 1
+	nonExistingResourceName           = "non-existing-resource"
+)
 
 var _ = Describe("Instancetype and Preferences", func() {
 	var (
@@ -122,7 +124,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 	})
 
 	Context("Find and store instancetype", func() {
-
 		It("find returns nil when no instancetype is specified", func() {
 			vm.Spec.Instancetype = nil
 			spec, err := instancetypeMethods.FindInstancetypeSpec(vm)
@@ -235,7 +236,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(Succeed())
 				Expect(vm.Spec.Instancetype.RevisionName).To(Equal(clusterInstancetypeControllerRevision.Name))
-
 			})
 
 			It("store returns a nil revision when RevisionName already populated", func() {
@@ -465,7 +465,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(Succeed())
 				Expect(vm.Spec.Instancetype.RevisionName).To(Equal(instancetypeControllerRevision.Name))
-
 			})
 
 			It("store ControllerRevision fails if a revision exists with unexpected data", func() {
@@ -574,7 +573,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 	})
 
 	Context("Find and store preference", func() {
-
 		It("find returns nil when no preference is specified", func() {
 			vm.Spec.Preference = nil
 			preference, err := instancetypeMethods.FindPreferenceSpec(vm)
@@ -720,7 +718,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(Succeed())
 				Expect(vm.Spec.Preference.RevisionName).To(Equal(clusterPreferenceControllerRevision.Name))
-
 			})
 
 			It("store ControllerRevision fails if a revision exists with unexpected data", func() {
@@ -819,7 +816,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(Succeed())
 				Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceControllerRevision.Name))
-
 			})
 
 			It("store fails when VirtualMachinePreference doesn't exist", func() {
@@ -840,7 +836,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(Succeed())
 				Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceControllerRevision.Name))
-
 			})
 
 			It("store ControllerRevision succeeds if a revision exists with expected data", func() {
@@ -857,7 +852,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(Succeed())
 				Expect(vm.Spec.Preference.RevisionName).To(Equal(preferenceControllerRevision.Name))
-
 			})
 
 			It("store ControllerRevision fails if a revision exists with unexpected data", func() {
@@ -916,7 +910,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 	})
 
 	Context("Apply", func() {
-
 		var (
 			instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec
 			preferenceSpec   *instancetypev1beta1.VirtualMachinePreferenceSpec
@@ -997,7 +990,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("instancetype.spec.CPU and preference.spec.CPU", func() {
-
 			BeforeEach(func() {
 				instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					CPU: instancetypev1beta1.CPUInstancetype{
@@ -1582,7 +1574,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 		})
 		Context("instancetype.Spec.ioThreadsPolicy", func() {
-
 			var instancetypePolicy v1.IOThreadsPolicy
 
 			BeforeEach(func() {
@@ -1609,7 +1600,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("instancetype.Spec.LaunchSecurity", func() {
-
 			BeforeEach(func() {
 				instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					LaunchSecurity: &v1.LaunchSecurity{
@@ -1637,7 +1627,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("instancetype.Spec.GPUs", func() {
-
 			BeforeEach(func() {
 				instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					GPUs: []v1.GPU{
@@ -1671,7 +1660,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("instancetype.Spec.HostDevices", func() {
-
 			BeforeEach(func() {
 				instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					HostDevices: []v1.HostDevice{
@@ -1705,7 +1693,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("Instancetype.Spec.Annotations", func() {
-
 			var multipleAnnotations map[string]string
 
 			BeforeEach(func() {
@@ -1749,7 +1736,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("Preference.Spec.Annotations", func() {
-
 			var multipleAnnotations map[string]string
 
 			BeforeEach(func() {
@@ -1789,7 +1775,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 		// TODO - break this up into smaller more targeted tests
 		Context("Preference.Devices", func() {
-
 			var userDefinedBlockSize *v1.BlockSize
 
 			BeforeEach(func() {
@@ -1983,7 +1968,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("Preference.Features", func() {
-
 			BeforeEach(func() {
 				spinLockRetries := uint32(32)
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
@@ -2056,7 +2040,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("Preference.Firmware", func() {
-
 			It("should apply BIOS preferences full to VMI", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Firmware: &instancetypev1beta1.FirmwarePreferences{
@@ -2165,7 +2148,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 		})
 
 		Context("Preference.Machine", func() {
-
 			It("should apply to VMI", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Machine: &instancetypev1beta1.MachinePreferences{
@@ -2180,7 +2162,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 		})
 		Context("Preference.Clock", func() {
-
 			It("should apply to VMI", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Clock: &instancetypev1beta1.ClockPreferences{
@@ -2688,6 +2669,5 @@ var _ = Describe("Instancetype and Preferences", func() {
 				instancetype.Conflicts{k8sfield.NewPath("spec", "template", "spec", "domain", "memory")},
 				fmt.Sprintf(instancetype.InsufficientVMMemoryResourcesErrorFmt, "1Gi", "2Gi"),
 			))
-
 	})
 })

--- a/pkg/libvmi/selector.go
+++ b/pkg/libvmi/selector.go
@@ -62,8 +62,10 @@ func WithNodeAffinityForLabel(nodeLabelKey, nodeLabelValue string) Option {
 			vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []k8sv1.NodeSelectorTerm{}
 		}
 
-		vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms =
-			append(vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, nodeSelectorTerm)
+		vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+			vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+			nodeSelectorTerm,
+		)
 	}
 }
 

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -237,7 +237,8 @@ func newPersistentVolumeClaimVolume(name, claimName string) v1.Volume {
 			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 				PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
 					ClaimName: claimName,
-				}},
+				},
+			},
 		},
 	}
 }

--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -158,7 +158,8 @@ func WithDownwardMetricsVolume(volumeName string) Option {
 			Name: volumeName,
 			VolumeSource: v1.VolumeSource{
 				DownwardMetrics: &v1.DownwardMetricsVolumeSource{},
-			}})
+			},
+		})
 
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 			Name: volumeName,

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -34,13 +34,14 @@ import (
 )
 
 var _ = Describe("Validating VMI network spec", func() {
-
 	DescribeTable("network interface state valid value", func(value v1.InterfaceState) {
 		vm := api.NewMinimalVMI("testvm")
-		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "foo",
-			State:                  value,
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
+			{
+				Name:                   "foo",
+				State:                  value,
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+			},
 		}
 		vm.Spec.Networks = []v1.Network{
 			{Name: "foo", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}}},

--- a/pkg/network/admitter/binding.go
+++ b/pkg/network/admitter/binding.go
@@ -32,7 +32,8 @@ import (
 )
 
 func validateInterfaceBinding(
-	fieldPath *field.Path, spec *v1.VirtualMachineInstanceSpec, config clusterConfigChecker) []metav1.StatusCause {
+	fieldPath *field.Path, spec *v1.VirtualMachineInstanceSpec, config clusterConfigChecker,
+) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	networksByName := vmispec.IndexNetworkSpecByName(spec.Networks)
 	for idx, iface := range spec.Domain.Devices.Interfaces {
@@ -86,7 +87,8 @@ func validateMasqueradeBinding(fieldPath *field.Path, idx int, iface v1.Interfac
 }
 
 func validateBridgeBinding(
-	fieldPath *field.Path, idx int, iface v1.Interface, net v1.Network, config clusterConfigChecker) []metav1.StatusCause {
+	fieldPath *field.Path, idx int, iface v1.Interface, net v1.Network, config clusterConfigChecker,
+) []metav1.StatusCause {
 	if iface.InterfaceBindingMethod.Bridge != nil && net.NetworkSource.Pod != nil && !config.IsBridgeInterfaceOnPodNetworkEnabled() {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 var _ = Describe("Validating network binding combinations", func() {
-
 	It("network interface has both binding plugin and interface binding method", func() {
 		vm := api.NewMinimalVMI("testvm")
 		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{

--- a/pkg/network/admitter/macvtap.go
+++ b/pkg/network/admitter/macvtap.go
@@ -27,7 +27,8 @@ import (
 )
 
 func validateMacvtapBinding(
-	fieldPath *field.Path, idx int, iface v1.Interface, net v1.Network, config clusterConfigChecker) []metav1.StatusCause {
+	fieldPath *field.Path, idx int, iface v1.Interface, net v1.Network, config clusterConfigChecker,
+) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	if iface.InterfaceBindingMethod.Macvtap != nil && !config.MacvtapEnabled() {
 		causes = append(causes, metav1.StatusCause{

--- a/pkg/network/admitter/netiface_test.go
+++ b/pkg/network/admitter/netiface_test.go
@@ -338,7 +338,8 @@ var _ = Describe("Validating VMI network spec", func() {
 				v1.DHCPOptions{
 					PrivateOptions: []v1.DHCPPrivateOptions{
 						{Option: 240, Value: "extra.options.kubevirt.io"},
-						{Option: 240, Value: "sameextra.options.kubevirt.io"}},
+						{Option: 240, Value: "sameextra.options.kubevirt.io"},
+					},
 				},
 				[]metav1.StatusCause{{
 					Type:    "FieldValueInvalid",
@@ -382,7 +383,8 @@ var _ = Describe("Validating VMI network spec", func() {
 				v1.DHCPOptions{
 					PrivateOptions: []v1.DHCPPrivateOptions{
 						{Option: 240, Value: "extra.options.kubevirt.io"},
-						{Option: 241, Value: "extra.options.kubevirt.io"}},
+						{Option: 241, Value: "extra.options.kubevirt.io"},
+					},
 				},
 			),
 		)

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 var _ = Describe("Validate network source", func() {
-
 	It("support only a single pod network", func() {
 		const net1Name = "default"
 		const net2Name = "default2"

--- a/pkg/network/admitter/passt.go
+++ b/pkg/network/admitter/passt.go
@@ -27,7 +27,8 @@ import (
 )
 
 func validatePasstBinding(
-	fieldPath *field.Path, idx int, iface v1.Interface, net v1.Network, config clusterConfigChecker) []metav1.StatusCause {
+	fieldPath *field.Path, idx int, iface v1.Interface, net v1.Network, config clusterConfigChecker,
+) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	if iface.InterfaceBindingMethod.Passt != nil && !config.PasstEnabled() {
 		causes = append(causes, metav1.StatusCause{

--- a/pkg/network/admitter/slirp.go
+++ b/pkg/network/admitter/slirp.go
@@ -35,7 +35,8 @@ type slirpClusterConfigChecker interface {
 func validateSlirpBinding(
 	field *k8sfield.Path,
 	spec *v1.VirtualMachineInstanceSpec,
-	configChecker slirpClusterConfigChecker) (causes []metav1.StatusCause) {
+	configChecker slirpClusterConfigChecker,
+) (causes []metav1.StatusCause) {
 	for idx, ifaceSpec := range spec.Domain.Devices.Interfaces {
 		if ifaceSpec.DeprecatedSlirp == nil {
 			continue

--- a/pkg/network/deviceinfo/deviceinfo_test.go
+++ b/pkg/network/deviceinfo/deviceinfo_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 var _ = Describe("DeviceInfo", func() {
-
 	const deviceInfoPlugin = "deviceinfo"
 
 	networkStatusWithMixedNetworks := `[

--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -40,11 +40,16 @@ import (
 )
 
 var istioPortForwardRange = []api.InterfacePortForwardRange{
-	{Start: 15000, Exclude: "yes"}, {Start: 15001, Exclude: "yes"},
-	{Start: 15004, Exclude: "yes"}, {Start: 15006, Exclude: "yes"},
-	{Start: 15008, Exclude: "yes"}, {Start: 15009, Exclude: "yes"},
-	{Start: 15020, Exclude: "yes"}, {Start: 15021, Exclude: "yes"},
-	{Start: 15053, Exclude: "yes"}, {Start: 15090, Exclude: "yes"},
+	{Start: 15000, Exclude: "yes"},
+	{Start: 15001, Exclude: "yes"},
+	{Start: 15004, Exclude: "yes"},
+	{Start: 15006, Exclude: "yes"},
+	{Start: 15008, Exclude: "yes"},
+	{Start: 15009, Exclude: "yes"},
+	{Start: 15020, Exclude: "yes"},
+	{Start: 15021, Exclude: "yes"},
+	{Start: 15053, Exclude: "yes"},
+	{Start: 15090, Exclude: "yes"},
 }
 
 var _ = Describe("Pod Network", func() {
@@ -235,7 +240,8 @@ var _ = Describe("Pod Network", func() {
 					MacAddress:             "02:02:02:02:02:02",
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Passt: &v1.InterfacePasst{}},
 					Ports: []v1.Port{
-						{Protocol: "udp", Port: 100}, {Protocol: "udp", Port: 200},
+						{Protocol: "udp", Port: 100},
+						{Protocol: "udp", Port: 200},
 						{Protocol: "tcp", Port: 8080},
 						{Port: 80},
 					},

--- a/pkg/network/domainspec/interface.go
+++ b/pkg/network/domainspec/interface.go
@@ -58,7 +58,8 @@ func DomainAttachmentByInterfaceName(vmiSpecIfaces []v1.Interface, networkBindin
 }
 
 func BindingMigrationByInterfaceName(vmiSpecIfaces []v1.Interface,
-	networkBindings map[string]v1.InterfaceBindingPlugin) map[string]*cmdv1.InterfaceBindingMigration {
+	networkBindings map[string]v1.InterfaceBindingPlugin,
+) map[string]*cmdv1.InterfaceBindingMigration {
 	bindingMigrationByPluginName := map[string]*cmdv1.InterfaceBindingMigration{}
 	for name, binding := range networkBindings {
 		if binding.Migration != nil {

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -239,7 +239,8 @@ func NewExpecter(
 	virtCli kubecli.KubevirtClient,
 	vmi *v1.VirtualMachineInstance,
 	timeout time.Duration,
-	opts ...expect.Option) (expect.Expecter, <-chan error, error) {
+	opts ...expect.Option,
+) (expect.Expecter, <-chan error, error) {
 	vmiReader, vmiWriter := io.Pipe()
 	expecterReader, expecterWriter := io.Pipe()
 	resCh := make(chan error)

--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -60,7 +60,6 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) err
 		loginTimeout = timeout[0]
 	}
 	resp, err := expecter.ExpectBatch(b, loginTimeout)
-
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %v", resp)
 		return err

--- a/tests/libnet/cloudinit/cloudinit.go
+++ b/tests/libnet/cloudinit/cloudinit.go
@@ -27,8 +27,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type NetworkDataOption func(*CloudInitNetworkData) error
-type NetworkDataInterfaceOption func(*CloudInitInterface) error
+type (
+	NetworkDataOption          func(*CloudInitNetworkData) error
+	NetworkDataInterfaceOption func(*CloudInitInterface) error
+)
 
 func NewNetworkData(options ...NetworkDataOption) (string, error) {
 	networkData := CloudInitNetworkData{

--- a/tests/libnet/cluster/cluster.go
+++ b/tests/libnet/cluster/cluster.go
@@ -15,12 +15,14 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-var onceIPv4 sync.Once
-var clusterSupportsIpv4 bool
-var errIPv4 error
-var onceIPv6 sync.Once
-var clusterSupportsIpv6 bool
-var errIPv6 error
+var (
+	onceIPv4            sync.Once
+	clusterSupportsIpv4 bool
+	errIPv4             error
+	onceIPv6            sync.Once
+	clusterSupportsIpv6 bool
+	errIPv6             error
+)
 
 func DualStack() (bool, error) {
 	supportsIpv4, err := SupportsIpv4()

--- a/tests/libnet/job/job.go
+++ b/tests/libnet/job/job.go
@@ -83,7 +83,7 @@ fi`,
 // NewHelloWorldJob takes a DNS entry or an IP and a port which it will use to create a job
 // which tries to contact the host on the provided port.
 // It expects to receive "Hello World!" to succeed.
-func NewHelloWorldJobTCP(host string, port string) *batchv1.Job {
+func NewHelloWorldJobTCP(host, port string) *batchv1.Job {
 	check := fmt.Sprintf(`set -x; x="$(head -n 1 < <(nc %s %s -i 3 -w 3 --no-shutdown))"; echo "$x" ; \
 	  if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, port)
 	return NewHelloWorldJob(check)
@@ -92,7 +92,7 @@ func NewHelloWorldJobTCP(host string, port string) *batchv1.Job {
 // NewHelloWorldJobHTTP gets an IP address and a port, which it uses to create a pod.
 // This pod tries to contact the host on the provided port, over HTTP.
 // On success - it expects to receive "Hello World!".
-func NewHelloWorldJobHTTP(host string, port string) *batchv1.Job {
+func NewHelloWorldJobHTTP(host, port string) *batchv1.Job {
 	check := fmt.Sprintf(`set -x; x="$(head -n 1 < <(curl --silent %s:%s))"; echo "$x" ; \
 	  if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, libnet.FormatIPForURL(host), port)
 	return NewHelloWorldJob(check)
@@ -143,7 +143,6 @@ func WaitForJob(job *batchv1.Job, toSucceed bool, timeout time.Duration) error {
 		}
 		return !finish, nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("job %s timeout reached, status: %+v, err: %v", job.Name, job.Status, err)
 	}

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -239,15 +239,15 @@ func AddAnnotationToNode(nodeName, key, value string) *k8sv1.Node {
 	return addRemoveLabelAnnotationHelper(nodeName, key, value, annotation, add)
 }
 
-func RemoveLabelFromNode(nodeName string, key string) *k8sv1.Node {
+func RemoveLabelFromNode(nodeName, key string) *k8sv1.Node {
 	return addRemoveLabelAnnotationHelper(nodeName, key, "", label, remove)
 }
 
-func RemoveAnnotationFromNode(nodeName string, key string) *k8sv1.Node {
+func RemoveAnnotationFromNode(nodeName, key string) *k8sv1.Node {
 	return addRemoveLabelAnnotationHelper(nodeName, key, "", annotation, remove)
 }
 
-func Taint(nodeName string, key string, effect k8sv1.TaintEffect) {
+func Taint(nodeName, key string, effect k8sv1.TaintEffect) {
 	virtCli := kubevirt.Client()
 	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
@@ -390,7 +390,7 @@ func GetWorkerNodesWithCPUManagerEnabled(virtClient kubecli.KubevirtClient) []k8
 }
 
 func GetSupportedCPUFeatures(nodesList k8sv1.NodeList) []string {
-	var featureDenyList = map[string]bool{
+	featureDenyList := map[string]bool{
 		"svm": true,
 	}
 	featuresMap := make(map[string]bool)
@@ -413,7 +413,7 @@ func GetSupportedCPUFeatures(nodesList k8sv1.NodeList) []string {
 }
 
 func GetSupportedCPUModels(nodeList k8sv1.NodeList) []string {
-	var cpuDenyList = map[string]bool{
+	cpuDenyList := map[string]bool{
 		"qemu64":     true,
 		"Opteron_G2": true,
 	}
@@ -446,7 +446,7 @@ func GetNodeHostModel(node *k8sv1.Node) (hostModel string) {
 	return hostModel
 }
 
-func ExecuteCommandOnNodeThroughVirtHandler(nodeName string, command []string) (stdout string, stderr string, err error) {
+func ExecuteCommandOnNodeThroughVirtHandler(nodeName string, command []string) (stdout, stderr string, err error) {
 	virtHandlerPod, err := GetVirtHandlerPod(kubevirt.Client(), nodeName)
 	if err != nil {
 		return "", "", err

--- a/tests/libpod/certs.go
+++ b/tests/libpod/certs.go
@@ -45,7 +45,7 @@ import (
 )
 
 // GetCertsForPods returns the used certificates for all pods matching  the label selector
-func GetCertsForPods(labelSelector string, namespace string, port string) ([][]byte, error) {
+func GetCertsForPods(labelSelector, namespace, port string) ([][]byte, error) {
 	cli := kubevirt.Client()
 	pods, err := cli.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/libpod/render.go
+++ b/tests/libpod/render.go
@@ -31,7 +31,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-func RenderPrivilegedPod(name string, cmd []string, args []string) *v1.Pod {
+func RenderPrivilegedPod(name string, cmd, args []string) *v1.Pod {
 	pod := RenderPod(name, cmd, args)
 	pod.Namespace = testsuite.NamespacePrivileged
 	pod.Spec.HostPID = true
@@ -49,7 +49,7 @@ func RenderPrivilegedPod(name string, cmd []string, args []string) *v1.Pod {
 	return pod
 }
 
-func RenderPod(name string, cmd []string, args []string) *v1.Pod {
+func RenderPod(name string, cmd, args []string) *v1.Pod {
 	pod := v1.Pod{
 		ObjectMeta: v12.ObjectMeta{
 			GenerateName: name,
@@ -72,7 +72,7 @@ func RenderPod(name string, cmd []string, args []string) *v1.Pod {
 	return &pod
 }
 
-func renderContainerSpec(imgPath string, name string, cmd []string, args []string) v1.Container {
+func renderContainerSpec(imgPath, name string, cmd, args []string) v1.Container {
 	return v1.Container{
 		Name:    name,
 		Image:   imgPath,
@@ -92,7 +92,7 @@ func renderContainerSpec(imgPath string, name string, cmd []string, args []strin
 	}
 }
 
-func renderPrivilegedContainerSpec(imgPath string, name string, cmd []string, args []string) v1.Container {
+func renderPrivilegedContainerSpec(imgPath, name string, cmd, args []string) v1.Container {
 	return v1.Container{
 		Name:    name,
 		Image:   imgPath,
@@ -106,7 +106,8 @@ func renderPrivilegedContainerSpec(imgPath string, name string, cmd []string, ar
 }
 
 func RenderHostPathPod(
-	podName string, dir string, hostPathType v1.HostPathType, mountPropagation v1.MountPropagationMode, cmd []string, args []string) *v1.Pod {
+	podName, dir string, hostPathType v1.HostPathType, mountPropagation v1.MountPropagationMode, cmd, args []string,
+) *v1.Pod {
 	pod := RenderPrivilegedPod(podName, cmd, args)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
 		Name:             "hostpath-mount",


### PR DESCRIPTION
### What this PR does

A stricter formater allows to reduce formatting and style opinionated comments in reviews.
It provides consistency and helps with code readability.

[gofumpt](https://github.com/mvdan/gofumpt) seems to be popular among the Go community, therefore chosen for this task.

Used the `extra` flag to add all rules.

To automatically format the code, use: `make gofumpt` or:
```
gofumpt -l -w -extra \
  pkg/instancetype \
  pkg/libvmi \
  pkg/network/admitter \
  pkg/network/namescheme \
  pkg/network/domainspec \
  pkg/network/deviceinfo \
  tests/console \
  tests/libnet \
  tests/libnode \
  tests/libconfigmap \
  tests/libpod \
  tests/libvmifact \
  tests/libsecret
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

