### PR TITLE
Retire the NewRandomVMIWithEphemeralDisk function (cont)

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -62,8 +62,10 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	})
 
 	DescribeTable("should", func(image string, policy k8sv1.PullPolicy, expectedPolicy k8sv1.PullPolicy) {
-		vmi := tests.NewRandomVMIWithEphemeralDisk(image)
+		vmi := libvmifact.NewGuestless(libvmi.WithContainerDisk("disk0", image))
+
 		vmi.Spec.Volumes[0].ContainerDisk.ImagePullPolicy = policy
+
 		vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 		Expect(vmi.Spec.Volumes[0].ContainerDisk.ImagePullPolicy).To(Equal(expectedPolicy))
 		pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)


### PR DESCRIPTION
### What this PR does
Continue to remove the calls to the `NewRandomVMIWithEphemeralDisk` function, and replace it with libvmi functions.

Also, replace several lambda function in tests/operator/operator.go, to be a regular function.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/sig code-quality