### PR TITLE
e2e suite: slight improvement to developer experience

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -45,8 +45,6 @@ const (
 	vmAPIGroup = "kubevirt.io"
 )
 
-type loginFunction func(*virtv1.VirtualMachineInstance) error
-
 var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -189,7 +187,7 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 		}, 3*time.Minute, 3*time.Second).Should(Equal(clonev1alpha1.Succeeded), "clone should finish successfully")
 	}
 
-	expectVMRunnable := func(vm *virtv1.VirtualMachine, login loginFunction) *virtv1.VirtualMachine {
+	expectVMRunnable := func(vm *virtv1.VirtualMachine, login console.LoginToFunction) *virtv1.VirtualMachine {
 		By(fmt.Sprintf("Starting VM %s", vm.Name))
 		vm = StartVirtualMachine(vm)
 		targetVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, v1.GetOptions{})

--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -23,10 +23,10 @@ const (
 )
 
 // LoginToFunction represents any of the LoginTo* functions
-type LoginToFunction func(*v1.VirtualMachineInstance) error
+type LoginToFunction func(*v1.VirtualMachineInstance, ...time.Duration) error
 
 // LoginToCirros performs a console login to a Cirros base VM
-func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
+func LoginToCirros(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) error {
 	virtClient := kubevirt.Client()
 	expecter, _, err := NewExpecter(virtClient, vmi, connectionTimeout)
 	if err != nil {
@@ -55,7 +55,10 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 		&expect.BSnd{S: "gocubsgo\n"},
 		&expect.BExp{R: PromptExpression},
 	}
-	const loginTimeout = 180 * time.Second
+	loginTimeout := 180 * time.Second
+	if len(timeout) > 0 {
+		loginTimeout = timeout[0]
+	}
 	resp, err := expecter.ExpectBatch(b, loginTimeout)
 
 	if err != nil {
@@ -71,7 +74,7 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 }
 
 // LoginToAlpine performs a console login to an Alpine base VM
-func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
+func LoginToAlpine(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) error {
 	virtClient := kubevirt.Client()
 
 	expecter, _, err := NewExpecter(virtClient, vmi, connectionTimeout)
@@ -103,7 +106,10 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
 		&expect.BSnd{S: "root\n"},
 		&expect.BExp{R: PromptExpression},
 	}
-	const loginTimeout = 180 * time.Second
+	loginTimeout := 180 * time.Second
+	if len(timeout) > 0 {
+		loginTimeout = timeout[0]
+	}
 	res, err := expecter.ExpectBatch(b, loginTimeout)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Reason(err).Errorf("Login failed: %+v", res)
@@ -118,7 +124,7 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
 }
 
 // LoginToFedora performs a console login to a Fedora base VM
-func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
+func LoginToFedora(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) error {
 	virtClient := kubevirt.Client()
 
 	// TODO: This is temporary workaround for issue seen in CI
@@ -183,7 +189,10 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 		&expect.BSnd{S: "sudo su\n"},
 		&expect.BExp{R: PromptExpression},
 	}
-	const loginTimeout = 2 * time.Minute
+	loginTimeout := 2 * time.Minute
+	if len(timeout) > 0 {
+		loginTimeout = timeout[0]
+	}
 	res, err := expecter.ExpectBatch(b, loginTimeout)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Reason(err).Errorf("Login attempt failed: %+v", res)

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1255,7 +1255,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				libstorage.DeleteDataVolume(&dv)
 			})
 
-			DescribeTable("should migrate root implementation to nonroot", func(createVMI func() *v1.VirtualMachineInstance, loginFunc func(*v1.VirtualMachineInstance) error) {
+			DescribeTable("should migrate root implementation to nonroot", func(createVMI func() *v1.VirtualMachineInstance, loginFunc console.LoginToFunction) {
 				By("Create a VMI that will run root(default)")
 				vmi := createVMI()
 
@@ -1343,7 +1343,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				}
 			})
 
-			DescribeTable("should migrate nonroot implementation to root", func(createVMI func() *v1.VirtualMachineInstance, loginFunc func(*v1.VirtualMachineInstance) error) {
+			DescribeTable("should migrate nonroot implementation to root", func(createVMI func() *v1.VirtualMachineInstance, loginFunc console.LoginToFunction) {
 				By("Create a VMI that will run root(default)")
 				vmi := createVMI()
 				// force VMI on privileged namespace since we will be migrating to a root VMI

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1092,7 +1092,8 @@ func (r *KubernetesReporter) dumpK8sEntityToFile(virtCli kubecli.KubevirtClient,
 
 	response, err := virtCli.RestClient().Get().RequestURI(requestURI).Do(context.Background()).Raw()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "dump %s: %v\n", entityName, err)
+		// If a cluster doesn't support network-attachment-definitions (the only thing this function is used for),
+		// logging an error here would spam the logs.
 		return
 	}
 

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1188,13 +1188,15 @@ func getVmiType(vmi v12.VirtualMachineInstance) (string, error) {
 }
 
 func prepareVmiConsole(vmi v12.VirtualMachineInstance, vmiType string) error {
+	// 20 seconds is plenty here. If the VMI is not ready for login, there's a low chance it has interesting logs
+	timeout := 20 * time.Second
 	switch vmiType {
 	case "fedora":
-		return console.LoginToFedora(&vmi)
+		return console.LoginToFedora(&vmi, timeout)
 	case "cirros":
-		return console.LoginToCirros(&vmi)
+		return console.LoginToCirros(&vmi, timeout)
 	case "alpine":
-		return console.LoginToAlpine(&vmi)
+		return console.LoginToAlpine(&vmi, timeout)
 	default:
 		return fmt.Errorf("unknown vmi %s type", vmi.ObjectMeta.Name)
 	}

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -47,7 +47,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-func waitForVMIRebooted(vmi *v1.VirtualMachineInstance, login func(vmi *v1.VirtualMachineInstance) error) {
+func waitForVMIRebooted(vmi *v1.VirtualMachineInstance, login console.LoginToFunction) {
 	By(fmt.Sprintf("Waiting for vmi %s rebooted", vmi.Name))
 	if vmi.Namespace == "" {
 		vmi.Namespace = testsuite.GetTestNamespace(vmi)


### PR DESCRIPTION
### What this PR does
Before this PR:
Developers running functional tests locally sometimes have to wait multiple time 3 minutes waiting for the log collector to fail to login to some VMI(s).
Those who use a lightweight cluster without things like CNAO also keep seeing:
dump network-attachment-definitions: the server could not find the requested resource

After this PR:
When collecting logs, we only try to login to VMIs for 20 seconds, which might still be too long.
That message about NADs is also removed.

### Special notes for your reviewer
Just a convenience PR, but the shorter timeout might actually improve lane runtime

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

