### PR TITLE
Adding Eddy as a sig-network approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,6 +69,7 @@ aliases:
     - ormergi
   sig-network-approvers:
     - AlonaKaplan
+    - EdDev
 
   #
   # SIG Scale


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Edward is a core developer in the kubevirt network team,  
he sent more than 250 PRs to kubevirt and reviewed more than 750.

He pays close attention to the broad picture, clean code, project conventions and CI limitations . His reviews are comprehensive.

He certainly deserves to be a network approver.

Before this PR:
Eddy wasn't sig-network approver.

After this PR:
Eddy is a sig-network approver.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

The following apply to the part of project for which one would be an approver in the [OWNERS_ALIASES](https://github.com/kubevirt/kubevirt/tree/main/OWNERS_ALIASES) file.

- [x] Reviewer of the project for at least 3 months
- [x] Primary reviewer for at least 10 substantial PRs to the project
- [x] Reviewed or merged at least 30 PRs to the project
- [x] Nominated by an approver
- [x] With no objections from other approvers
- [x] Done through PR to update the top-level OWNERS file

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

