### PR TITLE
WIP/DNM - controller: Apply preferences to hot plugged interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ lint:
 	if [ $$(wc -l < tests/utils.go) -gt 1401 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 	hack/dockerized "golangci-lint run --timeout 20m --verbose \
 	  pkg/instancetype/... \
+	  pkg/preference/... \
 	  pkg/libvmi/... \
 	  pkg/network/admitter/... \
 	  pkg/network/namescheme/... \

--- a/hack/gofumpt.sh
+++ b/hack/gofumpt.sh
@@ -21,6 +21,7 @@ set -e
 
 coveredpaths="\
   pkg/instancetype \
+  pkg/preference \
   pkg/libvmi \
   pkg/network/admitter \
   pkg/network/namescheme \

--- a/pkg/instancetype/compatibility/BUILD.bazel
+++ b/pkg/instancetype/compatibility/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["compatibility.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/instancetype/compatibility",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/instancetype/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/sigs.k8s.io/json:go_default_library",
+    ],
+)

--- a/pkg/instancetype/compatibility/compatibility.go
+++ b/pkg/instancetype/compatibility/compatibility.go
@@ -1,0 +1,168 @@
+//nolint:dupl,lll,gocyclo
+package compatibility
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/json"
+
+	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
+	generatedscheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
+)
+
+func DecodeControllerRevision(revision *appsv1.ControllerRevision) error {
+	if len(revision.Data.Raw) == 0 {
+		return nil
+	}
+
+	// Backward compatibility check. Try to decode ControllerRevision from v1alpha1 version.
+	oldObject, err := decodeSpecRevision(revision.Data.Raw)
+	if err != nil {
+		return fmt.Errorf("failed to decode old ControllerRevision: %w", err)
+	}
+	if oldObject != nil {
+		revision.Data.Object = oldObject
+		return nil
+	}
+	return decodeControllerRevisionObject(revision)
+}
+
+func decodeControllerRevisionObject(revision *appsv1.ControllerRevision) error {
+	decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), revision.Data.Raw)
+	if err != nil {
+		return fmt.Errorf("failed to decode object in ControllerRevision: %w", err)
+	}
+	revision.Data.Object = decodedObj
+	switch obj := revision.Data.Object.(type) {
+	case *instancetypev1beta1.VirtualMachineInstancetype, *instancetypev1beta1.VirtualMachineClusterInstancetype, *instancetypev1beta1.VirtualMachinePreference, *instancetypev1beta1.VirtualMachineClusterPreference:
+		return nil
+	case *instancetypev1alpha2.VirtualMachineInstancetype:
+		dest := &instancetypev1beta1.VirtualMachineInstancetype{}
+		if err := instancetypev1alpha2.Convert_v1alpha2_VirtualMachineInstancetype_To_v1beta1_VirtualMachineInstancetype(obj, dest, nil); err != nil {
+			return err
+		}
+		revision.Data.Object = dest
+	case *instancetypev1alpha2.VirtualMachineClusterInstancetype:
+		dest := &instancetypev1beta1.VirtualMachineClusterInstancetype{}
+		if err := instancetypev1alpha2.Convert_v1alpha2_VirtualMachineClusterInstancetype_To_v1beta1_VirtualMachineClusterInstancetype(obj, dest, nil); err != nil {
+			return err
+		}
+		revision.Data.Object = dest
+	case *instancetypev1alpha2.VirtualMachinePreference:
+		dest := &instancetypev1beta1.VirtualMachinePreference{}
+		if err := instancetypev1alpha2.Convert_v1alpha2_VirtualMachinePreference_To_v1beta1_VirtualMachinePreference(obj, dest, nil); err != nil {
+			return err
+		}
+		revision.Data.Object = dest
+	case *instancetypev1alpha2.VirtualMachineClusterPreference:
+		dest := &instancetypev1beta1.VirtualMachineClusterPreference{}
+		if err := instancetypev1alpha2.Convert_v1alpha2_VirtualMachineClusterPreference_To_v1beta1_VirtualMachineClusterPreference(obj, dest, nil); err != nil {
+			return err
+		}
+		revision.Data.Object = dest
+	case *instancetypev1alpha1.VirtualMachineInstancetype:
+		dest := &instancetypev1beta1.VirtualMachineInstancetype{}
+		if err := instancetypev1alpha1.Convert_v1alpha1_VirtualMachineInstancetype_To_v1beta1_VirtualMachineInstancetype(obj, dest, nil); err != nil {
+			return err
+		}
+		revision.Data.Object = dest
+	case *instancetypev1alpha1.VirtualMachineClusterInstancetype:
+		dest := &instancetypev1beta1.VirtualMachineClusterInstancetype{}
+		if err := instancetypev1alpha1.Convert_v1alpha1_VirtualMachineClusterInstancetype_To_v1beta1_VirtualMachineClusterInstancetype(obj, dest, nil); err != nil {
+			return err
+		}
+		revision.Data.Object = dest
+	case *instancetypev1alpha1.VirtualMachinePreference:
+		dest := &instancetypev1beta1.VirtualMachinePreference{}
+		if err := instancetypev1alpha1.Convert_v1alpha1_VirtualMachinePreference_To_v1beta1_VirtualMachinePreference(obj, dest, nil); err != nil {
+			return err
+		}
+		revision.Data.Object = dest
+	case *instancetypev1alpha1.VirtualMachineClusterPreference:
+		dest := &instancetypev1beta1.VirtualMachineClusterPreference{}
+		if err := instancetypev1alpha1.Convert_v1alpha1_VirtualMachineClusterPreference_To_v1beta1_VirtualMachineClusterPreference(obj, dest, nil); err != nil {
+			return err
+		}
+		revision.Data.Object = dest
+	default:
+		return fmt.Errorf("unexpected type in ControllerRevision: %T", obj)
+	}
+	return nil
+}
+
+func decodeSpecRevision(data []byte) (runtime.Object, error) {
+	if oldPreferenceObject := decodeVirtualMachinePreferenceSpecRevision(data); oldPreferenceObject != nil {
+		newPreferenceObject := &instancetypev1beta1.VirtualMachinePreference{}
+		if err := instancetypev1alpha1.Convert_v1alpha1_VirtualMachinePreference_To_v1beta1_VirtualMachinePreference(oldPreferenceObject, newPreferenceObject, nil); err != nil {
+			return nil, err
+		}
+		return newPreferenceObject, nil
+	}
+
+	if oldInstancetypeObject := decodeVirtualMachineInstancetypeSpecRevision(data); oldInstancetypeObject != nil {
+		newInstancetypeObject := &instancetypev1beta1.VirtualMachineInstancetype{}
+		if err := instancetypev1alpha1.Convert_v1alpha1_VirtualMachineInstancetype_To_v1beta1_VirtualMachineInstancetype(oldInstancetypeObject, newInstancetypeObject, nil); err != nil {
+			return nil, err
+		}
+		return newInstancetypeObject, nil
+	}
+
+	return nil, nil
+}
+
+func decodeVirtualMachineInstancetypeSpecRevision(data []byte) *instancetypev1alpha1.VirtualMachineInstancetype {
+	revision := &instancetypev1alpha1.VirtualMachineInstancetypeSpecRevision{}
+	strictErr, err := json.UnmarshalStrict(data, revision)
+	if err != nil || strictErr != nil {
+		// Failed to unmarshal, so the object is not the expected type
+		return nil
+	}
+
+	instancetypeSpec := &instancetypev1alpha1.VirtualMachineInstancetypeSpec{}
+	strictErr, err = json.UnmarshalStrict(revision.Spec, instancetypeSpec)
+	if err != nil || strictErr != nil {
+		return nil
+	}
+
+	return &instancetypev1alpha1.VirtualMachineInstancetype{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: instancetypev1alpha1.SchemeGroupVersion.String(),
+			Kind:       "VirtualMachineInstancetype",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-version-of-instancetype-object",
+		},
+		Spec: *instancetypeSpec,
+	}
+}
+
+func decodeVirtualMachinePreferenceSpecRevision(data []byte) *instancetypev1alpha1.VirtualMachinePreference {
+	revision := &instancetypev1alpha1.VirtualMachinePreferenceSpecRevision{}
+	strictErr, err := json.UnmarshalStrict(data, revision)
+	if err != nil || strictErr != nil {
+		// Failed to unmarshall, so the object is not the expected type
+		return nil
+	}
+
+	preferenceSpec := &instancetypev1alpha1.VirtualMachinePreferenceSpec{}
+	strictErr, err = json.UnmarshalStrict(revision.Spec, preferenceSpec)
+	if err != nil || strictErr != nil {
+		return nil
+	}
+
+	return &instancetypev1alpha1.VirtualMachinePreference{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: instancetypev1alpha1.SchemeGroupVersion.String(),
+			Kind:       "VirtualMachinePreference",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "old-version-of-preference-object",
+		},
+		Spec: *preferenceSpec,
+	}
+}

--- a/pkg/preference/BUILD.bazel
+++ b/pkg/preference/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["find.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/preference",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/instancetype/compatibility:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)

--- a/pkg/preference/find.go
+++ b/pkg/preference/find.go
@@ -1,0 +1,185 @@
+//nolint:lll,goimports
+package preference
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+	apiinstancetype "kubevirt.io/api/instancetype"
+	"kubevirt.io/api/instancetype/v1beta1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/instancetype/compatibility"
+)
+
+type Finder struct {
+	PreferenceStore         cache.Store
+	ClusterPreferenceStore  cache.Store
+	ControllerRevisionStore cache.Store
+	Clientset               kubecli.KubevirtClient
+}
+
+func (f *Finder) Find(vm *v1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error) {
+	matcher := vm.Spec.Preference
+	if matcher == nil {
+		return nil, nil
+	}
+
+	if matcher.RevisionName != "" {
+		return f.findSpecRevision(types.NamespacedName{
+			Namespace: vm.Namespace,
+			Name:      matcher.RevisionName,
+		})
+	}
+
+	switch strings.ToLower(vm.Spec.Preference.Kind) {
+	case apiinstancetype.SingularPreferenceResourceName, apiinstancetype.PluralPreferenceResourceName:
+		preference, err := f.findPreference(vm)
+		if err != nil {
+			return nil, err
+		}
+		return &preference.Spec, nil
+
+	case apiinstancetype.ClusterSingularPreferenceResourceName, apiinstancetype.ClusterPluralPreferenceResourceName, "":
+		clusterPreference, err := f.findClusterPreference(vm)
+		if err != nil {
+			return nil, err
+		}
+		return &clusterPreference.Spec, nil
+
+	default:
+		return nil, fmt.Errorf("got unexpected kind in PreferenceMatcher: %s", vm.Spec.Preference.Kind)
+	}
+}
+
+func (f *Finder) findSpecRevision(namespacedName types.NamespacedName) (*v1beta1.VirtualMachinePreferenceSpec, error) {
+	var (
+		err      error
+		revision *appsv1.ControllerRevision
+	)
+
+	if f.ControllerRevisionStore != nil {
+		revision, err = f.getCRByInformer(namespacedName)
+	} else {
+		revision, err = f.getCRByClient(namespacedName)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return getSpecFromCR(revision)
+}
+
+func (f *Finder) getCRByInformer(namespacedName types.NamespacedName) (*appsv1.ControllerRevision, error) {
+	obj, exists, err := f.ControllerRevisionStore.GetByKey(namespacedName.String())
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return f.getCRByClient(namespacedName)
+	}
+	revision, ok := obj.(*appsv1.ControllerRevision)
+	if !ok {
+		return nil, fmt.Errorf("unknown object type found in ControllerRevision informer")
+	}
+	return revision, nil
+}
+
+func (f *Finder) getCRByClient(namespacedName types.NamespacedName) (*appsv1.ControllerRevision, error) {
+	revision, err := f.Clientset.AppsV1().ControllerRevisions(namespacedName.Namespace).Get(context.Background(), namespacedName.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return revision, nil
+}
+
+func (f *Finder) findPreference(vm *v1.VirtualMachine) (*v1beta1.VirtualMachinePreference, error) {
+	if vm.Spec.Preference == nil {
+		return nil, nil
+	}
+	namespacedName := types.NamespacedName{
+		Namespace: vm.Namespace,
+		Name:      vm.Spec.Preference.Name,
+	}
+	if f.PreferenceStore != nil {
+		return f.findPreferenceByInformer(namespacedName)
+	}
+	return f.findPreferenceByClient(namespacedName)
+}
+
+func (f *Finder) findPreferenceByInformer(namespacedName types.NamespacedName) (*v1beta1.VirtualMachinePreference, error) {
+	obj, exists, err := f.PreferenceStore.GetByKey(namespacedName.String())
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return f.findPreferenceByClient(namespacedName)
+	}
+	preference, ok := obj.(*v1beta1.VirtualMachinePreference)
+	if !ok {
+		return nil, fmt.Errorf("unknown object type found in VirtualMachinePreference informer")
+	}
+	return preference, nil
+}
+
+func (f *Finder) findPreferenceByClient(namespacedName types.NamespacedName) (*v1beta1.VirtualMachinePreference, error) {
+	preference, err := f.Clientset.VirtualMachinePreference(namespacedName.Namespace).Get(context.Background(), namespacedName.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return preference, nil
+}
+
+func (f *Finder) findClusterPreference(vm *v1.VirtualMachine) (*v1beta1.VirtualMachineClusterPreference, error) {
+	if vm.Spec.Preference == nil {
+		return nil, nil
+	}
+	if f.ClusterPreferenceStore != nil {
+		return f.findClusterPreferenceByInformer(vm.Spec.Preference.Name)
+	}
+	return f.findClusterPreferenceByClient(vm.Spec.Preference.Name)
+}
+
+func (f *Finder) findClusterPreferenceByInformer(resourceName string) (*v1beta1.VirtualMachineClusterPreference, error) {
+	obj, exists, err := f.PreferenceStore.GetByKey(resourceName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return f.findClusterPreferenceByClient(resourceName)
+	}
+	preference, ok := obj.(*v1beta1.VirtualMachineClusterPreference)
+	if !ok {
+		return nil, fmt.Errorf("unknown object type found in VirtualMachineClusterPreference informer")
+	}
+	return preference, nil
+}
+
+func (f *Finder) findClusterPreferenceByClient(resourceName string) (*v1beta1.VirtualMachineClusterPreference, error) {
+	preference, err := f.Clientset.VirtualMachineClusterPreference().Get(context.Background(), resourceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return preference, nil
+}
+
+func getSpecFromCR(revision *appsv1.ControllerRevision) (*v1beta1.VirtualMachinePreferenceSpec, error) {
+	if err := compatibility.DecodeControllerRevision(revision); err != nil {
+		return nil, err
+	}
+	switch obj := revision.Data.Object.(type) {
+	case *v1beta1.VirtualMachinePreference:
+		return &obj.Spec, nil
+	case *v1beta1.VirtualMachineClusterPreference:
+		return &obj.Spec, nil
+	default:
+		return nil, fmt.Errorf("unexpected type in ControllerRevision: %T", obj)
+	}
+}

--- a/pkg/preference/network/BUILD.bazel
+++ b/pkg/preference/network/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["apply.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/preference/network",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/pointer:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+    ],
+)

--- a/pkg/preference/network/apply.go
+++ b/pkg/preference/network/apply.go
@@ -1,0 +1,54 @@
+//nolint:lll
+package network
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/api/instancetype/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+)
+
+type (
+	Conflicts []*field.Path
+	Applier   struct{}
+)
+
+func isInterfaceBindingUnset(iface *v1.Interface) bool {
+	return reflect.ValueOf(iface.InterfaceBindingMethod).IsZero() && iface.Binding == nil
+}
+
+func isInterfaceOnPodNetwork(interfaceName string, vmiSpec v1.VirtualMachineInstanceSpec) bool {
+	for _, network := range vmiSpec.Networks {
+		if network.Name == interfaceName {
+			return network.Pod != nil
+		}
+	}
+	return false
+}
+
+func (n *Applier) Apply(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec {
+	if preferenceSpec == nil {
+		return &vmiSpec
+	}
+
+	vmiSpecCopy := vmiSpec.DeepCopy()
+
+	if preferenceSpec.Devices.PreferredNetworkInterfaceMultiQueue != nil && vmiSpec.Domain.Devices.NetworkInterfaceMultiQueue == nil {
+		vmiSpecCopy.Domain.Devices.NetworkInterfaceMultiQueue = pointer.P(*preferenceSpec.Devices.PreferredNetworkInterfaceMultiQueue)
+	}
+
+	for ifaceIndex := range vmiSpecCopy.Domain.Devices.Interfaces {
+		vmiIface := &vmiSpecCopy.Domain.Devices.Interfaces[ifaceIndex]
+		if preferenceSpec.Devices.PreferredInterfaceModel != "" && vmiIface.Model == "" {
+			vmiIface.Model = preferenceSpec.Devices.PreferredInterfaceModel
+		}
+		if preferenceSpec.Devices.PreferredInterfaceMasquerade != nil && isInterfaceBindingUnset(vmiIface) && isInterfaceOnPodNetwork(vmiIface.Name, vmiSpec) {
+			vmiIface.Masquerade = preferenceSpec.Devices.PreferredInterfaceMasquerade.DeepCopy()
+		}
+	}
+	return vmiSpecCopy
+}

--- a/pkg/virt-controller/network/BUILD.bazel
+++ b/pkg/virt-controller/network/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-controller/network/vmcontroller_test.go
+++ b/pkg/virt-controller/network/vmcontroller_test.go
@@ -43,12 +43,12 @@ import (
 
 var _ = Describe("VM Network Controller", func() {
 	It("sync does nothing when the hotplug FG is unset", func() {
-		c := network.NewVMNetController(fake.NewSimpleClientset(), stubClusterConfig{}, stubPodGetter{})
+		c := network.NewVMNetController(fake.NewSimpleClientset(), stubClusterConfig{}, stubPodGetter{}, nil)
 		Expect(c.Sync(newEmptyVM(), libvmi.New())).To(Equal(newEmptyVM()))
 	})
 
 	DescribeTable("sync does nothing when", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, podGetter stubPodGetter) {
-		c := network.NewVMNetController(fake.NewSimpleClientset(), stubClusterConfig{netHotplugEnabled: true}, podGetter)
+		c := network.NewVMNetController(fake.NewSimpleClientset(), stubClusterConfig{netHotplugEnabled: true}, podGetter, nil)
 		originalVM := vm.DeepCopy()
 		Expect(c.Sync(vm, vmi)).To(Equal(originalVM))
 	},
@@ -85,6 +85,7 @@ var _ = Describe("VM Network Controller", func() {
 			fake.NewSimpleClientset(),
 			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{err: errors.New("test")},
+			nil,
 		)
 		updatedVM, err := c.Sync(newEmptyVM(), libvmi.New())
 		Expect(err).To(MatchError(isSyncErrorType, "syncError"))
@@ -97,6 +98,7 @@ var _ = Describe("VM Network Controller", func() {
 			clientset,
 			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: &k8sv1.Pod{}},
+			nil,
 		)
 
 		// Setup `Patch` to fail.
@@ -130,6 +132,7 @@ var _ = Describe("VM Network Controller", func() {
 			clientset,
 			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: &k8sv1.Pod{}},
+			nil,
 		)
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -163,6 +166,7 @@ var _ = Describe("VM Network Controller", func() {
 			clientset,
 			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: &k8sv1.Pod{}},
+			nil,
 		)
 		unpluggedIface := libvmi.InterfaceDeviceWithBridgeBinding("foonet")
 		unpluggedIface.State = v1.InterfaceStateAbsent
@@ -201,6 +205,7 @@ var _ = Describe("VM Network Controller", func() {
 			clientset,
 			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: nil},
+			nil,
 		)
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -254,6 +259,7 @@ var _ = Describe("VM Network Controller", func() {
 			clientset,
 			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: pod},
+			nil,
 		)
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -29,6 +29,8 @@ go_library(
         "//pkg/network/netbinding:go_default_library",
         "//pkg/network/pod/annotations:go_default_library",
         "//pkg/network/vmispec:go_default_library",
+        "//pkg/preference:go_default_library",
+        "//pkg/preference/network:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/storage/export/export:go_default_library",
         "//pkg/storage/pod/annotations:go_default_library",


### PR DESCRIPTION
/area instancetype
/cc @EdDev 
/cc @orelmisan 

### What this PR does

This is very much WIP/DNM for now while I work out how to further refactor `pkg/instancetype`, feedback however welcome on the direction.

The current series does the following:

* Breaks the preference specific code out of `pkg/instancetype`
* Defines a `preferenceHandler` interface for use within `VMNetController` that provides `Find` and `Apply` methods
* Defines stand alone implementations for both of these
* Passes the implementations to `NewVMNetController` during setup
* Uses all of the above to find and apply network interface preferences during hot plug

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

