### PR TITLE
sidecar to inject qemu args

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -377,6 +377,15 @@ container_push(
     tag = "$(container_tag)",
 )
 
+container_push(
+    name = "push-example-qemu-args-sidecar",
+    format = "Docker",
+    image = "//cmd/sidecars/qemu-args:example-qemu-args-sidecar-image",
+    registry = "$(container_prefix)",
+    repository = "$(image_prefix)example-example-qemu-args-sidecar",
+    tag = "$(container_tag)",
+)
+
 # container-disk images
 container_push(
     name = "push-alpine-container-disk-demo",

--- a/cmd/sidecars/qemu-args/BUILD.bazel
+++ b/cmd/sidecars/qemu-args/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["qemu-args.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/qemu-args",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "onDefineDomain",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+)
+
+container_image(
+    name = "example-qemu-args-sidecar-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    base = "//cmd/sidecars:sidecar-shim-image",
+    directory = "/usr/bin/",
+    entrypoint = ["/sidecar-shim"],
+    files = [
+        ":onDefineDomain",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sidecars/qemu-args/README.md
+++ b/cmd/sidecars/qemu-args/README.md
@@ -1,0 +1,27 @@
+# KubeVirt SMBIOS hook sidecar
+
+To use this hook, use following annotations:
+
+```yaml
+annotations:
+  # Request the hook sidecar
+  hooks.kubevirt.io/hookSidecars: '[{"args": ["--version", "v1alpha2"], "image":"registry/example-example-qemu-args-sidecar:devel"}]'
+  # Append additional qemu args
+  qemu.vm.kubevirt.io/additionalArgs: '-fw_cfg name=opt/ovmf/X-PciMmio64Mb,string=65535'
+```
+
+## To build
+To build sidecar image run the following from project root:
+
+```shell
+DOCKER_PREFIX=registry DOCKER_TAG=devel PUSH_TARGETS=example-qemu-args-sidecar make push
+```
+
+## To verify
+Based on value for annotation key `qemu.vm.kubevirt.io/additionalArgs` the additional args will be added to the domain. 
+
+This can be verified by running the following and checking the qemu commandLine section
+
+```shell
+kubectl exec -it virt-launcher-pod-name -- virsh dumpxml domainName
+```

--- a/cmd/sidecars/qemu-args/qemu-args.go
+++ b/cmd/sidecars/qemu-args/qemu-args.go
@@ -1,0 +1,96 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	vmSchema "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+const (
+	qemuArgsAnnotation = "qemu.vm.kubevirt.io/additionalArgs"
+	qemuv1NS           = "http://libvirt.org/schemas/domain/qemu/1.0"
+)
+
+func onDefineDomain(vmiJSON, domainXML []byte) (string, error) {
+	vmiSpec := vmSchema.VirtualMachineInstance{}
+	if err := json.Unmarshal(vmiJSON, &vmiSpec); err != nil {
+		return "", fmt.Errorf("failed to unmarshal given VMI spec: %s %s", err, string(vmiJSON))
+	}
+
+	domainSpec := api.DomainSpec{}
+	if err := xml.Unmarshal(domainXML, &domainSpec); err != nil {
+		return "", fmt.Errorf("failed to unmarshal given Domain spec: %s %s", err, string(domainXML))
+	}
+
+	annotations := vmiSpec.GetAnnotations()
+	qemuArgsString, found := annotations[qemuArgsAnnotation]
+	if !found {
+		return string(domainXML), nil
+	}
+
+	if domainSpec.QEMUCmd == nil {
+		domainSpec.QEMUCmd = &api.Commandline{}
+	}
+
+	qemuArgs := strings.Fields(qemuArgsString)
+	for _, arg := range qemuArgs {
+		domainSpec.QEMUCmd.QEMUArg = append(domainSpec.QEMUCmd.QEMUArg, api.Arg{Value: arg})
+	}
+
+	if len(domainSpec.QEMUCmd.QEMUArg) > 0 {
+		domainSpec.XmlNS = qemuv1NS
+	}
+	newDomainXML, err := xml.Marshal(domainSpec)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal new Domain spec: %s %+v", err, domainSpec)
+	}
+
+	return string(newDomainXML), nil
+}
+
+func main() {
+	var vmiJSON, domainXML string
+	pflag.StringVar(&vmiJSON, "vmi", "", "VMI to change in JSON format")
+	pflag.StringVar(&domainXML, "domain", "", "Domain spec in XML format")
+	pflag.Parse()
+
+	logger := log.New(os.Stderr, "qemu-args", log.Ldate)
+	if vmiJSON == "" || domainXML == "" {
+		logger.Printf("Bad input vmi=%d, domain=%d", len(vmiJSON), len(domainXML))
+		os.Exit(1)
+	}
+
+	newDomainXML, err := onDefineDomain([]byte(vmiJSON), []byte(domainXML))
+	if err != nil {
+		logger.Printf("onDefineDomain failed: %s", err)
+		panic(err)
+	}
+	fmt.Println(newDomainXML)
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
PR introduces an additional sample sidecar to inject additional qemu args to the domain definition, based on annotations present on the VMI.

After this PR:
Users can fine tune qemu args in the domain definition to control specific behavior. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
https://github.com/kubevirt/kubevirt/issues/11093
### Why we need it and why it was done in this way
The following tradeoffs were made:
The sidecar approach seems the least disruptive means to perform this operation without changing core kubevirt api to allow inject of random qemu arguments.

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
Please refer to conversation from here: https://github.com/kubevirt/kubevirt/issues/11093#issuecomment-2078541705
### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

