### PR TITLE
tests: Extract GetCertsForPods (and related functions) from utils

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -44,8 +44,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
-        "//vendor/k8s.io/client-go/tools/portforward:go_default_library",
-        "//vendor/k8s.io/client-go/transport/spdy:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],

--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//tests/libmonitoring:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnode:go_default_library",
+        "//tests/libpod:go_default_library",
         "//tests/libreplicaset:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/libwait:go_default_library",

--- a/tests/infrastructure/certificates.go
+++ b/tests/infrastructure/certificates.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/libinfra"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -150,14 +151,14 @@ var _ = DescribeInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][leve
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			apiCerts, err := tests.GetCertsForPods(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
+			apiCerts, err := libpod.GetCertsForPods(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
 			Expect(err).ToNot(HaveOccurred())
 			if !hasIdenticalCerts(apiCerts) {
 				return false
 			}
 			newAPICert := apiCerts[0]
 
-			handlerCerts, err := tests.GetCertsForPods(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
+			handlerCerts, err := libpod.GetCertsForPods(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
 			Expect(err).ToNot(HaveOccurred())
 			if !hasIdenticalCerts(handlerCerts) {
 				return false

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libpod"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
@@ -92,7 +93,7 @@ var _ = DescribeInfra("tls configuration", func() {
 			func(i int, pod k8sv1.Pod) {
 				stopChan := make(chan struct{})
 				defer close(stopChan)
-				Expect(tests.ForwardPorts(&pod, []string{fmt.Sprintf("844%d:%d", i, 8443)}, stopChan, 10*time.Second)).To(Succeed())
+				Expect(libpod.ForwardPorts(&pod, []string{fmt.Sprintf("844%d:%d", i, 8443)}, stopChan, 10*time.Second)).To(Succeed())
 
 				acceptedTLSConfig := &tls.Config{
 					InsecureSkipVerify: true,

--- a/tests/libpod/BUILD.bazel
+++ b/tests/libpod/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "blackhole.go",
+        "certs.go",
         "container.go",
         "query.go",
         "render.go",
@@ -14,12 +15,16 @@ go_library(
     deps = [
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libregistry:go_default_library",
         "//tests/testsuite:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/portforward:go_default_library",
+        "//vendor/k8s.io/client-go/transport/spdy:go_default_library",
     ],
 )

--- a/tests/libpod/certs.go
+++ b/tests/libpod/certs.go
@@ -1,0 +1,145 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package libpod
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+)
+
+// GetCertsForPods returns the used certificates for all pods matching  the label selector
+func GetCertsForPods(labelSelector string, namespace string, port string) ([][]byte, error) {
+	cli := kubevirt.Client()
+	pods, err := cli.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(pods.Items).ToNot(BeEmpty())
+
+	var certs [][]byte
+
+	for _, pod := range pods.Items {
+		err := func() error {
+			certs = append(certs, getCert(&pod, port))
+			return nil
+		}()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return certs, nil
+}
+
+func getCert(pod *k8sv1.Pod, port string) []byte {
+	randPort := strconv.Itoa(4321 + rand.Intn(6000))
+	var rawCert []byte
+	mutex := &sync.Mutex{}
+	conf := &tls.Config{
+		InsecureSkipVerify: true,
+		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			mutex.Lock()
+			defer mutex.Unlock()
+			rawCert = rawCerts[0]
+			return nil
+		},
+	}
+
+	var certificate []byte
+	EventuallyWithOffset(2, func() []byte {
+		stopChan := make(chan struct{})
+		defer close(stopChan)
+		err := ForwardPorts(pod, []string{fmt.Sprintf("%s:%s", randPort, port)}, stopChan, 10*time.Second)
+		ExpectWithOffset(2, err).ToNot(HaveOccurred())
+
+		conn, err := tls.Dial("tcp4", fmt.Sprintf("localhost:%s", randPort), conf)
+		if err == nil {
+			defer conn.Close()
+		}
+		mutex.Lock()
+		defer mutex.Unlock()
+		certificate = make([]byte, len(rawCert))
+		copy(certificate, rawCert)
+		return certificate
+	}, 40*time.Second, 1*time.Second).Should(Not(BeEmpty()))
+
+	return certificate
+}
+
+func ForwardPorts(pod *k8sv1.Pod, ports []string, stop chan struct{}, readyTimeout time.Duration) error {
+	errChan := make(chan error, 1)
+	readyChan := make(chan struct{})
+	go func() {
+		cli := kubevirt.Client()
+
+		req := cli.CoreV1().RESTClient().Post().
+			Resource("pods").
+			Namespace(pod.Namespace).
+			Name(pod.Name).
+			SubResource("portforward")
+
+		kubevirtClientConfig, err := kubecli.GetKubevirtClientConfig()
+		if err != nil {
+			errChan <- err
+			return
+		}
+		transport, upgrader, err := spdy.RoundTripperFor(kubevirtClientConfig)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+		forwarder, err := portforward.New(dialer, ports, stop, readyChan, GinkgoWriter, GinkgoWriter)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		err = forwarder.ForwardPorts()
+		if err != nil {
+			errChan <- err
+		}
+	}()
+
+	select {
+	case err := <-errChan:
+		return err
+	case <-readyChan:
+		return nil
+	case <-time.After(readyTimeout):
+		return fmt.Errorf("failed to forward ports, timed out")
+	}
+}

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1493,7 +1493,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 							defer wg.Done()
 							stopChan := make(chan struct{})
 							defer close(stopChan)
-							Expect(tests.ForwardPorts(handler, []string{fmt.Sprintf("4321%d:%d", i, port)}, stopChan, 10*time.Second)).To(Succeed())
+							Expect(libpod.ForwardPorts(handler, []string{fmt.Sprintf("4321%d:%d", i, port)}, stopChan, 10*time.Second)).To(Succeed())
 							_, err := tls.Dial("tcp", fmt.Sprintf("localhost:4321%d", i), tlsConfig)
 							Expect(err).To(HaveOccurred())
 							errors <- err
@@ -1573,7 +1573,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 							defer wg.Done()
 							stopChan := make(chan struct{})
 							defer close(stopChan)
-							Expect(tests.ForwardPorts(handler, []string{fmt.Sprintf("4321%d:%d", i, port)}, stopChan, 10*time.Second)).To(Succeed())
+							Expect(libpod.ForwardPorts(handler, []string{fmt.Sprintf("4321%d:%d", i, port)}, stopChan, 10*time.Second)).To(Succeed())
 							conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:4321%d", i), tlsConfig)
 							if conn != nil {
 								b := make([]byte, 1)

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -3288,7 +3288,7 @@ func verifyOperatorWebhookCertificate() {
 	certPool.AppendCertsFromPEM(caBundle)
 	// ensure that the state is fully restored before each test
 	Eventually(func() error {
-		currentCert, err := tests.GetCertsForPods(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-operator"), flags.KubeVirtInstallNamespace, "8444")
+		currentCert, err := libpod.GetCertsForPods(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-operator"), flags.KubeVirtInstallNamespace, "8444")
 		Expect(err).ToNot(HaveOccurred())
 		crt, err := x509.ParseCertificate(currentCert[0])
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Extract functions from utils, to reduce utils size.
Fix linter problems (since we moved the function to a new file, which is now scanned).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

