### PR TITLE
Create kubevirt_vmi_info metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -123,6 +123,9 @@ Total VM filesystem capacity in bytes. Type: Gauge.
 ### kubevirt_vmi_filesystem_used_bytes
 Used VM filesystem capacity in bytes. Type: Gauge.
 
+### kubevirt_vmi_info
+Information about VirtualMachineInstances. Type: Gauge.
+
 ### kubevirt_vmi_memory_actual_balloon_bytes
 Current balloon size in bytes. Type: Gauge.
 

--- a/pkg/monitoring/rules/recordingrules/vmi.go
+++ b/pkg/monitoring/rules/recordingrules/vmi.go
@@ -25,6 +25,14 @@ import (
 var vmiRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_phase_count",
+			Help: "Sum of VMIs per phase and node. `phase` can be one of the following: [`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`].",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum by (node, phase, os, workload, flavor, instance_type, preference, guest_os_kernel_release, guest_os_machine, guest_os_name, guest_os_version_id) (kubevirt_vmi_info)"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
 			Name: "kubevirt_vmi_memory_used_bytes",
 			Help: "Amount of `used` memory as seen by the domain.",
 		},

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -492,7 +492,7 @@ var _ = DescribeInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][leve
 
 		for _, key := range keys {
 			// we don't care about the ordering of the labels
-			if strings.HasPrefix(key, "kubevirt_vmi_phase_count") {
+			if strings.HasPrefix(key, "kubevirt_vmi_info") {
 				// special case: namespace and name don't make sense for this metric
 				Expect(key).To(ContainSubstring(`node="%s"`, nodeName))
 				continue

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -248,7 +248,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 	})
 
 	Context("VM metrics that are based on the guest agent", func() {
-		It("should have kubevirt_vmi_phase_count correctly configured with guest OS labels", func() {
+		It("should have kubevirt_vmi_info correctly configured with guest OS labels", func() {
 			agentVMI := createAgentVMI()
 			Expect(agentVMI.Status.GuestOSInfo.KernelRelease).ToNot(BeEmpty())
 			Expect(agentVMI.Status.GuestOSInfo.Machine).ToNot(BeEmpty())
@@ -262,7 +262,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 				"guest_os_version_id":     agentVMI.Status.GuestOSInfo.VersionID,
 			}
 
-			libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_phase_count", 1, labels, 1)
+			libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_info", 1, labels, 1)
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

kubevirt_vmi_phase_count has OS label but doesn't identify VMI, so we cannot use this information to filter VMStorageClassWarning only for VMI with Windows OS reported by the guest.

After this PR:

We create a kubevirt_vmi_info metric, similar to kube_pod_info, that contains detailed information about the workload, including the name and namespace.

We also create a recording rule for kubevirt_vmi_phase_count, that aggregates the new kubevirt_vmi_info by node, phase, os, workload, flavor, instance_type and preference.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Create kubevirt_vmi_info metric
```

### Jira Ticket
```jira-ticket
https://issues.redhat.com/browse/CNV-41650
```
