### PR TITLE
VM: Add CPU model struct to domain

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -273,9 +273,16 @@ type VCPUs struct {
 	VCPU []VCPUsVCPU `xml:"vcpu"`
 }
 
+type CPUModel struct {
+	Fallback string `xml:"fallback,attr,omitempty"`
+	VendorID string `xml:"vendor_id,attr,omitempty"`
+	Value    string `xml:",chardata"`
+}
+
 type CPU struct {
+	Check    string       `xml:"check,attr,omitempty"`
 	Mode     string       `xml:"mode,attr,omitempty"`
-	Model    string       `xml:"model,omitempty"`
+	Model    *CPUModel    `xml:"model,omitempty"`
 	Features []CPUFeature `xml:"feature"`
 	Topology *CPUTopology `xml:"topology"`
 	NUMA     *NUMA        `xml:"numa,omitempty"`

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -178,7 +178,7 @@ var _ = ginkgo.Describe("Schema", func() {
 			CPUs:      2,
 		}
 		exampleDomain.Spec.CPU.Mode = "custom"
-		exampleDomain.Spec.CPU.Model = "Conroe"
+		exampleDomain.Spec.CPU.Model = &CPUModel{Value: "Conroe"}
 		exampleDomain.Spec.CPU.Features = []CPUFeature{
 			{
 				Name:   "pcid",

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1825,7 +1825,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 				domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
 			} else {
 				domain.Spec.CPU.Mode = "custom"
-				domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
+				domain.Spec.CPU.Model = &api.CPUModel{Value: vmi.Spec.Domain.CPU.Model}
 			}
 		}
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -755,7 +755,7 @@ var _ = Describe("Converter", func() {
 				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(2)), "Expect sockets")
 				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(2)), "Expect threads")
 				Expect(domainSpec.CPU.Mode).To(Equal("custom"), "Expect cpu mode")
-				Expect(domainSpec.CPU.Model).To(Equal("Conroe"), "Expect cpu model")
+				Expect(domainSpec.CPU.Model.Value).To(Equal("Conroe"), "Expect cpu model")
 				Expect(domainSpec.CPU.Features[0].Name).To(Equal("lahf_lm"), "Expect cpu feature name")
 				Expect(domainSpec.CPU.Features[0].Policy).To(Equal("require"), "Expect cpu feature policy")
 				Expect(domainSpec.CPU.Features[1].Name).To(Equal("mmx"), "Expect cpu feature name")


### PR DESCRIPTION
### What this PR does

Add latest CPU model struct to domain.

Before this PR:

```go
type CPU struct {
	Mode     string       `xml:"mode,attr,omitempty"`
	Model    string       `xml:"model,omitempty"`
	Features []CPUFeature `xml:"feature"`
	Topology *CPUTopology `xml:"topology"`
	NUMA     *NUMA        `xml:"numa,omitempty"`
}
```

After this PR:

```go
type CPUModel struct {
	Fallback string `xml:"fallback,attr,omitempty"`
	VendorID string `xml:"vendor_id,attr,omitempty"`
	Value    string `xml:",chardata"`
}

type CPU struct {
	Check    string       `xml:"check,attr,omitempty"`
	Mode     string       `xml:"mode,attr,omitempty"`
	Model    *CPUModel    `xml:"model,omitempty"`
	Features []CPUFeature `xml:"feature"`
	Topology *CPUTopology `xml:"topology"`
	NUMA     *NUMA        `xml:"numa,omitempty"`
}
```

According to <https://libvirt.org/formatdomain.html#cpu-model-and-topology>:
> The optional `vendor_id` attribute ( Since 0.10.0 ) can be used to set the vendor id seen by the guest.

### Why we need it and why it was done in this way

Update CPU model struct to latest.

### Release note

```release-note
NONE
```

