### PR TITLE
test/utils: Remove NotDeleted() and NotDeletedVMs()

### DIFF
--- a/tests/libreplicaset/BUILD.bazel
+++ b/tests/libreplicaset/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libreplicaset",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
         "//tests/testsuite:go_default_library",

--- a/tests/libreplicaset/replicaset.go
+++ b/tests/libreplicaset/replicaset.go
@@ -40,14 +40,15 @@ func DoScaleWithScaleSubresource(virtClient kubecli.KubevirtClient, name string,
 
 	vmis, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).List(context.Background(), v12.ListOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, NotDeleted(vmis)).To(HaveLen(int(scale)))
+	ExpectWithOffset(1, FilterNotDeletedVMIs(vmis)).To(HaveLen(int(scale)))
 }
 
-func NotDeleted(vmis *v1.VirtualMachineInstanceList) (notDeleted []v1.VirtualMachineInstance) {
+func FilterNotDeletedVMIs(vmis *v1.VirtualMachineInstanceList) []v1.VirtualMachineInstance {
+	var notDeleted []v1.VirtualMachineInstance
 	for _, vmi := range vmis.Items {
 		if vmi.DeletionTimestamp == nil {
 			notDeleted = append(notDeleted, vmi)
 		}
 	}
-	return
+	return notDeleted
 }

--- a/tests/libreplicaset/replicaset.go
+++ b/tests/libreplicaset/replicaset.go
@@ -10,6 +10,7 @@ import (
 	autov1 "k8s.io/api/autoscaling/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
@@ -39,5 +40,14 @@ func DoScaleWithScaleSubresource(virtClient kubecli.KubevirtClient, name string,
 
 	vmis, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).List(context.Background(), v12.ListOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, tests.NotDeleted(vmis)).To(HaveLen(int(scale)))
+	ExpectWithOffset(1, NotDeleted(vmis)).To(HaveLen(int(scale)))
+}
+
+func NotDeleted(vmis *v1.VirtualMachineInstanceList) (notDeleted []v1.VirtualMachineInstance) {
+	for _, vmi := range vmis.Items {
+		if vmi.DeletionTimestamp == nil {
+			notDeleted = append(notDeleted, vmi)
+		}
+	}
+	return
 }

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -54,7 +54,6 @@ import (
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -624,12 +623,21 @@ func newPoolFromVMI(vmi *v1.VirtualMachineInstance) *poolv1.VirtualMachinePool {
 }
 
 func notDeletedVMs(poolName string, vms *v1.VirtualMachineList) (notDeleted []v1.VirtualMachine) {
-	nonDeletedVms := tests.NotDeletedVMs(vms)
+	nonDeletedVms := NotDeletedVMs(vms)
 	for _, vm := range nonDeletedVms {
 		for _, ref := range vm.OwnerReferences {
 			if ref.Name == poolName {
 				notDeleted = append(notDeleted, vm)
 			}
+		}
+	}
+	return
+}
+
+func NotDeletedVMs(vms *v1.VirtualMachineList) (notDeleted []v1.VirtualMachine) {
+	for _, vm := range vms.Items {
+		if vm.DeletionTimestamp == nil {
+			notDeleted = append(notDeleted, vm)
 		}
 	}
 	return

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -108,7 +108,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 
 		vms, err := virtClient.VirtualMachine(util.NamespaceTestDefault).List(context.Background(), v12.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(notDeletedVMs(pool.Name, vms)).To(HaveLen(int(scale)))
+		Expect(filterNotDeletedVMsOwnedByPool(pool.Name, vms)).To(HaveLen(int(scale)))
 	}
 	createVirtualMachinePool := func(pool *poolv1.VirtualMachinePool) *poolv1.VirtualMachinePool {
 		pool, err = virtClient.VirtualMachinePool(util.NamespaceTestDefault).Create(context.Background(), pool, metav1.CreateOptions{})
@@ -622,23 +622,17 @@ func newPoolFromVMI(vmi *v1.VirtualMachineInstance) *poolv1.VirtualMachinePool {
 	return pool
 }
 
-func notDeletedVMs(poolName string, vms *v1.VirtualMachineList) (notDeleted []v1.VirtualMachine) {
-	nonDeletedVms := NotDeletedVMs(vms)
-	for _, vm := range nonDeletedVms {
+func filterNotDeletedVMsOwnedByPool(poolName string, vms *v1.VirtualMachineList) []v1.VirtualMachine {
+	var result []v1.VirtualMachine
+	for _, vm := range vms.Items {
+		if vm.DeletionTimestamp != nil {
+			continue
+		}
 		for _, ref := range vm.OwnerReferences {
 			if ref.Name == poolName {
-				notDeleted = append(notDeleted, vm)
+				result = append(result, vm)
 			}
 		}
 	}
-	return
-}
-
-func NotDeletedVMs(vms *v1.VirtualMachineList) (notDeleted []v1.VirtualMachine) {
-	for _, vm := range vms.Items {
-		if vm.DeletionTimestamp == nil {
-			notDeleted = append(notDeleted, vm)
-		}
-	}
-	return
+	return result
 }

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -80,7 +80,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		vmis, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(rs)).List(context.Background(), v12.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(tests.NotDeleted(vmis)).To(HaveLen(int(scale)))
+		Expect(libreplicaset.NotDeleted(vmis)).To(HaveLen(int(scale)))
 	}
 
 	doScaleWithHPA := func(name string, min int32, max int32, expected int32) {
@@ -114,7 +114,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		vmis, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).List(context.Background(), v12.ListOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		ExpectWithOffset(1, tests.NotDeleted(vmis)).To(HaveLen(int(min)))
+		ExpectWithOffset(1, libreplicaset.NotDeleted(vmis)).To(HaveLen(int(min)))
 		err = virtClient.AutoscalingV1().HorizontalPodAutoscalers(testsuite.GetTestNamespace(nil)).Delete(context.Background(), name, v12.DeleteOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	}

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -80,7 +80,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		vmis, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(rs)).List(context.Background(), v12.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(libreplicaset.NotDeleted(vmis)).To(HaveLen(int(scale)))
+		Expect(libreplicaset.FilterNotDeletedVMIs(vmis)).To(HaveLen(int(scale)))
 	}
 
 	doScaleWithHPA := func(name string, min int32, max int32, expected int32) {
@@ -114,7 +114,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		vmis, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).List(context.Background(), v12.ListOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		ExpectWithOffset(1, libreplicaset.NotDeleted(vmis)).To(HaveLen(int(min)))
+		ExpectWithOffset(1, libreplicaset.FilterNotDeletedVMIs(vmis)).To(HaveLen(int(min)))
 		err = virtClient.AutoscalingV1().HorizontalPodAutoscalers(testsuite.GetTestNamespace(nil)).Delete(context.Background(), name, v12.DeleteOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -519,15 +519,6 @@ func GenerateVMJson(vm *v1.VirtualMachine, generateDirectory string) (string, er
 	return jsonFile, nil
 }
 
-func NotDeletedVMs(vms *v1.VirtualMachineList) (notDeleted []v1.VirtualMachine) {
-	for _, vm := range vms.Items {
-		if vm.DeletionTimestamp == nil {
-			notDeleted = append(notDeleted, vm)
-		}
-	}
-	return
-}
-
 func UnfinishedVMIPodSelector(vmi *v1.VirtualMachineInstance) metav1.ListOptions {
 	virtClient := kubevirt.Client()
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -519,15 +519,6 @@ func GenerateVMJson(vm *v1.VirtualMachine, generateDirectory string) (string, er
 	return jsonFile, nil
 }
 
-func NotDeleted(vmis *v1.VirtualMachineInstanceList) (notDeleted []v1.VirtualMachineInstance) {
-	for _, vmi := range vmis.Items {
-		if vmi.DeletionTimestamp == nil {
-			notDeleted = append(notDeleted, vmi)
-		}
-	}
-	return
-}
-
 func NotDeletedVMs(vms *v1.VirtualMachineList) (notDeleted []v1.VirtualMachine) {
 	for _, vm := range vms.Items {
 		if vm.DeletionTimestamp == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- Move `NotDeleted()` to `/libreplicaset` (since it's used only by replicaset test), rename it to `FilterNotDeletedVMIs()` and remove its [named returned value](https://go.dev/tour/basics/7).
- Move `NotDeletedVMs()` to `pool_test.go` (the only file it's used in), and improve by integrating it within
`notDeletedVMs()` function, which was renamed to `filterNotDeletedVMIsOwnedByPool()`.

/sig code-quality

```release-note
None
```
