### PR TITLE
virt-launcher: Use interface for arch specific conversions

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -3,11 +3,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "amd64.go",
+        "archconverter.go",
+        "arm64.go",
         "converter.go",
         "downwardmetrics.go",
         "generated_mock_converter.go",
         "network.go",
         "pci-placement.go",
+        "ppc64le.go",
         "virtiofs.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter",
@@ -24,6 +28,7 @@ go_library(
         "//pkg/ignition:go_default_library",
         "//pkg/network/dns:go_default_library",
         "//pkg/network/vmispec:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
@@ -45,6 +50,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "archconverter_test.go",
         "converter_suite_test.go",
         "converter_test.go",
     ],

--- a/pkg/virt-launcher/virtwrap/converter/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/amd64.go
@@ -1,0 +1,81 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package converter
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
+)
+
+// Ensure that there is a compile error should the struct not implement the archConverter interface anymore.
+var _ = archConverter(&archConverterAMD64{})
+
+type archConverterAMD64 struct{}
+
+func (archConverterAMD64) addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext) {
+	// For AMD64 + EFI, use bochs. For BIOS, use VGA
+	if c.BochsForEFIGuests && util.IsEFIVMI(vmi) {
+		domain.Spec.Devices.Video = []api.Video{
+			{
+				Model: api.VideoModel{
+					Type:  "bochs",
+					Heads: pointer.P(graphicsDeviceDefaultHeads),
+				},
+			},
+		}
+	} else {
+		domain.Spec.Devices.Video = []api.Video{
+			{
+				Model: api.VideoModel{
+					Type:  "vga",
+					Heads: pointer.P(graphicsDeviceDefaultHeads),
+					VRam:  pointer.P(graphicsDeviceDefaultVRAM),
+				},
+			},
+		}
+	}
+}
+
+func (archConverterAMD64) isUSBNeeded(vmi *v1.VirtualMachineInstance) bool {
+	for i := range vmi.Spec.Domain.Devices.Inputs {
+		if vmi.Spec.Domain.Devices.Inputs[i].Bus == "usb" {
+			return true
+		}
+	}
+
+	for i := range vmi.Spec.Domain.Devices.Disks {
+		disk := vmi.Spec.Domain.Devices.Disks[i].Disk
+
+		if disk != nil && disk.Bus == v1.DiskBusUSB {
+			return true
+		}
+	}
+
+	if vmi.Spec.Domain.Devices.ClientPassthrough != nil {
+		return true
+	}
+
+	if device.USBDevicesFound(vmi.Spec.Domain.Devices.HostDevices) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/virt-launcher/virtwrap/converter/archconverter.go
+++ b/pkg/virt-launcher/virtwrap/converter/archconverter.go
@@ -1,0 +1,49 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package converter
+
+import (
+	"kubevirt.io/client-go/log"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+const (
+	graphicsDeviceDefaultHeads uint = 1
+	graphicsDeviceDefaultVRAM  uint = 16384
+)
+
+type archConverter interface {
+	addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext)
+	isUSBNeeded(vmi *v1.VirtualMachineInstance) bool
+}
+
+func newArchConverter(arch string) archConverter {
+	switch {
+	case isARM64(arch):
+		return archConverterARM64{}
+	case isPPC64(arch):
+		return archConverterPPC64{}
+	case isAMD64(arch):
+		return archConverterAMD64{}
+	default:
+		log.Log.Warning("Trying to create an arch converter from an unknown arch: " + arch + ". Falling back to AMD64")
+		return archConverterAMD64{}
+	}
+}

--- a/pkg/virt-launcher/virtwrap/converter/archconverter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/archconverter_test.go
@@ -1,0 +1,36 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package converter
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Arch Converter", func() {
+
+	DescribeTable("Should create a new archConverter for the correct architecture", func(arch string, result archConverter) {
+		ac := newArchConverter(arch)
+
+		Expect(ac).To(Equal(result))
+	},
+		Entry("amd64", "amd64", archConverterAMD64{}),
+		Entry("arm64", "arm64", archConverterARM64{}),
+		Entry("ppc64le", "ppc64le", archConverterPPC64{}),
+		Entry("unkown", "unknown", archConverterAMD64{}),
+	)
+})

--- a/pkg/virt-launcher/virtwrap/converter/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arm64.go
@@ -1,0 +1,62 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package converter
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+// Ensure that there is a compile error should the struct not implement the archConverter interface anymore.
+var _ = archConverter(&archConverterARM64{})
+
+type archConverterARM64 struct{}
+
+func (archConverterARM64) addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, _ *ConverterContext) {
+	// For arm64, qemu-kvm only support virtio-gpu display device, so set it as default video device.
+	// tablet and keyboard devices are necessary for control the VM via vnc connection
+	domain.Spec.Devices.Video = []api.Video{
+		{
+			Model: api.VideoModel{
+				Type:  v1.VirtIO,
+				Heads: pointer.P(graphicsDeviceDefaultHeads),
+			},
+		},
+	}
+
+	if !hasTabletDevice(vmi) {
+		domain.Spec.Devices.Inputs = append(domain.Spec.Devices.Inputs,
+			api.Input{
+				Bus:  "usb",
+				Type: "tablet",
+			},
+		)
+	}
+
+	domain.Spec.Devices.Inputs = append(domain.Spec.Devices.Inputs,
+		api.Input{
+			Bus:  "usb",
+			Type: "keyboard",
+		},
+	)
+}
+
+func (archConverterARM64) isUSBNeeded(_ *v1.VirtualMachineInstance) bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -56,7 +56,6 @@ import (
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	kubevirtpointer "kubevirt.io/kubevirt/pkg/pointer"
-	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
 	sev "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/launchsecurity"
 )
 
@@ -1016,7 +1015,7 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "scsi"
 			vmi.Spec.Domain.IOThreadsPolicy = nil
-			for i, _ := range vmi.Spec.Domain.Devices.Disks {
+			for i := range vmi.Spec.Domain.Devices.Disks {
 				vmi.Spec.Domain.Devices.Disks[i].DedicatedIOThread = nil
 			}
 			dom := &api.Domain{}
@@ -1744,7 +1743,7 @@ var _ = Describe("Converter", func() {
 				Spec: v1.VirtualMachineInstanceSpec{
 					Domain: v1.DomainSpec{
 						Features: &v1.Features{
-							HypervPassthrough: &v1.HyperVPassthrough{Enabled: virtpointer.P(true)},
+							HypervPassthrough: &v1.HyperVPassthrough{Enabled: kubevirtpointer.P(true)},
 						},
 					},
 				},
@@ -2571,7 +2570,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{
-						SecureBoot: pointer.BoolPtr(false),
+						SecureBoot: kubevirtpointer.P(false),
 					},
 				},
 			}
@@ -2846,7 +2845,7 @@ var _ = Describe("Converter", func() {
 			vmi = kvapi.NewMinimalVMI("testvmi")
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
-			vmi.Spec.Domain.Devices.AutoattachMemBalloon = pointer.BoolPtr(true)
+			vmi.Spec.Domain.Devices.AutoattachMemBalloon = kubevirtpointer.P(true)
 			nonVirtioIface := v1.Interface{Name: "red", Model: "e1000"}
 			secondaryNetwork := v1.Network{Name: "red"}
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
@@ -2860,13 +2859,13 @@ var _ = Describe("Converter", func() {
 			}
 			vmi.Spec.Domain.Features = &v1.Features{
 				SMM: &v1.FeatureState{
-					Enabled: pointer.BoolPtr(false),
+					Enabled: kubevirtpointer.P(false),
 				},
 			}
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				Bootloader: &v1.Bootloader{
 					EFI: &v1.EFI{
-						SecureBoot: pointer.BoolPtr(false),
+						SecureBoot: kubevirtpointer.P(false),
 					},
 				},
 			}

--- a/pkg/virt-launcher/virtwrap/converter/ppc64le.go
+++ b/pkg/virt-launcher/virtwrap/converter/ppc64le.go
@@ -1,0 +1,48 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package converter
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+// Ensure that there is a compile error should the struct not implement the archConverter interface anymore.
+var _ = archConverter(&archConverterPPC64{})
+
+type archConverterPPC64 struct{}
+
+func (archConverterPPC64) addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext) {
+	domain.Spec.Devices.Video = []api.Video{
+		{
+			Model: api.VideoModel{
+				Type:  "vga",
+				Heads: pointer.P(graphicsDeviceDefaultHeads),
+				VRam:  pointer.P(graphicsDeviceDefaultVRAM),
+			},
+		},
+	}
+}
+
+func (archConverterPPC64) isUSBNeeded(_ *v1.VirtualMachineInstance) bool {
+	//In ppc64le usb devices like mouse / keyboard are set by default,
+	//so we can't disable the controller otherwise we run into the following error:
+	//"unsupported configuration: USB is disabled for this domain, but USB devices are present in the domain XML"
+	return true
+}


### PR DESCRIPTION
Replace long switch case statements for arch specific conversions into separate code files by utilizing an interface.
Fix some code warnings in converter.go

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Big chunks of arch specific code is mixed with general virt-launcher code
After this PR:
arch specific code is mostly in arch specific files. Exceptions is for trivial paths where only single string values are different and the effort and additional complexity of splitting it would not be worth it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Some arch specific configuration values are still in the main code
The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/10490#issuecomment-2024935029
### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

