### PR TITLE
backend storage: add logic to improve usability

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -189,6 +189,12 @@ type KubeInformerFactory interface {
 	// Fake CDI DataSource informer used when feature gate is disabled
 	DummyDataSource() cache.SharedIndexInformer
 
+	// Watches for CDI StorageProfile objects
+	StorageProfile() cache.SharedIndexInformer
+
+	// Fake CDI StorageProfile informer used when feature gate is disabled
+	DummyStorageProfile() cache.SharedIndexInformer
+
 	// Watches for CDI objects
 	CDI() cache.SharedIndexInformer
 
@@ -820,6 +826,20 @@ func (f *kubeInformerFactory) DataSource() cache.SharedIndexInformer {
 func (f *kubeInformerFactory) DummyDataSource() cache.SharedIndexInformer {
 	return f.getInformer("fakeDataSourceInformer", func() cache.SharedIndexInformer {
 		informer, _ := testutils.NewFakeInformerFor(&cdiv1.DataSource{})
+		return informer
+	})
+}
+
+func (f *kubeInformerFactory) StorageProfile() cache.SharedIndexInformer {
+	return f.getInformer("storageProfileInformer", func() cache.SharedIndexInformer {
+		lw := cache.NewListWatchFromClient(f.clientSet.CdiClient().CdiV1beta1().RESTClient(), "storageprofiles", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &cdiv1.StorageProfile{}, f.defaultResync, cache.Indexers{})
+	})
+}
+
+func (f *kubeInformerFactory) DummyStorageProfile() cache.SharedIndexInformer {
+	return f.getInformer("fakeStorageProfileInformer", func() cache.SharedIndexInformer {
+		informer, _ := testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 		return informer
 	})
 }

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -16,5 +16,32 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "backend-storage_suite_test.go",
+        "backend-storage_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/pointer:go_default_library",
+        "//pkg/storage/types:go_default_library",
+        "//pkg/testutils:go_default_library",
+        "//pkg/virt-config:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/storage/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )
 
@@ -28,11 +29,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/pointer:go_default_library",
-        "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -22,6 +22,9 @@ package backendstorage
 import (
 	"context"
 	"fmt"
+	"sync"
+
+	"kubevirt.io/client-go/log"
 
 	"k8s.io/client-go/tools/cache"
 
@@ -71,24 +74,127 @@ func IsBackendStorageNeededForVM(vm *corev1.VirtualMachine) bool {
 	return HasPersistentTPMDevice(&vm.Spec.Template.Spec)
 }
 
-func CreateIfNeeded(vmi *corev1.VirtualMachineInstance, clusterConfig *virtconfig.ClusterConfig, client kubecli.KubevirtClient) error {
+type BackendStorage struct {
+	client          kubecli.KubevirtClient
+	clusterConfig   *virtconfig.ClusterConfig
+	scStore         cache.Store
+	accessModeCache map[string]v1.PersistentVolumeAccessMode
+	cacheLock       sync.Mutex
+}
+
+func NewBackendStorage(client kubecli.KubevirtClient, clusterConfig *virtconfig.ClusterConfig, scStore cache.Store) *BackendStorage {
+	return &BackendStorage{
+		client:          client,
+		clusterConfig:   clusterConfig,
+		scStore:         scStore,
+		accessModeCache: map[string]v1.PersistentVolumeAccessMode{},
+	}
+}
+
+func (bs *BackendStorage) getStorageClass() (string, error) {
+	storageClass := bs.clusterConfig.GetVMStateStorageClass()
+	if storageClass != "" {
+		return storageClass, nil
+	}
+
+	for _, obj := range bs.scStore.List() {
+		sc := obj.(*storagev1.StorageClass)
+		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			return sc.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no default storage class found")
+}
+
+func (bs *BackendStorage) getAccessMode(storageClass string, mode v1.PersistentVolumeMode) v1.PersistentVolumeAccessMode {
+	bs.cacheLock.Lock()
+	defer bs.cacheLock.Unlock()
+	if accessMode, exists := bs.accessModeCache[storageClass]; exists {
+		return accessMode
+	}
+
+	// Storage profiles are guaranteed to have the same name as their storage class
+	storageProfile, err := bs.client.CdiClient().CdiV1beta1().StorageProfiles().Get(context.Background(), storageClass, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		log.Log.Infof("no storage profile found for %s, defaulting to RWX", storageClass)
+		return v1.ReadWriteMany
+	}
+	if err != nil {
+		// CDI not present most likely
+		log.Log.Reason(err).Info("couldn't access storage profiles, defaulting to RWX")
+		return v1.ReadWriteMany
+	}
+
+	bs.accessModeCache[storageClass] = v1.ReadWriteMany
+	if storageProfile.Status.ClaimPropertySets == nil || len(storageProfile.Status.ClaimPropertySets) == 0 {
+		log.Log.Infof("no ClaimPropertySets in storage profile %s, defaulting to RWX", storageProfile.Name)
+		return v1.ReadWriteMany
+	}
+
+	foundrwo := false
+	for _, property := range storageProfile.Status.ClaimPropertySets {
+		if property.VolumeMode == nil || *property.VolumeMode != mode || property.AccessModes == nil {
+			continue
+		}
+		for _, accessMode := range property.AccessModes {
+			switch accessMode {
+			case v1.ReadWriteMany:
+				return v1.ReadWriteMany
+			case v1.ReadWriteOnce:
+				foundrwo = true
+			}
+		}
+	}
+	if foundrwo {
+		bs.accessModeCache[storageClass] = v1.ReadWriteOnce
+		return v1.ReadWriteOnce
+	}
+
+	return v1.ReadWriteMany
+}
+
+func updateVolumeStatus(vmi *corev1.VirtualMachineInstance, accessMode v1.PersistentVolumeAccessMode) {
+	if vmi.Status.VolumeStatus == nil {
+		vmi.Status.VolumeStatus = []corev1.VolumeStatus{}
+	}
+	for i := range vmi.Status.VolumeStatus {
+		if vmi.Status.VolumeStatus[i].Name == PVCForVMI(vmi) {
+			if vmi.Status.VolumeStatus[i].PersistentVolumeClaimInfo == nil {
+				vmi.Status.VolumeStatus[i].PersistentVolumeClaimInfo = &corev1.PersistentVolumeClaimInfo{}
+			}
+			vmi.Status.VolumeStatus[i].PersistentVolumeClaimInfo.AccessModes = []v1.PersistentVolumeAccessMode{accessMode}
+			return
+		}
+	}
+	vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, corev1.VolumeStatus{
+		Name: PVCForVMI(vmi),
+		PersistentVolumeClaimInfo: &corev1.PersistentVolumeClaimInfo{
+			AccessModes: []v1.PersistentVolumeAccessMode{accessMode},
+		},
+	})
+}
+
+func (bs *BackendStorage) CreateIfNeededAndUpdateVolumeStatus(vmi *corev1.VirtualMachineInstance) error {
 	if !IsBackendStorageNeededForVMI(&vmi.Spec) {
 		return nil
 	}
 
-	_, err := client.CoreV1().PersistentVolumeClaims(vmi.Namespace).Get(context.Background(), PVCForVMI(vmi), metav1.GetOptions{})
+	pvc, err := bs.client.CoreV1().PersistentVolumeClaims(vmi.Namespace).Get(context.Background(), PVCForVMI(vmi), metav1.GetOptions{})
 	if err == nil {
+		updateVolumeStatus(vmi, pvc.Spec.AccessModes[0])
 		return nil
 	}
 	if !errors.IsNotFound(err) {
 		return err
 	}
 
-	modeFile := v1.PersistentVolumeFilesystem
-	storageClass := clusterConfig.GetVMStateStorageClass()
-	if storageClass == "" {
-		return fmt.Errorf("backend VM storage requires a backend storage class defined in the custom resource")
+	storageClass, err := bs.getStorageClass()
+	if err != nil {
+		return err
 	}
+	mode := v1.PersistentVolumeFilesystem
+	accessMode := bs.getAccessMode(storageClass, mode)
 	ownerReferences := vmi.OwnerReferences
 	if len(vmi.OwnerReferences) == 0 {
 		// If the VMI has no owner, then it did not originate from a VM.
@@ -99,22 +205,24 @@ func CreateIfNeeded(vmi *corev1.VirtualMachineInstance, clusterConfig *virtconfi
 			*metav1.NewControllerRef(vmi, corev1.VirtualMachineInstanceGroupVersionKind),
 		}
 	}
-	pvc := &v1.PersistentVolumeClaim{
+	pvc = &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            PVCForVMI(vmi),
 			OwnerReferences: ownerReferences,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			AccessModes: []v1.PersistentVolumeAccessMode{accessMode},
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse(PVCSize)},
 			},
 			StorageClassName: &storageClass,
-			VolumeMode:       &modeFile,
+			VolumeMode:       &mode,
 		},
 	}
 
-	_, err = client.CoreV1().PersistentVolumeClaims(vmi.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
+	updateVolumeStatus(vmi, accessMode)
+
+	pvc, err = bs.client.CoreV1().PersistentVolumeClaims(vmi.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(err) {
 		return nil
 	}
@@ -126,12 +234,12 @@ func CreateIfNeeded(vmi *corev1.VirtualMachineInstance, clusterConfig *virtconfi
 // - No PVC is needed for the VMI since it doesn't use backend storage
 // - The backend storage PVC is bound
 // - The backend storage PVC is pending uses a WaitForFirstConsumer storage class
-func IsPVCReady(vmi *corev1.VirtualMachineInstance, client kubecli.KubevirtClient, scStore cache.Store) (bool, error) {
+func (bs *BackendStorage) IsPVCReady(vmi *corev1.VirtualMachineInstance) (bool, error) {
 	if !IsBackendStorageNeededForVMI(&vmi.Spec) {
 		return true, nil
 	}
 
-	pvc, err := client.CoreV1().PersistentVolumeClaims(vmi.Namespace).Get(context.Background(), PVCForVMI(vmi), metav1.GetOptions{})
+	pvc, err := bs.client.CoreV1().PersistentVolumeClaims(vmi.Namespace).Get(context.Background(), PVCForVMI(vmi), metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -145,7 +253,7 @@ func IsPVCReady(vmi *corev1.VirtualMachineInstance, client kubecli.KubevirtClien
 		if pvc.Spec.StorageClassName == nil {
 			return false, fmt.Errorf("no storage class name")
 		}
-		obj, exists, err := scStore.GetByKey(*pvc.Spec.StorageClassName)
+		obj, exists, err := bs.scStore.GetByKey(*pvc.Spec.StorageClassName)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/storage/backend-storage/backend-storage_suite_test.go
+++ b/pkg/storage/backend-storage/backend-storage_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Contributors
+ *
+ */
+
+package backendstorage_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestBackendStorage(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/storage/backend-storage/backend-storage_test.go
+++ b/pkg/storage/backend-storage/backend-storage_test.go
@@ -52,8 +52,9 @@ var _ = Describe("Backend Storage", func() {
 		config, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		storageClassInformer, _ = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		storageProfileInformer, _ = testutils.NewFakeInformerFor(&v1beta1.StorageProfile{})
+		pvcInformer, _ := testutils.NewFakeInformerFor(&v1.PersistentVolumeClaim{})
 
-		backendStorage = NewBackendStorage(virtClient, config, storageClassInformer.GetStore(), storageProfileInformer.GetStore())
+		backendStorage = NewBackendStorage(virtClient, config, storageClassInformer.GetStore(), storageProfileInformer.GetStore(), pvcInformer.GetIndexer())
 	})
 
 	Context("Storage class", func() {

--- a/pkg/storage/backend-storage/backend-storage_test.go
+++ b/pkg/storage/backend-storage/backend-storage_test.go
@@ -1,0 +1,164 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Contributors
+ *
+ */
+
+package backendstorage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	virtv1 "kubevirt.io/api/core/v1"
+	cdifake "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
+	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+)
+
+var _ = Describe("Backend Storage", func() {
+	var backendStorage *BackendStorage
+	var cdiClient *cdifake.Clientset
+	var config *virtconfig.ClusterConfig
+	var kvInformer cache.SharedIndexInformer
+	var storageClassInformer cache.SharedIndexInformer
+
+	cdiConfigInit := func() (cdiConfig *v1beta1.CDIConfig) {
+		cdiConfig = &v1beta1.CDIConfig{
+			ObjectMeta: k8smetav1.ObjectMeta{
+				Name: storagetypes.ConfigName,
+			},
+			Spec: v1beta1.CDIConfigSpec{
+				UploadProxyURLOverride: nil,
+			},
+			Status: v1beta1.CDIConfigStatus{
+				FilesystemOverhead: &v1beta1.FilesystemOverhead{
+					Global: storagetypes.DefaultFSOverhead,
+				},
+			},
+		}
+		return
+	}
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		virtClient := kubecli.NewMockKubevirtClient(ctrl)
+		kubevirtFakeConfig := &virtv1.KubeVirtConfiguration{}
+		config, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
+		storageClassInformer, _ = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
+		cdiConfig := cdiConfigInit()
+		cdiClient = cdifake.NewSimpleClientset(cdiConfig)
+		virtClient.EXPECT().CdiClient().Return(cdiClient).AnyTimes()
+
+		backendStorage = NewBackendStorage(virtClient, config, storageClassInformer.GetStore())
+	})
+
+	Context("Storage class", func() {
+		It("Should return VMStateStorageClass when set", func() {
+			kvCR := testutils.GetFakeKubeVirtClusterConfig(kvInformer)
+			kvCR.Spec.Configuration.VMStateStorageClass = "myfave"
+			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvCR)
+			sc, err := backendStorage.getStorageClass()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sc).To(Equal("myfave"))
+		})
+
+		It("Should return the default storage class when VMStateStorageClass is not set", func() {
+			for i := 0; i < 5; i++ {
+				sc := storagev1.StorageClass{
+					ObjectMeta: k8smetav1.ObjectMeta{
+						Name: fmt.Sprintf("sc%d", i),
+					},
+				}
+				if i == 3 {
+					sc.Annotations = map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}
+				}
+				err := storageClassInformer.GetStore().Add(&sc)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			sc, err := backendStorage.getStorageClass()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sc).To(Equal("sc3"))
+		})
+	})
+
+	Context("Access mode", func() {
+		BeforeEach(func() {
+			By("Creating a storage profile with no access/volume mode")
+			sp := v1beta1.StorageProfile{
+				ObjectMeta: k8smetav1.ObjectMeta{
+					Name: "noMode",
+				},
+				Spec: v1beta1.StorageProfileSpec{},
+				Status: v1beta1.StorageProfileStatus{
+					ClaimPropertySets: []v1beta1.ClaimPropertySet{},
+				},
+			}
+			_, err := cdiClient.CdiV1beta1().StorageProfiles().Create(context.Background(), &sp, k8smetav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a storage profile with RWO FS as its only mode")
+			sp.Name = "onlyrwo"
+			sp.Status.ClaimPropertySets = append(sp.Status.ClaimPropertySets, v1beta1.ClaimPropertySet{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				VolumeMode:  pointer.P(v1.PersistentVolumeFilesystem),
+			})
+			_, err = cdiClient.CdiV1beta1().StorageProfiles().Create(context.Background(), &sp, k8smetav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a storage profile that supports FS in both RWO and RWX")
+			sp.Name = "both"
+			sp.Status.ClaimPropertySets = append(sp.Status.ClaimPropertySets, v1beta1.ClaimPropertySet{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany, v1.ReadWriteOnce},
+				VolumeMode:  pointer.P(v1.PersistentVolumeFilesystem),
+			})
+			_, err = cdiClient.CdiV1beta1().StorageProfiles().Create(context.Background(), &sp, k8smetav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should default to RWX when no storage profile is defined", func() {
+			accessMode := backendStorage.getAccessMode("doesntexist", v1.PersistentVolumeFilesystem)
+			Expect(accessMode).To(Equal(v1.ReadWriteMany))
+		})
+
+		It("Should default to RWX when the storage profile doesn't have any access mode", func() {
+			accessMode := backendStorage.getAccessMode("nomode", v1.PersistentVolumeFilesystem)
+			Expect(accessMode).To(Equal(v1.ReadWriteMany))
+		})
+
+		It("Should pick RWX when both RWX and RWO are available", func() {
+			accessMode := backendStorage.getAccessMode("both", v1.PersistentVolumeFilesystem)
+			Expect(accessMode).To(Equal(v1.ReadWriteMany))
+		})
+
+		It("Should pick RWO when RWX isn't possible", func() {
+			accessMode := backendStorage.getAccessMode("onlyrwo", v1.PersistentVolumeFilesystem)
+			Expect(accessMode).To(Equal(v1.ReadWriteOnce))
+		})
+	})
+})

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -165,10 +165,11 @@ type VirtControllerApp struct {
 
 	controllerRevisionInformer cache.SharedIndexInformer
 
-	dataVolumeInformer cache.SharedIndexInformer
-	dataSourceInformer cache.SharedIndexInformer
-	cdiInformer        cache.SharedIndexInformer
-	cdiConfigInformer  cache.SharedIndexInformer
+	dataVolumeInformer     cache.SharedIndexInformer
+	dataSourceInformer     cache.SharedIndexInformer
+	storageProfileInformer cache.SharedIndexInformer
+	cdiInformer            cache.SharedIndexInformer
+	cdiConfigInformer      cache.SharedIndexInformer
 
 	migrationController *MigrationController
 	migrationInformer   cache.SharedIndexInformer
@@ -382,6 +383,7 @@ func Execute() {
 		app.cdiInformer = app.informerFactory.CDI()
 		app.cdiConfigInformer = app.informerFactory.CDIConfig()
 		app.dataSourceInformer = app.informerFactory.DataSource()
+		app.storageProfileInformer = app.informerFactory.StorageProfile()
 		log.Log.Infof("CDI detected, DataVolume integration enabled")
 	} else {
 		// Add a dummy DataVolume informer in the event datavolume support
@@ -391,6 +393,7 @@ func Execute() {
 		app.cdiInformer = app.informerFactory.DummyCDI()
 		app.cdiConfigInformer = app.informerFactory.DummyCDIConfig()
 		app.dataSourceInformer = app.informerFactory.DummyDataSource()
+		app.storageProfileInformer = app.informerFactory.DummyStorageProfile()
 		log.Log.Infof("CDI not detected, DataVolume integration disabled")
 	}
 
@@ -627,6 +630,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.vmiRecorder,
 		vca.clientSet,
 		vca.dataVolumeInformer,
+		vca.storageProfileInformer,
 		vca.cdiInformer,
 		vca.cdiConfigInformer,
 		vca.clusterConfig,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -98,6 +98,7 @@ var _ = Describe("Application", func() {
 		crInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 		dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		dataSourceInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataSource{})
+		storageProfileInformer, _ := testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 		cdiInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		cdiConfigInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		rsInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceReplicaSet{})
@@ -135,6 +136,7 @@ var _ = Describe("Application", func() {
 			recorder,
 			virtClient,
 			dataVolumeInformer,
+			storageProfileInformer,
 			cdiInformer,
 			cdiConfigInformer,
 			config,

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -171,7 +171,7 @@ func NewVMIController(templateService services.TemplateService,
 		clusterConfig:     clusterConfig,
 		topologyHinter:    topologyHinter,
 		cidsMap:           newCIDsMap(),
-		backendStorage:    backendstorage.NewBackendStorage(clientset, clusterConfig, storageClassInformer.GetStore(), storageProfileInformer.GetStore()),
+		backendStorage:    backendstorage.NewBackendStorage(clientset, clusterConfig, storageClassInformer.GetStore(), storageProfileInformer.GetStore(), pvcInformer.GetIndexer()),
 	}
 
 	c.hasSynced = func() bool {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -147,6 +147,7 @@ func NewVMIController(templateService services.TemplateService,
 	recorder record.EventRecorder,
 	clientset kubecli.KubevirtClient,
 	dataVolumeInformer cache.SharedIndexInformer,
+	storageProfileInformer cache.SharedIndexInformer,
 	cdiInformer cache.SharedIndexInformer,
 	cdiConfigInformer cache.SharedIndexInformer,
 	clusterConfig *virtconfig.ClusterConfig,
@@ -170,11 +171,13 @@ func NewVMIController(templateService services.TemplateService,
 		clusterConfig:     clusterConfig,
 		topologyHinter:    topologyHinter,
 		cidsMap:           newCIDsMap(),
-		backendStorage:    backendstorage.NewBackendStorage(clientset, clusterConfig, storageClassInformer.GetStore()),
+		backendStorage:    backendstorage.NewBackendStorage(clientset, clusterConfig, storageClassInformer.GetStore(), storageProfileInformer.GetStore()),
 	}
 
 	c.hasSynced = func() bool {
-		return vmInformer.HasSynced() && vmiInformer.HasSynced() && podInformer.HasSynced() && dataVolumeInformer.HasSynced() && cdiConfigInformer.HasSynced() && cdiInformer.HasSynced() && pvcInformer.HasSynced() && storageClassInformer.HasSynced()
+		return vmInformer.HasSynced() && vmiInformer.HasSynced() && podInformer.HasSynced() &&
+			dataVolumeInformer.HasSynced() && cdiConfigInformer.HasSynced() && cdiInformer.HasSynced() &&
+			pvcInformer.HasSynced() && storageClassInformer.HasSynced() && storageProfileInformer.HasSynced()
 	}
 
 	_, err := vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -578,6 +578,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pvc := NewPvc(vmi.Namespace, backendstorage.PVCForVMI(vmi))
 				pvc.Status.Phase = k8sv1.ClaimPending
 				pvc.Spec.StorageClassName = pointer.P("testsc123")
+				pvc.Spec.AccessModes = []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteMany}
 				addDataVolumePVC(pvc)
 
 				controller.Execute()
@@ -598,6 +599,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pvc := NewPvc(vmi.Namespace, backendstorage.PVCForVMI(vmi))
 				pvc.Status.Phase = k8sv1.ClaimPending
 				pvc.Spec.StorageClassName = pointer.P("testsc456")
+				pvc.Spec.AccessModes = []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteMany}
 				addDataVolumePVC(pvc)
 
 				controller.Execute()

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -259,6 +259,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachine{}, kvcontroller.GetVirtualMachineInformerIndexers())
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		dataVolumeInformer, _ = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
+		storageProfileInformer, _ := testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 
@@ -285,6 +286,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			recorder,
 			virtClient,
 			dataVolumeInformer,
+			storageProfileInformer,
 			cdiInformer,
 			cdiConfigInformer,
 			config,

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/safepath:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "backendstorage.go",
         "datavolume.go",
         "events.go",
         "export.go",
@@ -22,9 +23,11 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/tests/storage/backendstorage.go
+++ b/tests/storage/backendstorage.go
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Contributors
+ *
+ */
+
+package storage
+
+import (
+	"context"
+
+	"kubevirt.io/kubevirt/pkg/controller"
+
+	"kubevirt.io/kubevirt/tests/libnet"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = SIGDescribe("[Serial]Backend Storage", Serial, func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		virtClient = kubevirt.Client()
+	})
+
+	// TODO: create a RequiresRWXFilesystemStorage decorator to remove the skip?
+	It("Should use RWO when RWX is not supported", func() {
+		var storageClass string
+
+		By("Finding a storage class that only supports filesystem in RWO")
+		sps, err := virtClient.CdiClient().CdiV1beta1().StorageProfiles().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred()) // Assumes CDI is present. Should we also add a decorator for that?
+		for _, sp := range sps.Items {
+			fsrwo := false
+			fsrwx := false
+			for _, property := range sp.Status.ClaimPropertySets {
+				if property.VolumeMode == nil || *property.VolumeMode != corev1.PersistentVolumeFilesystem || property.AccessModes == nil {
+					continue
+				}
+				for _, accessMode := range property.AccessModes {
+					switch accessMode {
+					case corev1.ReadWriteMany:
+						fsrwx = true
+					case corev1.ReadWriteOnce:
+						fsrwo = true
+					}
+				}
+			}
+			if fsrwo && !fsrwx && sp.Status.StorageClass != nil {
+				storageClass = *sp.Status.StorageClass
+				break
+			}
+		}
+		if storageClass == "" {
+			Skip("Failed to find a suitable storage class") // See TODO above
+		}
+
+		By("Setting the VM storage class to it")
+		kv := util.GetCurrentKv(virtClient)
+		kv.Spec.Configuration.VMStateStorageClass = storageClass
+		tests.UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
+
+		By("Creating a VMI with persistent TPM")
+		vmi := libvmifact.NewCirros(
+			libnet.WithMasqueradeNetworking()...,
+		)
+		vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+
+		By("Expecting the creation of a backend storage PVC with the right storage class")
+		pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).Get(context.Background(), backendstorage.PVCForVMI(vmi), metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvc.Spec.StorageClassName).NotTo(BeNil())
+		Expect(*pvc.Spec.StorageClassName).To(Equal(storageClass))
+		Expect(pvc.Status.AccessModes).To(HaveLen(1))
+		Expect(pvc.Status.AccessModes[0]).To(Equal(corev1.ReadWriteOnce))
+
+		By("Expecting the VMI to be non-migratable")
+		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		cond := controller.NewVirtualMachineInstanceConditionManager().GetCondition(vmi, v1.VirtualMachineInstanceIsMigratable)
+		Expect(cond).NotTo(BeNil(), "LiveMigratable condition not found")
+		Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(v1.VirtualMachineInstanceReasonDisksNotMigratable))
+		Expect(cond.Message).To(ContainSubstring("Backend storage PVC is not RWX"))
+	})
+})


### PR DESCRIPTION
### What this PR does
Before this PR:
- Using backend storage (i.e. persistent TPM and/or UEFI) requires setting a storage class in the CR
- The storage class has to support RWX Filesystem mode

After this PR:
- The default storage class will be used if none is specified in the CR
- If that storage class has a storage profile that indicates it only supports Filesystem in RWO then a RWO PVC will be created and the VMI will be marked as non-migratable.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:
A VMI status field was added for virt-controller to let virt-handler know that the backend storage PVC is RWO.

The following alternatives were considered:
Having virt-handler check if the PVC is RWX or RWO but virt-handler currently has no PVC informer.
Having virt-controller add the non-migratable condition, but that would require changing the logic in virt-handler.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Backend storage now keeps a cache of which storage class supports which access mode, since it's quite expensive to figure out.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Persistent TPM/UEFI will use the default storage class if none is specified in the CR.
```

