### PR TITLE
Add test IDs for tests

### DIFF
--- a/tests/hotplug/affinity.go
+++ b/tests/hotplug/affinity.go
@@ -100,7 +100,7 @@ var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.S
 			Expect(err).ToNot(HaveOccurred())
 		}
 
-		It("should successfully update node selector", func() {
+		It("[test_id:11208]should successfully update node selector", func() {
 
 			By("Creating a running VM")
 			options := libnet.WithMasqueradeNetworking()
@@ -159,7 +159,7 @@ var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.S
 			}, 240*time.Second, time.Second).Should(BeTrue())
 
 		})
-		It("should successfully update node affinity", func() {
+		It("[test_id:11209]should successfully update node affinity", func() {
 
 			By("Creating a running VM")
 			vmi := libvmifact.NewAlpineWithTestTooling(

--- a/tests/hotplug/rolloutstrategy.go
+++ b/tests/hotplug/rolloutstrategy.go
@@ -54,7 +54,7 @@ var _ = Describe("[Serial][sig-compute]VM Rollout Strategy", decorators.SigCompu
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		})
 
-		It("should set RestartRequired when changing any spec field", func() {
+		It("[test_id:11207]should set RestartRequired when changing any spec field", func() {
 			By("Creating a VM with CPU topology")
 			vmi := libvmifact.NewCirros()
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Add polarion test IDs for RollOutStrategy and Affinity test cases

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

