### PR TITLE
Don't timeout assertion

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1062,7 +1062,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with hugepages", func() {
 			var hugepagesVmi *v1.VirtualMachineInstance
 
-			verifyHugepagesConsumption := func() bool {
+			verifyHugepagesConsumption := func() {
 				// TODO: we need to check hugepages state via node allocated resources, but currently it has the issue
 				// https://github.com/kubernetes/kubernetes/issues/64691
 				pods, err := virtClient.CoreV1().Pods(hugepagesVmi.Namespace).List(context.Background(), tests.UnfinishedVMIPodSelector(hugepagesVmi))
@@ -1110,10 +1110,10 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					vmMemory = *hugepagesVmi.Spec.Domain.Memory.Guest
 				}
 
-				if vmHugepagesConsumption == vmMemory.Value() {
-					return true
-				}
-				return false
+				Expect(vmHugepagesConsumption).To(Equal(vmMemory.Value()),
+					fmt.Sprintf("%d total HP, %d free HP, %d resv HP, %d size", totalHugepages, freeHugepages, resvHugepages, hugepagesSize.Value()),
+				)
+
 			}
 			BeforeEach(func() {
 				hugepagesVmi = libvmifact.NewCirros()
@@ -1164,7 +1164,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				libwait.WaitForSuccessfulVMIStart(hugepagesVmi)
 
 				By("Checking that the VM memory equals to a number of consumed hugepages")
-				Eventually(func() bool { return verifyHugepagesConsumption() }, 30*time.Second, 5*time.Second).Should(BeTrue())
+				verifyHugepagesConsumption()
 			},
 				Entry("[Serial][test_id:1671]hugepages-2Mi", Serial, "2Mi", "64Mi", "None"),
 				Entry("[Serial][test_id:1672]hugepages-1Gi", Serial, "1Gi", "1Gi", "None"),


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
It is most likely that assertion doesn't
have enough time to finish within 30 seconds.

Let's see if this really needs to be wrapped
in Eventually.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

