### PR TITLE
[release-1.2] Generated client: embed generated methods into VMIM, KV, VMIRS, VMIP interfaces

### DIFF
--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -222,7 +222,7 @@ func (u *updater) updateStatusUnstructured(obj runtime.Object) (err error) {
 		_, err = u.cli.ReplicaSet(a.GetNamespace()).UpdateStatus(oldObj)
 	case *v1.VirtualMachineInstanceMigration:
 		oldObj := obj.(*v1.VirtualMachineInstanceMigration)
-		_, err = u.cli.VirtualMachineInstanceMigration(a.GetNamespace()).UpdateStatus(oldObj)
+		_, err = u.cli.VirtualMachineInstanceMigration(a.GetNamespace()).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
 	case *v1.KubeVirt:
 		oldObj := obj.(*v1.KubeVirt)
 		_, err = u.cli.KubeVirt(a.GetNamespace()).UpdateStatus(oldObj)

--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -191,7 +191,7 @@ func (u *updater) updateUnstructured(obj runtime.Object) (oldStatus interface{},
 		return oldObj.Status, newObj.Status, nil
 	case *v1.KubeVirt:
 		oldObj := obj.(*v1.KubeVirt)
-		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Update(oldObj)
+		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Update(context.Background(), oldObj, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -225,7 +225,7 @@ func (u *updater) updateStatusUnstructured(obj runtime.Object) (err error) {
 		_, err = u.cli.VirtualMachineInstanceMigration(a.GetNamespace()).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
 	case *v1.KubeVirt:
 		oldObj := obj.(*v1.KubeVirt)
-		_, err = u.cli.KubeVirt(a.GetNamespace()).UpdateStatus(oldObj)
+		_, err = u.cli.KubeVirt(a.GetNamespace()).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
 	case *clonev1alpha1.VirtualMachineClone:
 		oldObj := obj.(*clonev1alpha1.VirtualMachineClone)
 		_, err = u.cli.VirtualMachineClone(oldObj.Namespace).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})

--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -128,7 +128,7 @@ func (u *updater) patchUnstructured(obj runtime.Object, patchType types.PatchTyp
 		return oldObj.ResourceVersion, newObj.ResourceVersion, nil
 	case *v1.KubeVirt:
 		oldObj := obj.(*v1.KubeVirt)
-		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Patch(a.GetName(), patchType, data, patchOptions)
+		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Patch(context.Background(), a.GetName(), patchType, data, *patchOptions)
 		if err != nil {
 			return "", "", err
 		}
@@ -155,7 +155,7 @@ func (u *updater) patchStatusUnstructured(obj runtime.Object, patchType types.Pa
 		_, err = u.cli.VirtualMachine(a.GetNamespace()).PatchStatus(context.Background(), a.GetName(), patchType, data, *patchOptions)
 		return err
 	case *v1.KubeVirt:
-		_, err = u.cli.KubeVirt(a.GetNamespace()).PatchStatus(a.GetName(), patchType, data, patchOptions)
+		_, err = u.cli.KubeVirt(a.GetNamespace()).PatchStatus(context.Background(), a.GetName(), patchType, data, *patchOptions)
 		return err
 	default:
 		panic(unknownObj)

--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -184,7 +184,7 @@ func (u *updater) updateUnstructured(obj runtime.Object) (oldStatus interface{},
 		return oldObj.Status, newObj.Status, nil
 	case *v1.VirtualMachineInstanceMigration:
 		oldObj := obj.(*v1.VirtualMachineInstanceMigration)
-		newObj, err := u.cli.VirtualMachineInstanceMigration(a.GetNamespace()).Update(oldObj)
+		newObj, err := u.cli.VirtualMachineInstanceMigration(a.GetNamespace()).Update(context.Background(), oldObj, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -177,7 +177,7 @@ func (u *updater) updateUnstructured(obj runtime.Object) (oldStatus interface{},
 		return oldObj.Status, newObj.Status, nil
 	case *v1.VirtualMachineInstanceReplicaSet:
 		oldObj := obj.(*v1.VirtualMachineInstanceReplicaSet)
-		newObj, err := u.cli.ReplicaSet(a.GetNamespace()).Update(oldObj)
+		newObj, err := u.cli.ReplicaSet(a.GetNamespace()).Update(context.Background(), oldObj, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -219,7 +219,7 @@ func (u *updater) updateStatusUnstructured(obj runtime.Object) (err error) {
 		_, err = u.cli.VirtualMachine(a.GetNamespace()).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
 	case *v1.VirtualMachineInstanceReplicaSet:
 		oldObj := obj.(*v1.VirtualMachineInstanceReplicaSet)
-		_, err = u.cli.ReplicaSet(a.GetNamespace()).UpdateStatus(oldObj)
+		_, err = u.cli.ReplicaSet(a.GetNamespace()).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
 	case *v1.VirtualMachineInstanceMigration:
 		oldObj := obj.(*v1.VirtualMachineInstanceMigration)
 		_, err = u.cli.VirtualMachineInstanceMigration(a.GetNamespace()).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})

--- a/pkg/util/status/status_test.go
+++ b/pkg/util/status/status_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Status", func() {
 			By("checking the VirtualMachineInstanceReplicaSet resource")
 			vmirsUpdater := NewVMIRSStatusUpdater(virtClient)
 			vmirs := &v1.VirtualMachineInstanceReplicaSet{Status: v1.VirtualMachineInstanceReplicaSetStatus{Replicas: 2}}
-			vmirsInterface.EXPECT().UpdateStatus(vmirs).Return(vmirs, nil).Times(1)
+			vmirsInterface.EXPECT().UpdateStatus(context.Background(), vmirs, metav1.UpdateOptions{}).Return(vmirs, nil).Times(1)
 			Expect(vmirsUpdater.UpdateStatus(vmirs)).To(Succeed())
 
 			By("checking the VirtualMachineInstanceMigration resource")
@@ -290,7 +290,7 @@ var _ = Describe("Status", func() {
 			vmirsUpdater := NewVMIRSStatusUpdater(virtClient)
 			vmirsUpdater.updater.subresource = false
 			vmirs := &v1.VirtualMachineInstanceReplicaSet{Status: v1.VirtualMachineInstanceReplicaSetStatus{Replicas: 2}}
-			vmirsInterface.EXPECT().Update(vmirs).Return(vmirs, nil).Times(1)
+			vmirsInterface.EXPECT().Update(context.Background(), vmirs, metav1.UpdateOptions{}).Return(vmirs, nil).Times(1)
 			Expect(vmirsUpdater.UpdateStatus(vmirs)).To(Succeed())
 
 			By("checking the VirtualMachineInstanceMigration resource")

--- a/pkg/util/status/status_test.go
+++ b/pkg/util/status/status_test.go
@@ -298,7 +298,7 @@ var _ = Describe("Status", func() {
 			migrationUpdater := NewMigrationStatusUpdater(virtClient)
 			migrationUpdater.updater.subresource = false
 			migration := &v1.VirtualMachineInstanceMigration{Status: v1.VirtualMachineInstanceMigrationStatus{Phase: v1.MigrationPhaseUnset}}
-			migrationInterface.EXPECT().Update(migration).Return(migration, nil).Times(1)
+			migrationInterface.EXPECT().Update(context.Background(), migration, v12.UpdateOptions{}).Return(migration, nil).Times(1)
 			Expect(migrationUpdater.UpdateStatus(migration)).To(Succeed())
 		})
 	})

--- a/pkg/util/status/status_test.go
+++ b/pkg/util/status/status_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Status", func() {
 			It("should continuously use the /status subresource if no errors occur", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(2)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
@@ -50,8 +50,8 @@ var _ = Describe("Status", func() {
 			It("should fall back on a 404 error on the /status subresource to an ordinary update", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				kvInterface.EXPECT().Update(kv).Return(kv, nil).Times(2)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
@@ -59,10 +59,10 @@ var _ = Describe("Status", func() {
 			It("should fall back on a 404 error on the /status subresource to an ordinary update but keep in mind that objects may have disappeared", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				kvInterface.EXPECT().Update(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
 
@@ -71,18 +71,18 @@ var _ = Describe("Status", func() {
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
 				newKV := kv.DeepCopy()
 				newKV.Status.Phase = v1.KubeVirtPhaseDeleted
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				kvInterface.EXPECT().Update(kv).Return(newKV, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(newKV, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
 
 			It("should stick with /status if an arbitrary error occurs", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, fmt.Errorf("I am not 404")).Times(1)
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, fmt.Errorf("I am not 404")).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
@@ -152,7 +152,7 @@ var _ = Describe("Status", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				updater.updater.subresource = false
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().Update(kv).Return(kv, nil).Times(2)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
@@ -161,7 +161,7 @@ var _ = Describe("Status", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				updater.updater.subresource = false
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().Update(kv).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(2)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, errors.NewNotFound(schema.GroupResource{}, "something")).Times(2)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 			})
@@ -170,7 +170,7 @@ var _ = Describe("Status", func() {
 				updater := NewKubeVirtStatusUpdater(virtClient)
 				updater.updater.subresource = false
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-				kvInterface.EXPECT().Update(kv).Return(kv, fmt.Errorf("I am not 404")).Times(2)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, fmt.Errorf("I am not 404")).Times(2)
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 				Expect(updater.UpdateStatus(kv)).ToNot(Succeed())
 			})
@@ -181,10 +181,10 @@ var _ = Describe("Status", func() {
 				kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
 				oldKV := kv.DeepCopy()
 				oldKV.Status.Phase = v1.KubeVirtPhaseDeploying
-				kvInterface.EXPECT().Update(kv).Return(oldKV, nil).Times(1)
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(oldKV, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
-				kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(1)
+				kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(1)
 				Expect(updater.UpdateStatus(kv)).To(Succeed())
 			})
 		})
@@ -246,7 +246,7 @@ var _ = Describe("Status", func() {
 			By("checking the KubeVirt resource")
 			kvUpdater := NewKubeVirtStatusUpdater(virtClient)
 			kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-			kvInterface.EXPECT().UpdateStatus(kv).Return(kv, nil).Times(2)
+			kvInterface.EXPECT().UpdateStatus(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 			Expect(kvUpdater.UpdateStatus(kv)).To(Succeed())
 			Expect(kvUpdater.UpdateStatus(kv)).To(Succeed())
 
@@ -275,7 +275,7 @@ var _ = Describe("Status", func() {
 			kvUpdater := NewKubeVirtStatusUpdater(virtClient)
 			kvUpdater.updater.subresource = false
 			kv := &v1.KubeVirt{Status: v1.KubeVirtStatus{Phase: v1.KubeVirtPhaseDeployed}}
-			kvInterface.EXPECT().Update(kv).Return(kv, nil).Times(2)
+			kvInterface.EXPECT().Update(context.Background(), kv, metav1.UpdateOptions{}).Return(kv, nil).Times(2)
 			Expect(kvUpdater.UpdateStatus(kv)).To(Succeed())
 			Expect(kvUpdater.UpdateStatus(kv)).To(Succeed())
 

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -332,14 +332,14 @@ func (app *SubresourceAPIApp) MigrateVMRequestHandler(request *restful.Request, 
 	}
 
 	createMigrationJob := func() *errors.StatusError {
-		_, err := app.virtCli.VirtualMachineInstanceMigration(namespace).Create(&v1.VirtualMachineInstanceMigration{
+		_, err := app.virtCli.VirtualMachineInstanceMigration(namespace).Create(context.Background(), &v1.VirtualMachineInstanceMigration{
 			ObjectMeta: k8smetav1.ObjectMeta{
 				GenerateName: "kubevirt-migrate-vm-",
 			},
 			Spec: v1.VirtualMachineInstanceMigrationSpec{
 				VMIName: name,
 			},
-		}, &k8smetav1.CreateOptions{DryRun: bodyStruct.DryRun})
+		}, k8smetav1.CreateOptions{DryRun: bodyStruct.DryRun})
 		if err != nil {
 			return errors.NewInternalError(err)
 		}

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1727,7 +1727,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			vmClient.EXPECT().Get(context.Background(), testVMName, k8smetav1.GetOptions{}).Return(&vm, nil)
 			vmiClient.EXPECT().Get(context.Background(), testVMName, k8smetav1.GetOptions{}).Return(&vmi, nil)
-			migrateClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil, errors.NewInternalError(fmt.Errorf("error creating object")))
+			migrateClient.EXPECT().Create(context.Background(), gomock.Any(), gomock.Any()).Return(nil, errors.NewInternalError(fmt.Errorf("error creating object")))
 			app.MigrateVMRequestHandler(request, response)
 
 			ExpectStatusErrorWithCode(recorder, http.StatusInternalServerError)
@@ -1755,8 +1755,8 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmClient.EXPECT().Get(context.Background(), testVMName, k8smetav1.GetOptions{}).Return(&vm, nil)
 			vmiClient.EXPECT().Get(context.Background(), testVMName, k8smetav1.GetOptions{}).Return(&vmi, nil)
 
-			migrateClient.EXPECT().Create(gomock.Any(), gomock.Any()).Do(
-				func(obj interface{}, opts *k8smetav1.CreateOptions) {
+			migrateClient.EXPECT().Create(context.Background(), gomock.Any(), gomock.Any()).Do(
+				func(ctx context.Context, obj interface{}, opts k8smetav1.CreateOptions) {
 					Expect(opts.DryRun).To(BeEquivalentTo(migrateOptions.DryRun))
 				}).Return(&migration, nil)
 			app.MigrateVMRequestHandler(request, response)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -59,7 +59,7 @@ func EnsureNoMigrationConflict(virtClient kubecli.KubevirtClient, vmiName string
 	if err != nil {
 		return err
 	}
-	list, err := virtClient.VirtualMachineInstanceMigration(namespace).List(&metav1.ListOptions{
+	list, err := virtClient.VirtualMachineInstanceMigration(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	})
 	if err != nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			},
 		}
 		mockVMIClient.EXPECT().Get(context.Background(), inFlightMigration.Spec.VMIName, gomock.Any()).Return(vmi, nil)
-		migrationInterface.EXPECT().List(gomock.Any()).Return(kubecli.NewMigrationList(inFlightMigration), nil).AnyTimes()
+		migrationInterface.EXPECT().List(context.Background(), gomock.Any()).Return(kubecli.NewMigrationList(inFlightMigration), nil).AnyTimes()
 
 		migration := v1.VirtualMachineInstanceMigration{
 			ObjectMeta: metav1.ObjectMeta{
@@ -125,7 +125,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 	Context("with no conflicting migration", func() {
 
 		BeforeEach(func() {
-			migrationInterface.EXPECT().List(gomock.Any()).Return(&v1.VirtualMachineInstanceMigrationList{}, nil).MaxTimes(1)
+			migrationInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&v1.VirtualMachineInstanceMigrationList{}, nil).MaxTimes(1)
 
 		})
 

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -1,6 +1,7 @@
 package evacuation
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sync"
@@ -446,7 +447,7 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 	for _, vmi := range selectedCandidates {
 		go func(vmi *virtv1.VirtualMachineInstance) {
 			defer wg.Done()
-			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(GenerateNewMigration(vmi.Name, node.Name), &v1.CreateOptions{})
+			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(context.Background(), GenerateNewMigration(vmi.Name, node.Name), v1.CreateOptions{})
 			if err != nil {
 				c.migrationExpectations.CreationObserved(node.Name)
 				c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedCreateVirtualMachineInstanceMigrationReason, "Error creating a Migration: %v", err)

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -1,6 +1,7 @@
 package evacuation_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -155,7 +156,7 @@ var _ = Describe("Evacuation", func() {
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
 			vmiFeeder.Add(vmi)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
@@ -232,7 +233,7 @@ var _ = Describe("Evacuation", func() {
 
 			migrationInterface.
 				EXPECT().
-				Create(gomock.Any(), &v13.CreateOptions{}).
+				Create(context.Background(), gomock.Any(), v13.CreateOptions{}).
 				Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
 
 			controller.Execute()
@@ -249,7 +250,7 @@ var _ = Describe("Evacuation", func() {
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
 			vmi.Status.EvacuationNodeName = node.Name
 			vmiFeeder.Add(vmi)
-			migrationInterface.EXPECT().Create(gomock.Any(), &v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
 		})
@@ -374,7 +375,7 @@ var _ = Describe("Evacuation", func() {
 
 			vmiFeeder.Add(vmi)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
@@ -417,7 +418,7 @@ var _ = Describe("Evacuation", func() {
 			vmi := newVirtualMachine("testvm", node.Name)
 			vmiFeeder.Add(vmi)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
@@ -483,7 +484,7 @@ var _ = Describe("Evacuation", func() {
 			By(fmt.Sprintf("Expect only one new migration from node %s although cluster capacity allows more candidates", nodeName))
 			migrationInterface.
 				EXPECT().
-				Create(gomock.Any(), &v13.CreateOptions{}).
+				Create(context.Background(), gomock.Any(), v13.CreateOptions{}).
 				Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).
 				Times(1)
 
@@ -531,7 +532,7 @@ var _ = Describe("Evacuation", func() {
 			By("migration should be created for the candidate")
 			migrationInterface.
 				EXPECT().
-				Create(gomock.Any(), &v13.CreateOptions{}).
+				Create(context.Background(), gomock.Any(), v13.CreateOptions{}).
 				Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).
 				Times(1)
 

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -315,7 +315,7 @@ func (c *MigrationController) execute(key string) error {
 		controller.SetLatestApiVersionAnnotation(migration)
 		// Ensure the migration contains our selector label
 		ensureSelectorLabelPresent(migration)
-		_, err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Update(migration)
+		_, err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Update(context.Background(), migration, metav1.UpdateOptions{})
 		return err
 	}
 
@@ -513,7 +513,7 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 			return err
 		}
 	} else if !equality.Semantic.DeepEqual(migration.Finalizers, migrationCopy.Finalizers) {
-		_, err := c.clientset.VirtualMachineInstanceMigration(migrationCopy.Namespace).Update(migrationCopy)
+		_, err := c.clientset.VirtualMachineInstanceMigration(migrationCopy.Namespace).Update(context.Background(), migrationCopy, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -329,7 +329,7 @@ func (c *MigrationController) execute(key string) error {
 
 		if migration.DeletionTimestamp == nil {
 			logger.V(3).Infof("Deleting migration for deleted vmi %s/%s", migration.Namespace, migration.Spec.VMIName)
-			err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Delete(migration.Name, &v1.DeleteOptions{})
+			err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Delete(context.Background(), migration.Name, v1.DeleteOptions{})
 		}
 		// nothing to process for a migration that's being deleted
 		return err
@@ -1675,7 +1675,7 @@ func (c *MigrationController) garbageCollectFinalizedMigrations(vmi *virtv1.Virt
 	}
 
 	for i := 0; i < garbageCollectionCount; i++ {
-		err = c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(finalizedMigrations[i], &v1.DeleteOptions{})
+		err = c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(context.Background(), finalizedMigrations[i], v1.DeleteOptions{})
 		if err != nil && k8serrors.IsNotFound(err) {
 			// This is safe to ignore. It's possible in some
 			// scenarios that the migration we're trying to garbage

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -241,7 +241,7 @@ var _ = Describe("Migration watcher", func() {
 
 	shouldExpectMigrationDeletion := func(namePrefix string, times int) {
 
-		migrationInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(times).Do(func(arg1 interface{}, arg2 interface{}) interface{} {
+		migrationInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Times(times).Do(func(ctx context.Context, arg1 interface{}, arg2 interface{}) interface{} {
 			Expect(arg1.(string)).To(ContainSubstring(namePrefix))
 			return nil
 		})
@@ -1431,7 +1431,7 @@ var _ = Describe("Migration watcher", func() {
 			migration := newMigration("testmigration", "somevmi", virtv1.MigrationRunning)
 			addMigration(migration)
 
-			migrationInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+			migrationInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 			controller.Execute()
 		})

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -184,48 +184,48 @@ var _ = Describe("Migration watcher", func() {
 	}
 
 	shouldExpectGenericMigrationUpdate := func() {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).DoAndReturn(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).DoAndReturn(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			return arg, nil
 		})
 	}
 
 	shouldExpectMigrationSchedulingState := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).DoAndReturn(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).DoAndReturn(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Status.Phase).To(Equal(virtv1.MigrationScheduling))
 			return arg, nil
 		})
 	}
 
 	shouldExpectMigrationPreparingTargetState := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).DoAndReturn(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).DoAndReturn(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Status.Phase).To(Equal(virtv1.MigrationPreparingTarget))
 			return arg, nil
 		})
 	}
 
 	shouldExpectMigrationTargetReadyState := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).DoAndReturn(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).DoAndReturn(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Status.Phase).To(Equal(virtv1.MigrationTargetReady))
 			return arg, nil
 		})
 	}
 
 	shouldExpectMigrationRunningState := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).DoAndReturn(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).DoAndReturn(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Status.Phase).To(Equal(virtv1.MigrationRunning))
 			return arg, nil
 		})
 	}
 
 	shouldExpectMigrationCompletedState := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Status.Phase).To(Equal(virtv1.MigrationSucceeded))
 			return arg, nil
 		})
 	}
 
 	shouldExpectMigrationStateUpdatedAndFinalizerRemoved := func(migration *virtv1.VirtualMachineInstanceMigration, mState *virtv1.VirtualMachineInstanceMigrationState) {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Status.MigrationState).To(Equal(mState))
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Finalizers).To(BeEmpty())
 			return arg, nil
@@ -233,7 +233,7 @@ var _ = Describe("Migration watcher", func() {
 	}
 
 	shouldExpectMigrationFailedState := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Status.Phase).To(Equal(virtv1.MigrationFailed))
 			return arg, nil
 		})
@@ -252,7 +252,7 @@ var _ = Describe("Migration watcher", func() {
 	}
 
 	shouldExpectMigrationCondition := func(migration *virtv1.VirtualMachineInstanceMigration, conditionType virtv1.VirtualMachineInstanceMigrationConditionType) {
-		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			vmim := arg.(*virtv1.VirtualMachineInstanceMigration)
 			ExpectWithOffset(1, vmim.Name).To(Equal(migration.Name))
 
@@ -1018,7 +1018,7 @@ var _ = Describe("Migration watcher", func() {
 				finalizedMigrations++
 				shouldExpectMigrationDeletion("should-delete", finalizedMigrations-defaultFinalizedMigrationGarbageCollectionBuffer)
 			} else {
-				migrationInterface.EXPECT().UpdateStatus(gomock.Any()).AnyTimes().DoAndReturn(func(arg interface{}) (interface{}, interface{}) {
+				migrationInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).AnyTimes().DoAndReturn(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 					return arg, nil
 				})
 			}

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Migration watcher", func() {
 	var namespace k8sv1.Namespace
 
 	shouldExpectMigrationFinalizerRemoval := func(migration *virtv1.VirtualMachineInstanceMigration) {
-		migrationInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) (interface{}, interface{}) {
+		migrationInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, opts metav1.UpdateOptions) (interface{}, interface{}) {
 			Expect(arg.(*virtv1.VirtualMachineInstanceMigration).Finalizers).To(BeEmpty())
 			return arg, nil
 		})

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -208,7 +208,7 @@ func (c *VMIReplicaSet) execute(key string) error {
 	// If any adoptions are attempted, we should first recheck for deletion with
 	// an uncached quorum read sometime after listing VirtualMachines (see kubernetes/kubernetes#42639).
 	canAdoptFunc := controller.RecheckDeletionTimestamp(func() (metav1.Object, error) {
-		fresh, err := c.clientset.ReplicaSet(rs.ObjectMeta.Namespace).Get(rs.ObjectMeta.Name, metav1.GetOptions{})
+		fresh, err := c.clientset.ReplicaSet(rs.ObjectMeta.Namespace).Get(context.Background(), rs.ObjectMeta.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -174,7 +174,7 @@ func (c *VMIReplicaSet) execute(key string) error {
 	if !controller.ObservedLatestApiVersionAnnotation(rs) {
 		rs := rs.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(rs)
-		_, err = c.clientset.ReplicaSet(rs.Namespace).Update(rs)
+		_, err = c.clientset.ReplicaSet(rs.Namespace).Update(context.Background(), rs, metav1.UpdateOptions{})
 		return err
 	}
 

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -325,7 +325,7 @@ var _ = Describe("Replicaset", func() {
 			addReplicaSet(rs)
 			vmiFeeder.Add(vmi)
 
-			rsInterface.EXPECT().Get(rs.ObjectMeta.Name, gomock.Any()).Return(rs, nil)
+			rsInterface.EXPECT().Get(context.Background(), rs.ObjectMeta.Name, gomock.Any()).Return(rs, nil)
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.ObjectMeta.Name, gomock.Any(), gomock.Any(), metav1.PatchOptions{})
 
 			controller.Execute()

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Replicaset", func() {
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Times(3).Do(func(ctx context.Context, arg interface{}, opts metav1.CreateOptions) {
 				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.GenerateName).To(Equal("testvmi"))
 			}).Return(vmi, nil)
-			rsInterface.EXPECT().UpdateStatus(expectedRS)
+			rsInterface.EXPECT().UpdateStatus(context.Background(), expectedRS, metav1.UpdateOptions{})
 
 			controller.Execute()
 
@@ -147,7 +147,7 @@ var _ = Describe("Replicaset", func() {
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Times(0)
 
 			// Synchronizing the state is expected
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Do(func(obj *v1.VirtualMachineInstanceReplicaSet) {
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Times(1).Do(func(ctx context.Context, obj *v1.VirtualMachineInstanceReplicaSet, options metav1.UpdateOptions) {
 				Expect(obj.Status.Replicas).To(Equal(int32(0)))
 				Expect(obj.Status.ReadyReplicas).To(Equal(int32(0)))
 				Expect(obj.Status.Conditions[0].Type).To(Equal(v1.VirtualMachineInstanceReplicaSetReplicaPaused))
@@ -163,7 +163,7 @@ var _ = Describe("Replicaset", func() {
 
 			addReplicaSet(rs)
 
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).AnyTimes()
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).AnyTimes()
 
 			// Check if only 10 are created
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Times(10).Do(func(ctx context.Context, arg interface{}, opts metav1.CreateOptions) {
@@ -201,7 +201,7 @@ var _ = Describe("Replicaset", func() {
 				vmiFeeder.Add(vmi)
 			}
 
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).AnyTimes()
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).AnyTimes()
 
 			// Should create 7 vms, 3 are already there and 3 are there but marked for deletion
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Times(7).Do(func(ctx context.Context, arg interface{}, opts metav1.CreateOptions) {
@@ -228,7 +228,7 @@ var _ = Describe("Replicaset", func() {
 				vmiFeeder.Add(vmi)
 			}
 
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).AnyTimes()
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).AnyTimes()
 
 			// Check if only 10 are deleted
 			vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).
@@ -264,7 +264,7 @@ var _ = Describe("Replicaset", func() {
 				vmiFeeder.Add(vmi)
 			}
 
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).AnyTimes()
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).AnyTimes()
 
 			// Check if only two vms get deleted
 			vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).
@@ -309,7 +309,7 @@ var _ = Describe("Replicaset", func() {
 			vmiFeeder.Add(vmi)
 
 			vmiInterface.EXPECT().Delete(context.Background(), vmi.ObjectMeta.Name, gomock.Any())
-			rsInterface.EXPECT().UpdateStatus(expectedRS)
+			rsInterface.EXPECT().UpdateStatus(context.Background(), expectedRS, metav1.UpdateOptions{})
 
 			controller.Execute()
 
@@ -353,7 +353,7 @@ var _ = Describe("Replicaset", func() {
 			vmiFeeder.Add(vmi)
 
 			// We should see the failed condition, replicas should stay at 0
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(obj interface{}) {
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, obj interface{}, options metav1.UpdateOptions) {
 				objRS := obj.(*v1.VirtualMachineInstanceReplicaSet)
 				Expect(objRS.Status.LabelSelector).To(Equal(s.String()))
 			})
@@ -384,7 +384,7 @@ var _ = Describe("Replicaset", func() {
 			vmiFeeder.Modify(modifiedVMI)
 
 			// Expect the re-crate of the VirtualMachineInstance
-			rsInterface.EXPECT().UpdateStatus(rsCopy).Times(1)
+			rsInterface.EXPECT().UpdateStatus(context.Background(), rsCopy, metav1.UpdateOptions{}).Times(1)
 			vmiInterface.EXPECT().Delete(context.Background(), vmi.ObjectMeta.Name, gomock.Any()).Return(nil)
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(vmi, nil)
 			// Run the controller again
@@ -405,7 +405,7 @@ var _ = Describe("Replicaset", func() {
 			addReplicaSet(rs)
 			vmiFeeder.Add(vmi)
 
-			rsInterface.EXPECT().UpdateStatus(expectedRS).Times(1)
+			rsInterface.EXPECT().UpdateStatus(context.Background(), expectedRS, metav1.UpdateOptions{}).Times(1)
 
 			// First make sure that we don't have to do anything
 			controller.Execute()
@@ -435,7 +435,7 @@ var _ = Describe("Replicaset", func() {
 			addReplicaSet(rs)
 			vmiFeeder.Add(vmi)
 
-			rsInterface.EXPECT().UpdateStatus(expectedRS).Times(1)
+			rsInterface.EXPECT().UpdateStatus(context.Background(), expectedRS, metav1.UpdateOptions{}).Times(1)
 
 			// First make sure that we don't have to do anything
 			controller.Execute()
@@ -468,7 +468,7 @@ var _ = Describe("Replicaset", func() {
 			vmiFeeder.Delete(vmi)
 
 			// Expect the update from 1 to zero replicas
-			rsInterface.EXPECT().UpdateStatus(rsCopy).Times(1)
+			rsInterface.EXPECT().UpdateStatus(context.Background(), rsCopy, metav1.UpdateOptions{}).Times(1)
 
 			// Expect the recrate of the VirtualMachineInstance
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(vmi, nil)
@@ -503,7 +503,7 @@ var _ = Describe("Replicaset", func() {
 				return vmi, nil
 			})
 			vmiInterface.EXPECT().Delete(context.Background(), vmi.ObjectMeta.Name, gomock.Any()).Return(nil)
-			rsInterface.EXPECT().UpdateStatus(gomock.Any())
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{})
 
 			// Run the cleanFinishedVmis method
 			controller.Execute()
@@ -536,7 +536,7 @@ var _ = Describe("Replicaset", func() {
 				return vmi, nil
 			})
 			vmiInterface.EXPECT().Delete(context.Background(), vmi.ObjectMeta.Name, gomock.Any()).Return(nil)
-			rsInterface.EXPECT().UpdateStatus(gomock.Any())
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{})
 
 			// Run the cleanFinishedVmis method
 			controller.Execute()
@@ -557,7 +557,7 @@ var _ = Describe("Replicaset", func() {
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(nil, fmt.Errorf("failure"))
 
 			// We should see the failed condition, replicas should stay at 0
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(obj interface{}) {
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, obj interface{}, options metav1.UpdateOptions) {
 				objRS := obj.(*v1.VirtualMachineInstanceReplicaSet)
 				Expect(objRS.Status.Replicas).To(Equal(int32(1)))
 				Expect(objRS.Status.Conditions).To(HaveLen(1))
@@ -588,7 +588,7 @@ var _ = Describe("Replicaset", func() {
 			vmiInterface.EXPECT().Delete(context.Background(), vmi1.ObjectMeta.Name, gomock.Any()).Return(fmt.Errorf("failure"))
 
 			// We should see the failed condition, replicas should stay at 2
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(obj interface{}) {
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, obj interface{}, options metav1.UpdateOptions) {
 				objRS := obj.(*v1.VirtualMachineInstanceReplicaSet)
 				Expect(objRS.Status.Replicas).To(Equal(int32(2)))
 				Expect(objRS.Status.Conditions).To(HaveLen(1))
@@ -618,7 +618,7 @@ var _ = Describe("Replicaset", func() {
 			vmiInterface.EXPECT().Delete(context.Background(), vmi1.ObjectMeta.Name, gomock.Any()).Return(fmt.Errorf("failure"))
 
 			// We should see the failed condition, replicas should stay at 2
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(obj interface{}) {
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, obj interface{}, options metav1.UpdateOptions) {
 				objRS := obj.(*v1.VirtualMachineInstanceReplicaSet)
 				Expect(objRS.Status.Replicas).To(Equal(int32(2)))
 				Expect(objRS.Status.Conditions).To(HaveLen(1))
@@ -655,7 +655,7 @@ var _ = Describe("Replicaset", func() {
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(nil, fmt.Errorf("failure"))
 
 			// We should see the failed condition, replicas should stay at 0
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(obj interface{}) {
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, obj interface{}, options metav1.UpdateOptions) {
 				objRS := obj.(*v1.VirtualMachineInstanceReplicaSet)
 				Expect(objRS.Status.Replicas).To(Equal(int32(1)))
 				Expect(objRS.Status.Conditions).To(HaveLen(1))
@@ -684,7 +684,7 @@ var _ = Describe("Replicaset", func() {
 			vmiInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Times(2).Return(vmi, nil)
 
 			// We should see the failed condition, replicas should stay at 0
-			rsInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(obj interface{}) {
+			rsInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, obj interface{}, options metav1.UpdateOptions) {
 				objRS := obj.(*v1.VirtualMachineInstanceReplicaSet)
 				Expect(objRS.Status.Replicas).To(Equal(int32(1)))
 				Expect(objRS.Status.Conditions).To(BeEmpty())

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -529,7 +529,7 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 	for _, vmi := range migrationCandidates {
 		go func(vmi *virtv1.VirtualMachineInstance) {
 			defer wg.Done()
-			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(&virtv1.VirtualMachineInstanceMigration{
+			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(context.Background(), &virtv1.VirtualMachineInstanceMigration{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						virtv1.WorkloadUpdateMigrationAnnotation: "",
@@ -539,7 +539,7 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 				Spec: virtv1.VirtualMachineInstanceMigrationSpec{
 					VMIName: vmi.Name,
 				},
-			}, &metav1.CreateOptions{})
+			}, metav1.CreateOptions{})
 			if err != nil {
 				log.Log.Object(vmi).Reason(err).Errorf("Failed to migrate vmi as part of workload update")
 				c.migrationExpectations.CreationObserved(key)

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -1,6 +1,7 @@
 package workloadupdater
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -143,7 +144,7 @@ var _ = Describe("Workload Updater", func() {
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
@@ -203,7 +204,7 @@ var _ = Describe("Workload Updater", func() {
 
 			}).Return(nil, nil).Times(1)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(int(virtconfig.ParallelMigrationsPerClusterDefault))
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(int(virtconfig.ParallelMigrationsPerClusterDefault))
 
 			evictionCount := 0
 			shouldExpectMultiplePodEvictions(&evictionCount)
@@ -245,7 +246,7 @@ var _ = Describe("Workload Updater", func() {
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(int(virtconfig.ParallelMigrationsPerClusterDefault))
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(int(virtconfig.ParallelMigrationsPerClusterDefault))
 			evictionCount := 0
 			shouldExpectMultiplePodEvictions(&evictionCount)
 
@@ -283,7 +284,7 @@ var _ = Describe("Workload Updater", func() {
 
 			waitForNumberOfInstancesOnVMIInformerCache(controller, desiredNumberOfVMs)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(1)
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(1)
 
 			controller.Execute()
 			testutils.ExpectEvents(recorder, reasons...)
@@ -309,7 +310,7 @@ var _ = Describe("Workload Updater", func() {
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(1)
+			migrationInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil).Times(1)
 			evictionCount := 0
 			shouldExpectMultiplePodEvictions(&evictionCount)
 

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Workload Updater", func() {
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
 
-			kubeVirtInterface.EXPECT().PatchStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) {
+			kubeVirtInterface.EXPECT().PatchStatus(context.Background(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) {
 				str := string(data)
 				Expect(str).To(Equal("[{ \"op\": \"test\", \"path\": \"/status/outdatedVirtualMachineInstanceWorkloads\", \"value\": 0}, { \"op\": \"replace\", \"path\": \"/status/outdatedVirtualMachineInstanceWorkloads\", \"value\": 100}]"))
 

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -764,7 +764,7 @@ func (c *KubeVirtController) execute(key string) error {
 			return err
 		}
 		patch := fmt.Sprintf(`[{"op": "replace", "path": "/metadata/finalizers", "value": %s}]`, string(finalizersJson))
-		_, err = c.clientset.KubeVirt(kvCopy.ObjectMeta.Namespace).Patch(kvCopy.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{})
+		_, err = c.clientset.KubeVirt(kvCopy.ObjectMeta.Namespace).Patch(context.Background(), kvCopy.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 		if err != nil {
 			logger.Reason(err).Errorf("Could not patch the KubeVirt finalizers.")
 			return err

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -709,7 +709,7 @@ func (c *KubeVirtController) execute(key string) error {
 	if !controller.ObservedLatestApiVersionAnnotation(kv) {
 		kv := kv.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(kv)
-		_, err = c.clientset.KubeVirt(kv.ObjectMeta.Namespace).Update(kv)
+		_, err = c.clientset.KubeVirt(kv.ObjectMeta.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 		if err != nil {
 			logger.Reason(err).Errorf("Could not update the KubeVirt resource.")
 		}

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -412,7 +412,7 @@ func (k *KubeVirtTestData) shouldExpectKubeVirtFinalizersPatch(times int) {
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdate(times int) {
-	update := k.kvInterface.EXPECT().Update(gomock.Any())
+	update := k.kvInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{})
 	update.Do(func(kv *v1.KubeVirt) {
 		k.kvInformer.GetStore().Update(kv)
 		update.Return(kv, nil)
@@ -420,16 +420,16 @@ func (k *KubeVirtTestData) shouldExpectKubeVirtUpdate(times int) {
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatus(times int) {
-	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
-	update.Do(func(kv *v1.KubeVirt) {
+	update := k.kvInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{})
+	update.Do(func(ctx context.Context, kv *v1.KubeVirt, options metav1.UpdateOptions) {
 		k.kvInformer.GetStore().Update(kv)
 		update.Return(kv, nil)
 	}).Times(times)
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusVersion(times int, config *util.KubeVirtDeploymentConfig) {
-	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
-	update.Do(func(kv *v1.KubeVirt) {
+	update := k.kvInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{})
+	update.Do(func(ctx context.Context, kv *v1.KubeVirt, options metav1.UpdateOptions) {
 
 		Expect(kv.Status.TargetKubeVirtVersion).To(Equal(config.GetKubeVirtVersion()))
 		Expect(kv.Status.ObservedKubeVirtVersion).To(Equal(config.GetKubeVirtVersion()))
@@ -439,8 +439,8 @@ func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusVersion(times int, co
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusFailureCondition(reason string) {
-	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
-	update.Do(func(kv *v1.KubeVirt) {
+	update := k.kvInterface.EXPECT().UpdateStatus(context.Background(), gomock.Any(), metav1.UpdateOptions{})
+	update.Do(func(ctx context.Context, kv *v1.KubeVirt, options metav1.UpdateOptions) {
 		Expect(kv.Status.Conditions).To(HaveLen(1))
 		Expect(kv.Status.Conditions[0].Reason).To(Equal(reason))
 		k.kvInformer.GetStore().Update(kv)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -396,8 +396,8 @@ func extractFinalizers(data []byte) []string {
 }
 
 func (k *KubeVirtTestData) shouldExpectKubeVirtFinalizersPatch(times int) {
-	patch := k.kvInterface.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	patch.DoAndReturn(func(name string, pt types.PatchType, data []byte, opts *metav1.PatchOptions, _ ...string) (*v1.KubeVirt, error) {
+	patch := k.kvInterface.EXPECT().Patch(context.Background(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	patch.DoAndReturn(func(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, _ ...string) (*v1.KubeVirt, error) {
 		Expect(pt).To(Equal(types.JSONPatchType))
 		finalizers := extractFinalizers(data)
 		obj, exists, err := k.kvInformer.GetStore().GetByKey(NAMESPACE + "/" + name)

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
@@ -20,6 +20,7 @@
 package webhooks
 
 import (
+	"context"
 	"fmt"
 
 	"kubevirt.io/client-go/log"
@@ -58,7 +59,7 @@ func (k *kubeVirtCreateAdmitter) Admit(review *admissionv1.AdmissionReview) *adm
 	//TODO: Do we want semantic validation
 
 	// Best effort
-	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(&metav1.ListOptions{})
+	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return webhooks.ToAdmissionResponseError(err)
 	}

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter_test.go
@@ -1,6 +1,7 @@
 package webhooks
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/golang/mock/gomock"
@@ -33,7 +34,7 @@ var _ = Describe("Validating KubeVirtCreate Admitter", func() {
 				Name:      "Existing",
 			},
 		}
-		kvInterface.EXPECT().List(gomock.Any()).
+		kvInterface.EXPECT().List(context.Background(), gomock.Any()).
 			Return(&v1.KubeVirtList{Items: []v1.KubeVirt{alreadyExistingKv}}, nil).AnyTimes()
 
 		newKv := v1.KubeVirt{
@@ -59,7 +60,7 @@ var _ = Describe("Validating KubeVirtCreate Admitter", func() {
 	})
 
 	It("should allow creating new Kubevirt resource", func() {
-		kvInterface.EXPECT().List(gomock.Any()).
+		kvInterface.EXPECT().List(context.Background(), gomock.Any()).
 			Return(&v1.KubeVirtList{Items: []v1.KubeVirt{}}, nil).AnyTimes()
 
 		newKv := v1.KubeVirt{

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -36,7 +36,7 @@ func (k *KubeVirtDeletionAdmitter) Admit(review *admissionv1.AdmissionReview) *a
 	var kv *v1.KubeVirt
 	var err error
 	if review.Request.Name != "" {
-		kv, err = k.client.KubeVirt(review.Request.Namespace).Get(review.Request.Name, &metav1.GetOptions{})
+		kv, err = k.client.KubeVirt(review.Request.Namespace).Get(context.Background(), review.Request.Name, metav1.GetOptions{})
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -80,7 +80,7 @@ func (k *KubeVirtDeletionAdmitter) Admit(review *admissionv1.AdmissionReview) *a
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf(uninstallErrorMsg, "Virtual Machines"))
 	}
 
-	vmirs, err := k.client.ReplicaSet(metav1.NamespaceAll).List(metav1.ListOptions{Limit: 2})
+	vmirs, err := k.client.ReplicaSet(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{Limit: 2})
 
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -41,7 +41,7 @@ func (k *KubeVirtDeletionAdmitter) Admit(review *admissionv1.AdmissionReview) *a
 			return webhookutils.ToAdmissionResponseError(err)
 		}
 	} else {
-		list, err := k.client.KubeVirt(review.Request.Namespace).List(&metav1.ListOptions{})
+		list, err := k.client.KubeVirt(review.Request.Namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}

--- a/pkg/virt-operator/webhooks/webhook_test.go
+++ b/pkg/virt-operator/webhooks/webhook_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Webhook", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		kubeCli = kubecli.NewMockKubevirtClient(ctrl)
 		kvInterface = kubecli.NewMockKubeVirtInterface(ctrl)
-		kvInterface.EXPECT().Get("kubevirt", gomock.Any()).Return(kv, nil).AnyTimes()
+		kvInterface.EXPECT().Get(context.Background(), "kubevirt", gomock.Any()).Return(kv, nil).AnyTimes()
 		kvInterface.EXPECT().List(gomock.Any()).Return(&k6tv1.KubeVirtList{}, nil).AnyTimes()
 		admitter = &KubeVirtDeletionAdmitter{kubeCli}
 		kubeCli.EXPECT().KubeVirt("test").Return(kvInterface)

--- a/pkg/virt-operator/webhooks/webhook_test.go
+++ b/pkg/virt-operator/webhooks/webhook_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Webhook", func() {
 		It("should allow the deletion if no workload exists", func() {
 			vmiInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceList{}, nil)
 			vmInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineList{}, nil)
-			vmirsInterface.EXPECT().List(gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{}, nil)
+			vmirsInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{}, nil)
 
 			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeTrue())
@@ -78,7 +78,7 @@ var _ = Describe("Webhook", func() {
 		It("should deny the deletion if a VMIRS exists", func() {
 			vmiInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceList{}, nil)
 			vmInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineList{}, nil)
-			vmirsInterface.EXPECT().List(gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{Items: []k6tv1.VirtualMachineInstanceReplicaSet{{}}}, nil)
+			vmirsInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{Items: []k6tv1.VirtualMachineInstanceReplicaSet{{}}}, nil)
 
 			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeFalse())
@@ -102,7 +102,7 @@ var _ = Describe("Webhook", func() {
 		It("should deny the deletion if checking VMIRS fails", func() {
 			vmiInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceList{}, nil)
 			vmInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineList{}, nil)
-			vmirsInterface.EXPECT().List(gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{}, fmt.Errorf("whatever"))
+			vmirsInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{}, fmt.Errorf("whatever"))
 
 			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeFalse())

--- a/pkg/virt-operator/webhooks/webhook_test.go
+++ b/pkg/virt-operator/webhooks/webhook_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Webhook", func() {
 		kubeCli = kubecli.NewMockKubevirtClient(ctrl)
 		kvInterface = kubecli.NewMockKubeVirtInterface(ctrl)
 		kvInterface.EXPECT().Get(context.Background(), "kubevirt", gomock.Any()).Return(kv, nil).AnyTimes()
-		kvInterface.EXPECT().List(gomock.Any()).Return(&k6tv1.KubeVirtList{}, nil).AnyTimes()
+		kvInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.KubeVirtList{}, nil).AnyTimes()
 		admitter = &KubeVirtDeletionAdmitter{kubeCli}
 		kubeCli.EXPECT().KubeVirt("test").Return(kvInterface)
 

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -1,6 +1,7 @@
 package logverbosity
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -369,7 +370,7 @@ func (c *Command) RunE(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	kv, err := virtClient.KubeVirt(namespace).Get(name, &k8smetav1.GetOptions{})
+	kv, err := virtClient.KubeVirt(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -181,7 +181,7 @@ func getJSONNameByComponentName(componentName string) string {
 }
 
 func detectInstallNamespaceAndName(virtClient kubecli.KubevirtClient) (string, string, error) {
-	kvs, err := virtClient.KubeVirt(k8smetav1.NamespaceAll).List(&k8smetav1.ListOptions{})
+	kvs, err := virtClient.KubeVirt(k8smetav1.NamespaceAll).List(context.Background(), k8smetav1.ListOptions{})
 	if err != nil {
 		return "", "", fmt.Errorf("could not list KubeVirt CRs across all namespaces: %v", err)
 	}

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -410,7 +410,7 @@ func (c *Command) RunE(cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		_, err = virtClient.KubeVirt(namespace).Patch(name, types.JSONPatchType, patchData, &k8smetav1.PatchOptions{})
+		_, err = virtClient.KubeVirt(namespace).Patch(context.Background(), name, types.JSONPatchType, patchData, k8smetav1.PatchOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -1,6 +1,7 @@
 package logverbosity_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -143,8 +144,8 @@ var _ = Describe("Log Verbosity", func() {
 			})
 
 			expectGetError := func() {
-				kvInterface.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(name string, _ any) (*v1.KubeVirt, error) {
+				kvInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, name string, _ any) (*v1.KubeVirt, error) {
 						Expect(name).To(Equal(kvs.Items[0].Name))
 						return nil, errors.New("Get error")
 					}).AnyTimes()
@@ -170,8 +171,8 @@ var _ = Describe("Log Verbosity", func() {
 		})
 
 		expectGetKv := func() {
-			kvInterface.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(
-				func(name string, _ any) (*v1.KubeVirt, error) {
+			kvInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, name string, _ any) (*v1.KubeVirt, error) {
 					Expect(name).To(Equal(kvs.Items[0].Name))
 					return &kvs.Items[0], nil
 				}).AnyTimes()
@@ -393,7 +394,7 @@ func NewKubeVirtWithoutDeveloperConfiguration(namespace, name string) *v1.KubeVi
 
 func commonSetup(kvInterface *kubecli.MockKubeVirtInterface, kvs *v1.KubeVirtList) {
 	kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
-	kvInterface.EXPECT().Get(kvs.Items[0].Name, gomock.Any()).Return(&kvs.Items[0], nil).AnyTimes()
+	kvInterface.EXPECT().Get(context.Background(), kvs.Items[0].Name, gomock.Any()).Return(&kvs.Items[0], nil).AnyTimes()
 }
 
 func commonShowTest(output []uint, args ...string) {

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -87,8 +87,8 @@ var _ = Describe("Log Verbosity", func() {
 		kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(kvs.Items[0].Namespace).Return(kvInterface).AnyTimes() // Get & Patch
 		kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(k8smetav1.NamespaceAll).Return(kvInterface).AnyTimes() // List
 
-		kvInterface.EXPECT().Patch(gomock.Any(), types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-			func(name string, _ any, patchData []byte, _ any, _ ...any) (*v1.KubeVirt, error) {
+		kvInterface.EXPECT().Patch(context.Background(), gomock.Any(), types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, name string, _ any, patchData []byte, _ any, _ ...any) (*v1.KubeVirt, error) {
 				Expect(name).To(Equal(kvs.Items[0].Name))
 
 				patch, err := jsonpatch.DecodePatch(patchData)

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -123,8 +123,8 @@ var _ = Describe("Log Verbosity", func() {
 
 		Context("detectInstallNamespaceAndName has en error", func() {
 			expectListError := func() {
-				kvInterface.EXPECT().List(gomock.Any()).DoAndReturn(
-					func(_ any) (*v1.KubeVirt, error) {
+				kvInterface.EXPECT().List(context.Background(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, _ any) (*v1.KubeVirt, error) {
 						return nil, errors.New("List error")
 					}).AnyTimes()
 			}
@@ -140,7 +140,7 @@ var _ = Describe("Log Verbosity", func() {
 
 		Context("Get function has an error", func() {
 			BeforeEach(func() {
-				kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+				kvInterface.EXPECT().List(context.Background(), gomock.Any()).Return(kvs, nil).AnyTimes()
 			})
 
 			expectGetError := func() {
@@ -167,7 +167,7 @@ var _ = Describe("Log Verbosity", func() {
 			kvs = kubecli.NewKubeVirtList(*kv)
 
 			kubecli.MockKubevirtClientInstance.EXPECT().KubeVirt(kvs.Items[0].Namespace).Return(kvInterface).AnyTimes() // Get & Patch
-			kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+			kvInterface.EXPECT().List(context.Background(), gomock.Any()).Return(kvs, nil).AnyTimes()
 		})
 
 		expectGetKv := func() {
@@ -393,7 +393,7 @@ func NewKubeVirtWithoutDeveloperConfiguration(namespace, name string) *v1.KubeVi
 }
 
 func commonSetup(kvInterface *kubecli.MockKubeVirtInterface, kvs *v1.KubeVirtList) {
-	kvInterface.EXPECT().List(gomock.Any()).Return(kvs, nil).AnyTimes()
+	kvInterface.EXPECT().List(context.Background(), gomock.Any()).Return(kvs, nil).AnyTimes()
 	kvInterface.EXPECT().Get(context.Background(), kvs.Items[0].Name, gomock.Any()).Return(&kvs.Items[0], nil).AnyTimes()
 }
 

--- a/pkg/virtctl/configuration/configuration.go
+++ b/pkg/virtctl/configuration/configuration.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -52,7 +53,7 @@ func (c *command) run() error {
 		return fmt.Errorf("cannot obtain KubeVirt client: %v", err)
 	}
 
-	kvList, err := virtClient.KubeVirt(namespace).List(&metav1.ListOptions{})
+	kvList, err := virtClient.KubeVirt(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -189,7 +189,7 @@ func (o *Command) RunE(args []string) error {
 		delete(serviceSelector, virtv1.VirtualMachinePoolRevisionName)
 	case "vmirs", "vmirss", "virtualmachineinstancereplicaset", "virtualmachineinstancereplicasets":
 		// get the VM replica set
-		vmirs, err := virtClient.ReplicaSet(namespace).Get(vmName, options)
+		vmirs, err := virtClient.ReplicaSet(namespace).Get(context.Background(), vmName, options)
 		if err != nil {
 			return fmt.Errorf("error fetching VirtualMachineInstance ReplicaSet: %v", err)
 		}

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -83,8 +83,8 @@ var _ = Describe("Expose", func() {
 		vmiInterface.EXPECT().Get(context.Background(), unknownVM, gomock.Any()).Return(nil, errors.New("unknown VM")).AnyTimes()
 		vmInterface.EXPECT().Get(context.Background(), vmi.Name, gomock.Any()).Return(vm, nil).AnyTimes()
 		vmInterface.EXPECT().Get(context.Background(), unknownVM, gomock.Any()).Return(nil, errors.New("unknown VM")).AnyTimes()
-		vmrsInterface.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmrs, nil).AnyTimes()
-		vmrsInterface.EXPECT().Get(unknownVM, gomock.Any()).Return(nil, errors.New("unknonw VMRS")).AnyTimes()
+		vmrsInterface.EXPECT().Get(context.Background(), vmi.Name, gomock.Any()).Return(vmrs, nil).AnyTimes()
+		vmrsInterface.EXPECT().Get(context.Background(), unknownVM, gomock.Any()).Return(nil, errors.New("unknonw VMRS")).AnyTimes()
 
 		// Make sure that all unexpected calls to kubeClient will fail
 		// this should be called first

--- a/pkg/virtctl/vm/migrate_cancel.go
+++ b/pkg/virtctl/vm/migrate_cancel.go
@@ -72,7 +72,7 @@ func (o *Command) migrateCancelRun(args []string) error {
 
 		if !mig.IsFinal() {
 			// Cancel the active migration by calling Delete
-			err = virtClient.VirtualMachineInstanceMigration(namespace).Delete(migname, &metav1.DeleteOptions{})
+			err = virtClient.VirtualMachineInstanceMigration(namespace).Delete(context.Background(), migname, metav1.DeleteOptions{})
 			if err != nil {
 				return fmt.Errorf("Error canceling migration %s of a VirtualMachine %s: %v", migname, vmiName, err)
 			}

--- a/pkg/virtctl/vm/migrate_cancel.go
+++ b/pkg/virtctl/vm/migrate_cancel.go
@@ -20,6 +20,7 @@
 package vm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -57,7 +58,7 @@ func (o *Command) migrateCancelRun(args []string) error {
 
 	// get a list of migrations for vmiName (use LabelSelector filter)
 	labelselector := fmt.Sprintf("%s==%s", v1.MigrationSelectorLabel, vmiName)
-	migrations, err := virtClient.VirtualMachineInstanceMigration(namespace).List(&metav1.ListOptions{
+	migrations, err := virtClient.VirtualMachineInstanceMigration(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelselector})
 	if err != nil {
 		return fmt.Errorf("Error fetching virtual machine instance migration list  %v", err)

--- a/pkg/virtctl/vm/migrate_cancel_test.go
+++ b/pkg/virtctl/vm/migrate_cancel_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Migrate cancel command", func() {
 			Return(migrationInterface).Times(2)
 
 		migrationInterface.EXPECT().List(context.Background(), listoptions).Return(&migList, nil).Times(1)
-		migrationInterface.EXPECT().Delete(vmiMigration.Name, &k8smetav1.DeleteOptions{}).Return(nil).Times(1)
+		migrationInterface.EXPECT().Delete(context.Background(), vmiMigration.Name, k8smetav1.DeleteOptions{}).Return(nil).Times(1)
 
 		Expect(cmd()).To(Succeed())
 	})

--- a/pkg/virtctl/vm/migrate_cancel_test.go
+++ b/pkg/virtctl/vm/migrate_cancel_test.go
@@ -20,6 +20,7 @@
 package vm_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/golang/mock/gomock"
@@ -74,7 +75,7 @@ var _ = Describe("Migrate cancel command", func() {
 			VirtualMachineInstanceMigration(k8smetav1.NamespaceDefault).
 			Return(migrationInterface).Times(2)
 
-		migrationInterface.EXPECT().List(&listoptions).Return(&migList, nil).Times(1)
+		migrationInterface.EXPECT().List(context.Background(), listoptions).Return(&migList, nil).Times(1)
 		migrationInterface.EXPECT().Delete(vmiMigration.Name, &k8smetav1.DeleteOptions{}).Return(nil).Times(1)
 
 		Expect(cmd()).To(Succeed())
@@ -94,7 +95,7 @@ var _ = Describe("Migrate cancel command", func() {
 			VirtualMachineInstanceMigration(k8smetav1.NamespaceDefault).
 			Return(migrationInterface).Times(1)
 
-		migrationInterface.EXPECT().List(&listoptions).Return(&migList, nil).Times(1)
+		migrationInterface.EXPECT().List(context.Background(), listoptions).Return(&migList, nil).Times(1)
 
 		err := cmd()
 		Expect(err).To(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -2032,8 +2032,8 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []byte, patchOptions *v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {
-	_s := []interface{}{name, pt, data, patchOptions}
+func (_m *MockKubeVirtInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {
+	_s := []interface{}{ctx, name, pt, data, patchOptions}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -2043,8 +2043,8 @@ func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []b
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
-	_s := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
+func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
@@ -2059,15 +2059,15 @@ func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *v12.PatchOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "PatchStatus", name, pt, data, patchOptions)
+func (_m *MockKubeVirtInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions v12.PatchOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "PatchStatus", ctx, name, pt, data, patchOptions)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3)
+func (_mr *_MockKubeVirtInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3, arg4)
 }
 
 // Mock of ServerVersionInterface interface

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1475,15 +1475,15 @@ func (_mr *_MockReplicaSetInterfaceRecorder) GetScale(arg0, arg1, arg2 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetScale", arg0, arg1, arg2)
 }
 
-func (_m *MockReplicaSetInterface) UpdateScale(replicaSetName string, scale *v11.Scale) (*v11.Scale, error) {
-	ret := _m.ctrl.Call(_m, "UpdateScale", replicaSetName, scale)
+func (_m *MockReplicaSetInterface) UpdateScale(ctx context.Context, replicaSetName string, scale *v11.Scale) (*v11.Scale, error) {
+	ret := _m.ctrl.Call(_m, "UpdateScale", ctx, replicaSetName, scale)
 	ret0, _ := ret[0].(*v11.Scale)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) UpdateScale(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateScale", arg0, arg1)
+func (_mr *_MockReplicaSetInterfaceRecorder) UpdateScale(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateScale", arg0, arg1, arg2)
 }
 
 func (_m *MockReplicaSetInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1572,8 +1572,8 @@ func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Delete(arg0, arg1
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInstancePresetInterface) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*v120.VirtualMachineInstancePreset, error) {
-	_s := []interface{}{name, pt, data}
+func (_m *MockVirtualMachineInstancePresetInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.VirtualMachineInstancePreset, error) {
+	_s := []interface{}{ctx, name, pt, data, opts}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -1583,8 +1583,8 @@ func (_m *MockVirtualMachineInstancePresetInterface) Patch(name string, pt types
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1855,15 +1855,15 @@ func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Get(arg0, arg1
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) List(opts *v12.ListOptions) (*v120.VirtualMachineInstanceMigrationList, error) {
-	ret := _m.ctrl.Call(_m, "List", opts)
+func (_m *MockVirtualMachineInstanceMigrationInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.VirtualMachineInstanceMigrationList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigrationList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) List(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
 func (_m *MockVirtualMachineInstanceMigrationInterface) Create(migration *v120.VirtualMachineInstanceMigration, options *v12.CreateOptions) (*v120.VirtualMachineInstanceMigration, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1888,14 +1888,14 @@ func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Update(arg0, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) Delete(name string, options *v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", name, options)
+func (_m *MockVirtualMachineInstanceMigrationInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstanceMigrationInterface) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*v120.VirtualMachineInstanceMigration, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1518,15 +1518,15 @@ func (_m *MockVirtualMachineInstancePresetInterface) EXPECT() *_MockVirtualMachi
 	return _m.recorder
 }
 
-func (_m *MockVirtualMachineInstancePresetInterface) Get(name string, options v12.GetOptions) (*v120.VirtualMachineInstancePreset, error) {
-	ret := _m.ctrl.Call(_m, "Get", name, options)
+func (_m *MockVirtualMachineInstancePresetInterface) Get(ctx context.Context, name string, options v12.GetOptions) (*v120.VirtualMachineInstancePreset, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstancePreset)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstancePresetInterface) List(opts v12.ListOptions) (*v120.VirtualMachineInstancePresetList, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1844,15 +1844,15 @@ func (_m *MockVirtualMachineInstanceMigrationInterface) EXPECT() *_MockVirtualMa
 	return _m.recorder
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) Get(name string, options *v12.GetOptions) (*v120.VirtualMachineInstanceMigration, error) {
-	ret := _m.ctrl.Call(_m, "Get", name, options)
+func (_m *MockVirtualMachineInstanceMigrationInterface) Get(ctx context.Context, name string, opts v12.GetOptions) (*v120.VirtualMachineInstanceMigration, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstanceMigrationInterface) List(opts *v12.ListOptions) (*v120.VirtualMachineInstanceMigrationList, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1362,15 +1362,15 @@ func (_m *MockReplicaSetInterface) EXPECT() *_MockReplicaSetInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockReplicaSetInterface) Get(name string, options v12.GetOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	ret := _m.ctrl.Call(_m, "Get", name, options)
+func (_m *MockReplicaSetInterface) Get(ctx context.Context, name string, options v12.GetOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+func (_mr *_MockReplicaSetInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
 func (_m *MockReplicaSetInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.VirtualMachineInstanceReplicaSetList, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1518,28 +1518,6 @@ func (_m *MockVirtualMachineInstancePresetInterface) EXPECT() *_MockVirtualMachi
 	return _m.recorder
 }
 
-func (_m *MockVirtualMachineInstancePresetInterface) Get(ctx context.Context, name string, options v12.GetOptions) (*v120.VirtualMachineInstancePreset, error) {
-	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstancePreset)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
-}
-
-func (_m *MockVirtualMachineInstancePresetInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.VirtualMachineInstancePresetList, error) {
-	ret := _m.ctrl.Call(_m, "List", ctx, opts)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstancePresetList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
-}
-
 func (_m *MockVirtualMachineInstancePresetInterface) Create(ctx context.Context, virtualMachineInstancePreset *v120.VirtualMachineInstancePreset, opts v12.CreateOptions) (*v120.VirtualMachineInstancePreset, error) {
 	ret := _m.ctrl.Call(_m, "Create", ctx, virtualMachineInstancePreset, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstancePreset)
@@ -1562,14 +1540,57 @@ func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Update(arg0, arg1
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInstancePresetInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
+func (_m *MockVirtualMachineInstancePresetInterface) Delete(ctx context.Context, name string, opts v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
+}
+
+func (_m *MockVirtualMachineInstancePresetInterface) DeleteCollection(ctx context.Context, opts v12.DeleteOptions, listOpts v12.ListOptions) error {
+	ret := _m.ctrl.Call(_m, "DeleteCollection", ctx, opts, listOpts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) DeleteCollection(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCollection", arg0, arg1, arg2)
+}
+
+func (_m *MockVirtualMachineInstancePresetInterface) Get(ctx context.Context, name string, opts v12.GetOptions) (*v120.VirtualMachineInstancePreset, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, opts)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstancePreset)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
+}
+
+func (_m *MockVirtualMachineInstancePresetInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.VirtualMachineInstancePresetList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstancePresetList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
+}
+
+func (_m *MockVirtualMachineInstancePresetInterface) Watch(ctx context.Context, opts v12.ListOptions) (watch.Interface, error) {
+	ret := _m.ctrl.Call(_m, "Watch", ctx, opts)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Watch(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Watch", arg0, arg1)
 }
 
 func (_m *MockVirtualMachineInstancePresetInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.VirtualMachineInstancePreset, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -2011,15 +2011,15 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Create(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Update(_param0 *v120.KubeVirt) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Update", _param0)
+func (_m *MockKubeVirtInterface) Update(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.UpdateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Update", ctx, kubeVirt, opts)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Update(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0)
+func (_mr *_MockKubeVirtInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) Delete(name string, options *v12.DeleteOptions) error {
@@ -2048,15 +2048,15 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockKubeVirtInterface) UpdateStatus(_param0 *v120.KubeVirt) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "UpdateStatus", _param0)
+func (_m *MockKubeVirtInterface) UpdateStatus(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.UpdateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, kubeVirt, opts)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0)
+func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *v12.PatchOptions) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1844,6 +1844,59 @@ func (_m *MockVirtualMachineInstanceMigrationInterface) EXPECT() *_MockVirtualMa
 	return _m.recorder
 }
 
+func (_m *MockVirtualMachineInstanceMigrationInterface) Create(ctx context.Context, virtualMachineInstanceMigration *v120.VirtualMachineInstanceMigration, opts v12.CreateOptions) (*v120.VirtualMachineInstanceMigration, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, virtualMachineInstanceMigration, opts)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
+}
+
+func (_m *MockVirtualMachineInstanceMigrationInterface) Update(ctx context.Context, virtualMachineInstanceMigration *v120.VirtualMachineInstanceMigration, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceMigration, error) {
+	ret := _m.ctrl.Call(_m, "Update", ctx, virtualMachineInstanceMigration, opts)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
+}
+
+func (_m *MockVirtualMachineInstanceMigrationInterface) UpdateStatus(ctx context.Context, virtualMachineInstanceMigration *v120.VirtualMachineInstanceMigration, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceMigration, error) {
+	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, virtualMachineInstanceMigration, opts)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
+}
+
+func (_m *MockVirtualMachineInstanceMigrationInterface) Delete(ctx context.Context, name string, opts v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
+}
+
+func (_m *MockVirtualMachineInstanceMigrationInterface) DeleteCollection(ctx context.Context, opts v12.DeleteOptions, listOpts v12.ListOptions) error {
+	ret := _m.ctrl.Call(_m, "DeleteCollection", ctx, opts, listOpts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) DeleteCollection(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCollection", arg0, arg1, arg2)
+}
+
 func (_m *MockVirtualMachineInstanceMigrationInterface) Get(ctx context.Context, name string, opts v12.GetOptions) (*v120.VirtualMachineInstanceMigration, error) {
 	ret := _m.ctrl.Call(_m, "Get", ctx, name, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
@@ -1866,36 +1919,15 @@ func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) List(arg0, arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) Create(ctx context.Context, migration *v120.VirtualMachineInstanceMigration, options v12.CreateOptions) (*v120.VirtualMachineInstanceMigration, error) {
-	ret := _m.ctrl.Call(_m, "Create", ctx, migration, options)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
+func (_m *MockVirtualMachineInstanceMigrationInterface) Watch(ctx context.Context, opts v12.ListOptions) (watch.Interface, error) {
+	ret := _m.ctrl.Call(_m, "Watch", ctx, opts)
+	ret0, _ := ret[0].(watch.Interface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
-}
-
-func (_m *MockVirtualMachineInstanceMigrationInterface) Update(ctx context.Context, virtualMachineInstanceMigration *v120.VirtualMachineInstanceMigration, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceMigration, error) {
-	ret := _m.ctrl.Call(_m, "Update", ctx, virtualMachineInstanceMigration, opts)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
-}
-
-func (_m *MockVirtualMachineInstanceMigrationInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Watch(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Watch", arg0, arg1)
 }
 
 func (_m *MockVirtualMachineInstanceMigrationInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.VirtualMachineInstanceMigration, error) {
@@ -1912,17 +1944,6 @@ func (_m *MockVirtualMachineInstanceMigrationInterface) Patch(ctx context.Contex
 func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
 	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
-}
-
-func (_m *MockVirtualMachineInstanceMigrationInterface) UpdateStatus(ctx context.Context, virtualMachineInstanceMigration *v120.VirtualMachineInstanceMigration, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceMigration, error) {
-	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, virtualMachineInstanceMigration, opts)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstanceMigrationInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions) (*v120.VirtualMachineInstanceMigration, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1362,30 +1362,8 @@ func (_m *MockReplicaSetInterface) EXPECT() *_MockReplicaSetInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockReplicaSetInterface) Get(ctx context.Context, name string, options v12.GetOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockReplicaSetInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
-}
-
-func (_m *MockReplicaSetInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.VirtualMachineInstanceReplicaSetList, error) {
-	ret := _m.ctrl.Call(_m, "List", ctx, opts)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSetList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockReplicaSetInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
-}
-
-func (_m *MockReplicaSetInterface) Create(ctx context.Context, replicaset *v120.VirtualMachineInstanceReplicaSet, opts v12.CreateOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	ret := _m.ctrl.Call(_m, "Create", ctx, replicaset, opts)
+func (_m *MockReplicaSetInterface) Create(ctx context.Context, virtualMachineInstanceReplicaSet *v120.VirtualMachineInstanceReplicaSet, opts v12.CreateOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, virtualMachineInstanceReplicaSet, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -1406,14 +1384,84 @@ func (_mr *_MockReplicaSetInterfaceRecorder) Update(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockReplicaSetInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
+func (_m *MockReplicaSetInterface) UpdateStatus(ctx context.Context, virtualMachineInstanceReplicaSet *v120.VirtualMachineInstanceReplicaSet, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, virtualMachineInstanceReplicaSet, opts)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
+}
+
+func (_m *MockReplicaSetInterface) Delete(ctx context.Context, name string, opts v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 func (_mr *_MockReplicaSetInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
+}
+
+func (_m *MockReplicaSetInterface) DeleteCollection(ctx context.Context, opts v12.DeleteOptions, listOpts v12.ListOptions) error {
+	ret := _m.ctrl.Call(_m, "DeleteCollection", ctx, opts, listOpts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) DeleteCollection(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCollection", arg0, arg1, arg2)
+}
+
+func (_m *MockReplicaSetInterface) Get(ctx context.Context, name string, opts v12.GetOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, opts)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
+}
+
+func (_m *MockReplicaSetInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.VirtualMachineInstanceReplicaSetList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSetList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
+}
+
+func (_m *MockReplicaSetInterface) Watch(ctx context.Context, opts v12.ListOptions) (watch.Interface, error) {
+	ret := _m.ctrl.Call(_m, "Watch", ctx, opts)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) Watch(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Watch", arg0, arg1)
+}
+
+func (_m *MockReplicaSetInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	_s := []interface{}{ctx, name, pt, data, opts}
+	for _, _x := range subresources {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "Patch", _s...)
+	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
 func (_m *MockReplicaSetInterface) GetScale(replicaSetName string, options v12.GetOptions) (*v11.Scale, error) {
@@ -1436,33 +1484,6 @@ func (_m *MockReplicaSetInterface) UpdateScale(replicaSetName string, scale *v11
 
 func (_mr *_MockReplicaSetInterfaceRecorder) UpdateScale(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateScale", arg0, arg1)
-}
-
-func (_m *MockReplicaSetInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	_s := []interface{}{ctx, name, pt, data, opts}
-	for _, _x := range subresources {
-		_s = append(_s, _x)
-	}
-	ret := _m.ctrl.Call(_m, "Patch", _s...)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockReplicaSetInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
-	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
-}
-
-func (_m *MockReplicaSetInterface) UpdateStatus(ctx context.Context, virtualMachineInstanceReplicaSet *v120.VirtualMachineInstanceReplicaSet, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, virtualMachineInstanceReplicaSet, opts)
-	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockReplicaSetInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
 func (_m *MockReplicaSetInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1562,14 +1562,14 @@ func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Update(arg0, arg1
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInstancePresetInterface) Delete(name string, options *v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", name, options)
+func (_m *MockVirtualMachineInstancePresetInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstancePresetInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.VirtualMachineInstancePreset, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1384,15 +1384,15 @@ func (_mr *_MockReplicaSetInterfaceRecorder) List(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
 }
 
-func (_m *MockReplicaSetInterface) Create(_param0 *v120.VirtualMachineInstanceReplicaSet) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	ret := _m.ctrl.Call(_m, "Create", _param0)
+func (_m *MockReplicaSetInterface) Create(ctx context.Context, replicaset *v120.VirtualMachineInstanceReplicaSet, opts v12.CreateOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, replicaset, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) Create(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0)
+func (_mr *_MockReplicaSetInterfaceRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
 func (_m *MockReplicaSetInterface) Update(_param0 *v120.VirtualMachineInstanceReplicaSet) (*v120.VirtualMachineInstanceReplicaSet, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1373,15 +1373,15 @@ func (_mr *_MockReplicaSetInterfaceRecorder) Get(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
 }
 
-func (_m *MockReplicaSetInterface) List(opts v12.ListOptions) (*v120.VirtualMachineInstanceReplicaSetList, error) {
-	ret := _m.ctrl.Call(_m, "List", opts)
+func (_m *MockReplicaSetInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.VirtualMachineInstanceReplicaSetList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSetList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) List(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
+func (_mr *_MockReplicaSetInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
 func (_m *MockReplicaSetInterface) Create(ctx context.Context, replicaset *v120.VirtualMachineInstanceReplicaSet, opts v12.CreateOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1978,30 +1978,8 @@ func (_m *MockKubeVirtInterface) EXPECT() *_MockKubeVirtInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockKubeVirtInterface) Get(ctx context.Context, name string, options v12.GetOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
-	ret0, _ := ret[0].(*v120.KubeVirt)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
-}
-
-func (_m *MockKubeVirtInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.KubeVirtList, error) {
-	ret := _m.ctrl.Call(_m, "List", ctx, opts)
-	ret0, _ := ret[0].(*v120.KubeVirtList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
-}
-
-func (_m *MockKubeVirtInterface) Create(ctx context.Context, instance *v120.KubeVirt, opts v12.CreateOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Create", ctx, instance, opts)
+func (_m *MockKubeVirtInterface) Create(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.CreateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, kubeVirt, opts)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -2022,8 +2000,19 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
+func (_m *MockKubeVirtInterface) UpdateStatus(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.UpdateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, kubeVirt, opts)
+	ret0, _ := ret[0].(*v120.KubeVirt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
+}
+
+func (_m *MockKubeVirtInterface) Delete(ctx context.Context, name string, opts v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -2032,8 +2021,51 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {
-	_s := []interface{}{ctx, name, pt, data, patchOptions}
+func (_m *MockKubeVirtInterface) DeleteCollection(ctx context.Context, opts v12.DeleteOptions, listOpts v12.ListOptions) error {
+	ret := _m.ctrl.Call(_m, "DeleteCollection", ctx, opts, listOpts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) DeleteCollection(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCollection", arg0, arg1, arg2)
+}
+
+func (_m *MockKubeVirtInterface) Get(ctx context.Context, name string, opts v12.GetOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, opts)
+	ret0, _ := ret[0].(*v120.KubeVirt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
+}
+
+func (_m *MockKubeVirtInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.KubeVirtList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
+	ret0, _ := ret[0].(*v120.KubeVirtList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
+}
+
+func (_m *MockKubeVirtInterface) Watch(ctx context.Context, opts v12.ListOptions) (watch.Interface, error) {
+	ret := _m.ctrl.Call(_m, "Watch", ctx, opts)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKubeVirtInterfaceRecorder) Watch(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Watch", arg0, arg1)
+}
+
+func (_m *MockKubeVirtInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {
+	_s := []interface{}{ctx, name, pt, data, opts}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -2046,17 +2078,6 @@ func (_m *MockKubeVirtInterface) Patch(ctx context.Context, name string, pt type
 func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
 	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
-}
-
-func (_m *MockKubeVirtInterface) UpdateStatus(ctx context.Context, kubeVirt *v120.KubeVirt, opts v12.UpdateOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, kubeVirt, opts)
-	ret0, _ := ret[0].(*v120.KubeVirt)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions v12.PatchOptions) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1898,8 +1898,8 @@ func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Delete(arg0, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*v120.VirtualMachineInstanceMigration, error) {
-	_s := []interface{}{name, pt, data}
+func (_m *MockVirtualMachineInstanceMigrationInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.VirtualMachineInstanceMigration, error) {
+	_s := []interface{}{ctx, name, pt, data, opts}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -1909,8 +1909,8 @@ func (_m *MockVirtualMachineInstanceMigrationInterface) Patch(name string, pt ty
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
@@ -1925,15 +1925,15 @@ func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) UpdateStatus(a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0)
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) PatchStatus(name string, pt types.PatchType, data []byte) (*v120.VirtualMachineInstanceMigration, error) {
-	ret := _m.ctrl.Call(_m, "PatchStatus", name, pt, data)
+func (_m *MockVirtualMachineInstanceMigrationInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions) (*v120.VirtualMachineInstanceMigration, error) {
+	ret := _m.ctrl.Call(_m, "PatchStatus", ctx, name, pt, data, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) PatchStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3, arg4)
 }
 
 // Mock of KubeVirtInterface interface

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -2022,14 +2022,14 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) Delete(name string, options *v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", name, options)
+func (_m *MockKubeVirtInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []byte, patchOptions *v12.PatchOptions, subresources ...string) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1406,14 +1406,14 @@ func (_mr *_MockReplicaSetInterfaceRecorder) Update(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
-func (_m *MockReplicaSetInterface) Delete(name string, options *v12.DeleteOptions) error {
-	ret := _m.ctrl.Call(_m, "Delete", name, options)
+func (_m *MockReplicaSetInterface) Delete(ctx context.Context, name string, options v12.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, name, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+func (_mr *_MockReplicaSetInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
 func (_m *MockReplicaSetInterface) GetScale(replicaSetName string, options v12.GetOptions) (*v11.Scale, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1978,15 +1978,15 @@ func (_m *MockKubeVirtInterface) EXPECT() *_MockKubeVirtInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockKubeVirtInterface) Get(name string, options *v12.GetOptions) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Get", name, options)
+func (_m *MockKubeVirtInterface) Get(ctx context.Context, name string, options v12.GetOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) List(opts *v12.ListOptions) (*v120.KubeVirtList, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1866,15 +1866,15 @@ func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) List(arg0, arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) Create(migration *v120.VirtualMachineInstanceMigration, options *v12.CreateOptions) (*v120.VirtualMachineInstanceMigration, error) {
-	ret := _m.ctrl.Call(_m, "Create", migration, options)
+func (_m *MockVirtualMachineInstanceMigrationInterface) Create(ctx context.Context, migration *v120.VirtualMachineInstanceMigration, options v12.CreateOptions) (*v120.VirtualMachineInstanceMigration, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, migration, options)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstanceMigrationInterface) Update(_param0 *v120.VirtualMachineInstanceMigration) (*v120.VirtualMachineInstanceMigration, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1529,15 +1529,15 @@ func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Get(arg0, arg1, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInstancePresetInterface) List(opts v12.ListOptions) (*v120.VirtualMachineInstancePresetList, error) {
-	ret := _m.ctrl.Call(_m, "List", opts)
+func (_m *MockVirtualMachineInstancePresetInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.VirtualMachineInstancePresetList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstancePresetList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) List(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
 func (_m *MockVirtualMachineInstancePresetInterface) Create(ctx context.Context, virtualMachineInstancePreset *v120.VirtualMachineInstancePreset, opts v12.CreateOptions) (*v120.VirtualMachineInstancePreset, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1540,15 +1540,15 @@ func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) List(arg0 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
 }
 
-func (_m *MockVirtualMachineInstancePresetInterface) Create(_param0 *v120.VirtualMachineInstancePreset) (*v120.VirtualMachineInstancePreset, error) {
-	ret := _m.ctrl.Call(_m, "Create", _param0)
+func (_m *MockVirtualMachineInstancePresetInterface) Create(ctx context.Context, virtualMachineInstancePreset *v120.VirtualMachineInstancePreset, opts v12.CreateOptions) (*v120.VirtualMachineInstancePreset, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, virtualMachineInstancePreset, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstancePreset)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Create(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0)
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstancePresetInterface) Update(_param0 *v120.VirtualMachineInstancePreset) (*v120.VirtualMachineInstancePreset, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1877,15 +1877,15 @@ func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Create(arg0, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) Update(_param0 *v120.VirtualMachineInstanceMigration) (*v120.VirtualMachineInstanceMigration, error) {
-	ret := _m.ctrl.Call(_m, "Update", _param0)
+func (_m *MockVirtualMachineInstanceMigrationInterface) Update(ctx context.Context, virtualMachineInstanceMigration *v120.VirtualMachineInstanceMigration, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceMigration, error) {
+	ret := _m.ctrl.Call(_m, "Update", ctx, virtualMachineInstanceMigration, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Update(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstanceMigrationInterface) Delete(name string, options *v12.DeleteOptions) error {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1464,15 +1464,15 @@ func (_mr *_MockReplicaSetInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockReplicaSetInterface) GetScale(replicaSetName string, options v12.GetOptions) (*v11.Scale, error) {
-	ret := _m.ctrl.Call(_m, "GetScale", replicaSetName, options)
+func (_m *MockReplicaSetInterface) GetScale(ctx context.Context, replicaSetName string, options v12.GetOptions) (*v11.Scale, error) {
+	ret := _m.ctrl.Call(_m, "GetScale", ctx, replicaSetName, options)
 	ret0, _ := ret[0].(*v11.Scale)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) GetScale(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetScale", arg0, arg1)
+func (_mr *_MockReplicaSetInterfaceRecorder) GetScale(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetScale", arg0, arg1, arg2)
 }
 
 func (_m *MockReplicaSetInterface) UpdateScale(replicaSetName string, scale *v11.Scale) (*v11.Scale, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1989,15 +1989,15 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
-func (_m *MockKubeVirtInterface) List(opts *v12.ListOptions) (*v120.KubeVirtList, error) {
-	ret := _m.ctrl.Call(_m, "List", opts)
+func (_m *MockKubeVirtInterface) List(ctx context.Context, opts v12.ListOptions) (*v120.KubeVirtList, error) {
+	ret := _m.ctrl.Call(_m, "List", ctx, opts)
 	ret0, _ := ret[0].(*v120.KubeVirtList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
+func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
 func (_m *MockKubeVirtInterface) Create(instance *v120.KubeVirt) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1395,15 +1395,15 @@ func (_mr *_MockReplicaSetInterfaceRecorder) Create(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
-func (_m *MockReplicaSetInterface) Update(_param0 *v120.VirtualMachineInstanceReplicaSet) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	ret := _m.ctrl.Call(_m, "Update", _param0)
+func (_m *MockReplicaSetInterface) Update(ctx context.Context, virtualMachineInstanceReplicaSet *v120.VirtualMachineInstanceReplicaSet, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "Update", ctx, virtualMachineInstanceReplicaSet, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) Update(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0)
+func (_mr *_MockReplicaSetInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
 func (_m *MockReplicaSetInterface) Delete(name string, options *v12.DeleteOptions) error {
@@ -1454,15 +1454,15 @@ func (_mr *_MockReplicaSetInterfaceRecorder) Patch(arg0, arg1, arg2 interface{},
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockReplicaSetInterface) UpdateStatus(_param0 *v120.VirtualMachineInstanceReplicaSet) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	ret := _m.ctrl.Call(_m, "UpdateStatus", _param0)
+func (_m *MockReplicaSetInterface) UpdateStatus(ctx context.Context, virtualMachineInstanceReplicaSet *v120.VirtualMachineInstanceReplicaSet, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, virtualMachineInstanceReplicaSet, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) UpdateStatus(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0)
+func (_mr *_MockReplicaSetInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
 func (_m *MockReplicaSetInterface) PatchStatus(name string, pt types.PatchType, data []byte) (*v120.VirtualMachineInstanceReplicaSet, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1914,15 +1914,15 @@ func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) Patch(arg0, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockVirtualMachineInstanceMigrationInterface) UpdateStatus(_param0 *v120.VirtualMachineInstanceMigration) (*v120.VirtualMachineInstanceMigration, error) {
-	ret := _m.ctrl.Call(_m, "UpdateStatus", _param0)
+func (_m *MockVirtualMachineInstanceMigrationInterface) UpdateStatus(ctx context.Context, virtualMachineInstanceMigration *v120.VirtualMachineInstanceMigration, opts v12.UpdateOptions) (*v120.VirtualMachineInstanceMigration, error) {
+	ret := _m.ctrl.Call(_m, "UpdateStatus", ctx, virtualMachineInstanceMigration, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceMigration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) UpdateStatus(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0)
+func (_mr *_MockVirtualMachineInstanceMigrationInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstanceMigrationInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions) (*v120.VirtualMachineInstanceMigration, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -2000,15 +2000,15 @@ func (_mr *_MockKubeVirtInterfaceRecorder) List(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0, arg1)
 }
 
-func (_m *MockKubeVirtInterface) Create(instance *v120.KubeVirt) (*v120.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "Create", instance)
+func (_m *MockKubeVirtInterface) Create(ctx context.Context, instance *v120.KubeVirt, opts v12.CreateOptions) (*v120.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "Create", ctx, instance, opts)
 	ret0, _ := ret[0].(*v120.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Create(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0)
+func (_mr *_MockKubeVirtInterfaceRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
 func (_m *MockKubeVirtInterface) Update(_param0 *v120.KubeVirt) (*v120.KubeVirt, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1438,8 +1438,8 @@ func (_mr *_MockReplicaSetInterfaceRecorder) UpdateScale(arg0, arg1 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateScale", arg0, arg1)
 }
 
-func (_m *MockReplicaSetInterface) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	_s := []interface{}{name, pt, data}
+func (_m *MockReplicaSetInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions, subresources ...string) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	_s := []interface{}{ctx, name, pt, data, opts}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -1449,8 +1449,8 @@ func (_m *MockReplicaSetInterface) Patch(name string, pt types.PatchType, data [
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+func (_mr *_MockReplicaSetInterfaceRecorder) Patch(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
@@ -1465,15 +1465,15 @@ func (_mr *_MockReplicaSetInterfaceRecorder) UpdateStatus(arg0, arg1, arg2 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0, arg1, arg2)
 }
 
-func (_m *MockReplicaSetInterface) PatchStatus(name string, pt types.PatchType, data []byte) (*v120.VirtualMachineInstanceReplicaSet, error) {
-	ret := _m.ctrl.Call(_m, "PatchStatus", name, pt, data)
+func (_m *MockReplicaSetInterface) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts v12.PatchOptions) (*v120.VirtualMachineInstanceReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "PatchStatus", ctx, name, pt, data, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstanceReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockReplicaSetInterfaceRecorder) PatchStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2)
+func (_mr *_MockReplicaSetInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3, arg4)
 }
 
 // Mock of VirtualMachineInstancePresetInterface interface

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1551,15 +1551,15 @@ func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Create(arg0, arg1
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInstancePresetInterface) Update(_param0 *v120.VirtualMachineInstancePreset) (*v120.VirtualMachineInstancePreset, error) {
-	ret := _m.ctrl.Call(_m, "Update", _param0)
+func (_m *MockVirtualMachineInstancePresetInterface) Update(ctx context.Context, virtualMachineInstancePreset *v120.VirtualMachineInstancePreset, opts v12.UpdateOptions) (*v120.VirtualMachineInstancePreset, error) {
+	ret := _m.ctrl.Call(_m, "Update", ctx, virtualMachineInstancePreset, opts)
 	ret0, _ := ret[0].(*v120.VirtualMachineInstancePreset)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Update(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0)
+func (_mr *_MockVirtualMachineInstancePresetInterfaceRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInstancePresetInterface) Delete(name string, options *v12.DeleteOptions) error {

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -269,7 +269,7 @@ type VirtualMachineInstanceInterface interface {
 
 type ReplicaSetInterface interface {
 	Get(name string, options metav1.GetOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
-	List(opts metav1.ListOptions) (*v1.VirtualMachineInstanceReplicaSetList, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceReplicaSetList, error)
 	Create(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts metav1.CreateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	Update(*v1.VirtualMachineInstanceReplicaSet) (*v1.VirtualMachineInstanceReplicaSet, error)
 	Delete(name string, options *metav1.DeleteOptions) error

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -318,7 +318,7 @@ type KubeVirtInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
 	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
 	Update(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
-	Delete(name string, options *metav1.DeleteOptions) error
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
 	UpdateStatus(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
 	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.KubeVirt, err error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -310,7 +310,7 @@ type VirtualMachineInterface interface {
 
 type VirtualMachineInstanceMigrationInterface interface {
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.VirtualMachineInstanceMigration, error)
-	List(opts *metav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error)
 	Create(migration *v1.VirtualMachineInstanceMigration, options *metav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	Update(*v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error)
 	Delete(name string, options *metav1.DeleteOptions) error

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -269,7 +269,7 @@ type VirtualMachineInstanceInterface interface {
 
 type ReplicaSetInterface interface {
 	kvcorev1.VirtualMachineInstanceReplicaSetInterface
-	GetScale(replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error)
+	GetScale(ctx context.Context, replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error)
 	UpdateScale(replicaSetName string, scale *autov1.Scale) (*autov1.Scale, error)
 	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error)
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -313,7 +313,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error)
 	Create(ctx context.Context, migration *v1.VirtualMachineInstanceMigration, options metav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	Update(ctx context.Context, virtualMachineInstanceMigration *v1.VirtualMachineInstanceMigration, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceMigration, error)
-	Delete(name string, options *metav1.DeleteOptions) error
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error)
 	UpdateStatus(*v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error)
 	PatchStatus(name string, pt types.PatchType, data []byte) (result *v1.VirtualMachineInstanceMigration, err error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -277,7 +277,7 @@ type ReplicaSetInterface interface {
 type VirtualMachineInstancePresetInterface interface {
 	Get(name string, options metav1.GetOptions) (*v1.VirtualMachineInstancePreset, error)
 	List(opts metav1.ListOptions) (*v1.VirtualMachineInstancePresetList, error)
-	Create(*v1.VirtualMachineInstancePreset) (*v1.VirtualMachineInstancePreset, error)
+	Create(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.CreateOptions) (*v1.VirtualMachineInstancePreset, error)
 	Update(*v1.VirtualMachineInstancePreset) (*v1.VirtualMachineInstancePreset, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -275,12 +275,7 @@ type ReplicaSetInterface interface {
 }
 
 type VirtualMachineInstancePresetInterface interface {
-	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.VirtualMachineInstancePreset, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstancePresetList, error)
-	Create(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.CreateOptions) (*v1.VirtualMachineInstancePreset, error)
-	Update(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.UpdateOptions) (*v1.VirtualMachineInstancePreset, error)
-	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error)
+	kvcorev1.VirtualMachineInstancePresetInterface
 }
 
 // VirtualMachineInterface provides convenience methods to work with

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -272,7 +272,7 @@ type ReplicaSetInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceReplicaSetList, error)
 	Create(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts metav1.CreateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	Update(ctx context.Context, virtualMachineInstanceReplicaSet *v1.VirtualMachineInstanceReplicaSet, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
-	Delete(name string, options *metav1.DeleteOptions) error
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
 	GetScale(replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error)
 	UpdateScale(replicaSetName string, scale *autov1.Scale) (*autov1.Scale, error)
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -314,9 +314,9 @@ type VirtualMachineInstanceMigrationInterface interface {
 	Create(ctx context.Context, migration *v1.VirtualMachineInstanceMigration, options metav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	Update(ctx context.Context, virtualMachineInstanceMigration *v1.VirtualMachineInstanceMigration, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error)
 	UpdateStatus(*v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error)
-	PatchStatus(name string, pt types.PatchType, data []byte) (result *v1.VirtualMachineInstanceMigration, err error)
+	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *v1.VirtualMachineInstanceMigration, err error)
 }
 
 type KubeVirtInterface interface {

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -316,7 +316,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 type KubeVirtInterface interface {
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
-	Create(instance *v1.KubeVirt) (*v1.KubeVirt, error)
+	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
 	Update(*v1.KubeVirt) (*v1.KubeVirt, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -280,7 +280,7 @@ type VirtualMachineInstancePresetInterface interface {
 	Create(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.CreateOptions) (*v1.VirtualMachineInstancePreset, error)
 	Update(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.UpdateOptions) (*v1.VirtualMachineInstancePreset, error)
 	Delete(name string, options *metav1.DeleteOptions) error
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error)
 }
 
 // VirtualMachineInterface provides convenience methods to work with

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -271,12 +271,12 @@ type ReplicaSetInterface interface {
 	Get(name string, options metav1.GetOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceReplicaSetList, error)
 	Create(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts metav1.CreateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
-	Update(*v1.VirtualMachineInstanceReplicaSet) (*v1.VirtualMachineInstanceReplicaSet, error)
+	Update(ctx context.Context, virtualMachineInstanceReplicaSet *v1.VirtualMachineInstanceReplicaSet, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	GetScale(replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error)
 	UpdateScale(replicaSetName string, scale *autov1.Scale) (*autov1.Scale, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error)
-	UpdateStatus(*v1.VirtualMachineInstanceReplicaSet) (*v1.VirtualMachineInstanceReplicaSet, error)
+	UpdateStatus(ctx context.Context, virtualMachineInstanceReplicaSet *v1.VirtualMachineInstanceReplicaSet, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	PatchStatus(name string, pt types.PatchType, data []byte) (result *v1.VirtualMachineInstanceReplicaSet, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -276,7 +276,7 @@ type ReplicaSetInterface interface {
 
 type VirtualMachineInstancePresetInterface interface {
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.VirtualMachineInstancePreset, error)
-	List(opts metav1.ListOptions) (*v1.VirtualMachineInstancePresetList, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstancePresetList, error)
 	Create(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.CreateOptions) (*v1.VirtualMachineInstancePreset, error)
 	Update(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.UpdateOptions) (*v1.VirtualMachineInstancePreset, error)
 	Delete(name string, options *metav1.DeleteOptions) error

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -275,9 +275,9 @@ type ReplicaSetInterface interface {
 	Delete(name string, options *metav1.DeleteOptions) error
 	GetScale(replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error)
 	UpdateScale(replicaSetName string, scale *autov1.Scale) (*autov1.Scale, error)
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error)
 	UpdateStatus(ctx context.Context, virtualMachineInstanceReplicaSet *v1.VirtualMachineInstanceReplicaSet, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
-	PatchStatus(name string, pt types.PatchType, data []byte) (result *v1.VirtualMachineInstanceReplicaSet, err error)
+	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error)
 }
 
 type VirtualMachineInstancePresetInterface interface {

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -312,7 +312,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.VirtualMachineInstanceMigration, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error)
 	Create(ctx context.Context, migration *v1.VirtualMachineInstanceMigration, options metav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error)
-	Update(*v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error)
+	Update(ctx context.Context, virtualMachineInstanceMigration *v1.VirtualMachineInstanceMigration, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error)
 	UpdateStatus(*v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -311,7 +311,7 @@ type VirtualMachineInterface interface {
 type VirtualMachineInstanceMigrationInterface interface {
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.VirtualMachineInstanceMigration, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error)
-	Create(migration *v1.VirtualMachineInstanceMigration, options *metav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error)
+	Create(ctx context.Context, migration *v1.VirtualMachineInstanceMigration, options metav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	Update(*v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -278,7 +278,7 @@ type VirtualMachineInstancePresetInterface interface {
 	Get(name string, options metav1.GetOptions) (*v1.VirtualMachineInstancePreset, error)
 	List(opts metav1.ListOptions) (*v1.VirtualMachineInstancePresetList, error)
 	Create(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.CreateOptions) (*v1.VirtualMachineInstancePreset, error)
-	Update(*v1.VirtualMachineInstancePreset) (*v1.VirtualMachineInstancePreset, error)
+	Update(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.UpdateOptions) (*v1.VirtualMachineInstancePreset, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error)
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -315,7 +315,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 
 type KubeVirtInterface interface {
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
-	List(opts *metav1.ListOptions) (*v1.KubeVirtList, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
 	Create(instance *v1.KubeVirt) (*v1.KubeVirt, error)
 	Update(*v1.KubeVirt) (*v1.KubeVirt, error)
 	Delete(name string, options *metav1.DeleteOptions) error

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -317,10 +317,10 @@ type KubeVirtInterface interface {
 	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
 	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
-	Update(*v1.KubeVirt) (*v1.KubeVirt, error)
+	Update(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
-	UpdateStatus(*v1.KubeVirt) (*v1.KubeVirt, error)
+	UpdateStatus(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
 	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.KubeVirt, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -268,7 +268,7 @@ type VirtualMachineInstanceInterface interface {
 }
 
 type ReplicaSetInterface interface {
-	Get(name string, options metav1.GetOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceReplicaSetList, error)
 	Create(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts metav1.CreateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	Update(ctx context.Context, virtualMachineInstanceReplicaSet *v1.VirtualMachineInstanceReplicaSet, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -270,7 +270,7 @@ type VirtualMachineInstanceInterface interface {
 type ReplicaSetInterface interface {
 	kvcorev1.VirtualMachineInstanceReplicaSetInterface
 	GetScale(ctx context.Context, replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error)
-	UpdateScale(replicaSetName string, scale *autov1.Scale) (*autov1.Scale, error)
+	UpdateScale(ctx context.Context, replicaSetName string, scale *autov1.Scale) (*autov1.Scale, error)
 	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -268,15 +268,9 @@ type VirtualMachineInstanceInterface interface {
 }
 
 type ReplicaSetInterface interface {
-	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceReplicaSetList, error)
-	Create(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts metav1.CreateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
-	Update(ctx context.Context, virtualMachineInstanceReplicaSet *v1.VirtualMachineInstanceReplicaSet, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
-	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
+	kvcorev1.VirtualMachineInstanceReplicaSetInterface
 	GetScale(replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error)
 	UpdateScale(replicaSetName string, scale *autov1.Scale) (*autov1.Scale, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error)
-	UpdateStatus(ctx context.Context, virtualMachineInstanceReplicaSet *v1.VirtualMachineInstanceReplicaSet, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -314,7 +314,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 }
 
 type KubeVirtInterface interface {
-	Get(name string, options *metav1.GetOptions) (*v1.KubeVirt, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
 	List(opts *metav1.ListOptions) (*v1.KubeVirtList, error)
 	Create(instance *v1.KubeVirt) (*v1.KubeVirt, error)
 	Update(*v1.KubeVirt) (*v1.KubeVirt, error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -319,9 +319,9 @@ type KubeVirtInterface interface {
 	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
 	Update(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
 	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
-	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
 	UpdateStatus(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
-	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.KubeVirt, err error)
+	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) (result *v1.KubeVirt, err error)
 }
 
 type ServerVersionInterface interface {

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -270,7 +270,7 @@ type VirtualMachineInstanceInterface interface {
 type ReplicaSetInterface interface {
 	Get(name string, options metav1.GetOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	List(opts metav1.ListOptions) (*v1.VirtualMachineInstanceReplicaSetList, error)
-	Create(*v1.VirtualMachineInstanceReplicaSet) (*v1.VirtualMachineInstanceReplicaSet, error)
+	Create(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts metav1.CreateOptions) (*v1.VirtualMachineInstanceReplicaSet, error)
 	Update(*v1.VirtualMachineInstanceReplicaSet) (*v1.VirtualMachineInstanceReplicaSet, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 	GetScale(replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -309,7 +309,7 @@ type VirtualMachineInterface interface {
 }
 
 type VirtualMachineInstanceMigrationInterface interface {
-	Get(name string, options *metav1.GetOptions) (*v1.VirtualMachineInstanceMigration, error)
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.VirtualMachineInstanceMigration, error)
 	List(opts *metav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error)
 	Create(migration *v1.VirtualMachineInstanceMigration, options *metav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	Update(*v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -315,7 +315,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 	Update(ctx context.Context, virtualMachineInstanceMigration *v1.VirtualMachineInstanceMigration, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error)
-	UpdateStatus(*v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error)
+	UpdateStatus(ctx context.Context, virtualMachineInstanceMigration *v1.VirtualMachineInstanceMigration, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceMigration, error)
 	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *v1.VirtualMachineInstanceMigration, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -275,7 +275,7 @@ type ReplicaSetInterface interface {
 }
 
 type VirtualMachineInstancePresetInterface interface {
-	Get(name string, options metav1.GetOptions) (*v1.VirtualMachineInstancePreset, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.VirtualMachineInstancePreset, error)
 	List(opts metav1.ListOptions) (*v1.VirtualMachineInstancePresetList, error)
 	Create(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.CreateOptions) (*v1.VirtualMachineInstancePreset, error)
 	Update(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.UpdateOptions) (*v1.VirtualMachineInstancePreset, error)

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -279,7 +279,7 @@ type VirtualMachineInstancePresetInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstancePresetList, error)
 	Create(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.CreateOptions) (*v1.VirtualMachineInstancePreset, error)
 	Update(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts metav1.UpdateOptions) (*v1.VirtualMachineInstancePreset, error)
-	Delete(name string, options *metav1.DeleteOptions) error
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -309,13 +309,7 @@ type VirtualMachineInterface interface {
 }
 
 type VirtualMachineInstanceMigrationInterface interface {
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.VirtualMachineInstanceMigration, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error)
-	Create(ctx context.Context, migration *v1.VirtualMachineInstanceMigration, options metav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error)
-	Update(ctx context.Context, virtualMachineInstanceMigration *v1.VirtualMachineInstanceMigration, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceMigration, error)
-	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error)
-	UpdateStatus(ctx context.Context, virtualMachineInstanceMigration *v1.VirtualMachineInstanceMigration, opts metav1.UpdateOptions) (*v1.VirtualMachineInstanceMigration, error)
+	kvcorev1.VirtualMachineInstanceMigrationInterface
 	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (result *v1.VirtualMachineInstanceMigration, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -314,13 +314,7 @@ type VirtualMachineInstanceMigrationInterface interface {
 }
 
 type KubeVirtInterface interface {
-	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.KubeVirt, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.KubeVirtList, error)
-	Create(ctx context.Context, instance *v1.KubeVirt, opts metav1.CreateOptions) (*v1.KubeVirt, error)
-	Update(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
-	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
-	UpdateStatus(ctx context.Context, kubeVirt *v1.KubeVirt, opts metav1.UpdateOptions) (*v1.KubeVirt, error)
+	kvcorev1.KubeVirtInterface
 	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) (result *v1.KubeVirt, err error)
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -55,14 +55,9 @@ func (o *kv) Create(kv *v1.KubeVirt) (*v1.KubeVirt, error) {
 }
 
 // Get the KubeVirt from the cluster by its name and namespace
-func (o *kv) Get(name string, options *k8smetav1.GetOptions) (*v1.KubeVirt, error) {
-	opts := k8smetav1.GetOptions{}
-	if options != nil {
-		opts = *options
-	}
-	newKv, err := o.KubeVirtInterface.Get(context.Background(), name, opts)
+func (o *kv) Get(ctx context.Context, name string, options k8smetav1.GetOptions) (*v1.KubeVirt, error) {
+	newKv, err := o.KubeVirtInterface.Get(ctx, name, options)
 	newKv.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
-
 	return newKv, err
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -47,10 +47,9 @@ type kv struct {
 }
 
 // Create new KubeVirt in the cluster to specified namespace
-func (o *kv) Create(kv *v1.KubeVirt) (*v1.KubeVirt, error) {
-	newKv, err := o.KubeVirtInterface.Create(context.Background(), kv, k8smetav1.CreateOptions{})
+func (o *kv) Create(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.CreateOptions) (*v1.KubeVirt, error) {
+	newKv, err := o.KubeVirtInterface.Create(ctx, kv, opts)
 	newKv.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
-
 	return newKv, err
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -61,10 +61,9 @@ func (o *kv) Get(ctx context.Context, name string, options k8smetav1.GetOptions)
 }
 
 // Update the KubeVirt instance in the cluster in given namespace
-func (o *kv) Update(kv *v1.KubeVirt) (*v1.KubeVirt, error) {
-	updatedKv, err := o.KubeVirtInterface.Update(context.Background(), kv, k8smetav1.UpdateOptions{})
+func (o *kv) Update(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateOptions) (*v1.KubeVirt, error) {
+	updatedKv, err := o.KubeVirtInterface.Update(ctx, kv, opts)
 	updatedKv.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
-
 	return updatedKv, err
 }
 
@@ -98,8 +97,8 @@ func (o *kv) PatchStatus(name string, pt types.PatchType, data []byte, patchOpti
 	return o.Patch(name, pt, data, patchOptions, "status")
 }
 
-func (o *kv) UpdateStatus(kv *v1.KubeVirt) (result *v1.KubeVirt, err error) {
-	result, err = o.KubeVirtInterface.UpdateStatus(context.Background(), kv, k8smetav1.UpdateOptions{})
+func (o *kv) UpdateStatus(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateOptions) (result *v1.KubeVirt, err error) {
+	result, err = o.KubeVirtInterface.UpdateStatus(ctx, kv, opts)
 	result.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -68,12 +68,8 @@ func (o *kv) Update(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateO
 }
 
 // Delete the defined KubeVirt in the cluster in defined namespace
-func (o *kv) Delete(name string, options *k8smetav1.DeleteOptions) error {
-	opts := k8smetav1.DeleteOptions{}
-	if options != nil {
-		opts = *options
-	}
-	return o.KubeVirtInterface.Delete(context.Background(), name, opts)
+func (o *kv) Delete(ctx context.Context, name string, options k8smetav1.DeleteOptions) error {
+	return o.KubeVirtInterface.Delete(ctx, name, options)
 }
 
 // List all KubeVirts in given namespace

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -79,16 +79,11 @@ func (o *kv) Delete(name string, options *k8smetav1.DeleteOptions) error {
 }
 
 // List all KubeVirts in given namespace
-func (o *kv) List(options *k8smetav1.ListOptions) (*v1.KubeVirtList, error) {
-	opts := k8smetav1.ListOptions{}
-	if options != nil {
-		opts = *options
-	}
-	newKvList, err := o.KubeVirtInterface.List(context.Background(), opts)
+func (o *kv) List(ctx context.Context, options k8smetav1.ListOptions) (*v1.KubeVirtList, error) {
+	newKvList, err := o.KubeVirtInterface.List(ctx, options)
 	for i := range newKvList.Items {
 		newKvList.Items[i].SetGroupVersionKind(v1.KubeVirtGroupVersionKind)
 	}
-
 	return newKvList, err
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -81,16 +81,12 @@ func (o *kv) List(ctx context.Context, options k8smetav1.ListOptions) (*v1.KubeV
 	return newKvList, err
 }
 
-func (o *kv) Patch(name string, pt types.PatchType, data []byte, patchOptions *k8smetav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error) {
-	opts := k8smetav1.PatchOptions{}
-	if patchOptions != nil {
-		opts = *patchOptions
-	}
-	return o.KubeVirtInterface.Patch(context.Background(), name, pt, data, opts, subresources...)
+func (o *kv) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions k8smetav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error) {
+	return o.KubeVirtInterface.Patch(ctx, name, pt, data, patchOptions, subresources...)
 }
 
-func (o *kv) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *k8smetav1.PatchOptions) (result *v1.KubeVirt, err error) {
-	return o.Patch(name, pt, data, patchOptions, "status")
+func (o *kv) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions k8smetav1.PatchOptions) (result *v1.KubeVirt, err error) {
+	return o.Patch(ctx, name, pt, data, patchOptions, "status")
 }
 
 func (o *kv) UpdateStatus(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateOptions) (result *v1.KubeVirt, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err = client.KubeVirt(k8sv1.NamespaceDefault).Delete("testkubevirt", &k8smetav1.DeleteOptions{})
+		err = client.KubeVirt(k8sv1.NamespaceDefault).Delete(context.Background(), "testkubevirt", k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -156,8 +156,8 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
 
-		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Patch(kubevirt.Name, types.MergePatchType,
-			[]byte("{\"spec\":{\"imagePullPolicy\":something}}"), &k8smetav1.PatchOptions{})
+		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Patch(context.Background(), kubevirt.Name, types.MergePatchType,
+			[]byte("{\"spec\":{\"imagePullPolicy\":something}}"), k8smetav1.PatchOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("PUT", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
-		updatedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Update(kubevirt)
+		updatedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Update(context.Background(), kubevirt, k8smetav1.UpdateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewKubeVirtList(*kubevirt)),
 		))
-		fetchedKubeVirtList, err := client.KubeVirt(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
+		fetchedKubeVirtList, err := client.KubeVirt(k8sv1.NamespaceDefault).List(context.Background(), k8smetav1.ListOptions{})
 		apiVersion, kind := v1.KubeVirtGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -20,6 +20,7 @@
 package kubecli
 
 import (
+	"context"
 	"net/http"
 	"path"
 
@@ -53,7 +54,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
-		fetchedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Get("testkubevirt", &k8smetav1.GetOptions{})
+		fetchedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Get(context.Background(), "testkubevirt", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
@@ -71,7 +72,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testkubevirt")),
 		))
-		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Get("testkubevirt", &k8smetav1.GetOptions{})
+		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Get(context.Background(), "testkubevirt", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Kubevirt Client", func() {
 			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, kubevirt),
 		))
-		createdKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Create(kubevirt)
+		createdKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Create(context.Background(), kubevirt, k8smetav1.CreateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -59,12 +59,8 @@ func (o *migration) Create(newMigration *v1.VirtualMachineInstanceMigration, opt
 }
 
 // Get the VirtualMachineInstanceMigration from the cluster by its name and namespace
-func (o *migration) Get(name string, options *k8smetav1.GetOptions) (*v1.VirtualMachineInstanceMigration, error) {
-	opts := k8smetav1.GetOptions{}
-	if options != nil {
-		opts = *options
-	}
-	newVm, err := o.VirtualMachineInstanceMigrationInterface.Get(context.Background(), name, opts)
+func (o *migration) Get(ctx context.Context, name string, options k8smetav1.GetOptions) (*v1.VirtualMachineInstanceMigration, error) {
+	newVm, err := o.VirtualMachineInstanceMigrationInterface.Get(ctx, name, options)
 	newVm.SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
 
 	return newVm, err

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -85,12 +85,12 @@ func (o *migration) List(ctx context.Context, options k8smetav1.ListOptions) (*v
 	return newVmiMigrationList, err
 }
 
-func (o *migration) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error) {
-	return o.VirtualMachineInstanceMigrationInterface.Patch(context.Background(), name, pt, data, k8smetav1.PatchOptions{}, subresources...)
+func (o *migration) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceMigration, err error) {
+	return o.VirtualMachineInstanceMigrationInterface.Patch(ctx, name, pt, data, opts, subresources...)
 }
 
-func (o *migration) PatchStatus(name string, pt types.PatchType, data []byte) (result *v1.VirtualMachineInstanceMigration, err error) {
-	return o.Patch(name, pt, data, "status")
+func (o *migration) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions) (result *v1.VirtualMachineInstanceMigration, err error) {
+	return o.Patch(ctx, name, pt, data, opts, "status")
 }
 
 func (o *migration) UpdateStatus(vmim *v1.VirtualMachineInstanceMigration) (result *v1.VirtualMachineInstanceMigration, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -71,12 +71,8 @@ func (o *migration) Update(ctx context.Context, migration *v1.VirtualMachineInst
 }
 
 // Delete the defined VirtualMachineInstanceMigration in the cluster in defined namespace
-func (o *migration) Delete(name string, options *k8smetav1.DeleteOptions) error {
-	opts := k8smetav1.DeleteOptions{}
-	if options != nil {
-		opts = *options
-	}
-	return o.VirtualMachineInstanceMigrationInterface.Delete(context.Background(), name, opts)
+func (o *migration) Delete(ctx context.Context, name string, options k8smetav1.DeleteOptions) error {
+	return o.VirtualMachineInstanceMigrationInterface.Delete(ctx, name, options)
 }
 
 // List all VirtualMachineInstanceMigrations in given namespace

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -63,8 +63,8 @@ func (o *migration) Get(ctx context.Context, name string, options k8smetav1.GetO
 }
 
 // Update the VirtualMachineInstanceMigration instance in the cluster in given namespace
-func (o *migration) Update(migration *v1.VirtualMachineInstanceMigration) (*v1.VirtualMachineInstanceMigration, error) {
-	updatedVm, err := o.VirtualMachineInstanceMigrationInterface.Update(context.Background(), migration, k8smetav1.UpdateOptions{})
+func (o *migration) Update(ctx context.Context, migration *v1.VirtualMachineInstanceMigration, opts k8smetav1.UpdateOptions) (*v1.VirtualMachineInstanceMigration, error) {
+	updatedVm, err := o.VirtualMachineInstanceMigrationInterface.Update(ctx, migration, opts)
 	updatedVm.SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
 
 	return updatedVm, err

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -84,12 +84,8 @@ func (o *migration) Delete(name string, options *k8smetav1.DeleteOptions) error 
 }
 
 // List all VirtualMachineInstanceMigrations in given namespace
-func (o *migration) List(options *k8smetav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error) {
-	opts := k8smetav1.ListOptions{}
-	if options != nil {
-		opts = *options
-	}
-	newVmiMigrationList, err := o.VirtualMachineInstanceMigrationInterface.List(context.Background(), opts)
+func (o *migration) List(ctx context.Context, options k8smetav1.ListOptions) (*v1.VirtualMachineInstanceMigrationList, error) {
+	newVmiMigrationList, err := o.VirtualMachineInstanceMigrationInterface.List(ctx, options)
 	for i := range newVmiMigrationList.Items {
 		newVmiMigrationList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
 	}

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -47,12 +47,8 @@ type migration struct {
 }
 
 // Create new VirtualMachineInstanceMigration in the cluster to specified namespace
-func (o *migration) Create(newMigration *v1.VirtualMachineInstanceMigration, options *k8smetav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error) {
-	opts := k8smetav1.CreateOptions{}
-	if options != nil {
-		opts = *options
-	}
-	newMigrationResult, err := o.VirtualMachineInstanceMigrationInterface.Create(context.Background(), newMigration, opts)
+func (o *migration) Create(ctx context.Context, newMigration *v1.VirtualMachineInstanceMigration, options k8smetav1.CreateOptions) (*v1.VirtualMachineInstanceMigration, error) {
+	newMigrationResult, err := o.VirtualMachineInstanceMigrationInterface.Create(ctx, newMigration, options)
 	newMigrationResult.SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
 
 	return newMigrationResult, err

--- a/staging/src/kubevirt.io/client-go/kubecli/migration.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration.go
@@ -93,8 +93,8 @@ func (o *migration) PatchStatus(ctx context.Context, name string, pt types.Patch
 	return o.Patch(ctx, name, pt, data, opts, "status")
 }
 
-func (o *migration) UpdateStatus(vmim *v1.VirtualMachineInstanceMigration) (result *v1.VirtualMachineInstanceMigration, err error) {
-	result, err = o.VirtualMachineInstanceMigrationInterface.UpdateStatus(context.Background(), vmim, k8smetav1.UpdateOptions{})
+func (o *migration) UpdateStatus(ctx context.Context, vmim *v1.VirtualMachineInstanceMigration, opts k8smetav1.UpdateOptions) (result *v1.VirtualMachineInstanceMigration, err error) {
+	result, err = o.VirtualMachineInstanceMigrationInterface.UpdateStatus(ctx, vmim, opts)
 	result.SetGroupVersionKind(v1.VirtualMachineInstanceMigrationGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -156,8 +156,8 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, migration),
 		))
 
-		_, err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Patch(migration.Name, types.MergePatchType,
-			[]byte("{\"spec\":{\"vmiName\":something}}"))
+		_, err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Patch(context.Background(), migration.Name, types.MergePatchType,
+			[]byte("{\"spec\":{\"vmiName\":something}}"), k8smetav1.PatchOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, migration),
 		))
-		createdMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Create(migration, &k8smetav1.CreateOptions{})
+		createdMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Create(context.Background(), migration, k8smetav1.CreateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -20,6 +20,7 @@
 package kubecli
 
 import (
+	"context"
 	"net/http"
 	"path"
 
@@ -53,7 +54,7 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, migrationPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, migration),
 		))
-		fetchedMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Get("testmigration", &k8smetav1.GetOptions{})
+		fetchedMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Get(context.Background(), "testmigration", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
@@ -71,7 +72,7 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, migrationPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testmigration")),
 		))
-		_, err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Get("testmigration", &k8smetav1.GetOptions{})
+		_, err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Get(context.Background(), "testmigration", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, migrationPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Delete("testmigration", &k8smetav1.DeleteOptions{})
+		err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Delete(context.Background(), "testmigration", k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.VerifyRequest("PUT", path.Join(proxyPath, migrationPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, migration),
 		))
-		updatedMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Update(migration)
+		updatedMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Update(context.Background(), migration, k8smetav1.UpdateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Kubevirt Migration Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewMigrationList(*migration)),
 		))
-		fetchedMigrationList, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
+		fetchedMigrationList, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).List(context.Background(), k8smetav1.ListOptions{})
 		apiVersion, kind := v1.VirtualMachineInstanceMigrationGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -47,14 +47,14 @@ type rc struct {
 	resource   string
 }
 
-func (v *rc) GetScale(replicaSetName string, options k8smetav1.GetOptions) (result *autov1.Scale, err error) {
+func (v *rc) GetScale(ctx context.Context, replicaSetName string, options k8smetav1.GetOptions) (result *autov1.Scale, err error) {
 	result = &autov1.Scale{}
 	err = v.restClient.Get().
 		Namespace(v.namespace).
 		Resource(v.resource).
 		Name(replicaSetName).
 		SubResource("scale").
-		Do(context.Background()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -106,12 +106,12 @@ func (v *rc) Delete(name string, options *k8smetav1.DeleteOptions) error {
 	return v.VirtualMachineInstanceReplicaSetInterface.Delete(context.Background(), name, opts)
 }
 
-func (v *rc) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
-	return v.VirtualMachineInstanceReplicaSetInterface.Patch(context.Background(), name, pt, data, k8smetav1.PatchOptions{}, subresources...)
+func (v *rc) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
+	return v.VirtualMachineInstanceReplicaSetInterface.Patch(ctx, name, pt, data, opts, subresources...)
 }
 
-func (v *rc) PatchStatus(name string, pt types.PatchType, data []byte) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
-	return v.Patch(name, pt, data, "status")
+func (v *rc) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
+	return v.Patch(ctx, name, pt, data, opts, "status")
 }
 
 func (v *rc) UpdateStatus(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts k8smetav1.UpdateOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -72,8 +72,8 @@ func (v *rc) UpdateScale(replicaSetName string, scale *autov1.Scale) (result *au
 	return
 }
 
-func (v *rc) Get(name string, options k8smetav1.GetOptions) (replicaset *v1.VirtualMachineInstanceReplicaSet, err error) {
-	replicaset, err = v.VirtualMachineInstanceReplicaSetInterface.Get(context.Background(), name, options)
+func (v *rc) Get(ctx context.Context, name string, options k8smetav1.GetOptions) (replicaset *v1.VirtualMachineInstanceReplicaSet, err error) {
+	replicaset, err = v.VirtualMachineInstanceReplicaSetInterface.Get(ctx, name, options)
 	replicaset.SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -92,8 +92,8 @@ func (v *rc) Create(ctx context.Context, replicaset *v1.VirtualMachineInstanceRe
 	return
 }
 
-func (v *rc) Update(replicaset *v1.VirtualMachineInstanceReplicaSet) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
-	result, err = v.VirtualMachineInstanceReplicaSetInterface.Update(context.Background(), replicaset, k8smetav1.UpdateOptions{})
+func (v *rc) Update(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts k8smetav1.UpdateOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
+	result, err = v.VirtualMachineInstanceReplicaSetInterface.Update(ctx, replicaset, opts)
 	result.SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
 	return
 }
@@ -114,8 +114,8 @@ func (v *rc) PatchStatus(name string, pt types.PatchType, data []byte) (result *
 	return v.Patch(name, pt, data, "status")
 }
 
-func (v *rc) UpdateStatus(vmi *v1.VirtualMachineInstanceReplicaSet) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
-	result, err = v.VirtualMachineInstanceReplicaSetInterface.UpdateStatus(context.Background(), vmi, k8smetav1.UpdateOptions{})
+func (v *rc) UpdateStatus(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts k8smetav1.UpdateOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
+	result, err = v.VirtualMachineInstanceReplicaSetInterface.UpdateStatus(ctx, replicaset, opts)
 	result.SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -98,12 +98,8 @@ func (v *rc) Update(ctx context.Context, replicaset *v1.VirtualMachineInstanceRe
 	return
 }
 
-func (v *rc) Delete(name string, options *k8smetav1.DeleteOptions) error {
-	opts := k8smetav1.DeleteOptions{}
-	if options != nil {
-		opts = *options
-	}
-	return v.VirtualMachineInstanceReplicaSetInterface.Delete(context.Background(), name, opts)
+func (v *rc) Delete(ctx context.Context, name string, options k8smetav1.DeleteOptions) error {
+	return v.VirtualMachineInstanceReplicaSetInterface.Delete(ctx, name, options)
 }
 
 func (v *rc) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -59,7 +59,7 @@ func (v *rc) GetScale(ctx context.Context, replicaSetName string, options k8smet
 	return
 }
 
-func (v *rc) UpdateScale(replicaSetName string, scale *autov1.Scale) (result *autov1.Scale, err error) {
+func (v *rc) UpdateScale(ctx context.Context, replicaSetName string, scale *autov1.Scale) (result *autov1.Scale, err error) {
 	result = &autov1.Scale{}
 	err = v.restClient.Put().
 		Namespace(v.namespace).
@@ -67,7 +67,7 @@ func (v *rc) UpdateScale(replicaSetName string, scale *autov1.Scale) (result *au
 		Name(replicaSetName).
 		SubResource("scale").
 		Body(scale).
-		Do(context.Background()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -78,12 +78,11 @@ func (v *rc) Get(name string, options k8smetav1.GetOptions) (replicaset *v1.Virt
 	return
 }
 
-func (v *rc) List(options k8smetav1.ListOptions) (replicasetList *v1.VirtualMachineInstanceReplicaSetList, err error) {
-	replicasetList, err = v.VirtualMachineInstanceReplicaSetInterface.List(context.Background(), options)
+func (v *rc) List(ctx context.Context, options k8smetav1.ListOptions) (replicasetList *v1.VirtualMachineInstanceReplicaSetList, err error) {
+	replicasetList, err = v.VirtualMachineInstanceReplicaSetInterface.List(ctx, options)
 	for i := range replicasetList.Items {
 		replicasetList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
 	}
-
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -87,8 +87,8 @@ func (v *rc) List(options k8smetav1.ListOptions) (replicasetList *v1.VirtualMach
 	return
 }
 
-func (v *rc) Create(replicaset *v1.VirtualMachineInstanceReplicaSet) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
-	result, err = v.VirtualMachineInstanceReplicaSetInterface.Create(context.Background(), replicaset, k8smetav1.CreateOptions{})
+func (v *rc) Create(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts k8smetav1.CreateOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
+	result, err = v.VirtualMachineInstanceReplicaSetInterface.Create(ctx, replicaset, opts)
 	result.SetGroupVersionKind(v1.VirtualMachineInstanceReplicaSetGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, rsPath, "scale")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, scale),
 		))
-		scaleResponse, err := client.ReplicaSet(k8sv1.NamespaceDefault).GetScale(rs.Name, k8smetav1.GetOptions{})
+		scaleResponse, err := client.ReplicaSet(k8sv1.NamespaceDefault).GetScale(context.Background(), rs.Name, k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.VerifyRequest("PUT", path.Join(proxyPath, rsPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, rs),
 		))
-		updatedVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Update(rs)
+		updatedVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Update(context.Background(), rs, k8smetav1.UpdateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, rsPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, rs),
 		))
-		fetchedVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Get("testrs", k8smetav1.GetOptions{})
+		fetchedVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Get(context.Background(), "testrs", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
@@ -72,7 +72,7 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, rsPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testrs")),
 		))
-		_, err = client.ReplicaSet(k8sv1.NamespaceDefault).Get("testrs", k8smetav1.GetOptions{})
+		_, err = client.ReplicaSet(k8sv1.NamespaceDefault).Get(context.Background(), "testrs", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -20,6 +20,7 @@
 package kubecli
 
 import (
+	"context"
 	"net/http"
 	"path"
 
@@ -113,7 +114,7 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, rs),
 		))
-		createdVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Create(rs)
+		createdVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Create(context.Background(), rs, k8smetav1.CreateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.VerifyRequest("PUT", path.Join(proxyPath, rsPath, "scale")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, scale),
 		))
-		scaleResponse, err := client.ReplicaSet(k8sv1.NamespaceDefault).UpdateScale(rs.Name, scale)
+		scaleResponse, err := client.ReplicaSet(k8sv1.NamespaceDefault).UpdateScale(context.Background(), rs.Name, scale)
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, rsPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err = client.ReplicaSet(k8sv1.NamespaceDefault).Delete("testrs", &k8smetav1.DeleteOptions{})
+		err = client.ReplicaSet(k8sv1.NamespaceDefault).Delete(context.Background(), "testrs", k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVirtualMachineInstanceReplicaSetList(*rs)),
 		))
-		fetchedVMIReplicaSetList, err := client.ReplicaSet(k8sv1.NamespaceDefault).List(k8smetav1.ListOptions{})
+		fetchedVMIReplicaSetList, err := client.ReplicaSet(k8sv1.NamespaceDefault).List(context.Background(), k8smetav1.ListOptions{})
 		apiVersion, kind := virtv1.VirtualMachineInstanceReplicaSetGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
@@ -72,12 +72,8 @@ func (v *vmiPresets) Update(ctx context.Context, virtualMachineInstancePreset *v
 	return
 }
 
-func (v *vmiPresets) Delete(name string, options *k8smetav1.DeleteOptions) error {
-	opts := k8smetav1.DeleteOptions{}
-	if options != nil {
-		opts = *options
-	}
-	return v.VirtualMachineInstancePresetInterface.Delete(context.Background(), name, opts)
+func (v *vmiPresets) Delete(ctx context.Context, name string, options k8smetav1.DeleteOptions) error {
+	return v.VirtualMachineInstancePresetInterface.Delete(ctx, name, options)
 }
 
 func (v *vmiPresets) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
@@ -52,12 +52,11 @@ func (v *vmiPresets) Get(ctx context.Context, name string, options k8smetav1.Get
 	return
 }
 
-func (v *vmiPresets) List(options k8smetav1.ListOptions) (vmiPresetList *v1.VirtualMachineInstancePresetList, err error) {
-	vmiPresetList, err = v.VirtualMachineInstancePresetInterface.List(context.Background(), options)
+func (v *vmiPresets) List(ctx context.Context, options k8smetav1.ListOptions) (vmiPresetList *v1.VirtualMachineInstancePresetList, err error) {
+	vmiPresetList, err = v.VirtualMachineInstancePresetInterface.List(ctx, options)
 	for i := range vmiPresetList.Items {
 		vmiPresetList.Items[i].SetGroupVersionKind(v1.VirtualMachineInstancePresetGroupVersionKind)
 	}
-
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
@@ -81,6 +81,6 @@ func (v *vmiPresets) Delete(name string, options *k8smetav1.DeleteOptions) error
 	return v.VirtualMachineInstancePresetInterface.Delete(context.Background(), name, opts)
 }
 
-func (v *vmiPresets) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error) {
-	return v.VirtualMachineInstancePresetInterface.Patch(context.Background(), name, pt, data, k8smetav1.PatchOptions{}, subresources...)
+func (v *vmiPresets) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstancePreset, err error) {
+	return v.VirtualMachineInstancePresetInterface.Patch(ctx, name, pt, data, opts, subresources...)
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
@@ -61,8 +61,8 @@ func (v *vmiPresets) List(options k8smetav1.ListOptions) (vmiPresetList *v1.Virt
 	return
 }
 
-func (v *vmiPresets) Create(vmi *v1.VirtualMachineInstancePreset) (result *v1.VirtualMachineInstancePreset, err error) {
-	result, err = v.VirtualMachineInstancePresetInterface.Create(context.Background(), vmi, k8smetav1.CreateOptions{})
+func (v *vmiPresets) Create(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts k8smetav1.CreateOptions) (result *v1.VirtualMachineInstancePreset, err error) {
+	result, err = v.VirtualMachineInstancePresetInterface.Create(ctx, virtualMachineInstancePreset, opts)
 	result.SetGroupVersionKind(v1.VirtualMachineInstancePresetGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
@@ -46,8 +46,8 @@ type vmiPresets struct {
 	resource   string
 }
 
-func (v *vmiPresets) Get(name string, options k8smetav1.GetOptions) (vmi *v1.VirtualMachineInstancePreset, err error) {
-	vmi, err = v.VirtualMachineInstancePresetInterface.Get(context.Background(), name, options)
+func (v *vmiPresets) Get(ctx context.Context, name string, options k8smetav1.GetOptions) (vmi *v1.VirtualMachineInstancePreset, err error) {
+	vmi, err = v.VirtualMachineInstancePresetInterface.Get(ctx, name, options)
 	vmi.SetGroupVersionKind(v1.VirtualMachineInstancePresetGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset.go
@@ -67,8 +67,8 @@ func (v *vmiPresets) Create(ctx context.Context, virtualMachineInstancePreset *v
 	return
 }
 
-func (v *vmiPresets) Update(vmi *v1.VirtualMachineInstancePreset) (result *v1.VirtualMachineInstancePreset, err error) {
-	result, err = v.VirtualMachineInstancePresetInterface.Update(context.Background(), vmi, k8smetav1.UpdateOptions{})
+func (v *vmiPresets) Update(ctx context.Context, virtualMachineInstancePreset *v1.VirtualMachineInstancePreset, opts k8smetav1.UpdateOptions) (result *v1.VirtualMachineInstancePreset, err error) {
+	result, err = v.VirtualMachineInstancePresetInterface.Update(ctx, virtualMachineInstancePreset, opts)
 	result.SetGroupVersionKind(v1.VirtualMachineInstancePresetGroupVersionKind)
 	return
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVirtualMachineInstancePresetList(*preset)),
 		))
-		fetchedVMIPresetList, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).List(k8smetav1.ListOptions{})
+		fetchedVMIPresetList, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).List(context.Background(), k8smetav1.ListOptions{})
 		apiVersion, kind := v1.VirtualMachineInstancePresetGroupVersionKind.ToAPIVersionAndKind()
 
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
@@ -20,6 +20,7 @@
 package kubecli
 
 import (
+	"context"
 	"net/http"
 	"path"
 
@@ -112,7 +113,7 @@ var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, preset),
 		))
-		createdVMIPreset, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Create(preset)
+		createdVMIPreset, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Create(context.Background(), preset, k8smetav1.CreateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, presetPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err = client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Delete("testpreset", &k8smetav1.DeleteOptions{})
+		err = client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Delete(context.Background(), "testpreset", k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, presetPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, preset),
 		))
-		fetchedVMIPreset, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Get("testpreset", k8smetav1.GetOptions{})
+		fetchedVMIPreset, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Get(context.Background(), "testpreset", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
@@ -71,7 +71,7 @@ var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, presetPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testpreset")),
 		))
-		_, err = client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Get("testpreset", k8smetav1.GetOptions{})
+		_, err = client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Get(context.Background(), "testpreset", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 			ghttp.VerifyRequest("PUT", path.Join(proxyPath, presetPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, preset),
 		))
-		updatedVMIPreset, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Update(preset)
+		updatedVMIPreset, err := client.VirtualMachineInstancePreset(k8sv1.NamespaceDefault).Update(context.Background(), preset, k8smetav1.UpdateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, de
 		close(stopCh)
 
 		retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			_, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(originalKV)
+			_, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(context.Background(), originalKV, metav1.UpdateOptions{})
 			return err
 		})
 
@@ -114,7 +114,7 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, de
 			},
 		}
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			_, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			_, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			return err
 		})
 	}

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -419,7 +419,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 				DryRun:            []string{metav1.DryRunAll},
 				PropagationPolicy: &deletePolicy,
 			}
-			err = virtClient.ReplicaSet(vmirs.Namespace).Delete(vmirs.Name, &opts)
+			err = virtClient.ReplicaSet(vmirs.Namespace).Delete(context.Background(), vmirs.Name, opts)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no VMI replicaset was actually deleted")

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -331,7 +331,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7640]delete a VMI preset", func() {
 			By("Create a VMI preset")
-			_, err := virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
+			_, err := virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(context.Background(), preset, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to delete a VMI preset")
@@ -350,7 +350,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7641]update a VMI preset", func() {
 			By("Create a VMI preset")
-			_, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
+			_, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(context.Background(), preset, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to update a VMI preset")
@@ -375,7 +375,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7642]patch a VMI preset", func() {
 			By("Create a VMI preset")
-			preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
+			preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(context.Background(), preset, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to patch a VMI preset")

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -249,7 +249,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7636]delete a migration", func() {
 			By("Create a migration")
-			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
+			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(context.Background(), vmim, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to delete a Migration")
@@ -268,7 +268,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7637]update a migration", func() {
 			By("Create a migration")
-			vmim, err := virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
+			vmim, err := virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(context.Background(), vmim, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to update the migration")
@@ -294,7 +294,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7638]patch a migration", func() {
 			By("Create a migration")
-			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
+			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(context.Background(), vmim, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to patch the migration")

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -325,7 +325,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no VMI preset was actually created")
-			_, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(preset.Name, metav1.GetOptions{})
+			_, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(context.Background(), preset.Name, metav1.GetOptions{})
 			Expect(err).To(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 		})
 
@@ -344,7 +344,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no VMI preset was actually deleted")
-			_, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(preset.Name, metav1.GetOptions{})
+			_, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(context.Background(), preset.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -355,7 +355,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 			By("Make a Dry-Run request to update a VMI preset")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(preset.Name, metav1.GetOptions{})
+				preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(context.Background(), preset.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -368,7 +368,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(preset.Name, metav1.GetOptions{})
+			preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(context.Background(), preset.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(preset.Labels["key"]).ToNot(Equal("42"))
 		})
@@ -384,7 +384,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(preset.Name, metav1.GetOptions{})
+			preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Get(context.Background(), preset.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(preset.Labels["key"]).ToNot(Equal("42"))
 		})

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -488,14 +488,14 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no KubeVirt CR was actually deleted")
-			_, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+			_, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("[test_id:7649]update a KubeVirt CR", func() {
 			By("Make a Dry-Run request to update a KubeVirt CR")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -508,7 +508,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.Labels["key"]).ToNot(Equal("42"))
 		})
@@ -520,7 +520,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.Labels["key"]).ToNot(Equal("42"))
 		})

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -243,7 +243,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no migration was actually created")
-			_, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(vmim.Name, &metav1.GetOptions{})
+			_, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(context.Background(), vmim.Name, metav1.GetOptions{})
 			Expect(err).To(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 		})
 
@@ -262,7 +262,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no migration was actually deleted")
-			_, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(vmim.Name, &metav1.GetOptions{})
+			_, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(context.Background(), vmim.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -273,7 +273,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 			By("Make a Dry-Run request to update the migration")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(vmim.Name, &metav1.GetOptions{})
+				vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(context.Background(), vmim.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -287,7 +287,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(vmim.Name, &metav1.GetOptions{})
+			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(context.Background(), vmim.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmim.Annotations["key"]).ToNot(Equal("42"))
 		})
@@ -303,7 +303,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(vmim.Name, &metav1.GetOptions{})
+			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(context.Background(), vmim.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmim.Labels["key"]).ToNot(Equal("42"))
 		})

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -484,7 +484,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 				DryRun:            []string{metav1.DryRunAll},
 				PropagationPolicy: &deletePolicy,
 			}
-			err = virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &opts)
+			err = virtClient.KubeVirt(kv.Namespace).Delete(context.Background(), kv.Name, opts)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no KubeVirt CR was actually deleted")

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -258,7 +258,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 				DryRun:            []string{metav1.DryRunAll},
 				PropagationPolicy: &deletePolicy,
 			}
-			err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Delete(vmim.Name, &opts)
+			err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Delete(context.Background(), vmim.Name, opts)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no migration was actually deleted")

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -410,7 +410,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7644]delete a VMI replicaset", func() {
 			By("Create a VMI replicaset")
-			_, err := virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
+			_, err := virtClient.ReplicaSet(vmirs.Namespace).Create(context.Background(), vmirs, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to delete a VMI replicaset")
@@ -429,7 +429,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7645]update a VMI replicaset", func() {
 			By("Create a VMI replicaset")
-			_, err = virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
+			_, err = virtClient.ReplicaSet(vmirs.Namespace).Create(context.Background(), vmirs, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to update a VMI replicaset")
@@ -454,7 +454,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7646]patch a VMI replicaset", func() {
 			By("Create a VMI replicaset")
-			vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
+			vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Create(context.Background(), vmirs, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to patch a VMI replicaset")

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -404,7 +404,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no VMI replicaset was actually created")
-			_, err = virtClient.ReplicaSet(vmirs.Namespace).Get(vmirs.Name, metav1.GetOptions{})
+			_, err = virtClient.ReplicaSet(vmirs.Namespace).Get(context.Background(), vmirs.Name, metav1.GetOptions{})
 			Expect(err).To(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 		})
 
@@ -423,7 +423,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no VMI replicaset was actually deleted")
-			_, err = virtClient.ReplicaSet(vmirs.Namespace).Get(vmirs.Name, metav1.GetOptions{})
+			_, err = virtClient.ReplicaSet(vmirs.Namespace).Get(context.Background(), vmirs.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -434,7 +434,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 			By("Make a Dry-Run request to update a VMI replicaset")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Get(vmirs.Name, metav1.GetOptions{})
+				vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Get(context.Background(), vmirs.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -447,7 +447,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Get(vmirs.Name, metav1.GetOptions{})
+			vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Get(context.Background(), vmirs.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmirs.Labels["key"]).ToNot(Equal("42"))
 		})
@@ -463,7 +463,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Get(vmirs.Name, metav1.GetOptions{})
+			vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Get(context.Background(), vmirs.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmirs.Labels["key"]).ToNot(Equal("42"))
 		})

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -340,7 +340,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 				DryRun:            []string{metav1.DryRunAll},
 				PropagationPolicy: &deletePolicy,
 			}
-			err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Delete(preset.Name, &opts)
+			err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Delete(context.Background(), preset.Name, opts)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no VMI preset was actually deleted")

--- a/tests/framework/matcher/getter.go
+++ b/tests/framework/matcher/getter.go
@@ -133,7 +133,7 @@ func ThisMigration(migration *virtv1.VirtualMachineInstanceMigration) func() (*v
 func ThisMigrationWith(namespace string, name string) func() (*virtv1.VirtualMachineInstanceMigration, error) {
 	return func() (p *virtv1.VirtualMachineInstanceMigration, err error) {
 		virtClient := kubevirt.Client()
-		p, err = virtClient.VirtualMachineInstanceMigration(namespace).Get(name, &k8smetav1.GetOptions{})
+		p, err = virtClient.VirtualMachineInstanceMigration(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -132,7 +132,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 			By("Ensuring live-migration started")
 			var migration *v1.VirtualMachineInstanceMigration
 			Eventually(func() bool {
-				migrations, err := virtClient.VirtualMachineInstanceMigration(vm.Namespace).List(&k8smetav1.ListOptions{})
+				migrations, err := virtClient.VirtualMachineInstanceMigration(vm.Namespace).List(context.Background(), k8smetav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				for _, mig := range migrations.Items {
 					if mig.Spec.VMIName == vmi.Name {

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -220,7 +220,7 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 
 			By("starting the migration")
 			migration := libmigration.New(vm.Name, vm.Namespace)
-			migration, err = virtClient.VirtualMachineInstanceMigration(vm.Namespace).Create(migration, &metav1.CreateOptions{})
+			migration, err = virtClient.VirtualMachineInstanceMigration(vm.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration)

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -273,7 +273,7 @@ func patchWorkloadUpdateMethodAndRolloutStrategy(kvName string, virtClient kubec
 	data := []byte(fmt.Sprintf(`[%s, %s]`, data1, data2))
 
 	EventuallyWithOffset(1, func() error {
-		_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(kvName, types.JSONPatchType, data, &k8smetav1.PatchOptions{})
+		_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), kvName, types.JSONPatchType, data, k8smetav1.PatchOptions{})
 		return err
 	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 }

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -120,7 +120,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			By("Ensuring live-migration started")
 			var migration *v1.VirtualMachineInstanceMigration
 			Eventually(func() bool {
-				migrations, err := virtClient.VirtualMachineInstanceMigration(vm.Namespace).List(&k8smetav1.ListOptions{})
+				migrations, err := virtClient.VirtualMachineInstanceMigration(vm.Namespace).List(context.Background(), k8smetav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				for _, mig := range migrations.Items {
 					if mig.Spec.VMIName == vmi.Name {

--- a/tests/hotplug/rolloutstrategy.go
+++ b/tests/hotplug/rolloutstrategy.go
@@ -47,7 +47,7 @@ var _ = Describe("[Serial][sig-compute]VM Rollout Strategy", decorators.SigCompu
 
 			kv := util2.GetCurrentKv(virtClient)
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(kv.Name, types.JSONPatchType, []byte(data), &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), kv.Name, types.JSONPatchType, []byte(data), metav1.PatchOptions{})
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		})

--- a/tests/infrastructure/k8s-client-changes.go
+++ b/tests/infrastructure/k8s-client-changes.go
@@ -20,6 +20,7 @@
 package infrastructure
 
 import (
+	"context"
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -73,7 +74,7 @@ var _ = DescribeInfra("changes to the kubernetes client", func() {
 	It("on the controller rate limiter should lead to delayed VMI starts", func() {
 		By("first getting the basetime for a replicaset")
 		replicaset := tests.NewRandomReplicaSetFromVMI(libvmi.NewCirros(libvmi.WithResourceMemory("1Mi")), int32(0))
-		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(replicaset)
+		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(context.Background(), replicaset, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		start := time.Now()
 		libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 10)
@@ -109,7 +110,7 @@ var _ = DescribeInfra("changes to the kubernetes client", func() {
 		)
 
 		replicaset := tests.NewRandomReplicaSetFromVMI(vmi, 0)
-		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(replicaset)
+		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(context.Background(), replicaset, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 10)
 		Eventually(matcher.AllVMIs(replicaset.Namespace), 90*time.Second, 1*time.Second).Should(matcher.BeInPhase(v1.Running))

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -187,7 +187,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 				var migrationCreated *v1.VirtualMachineInstanceMigration
 				By("starting migration")
 				Eventually(func() error {
-					migrationCreated, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+					migrationCreated, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 					return err
 				}, libmigration.MigrationWaitTime, 1*time.Second).Should(Succeed(), "migration creation should succeed")
 				migration = migrationCreated

--- a/tests/libkvconfig/kvconfig.go
+++ b/tests/libkvconfig/kvconfig.go
@@ -20,6 +20,7 @@
 package libkvconfig
 
 import (
+	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,6 +53,6 @@ func patchKV(namespace, name string, patchOps []patch.PatchOperation) error {
 	if err != nil {
 		return err
 	}
-	_, err = kubevirt.Client().KubeVirt(namespace).Patch(name, types.JSONPatchType, patchData, &metav1.PatchOptions{})
+	_, err = kubevirt.Client().KubeVirt(namespace).Patch(context.Background(), name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 	return err
 }

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -64,7 +64,7 @@ func ExpectMigrationToSucceedWithDefaultTimeout(virtClient kubecli.KubevirtClien
 func ExpectMigrationToSucceedWithOffset(offset int, virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) *v1.VirtualMachineInstanceMigration {
 	By("Waiting until the Migration Completes")
 	EventuallyWithOffset(offset, func() error {
-		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ func ConfirmMigrationDataIsStored(virtClient kubecli.KubevirtClient, migration *
 	By("Retrieving the VMI and the migration object")
 	vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred(), "should have been able to retrive the VMI instance")
-	migration, migerr := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+	migration, migerr := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 	Expect(migerr).ToNot(HaveOccurred(), "should have been able to retrive the migration")
 
 	By("Verifying the stored migration state")
@@ -441,7 +441,7 @@ func RunAndCancelMigration(migration *v1.VirtualMachineInstanceMigration, vmi *v
 	By("Waiting until the Migration is Running")
 
 	Eventually(func() bool {
-		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(migration.Status.Phase).ToNot(Equal(v1.MigrationFailed))
@@ -472,7 +472,7 @@ func RunAndImmediatelyCancelMigration(migration *v1.VirtualMachineInstanceMigrat
 
 	By("Waiting until the Migration is Running")
 	Eventually(func() bool {
-		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return migration.Status.Phase == v1.MigrationRunning
 	}, timeout, 1*time.Second).Should(BeTrue())
@@ -494,7 +494,7 @@ func RunMigrationAndExpectFailure(migration *v1.VirtualMachineInstanceMigration,
 
 	uid := ""
 	Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
-		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		phase := migration.Status.Phase

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -93,7 +93,7 @@ func RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient kubecli.Kubevi
 func RunMigration(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration) *v1.VirtualMachineInstanceMigration {
 	By("Starting a Migration")
 
-	migrationCreated, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+	migrationCreated, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
 	return migrationCreated
@@ -434,7 +434,7 @@ func RunAndCancelMigration(migration *v1.VirtualMachineInstanceMigration, vmi *v
 	virtClient := kubevirt.Client()
 	By("Starting a Migration")
 	Eventually(func() error {
-		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 		return err
 	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
 
@@ -466,7 +466,7 @@ func RunAndImmediatelyCancelMigration(migration *v1.VirtualMachineInstanceMigrat
 	virtClient := kubevirt.Client()
 	By("Starting a Migration")
 	Eventually(func() error {
-		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 		return err
 	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
 
@@ -487,7 +487,7 @@ func RunMigrationAndExpectFailure(migration *v1.VirtualMachineInstanceMigration,
 	virtClient := kubevirt.Client()
 	By("Starting a Migration")
 	Eventually(func() error {
-		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 		return err
 	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
 	By("Waiting until the Migration Completes")

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/onsi/gomega/gstruct"
 
-	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/libinfra"
 
 	"kubevirt.io/kubevirt/tests"
@@ -21,6 +20,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
@@ -421,7 +421,7 @@ func CancelMigration(migration *v1.VirtualMachineInstanceMigration, vminame stri
 	virtClient := kubevirt.Client()
 	if !with_virtctl {
 		By("Cancelling a Migration")
-		Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(migration.Name, &metav1.DeleteOptions{})).To(Succeed(), "Migration should be deleted successfully")
+		Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(context.Background(), migration.Name, metav1.DeleteOptions{})).To(Succeed(), "Migration should be deleted successfully")
 	} else {
 		By("Cancelling a Migration with virtctl")
 		command := clientcmd.NewRepeatableVirtctlCommand("migrate-cancel", "--namespace", migration.Namespace, vminame)

--- a/tests/libreplicaset/replicaset.go
+++ b/tests/libreplicaset/replicaset.go
@@ -24,7 +24,7 @@ func DoScaleWithScaleSubresource(virtClient kubecli.KubevirtClient, name string,
 		s, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).GetScale(context.Background(), name, v12.GetOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		s.Spec.Replicas = scale
-		s, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).UpdateScale(name, s)
+		s, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).UpdateScale(context.Background(), name, s)
 		return err
 	})
 

--- a/tests/libreplicaset/replicaset.go
+++ b/tests/libreplicaset/replicaset.go
@@ -21,7 +21,7 @@ func DoScaleWithScaleSubresource(virtClient kubecli.KubevirtClient, name string,
 	By(fmt.Sprintf("Scaling to %d", scale))
 	var s *autov1.Scale
 	err := tests.RetryIfModified(func() error {
-		s, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).GetScale(name, v12.GetOptions{})
+		s, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).GetScale(context.Background(), name, v12.GetOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		s.Spec.Replicas = scale
 		s, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).UpdateScale(name, s)
@@ -32,7 +32,7 @@ func DoScaleWithScaleSubresource(virtClient kubecli.KubevirtClient, name string,
 
 	By("Checking the number of replicas")
 	EventuallyWithOffset(1, func() int32 {
-		s, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).GetScale(name, v12.GetOptions{})
+		s, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).GetScale(context.Background(), name, v12.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return s.Status.Replicas
 	}, 90*time.Second, time.Second).Should(Equal(scale))

--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -212,7 +212,7 @@ func WaitForMigrationToDisappearWithTimeout(migration *v1.VirtualMachineInstance
 	virtClient, err := kubecli.GetKubevirtClient()
 	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred())
 	gomega.EventuallyWithOffset(1, func() error {
-		_, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+		_, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 		return err
 	}, seconds, 1*time.Second).Should(gomega.MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), fmt.Sprintf("migration %s was expected to disappear after %d seconds, but it did not", migration.Name, seconds))
 }

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -204,7 +204,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
-				migration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(migration, &metav1.CreateOptions{})
+				migration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting until we have two available pods")

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -336,7 +336,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 					expectVMIMigratedToAnotherNode(vmi.Name, node)
 
 					Consistently(func() error {
-						migrations, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).List(&metav1.ListOptions{})
+						migrations, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).List(context.Background(), metav1.ListOptions{})
 						if err != nil {
 							return err
 						}
@@ -530,7 +530,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 
 				By("waiting until migration kicks in")
 				Eventually(func() int {
-					migrationList, err := virtClient.VirtualMachineInstanceMigration(k8sv1.NamespaceAll).List(&metav1.ListOptions{})
+					migrationList, err := virtClient.VirtualMachineInstanceMigration(k8sv1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					runningMigrations := filterRunningMigrations(migrationList.Items)
@@ -546,7 +546,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 						nodes = append(nodes, vmi.Status.NodeName)
 					}
 
-					migrationList, err := virtClient.VirtualMachineInstanceMigration(k8sv1.NamespaceAll).List(&metav1.ListOptions{})
+					migrationList, err := virtClient.VirtualMachineInstanceMigration(k8sv1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					runningMigrations := filterRunningMigrations(migrationList.Items)

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -225,7 +225,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 				By("Verifying that both pods are protected by the PodDisruptionBudget for the whole migration")
 				getOptions := metav1.GetOptions{}
 				Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
-					currentMigration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Get(migration.Name, &getOptions)
+					currentMigration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Get(context.Background(), migration.Name, getOptions)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(currentMigration.Status.Phase).NotTo(Equal(v1.MigrationFailed))
 					for _, p := range pods.Items {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -894,7 +894,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Migration should observe a timeout period before canceling unschedulable target pod")
 				Consistently(func() error {
 
-					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
@@ -908,7 +908,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				By("Migration should fail eventually due to pending target pod timeout")
 				Eventually(func() error {
-					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
@@ -948,7 +948,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Migration should observe a timeout period before canceling pending target pod")
 				Consistently(func() error {
 
-					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
@@ -962,7 +962,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				By("Migration should fail eventually due to pending target pod timeout")
 				Eventually(func() error {
-					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
@@ -2013,7 +2013,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				By("Waiting for Migration to reach Preparing Target Phase")
 				Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
-					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					phase := migration.Status.Phase
@@ -2093,7 +2093,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				By("Waiting for Migration to reach Preparing Target Phase")
 				Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
-					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					phase := migration.Status.Phase
@@ -2308,7 +2308,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				By("Waiting until the Migration has UID")
 				Eventually(func() bool {
-					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return migration.UID != ""
 				}, timeout, 1*time.Second).Should(BeTrue())
@@ -2366,7 +2366,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					migration := libmigration.New(vmi.Name, vmi.Namespace)
 					migration = libmigration.RunMigration(virtClient, migration)
 					expectMigrationSchedulingPhase := func() v1.VirtualMachineInstanceMigrationPhase {
-						migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+						migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 						Expect(err).ShouldNot(HaveOccurred())
 
 						return migration.Status.Phase
@@ -2399,7 +2399,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 					By("Expecting migration to be deleted")
 					Eventually(func() error {
-						_, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+						_, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 						return err
 					}, 60*time.Second, 5*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 
@@ -3472,7 +3472,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			migration := libmigration.New(vmi.Name, testsuite.GetTestNamespace(vmi))
 			migration = libmigration.RunMigration(virtClient, migration)
 			Eventually(func() *v1.VirtualMachineInstanceMigration {
-				migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+				migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
 				if err != nil {
 					return nil
 				}

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1956,7 +1956,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					}, 10*time.Second, time.Second).Should(Succeed(), "Target pod should exit quickly after migration fails.")
 				}
 
-				migrations, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).List(&metav1.ListOptions{})
+				migrations, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(migrations.Items).To(HaveLen(5))
 			})
@@ -3316,10 +3316,10 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", v1.MigrationSelectorLabel, vmi.Name))
 				Expect(err).ToNot(HaveOccurred())
-				listOptions := &metav1.ListOptions{
+				listOptions := metav1.ListOptions{
 					LabelSelector: labelSelector.String(),
 				}
-				migrations, err := virtClient.VirtualMachineInstanceMigration(vmim.Namespace).List(listOptions)
+				migrations, err := virtClient.VirtualMachineInstanceMigration(vmim.Namespace).List(context.Background(), listOptions)
 				Expect(err).ToNot(HaveOccurred())
 
 				activeMigrations := 0

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -360,7 +360,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 
 				By("Starting a Migration")
-				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("InterfaceNotLiveMigratable"))
 			})
@@ -879,7 +879,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				var err error
 				Eventually(func() error {
-					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 					return err
 				}, 5, 1*time.Second).Should(Succeed(), "migration creation should succeed")
 
@@ -941,7 +941,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Starting a Migration")
 				var err error
 				Eventually(func() error {
-					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 					return err
 				}, 5, 1*time.Second).Should(Succeed(), "migration creation should succeed")
 
@@ -1097,7 +1097,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 
 				By("Starting a Migration")
-				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("DisksNotLiveMigratable"))
 			})
@@ -1136,7 +1136,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				By("Starting a first migration")
 				migration1 := libmigration.New(vmi.Name, vmi.Namespace)
-				migration1, err = virtClient.VirtualMachineInstanceMigration(migration1.Namespace).Create(migration1, &metav1.CreateOptions{})
+				migration1, err = virtClient.VirtualMachineInstanceMigration(migration1.Namespace).Create(context.Background(), migration1, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				// Successfully tested with 40, but requests start getting throttled above 10, which is better to avoid to prevent flakyness
@@ -1148,7 +1148,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 						defer GinkgoRecover()
 						defer wg.Done()
 						migration := libmigration.New(vmi.Name, vmi.Namespace)
-						_, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+						_, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 						Expect(err).To(HaveOccurred(), fmt.Sprintf("Extra migration %d should have failed to create", n))
 						Expect(err.Error()).To(ContainSubstring(`admission webhook "migration-create-validator.kubevirt.io" denied the request: in-flight migration detected.`))
 					}(n)
@@ -1530,7 +1530,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					// execute a migration, wait for finalized state
 					By("Starting the Migration")
 					migration := libmigration.New(vmi.Name, vmi.Namespace)
-					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 
 					By("Waiting for the proxy connection details to appear")
 					Eventually(func() bool {
@@ -1609,7 +1609,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					// execute a migration, wait for finalized state
 					By("Starting the Migration")
 					migration := libmigration.New(vmi.Name, vmi.Namespace)
-					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Waiting for the proxy connection details to appear")
@@ -2008,7 +2008,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				// execute a migration
 				By("Starting the Migration")
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
-				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for Migration to reach Preparing Target Phase")
@@ -2088,7 +2088,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				// execute a migration
 				By("Starting the Migration")
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
-				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for Migration to reach Preparing Target Phase")
@@ -2159,7 +2159,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 
 				By("Starting a Migration")
-				_, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+				_, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("DisksNotLiveMigratable"))
 			})
@@ -2302,7 +2302,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Starting a Migration")
 				const timeout = 180
 				Eventually(func() error {
-					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
 					return err
 				}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
 
@@ -3312,7 +3312,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmim := libmigration.New(vmi.Name, vmi.Namespace)
 				// not checking err as the migration creation will be blocked immediately by virt-api's validating webhook
 				// if another one is currently running
-				vmim, err = virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(vmim, &metav1.CreateOptions{})
+				vmim, err = virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(context.Background(), vmim, metav1.CreateOptions{})
 
 				labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", v1.MigrationSelectorLabel, vmi.Name))
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2394,7 +2394,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					}
 
 					By("Aborting the migration")
-					err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(migration.Name, &metav1.DeleteOptions{})
+					err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(context.Background(), migration.Name, metav1.DeleteOptions{})
 					Expect(err).ShouldNot(HaveOccurred())
 
 					By("Expecting migration to be deleted")

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -131,7 +131,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			}
 
 			Eventually(func() error {
-				kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+				kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 				return err
 			}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
@@ -158,7 +158,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{}
 
 			Eventually(func() error {
-				kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+				kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 				return err
 			}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -117,7 +117,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 	Context("System Alerts", func() {
 		disableVirtHandler := func() *v1.KubeVirt {
 			originalKv := util.GetCurrentKv(virtClient)
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{
 				Patches: []v1.CustomizeComponentsPatch{
@@ -152,7 +152,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 
 		restoreVirtHandler := func(kv *v1.KubeVirt) {
 			originalKv := util.GetCurrentKv(virtClient)
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{}

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -525,7 +525,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 			By("Checking the number of ready replicas")
 			Eventually(func() int {
-				rs, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Get(vmrs.ObjectMeta.Name, k8smetav1.GetOptions{})
+				rs, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Get(context.Background(), vmrs.ObjectMeta.Name, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return int(rs.Status.ReadyReplicas)
 			}, 120*time.Second, 1*time.Second).Should(Equal(numberOfVMs))

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -520,7 +520,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			vmrs.Labels = map[string]string{"expose": "vmirs"}
 
 			By("Start the replica set")
-			vmrs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(vmrs)
+			vmrs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmrs, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking the number of ready replicas")

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -199,7 +199,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 		createKv = func(newKv *v1.KubeVirt) {
 			Eventually(func() error {
-				_, err = virtClient.KubeVirt(newKv.Namespace).Create(newKv)
+				_, err = virtClient.KubeVirt(newKv.Namespace).Create(context.Background(), newKv, metav1.CreateOptions{})
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}
@@ -2213,7 +2213,7 @@ spec:
 			newKv.Name = "someother-kubevirt"
 
 			By("Creating another KubeVirt object")
-			_, err = virtClient.KubeVirt(newKv.Namespace).Create(newKv)
+			_, err = virtClient.KubeVirt(newKv.Namespace).Create(context.Background(), newKv, metav1.CreateOptions{})
 			Expect(err).To(MatchError(ContainSubstring("Kubevirt is already created")))
 		})
 
@@ -2728,7 +2728,7 @@ spec:
 			}
 			var one uint8 = 1
 			kv.Spec.Infra.Replicas = &one
-			kv, err = virtClient.KubeVirt(kv.Namespace).Create(kv)
+			kv, err = virtClient.KubeVirt(kv.Namespace).Create(context.Background(), kv, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the kv CR to get a finalizer")

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -639,7 +639,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 					if kv.DeletionTimestamp == nil {
 
 						By("deleting the kv object")
-						err := virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
+						err := virtClient.KubeVirt(kv.Namespace).Delete(context.Background(), kv.Name, metav1.DeleteOptions{})
 						if err != nil {
 							return err
 						}
@@ -1982,7 +1982,7 @@ spec:
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Deleting KubeVirt object")
-				err = virtClient.KubeVirt(originalKv.Namespace).Delete(originalKv.Name, &metav1.DeleteOptions{})
+				err = virtClient.KubeVirt(originalKv.Namespace).Delete(context.Background(), originalKv.Name, metav1.DeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("there are still Virtual Machine Instances present"))
 			})
@@ -2701,7 +2701,7 @@ spec:
 			}
 
 			By("deleting the kv CR")
-			err = virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
+			err = virtClient.KubeVirt(kv.Namespace).Delete(context.Background(), kv.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for virt-api and virt-controller to be gone")

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -856,7 +856,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 			// the results
 			Eventually(func() error {
 				By("Verifying only a single successful migration took place for each vmi")
-				migrationList, err := virtClient.VirtualMachineInstanceMigration(testsuite.GetTestNamespace(nil)).List(&metav1.ListOptions{})
+				migrationList, err := virtClient.VirtualMachineInstanceMigration(testsuite.GetTestNamespace(nil)).List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred(), "retrieving migrations")
 				for _, vmi := range vmis {
 					count := 0

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -256,7 +256,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		allPodsAreReady = func(kv *v1.KubeVirt) {
 			Eventually(func() error {
 
-				curKv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				curKv, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -308,7 +308,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 		waitForUpdateCondition = func(kv *v1.KubeVirt) {
 			Eventually(func() *v1.KubeVirt {
-				kv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				return kv
@@ -323,7 +323,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 		waitForKvWithTimeout = func(newKv *v1.KubeVirt, timeoutSeconds int) {
 			Eventually(func() error {
-				kv, err := virtClient.KubeVirt(newKv.Namespace).Get(newKv.Name, &metav1.GetOptions{})
+				kv, err := virtClient.KubeVirt(newKv.Namespace).Get(context.Background(), newKv.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -1379,7 +1379,7 @@ spec:
 			maxDevicesCommandArgument := fmt.Sprintf("--max-devices %d", newVirtualMachineInstancesPerNode)
 
 			By("Updating KubeVirt Object")
-			kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.Spec.Configuration.VirtualMachineInstancesPerNode).ToNot(Equal(&newVirtualMachineInstancesPerNode))
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = &newVirtualMachineInstancesPerNode
@@ -1394,7 +1394,7 @@ spec:
 			Eventually(fetchVirtHandlerCommand, 60*time.Second, 5*time.Second).Should(ContainSubstring(maxDevicesCommandArgument))
 
 			By("Deleting patch from KubeVirt object")
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = nil
@@ -1416,7 +1416,7 @@ spec:
 			annotationPatchKey := "applied-patch"
 
 			By("Updating KubeVirt Object")
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{
 				Patches: []v1.CustomizeComponentsPatch{
@@ -1450,7 +1450,7 @@ spec:
 			waitForKvWithTimeout(kv, 120)
 
 			By("Check that KubeVirt CR generation does not get updated when applying patch")
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.GetGeneration()).To(Equal(generation))
 
@@ -1511,7 +1511,7 @@ spec:
 		It("should not be present if not specified on the KubeVirt CR", func() {
 
 			By("Check that KubeVirt CR has empty imagePullSecrets")
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(kv.Spec.ImagePullSecrets).To(BeEmpty())
 
@@ -1555,7 +1555,7 @@ spec:
 			})
 
 			By("Updating KubeVirt Object")
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = imagePullSecrets
 			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
@@ -1577,7 +1577,7 @@ spec:
 			checkVirtLauncherPod(vmi)
 
 			By("Deleting imagePullSecrets from KubeVirt object")
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = []k8sv1.LocalObjectReference{}
 			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
@@ -1970,7 +1970,7 @@ spec:
 
 				By("setting the right uninstall strategy")
 				Eventually(func() error {
-					kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+					kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					kv.Spec.UninstallStrategy = v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
 					_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
@@ -2718,7 +2718,7 @@ spec:
 
 			By("waiting for the kv CR to be gone")
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				_, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				return err
 			}, 120*time.Second, 4*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 
@@ -2733,7 +2733,7 @@ spec:
 
 			By("waiting for the kv CR to get a finalizer")
 			Eventually(func() bool {
-				kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv, err = virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return len(kv.Finalizers) > 0
 			}, 120*time.Second, 4*time.Second).Should(BeTrue())
@@ -2741,7 +2741,7 @@ spec:
 			By("ensuring the CR generation is stable")
 			Expect(err).ToNot(HaveOccurred())
 			Consistently(func() int64 {
-				kv2, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv2, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return kv2.GetGeneration()
 			}, 30*time.Second, 2*time.Second).Should(Equal(kv.GetGeneration()))

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1902,7 +1902,7 @@ spec:
 			if len(migratableVMIs) > 0 {
 				By("Verifying that a once migrated VMI after an update can be migrated again")
 				vmi := migratableVMIs[0]
-				migration, err := virtClient.VirtualMachineInstanceMigration(testsuite.GetTestNamespace(vmi)).Create(libmigration.New(vmi.Name, vmi.Namespace), &metav1.CreateOptions{})
+				migration, err := virtClient.VirtualMachineInstanceMigration(testsuite.GetTestNamespace(vmi)).Create(context.Background(), libmigration.New(vmi.Name, vmi.Namespace), metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(ThisMigration(migration), 180).Should(HaveSucceeded())
 			}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1384,7 +1384,7 @@ spec:
 			Expect(kv.Spec.Configuration.VirtualMachineInstancesPerNode).ToNot(Equal(&newVirtualMachineInstancesPerNode))
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = &newVirtualMachineInstancesPerNode
 
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -1398,7 +1398,7 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = nil
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -1429,7 +1429,7 @@ spec:
 				},
 			}
 
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			generation := kv.GetGeneration()
 
@@ -1456,7 +1456,7 @@ spec:
 
 			By("Deleting patch from KubeVirt object")
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{}
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			generation = kv.GetGeneration()
 
@@ -1558,7 +1558,7 @@ spec:
 			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = imagePullSecrets
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -1580,7 +1580,7 @@ spec:
 			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = []k8sv1.LocalObjectReference{}
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -1973,7 +1973,7 @@ spec:
 					kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					kv.Spec.UninstallStrategy = v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
-					_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
+					_, err = virtClient.KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 					return err
 				}, 60*time.Second, time.Second).ShouldNot(HaveOccurred())
 

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -380,7 +380,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 				"]")
 
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -389,7 +389,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		patchKvVersionAndRegistry = func(name string, version string, registry string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/imageTag", "value": "%s"},{ "op": "replace", "path": "/spec/imageRegistry", "value": "%s"}]`, version, registry))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -398,7 +398,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		patchKvVersion = func(name string, version string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "add", "path": "/spec/imageTag", "value": "%s"}]`, version))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -412,7 +412,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -426,7 +426,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
-			_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+			_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(errMsg))
 
@@ -477,7 +477,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -494,7 +494,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).Should(HaveOccurred())

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -67,7 +67,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	doScale := func(name string, scale int32) {
 
 		By(fmt.Sprintf("Scaling to %d", scale))
-		rs, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Patch(name, types.JSONPatchType, []byte(fmt.Sprintf("[{ \"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": %v }]", scale)))
+		rs, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Patch(context.Background(), name, types.JSONPatchType, []byte(fmt.Sprintf("[{ \"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": %v }]", scale)), v12.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Checking the number of replicas")
@@ -325,7 +325,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		rs := newReplicaSet()
 		// pause controller
 		By("Pausing the replicaset")
-		_, err := virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"add\", \"path\": \"/spec/paused\", \"value\": true }]"))
+		_, err := virtClient.ReplicaSet(rs.Namespace).Patch(context.Background(), rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"add\", \"path\": \"/spec/paused\", \"value\": true }]"), v12.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() *v1.VirtualMachineInstanceReplicaSet {
@@ -338,7 +338,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		By("Updating the number of replicas")
 		patchData, err := patch.GenerateTestReplacePatch("/spec/replicas", rs.Spec.Replicas, pointer.P(2))
 		Expect(err).ToNot(HaveOccurred())
-		rs, err = virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, patchData)
+		rs, err = virtClient.ReplicaSet(rs.Namespace).Patch(context.Background(), rs.Name, types.JSONPatchType, patchData, v12.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// make sure that we don't scale up
@@ -353,7 +353,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		// resume controller
 		By("Resuming the replicaset")
-		_, err = virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"replace\", \"path\": \"/spec/paused\", \"value\": false }]"))
+		_, err = virtClient.ReplicaSet(rs.Namespace).Patch(context.Background(), rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"replace\", \"path\": \"/spec/paused\", \"value\": false }]"), v12.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// Paused condition should disappear

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -275,7 +275,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		doScale(newRS.ObjectMeta.Name, 2)
 		// Delete it
 		By("Deleting the VirtualMachineInstance replica set")
-		Expect(virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).Delete(newRS.ObjectMeta.Name, &v12.DeleteOptions{})).To(Succeed())
+		Expect(virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).Delete(context.Background(), newRS.ObjectMeta.Name, v12.DeleteOptions{})).To(Succeed())
 		// Wait until VMIs are gone
 		By("Waiting until all VMIs are gone")
 		Eventually(func() int {
@@ -302,7 +302,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		By("Deleting the VirtualMachineInstance replica set with the 'orphan' deletion strategy")
 		orphanPolicy := v12.DeletePropagationOrphan
 		Expect(virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).
-			Delete(newRS.ObjectMeta.Name, &v12.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
+			Delete(context.Background(), newRS.ObjectMeta.Name, v12.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
 		// Wait until the replica set is deleted
 		By("Waiting until the replica set got deleted")
 		Eventually(func() error {

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -106,7 +106,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		var s *autov1.Scale
 		By("Checking the number of replicas")
 		EventuallyWithOffset(1, func() int32 {
-			s, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).GetScale(name, v12.GetOptions{})
+			s, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).GetScale(context.Background(), name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return s.Status.Replicas
 		}, 90*time.Second, time.Second).Should(Equal(int32(expected)))

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -72,7 +72,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		By("Checking the number of replicas")
 		Eventually(func() int32 {
-			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(name, v12.GetOptions{})
+			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(context.Background(), name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return rs.Status.Replicas
 		}, 90*time.Second, time.Second).Should(Equal(int32(scale)))
@@ -227,7 +227,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		By("checking the number of ready replicas in the returned yaml")
 		Eventually(func() int {
-			rs, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(newRS)).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
+			rs, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(newRS)).Get(context.Background(), newRS.ObjectMeta.Name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return int(rs.Status.ReadyReplicas)
 		}, 120*time.Second, 1*time.Second).Should(Equal(2))
@@ -239,7 +239,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		By("waiting until all VMIs are ready")
 		Eventually(func() int {
-			rs, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(newRS)).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
+			rs, err := virtClient.ReplicaSet(testsuite.GetTestNamespace(newRS)).Get(context.Background(), newRS.ObjectMeta.Name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return int(rs.Status.ReadyReplicas)
 		}, 120*time.Second, 1*time.Second).Should(Equal(2))
@@ -306,7 +306,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		// Wait until the replica set is deleted
 		By("Waiting until the replica set got deleted")
 		Eventually(func() error {
-			_, err := virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
+			_, err := virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).Get(context.Background(), newRS.ObjectMeta.Name, v12.GetOptions{})
 			return err
 		}, 60*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 
@@ -329,7 +329,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() *v1.VirtualMachineInstanceReplicaSet {
-			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(context.Background(), rs.ObjectMeta.Name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return rs
 		}, 10*time.Second, 1*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReplicaSetReplicaPaused))
@@ -344,7 +344,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		// make sure that we don't scale up
 		By("Checking that the replicaset do not scale while it is paused")
 		Consistently(func() int32 {
-			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(context.Background(), rs.ObjectMeta.Name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			// Make sure that no failure happened, so that ensure that we don't scale because we are paused
 			Expect(rs.Status.Conditions).To(HaveLen(1))
@@ -359,7 +359,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		// Paused condition should disappear
 		By("Checking that the pause condition disappeared from the replicaset")
 		Eventually(func() int {
-			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(context.Background(), rs.ObjectMeta.Name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return len(rs.Status.Conditions)
 		}, 10*time.Second, 1*time.Second).Should(Equal(0))
@@ -367,7 +367,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		// Replicas should be created
 		By("Checking that the missing replicas are now created")
 		Eventually(func() int32 {
-			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+			rs, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(rs)).Get(context.Background(), rs.ObjectMeta.Name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return rs.Status.Replicas
 		}, 10*time.Second, 1*time.Second).Should(Equal(int32(2)))

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -120,7 +120,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	newReplicaSetWithTemplate := func(template *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceReplicaSet {
 		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(0))
-		newRS, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(template)).Create(newRS)
+		newRS, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(template)).Create(context.Background(), newRS, v12.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return newRS
 	}
@@ -161,7 +161,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(1))
-		newRS, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(newRS)).Create(newRS)
+		newRS, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(newRS)).Create(context.Background(), newRS, v12.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		doScaleWithHPA(newRS.ObjectMeta.Name, int32(startScale), int32(startScale), int32(startScale))
 		doScaleWithHPA(newRS.ObjectMeta.Name, int32(stopScale), int32(stopScale), int32(stopScale))

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -673,7 +673,7 @@ func (r *KubernetesReporter) logConfigMaps(virtCli kubecli.KubevirtClient) {
 }
 
 func (r *KubernetesReporter) logKubeVirtCR(virtCli kubecli.KubevirtClient) {
-	kvs, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).List(&metav1.ListOptions{})
+	kvs, err := virtCli.KubeVirt(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to fetch kubevirts: %v\n", err)
 		return

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -928,7 +928,7 @@ func getVMIList(virtCli kubecli.KubevirtClient) *v12.VirtualMachineInstanceList 
 
 func getVMIMList(virtCli kubecli.KubevirtClient) *v12.VirtualMachineInstanceMigrationList {
 
-	vmims, err := virtCli.VirtualMachineInstanceMigration(v1.NamespaceAll).List(&metav1.ListOptions{})
+	vmims, err := virtCli.VirtualMachineInstanceMigration(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to fetch vmims: %v\n", err)
 		return nil

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -26,7 +26,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 
 	setccs := func(ccs v12.CustomizeComponents) (oldcss v12.CustomizeComponents) {
 		originalKv := util.GetCurrentKv(virtClient)
-		kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &v1.GetOptions{})
+		kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, v1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		oldcss = kv.Spec.CustomizeComponents
 		kv.Spec.CustomizeComponents = ccs
@@ -40,7 +40,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 
 	restorescc := func(ccs v12.CustomizeComponents) {
 		originalKv := util.GetCurrentKv(virtClient)
-		kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &v1.GetOptions{})
+		kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, v1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		kv.Spec.CustomizeComponents = v12.CustomizeComponents{}
 

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -31,7 +31,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 		oldcss = kv.Spec.CustomizeComponents
 		kv.Spec.CustomizeComponents = ccs
 		EventuallyWithOffset(1, func() error {
-			_, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			_, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, v1.UpdateOptions{})
 			return err
 		}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
@@ -45,7 +45,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 		kv.Spec.CustomizeComponents = v12.CustomizeComponents{}
 
 		EventuallyWithOffset(1, func() error {
-			_, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			_, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, v1.UpdateOptions{})
 			return err
 		}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2047,7 +2047,7 @@ var _ = SIGDescribe("Export", func() {
 				return
 			}
 			kv.Spec.CertificateRotationStrategy = *beforeCertParams
-			_, err := virtClient.KubeVirt(kv.Namespace).Update(kv)
+			_, err := virtClient.KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -2063,7 +2063,7 @@ var _ = SIGDescribe("Export", func() {
 					RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
 				},
 			}
-			_, err := virtClient.KubeVirt(kv.Namespace).Update(kv)
+			_, err := virtClient.KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		}
 

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -149,7 +149,7 @@ func EnsureKubevirtReadyWithTimeout(timeout time.Duration) {
 			"virt-operator deployment is not ready")
 
 	Eventually(func() *v1.KubeVirt {
-		kv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+		kv, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return kv
 	}, timeout, 1*time.Second).Should(

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -133,7 +133,7 @@ func AdjustKubeVirtResource() {
 	data, err := json.Marshal(kv.Spec)
 	Expect(err).ToNot(HaveOccurred())
 	patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
-	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(kv.Name, types.JSONPatchType, []byte(patchData), &metav1.PatchOptions{})
+	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
 	util.PanicOnError(err)
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
 	if checks.HasFeature(virtconfig.CPUManager) {
@@ -159,7 +159,7 @@ func RestoreKubeVirtResource() {
 		data, err := json.Marshal(originalKV.Spec)
 		Expect(err).ToNot(HaveOccurred())
 		patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
-		_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(originalKV.Name, types.JSONPatchType, []byte(patchData), &metav1.PatchOptions{})
+		_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(context.Background(), originalKV.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
 		util.PanicOnError(err)
 	}
 }
@@ -198,7 +198,7 @@ func UpdateKubeVirtConfigValue(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
 	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, kv)
 	Expect(err).ToNot(HaveOccurred())
 
-	kv, err = virtClient.KubeVirt(kv.Namespace).Patch(kv.GetName(), types.MergePatchType, patch, &metav1.PatchOptions{})
+	kv, err = virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
 	return kv

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -215,7 +215,7 @@ func CleanNamespaces() {
 
 		// Remove all Migration Objects
 		util.PanicOnError(virtCli.RestClient().Delete().Namespace(namespace).Resource("virtualmachineinstancemigrations").Do(context.Background()).Error())
-		migrations, err := virtCli.VirtualMachineInstanceMigration(namespace).List(&metav1.ListOptions{})
+		migrations, err := virtCli.VirtualMachineInstanceMigration(namespace).List(context.Background(), metav1.ListOptions{})
 		util.PanicOnError(err)
 		for _, migration := range migrations.Items {
 			if controller.HasFinalizer(&migration, v1.VirtualMachineInstanceMigrationFinalizer) {

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -219,7 +219,7 @@ func CleanNamespaces() {
 		util.PanicOnError(err)
 		for _, migration := range migrations.Items {
 			if controller.HasFinalizer(&migration, v1.VirtualMachineInstanceMigrationFinalizer) {
-				_, err := virtCli.VirtualMachineInstanceMigration(namespace).Patch(migration.Name, types.JSONPatchType, []byte("[{ \"op\": \"remove\", \"path\": \"/metadata/finalizers\" }]"))
+				_, err := virtCli.VirtualMachineInstanceMigration(namespace).Patch(context.Background(), migration.Name, types.JSONPatchType, []byte("[{ \"op\": \"remove\", \"path\": \"/metadata/finalizers\" }]"), metav1.PatchOptions{})
 				if !errors.IsNotFound(err) {
 					util.PanicOnError(err)
 				}

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -318,7 +318,7 @@ func removeAllGroupVersionResourceFromNamespace(groupVersionResource schema.Grou
 
 func detectInstallNamespace() {
 	virtCli := kubevirt.Client()
-	kvs, err := virtCli.KubeVirt("").List(&metav1.ListOptions{})
+	kvs, err := virtCli.KubeVirt("").List(context.Background(), metav1.ListOptions{})
 	util.PanicOnError(err)
 	if len(kvs.Items) == 0 {
 		util.PanicOnError(fmt.Errorf("Could not detect a kubevirt installation"))

--- a/tests/util/util.go
+++ b/tests/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"time"
 
 	"github.com/onsi/gomega"
@@ -36,14 +37,14 @@ func GetKvList(virtClient kubecli.KubevirtClient) []k6sv1.KubeVirt {
 
 	gomega.Eventually(func() error {
 
-		kvListInstallNS, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).List(&k8smetav1.ListOptions{})
+		kvListInstallNS, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).List(context.Background(), k8smetav1.ListOptions{})
 
 		return err
 	}, 10*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 
 	gomega.Eventually(func() error {
 
-		kvListDefaultNS, err = virtClient.KubeVirt(NamespaceTestDefault).List(&k8smetav1.ListOptions{})
+		kvListDefaultNS, err = virtClient.KubeVirt(NamespaceTestDefault).List(context.Background(), k8smetav1.ListOptions{})
 
 		return err
 	}, 10*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -927,7 +927,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 					By("Check that no migration was actually created")
 					Consistently(func() error {
-						_, err = virtClient.VirtualMachineInstanceMigration(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+						_, err = virtClient.VirtualMachineInstanceMigration(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 						return err
 					}, 60*time.Second, 5*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "migration should not be created in a dry run mode")
 				})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1738,7 +1738,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 			By("Ensuring that all VMIs are ready")
 			Eventually(func() int32 {
-				rs, err := kubevirt.Client().ReplicaSet(vmi.Namespace).Get(createdRs.ObjectMeta.Name, metav1.GetOptions{})
+				rs, err := kubevirt.Client().ReplicaSet(vmi.Namespace).Get(context.Background(), createdRs.ObjectMeta.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return rs.Status.ReadyReplicas
 			}, 120*time.Second, 1*time.Second).Should(Equal(replicas))

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -709,7 +709,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 						},
 					},
 				}
-				_, err = kubevirt.Client().KubeVirt(kv.Namespace).Update(kv)
+				_, err = kubevirt.Client().KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should update kubevirt infra placement")
 
 				Eventually(func() error {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1733,7 +1733,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					},
 				},
 			}
-			createdRs, err := kubevirt.Client().ReplicaSet(vmi.Namespace).Create(rs)
+			createdRs, err := kubevirt.Client().ReplicaSet(vmi.Namespace).Create(context.Background(), rs, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Should create replicaset")
 
 			By("Ensuring that all VMIs are ready")

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -472,7 +472,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		It("[test_id:726] Should match multiple VMs via MatchExpression", func() {
 			By("Creating preset with MatchExpression")
-			_, err := virtClient.VirtualMachineInstancePreset(testsuite.GetTestNamespace(nil)).Create(preset)
+			_, err := virtClient.VirtualMachineInstancePreset(testsuite.GetTestNamespace(nil)).Create(context.Background(), preset, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
@@ -534,7 +534,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		It("[test_id:672] Should match multiple VMs via MatchLabel", func() {
 			By("Creating preset with MatchExpression")
-			_, err := virtClient.VirtualMachineInstancePreset(testsuite.GetTestNamespace(nil)).Create(preset)
+			_, err := virtClient.VirtualMachineInstancePreset(testsuite.GetTestNamespace(nil)).Create(context.Background(), preset, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is a manual cherrypick of https://github.com/kubevirt/kubevirt/pull/11639, https://github.com/kubevirt/kubevirt/pull/11695, https://github.com/kubevirt/kubevirt/pull/11715, https://github.com/kubevirt/kubevirt/pull/11719

This backport is mandatory to have the possibility to fix unit tests with false positive, with PRs like:
https://github.com/kubevirt/kubevirt/pull/11751 and https://github.com/kubevirt/kubevirt/pull/11726

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @acardace @xpivarc 