### PR TITLE
libvmifact: expose cirros memory

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -259,15 +259,6 @@ func NewRandomVMWithDataVolumeWithRegistryImport(imageUrl, namespace, storageCla
 	return vm
 }
 
-func cirrosMemory() string {
-	// Cirros image need 256M to boot on ARM64,
-	// this issue is traced in https://github.com/kubevirt/kubevirt/issues/6363
-	if checks.IsARM64(testsuite.Arch) {
-		return "256Mi"
-	}
-	return "128Mi"
-}
-
 // NewRandomVMIWithEphemeralDisk
 //
 // Deprecated: Use libvmi directly
@@ -276,7 +267,7 @@ func NewRandomVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInst
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-		libvmi.WithResourceMemory(cirrosMemory()),
+		libvmifact.WithSmallOSResourceMemory(),
 		libvmi.WithContainerDisk("disk0", containerImage),
 	}
 	if containerImage == cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling) {


### PR DESCRIPTION
The minimal memory size of Cirros and Alpine operating systems is currently needed by multiple tests. Let us expose it in libvmifact.

```release-note
NONE
```

/sig code-quality