### PR TITLE
[release-1.2] Add rule to collect issues with the pods

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,6 +24,9 @@ Indicates whether the Software Emulation is enabled in the configuration. Type: 
 ### kubevirt_console_active_connections
 Amount of active Console connections, broken down by namespace and vmi name. Type: Gauge.
 
+### kubevirt_memory_delta_from_requested_bytes
+The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator. Type: Gauge.
+
 ### kubevirt_nodes_with_kvm
 The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. Type: Gauge.
 

--- a/pkg/monitoring/rules/recordingrules/BUILD.bazel
+++ b/pkg/monitoring/rules/recordingrules/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "api.go",
         "nodes.go",
+        "operator.go",
         "recordingrules.go",
         "virt.go",
         "vm.go",

--- a/pkg/monitoring/rules/recordingrules/operator.go
+++ b/pkg/monitoring/rules/recordingrules/operator.go
@@ -1,0 +1,45 @@
+/*
+Copyright The KubeVirt Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recordingrules
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var operatorRecordingRules = []operatorrules.RecordingRule{
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_memory_delta_from_requested_bytes",
+			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator.",
+			ConstLabels: map[string]string{
+				"reason": "memory_working_set",
+			},
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("topk by(container)(1,max by(container, namespace, node)(container_memory_working_set_bytes{container=~\"virt-controller|virt-api|virt-handler|virt-operator\"}  - on(pod) group_left(node) (kube_pod_container_resource_requests{ container=~\"virt-controller|virt-api|virt-handler|virt-operator\",resource=\"memory\"})))"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_memory_delta_from_requested_bytes",
+			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, virt-controller, virt-handler, virt-api and virt-operator.",
+			ConstLabels: map[string]string{
+				"reason": "memory_rss",
+			},
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("topk by(container)(1,max by(container, namespace, node)(container_memory_rss{container=~\"virt-controller|virt-api|virt-handler|virt-operator\"}  - on(pod) group_left(node) (kube_pod_container_resource_requests{ container=~\"virt-controller|virt-api|virt-handler|virt-operator\",resource=\"memory\"})))"),
+	},
+}

--- a/pkg/monitoring/rules/recordingrules/recordingrules.go
+++ b/pkg/monitoring/rules/recordingrules/recordingrules.go
@@ -6,6 +6,7 @@ func Register(namespace string) error {
 	return operatorrules.RegisterRecordingRules(
 		apiRecordingRules,
 		nodesRecordingRules,
+		operatorRecordingRules,
 		virtRecordingRules(namespace),
 		vmRecordingRules,
 		vmiRecordingRules,


### PR DESCRIPTION
This is a manual cherry-pick for https://github.com/kubevirt/kubevirt/pull/11557.
The automated one closed since had a rebase conflicts: https://github.com/kubevirt/kubevirt/pull/11703 

### Special notes
The operator-observability package was already bumped to 0.20 here: https://github.com/kubevirt/kubevirt/pull/11721

Jira-ticket: https://issues.redhat.com/browse/CNV-40387

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New memory statistics added named kubevirt_memory_delta_from_requested_bytes

```

