### PR TITLE
tests, libsecret: Generalize data used for secret

### DIFF
--- a/tests/libsecret/secret.go
+++ b/tests/libsecret/secret.go
@@ -24,8 +24,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type secretData interface {
+	Data() map[string][]byte
+	StringData() map[string]string
+}
+
 // New return Secret of Opaque type with "kubevirt.io/secret" label
-func New(name string, data map[string][]byte) *kubev1.Secret {
+func New(name string, data secretData) *kubev1.Secret {
 	// secretLabel set this label to make the test suite namespace clean-up delete the secret on teardown
 	const secretLabel = "kubevirt.io/secret" // #nosec G101
 	return &kubev1.Secret{
@@ -35,6 +40,27 @@ func New(name string, data map[string][]byte) *kubev1.Secret {
 				secretLabel: name,
 			},
 		},
-		Data: data,
+		Data:       data.Data(),
+		StringData: data.StringData(),
 	}
+}
+
+type DataBytes map[string][]byte
+
+func (s DataBytes) Data() map[string][]byte {
+	return s
+}
+
+func (DataBytes) StringData() map[string]string {
+	return nil
+}
+
+type DataString map[string]string
+
+func (DataString) Data() map[string][]byte {
+	return nil
+}
+
+func (s DataString) StringData() map[string]string {
+	return s
 }

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -324,9 +324,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				// Store userdata as k8s secret
 				By("Creating a user-data secret")
-				secret := libsecret.New(secretID, map[string][]byte{
-					"userdata": []byte(userData),
-				})
+				secret := libsecret.New(secretID, libsecret.DataString{"userdata": userData})
 				_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				break
@@ -394,9 +392,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				)
 
 				By("Creating a secret with network data")
-				secret := libsecret.New(secretID, map[string][]byte{
-					"networkdata": []byte(testNetworkData),
-				})
+				secret := libsecret.New(secretID, libsecret.DataString{"networkdata": testNetworkData})
 				_, err := virtClient.CoreV1().Secrets(testsuite.GetTestNamespace(vmi)).Create(context.Background(), secret, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -525,9 +521,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					// Store cloudinit data as k8s secret
 					By("Creating a secret with user and network data")
-					secret := libsecret.New(secretID, map[string][]byte{
-						"networkdata": []byte(testNetworkData),
-					})
+					secret := libsecret.New(secretID, libsecret.DataString{"networkdata": testNetworkData})
 
 					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -573,14 +567,10 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					// Store cloudinit data as k8s secret
 					By("Creating a secret with userdata")
-					uSecret := libsecret.New(uSecretID, map[string][]byte{
-						userDataLabel: []byte(testUserData),
-					})
+					uSecret := libsecret.New(uSecretID, libsecret.DataString{userDataLabel: testUserData})
 
 					By("Creating a secret with network data")
-					nSecret := libsecret.New(nSecretID, map[string][]byte{
-						networkDataLabel: []byte(testNetworkData),
-					})
+					nSecret := libsecret.New(nSecretID, libsecret.DataString{networkDataLabel: testNetworkData})
 
 					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), uSecret, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### What this PR does

Users can pass in data as a map of strings or a map of bytes.

The current usage requires only a map of strings, but the bytes version has been created to allow passing in also that type when needed.

In this form, it should be easier for the callers to pass the data in the most convenient manner.

Ref: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1/#Secret

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

