### PR TITLE
Adding newMacAddresses validatewebhook for  VMCloneAPI

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/instancetype:go_default_library",
         "//pkg/monitoring/metrics/virt-api:go_default_library",
         "//pkg/network/admitter:go_default_library",
+        "//pkg/network/link:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/snapshot:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -378,6 +378,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			Entry("negation in the beginning", "!mykey/something"),
 		)
 	})
+
 	Context("Template Annotations and labels filters", func() {
 		testFilter := func(filter string, expectAllowed bool) {
 			vmClone.Spec.Template.LabelFilters = []string{filter}
@@ -404,6 +405,16 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			Entry("templateFilter negation in the beginning", "!mykey/something"),
 		)
 	})
+
+	DescribeTable("newMacAddresses", func(mac string, expectAllowed bool) {
+		vmClone.Spec.NewMacAddresses = map[string]string{
+			"default": mac,
+		}
+		admitter.admitAndExpect(vmClone, expectAllowed)
+	},
+		Entry("valid mac address", "00:00:00:00:00:00", true),
+		Entry("invalid mac address", "00:00:00:00:00", false),
+	)
 
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
we have no validatewebhook for newMacAddresses and we can set invalid mac address
```yaml
kind: VirtualMachineClone
apiVersion: "clone.kubevirt.io/v1alpha1"
metadata:
  name: testclone
spec:
  newMacAddresses:
    interfaceName: "00-11-22"
```
After this PR:
only the valid mac address to be deployed.

```yaml
kind: VirtualMachineClone
apiVersion: "clone.kubevirt.io/v1alpha1"
metadata:
  name: testclone
spec:
  newMacAddresses:
    interfaceName: "00:11:22:33:44:55"
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding newMacAddresses validatewebhook for  VMCloneAPI
```

