### PR TITLE
Fix live updates for the volumes

### DIFF
--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -274,3 +274,19 @@ func IsHotplugVolume(vol *virtv1.Volume) bool {
 
 	return false
 }
+
+func GetVolumesByName(vmiSpec *virtv1.VirtualMachineInstanceSpec) map[string]*virtv1.Volume {
+	volumes := map[string]*virtv1.Volume{}
+	for _, vol := range vmiSpec.Volumes {
+		volumes[vol.Name] = vol.DeepCopy()
+	}
+	return volumes
+}
+
+func GetDisksByName(vmiSpec *virtv1.VirtualMachineInstanceSpec) map[string]*virtv1.Disk {
+	disks := map[string]*virtv1.Disk{}
+	for _, disk := range vmiSpec.Domain.Devices.Disks {
+		disks[disk.Name] = disk.DeepCopy()
+	}
+	return disks
+}

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -256,3 +256,21 @@ func RenderPVC(size *resource.Quantity, claimName, namespace, storageClass, acce
 
 	return pvc
 }
+
+func IsHotplugVolume(vol *virtv1.Volume) bool {
+	if vol == nil {
+		return false
+	}
+	volSrc := vol.VolumeSource
+	if volSrc.PersistentVolumeClaim != nil && volSrc.PersistentVolumeClaim.Hotpluggable {
+		return true
+	}
+	if volSrc.DataVolume != nil && volSrc.DataVolume.Hotpluggable {
+		return true
+	}
+	if volSrc.MemoryDump != nil && volSrc.MemoryDump.PersistentVolumeClaimVolumeSource.Hotpluggable {
+		return true
+	}
+
+	return false
+}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2899,6 +2899,68 @@ func (c *VMController) trimDoneVolumeRequests(vm *virtv1.VirtualMachine) {
 	vm.Status.VolumeRequests = tmpVolRequests
 }
 
+func validLiveUpdateVolumes(oldVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.VirtualMachine) bool {
+	oldVols := storagetypes.GetVolumesByName(&oldVMSpec.Template.Spec)
+	// Evaluate if any volume has changed or has been added
+	for _, v := range vm.Spec.Template.Spec.Volumes {
+		oldVol, okOld := oldVols[v.Name]
+		switch {
+		// Changes for hotlpugged volumes are valid
+		case storagetypes.IsHotplugVolume(&v):
+			delete(oldVols, v.Name)
+		// The volume has been freshly added
+		case !okOld:
+			return false
+		// The volume has changed
+		case !equality.Semantic.DeepEqual(*oldVol, v):
+			return false
+		default:
+			delete(oldVols, v.Name)
+		}
+	}
+	// Evaluate if any volumes were removed and they were hotplugged volumes
+	for _, v := range oldVols {
+		if !storagetypes.IsHotplugVolume(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func validLiveUpdateDisks(oldVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.VirtualMachine) bool {
+	oldDisks := storagetypes.GetDisksByName(&oldVMSpec.Template.Spec)
+	oldVols := storagetypes.GetVolumesByName(&oldVMSpec.Template.Spec)
+	vols := storagetypes.GetVolumesByName(&vm.Spec.Template.Spec)
+	// Evaluate if any disk has changed or has been added
+	for _, newDisk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+		v := vols[newDisk.Name]
+		oldDisk, okOld := oldDisks[newDisk.Name]
+		switch {
+		// Changes for disks associated to a hotpluggable volume are valid
+		case storagetypes.IsHotplugVolume(v):
+			delete(oldDisks, v.Name)
+		// The disk has been freshly added
+		case !okOld:
+			return false
+		// The disk has changed
+		case !equality.Semantic.DeepEqual(*oldDisk, newDisk):
+			return false
+		default:
+			delete(oldDisks, v.Name)
+		}
+	}
+	// Evaluate if any disks were removed and they were hotplugged volumes
+	for _, d := range oldDisks {
+		v := oldVols[d.Name]
+		if !storagetypes.IsHotplugVolume(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // addRestartRequiredIfNeeded adds the restartRequired condition to the VM if any non-live-updatable field was changed
 func (c *VMController) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine, bool) {
 	if lastSeenVMSpec == nil {
@@ -2908,8 +2970,12 @@ func (c *VMController) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.Virtual
 	// Note: this list needs to stay up-to-date with everything that can be live-updated
 	// Note2: destroying lastSeenVMSpec here is fine, we don't need it later
 	if c.clusterConfig.IsVMRolloutStrategyLiveUpdate() {
-		lastSeenVMSpec.Template.Spec.Volumes = vm.Spec.Template.Spec.Volumes
-		lastSeenVMSpec.Template.Spec.Domain.Devices.Disks = vm.Spec.Template.Spec.Domain.Devices.Disks
+		if validLiveUpdateVolumes(lastSeenVMSpec, vm) {
+			lastSeenVMSpec.Template.Spec.Volumes = vm.Spec.Template.Spec.Volumes
+		}
+		if validLiveUpdateDisks(lastSeenVMSpec, vm) {
+			lastSeenVMSpec.Template.Spec.Domain.Devices.Disks = vm.Spec.Template.Spec.Domain.Devices.Disks
+		}
 		if lastSeenVMSpec.Template.Spec.Domain.CPU != nil && vm.Spec.Template.Spec.Domain.CPU != nil {
 			lastSeenVMSpec.Template.Spec.Domain.CPU.Sockets = vm.Spec.Template.Spec.Domain.CPU.Sockets
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
All the type of volumes were live-updatable. However, this assumption is incorrect. The only volumes that can be changed while the VM is running are hotpluggable volumes which can be added, replaced or removed.

After this PR:
This PR takes into account the volume types for the volume update and add the restart required condition accordingly.

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the live updates for volumes and disks
```

