### PR TITLE
[release-1.2] VMI controller - move unit tests to fake client (VirtualMachineInstanceInterface)

### DIFF
--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -26,24 +26,16 @@ import (
 	"strings"
 	"time"
 
-	storagev1 "k8s.io/api/storage/v1"
-
-	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
-
-	"kubevirt.io/kubevirt/pkg/network/vmispec"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-
-	"kubevirt.io/kubevirt/pkg/pointer"
-
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/mock/gomock"
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegaTypes "github.com/onsi/gomega/types"
+
 	k8sv1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -65,8 +57,12 @@ import (
 
 	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/network/sriov"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+	"kubevirt.io/kubevirt/pkg/pointer"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 )

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -37,6 +37,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -101,46 +102,25 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var cdiConfigInformer cache.SharedIndexInformer
 	var qemuGid int64 = 107
 
-	shouldExpectMatchingPodCreation := func(uid types.UID, matchers ...gomegaTypes.GomegaMatcher) {
-		// Expect pod creation
-		kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-			update, ok := action.(testing.CreateAction)
-			Expect(ok).To(BeTrue())
-			Expect(update.GetObject().(*k8sv1.Pod).Labels[virtv1.CreatedByLabel]).To(Equal(string(uid)))
-			Expect(update.GetObject().(*k8sv1.Pod)).To(SatisfyAny(matchers...))
-			return true, update.GetObject(), nil
-		})
+	expectMatchingPodCreation := func(vmi *virtv1.VirtualMachineInstance, matchers ...gomegaTypes.GomegaMatcher) {
+		pods, err := kubeClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", virtv1.CreatedByLabel, string(vmi.UID))})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pods.Items).To(HaveLen(1))
+		Expect(pods.Items[0].Labels[virtv1.CreatedByLabel]).To(Equal(string(vmi.UID)))
+		if len(matchers) > 0 {
+			Expect(&pods.Items[0]).To(SatisfyAny(matchers...))
+		}
 	}
 
-	shouldExpectPodCreation := func(uid types.UID) {
-		// Expect pod creation
-		kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-			update, ok := action.(testing.CreateAction)
-			Expect(ok).To(BeTrue())
-			Expect(update.GetObject().(*k8sv1.Pod).Labels[virtv1.CreatedByLabel]).To(Equal(string(uid)))
-			return true, update.GetObject(), nil
-		})
+	expectPodDoesNotExist := func(namespace, name string) {
+		_, err := kubeClient.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
 	}
 
-	shouldExpectMultiplePodDeletions := func(pod *k8sv1.Pod, deletionCount *int) {
-		// Expect pod deletion
-		kubeClient.Fake.PrependReactor("delete", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-			update, ok := action.(testing.DeleteAction)
-			Expect(ok).To(BeTrue())
-			Expect(pod.Namespace).To(Equal(update.GetNamespace()))
-			*deletionCount++
-			return true, nil, nil
-		})
-	}
-
-	shouldExpectPodDeletion := func(pod *k8sv1.Pod) {
-		// Expect pod deletion
-		kubeClient.Fake.PrependReactor("delete", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-			update, ok := action.(testing.DeleteAction)
-			Expect(ok).To(BeTrue())
-			Expect(pod.Namespace).To(Equal(update.GetNamespace()))
-			return true, nil, nil
-		})
+	expectPodExists := func(namespace, name string) {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pod).ToNot(BeNil())
 	}
 
 	prependInjectPodPatch := func(pod *k8sv1.Pod) {
@@ -238,14 +218,16 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		}).Return(vmi, nil)
 	}
 
-	shouldExpectHotplugPod := func() {
-		// Expect pod creation
-		kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-			update, ok := action.(testing.CreateAction)
-			Expect(ok).To(BeTrue())
-			Expect(update.GetObject().(*k8sv1.Pod).GenerateName).To(Equal("hp-volume-"))
-			return true, update.GetObject(), nil
-		})
+	expectHotplugPod := func() {
+		pods, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pods.Items).To(
+			ContainElement(
+				WithTransform(func(pod k8sv1.Pod) string {
+					return pod.GenerateName
+				}, Equal("hp-volume-")),
+			),
+		)
 	}
 
 	syncCaches := func(stop chan struct{}) {
@@ -375,10 +357,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addDataVolumePVC(dvPVC)
 			addDataVolume(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
-			shouldExpectPodCreation(vmi.UID)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+			expectMatchingPodCreation(vmi)
 		})
 
 		It("should create a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
@@ -415,10 +397,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 				Equal("/bin/bash -c echo bound PVCs"),
 			)
-			shouldExpectMatchingPodCreation(vmi.UID, IsPodWithoutVmPayload)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+
+			expectMatchingPodCreation(vmi, IsPodWithoutVmPayload)
 		})
 
 		It("should not delete a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
@@ -479,10 +462,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 			addDataVolume(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
-			shouldExpectPodDeletion(pod)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
+			expectPodDoesNotExist(pod.Namespace, pod.Name)
 		})
 
 		It("should only get WFFC pods that are associated with current VMI", func() {
@@ -624,10 +607,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pvc.Spec.StorageClassName = pointer.P("testsc456")
 				addDataVolumePVC(pvc)
 
-				shouldExpectPodCreation(vmi.UID)
-
 				controller.Execute()
 				testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+				expectMatchingPodCreation(vmi)
 			})
 
 		})
@@ -655,10 +637,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addDataVolumePVC(dvPVC)
 			addDataVolume(dataVolume)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
-			shouldExpectPodCreation(vmi.UID)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+			expectMatchingPodCreation(vmi)
 		})
 
 		It("should create a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
@@ -681,6 +663,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Fields{"Type": Equal(virtv1.VirtualMachineInstanceProvisioning)})))
 			}).Return(vmi, nil)
 
+			controller.Execute()
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 			IsPodWithoutVmPayload := WithTransform(
 				func(pod *k8sv1.Pod) string {
 					for _, c := range pod.Spec.Containers {
@@ -692,10 +676,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					return ""
 				},
 				Equal("/bin/bash -c echo bound PVCs"))
-			shouldExpectMatchingPodCreation(vmi.UID, IsPodWithoutVmPayload)
-
-			controller.Execute()
-			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+			expectMatchingPodCreation(vmi, IsPodWithoutVmPayload)
 		})
 
 		It("should not delete a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
@@ -755,11 +736,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 			addDataVolume(dataVolume)
-			shouldExpectPodDeletion(pod)
 			shouldExpectVirtualMachineDataVolumesReadyCondition(vmi, k8sv1.ConditionTrue)
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
+			expectPodDoesNotExist(pod.Namespace, pod.Name)
+
 		})
 
 		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
@@ -886,11 +868,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 
-			shouldExpectPodCreation(vmi.UID)
-
 			controller.Execute()
 
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+			expectMatchingPodCreation(vmi)
 		})
 		DescribeTable("should delete the corresponding Pods on VirtualMachineInstance deletion with vmi", func(phase virtv1.VirtualMachineInstancePhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
@@ -913,10 +894,15 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			// The 3rd one is not.
 			pod3 := pod.DeepCopy()
-			pod3.UID = "123-123-123"
-			pod3.Name = "test2"
-			pod3.Annotations = make(map[string]string)
-			pod3.Labels = make(map[string]string)
+			pod3.UID = "789-789-789"
+			pod3.Name = "test3"
+			pod3.Annotations = map[string]string{
+				virtv1.DomainAnnotation: "another-vmi",
+			}
+			pod3.Labels = map[string]string{
+				virtv1.AppLabel:       "virt-launcher",
+				virtv1.CreatedByLabel: "another-vmi-uid",
+			}
 
 			addActivePods(vmi, pod.UID, "")
 			addActivePods(vmi, pod2.UID, "")
@@ -925,8 +911,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addPod(pod)
 			addPod(pod2)
 
-			deletionCount := 0
-			shouldExpectMultiplePodDeletions(pod, &deletionCount)
+			_, err := kubeClient.CoreV1().Pods(pod3.Namespace).Create(context.Background(), pod3, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
 			if vmi.IsUnprocessed() {
 				shouldExpectVirtualMachineSchedulingState(vmi)
@@ -936,11 +922,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			controller.Execute()
 
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			// Verify only the 2 pods are deleted
-			Expect(deletionCount).To(Equal(2))
+			expectPodDoesNotExist(pod.Namespace, pod.Name)
+			expectPodDoesNotExist(pod2.Namespace, pod2.Name)
+			expectPodExists(pod3.Namespace, pod3.Name)
 
-			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
-			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 		},
 			Entry("in running state", virtv1.Running),
 			Entry("in unset state", virtv1.VmPhaseUnset),
@@ -962,11 +950,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addPod(pod)
 			addActivePods(vmi, pod.UID, "")
 
-			shouldExpectPodDeletion(pod)
-
 			controller.Execute()
 
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
+			expectPodDoesNotExist(pod.Namespace, pod.Name)
 
 			modifiedPod := pod.DeepCopy()
 			modifiedPod.DeletionTimestamp = now()
@@ -991,6 +978,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 
 			controller.Execute()
+			expectPodExists(pod.Namespace, pod.Name)
 		},
 			Entry("succeeded state", virtv1.Failed),
 			Entry("failed state", virtv1.Succeeded),
@@ -1058,14 +1046,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			addVirtualMachine(vmi)
 
-			// Expect pod creation
-			kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				update, ok := action.(testing.CreateAction)
-				Expect(ok).To(BeTrue())
-				Expect(update.GetObject().(*k8sv1.Pod).Labels[virtv1.CreatedByLabel]).To(Equal(string(vmi.UID)))
-				return true, update.GetObject(), nil
-			})
-
 			vmiInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).ToNot(ContainElement(MatchFields(IgnoreExtras,
 					Fields{
@@ -1076,6 +1056,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			controller.Execute()
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+			expectMatchingPodCreation(vmi)
 		})
 		DescribeTable("should never proceed to creating the launcher pod if not all PVCs are there to determine if they are WFFC and/or an import is done",
 			func(syncReason string, volumeSource virtv1.VolumeSource) {
@@ -2054,28 +2035,20 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			kvcontroller.NewPodConditionManager().RemoveCondition(pod, virtv1.VirtualMachineUnpaused)
-			if currUnpausedStatus != k8sv1.ConditionUnknown {
-				pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{
-					Type:   virtv1.VirtualMachineUnpaused,
-					Status: currUnpausedStatus,
-				})
-			}
-
 			addActivePods(vmi, pod.UID, "")
 			addVirtualMachine(vmi)
 			addPod(pod)
 
-			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(vmi, nil)
-			kubeClient.Fake.PrependReactor("patch", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				patch, _ := action.(testing.PatchAction)
-				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"type":"%s"`, virtv1.VirtualMachineUnpaused)))
-				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"status":"%s"`, k8sv1.ConditionFalse)))
-
-				return true, nil, nil
-			})
-
 			controller.Execute()
+
+			updatedPod, err := kubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedPod.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Fields{
+					"Type":   Equal(virtv1.VirtualMachineUnpaused),
+					"Status": Equal(k8sv1.ConditionFalse),
+				})),
+			)
 		},
 			Entry("when VirtualMachineUnpaused=True", k8sv1.ConditionTrue),
 			Entry("when VirtualMachineUnpaused condition is unset", k8sv1.ConditionUnknown),
@@ -2087,28 +2060,21 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, virtv1.VirtualMachineInstancePaused)
 
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			kvcontroller.NewPodConditionManager().RemoveCondition(pod, virtv1.VirtualMachineUnpaused)
-			if currUnpausedStatus != k8sv1.ConditionUnknown {
-				pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{
-					Type:   virtv1.VirtualMachineUnpaused,
-					Status: currUnpausedStatus,
-				})
-			}
-
 			addActivePods(vmi, pod.UID, "")
 			addVirtualMachine(vmi)
 			addPod(pod)
 
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, gomock.Any(), metav1.PatchOptions{}).Return(vmi, nil)
-			kubeClient.Fake.PrependReactor("patch", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
-				patch, _ := action.(testing.PatchAction)
-				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"type":"%s"`, virtv1.VirtualMachineUnpaused)))
-				Expect(string(patch.GetPatch())).To(ContainSubstring(fmt.Sprintf(`"status":"%s"`, k8sv1.ConditionTrue)))
-
-				return true, nil, nil
-			})
-
 			controller.Execute()
+
+			updatedPod, err := kubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedPod.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras,
+				Fields{
+					"Type":   Equal(virtv1.VirtualMachineUnpaused),
+					"Status": Equal(k8sv1.ConditionTrue),
+				})),
+			)
 		},
 			Entry("when VirtualMachineUnpaused=True", k8sv1.ConditionTrue),
 			Entry("when VirtualMachineUnpaused condition is unset", k8sv1.ConditionUnknown),
@@ -2227,21 +2193,21 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			attachmentPod1 := NewPodForVirtlauncher(virtlauncherPod, "pod1", "abcd", k8sv1.PodRunning)
-			attachmentPod2 := NewPodForVirtlauncher(virtlauncherPod, "pod2", "abcd", k8sv1.PodRunning)
-			attachmentPod3 := NewPodForVirtlauncher(virtlauncherPod, "pod3", "abcd", k8sv1.PodRunning)
+			attachmentPod2 := NewPodForVirtlauncher(virtlauncherPod, "pod2", "efgh", k8sv1.PodRunning)
+			attachmentPod3 := NewPodForVirtlauncher(virtlauncherPod, "pod3", "ilmn", k8sv1.PodRunning)
 			addVirtualMachine(vmi)
 			addPod(virtlauncherPod)
 			addPod(attachmentPod1)
 			addPod(attachmentPod2)
 			addPod(attachmentPod3)
-			shouldExpectPodDeletion(attachmentPod3)
-			shouldExpectPodDeletion(attachmentPod1)
-			shouldExpectPodDeletion(attachmentPod2)
 			err := controller.deleteAllAttachmentPods(vmi)
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			Expect(err).ToNot(HaveOccurred())
+			expectPodDoesNotExist(attachmentPod3.Namespace, attachmentPod3.Name)
+			expectPodDoesNotExist(attachmentPod1.Namespace, attachmentPod1.Name)
+			expectPodDoesNotExist(attachmentPod2.Namespace, attachmentPod2.Name)
 		})
 
 		It("CreateAttachmentPodTemplate should return error if volume is not DV or PVC", func() {
@@ -3063,13 +3029,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			addPod(virtlauncherPod)
 
-			shouldExpectHotplugPod()
 			//Modify by adding a new hotplugged disk
 			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":"","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"}},{"name":"hotplug","target":"","phase":"Bound","reason":"PVCNotReady","message":"PVC is in phase Bound","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"},"hotplugVolume":{}}] }]`
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
+			expectHotplugPod()
 		})
 
 		It("Should properly delete attachment, if volume and disk are removed", func() {
@@ -3151,13 +3117,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addPod(virtlauncherPod)
 			addPod(hpPod)
 
-			shouldExpectPodDeletion(hpPod)
 			//Modify by adding a new hotplugged disk
 			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":"","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"}},{"name":"hotplug","target":"","phase":"Detaching","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }]`
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
+			expectPodDoesNotExist(hpPod.Namespace, hpPod.Name)
 		})
 
 		DescribeTable("Should requeue if pod is not created before", func(pod *k8sv1.Pod, creationTimeAdd, requeueTime time.Duration, expected bool) {
@@ -3179,6 +3145,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 
 		DescribeTable("should clean up attachment pods, based on the number of volumes", func(readyVolumes []*virtv1.Volume, currentPod *k8sv1.Pod, oldPods []*k8sv1.Pod, expectDelete bool) {
+			// TODO should disappear
+			shouldExpectPodDeletion := func(pod *k8sv1.Pod) {
+				// Expect pod deletion
+				kubeClient.Fake.PrependReactor("delete", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
+					update, ok := action.(testing.DeleteAction)
+					Expect(ok).To(BeTrue())
+					Expect(pod.Namespace).To(Equal(update.GetNamespace()))
+					return true, nil, nil
+				})
+			}
+
 			vmi := NewRunningVirtualMachine("testvmi", &k8sv1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testnode",
@@ -3291,8 +3268,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			runController := func(vmi *virtv1.VirtualMachineInstance) {
 				addVirtualMachine(vmi)
-				shouldExpectPodCreation(vmi.UID)
 				controller.Execute()
+				expectMatchingPodCreation(vmi)
 			}
 
 			It("invtsc feature exists", func() {
@@ -3328,7 +3305,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						unexposeTscFrequency(topology.RequiredForMigration)
 						// Make sure no update occurs
 						runController(vmi)
-
+						expectMatchingPodCreation(vmi)
 						testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 					})
 				})
@@ -3364,9 +3341,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				vmi := NewPendingVirtualMachine("testvmi")
 				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.NotRequired))
 
-				shouldExpectPodCreation(vmi.UID)
 				runController(vmi)
 				testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+				expectMatchingPodCreation(vmi)
 			})
 		})
 	})
@@ -3688,10 +3665,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				addDataVolume(dataVolume2)
 				addDataVolume(dataVolume3)
 				shouldExpectVirtualMachineDataVolumesReadyConditionWithMessage(vmi, expectedStatus, expectedMessage)
-				shouldExpectPodCreation(vmi.UID)
 
 				controller.Execute()
 				testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+				expectMatchingPodCreation(vmi)
 			},
 			Entry("3 ready DataVolumes",
 				[]cdiv1.DataVolumeCondition{

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -339,6 +339,24 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		mockQueue.ExpectAdds(1)
 		vmiSource.Add(vmi)
 		mockQueue.Wait()
+		_, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	addPod := func(pod *k8sv1.Pod) {
+		Expect(podInformer.GetIndexer().Add(pod)).To(Succeed())
+		_, err := kubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	addDataVolumePVC := func(dvPVC *k8sv1.PersistentVolumeClaim) {
+		Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
+		_, err := kubeClient.CoreV1().PersistentVolumeClaims(dvPVC.Namespace).Create(context.Background(), dvPVC, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	addDataVolume := func(dv *cdiv1.DataVolume) {
+		Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
 	}
 
 	Context("On valid VirtualMachineInstance given with DataVolume source", func() {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -107,7 +107,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var cdiConfigInformer cache.SharedIndexInformer
 	var dataVolumeFeeder *testutils.DataVolumeFeeder
 	var qemuGid int64 = 107
-	controllerOf := true
 
 	shouldExpectMatchingPodCreation := func(uid types.UID, matchers ...gomegaTypes.GomegaMatcher) {
 		// Expect pod creation
@@ -387,7 +386,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
@@ -439,7 +438,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
@@ -478,7 +477,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
 			// be in available
 			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
@@ -541,7 +540,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				})
 
 				dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
-				dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+				dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 				dvPVC.Status.Phase = k8sv1.ClaimBound
 				Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
 
@@ -579,7 +578,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Pending)
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
 
@@ -668,7 +667,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			// we are mocking a successful DataVolume. we expect the PVC to
 			// be available in the store if DV is successful.
 			Expect(pvcInformer.GetIndexer().Add(dvPVC)).To(Succeed())
@@ -692,7 +691,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
@@ -738,7 +737,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "test1",
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
@@ -777,7 +776,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimBound
 			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
 			// be in available
@@ -805,7 +804,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", pointer.P(true))
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a successful DataVolume. we expect the PVC to
 			// be available in the store if DV is successful.
@@ -2770,7 +2769,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		makeVolumeStatusesForUpdateWithMessage := func(podName, podUID string, phase virtv1.VolumePhase, message, reason string, indexes ...int) []virtv1.VolumeStatus {
 			res := make([]virtv1.VolumeStatus, 0)
 			for _, index := range indexes {
-				fsOverhead := storagetypes.DefaultFSOverhead
 				res = append(res, virtv1.VolumeStatus{
 					Name: fmt.Sprintf("volume%d", index),
 					HotplugVolume: &virtv1.HotplugVolumeStatus{
@@ -2784,7 +2782,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						AccessModes: []k8sv1.PersistentVolumeAccessMode{
 							k8sv1.ReadOnlyMany,
 						},
-						FilesystemOverhead: &fsOverhead,
+						FilesystemOverhead: pointer.P(storagetypes.DefaultFSOverhead),
 					},
 				})
 			}
@@ -2813,9 +2811,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.VolumeStatus = oldStatus
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			attachmentPods := makePodWithVirtlauncher(virtlauncherPod, podIndexes...)
-			now := metav1.Now()
+
 			for _, pod := range attachmentPods {
-				pod.DeletionTimestamp = &now
+				pod.DeletionTimestamp = now()
 				Expect(podInformer.GetIndexer().Add(pod)).To(Succeed())
 			}
 			for _, pvcIndex := range pvcIndexes {
@@ -4054,7 +4052,6 @@ func NewPodForVirtualMachineWithMultusAnnotations(vmi *virtv1.VirtualMachineInst
 }
 
 func NewHotplugPVC(name, namespace string, phase k8sv1.PersistentVolumeClaimPhase) *k8sv1.PersistentVolumeClaim {
-	t := true
 	return &k8sv1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -4064,7 +4061,7 @@ func NewHotplugPVC(name, namespace string, phase k8sv1.PersistentVolumeClaimPhas
 					APIVersion: "v1alpha1",
 					Kind:       "DataVolume",
 					Name:       name,
-					Controller: &t,
+					Controller: pointer.P(true),
 				},
 			},
 		},
@@ -4080,7 +4077,6 @@ func NewHotplugPVC(name, namespace string, phase k8sv1.PersistentVolumeClaimPhas
 }
 
 func NewPodForVirtlauncher(virtlauncher *k8sv1.Pod, name, uid string, phase k8sv1.PodPhase) *k8sv1.Pod {
-	t := true
 	return &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -4091,7 +4087,7 @@ func NewPodForVirtlauncher(virtlauncher *k8sv1.Pod, name, uid string, phase k8sv
 					Name:       virtlauncher.Name,
 					Kind:       "Pod",
 					APIVersion: "v1",
-					Controller: &t,
+					Controller: pointer.P(true),
 					UID:        virtlauncher.UID,
 				},
 			},

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -76,7 +76,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var config *virtconfig.ClusterConfig
 
 	var ctrl *gomock.Controller
-	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
 	var vmiSource *framework.FakeControllerSource
 	var vmSource *framework.FakeControllerSource
 	var podSource *framework.FakeControllerSource
@@ -253,7 +252,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		stop = make(chan struct{})
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
-		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClientset = kubevirtfake.NewSimpleClientset()
 
 		vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, kvcontroller.GetVMIInformerIndexers())

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -2988,13 +2988,32 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			addPod(virtlauncherPod)
 
-			//Modify by adding a new hotplugged disk
-			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":"","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"}},{"name":"hotplug","target":"","phase":"Bound","reason":"PVCNotReady","message":"PVC is in phase Bound","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"},"hotplugVolume":{}}] }]`
-			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
-			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
 			expectHotplugPod()
+			updatedVmi, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVmi.Status.Phase).To(Equal(virtv1.Running))
+			Expect(updatedVmi.Status.VolumeStatus).To(BeEquivalentTo([]virtv1.VolumeStatus{
+				{
+					Name:   "existing",
+					Target: "",
+					PersistentVolumeClaimInfo: &virtv1.PersistentVolumeClaimInfo{
+						FilesystemOverhead: pointer.P(cdiv1.Percent("0.055")),
+					},
+				},
+				{
+					Name:    "hotplug",
+					Target:  "",
+					Phase:   virtv1.VolumeBound,
+					Reason:  "PVCNotReady",
+					Message: "PVC is in phase Bound",
+					PersistentVolumeClaimInfo: &virtv1.PersistentVolumeClaimInfo{
+						FilesystemOverhead: pointer.P(cdiv1.Percent("0.055")),
+					},
+					HotplugVolume: &virtv1.HotplugVolumeStatus{},
+				},
+			}))
 		})
 
 		It("Should properly delete attachment, if volume and disk are removed", func() {
@@ -3076,13 +3095,29 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			addPod(virtlauncherPod)
 			addPod(hpPod)
-
-			//Modify by adding a new hotplugged disk
-			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":"","persistentVolumeClaimInfo":{"filesystemOverhead":"0.055"}},{"name":"hotplug","target":"","phase":"Detaching","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }]`
-			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}).Return(vmi, nil)
 			controller.Execute()
+
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
-			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
+			updatedVmi, err := virtClientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVmi.Status.Phase).To(Equal(virtv1.Running))
+			Expect(updatedVmi.Status.VolumeStatus).To(BeEquivalentTo([]virtv1.VolumeStatus{
+				{
+					Name:   "existing",
+					Target: "",
+					PersistentVolumeClaimInfo: &virtv1.PersistentVolumeClaimInfo{
+						FilesystemOverhead: pointer.P(cdiv1.Percent("0.055"))},
+				},
+				{
+					Name:   "hotplug",
+					Target: "",
+					Phase:  virtv1.HotplugVolumeDetaching,
+					HotplugVolume: &virtv1.HotplugVolumeStatus{
+						AttachPodName: "hp-volume-hotplug",
+						AttachPodUID:  "abcd",
+					},
+				},
+			}))
 			expectPodDoesNotExist(hpPod.Namespace, hpPod.Name)
 		})
 

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -48,7 +48,6 @@ import (
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
-	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
@@ -3041,7 +3040,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "existing",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: v1.DiskBusVirtio,
+						Bus: virtv1.DiskBusVirtio,
 					},
 				},
 			})
@@ -3049,7 +3048,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "hotplug",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: v1.DiskBusSATA,
+						Bus: virtv1.DiskBusSATA,
 					},
 				},
 			})
@@ -3124,7 +3123,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "existing",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: v1.DiskBusVirtio,
+						Bus: virtv1.DiskBusVirtio,
 					},
 				},
 			})
@@ -3291,7 +3290,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		getVmiWithInvTsc := func() *virtv1.VirtualMachineInstance {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Spec.Architecture = "amd64"
-			vmi.Spec.Domain.CPU = &v1.CPU{
+			vmi.Spec.Domain.CPU = &virtv1.CPU{
 				Features: []virtv1.CPUFeature{
 					{
 						Name:   "invtsc",
@@ -3306,9 +3305,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		getVmiWithReenlightenment := func() *virtv1.VirtualMachineInstance {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Spec.Architecture = "amd64"
-			vmi.Spec.Domain.Features = &v1.Features{
-				Hyperv: &v1.FeatureHyperv{
-					Reenlightenment: &v1.FeatureState{Enabled: pointer.P(true)},
+			vmi.Spec.Domain.Features = &virtv1.Features{
+				Hyperv: &virtv1.FeatureHyperv{
+					Reenlightenment: &virtv1.FeatureState{Enabled: pointer.P(true)},
 				},
 			}
 
@@ -3339,7 +3338,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			Context("HyperV reenlightenment is enabled", func() {
-				var vmi *v1.VirtualMachineInstance
+				var vmi *virtv1.VirtualMachineInstance
 
 				BeforeEach(func() {
 					vmi = getVmiWithReenlightenment()
@@ -3500,7 +3499,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				prependInjectPodPatch(pod)
 			})
 
-			DescribeTable("update pods network annotation with", func(networks []v1.Network, interfaces []v1.Interface, matchers ...gomegaTypes.GomegaMatcher) {
+			DescribeTable("update pods network annotation with", func(networks []virtv1.Network, interfaces []virtv1.Interface, matchers ...gomegaTypes.GomegaMatcher) {
 				vmi.Spec.Networks = networks
 				vmi.Spec.Domain.Devices.Interfaces = interfaces
 				Expect(controller.updateMultusAnnotation(
@@ -3510,25 +3509,25 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				}
 			},
 				Entry("a single interface",
-					[]v1.Network{{
+					[]virtv1.Network{{
 						Name:          "iface1",
-						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net1"}},
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "net1"}},
 					}},
-					[]v1.Interface{{
+					[]virtv1.Interface{{
 						Name: "iface1",
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
 						`[{"name":"net1","namespace":"default","interface":"pod7e0055a6880"}]`)),
 				Entry("multiple interfaces",
-					[]v1.Network{{
+					[]virtv1.Network{{
 						Name:          "iface1",
-						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net1"}},
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "net1"}},
 					}, {
 						Name:          "iface2",
-						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net1"}},
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "net1"}},
 					}},
-					[]v1.Interface{{
+					[]virtv1.Interface{{
 						Name:       "iface1",
 						MacAddress: "mac1",
 					}, {
@@ -3542,17 +3541,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			DescribeTable("the subject interface name, in the pod networks annotation, should be in similar form as other interfaces",
 				func(testPodNetworkStatus []networkv1.NetworkStatus, expectedMultusNetworksAnnotation string) {
 					vmi = api.NewMinimalVMI(vmName)
-					vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+					vmi.Spec.Domain.Devices.Interfaces = []virtv1.Interface{{
 						Name:                   "red",
-						InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}, {
+						InterfaceBindingMethod: virtv1.InterfaceBindingMethod{Bridge: &virtv1.InterfaceBridge{}}}, {
 						Name:                   "blue",
-						InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+						InterfaceBindingMethod: virtv1.InterfaceBindingMethod{Bridge: &virtv1.InterfaceBridge{}}}}
 
-					vmi.Spec.Networks = []v1.Network{{
+					vmi.Spec.Networks = []virtv1.Network{{
 						Name:          "red",
-						NetworkSource: v1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "red-net"}}}, {
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "red-net"}}}, {
 						Name:          "blue",
-						NetworkSource: v1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "blue-net"}}}}
+						NetworkSource: virtv1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "blue-net"}}}}
 
 					pod, err := NewPodForVirtualMachineWithMultusAnnotations(vmi, k8sv1.PodRunning, config, testPodNetworkStatus...)
 					Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -2231,7 +2231,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("CreateAttachmentPodTemplate should update status to bound if DV owning PVC is bound but not ready", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, virtv1.VolumeStatus{
+			addVolumeStatuses(vmi, virtv1.VolumeStatus{
 				Name:          "test-pvc-volume",
 				HotplugVolume: &virtv1.HotplugVolumeStatus{},
 				Phase:         virtv1.VolumePending,
@@ -2911,7 +2911,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 			vmi.Spec.Domain.Devices.Disks = disks
 			vmi.Status.Phase = virtv1.Running
-			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, virtv1.VolumeStatus{
+			addVolumeStatuses(vmi, virtv1.VolumeStatus{
 				Name:   "existing",
 				Target: "",
 			})
@@ -2984,18 +2984,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 			vmi.Spec.Domain.Devices.Disks = disks
 			vmi.Status.Phase = virtv1.Running
-			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, virtv1.VolumeStatus{
-				Name:   "existing",
-				Target: "",
-			})
-			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, virtv1.VolumeStatus{
-				Name:   "hotplug",
-				Target: "",
-				HotplugVolume: &virtv1.HotplugVolumeStatus{
-					AttachPodName: "hp-volume-hotplug",
-					AttachPodUID:  "abcd",
+			addVolumeStatuses(vmi,
+				virtv1.VolumeStatus{
+					Name:   "existing",
+					Target: "",
+				}, virtv1.VolumeStatus{
+					Name:   "hotplug",
+					Target: "",
+					HotplugVolume: &virtv1.HotplugVolumeStatus{
+						AttachPodName: "hp-volume-hotplug",
+						AttachPodUID:  "abcd",
+					},
 				},
-			})
+			)
 			addActivePods(vmi, "virt-launch-uid", "")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
@@ -3840,8 +3841,6 @@ func NewPendingVirtualMachine(name string) *virtv1.VirtualMachineInstance {
 	vmi.Status.Phase = virtv1.Pending
 	setReadyCondition(vmi, k8sv1.ConditionFalse, virtv1.PodNotExistsReason)
 	kvcontroller.SetLatestApiVersionAnnotation(vmi)
-	vmi.Status.ActivePods = make(map[types.UID]string)
-	vmi.Status.VolumeStatus = make([]virtv1.VolumeStatus, 0)
 	return vmi
 }
 
@@ -4001,6 +4000,11 @@ func markAsNonReady(vmi *virtv1.VirtualMachineInstance) {
 
 func unmarkReady(vmi *virtv1.VirtualMachineInstance) {
 	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+}
+
+func addVolumeStatuses(vmi *virtv1.VirtualMachineInstance, volumeStatuses ...virtv1.VolumeStatus) *virtv1.VirtualMachineInstance {
+	vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, volumeStatuses...)
+	return vmi
 }
 
 func addActivePods(vmi *virtv1.VirtualMachineInstance, podUID types.UID, hostName string) *virtv1.VirtualMachineInstance {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/11751

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

