### PR TITLE
Fix vcpu metrics values

### DIFF
--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -278,7 +278,7 @@ func (metrics *vmiMetrics) updateVcpu(vcpuStats []stats.DomainStatsVcpu) {
 				"kubevirt_vmi_vcpu_seconds_total",
 				"Total amount of time spent in each state by each vcpu (cpu_time excluding hypervisor time). Where `id` is the vcpu identifier and `state` can be one of the following: [`OFFLINE`, `RUNNING`, `BLOCKED`].",
 				prometheus.CounterValue,
-				float64(vcpu.Time/1000000000),
+				float64(vcpu.Time/1000000),
 				[]string{"id", "state"},
 				[]string{stringVcpuIdx, humanReadableState(vcpu.State)},
 			)
@@ -289,7 +289,7 @@ func (metrics *vmiMetrics) updateVcpu(vcpuStats []stats.DomainStatsVcpu) {
 				"kubevirt_vmi_vcpu_wait_seconds_total",
 				"Amount of time spent by each vcpu while waiting on I/O.",
 				prometheus.CounterValue,
-				float64(vcpu.Wait)/float64(1000000000),
+				float64(vcpu.Wait)/float64(1000000),
 				[]string{"id"},
 				[]string{stringVcpuIdx},
 			)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
`kubevirt_vmi_vcpu_seconds_total` and `kubevirt_vmi_vcpu_wait_seconds_total` metrics values should divide domstats.vcpu values by 1000000, and not 1000000000, as they are in microseconds, according to https://www.libvirt.org/manpages/virsh.html#domstats.

Before this PR:
Metrics values are divided by 1000000000.
After this PR:
Metrics values are divided by 1000000.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-41517

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

