### PR TITLE
VMIM controller - move unit tests to fake client

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -192,7 +192,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -120,7 +120,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -659,25 +659,26 @@ var _ = Describe("Migration watcher", func() {
 
 			// Ensure that 4 migrations are there which are in non-final state
 			for i := 0; i < 4; i++ {
-				vmi := newVirtualMachine(fmt.Sprintf("testvmi%v", i), virtv1.Running)
-				addNodeNameToVMI(vmi, fmt.Sprintf("node%v", i))
-				migration := newMigration(fmt.Sprintf("testmigration%v", i), vmi.Name, virtv1.MigrationScheduling)
+				newVMI := newVirtualMachine(fmt.Sprintf("testvmi%v", i), virtv1.Running)
+				addNodeNameToVMI(newVMI, fmt.Sprintf("node%v", i))
+				migration := newMigration(fmt.Sprintf("testmigration%v", i), newVMI.Name, virtv1.MigrationScheduling)
 
 				addMigration(migration)
-				addVirtualMachineInstance(vmi)
+				addVirtualMachineInstance(newVMI)
 			}
 
 			// Add two pending migrations without a target pod to see that tye get ignored
 			for i := 0; i < 2; i++ {
-				vmi := newVirtualMachine(fmt.Sprintf("xtestvmi%v", i), virtv1.Running)
-				migration := newMigration(fmt.Sprintf("xtestmigration%v", i), vmi.Name, virtv1.MigrationPending)
-				addNodeNameToVMI(vmi, fmt.Sprintf("node%v", i))
+				newVMI := newVirtualMachine(fmt.Sprintf("xtestvmi%v", i), virtv1.Running)
+				migration := newMigration(fmt.Sprintf("xtestmigration%v", i), newVMI.Name, virtv1.MigrationPending)
+				addNodeNameToVMI(newVMI, fmt.Sprintf("node%v", i))
 
 				addMigration(migration)
-				addVirtualMachineInstance(vmi)
+				addVirtualMachineInstance(newVMI)
 			}
 
 			controller.Execute()
+
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 			expectPodCreation(vmi.Namespace, vmi.UID, migration.UID, 1, 0, 0)
 			for i := 0; i < 2; i++ {

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -31,9 +31,8 @@ import (
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
-
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
+	"kubevirt.io/kubevirt/pkg/pointer"
 
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 
@@ -1594,8 +1593,7 @@ var _ = Describe("Migration watcher", func() {
 	Context("Migration with protected VMI (PDB)", func() {
 		It("should update PDB before starting the migration", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			evictionStrategy := virtv1.EvictionStrategyLiveMigrate
-			vmi.Spec.EvictionStrategy = &evictionStrategy
+			vmi.Spec.EvictionStrategy = pointer.P(virtv1.EvictionStrategyLiveMigrate)
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 			pdb := newPDB("pdb-test", vmi, 1)
 
@@ -1611,8 +1609,7 @@ var _ = Describe("Migration watcher", func() {
 		})
 		It("should create the target Pod after the k8s PDB controller processed the PDB mutation", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			evictionStrategy := virtv1.EvictionStrategyLiveMigrate
-			vmi.Spec.EvictionStrategy = &evictionStrategy
+			vmi.Spec.EvictionStrategy = pointer.P(virtv1.EvictionStrategyLiveMigrate)
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
 			pdb := newPDB("pdb-test", vmi, 2)
 			pdb.Generation = 42
@@ -1636,8 +1633,7 @@ var _ = Describe("Migration watcher", func() {
 
 		Context("when cluster EvictionStrategy is set to 'LiveMigrate'", func() {
 			BeforeEach(func() {
-				evictionStrategy := virtv1.EvictionStrategyLiveMigrate
-				initController(&virtv1.KubeVirtConfiguration{EvictionStrategy: &evictionStrategy})
+				initController(&virtv1.KubeVirtConfiguration{EvictionStrategy: pointer.P(virtv1.EvictionStrategyLiveMigrate)})
 			})
 
 			It("should update PDB", func() {
@@ -1794,7 +1790,7 @@ var _ = Describe("Migration watcher", func() {
 			testutils.ExpectEvent(recorder, SuccessfulHandOverPodReason)
 		},
 			Entry("allow auto coverage",
-				func(p *migrationsv1.MigrationPolicySpec) { p.AllowAutoConverge = pointer.BoolPtr(true) },
+				func(p *migrationsv1.MigrationPolicySpec) { p.AllowAutoConverge = pointer.P(true) },
 				func(c *virtv1.MigrationConfiguration) {
 					Expect(c.AllowAutoConverge).ToNot(BeNil())
 					Expect(*c.AllowAutoConverge).To(BeTrue())
@@ -1802,7 +1798,7 @@ var _ = Describe("Migration watcher", func() {
 				true,
 			),
 			Entry("deny auto coverage",
-				func(p *migrationsv1.MigrationPolicySpec) { p.AllowAutoConverge = pointer.BoolPtr(false) },
+				func(p *migrationsv1.MigrationPolicySpec) { p.AllowAutoConverge = pointer.P(false) },
 				func(c *virtv1.MigrationConfiguration) {
 					Expect(c.AllowAutoConverge).ToNot(BeNil())
 					Expect(*c.AllowAutoConverge).To(BeFalse())
@@ -1826,7 +1822,7 @@ var _ = Describe("Migration watcher", func() {
 				true,
 			),
 			Entry("deny post copy",
-				func(p *migrationsv1.MigrationPolicySpec) { p.AllowPostCopy = pointer.BoolPtr(false) },
+				func(p *migrationsv1.MigrationPolicySpec) { p.AllowPostCopy = pointer.P(false) },
 				func(c *virtv1.MigrationConfiguration) {
 					Expect(c.AllowPostCopy).ToNot(BeNil())
 					Expect(*c.AllowPostCopy).To(BeFalse())
@@ -2043,7 +2039,7 @@ var _ = Describe("Migration watcher", func() {
 		It("should not be forced to the SELinux level of the source if the CR option is set to false", func() {
 			initController(&virtv1.KubeVirtConfiguration{
 				MigrationConfiguration: &virtv1.MigrationConfiguration{
-					MatchSELinuxLevelOnMigration: pointer.BoolPtr(false),
+					MatchSELinuxLevelOnMigration: pointer.P(false),
 				},
 			})
 			vmi := newVirtualMachine("testvmi", virtv1.Running)

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -470,7 +470,7 @@ var _ = Describe("Migration watcher", func() {
 		})
 
 		It("should hand pod over to target virt-handler if attachment pod is ready and running", func() {
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration.Status.Phase = virtv1.MigrationScheduled
 			targetPod.Spec.NodeName = "node01"
 			targetPod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
@@ -515,10 +515,10 @@ var _ = Describe("Migration watcher", func() {
 
 		BeforeEach(func() {
 			vmi = newVirtualMachine("testvmi", virtv1.Running)
+			addNodeNameToVMI(vmi, "node02")
 			migration = newMigration("testmigration", vmi.Name, virtv1.MigrationScheduled)
 			targetPod = newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			targetPod.Spec.NodeName = "node01"
-			vmi.Status.NodeName = "node02"
 		})
 
 		Context("CPU", func() {
@@ -684,7 +684,7 @@ var _ = Describe("Migration watcher", func() {
 			// Ensure that 4 migrations are there which are in non-final state
 			for i := 0; i < 4; i++ {
 				vmi := newVirtualMachine(fmt.Sprintf("testvmi%v", i), virtv1.Running)
-				vmi.Status.NodeName = fmt.Sprintf("node%v", i)
+				addNodeNameToVMI(vmi, fmt.Sprintf("node%v", i))
 				migration := newMigration(fmt.Sprintf("testmigration%v", i), vmi.Name, virtv1.MigrationScheduling)
 
 				addMigration(migration)
@@ -695,7 +695,7 @@ var _ = Describe("Migration watcher", func() {
 			for i := 0; i < 2; i++ {
 				vmi := newVirtualMachine(fmt.Sprintf("xtestvmi%v", i), virtv1.Running)
 				migration := newMigration(fmt.Sprintf("xtestmigration%v", i), vmi.Name, virtv1.MigrationPending)
-				vmi.Status.NodeName = fmt.Sprintf("node%v", i)
+				addNodeNameToVMI(vmi, fmt.Sprintf("node%v", i))
 
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
@@ -719,7 +719,7 @@ var _ = Describe("Migration watcher", func() {
 			for i := 0; i < 5; i++ {
 				vmi := newVirtualMachine(fmt.Sprintf("testvmi%v", i), virtv1.Running)
 				migration := newMigration(fmt.Sprintf("testmigration%v", i), vmi.Name, virtv1.MigrationScheduling)
-				vmi.Status.NodeName = fmt.Sprintf("node%v", i)
+				addNodeNameToVMI(vmi, fmt.Sprintf("node%v", i))
 
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
@@ -742,7 +742,7 @@ var _ = Describe("Migration watcher", func() {
 			for i := 0; i < 3; i++ {
 				vmi := newVirtualMachine(fmt.Sprintf("testvmi%v", i), virtv1.Running)
 				migration := newMigration(fmt.Sprintf("testmigration%v", i), vmi.Name, virtv1.MigrationScheduling)
-				vmi.Status.NodeName = fmt.Sprintf("node%v", i)
+				addNodeNameToVMI(vmi, fmt.Sprintf("node%v", i))
 
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
@@ -753,7 +753,7 @@ var _ = Describe("Migration watcher", func() {
 				vmi := newVirtualMachine(fmt.Sprintf("xtestvmi%v", i), virtv1.Running)
 				migration := newMigration(fmt.Sprintf("xtestmigration%v", i), vmi.Name, virtv1.MigrationPending)
 				pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
-				vmi.Status.NodeName = fmt.Sprintf("node%v", i)
+				addNodeNameToVMI(vmi, fmt.Sprintf("node%v", i))
 
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
@@ -1135,7 +1135,7 @@ var _ = Describe("Migration watcher", func() {
 	Context("Migration object ", func() {
 		DescribeTable("should hand pod over to target virt-handler if pod is ready and running", func(containerStatus []k8sv1.ContainerStatus) {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationScheduled)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			pod.Spec.NodeName = "node01"
@@ -1166,7 +1166,7 @@ var _ = Describe("Migration watcher", func() {
 
 		DescribeTable("should not hand pod over to target virt-handler if pod is not ready and running", func(containerStatus []k8sv1.ContainerStatus) {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationScheduled)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			pod.Spec.NodeName = "node01"
@@ -1188,7 +1188,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should hand pod over to target virt-handler with migration config", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationScheduled)
 
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
@@ -1211,7 +1211,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should hand pod over to target virt-handler overriding previous state", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
 				MigrationUID: "1111-2222-3333-4444",
 			}
@@ -1237,7 +1237,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should not hand pod over target pod that's already handed over", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationScheduled)
 			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
 				MigrationUID: migration.UID,
@@ -1256,7 +1256,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should not transition to PreparingTarget if VMI MigrationState is outdated", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationScheduled)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			pod.Spec.NodeName = "node01"
@@ -1280,7 +1280,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should transition to preparing target phase", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationScheduled)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			pod.Spec.NodeName = "node01"
@@ -1303,7 +1303,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should transition to target prepared phase", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationPreparingTarget)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
 			pod.Spec.NodeName = "node01"
@@ -1325,7 +1325,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should transition to running phase", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationTargetReady)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
 			pod.Spec.NodeName = "node01"
@@ -1348,7 +1348,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should transition to completed phase", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationRunning)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
 			pod.Spec.NodeName = "node01"
@@ -1377,7 +1377,7 @@ var _ = Describe("Migration watcher", func() {
 
 		DescribeTable("should not transit to succeeded phase when VMI status has", func(conditions []virtv1.VirtualMachineInstanceConditionType) {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationRunning)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
 			pod.Spec.NodeName = "node01"
@@ -1416,7 +1416,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should expect MigrationState to be updated on a completed migration", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationSucceeded)
 			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			pod.Spec.NodeName = "node01"
@@ -1451,7 +1451,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should abort the migration", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationRunning)
 			condition := virtv1.VirtualMachineInstanceMigrationCondition{
 				Type:          virtv1.VirtualMachineInstanceMigrationAbortRequested,
@@ -1478,9 +1478,10 @@ var _ = Describe("Migration watcher", func() {
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulAbortMigrationReason)
 		})
+
 		DescribeTable("should finalize migration on VMI if target pod fails before migration starts", func(phase virtv1.VirtualMachineInstanceMigrationPhase, hasPod bool, podPhase k8sv1.PodPhase, initializeMigrationState bool) {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = "node02"
+			addNodeNameToVMI(vmi, "node02")
 			migration := newMigration("testmigration", vmi.Name, phase)
 
 			vmi.Status.MigrationState = nil
@@ -1557,7 +1558,7 @@ var _ = Describe("Migration watcher", func() {
 			const nodeName = "testNode"
 
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = nodeName
+			addNodeNameToVMI(vmi, nodeName)
 			if toDefineHostModelCPU {
 				vmi.Spec.Domain.CPU = &virtv1.CPU{Model: virtv1.CPUModeHostModel}
 			}
@@ -1863,7 +1864,7 @@ var _ = Describe("Migration watcher", func() {
 
 			By("Defining VMI")
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
-			vmi.Status.NodeName = nodeName
+			addNodeNameToVMI(vmi, nodeName)
 			vmi.Spec.Domain.CPU = &virtv1.CPU{Model: virtv1.CPUModeHostModel}
 
 			By("Defining migration")
@@ -2130,6 +2131,11 @@ func newVirtualMachine(name string, phase virtv1.VirtualMachineInstancePhase) *v
 		virtv1.DeprecatedNonRootVMIAnnotation: "true",
 	}
 	return vmi
+}
+
+func addNodeNameToVMI(vmi *virtv1.VirtualMachineInstance, nodeName string) {
+	vmi.Status.NodeName = nodeName
+	vmi.Labels[virtv1.NodeNameLabel] = nodeName
 }
 
 func newVirtualMachineWithHotplugVolume(name string, phase virtv1.VirtualMachineInstancePhase) *virtv1.VirtualMachineInstance {

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -62,11 +62,8 @@ import (
 var _ = Describe("Migration watcher", func() {
 
 	var ctrl *gomock.Controller
-	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
-	var migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
 	var migrationSource *framework.FakeControllerSource
 	var vmiSource *framework.FakeControllerSource
-	var podSource *framework.FakeControllerSource
 	var vmiInformer cache.SharedIndexInformer
 	var podInformer cache.SharedIndexInformer
 	var migrationInformer cache.SharedIndexInformer
@@ -79,7 +76,6 @@ var _ = Describe("Migration watcher", func() {
 	var controller *MigrationController
 	var recorder *record.FakeRecorder
 	var mockQueue *testutils.MockWorkQueue
-	var podFeeder *testutils.PodFeeder
 	var virtClient *kubecli.MockKubevirtClient
 	var virtClientset *kubevirtfake.Clientset
 	var kubeClient *fake.Clientset
@@ -281,7 +277,6 @@ var _ = Describe("Migration watcher", func() {
 		// Wrap our workqueue to have a way to detect when we are done processing updates
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
 		controller.Queue = mockQueue
-		podFeeder = testutils.NewPodFeeder(mockQueue, podSource)
 	}
 
 	BeforeEach(func() {
@@ -289,12 +284,10 @@ var _ = Describe("Migration watcher", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		virtClientset = kubevirtfake.NewSimpleClientset()
-		migrationInterface = kubecli.NewMockVirtualMachineInstanceMigrationInterface(ctrl)
-		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 
 		vmiInformer, vmiSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
-		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
+		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		pdbInformer, _ = testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
 		resourceQuotaInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		namespaceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -26,23 +26,13 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
-	apimachpatch "kubevirt.io/kubevirt/pkg/apimachinery/patch"
-	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
-
-	"k8s.io/apimachinery/pkg/api/resource"
-	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
-	"kubevirt.io/kubevirt/pkg/pointer"
-
-	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
-
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	k8sv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -55,14 +45,20 @@ import (
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
-	"kubevirt.io/client-go/api"
-
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
+	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
+	"kubevirt.io/client-go/api"
+	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	apimachpatch "kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Use fake client instead of mocking in order to simulate real behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
Lower the bar for unit tests, eliminate false positives. The fake is standard for testing.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
