### PR TITLE
Remove NewRandomVMIWithEphemeralDisk from tests/utils.go

### DIFF
--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -37,6 +37,7 @@ func WithCloudInitNoCloudUserData(data string) Option {
 		volume := getVolume(vmi, cloudInitDiskName)
 		volume.CloudInitNoCloud.UserData = data
 		volume.CloudInitNoCloud.UserDataBase64 = ""
+		volume.CloudInitNoCloud.UserDataSecretRef = nil
 	}
 }
 
@@ -49,6 +50,19 @@ func WithCloudInitNoCloudEncodedUserData(data string) Option {
 		encodedData := base64.StdEncoding.EncodeToString([]byte(data))
 		volume.CloudInitNoCloud.UserData = ""
 		volume.CloudInitNoCloud.UserDataBase64 = encodedData
+		volume.CloudInitNoCloud.UserDataSecretRef = nil
+	}
+}
+
+// WithCloudInitNoCloudUserDataSecretName adds cloud-init no-cloud base64-encoded user data secret
+func WithCloudInitNoCloudUserDataSecretName(secretName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		volume.CloudInitNoCloud.UserData = ""
+		volume.CloudInitNoCloud.UserDataBase64 = ""
+		volume.CloudInitNoCloud.UserDataSecretRef = &k8scorev1.LocalObjectReference{Name: secretName}
 	}
 }
 
@@ -96,6 +110,67 @@ func WithCloudInitConfigDriveUserData(data string) Option {
 		volume := getVolume(vmi, cloudInitDiskName)
 		volume.CloudInitConfigDrive.UserData = data
 		volume.CloudInitConfigDrive.UserDataBase64 = ""
+		volume.CloudInitConfigDrive.UserDataSecretRef = nil
+	}
+}
+
+// WithCloudInitConfigDriveEncodedUserData adds cloud-init config-drive user data.
+func WithCloudInitConfigDriveEncodedUserData(data string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		volume.CloudInitConfigDrive.UserData = ""
+		volume.CloudInitConfigDrive.UserDataBase64 = base64.StdEncoding.EncodeToString([]byte(data))
+		volume.CloudInitConfigDrive.UserDataSecretRef = nil
+	}
+}
+
+// WithCloudInitConfigDriveUserDataSecretName adds cloud-init config-drive user data secret.
+func WithCloudInitConfigDriveUserDataSecretName(secretName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		volume.CloudInitConfigDrive.UserData = ""
+		volume.CloudInitConfigDrive.UserDataBase64 = ""
+		volume.CloudInitConfigDrive.UserDataSecretRef = &k8scorev1.LocalObjectReference{Name: secretName}
+	}
+}
+
+// WithCloudInitConfigDriveNetworkData adds cloud-init config-drive network data.
+func WithCloudInitConfigDriveNetworkData(data string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		volume.CloudInitConfigDrive.NetworkData = data
+		volume.CloudInitConfigDrive.NetworkDataBase64 = ""
+		volume.CloudInitConfigDrive.NetworkDataSecretRef = nil
+	}
+}
+
+// WithCloudInitConfigDriveEncodedNetworkData adds cloud-init config-drive encoded network data.
+func WithCloudInitConfigDriveEncodedNetworkData(data string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		volume.CloudInitConfigDrive.NetworkData = ""
+		volume.CloudInitConfigDrive.NetworkDataBase64 = base64.StdEncoding.EncodeToString([]byte(data))
+		volume.CloudInitConfigDrive.NetworkDataSecretRef = nil
+	}
+}
+
+// WithCloudInitConfigDriveNetworkDataSecretName adds cloud-init config-drive encoded network secret.
+func WithCloudInitConfigDriveNetworkDataSecretName(secretName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, cloudInitDiskName)
+		volume.CloudInitConfigDrive.NetworkData = ""
+		volume.CloudInitConfigDrive.NetworkDataBase64 = ""
+		volume.CloudInitConfigDrive.NetworkDataSecretRef = &k8scorev1.LocalObjectReference{Name: secretName}
 	}
 }
 

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -50,7 +50,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/testsuite"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -152,16 +151,10 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		var vm *v1.VirtualMachine
 		resource := "virtualmachines"
 
-		newVM := func() *v1.VirtualMachine {
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
-			vm := libvmi.NewVirtualMachine(vmi)
-			return vm
-		}
-
 		BeforeEach(func() {
-			vm = newVM()
-
+			vmi := libvmifact.NewCirros()
+			vm = libvmi.NewVirtualMachine(vmi)
+			vm.Namespace = testsuite.GetTestNamespace(vmi)
 		})
 
 		It("[test_id:7631]create a VirtualMachine", func() {
@@ -543,10 +536,9 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		BeforeEach(func() {
 			tests.EnableFeatureGate(virtconfig.SnapshotGate)
 
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
+			vmi := libvmifact.NewCirros()
 			vm := libvmi.NewVirtualMachine(vmi)
-			_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+			_, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			snap = newVMSnapshot(vm)
@@ -634,10 +626,9 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		BeforeEach(func() {
 			tests.EnableFeatureGate(virtconfig.SnapshotGate)
 
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
+			vmi := libvmifact.NewCirros()
 			vm := libvmi.NewVirtualMachine(vmi)
-			_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+			_, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			snap := newVMSnapshot(vm)

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -50,13 +50,25 @@ func NewFedora(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 // NewCirros instantiates a new CirrOS based VMI configuration
 func NewCirros(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	// Supplied with no user data, Cirros image takes 230s to allow login
-	withNonEmptyUserData := libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
+	cirrosOpts := []libvmi.Option{
+		libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n"),
+	}
 
+	cirrosOpts = append(cirrosOpts, opts...)
+
+	return NewCirrosNoUserData(cirrosOpts...)
+}
+
+// NewCirrosNoUserData instantiates a new CirrOS based VMI configuration; This function does not add user data. This is
+// not recommended as supplied with no user data, Cirros image takes 230s to allow login.
+// Use this method only if you want to add user data manually.
+func NewCirrosNoUserData(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
+	// Supplied with no user data, Cirros image takes 230s to allow login
 	cirrosOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
-		withNonEmptyUserData,
 		libvmi.WithResourceMemory(cirrosMemory()),
 	}
+
 	cirrosOpts = append(cirrosOpts, opts...)
 	return libvmi.New(cirrosOpts...)
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -290,15 +290,6 @@ func AddEphemeralDisk(vmi *v1.VirtualMachineInstance, name string, bus v1.DiskBu
 	return vmi
 }
 
-// NewRandomVMIWithEphemeralDiskAndUserdata
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
-	AddUserData(vmi, "disk1", userData)
-	return vmi
-}
-
 // AddUserData
 //
 // Deprecated: Use libvmi

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -299,15 +299,6 @@ func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData st
 	return vmi
 }
 
-// NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(containerImage, userData, networkData string, b64encode bool) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
-	AddCloudInitConfigDriveData(vmi, "disk1", userData, networkData, b64encode)
-	return vmi
-}
-
 // AddUserData
 //
 // Deprecated: Use libvmi

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -247,25 +247,6 @@ func cirrosMemory() string {
 	return "128Mi"
 }
 
-// NewRandomVMIWithEphemeralDisk
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInstance {
-	opts := []libvmi.Option{
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-		libvmi.WithResourceMemory(cirrosMemory()),
-		libvmi.WithContainerDisk("disk0", containerImage),
-	}
-	if containerImage == cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling) {
-		opts = append(
-			[]libvmi.Option{libvmi.WithRng()},
-			opts...)
-	}
-	return libvmi.New(opts...)
-}
-
 // AddEphemeralDisk
 //
 // Deprecated: Use libvmi

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -299,15 +299,6 @@ func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData st
 	return vmi
 }
 
-// NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(containerImage string, userData string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
-	AddCloudInitConfigDriveData(vmi, "disk1", userData, "", false)
-	return vmi
-}
-
 // NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData
 //
 // Deprecated: Use libvmi directly

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -180,7 +180,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Context("with cloudInitConfigDrive userDataBase64 source", func() {
 			It("[test_id:3178]should have cloud-init data", func() {
 				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+				vmi := libvmifact.NewCirrosNoUserData(libvmi.WithCloudInitConfigDriveEncodedUserData(userData))
 
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
@@ -293,16 +293,16 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			}
 
 			It("[test_id:1617] with cloudInitNoCloud userData source", func() {
-				vmi := libvmifact.NewCirros(
+				vmi := libvmifact.NewCirrosNoUserData(
 					libvmi.WithCloudInitNoCloudUserData(userData),
 				)
 
 				runTest(vmi, cloudinit.DataSourceNoCloud)
 			})
 			It("[test_id:3180] with cloudInitConfigDrive userData source", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros),
-					userData)
+				vmi := libvmifact.NewCirrosNoUserData(
+					libvmi.WithCloudInitConfigDriveEncodedUserData(userData),
+				)
 				runTest(vmi, cloudinit.DataSourceConfigDrive)
 			})
 		})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2409,11 +2409,17 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			// use a small disk for the other ones
 			containerImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
 			// virtio - added by NewRandomVMIWithEphemeralDisk
-			vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, "echo hi!\n")
+			vmi = libvmifact.NewCirros(libvmi.WithContainerDisk("disk2", containerImage))
 			// sata
-			tests.AddEphemeralDisk(vmi, "disk2", v1.DiskBusSATA, containerImage)
+			for i := range vmi.Spec.Domain.Devices.Disks {
+				if vmi.Spec.Domain.Devices.Disks[i].Name == "disk2" {
+					vmi.Spec.Domain.Devices.Disks[i].Disk.Bus = v1.DiskBusSATA
+					break
+				}
+			}
 			// NOTE: we have one disk per bus, so we expect vda, sda
 		})
+
 		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string) {
 			err := console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},


### PR DESCRIPTION
### What this PR does
#### Before this PR
The `NewRandomVMIWithEphemeralDisk` is deprecated. After merging several PRs to stop using it, it's now only called from 3 other deprecated tests/utils.go's deprecated functions:
* `NewRandomVMIWithEphemeralDiskAndUserdata`
* `NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata`
* `NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData`

 Now it's the time to finally remove these 4 functions by first replacing all the calls for the utils functions with libvmi functions.

#### After this PR
4 deprecated util functions removed, and replaced with libvmi functionms.

For the implementation of this change, new factory function added to the `libvmifact` package:
* `NewCirrosNoUserData` - this function creates a Cirros vmi, with no user-data, in order to user-defined user-data. The reason for that is that the existing `NewCirros` already adds CloudInitNoCloud UserData volume.
This makes it hard to add other user-data volume, like CloudInitConfigDrive.

In addition, several user-data related libvmi options were added:
* `WithCloudInitNoCloudUserDataSecretName`
* `WithCloudInitConfigDriveEncodedUserData`
* `WithCloudInitConfigDriveUserDataSecretName`
* `WithCloudInitConfigDriveNetworkData`
* `WithCloudInitConfigDriveEncodedNetworkData`
* `WithCloudInitConfigDriveNetworkDataSecretName`

Now we can use the `NewCirrosNoUserData` factory, together with one of the new (or existing) user-data options; e.g.
```golang
vmi := libvmifact.NewCirrosNoUserData(libvmi.WithCloudInitNoCloudUserDataSecretName(secretName))
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

