### PR TITLE
docs, network-binding-plugin: Document migration support

### DIFF
--- a/docs/network/network-binding-plugin.md
+++ b/docs/network/network-binding-plugin.md
@@ -466,3 +466,29 @@ There may be several options to implement this, one relatively simple
 method could be to preserve the data on a `dummy` interface.
 Aa a network binding plugin author, both the CNI plugin and the sidecar codebase
 is available, therefore both can be in sync to share such information.
+
+## Migration Support
+
+The VM migration operation is considered a core feature in Kubevirt and
+therefore the ability to support it needs to be addressed when designing
+a network binding plugin.
+
+The following points should be addressed in relation to migration support:
+- Kubevirt will allow migration only if the primary network supports it.
+- For a network binding plugin to support migration, the `migration` `method`
+  must be specified in the Kubevirt CR.
+  See the user-guide network binding plugin
+  [migration](https://kubevirt.io/user-guide/virtual_machines/network_binding_plugins/#migration)
+  section on how to define it.
+- The backend `libvirt` and `qemu` needs to support migration for the specific
+  device that is used in the domain.
+  - The `hostdevice` devices in the domain do not support migration out-of-the-box.
+    The network binding plugin infrastructure does not support migration for
+    interfaces that have a `hostdevice` backend.
+
+> **Note**:
+> Network interfaces with `hostdevice` backend require a special handling from
+> Kubevirt. One such handling is to unplug the device at the source before migration
+> is started and plugging it back at the destination after the migration completes.
+> Future development will consider adding a new migration method to support
+> migration for such interfaces.


### PR DESCRIPTION
### What this PR does

Document the migrations support details in the network binding plugin developer-guide.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

