### PR TITLE
 [release-1.0] Improve the handling of ordinal pod interface name for upgrade

### DIFF
--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -92,17 +92,13 @@ func CreateOrdinalNetworkNameScheme(vmiNetworks []v1.Network) map[string]string 
 	return networkNameSchemeMap
 }
 
+// OrdinalPodInterfaceName returns the ordinal interface name for the given network name.
+// Rereuse the `CreateOrdinalNetworkNameScheme` for various networks helps find the target interface name.
 func OrdinalPodInterfaceName(name string, networks []v1.Network) string {
-	for i, network := range networks {
-		if network.Name == name {
-			if vmispec.IsSecondaryMultusNetwork(network) {
-				return generateOrdinalInterfaceName(i)
-			}
-
-			return PrimaryPodInterfaceName
-		}
+	networkNameSchemeMap := CreateOrdinalNetworkNameScheme(networks)
+	if ordinalName, exist := networkNameSchemeMap[name]; exist {
+		return ordinalName
 	}
-
 	return ""
 }
 

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -259,6 +259,22 @@ var _ = Describe("Network Name Scheme", func() {
 				},
 				"net2",
 			),
+			Entry("given secondary network name with different order",
+				"multus01",
+				[]virtv1.Network{
+					createMultusSecondaryNetwork("blue", "test-br"),
+					createMultusSecondaryNetwork("multus01", "test-br"),
+					newPodNetwork("default"),
+				},
+				"net2",
+			),
+			Entry("given secondary network name, only one secondary network",
+				"multus01",
+				[]virtv1.Network{
+					createMultusSecondaryNetwork("multus01", "test-br"),
+				},
+				"net1",
+			),
 		)
 	})
 })


### PR DESCRIPTION
### What this PR does
The OrdinalPodInterfaceName() returned `net0` if it only had one secondary network
I will now return `net1` as it should.

This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/11678

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

### Release note
```release-note
Improve the handling of ordinal pod interface name for upgrade
```

