### PR TITLE
Better use of context in the tests/watcher pkg

### DIFF
--- a/tests/watcher/watcher.go
+++ b/tests/watcher/watcher.go
@@ -125,22 +125,6 @@ func (w *ObjectEventWatcher) Watch(ctx context.Context, processFunc ProcessFunc,
 
 	f := processFunc
 
-	objectRefOption := func(obj *v1.ObjectReference) []interface{} {
-		logParams := make([]interface{}, 0)
-		if obj == nil {
-			return logParams
-		}
-
-		if obj.Namespace != "" {
-			logParams = append(logParams, "namespace", obj.Namespace)
-		}
-		logParams = append(logParams, "name", obj.Name)
-		logParams = append(logParams, "kind", obj.Kind)
-		logParams = append(logParams, "uid", obj.UID)
-
-		return logParams
-	}
-
 	if w.warningPolicy.FailOnWarnings {
 		f = func(event *v1.Event) bool {
 			msg := fmt.Sprintf("Event(%#v): type: '%v' reason: '%v' %v", event.InvolvedObject, event.Type, event.Reason, event.Message)
@@ -290,3 +274,19 @@ const (
 	// Watch since the resourceVersion passed in to the builder
 	watchSinceResourceVersion startType = "watchSinceResourceVersion"
 )
+
+func objectRefOption(obj *v1.ObjectReference) []any {
+	logParams := make([]interface{}, 0)
+	if obj == nil {
+		return logParams
+	}
+
+	if obj.Namespace != "" {
+		logParams = append(logParams, "namespace", obj.Namespace)
+	}
+	logParams = append(logParams, "name", obj.Name)
+	logParams = append(logParams, "kind", obj.Kind)
+	logParams = append(logParams, "uid", obj.UID)
+
+	return logParams
+}


### PR DESCRIPTION
### What this PR does
#### Before this PR:
* timeout was manually handled 
* client call was done with a new context, instead of the context parameter
* confusing lambdas

#### After this PR:
* use the existing ability of the standard library context timeout handling
* use the context when using the client, to respect the context timeout and canceling, in the client.
* make lambdas a regular function to improve readability.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/sig code-quality
