### PR TITLE
Fix: UserDataSecretRef was incorrectly coding to secretRef

### DIFF
--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -134,7 +134,7 @@ type SysprepSource struct {
 type CloudInitNoCloudSource struct {
 	// UserDataSecretRef references a k8s secret that contains NoCloud userdata.
 	// + optional
-	UserDataSecretRef *v1.LocalObjectReference `json:"secretRef,omitempty"`
+	UserDataSecretRef *v1.LocalObjectReference `json:"userDataSecretRef,omitempty"`
 	// UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.
 	// + optional
 	UserDataBase64 string `json:"userDataBase64,omitempty"`


### PR DESCRIPTION
### What this PR does
Before this PR:
`UserDataSecretRef` is inconsistent with other CloudInitNoCloudSource labels as `secretRef`.

After this PR:
`UserDataSecretRef` will be consistent with other CloudInitNoCloudSource labels as `userDataSecretRef`.

### Why we need it and why it was done in this way
Convention for CloudInitNoCloudSource has the general form of:
```
UserData -> `userData`
NetworkData -> `networkData`
```
But the UserDataSecretRef is miscoded to just `secretRef`. Currently:
```
UserDataSecretRef -> `secretRef`
NetworkDataSecretRef -> `networkDataSecretRef`
```

This is inconsistent and is creating confusion in the documentation. [Here the secret is described](https://github.com/kubevirt/kubevirt/blob/main/docs/cloud-init.md) as `userDataSecretRef` which WILL NOT WORK until this PR is accepted. In [other documentation](https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#cloud-init-userdata-as-k8s-secret) the current operation is described correctly, but it is inconsistent with the rest of the CloudInitNoCloudSource naming convention.

Suggest this PR be accepted and the documentation in the User Guide be updated to userDataSecretRef instead of secretRef.

### Release note
```release-note
BREAKING CHANGE: The use of CloudInitNoCloudSource `secretRef` to reference a UserData secret must now be renamed to userDataSecretRef. This applies ONLY IF you are using a CloudInitNoCloudSource and `secretRef` key to set user data. A basic search and replace from secretRef to userDataSecretRef will accomplish this update.
```

