### PR TITLE
Restart required correctly propagate

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3155,13 +3155,15 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		}
 
 		if syncErr == nil {
-			if !equality.Semantic.DeepEqual(vm, vmCopy) {
+			if !equality.Semantic.DeepEqual(vm.Spec, vmCopy.Spec) || !equality.Semantic.DeepEqual(vm.ObjectMeta, vmCopy.ObjectMeta) {
 				updatedVm, err := c.clientset.VirtualMachine(vmCopy.Namespace).Update(context.Background(), vmCopy, metav1.UpdateOptions{})
 				if err != nil {
 					syncErr = &syncErrorImpl{fmt.Errorf("Error encountered when trying to update vm according to add volume and/or memory dump requests: %v", err), FailedUpdateErrorReason}
 				} else {
 					vm = updatedVm
 				}
+			} else {
+				vm = vmCopy
 			}
 		}
 	}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -306,8 +306,8 @@ func (c *VMController) execute(key string) error {
 		c.expectations.DeleteExpectations(key)
 		return nil
 	}
-	vm := obj.(*virtv1.VirtualMachine)
-	vm = vm.DeepCopy()
+	originalVM := obj.(*virtv1.VirtualMachine)
+	vm := originalVM.DeepCopy()
 
 	logger := log.Log.Object(vm)
 
@@ -390,7 +390,7 @@ func (c *VMController) execute(key string) error {
 		logger.Reason(syncErr).Error("Reconciling the VirtualMachine failed.")
 	}
 
-	err = c.updateStatus(vm, vmi, syncErr, logger)
+	err = c.updateStatus(vm, originalVM, vmi, syncErr, logger)
 	if err != nil {
 		logger.Reason(err).Error("Updating the VirtualMachine status failed.")
 		return err
@@ -2390,11 +2390,9 @@ func (c *VMController) syncGenerationInfo(vm *virtv1.VirtualMachine, vmi *virtv1
 	return nil
 }
 
-func (c *VMController) updateStatus(vmOrig *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, syncErr syncError, logger *log.FilteredLogger) error {
+func (c *VMController) updateStatus(vm, vmOrig *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, syncErr syncError, logger *log.FilteredLogger) error {
 	key := controller.VirtualMachineKey(vmOrig)
 	defer virtControllerVMWorkQueueTracer.StepTrace(key, "updateStatus", trace.Field{Key: "VM Name", Value: vmOrig.Name})
-
-	vm := vmOrig.DeepCopy()
 
 	created := vmi != nil
 	vm.Status.Created = created

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -6148,6 +6148,73 @@ var _ = Describe("VirtualMachine", func() {
 				}
 			})
 
+			It("should not call update if the condition is set", func() {
+				vm, vmi := DefaultVirtualMachine(true)
+				vm.Status.Conditions = append(vm.Status.Conditions, v1.VirtualMachineCondition{
+					Type:   v1.VirtualMachineInitialized,
+					Status: k8sv1.ConditionTrue,
+				})
+				vm.ObjectMeta.UID = types.UID(uuid.NewString())
+				vmi.ObjectMeta.UID = vm.ObjectMeta.UID
+				vm.Generation = 1
+				vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{
+					Cores: 2,
+				}
+				guest := resource.MustParse("128Mi")
+				vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
+					Guest: &guest,
+				}
+				kv := &v1.KubeVirt{
+					Spec: v1.KubeVirtSpec{
+						Configuration: v1.KubeVirtConfiguration{
+							LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{},
+							VMRolloutStrategy:       &liveUpdate,
+							DeveloperConfiguration: &v1.DeveloperConfiguration{
+								FeatureGates: []string{virtconfig.VMLiveUpdateFeaturesGate},
+							},
+						},
+					},
+				}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kv)
+
+				var maxSockets uint32 = 8
+
+				By("Setting a cluster-wide CPU maxSockets value")
+				kv.Spec.Configuration.LiveUpdateConfiguration.MaxCpuSockets = kvpointer.P(maxSockets)
+				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kv)
+
+				By("Creating a VM with CPU sockets set to the cluster maxiumum")
+				vm.Spec.Template.Spec.Domain.CPU.Sockets = maxSockets
+				crSource.Add(createVMRevision(vm))
+
+				By("Creating a VMI with cluster max")
+				vmi = controller.setupVMIFromVM(vm)
+				vmiSource.Add(vmi)
+				syncCache(controller.vmiIndexer)
+
+				By("Bumping the VM sockets above the cluster maximum")
+				vm.Spec.Template.Spec.Domain.CPU.Sockets = 10
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(vm)
+
+				virtFakeClient.PrependReactor("update", "virtualmachines", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					if action.GetSubresource() != "" {
+						return false, nil, nil
+					}
+
+					Fail("Update should not be called")
+					return true, &v1.VirtualMachine{}, fmt.Errorf("conflict")
+				})
+
+				By("Executing the controller expecting the RestartRequired condition to appear")
+				sanityExecute(vm)
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue))
+
+			})
+
 			It("should appear when changing a non-live-updatable field", func() {
 				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kv)
 
@@ -6198,10 +6265,9 @@ var _ = Describe("VirtualMachine", func() {
 
 				By("Executing the controller expecting the RestartRequired condition to appear")
 				sanityExecute(vm)
-				_, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).To(Succeed())
-				// TODO fix
-				// Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue), "restart required")
+				Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue), "restart required")
 			})
 
 			It("should appear when VM doesn't specify maxGuest and guest memory goes above cluster-wide maxGuest", func() {
@@ -6236,10 +6302,9 @@ var _ = Describe("VirtualMachine", func() {
 
 				By("Executing the controller expecting the RestartRequired condition to appear")
 				sanityExecute(vm)
-				_, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).To(Succeed())
-				// TODO fix
-				// Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue), "restart required")
+				Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue), "restart required")
 			})
 
 			DescribeTable("when changing a live-updatable field", func(fgs []string, strat *v1.VMRolloutStrategy, matcher gomegatypes.GomegaMatcher) {
@@ -6278,10 +6343,9 @@ var _ = Describe("VirtualMachine", func() {
 
 				By("Executing the controller expecting the RestartRequired condition to appear")
 				sanityExecute(vm)
-				_, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).To(Succeed())
-				// TODO fix
-				// Expect(vm.Status.Conditions).To(matcher, "restart Required")
+				Expect(vm.Status.Conditions).To(matcher, "restart Required")
 
 				if strat == &liveUpdate && len(fgs) > 0 {
 					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR fixes cases where RestartRequired condition is not propagated to Kubernetes API. The cause is `Update` call that should not be called when only `.Status` is changed (note if a change was made the condition will be missing). Also ensure that we detect a `.Status`  change in the `updateStatus`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: Correctly reflect RestartRequired condition
```

Based on https://github.com/kubevirt/kubevirt/pull/11726
