### PR TITLE
Prefer libvirtxml over schema.go in smbios sidecar example

### DIFF
--- a/cmd/sidecars/smbios/BUILD.bazel
+++ b/cmd/sidecars/smbios/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "kubevirt.io/kubevirt/cmd/sidecars/smbios",
     visibility = ["//visibility:private"],
     deps = [
-        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )
 

--- a/cmd/sidecars/smbios/smbios.go
+++ b/cmd/sidecars/smbios/smbios.go
@@ -49,7 +49,8 @@ func onDefineDomain(vmiJSON, domainXML []byte) (string, error) {
 	}
 
 	annotations := vmiSpec.GetAnnotations()
-	if _, found := annotations[baseBoardManufacturerAnnotation]; !found {
+	baseBoardManufacturer, found := annotations[baseBoardManufacturerAnnotation]
+	if !found {
 		return string(domainXML), nil
 	}
 
@@ -58,12 +59,10 @@ func onDefineDomain(vmiJSON, domainXML []byte) (string, error) {
 		domainSpec.SysInfo = &api.SysInfo{}
 	}
 	domainSpec.SysInfo.Type = "smbios"
-	if baseBoardManufacturer, found := annotations[baseBoardManufacturerAnnotation]; found {
-		domainSpec.SysInfo.BaseBoard = append(domainSpec.SysInfo.BaseBoard, api.Entry{
-			Name:  "manufacturer",
-			Value: baseBoardManufacturer,
-		})
-	}
+	domainSpec.SysInfo.BaseBoard = append(domainSpec.SysInfo.BaseBoard, api.Entry{
+		Name:  "manufacturer",
+		Value: baseBoardManufacturer,
+	})
 
 	newDomainXML, err := xml.Marshal(domainSpec)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Would require `virt-launcher/virtwrap/api` when building `smbios.go` out-of-tree.

After this PR:
Requires `libvirtxml` instead.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11817

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
SMBios sidecar can be built out-of-tree
```

