### PR TITLE
Fix: IsKubeVirtServiceAccount reads the namespaces everytime requested

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -31,11 +31,6 @@ import (
 	"syscall"
 	"time"
 
-	"k8s.io/kube-openapi/pkg/common/restfuladapter"
-	"k8s.io/kube-openapi/pkg/validation/spec"
-
-	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
-
 	restful "github.com/emicklei/go-restful/v3"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	flag "github.com/spf13/pflag"
@@ -46,16 +41,14 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	builderv3 "k8s.io/kube-openapi/pkg/builder3"
-
-	"kubevirt.io/kubevirt/pkg/util/ratelimiter"
-
+	"k8s.io/kube-openapi/pkg/common/restfuladapter"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 	v1 "kubevirt.io/api/core/v1"
+	v12 "kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	clientutil "kubevirt.io/client-go/util"
 	virtversion "kubevirt.io/client-go/version"
-
-	v12 "kubevirt.io/client-go/api"
 
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/controller"
@@ -67,6 +60,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/openapi"
+	"kubevirt.io/kubevirt/pkg/util/ratelimiter"
+	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 	"kubevirt.io/kubevirt/pkg/virt-api/definitions"
 	"kubevirt.io/kubevirt/pkg/virt-api/rest"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"

--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//staging/src/kubevirt.io/client-go/util:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
@@ -152,7 +151,7 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 		// TODO: As soon as CRDs support field selectors we can remove this and just enable
 		// the status subresource. Until then we need to update Status and Metadata labels in parallel for e.g. Migrations.
 		if !equality.Semantic.DeepEqual(newVMI.Status, oldVMI.Status) {
-			if !webhooks.IsKubeVirtServiceAccount(ar.Request.UserInfo.Username) {
+			if !webhooks.IsKubeVirtServiceAccount(ar.Request.Namespace, ar.Request.UserInfo.Username) {
 				patchOps = append(patchOps, patch.PatchOperation{
 					Op:    "replace",
 					Path:  "/status",

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -25,14 +25,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
-
+	v1 "kubevirt.io/api/core/v1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
-	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
-
-	v1 "kubevirt.io/api/core/v1"
-	clientutil "kubevirt.io/client-go/util"
 )
 
 var Arch = runtime.GOARCH
@@ -80,16 +76,16 @@ type Informers struct {
 	NamespaceInformer  cache.SharedIndexInformer
 }
 
-func IsKubeVirtServiceAccount(serviceAccount string) bool {
-	ns, err := clientutil.GetNamespace()
-	logger := log.DefaultLogger()
+func IsKubeVirtServiceAccount(namespace string, serviceAccount string) bool {
+	// ns, err := clientutil.GetNamespace()
+	// logger := log.DefaultLogger()
 
-	if err != nil {
-		logger.Info("Failed to get namespace. Fallback to default: 'kubevirt'")
-		ns = "kubevirt"
-	}
+	// if err != nil {
+	// 	logger.Info("Failed to get namespace. Fallback to default: 'kubevirt'")
+	// 	ns = "kubevirt"
+	// }
 
-	prefix := fmt.Sprintf("system:serviceaccount:%s", ns)
+	prefix := fmt.Sprintf("system:serviceaccount:%s", namespace)
 	return serviceAccount == fmt.Sprintf("%s:%s", prefix, components.ApiServiceAccountName) ||
 		serviceAccount == fmt.Sprintf("%s:%s", prefix, components.HandlerServiceAccountName) ||
 		serviceAccount == fmt.Sprintf("%s:%s", prefix, components.ControllerServiceAccountName)

--- a/pkg/virt-api/webhooks/utils_test.go
+++ b/pkg/virt-api/webhooks/utils_test.go
@@ -28,11 +28,11 @@ import (
 
 var _ = Describe("IsKubeVirtServiceAccount", func() {
 	It("rejects an invalid service account", func() {
-		Expect(webhooks.IsKubeVirtServiceAccount("invalid:service:account")).To(BeFalse())
+		Expect(webhooks.IsKubeVirtServiceAccount("", "invalid:service:account")).To(BeFalse())
 	})
 	It("recognizes all KubeVirt service accounts", func() {
-		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:kubevirt-apiserver")).To(BeTrue())
-		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:kubevirt-controller")).To(BeTrue())
-		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:kubevirt-handler")).To(BeTrue())
+		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:namespace", "system:serviceaccount:kubevirt:kubevirt-apiserver")).To(BeTrue())
+		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:namespace", "system:serviceaccount:kubevirt:kubevirt-controller")).To(BeTrue())
+		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:namespace", "system:serviceaccount:kubevirt:kubevirt-handler")).To(BeTrue())
 	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
@@ -100,7 +99,8 @@ func ValidateVMPoolSpec(ar *admissionv1.AdmissionReview, field *k8sfield.Path, p
 	}
 
 	accountName := ar.Request.UserInfo.Username
-	causes = append(causes, ValidateVirtualMachineSpec(field.Child("virtualMachineTemplate", "spec"), &spec.VirtualMachineTemplate.Spec, config, accountName)...)
+	namespace := ar.Request.Namespace
+	causes = append(causes, ValidateVirtualMachineSpec(field.Child("virtualMachineTemplate", "spec"), &spec.VirtualMachineTemplate.Spec, config, accountName, namespace)...)
 
 	selector, err := metav1.LabelSelectorAsSelector(spec.Selector)
 	if err != nil {


### PR DESCRIPTION
### What this PR does

Before this PR:

The function `IsKubeVirtServiceAccount()` reads the namespace every time it is invoked.


After this PR:

`IsKubeVirtServiceAccount()` function does not read the namespace, rather then use the namespace invoked during VMI startup. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11177

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note 
NONE
```

