### PR TITLE
Implement retries in vmexport download when server returns unexpected status

### DIFF
--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/virt-controller/watch/util:go_default_library",
         "//pkg/virt-operator/resource/apply:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
+        "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -922,6 +922,8 @@ var _ = Describe("Export controller", func() {
 		Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().MilliValue()).To(Equal(int64(1000)))
 		Expect(pod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
 		Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1073741824)))
+		Expect(pod.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
+		Expect(pod.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Path).To(Equal(ReadinessPath))
 	},
 		Entry("PVC", createPVCVMExport, 3),
 		Entry("VM", populateVmExportVM, 4),

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -462,7 +462,7 @@ func archiveHandler(mountPoint string) http.Handler {
 			return
 		}
 		if hasPermissions := checkDirectoryPermissions(mountPoint); !hasPermissions {
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
@@ -520,7 +520,7 @@ func gzipHandler(filePath string) http.Handler {
 		f, err := os.Open(filePath)
 		if err != nil {
 			log.Log.Reason(err).Errorf("error opening %s", filePath)
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		defer f.Close()

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -461,6 +461,11 @@ func archiveHandler(mountPoint string) http.Handler {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
+		if hasPermissions := checkDirectoryPermissions(mountPoint); !hasPermissions {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
 		tarReader, err := newTarReader(mountPoint)
 		if err != nil {
 			log.Log.Reason(err).Error("error creating tar reader")
@@ -478,6 +483,34 @@ func archiveHandler(mountPoint string) http.Handler {
 	})
 }
 
+func checkDirectoryPermissions(filePath string) bool {
+	dir, err := os.Open(filePath)
+	if err != nil {
+		log.Log.Reason(err).Errorf("error opening %s", filePath)
+		return false
+	}
+	defer dir.Close()
+
+	// Read all filenames
+	contents, err := dir.Readdirnames(-1)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to read directory contents: %v", err)
+		return false
+	}
+
+	for _, item := range contents {
+		itemPath := filepath.Join(filePath, item)
+		// Check if export server has permissions to manipulate the file
+		file, err := os.Open(itemPath)
+		if err != nil {
+			log.Log.Reason(err).Errorf("unable to open %s, file may lack read permissions", itemPath)
+			return false
+		}
+		file.Close()
+	}
+	return true
+}
+
 func gzipHandler(filePath string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet {
@@ -487,7 +520,7 @@ func gzipHandler(filePath string) http.Handler {
 		f, err := os.Open(filePath)
 		if err != nil {
 			log.Log.Reason(err).Errorf("error opening %s", filePath)
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 		defer f.Close()

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -503,7 +503,7 @@ func checkDirectoryPermissions(filePath string) bool {
 		// Check if export server has permissions to manipulate the file
 		file, err := os.Open(itemPath)
 		if err != nil {
-			log.Log.Reason(err).Errorf("unable to open %s, file may lack read permissions", itemPath)
+			log.Log.Reason(err).Errorf("%s may lack read permissions", itemPath)
 			return false
 		}
 		file.Close()

--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -338,6 +338,9 @@ func downloadMemoryDump(namespace, vmName string, virtClient kubecli.KubevirtCli
 		ExportSource: exportSource,
 		PortForward:  portForward,
 		LocalPort:    localPort,
+		// Using 2 as retry count to help mitigate a bug that might happen when creating the
+		// exporter pod just after the hotplug pod is deleted: https://issues.redhat.com/browse/CNV-39141
+		DownloadRetries: 2,
 	}
 
 	if portForward {

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -81,6 +81,7 @@ const (
 	INCLUDE_SECRET_FLAG = "--include-secret"
 	PORT_FORWARD_FLAG   = "--port-forward"
 	LOCAL_PORT_FLAG     = "--local-port"
+	RETRY_FLAG          = "--retry"
 
 	// Possible output format for manifests
 	OUTPUT_FORMAT_JSON = "json"
@@ -142,29 +143,29 @@ var (
 	volumeName           string
 	ttl                  string
 	manifestOutputFormat string
+	downloadRetries      int
 )
 
-const downloadRetries = 2
-
 type VMExportInfo struct {
-	ShouldCreate   bool
-	Insecure       bool
-	KeepVme        bool
-	DeleteVme      bool
-	IncludeSecret  bool
-	ExportManifest bool
-	Decompress     bool
-	PortForward    bool
-	LocalPort      string
-	OutputFile     string
-	OutputWriter   io.Writer
-	VolumeName     string
-	Namespace      string
-	Name           string
-	OutputFormat   string
-	ServiceURL     string
-	ExportSource   k8sv1.TypedLocalObjectReference
-	TTL            metav1.Duration
+	ShouldCreate    bool
+	Insecure        bool
+	KeepVme         bool
+	DeleteVme       bool
+	IncludeSecret   bool
+	ExportManifest  bool
+	Decompress      bool
+	PortForward     bool
+	LocalPort       string
+	OutputFile      string
+	OutputWriter    io.Writer
+	VolumeName      string
+	Namespace       string
+	Name            string
+	OutputFormat    string
+	ServiceURL      string
+	ExportSource    k8sv1.TypedLocalObjectReference
+	TTL             metav1.Duration
+	DownloadRetries int
 }
 
 type command struct {
@@ -292,6 +293,7 @@ func NewVirtualMachineExportCommand(clientConfig clientcmd.ClientConfig) *cobra.
 	cmd.Flags().StringVar(&serviceUrl, "service-url", "", "Specify service url to use in the returned manifest, instead of the external URL in the Virtual Machine export status. This is useful for NodePorts or if you don't have an external URL configured")
 	cmd.Flags().BoolVar(&portForward, "port-forward", false, "Configures port-forwarding on a random port. Useful to download without proper ingress/route configuration")
 	cmd.Flags().StringVar(&localPort, "local-port", "0", "Defines the specific port to be used in port-forward.")
+	cmd.Flags().IntVar(&downloadRetries, "retry", 0, "When export server returns a transient error, we retry this number of times before giving up")
 	cmd.Flags().BoolVar(&includeSecret, "include-secret", false, "When used with manifest and set to true include a secret that contains proper headers for CDI to import using the manifest")
 	cmd.Flags().BoolVar(&exportManifest, "manifest", false, "Instead of downloading a volume, retrieve the VM manifest")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
@@ -390,6 +392,7 @@ func (c *command) initVMExportInfo(vmeInfo *VMExportInfo) error {
 	if format == RAW_FORMAT {
 		vmeInfo.Decompress = true
 	}
+	vmeInfo.DownloadRetries = downloadRetries
 	vmeInfo.ShouldCreate = shouldCreate
 	vmeInfo.Insecure = insecure
 	vmeInfo.KeepVme = keepVme
@@ -488,7 +491,7 @@ func DeleteVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExport
 
 // DownloadVirtualMachineExport handles the process of downloading the requested volume from a VirtualMachineExport object
 func DownloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExportInfo) error {
-	for attempt := 0; attempt <= downloadRetries; attempt++ {
+	for attempt := 0; attempt <= vmeInfo.DownloadRetries; attempt++ {
 		succeeded, err := downloadVirtualMachineExport(client, vmeInfo)
 		if err != nil {
 			return err
@@ -496,8 +499,10 @@ func DownloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExpo
 		if succeeded {
 			return nil
 		}
-		printToOutput("Retrying...\n")
-		time.Sleep(2 * time.Second)
+		if attempt < vmeInfo.DownloadRetries {
+			printToOutput("Retrying...\n")
+			time.Sleep(2 * time.Second)
+		}
 	}
 	return fmt.Errorf("retry count reached, exiting unsuccesfully")
 }
@@ -942,6 +947,9 @@ func handleCreateFlags() error {
 	if serviceUrl != "" {
 		return fmt.Errorf(ErrIncompatibleFlag, SERVICE_URL_FLAG, CREATE)
 	}
+	if downloadRetries != 0 {
+		return fmt.Errorf(ErrIncompatibleFlag, RETRY_FLAG, CREATE)
+	}
 
 	return nil
 }
@@ -979,6 +987,9 @@ func handleDeleteFlags() error {
 	if serviceUrl != "" {
 		return fmt.Errorf(ErrIncompatibleFlag, SERVICE_URL_FLAG, DELETE)
 	}
+	if downloadRetries != 0 {
+		return fmt.Errorf(ErrIncompatibleFlag, RETRY_FLAG, DELETE)
+	}
 
 	return nil
 }
@@ -999,6 +1010,10 @@ func handleDownloadFlags() error {
 
 	if format != "" && format != GZIP_FORMAT && format != RAW_FORMAT {
 		return fmt.Errorf(ErrInvalidValue, FORMAT_FLAG, "gzip/raw")
+	}
+
+	if downloadRetries < 0 {
+		return fmt.Errorf(ErrInvalidValue, RETRY_FLAG, "positive integers")
 	}
 
 	if exportManifest {

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -144,6 +144,8 @@ var (
 	manifestOutputFormat string
 )
 
+const downloadRetries = 2
+
 type VMExportInfo struct {
 	ShouldCreate   bool
 	Insecure       bool
@@ -486,10 +488,25 @@ func DeleteVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExport
 
 // DownloadVirtualMachineExport handles the process of downloading the requested volume from a VirtualMachineExport object
 func DownloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExportInfo) error {
+	for attempt := 0; attempt <= downloadRetries; attempt++ {
+		succeeded, err := downloadVirtualMachineExport(client, vmeInfo)
+		if err != nil {
+			return err
+		}
+		if succeeded {
+			return nil
+		}
+		printToOutput("Retrying...\n")
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("retry count reached, exiting unsuccesfully")
+}
+
+func downloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExportInfo) (bool, error) {
 	if vmeInfo.ShouldCreate {
 		if err := CreateVirtualMachineExport(client, vmeInfo); err != nil {
 			if !errExportAlreadyExists(err) {
-				return err
+				return false, err
 			}
 		}
 	}
@@ -501,105 +518,101 @@ func DownloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExpo
 	if vmeInfo.PortForward {
 		stopChan, err := setupPortForward(client, vmeInfo)
 		if err != nil {
-			return err
+			return false, err
 		}
 		defer close(stopChan)
 	}
 
 	// Wait for the vmexport object to be ready
 	if err := ExportProcessingComplete(client, vmeInfo, processingWaitInterval, processingWaitTotal); err != nil {
-		return err
+		return false, err
 	}
 
 	vmexport, err := getVirtualMachineExport(client, vmeInfo)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if vmexport == nil {
-		return fmt.Errorf("unable to get '%s/%s' VirtualMachineExport", vmeInfo.Namespace, vmeInfo.Name)
+		return false, fmt.Errorf("unable to get '%s/%s' VirtualMachineExport", vmeInfo.Namespace, vmeInfo.Name)
 	}
 
+	// Grab the VM Manifest and display it.
 	if vmeInfo.ExportManifest {
-		// Grab the VM Manifest and display it.
-		if err := getVirtualMachineManifest(client, vmexport, vmeInfo); err != nil {
-			return err
-		}
-	} else {
-		// Download the exported volume
-		if err := downloadVolume(client, vmexport, vmeInfo); err != nil {
-			return err
-		}
+		return getVirtualMachineManifest(client, vmexport, vmeInfo)
 	}
-	return nil
+
+	// Download the exported volume
+	return downloadVolume(client, vmexport, vmeInfo)
 }
 
-func printRequestBody(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, vmeInfo *VMExportInfo, manifestUrl string, headers map[string]string) error {
+func printRequestBody(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, vmeInfo *VMExportInfo, manifestUrl string, headers map[string]string) (bool, error) {
 	resp, err := HandleHTTPRequest(client, vmexport, manifestUrl, vmeInfo.Insecure, vmeInfo.ServiceURL, headers)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer resp.Body.Close()
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("bad status: %s", resp.Status)
+		printToOutput("Bad status: %s\n", resp.Status)
+		return false, nil
 	}
 	bodyAll, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return false, err
 	}
 	fmt.Fprintf(vmeInfo.OutputWriter, "%s", bodyAll)
-	return nil
+	return true, nil
 }
 
-func getVirtualMachineManifest(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, vmeInfo *VMExportInfo) error {
+func getVirtualMachineManifest(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, vmeInfo *VMExportInfo) (bool, error) {
 	manifestMap, err := GetManifestUrlsFromVirtualMachineExport(vmexport, vmeInfo)
 	if err != nil {
-		return err
+		return false, err
 	}
 	headers := make(map[string]string)
 	headers[ACCEPT] = APPLICATION_YAML
 	if strings.ToLower(vmeInfo.OutputFormat) == OUTPUT_FORMAT_JSON {
 		headers[ACCEPT] = APPLICATION_JSON
 	}
-	if err := printRequestBody(client, vmexport, vmeInfo, manifestMap[exportv1.AllManifests], headers); err != nil {
-		return err
+	succeeded, err := printRequestBody(client, vmexport, vmeInfo, manifestMap[exportv1.AllManifests], headers)
+	if err != nil || !succeeded {
+		return false, err
 	}
 	if vmeInfo.IncludeSecret {
-		if err := printRequestBody(client, vmexport, vmeInfo, manifestMap[exportv1.AuthHeader], headers); err != nil {
-			return err
-		}
+		return printRequestBody(client, vmexport, vmeInfo, manifestMap[exportv1.AuthHeader], headers)
 	}
-	return nil
+	return true, nil
 }
 
 // downloadVolume handles the process of downloading the requested volume from a VirtualMachineExport
-func downloadVolume(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, vmeInfo *VMExportInfo) error {
+func downloadVolume(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, vmeInfo *VMExportInfo) (bool, error) {
 	// Extract the URL from the vmexport
 	downloadUrl, err := GetUrlFromVirtualMachineExport(vmexport, vmeInfo)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	resp, err := HandleHTTPRequest(client, vmexport, downloadUrl, vmeInfo.Insecure, vmeInfo.ServiceURL, nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer resp.Body.Close()
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("bad status: %s", resp.Status)
+		printToOutput("Bad status: %s\n", resp.Status)
+		return false, nil
 	}
 
 	// Lastly, copy the file to the expected output
 	if err := copyFileWithProgressBar(vmeInfo.OutputWriter, resp, vmeInfo.Decompress); err != nil {
-		return err
+		return false, err
 	}
 
 	printToOutput("Download finished succesfully\n")
 
-	return nil
+	return true, nil
 }
 
 // shouldDeleteVMExport decides wether we should retain or delete a VMExport after a download. If delete/retain are not explicitly specified,

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -243,7 +243,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err.Error()).Should(ContainSubstring(expectedError))
 		})
 
-		It("VirtualMachineExport download fails if the server returns a bad status", func() {
+		It("VirtualMachineExport retries until failure if the server returns a bad status", func() {
 			testInit(http.StatusInternalServerError)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
@@ -258,7 +258,7 @@ var _ = Describe("vmexport", func() {
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(Equal("bad status: 500 Internal Server Error"))
+			Expect(err.Error()).Should(Equal("retry count reached, exiting unsuccesfully"))
 		})
 
 		DescribeTable("Bad flag combination", func(errString string, args ...string) {

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -56,6 +56,10 @@ var _ = Describe("vmexport", func() {
 
 	})
 
+	defaultHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
 	setflag := func(flag, parameter string) string {
 		return fmt.Sprintf("%s=%s", flag, parameter)
 	}
@@ -79,16 +83,14 @@ var _ = Describe("vmexport", func() {
 		})
 	}
 
-	testInit := func(statusCode int) {
+	testInit := func(handlerFunc func(w http.ResponseWriter, r *http.Request)) {
 		kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().StorageV1().Return(kubeClient.StorageV1()).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineExport(metav1.NamespaceDefault).Return(vmExportClient.ExportV1beta1().VirtualMachineExports(metav1.NamespaceDefault)).AnyTimes()
 
 		addDefaultReactors()
 
-		server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(statusCode)
-		}))
+		server = httptest.NewTLSServer(http.HandlerFunc(handlerFunc))
 
 		virtctlvmexport.ExportProcessingComplete = utils.WaitExportCompleteDefault
 		virtctlvmexport.SetHTTPClientCreator(func(*http.Transport, bool) *http.Client {
@@ -109,7 +111,7 @@ var _ = Describe("vmexport", func() {
 
 	Context("VMExport fails", func() {
 		It("VirtualMachineExport already exists when using 'create'", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			utils.HandleVMExportGet(vmExportClient, vmexport, vmexportName)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"))
@@ -119,7 +121,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport doesn't exist when using 'download' without source type", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.OUTPUT_FLAG, "output.img"))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
@@ -127,7 +129,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport processing fails when using 'download'", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			virtctlvmexport.ExportProcessingComplete = utils.WaitExportCompleteError
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"), setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
@@ -136,7 +138,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when there's no volume available", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus(nil, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
@@ -149,7 +151,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when the volumes have a different name than expected", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -171,7 +173,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when there are multiple volumes and no volume name has been specified", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -193,7 +195,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when no format is available", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{{Name: volumeName}}, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
@@ -206,7 +208,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when the only available format is incompatible with download", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -224,7 +226,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when the secret token is not attainable", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -244,7 +246,9 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport retries until failure if the server returns a bad status", func() {
-			testInit(http.StatusInternalServerError)
+			testInit(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			})
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -255,14 +259,39 @@ var _ = Describe("vmexport", func() {
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 			utils.HandleSecretGet(kubeClient, secretName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.RETRY_FLAG, "2"))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal("retry count reached, exiting unsuccesfully"))
 		})
 
+		It("VirtualMachineExport succeeds after retrying due to bad status", func() {
+			count := 0
+			testInit(func(w http.ResponseWriter, r *http.Request) {
+				if count == 0 {
+					w.WriteHeader(http.StatusInternalServerError)
+				} else {
+					w.WriteHeader(http.StatusOK)
+				}
+				count++
+			})
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
+			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
+				{
+					Name:    volumeName,
+					Formats: utils.GetExportVolumeFormat(server.URL, exportv1.KubeVirtRaw),
+				},
+			}, secretName)
+			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
+			utils.HandleSecretGet(kubeClient, secretName)
+
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.RETRY_FLAG, "2"))
+			err := cmd()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		DescribeTable("Bad flag combination", func(errString string, args ...string) {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			args = append([]string{commandName}, args...)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
 			err := cmd()
@@ -274,7 +303,7 @@ var _ = Describe("vmexport", func() {
 		)
 
 		DescribeTable("Invalid arguments/flags", func(errString string, args ...string) {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			args = append([]string{commandName}, args...)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
 			err := cmd()
@@ -304,7 +333,7 @@ var _ = Describe("vmexport", func() {
 
 	Context("VMExport succeeds", func() {
 		BeforeEach(func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 		})
 
 		// Create tests
@@ -324,7 +353,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport doesn't exist when using 'delete'", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DELETE, vmexportName)
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
@@ -432,7 +461,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download succeeds when the volume has a different name than expected but there's only one volume", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -449,7 +478,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download succeeds when there's only one volume and no --volume has been specified", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -572,7 +601,7 @@ var _ = Describe("vmexport", func() {
 
 		BeforeEach(func() {
 			orgHttpFunc = virtctlvmexport.HandleHTTPRequest
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 		})
 
 		AfterEach(func() {
@@ -720,7 +749,7 @@ var _ = Describe("vmexport", func() {
 
 		BeforeEach(func() {
 			orgHttpFunc = virtctlvmexport.HandleHTTPRequest
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme = utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

An issue with the hotplug pod termination/export pod creation caused the memory dump to lack sufficient permissions to be manipulated by the server. This uncommon bug is usually solved automatically when restarting the exporter pod. 

This Pull Request introduces the two following changes:

- Improves handling of error cases in export server so we return appropriate status codes when the server lacks permission to read the files. The server will also shut down if it lacks open file permissions during initialization. The pod will be recreated automatically by the export controller.
- Adds a new flag in the vmexport client so we can specify the number of download retries if the server returns a bad status, helping to mitigate the previously described bug.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-39141


<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Implement retry mechanism in export server and vmexport
```

