### PR TITLE
Eviction admitter: Use KubeVirt generated clientset

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -73,6 +73,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -24,6 +24,13 @@ type PodEvictionAdmitter struct {
 	VirtClient    kubecli.KubevirtClient
 }
 
+func NewPodEvictionAdmitter(clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient) *PodEvictionAdmitter {
+	return &PodEvictionAdmitter{
+		ClusterConfig: clusterConfig,
+		VirtClient:    virtClient,
+	}
+}
+
 func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	pod, err := admitter.VirtClient.CoreV1().Pods(ar.Request.Namespace).Get(context.Background(), ar.Request.Name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -68,10 +68,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		virtClient := kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(nil),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(nil),
+			virtClient,
+		)
 
 		actualAdmissionResponse := admitter.Admit(
 			newAdmissionReview(evictedPod.Namespace, evictedPod.Name, !isDryRun),
@@ -88,10 +88,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		virtClient := kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(nil),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(nil),
+			virtClient,
+		)
 
 		actualAdmissionResponse := admitter.Admit(
 			newAdmissionReview(testNamespace, "does-not-exist", !isDryRun),
@@ -125,10 +125,10 @@ var _ = Describe("Pod eviction admitter", func() {
 				metav1.PatchOptions{}).
 			Return(nil, nil)
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(clusterWideEvictionStrategy),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(clusterWideEvictionStrategy),
+			virtClient,
+		)
 
 		expectedAdmissionResponse := newDeniedAdmissionResponse(
 			fmt.Sprintf("Eviction triggered evacuation of VMI \"%s/%s\"", vmi.Namespace, vmi.Name),
@@ -195,10 +195,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
 		vmiClient.EXPECT().Get(context.Background(), vmi.Name, metav1.GetOptions{}).Return(vmi, nil)
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(clusterWideEvictionStrategy),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(clusterWideEvictionStrategy),
+			virtClient,
+		)
 
 		actualAdmissionResponse := admitter.Admit(
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, !isDryRun),
@@ -258,10 +258,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
 		vmiClient.EXPECT().Get(context.Background(), vmi.Name, metav1.GetOptions{}).Return(vmi, nil)
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(clusterWideEvictionStrategy),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(clusterWideEvictionStrategy),
+			virtClient,
+		)
 
 		expectedAdmissionResponse := newDeniedAdmissionResponse(
 			fmt.Sprintf("VMI %s is configured with an eviction strategy but is not live-migratable", vmi.Name),
@@ -300,10 +300,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		expectedError := errors.New("some error")
 		vmiClient.EXPECT().Get(context.Background(), vmi.Name, metav1.GetOptions{}).Return(nil, expectedError)
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(nil),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(nil),
+			virtClient,
+		)
 
 		expectedAdmissionResponse := newDeniedAdmissionResponse(
 			fmt.Sprintf("kubevirt failed getting the vmi: %s", expectedError.Error()),
@@ -345,10 +345,10 @@ var _ = Describe("Pod eviction admitter", func() {
 				metav1.PatchOptions{}).
 			Return(nil, expectedError)
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(nil),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(nil),
+			virtClient,
+		)
 
 		expectedAdmissionResponse := newDeniedAdmissionResponse(
 			fmt.Sprintf("kubevirt failed marking the vmi for eviction: %s", expectedError.Error()),
@@ -379,10 +379,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
 		vmiClient.EXPECT().Get(context.Background(), migratableVMI.Name, metav1.GetOptions{}).Return(migratableVMI, nil)
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(nil),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(nil),
+			virtClient,
+		)
 
 		actualAdmissionResponse := admitter.Admit(
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, !isDryRun),
@@ -424,10 +424,10 @@ var _ = Describe("Pod eviction admitter", func() {
 			fmt.Sprintf("Eviction triggered evacuation of VMI \"%s/%s\"", migratableVMI.Namespace, migratableVMI.Name),
 		)
 
-		admitter := admitters.PodEvictionAdmitter{
-			ClusterConfig: newClusterConfig(nil),
-			VirtClient:    virtClient,
-		}
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(nil),
+			virtClient,
+		)
 
 		actualAdmissionResponse := admitter.Admit(
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, isDryRun),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -66,10 +66,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		kubeClient := fake.NewSimpleClientset(evictedPod)
 
 		virtClient := kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(nil),
+			kubeClient,
 			virtClient,
 		)
 
@@ -86,10 +86,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		Expect(kubeClient.Fake.Resources).To(BeEmpty())
 
 		virtClient := kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(nil),
+			kubeClient,
 			virtClient,
 		)
 
@@ -109,7 +109,6 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
@@ -127,6 +126,7 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(clusterWideEvictionStrategy),
+			kubeClient,
 			virtClient,
 		)
 
@@ -189,7 +189,6 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
@@ -197,6 +196,7 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(clusterWideEvictionStrategy),
+			kubeClient,
 			virtClient,
 		)
 
@@ -252,7 +252,6 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
@@ -260,6 +259,7 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(clusterWideEvictionStrategy),
+			kubeClient,
 			virtClient,
 		)
 
@@ -292,7 +292,6 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
@@ -302,6 +301,7 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(nil),
+			kubeClient,
 			virtClient,
 		)
 
@@ -328,7 +328,6 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
@@ -347,6 +346,7 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(nil),
+			kubeClient,
 			virtClient,
 		)
 
@@ -373,7 +373,6 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
@@ -381,6 +380,7 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(nil),
+			kubeClient,
 			virtClient,
 		)
 
@@ -403,7 +403,6 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		vmiClient := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiClient).AnyTimes()
@@ -426,6 +425,7 @@ var _ = Describe("Pod eviction admitter", func() {
 
 		admitter := admitters.NewPodEvictionAdmitter(
 			newClusterConfig(nil),
+			kubeClient,
 			virtClient,
 		)
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -297,8 +297,8 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should deny the request when the admitter fails to patch the VMI", func() {
-		evictionStratrgy := virtv1.EvictionStrategyLiveMigrate
-		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStratrgy), withLiveMigratableCondition()}
+		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
+		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStrategy), withLiveMigratableCondition()}
 
 		migratableVMI := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)
@@ -333,8 +333,8 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should allow the request and not mark the VMI again when the VMI is already marked for evacuation", func() {
-		evictionStratrgy := virtv1.EvictionStrategyLiveMigrate
-		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStratrgy), withLiveMigratableCondition(), withEvacuationNodeName(testNodeName)}
+		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
+		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStrategy), withLiveMigratableCondition(), withEvacuationNodeName(testNodeName)}
 
 		migratableVMI := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)
@@ -358,8 +358,8 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should deny the request and perform a dryRun patch on the VMI when the request is a dry run", func() {
-		evictionStratrgy := virtv1.EvictionStrategyLiveMigrate
-		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStratrgy), withLiveMigratableCondition()}
+		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
+		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStrategy), withLiveMigratableCondition()}
 
 		migratableVMI := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -102,9 +102,7 @@ func ServeStatusValidation(resp http.ResponseWriter,
 }
 
 func ServePodEvictionInterceptor(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, &admitters.PodEvictionAdmitter{
-		ClusterConfig: clusterConfig, VirtClient: virtCli,
-	})
+	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, virtCli))
 }
 
 func ServeMigrationPolicies(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -102,7 +102,7 @@ func ServeStatusValidation(resp http.ResponseWriter,
 }
 
 func ServePodEvictionInterceptor(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, virtCli))
+	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, virtCli, virtCli))
 }
 
 func ServeMigrationPolicies(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -102,7 +102,7 @@ func ServeStatusValidation(resp http.ResponseWriter,
 }
 
 func ServePodEvictionInterceptor(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, virtCli, virtCli))
+	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, virtCli, virtCli.GeneratedKubeVirtClient()))
 }
 
 func ServeMigrationPolicies(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
PodEvictionAdmitter:
1. Had exported (public) fields and could be instantiated incorrectly.
2. Used the old `kubecli.KubevirtClient` clientset.
3. Used gomock in unit tests.

After this PR:
PodEvictionAdmitter:
1. Has a factory function and only unexported (private) fields.
2. Uses kubernetes' official generated clientset.
3. Uses KubeVirt's generated clientset.
4. Uses KubeVirt's generated fake clientset in unit tests instead of gomock.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
This is a follow up to https://github.com/kubevirt/kubevirt/pull/11380.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
None
```

