### PR TITLE
Start dropping lambdas from operator.go

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -125,7 +125,6 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 	var vmYamls map[string]*vmYamlDefinition
 
 	var (
-		copyOriginalCDI                        func() *cdiv1.CDI
 		copyOriginalKv                         func() *v1.KubeVirt
 		createKv                               func(*v1.KubeVirt)
 		createCdi                              func()
@@ -174,19 +173,6 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 		k8sClient = clientcmd.GetK8sCmdClient()
 
-		copyOriginalCDI = func() *cdiv1.CDI {
-			newCDI := &cdiv1.CDI{
-				Spec: *originalCDI.Spec.DeepCopy(),
-			}
-			newCDI.Name = originalCDI.Name
-			newCDI.Namespace = originalCDI.Namespace
-			newCDI.ObjectMeta.Labels = originalCDI.ObjectMeta.Labels
-			newCDI.ObjectMeta.Annotations = originalCDI.ObjectMeta.Annotations
-
-			return newCDI
-
-		}
-
 		copyOriginalKv = func() *v1.KubeVirt {
 			newKv := &v1.KubeVirt{
 				Spec: *originalKv.Spec.DeepCopy(),
@@ -208,7 +194,17 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		}
 
 		createCdi = func() {
-			_, err = virtClient.CdiClient().CdiV1beta1().CDIs().Create(context.Background(), copyOriginalCDI(), metav1.CreateOptions{})
+			newCDI := &cdiv1.CDI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        originalCDI.Name,
+					Namespace:   originalCDI.Namespace,
+					Labels:      originalCDI.ObjectMeta.Labels,
+					Annotations: originalCDI.ObjectMeta.Annotations,
+				},
+				Spec: *originalCDI.Spec.DeepCopy(),
+			}
+
+			_, err = virtClient.CdiClient().CdiV1beta1().CDIs().Create(context.Background(), newCDI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {


### PR DESCRIPTION
### What this PR does
Get rid of several lambda functions from tests/operator/operator.go

### Why we need it and why it was done in this way
operator.go is a single file in its package. There is no reason to use lambdas there, because there is no risk for naming pollution, as there are no other files in this package.

Some of the functions are only used once - then this PR drops them and copies their logic to the relevant tests. Other lambdas are now regular functions.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

