### PR TITLE
client-go: Move custom <resource> struct methods to <resource>_expansion files

### DIFF
--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/subresources:go_default_library",
         "//vendor/github.com/gorilla/websocket:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/kubevirt_expansion.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/kubevirt_expansion.go
@@ -33,6 +33,5 @@ type KubeVirtExpansion interface {
 }
 
 func (c *kubeVirts) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) (*v1.KubeVirt, error) {
-	// TODO not implemented yet
-	return nil, nil
+	return c.Patch(ctx, name, pt, data, patchOptions, "status")
 }

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachine_expansion.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachine_expansion.go
@@ -21,10 +21,17 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	v1 "kubevirt.io/api/core/v1"
+)
+
+const (
+	cannotMarshalJSONErrFmt = "cannot Marshal to json: %s"
+	vmSubresourceURLFmt     = "/apis/subresources.kubevirt.io/%s"
 )
 
 type VirtualMachineExpansion interface {
@@ -44,66 +51,183 @@ type VirtualMachineExpansion interface {
 }
 
 func (c *virtualMachines) GetWithExpandedSpec(ctx context.Context, name string) (*v1.VirtualMachine, error) {
-	// TODO not implemented yet
-	return nil, nil
+	newVm := &v1.VirtualMachine{}
+	err := c.client.Get().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("expand-spec").
+		Do(ctx).
+		Into(newVm)
+	newVm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
+	return newVm, err
 }
 
 func (c *virtualMachines) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) (*v1.VirtualMachine, error) {
-	// TODO not implemented yet
-	return nil, nil
+	return c.Patch(ctx, name, pt, data, patchOptions, "status")
 }
 
 func (c *virtualMachines) Restart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(restartOptions)
+	if err != nil {
+		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
+	}
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("restart").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) ForceRestart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(restartOptions)
+	if err != nil {
+		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
+	}
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("restart").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) Start(ctx context.Context, name string, startOptions *v1.StartOptions) error {
-	// TODO not implemented yet
-	return nil
+	optsJson, err := json.Marshal(startOptions)
+	if err != nil {
+		return err
+	}
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("start").
+		Body(optsJson).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) Stop(ctx context.Context, name string, stopOptions *v1.StopOptions) error {
-	// TODO not implemented yet
-	return nil
+	optsJson, err := json.Marshal(stopOptions)
+	if err != nil {
+		return err
+	}
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("stop").
+		Body(optsJson).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) ForceStop(ctx context.Context, name string, stopOptions *v1.StopOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(stopOptions)
+	if err != nil {
+		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
+	}
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("stop").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) Migrate(ctx context.Context, name string, migrateOptions *v1.MigrateOptions) error {
-	// TODO not implemented yet
-	return nil
+	optsJson, err := json.Marshal(migrateOptions)
+	if err != nil {
+		return err
+	}
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("migrate").
+		Body(optsJson).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(addVolumeOptions)
+	if err != nil {
+		return err
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("addvolume").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(removeVolumeOptions)
+	if err != nil {
+		return err
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("removevolume").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) PortForward(name string, port int, protocol string) (StreamInterface, error) {
 	// TODO not implemented yet
-	return nil, nil
+	//  requires clientConfig
+	return nil, fmt.Errorf("PortForward is not implemented yet in generated client")
 }
 
 func (c *virtualMachines) MemoryDump(ctx context.Context, name string, memoryDumpRequest *v1.VirtualMachineMemoryDumpRequest) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(memoryDumpRequest)
+	if err != nil {
+		return err
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("memorydump").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachines) RemoveMemoryDump(ctx context.Context, name string) error {
-	// TODO not implemented yet
-	return nil
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachines").
+		Name(name).
+		SubResource("removememorydump").
+		Do(ctx).
+		Error()
 }

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachineinstance_expansion.go
@@ -21,10 +21,17 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
 )
+
+const vmiSubresourceURL = "/apis/subresources.kubevirt.io/%s"
 
 type SerialConsoleOptions struct {
 	ConnectionTimeout time.Duration
@@ -55,100 +62,303 @@ type VirtualMachineInstanceExpansion interface {
 
 func (c *virtualMachineInstances) SerialConsole(name string, options *SerialConsoleOptions) (StreamInterface, error) {
 	// TODO not implemented yet
-	return nil, nil
+	//  requires clientConfig
+	return nil, fmt.Errorf("SerialConsole is not implemented yet in generated client")
 }
 
 func (c *virtualMachineInstances) USBRedir(vmiName string) (StreamInterface, error) {
 	// TODO not implemented yet
-	return nil, nil
+	//  requires clientConfig
+	return nil, fmt.Errorf("USBRedir is not implemented yet in generated client")
 }
 
 func (c *virtualMachineInstances) VNC(name string) (StreamInterface, error) {
 	// TODO not implemented yet
-	return nil, nil
+	//  requires clientConfig
+	return nil, fmt.Errorf("VNC is not implemented yet in generated client")
 }
 
 func (c *virtualMachineInstances) Screenshot(ctx context.Context, name string, options *v1.ScreenshotOptions) ([]byte, error) {
-	// TODO not implemented yet
-	return nil, nil
+	moveCursor := "false"
+	if options.MoveCursor == true {
+		moveCursor = "true"
+	}
+	res := c.client.Get().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("vnc", "screenshot").
+		Param("moveCursor", moveCursor).
+		Do(ctx)
+
+	raw, err := res.Raw()
+	if err != nil {
+		return nil, res.Error()
+	}
+
+	return raw, nil
 }
 
 func (c *virtualMachineInstances) PortForward(name string, port int, protocol string) (StreamInterface, error) {
 	// TODO not implemented yet
-	return nil, nil
+	//  requires clientConfig
+	return nil, fmt.Errorf("PortForward is not implemented yet in generated client")
 }
 
 func (c *virtualMachineInstances) Pause(ctx context.Context, name string, pauseOptions *v1.PauseOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(pauseOptions)
+	if err != nil {
+		return err
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("pause").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachineInstances) Unpause(ctx context.Context, name string, unpauseOptions *v1.UnpauseOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(unpauseOptions)
+	if err != nil {
+		return err
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("unpause").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachineInstances) Freeze(ctx context.Context, name string, unfreezeTimeout time.Duration) error {
-	// TODO not implemented yet
-	return nil
+	log.Log.Infof("Freeze VMI %s", name)
+	freezeUnfreezeTimeout := &v1.FreezeUnfreezeTimeout{
+		UnfreezeTimeout: &metav1.Duration{
+			Duration: unfreezeTimeout,
+		},
+	}
+
+	body, err := json.Marshal(freezeUnfreezeTimeout)
+	if err != nil {
+		return err
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("freeze").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachineInstances) Unfreeze(ctx context.Context, name string) error {
-	// TODO not implemented yet
-	return nil
+	log.Log.Infof("Unfreeze VMI %s", name)
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("unfreeze").
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachineInstances) SoftReboot(ctx context.Context, name string) error {
-	// TODO not implemented yet
-	return nil
+	log.Log.Infof("SoftReboot VMI")
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("softreboot").
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachineInstances) GuestOsInfo(ctx context.Context, name string) (v1.VirtualMachineInstanceGuestAgentInfo, error) {
-	// TODO not implemented yet
-	return v1.VirtualMachineInstanceGuestAgentInfo{}, nil
+	guestInfo := v1.VirtualMachineInstanceGuestAgentInfo{}
+	// WORKAROUND:
+	// When doing c.client.Get().RequestURI(uri).Do(ctx).Into(guestInfo)
+	// k8s client-go requires the object to have metav1.ObjectMeta inlined and deepcopy generated
+	// without deepcopy the Into does not work.
+	// With metav1.ObjectMeta added the openapi validation fails on pkg/virt-api/api.go:310
+	// When returning object the openapi schema validation fails on invalid type field for
+	// metav1.ObjectMeta.CreationTimestamp of type time (the schema validation fails, not the object validation).
+	// In our schema we implemented workaround to have multiple types for this field (null, string), which is causing issues
+	// with deserialization.
+	// The issue popped up for this code since this is the first time anything is returned.
+	//
+	// The issue is present because KubeVirt have to support multiple k8s version. In newer k8s version (1.17+)
+	// this issue should be solved.
+	// This workaround can go away once the least supported k8s version is the working one.
+	// The issue has been described in: https://github.com/kubevirt/kubevirt/issues/3059
+	// Will be replaced by:
+	// 	err := c.client.Get().
+	//		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+	//		Namespace(c.ns).
+	//		Resource("virtualmachineinstances").
+	//		Name(name).
+	//		SubResource("guestosinfo").
+	//		Do(ctx).
+	//		Into(&guestInfo)
+	res := c.client.Get().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("guestosinfo").
+		Do(ctx)
+	rawInfo, err := res.Raw()
+	if err != nil {
+		log.Log.Errorf("cannot retrieve GuestOSInfo: %s", err.Error())
+		return guestInfo, err
+	}
+
+	err = json.Unmarshal(rawInfo, &guestInfo)
+	if err != nil {
+		log.Log.Errorf("cannot unmarshal GuestOSInfo response: %s", err.Error())
+	}
+
+	return guestInfo, err
 }
 
 func (c *virtualMachineInstances) UserList(ctx context.Context, name string) (v1.VirtualMachineInstanceGuestOSUserList, error) {
-	// TODO not implemented yet
-	return v1.VirtualMachineInstanceGuestOSUserList{}, nil
+	userList := v1.VirtualMachineInstanceGuestOSUserList{}
+	err := c.client.Get().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("userlist").
+		Do(ctx).
+		Into(&userList)
+	return userList, err
 }
 
 func (c *virtualMachineInstances) FilesystemList(ctx context.Context, name string) (v1.VirtualMachineInstanceFileSystemList, error) {
-	// TODO not implemented yet
-	return v1.VirtualMachineInstanceFileSystemList{}, nil
+	fsList := v1.VirtualMachineInstanceFileSystemList{}
+	err := c.client.Get().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("filesystemlist").
+		Do(ctx).
+		Into(&fsList)
+
+	return fsList, err
 }
 
 func (c *virtualMachineInstances) AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(addVolumeOptions)
+	if err != nil {
+		return err
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("addvolume").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachineInstances) RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(removeVolumeOptions)
+	if err != nil {
+		return err
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("removevolume").
+		Body(body).
+		Do(ctx).
+		Error()
 }
 
 func (c *virtualMachineInstances) VSOCK(name string, options *v1.VSOCKOptions) (StreamInterface, error) {
 	// TODO not implemented yet
-	return nil, nil
+	//  requires clientConfig
+	return nil, fmt.Errorf("VSOCK is not implemented yet in generated client")
 }
 
 func (c *virtualMachineInstances) SEVFetchCertChain(ctx context.Context, name string) (v1.SEVPlatformInfo, error) {
-	// TODO not implemented yet
-	return v1.SEVPlatformInfo{}, nil
+	sevPlatformInfo := v1.SEVPlatformInfo{}
+	err := c.client.Get().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("sev", "fetchcertchain").
+		Do(context.Background()).
+		Into(&sevPlatformInfo)
+
+	return sevPlatformInfo, err
 }
 
 func (c *virtualMachineInstances) SEVQueryLaunchMeasurement(ctx context.Context, name string) (v1.SEVMeasurementInfo, error) {
-	// TODO not implemented yet
-	return v1.SEVMeasurementInfo{}, nil
+	sevMeasurementInfo := v1.SEVMeasurementInfo{}
+	err := c.client.Get().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("sev", "querylaunchmeasurement").
+		Do(context.Background()).
+		Into(&sevMeasurementInfo)
+
+	return sevMeasurementInfo, err
 }
 
 func (c *virtualMachineInstances) SEVSetupSession(ctx context.Context, name string, sevSessionOptions *v1.SEVSessionOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(sevSessionOptions)
+	if err != nil {
+		return fmt.Errorf("cannot Marshal to json: %s", err)
+	}
+
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("sev", "setupsession").
+		Body(body).
+		Do(context.Background()).
+		Error()
 }
 
 func (c *virtualMachineInstances) SEVInjectLaunchSecret(ctx context.Context, name string, sevSecretOptions *v1.SEVSecretOptions) error {
-	// TODO not implemented yet
-	return nil
+	body, err := json.Marshal(sevSecretOptions)
+	if err != nil {
+		return fmt.Errorf("cannot Marshal to json: %s", err)
+	}
+	return c.client.Put().
+		AbsPath(fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion)).
+		Namespace(c.ns).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("sev", "injectlaunchsecret").
+		Body(body).
+		Do(context.Background()).
+		Error()
 }

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachineinstancereplicaset_expansion.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachineinstancereplicaset_expansion.go
@@ -35,16 +35,30 @@ type VirtualMachineInstanceReplicaSetExpansion interface {
 }
 
 func (c *virtualMachineInstanceReplicaSets) GetScale(ctx context.Context, replicaSetName string, options metav1.GetOptions) (*autov1.Scale, error) {
-	// TODO not implemented yet
-	return nil, nil
+	result := &autov1.Scale{}
+	err := c.client.Get().
+		Namespace(c.ns).
+		Resource("virtualmachineinstancereplicasets").
+		Name(replicaSetName).
+		SubResource("scale").
+		Do(ctx).
+		Into(result)
+	return result, err
 }
 
 func (c *virtualMachineInstanceReplicaSets) UpdateScale(ctx context.Context, replicaSetName string, scale *autov1.Scale) (*autov1.Scale, error) {
-	// TODO not implemented yet
-	return nil, nil
+	result := &autov1.Scale{}
+	err := c.client.Put().
+		Namespace(c.ns).
+		Resource("virtualmachineinstancereplicasets").
+		Name(replicaSetName).
+		SubResource("scale").
+		Body(scale).
+		Do(ctx).
+		Into(result)
+	return result, err
 }
 
 func (c *virtualMachineInstanceReplicaSets) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*v1.VirtualMachineInstanceReplicaSet, error) {
-	// TODO not implemented yet
-	return nil, nil
+	return c.Patch(ctx, name, pt, data, opts, "status")
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned:go_default_library",
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/version:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -85,10 +85,6 @@ func (o *kv) Patch(ctx context.Context, name string, pt types.PatchType, data []
 	return o.KubeVirtInterface.Patch(ctx, name, pt, data, patchOptions, subresources...)
 }
 
-func (o *kv) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions k8smetav1.PatchOptions) (result *v1.KubeVirt, err error) {
-	return o.Patch(ctx, name, pt, data, patchOptions, "status")
-}
-
 func (o *kv) UpdateStatus(ctx context.Context, kv *v1.KubeVirt, opts k8smetav1.UpdateOptions) (result *v1.KubeVirt, err error) {
 	result, err = o.KubeVirtInterface.UpdateStatus(ctx, kv, opts)
 	result.SetGroupVersionKind(v1.KubeVirtGroupVersionKind)

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset.go
@@ -22,7 +22,6 @@ package kubecli
 import (
 	"context"
 
-	autov1 "k8s.io/api/autoscaling/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -45,31 +44,6 @@ type rc struct {
 	restClient *rest.RESTClient
 	namespace  string
 	resource   string
-}
-
-func (v *rc) GetScale(ctx context.Context, replicaSetName string, options k8smetav1.GetOptions) (result *autov1.Scale, err error) {
-	result = &autov1.Scale{}
-	err = v.restClient.Get().
-		Namespace(v.namespace).
-		Resource(v.resource).
-		Name(replicaSetName).
-		SubResource("scale").
-		Do(ctx).
-		Into(result)
-	return
-}
-
-func (v *rc) UpdateScale(ctx context.Context, replicaSetName string, scale *autov1.Scale) (result *autov1.Scale, err error) {
-	result = &autov1.Scale{}
-	err = v.restClient.Put().
-		Namespace(v.namespace).
-		Resource(v.resource).
-		Name(replicaSetName).
-		SubResource("scale").
-		Body(scale).
-		Do(ctx).
-		Into(result)
-	return
 }
 
 func (v *rc) Get(ctx context.Context, name string, options k8smetav1.GetOptions) (replicaset *v1.VirtualMachineInstanceReplicaSet, err error) {
@@ -104,10 +78,6 @@ func (v *rc) Delete(ctx context.Context, name string, options k8smetav1.DeleteOp
 
 func (v *rc) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions, subresources ...string) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
 	return v.VirtualMachineInstanceReplicaSetInterface.Patch(ctx, name, pt, data, opts, subresources...)
-}
-
-func (v *rc) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, opts k8smetav1.PatchOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error) {
-	return v.Patch(ctx, name, pt, data, opts, "status")
 }
 
 func (v *rc) UpdateStatus(ctx context.Context, replicaset *v1.VirtualMachineInstanceReplicaSet, opts k8smetav1.UpdateOptions) (result *v1.VirtualMachineInstanceReplicaSet, err error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vm.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm.go
@@ -21,8 +21,6 @@ package kubecli
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/url"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,11 +29,6 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	kvcorev1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1"
-)
-
-const (
-	cannotMarshalJSONErrFmt = "Cannot Marshal to json: %s"
-	vmSubresourceURLFmt     = "/apis/subresources.kubevirt.io/%s/namespaces/%s/virtualmachines/%s/%s"
 )
 
 func (k *kubevirt) VirtualMachine(namespace string) VirtualMachineInterface {
@@ -72,19 +65,6 @@ func (v *vm) Get(ctx context.Context, name string, options k8smetav1.GetOptions)
 	return newVm, err
 }
 
-func (v *vm) GetWithExpandedSpec(ctx context.Context, name string) (*v1.VirtualMachine, error) {
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "expand-spec")
-	newVm := &v1.VirtualMachine{}
-	err := v.restClient.Get().
-		AbsPath(uri).
-		Do(ctx).
-		Into(newVm)
-
-	newVm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
-
-	return newVm, err
-}
-
 // Update the VirtualMachine instance in the cluster in given namespace
 func (v *vm) Update(ctx context.Context, vm *v1.VirtualMachine, opts k8smetav1.UpdateOptions) (*v1.VirtualMachine, error) {
 	updatedVm, err := v.VirtualMachineInterface.Update(ctx, vm, opts)
@@ -112,110 +92,10 @@ func (v *vm) Patch(ctx context.Context, name string, pt types.PatchType, data []
 	return v.VirtualMachineInterface.Patch(ctx, name, pt, data, patchOptions, subresources...)
 }
 
-func (v *vm) PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions k8smetav1.PatchOptions) (result *v1.VirtualMachine, err error) {
-	return v.Patch(ctx, name, pt, data, patchOptions, "status")
-}
-
 func (v *vm) UpdateStatus(ctx context.Context, vmi *v1.VirtualMachine, opts k8smetav1.UpdateOptions) (result *v1.VirtualMachine, err error) {
 	result, err = v.VirtualMachineInterface.UpdateStatus(ctx, vmi, opts)
 	result.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
 	return
-}
-
-func (v *vm) Restart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error {
-	body, err := json.Marshal(restartOptions)
-	if err != nil {
-		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
-	}
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "restart")
-	return v.restClient.Put().AbsPath(uri).Body(body).Do(ctx).Error()
-}
-
-func (v *vm) ForceRestart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error {
-	body, err := json.Marshal(restartOptions)
-	if err != nil {
-		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
-	}
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "restart")
-	return v.restClient.Put().AbsPath(uri).Body(body).Do(ctx).Error()
-}
-
-func (v *vm) Start(ctx context.Context, name string, startOptions *v1.StartOptions) error {
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "start")
-
-	optsJson, err := json.Marshal(startOptions)
-	if err != nil {
-		return err
-	}
-	return v.restClient.Put().AbsPath(uri).Body(optsJson).Do(ctx).Error()
-}
-
-func (v *vm) Stop(ctx context.Context, name string, stopOptions *v1.StopOptions) error {
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "stop")
-	optsJson, err := json.Marshal(stopOptions)
-	if err != nil {
-		return err
-	}
-	return v.restClient.Put().AbsPath(uri).Body(optsJson).Do(ctx).Error()
-}
-
-func (v *vm) ForceStop(ctx context.Context, name string, stopOptions *v1.StopOptions) error {
-	body, err := json.Marshal(stopOptions)
-	if err != nil {
-		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
-	}
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "stop")
-	return v.restClient.Put().AbsPath(uri).Body(body).Do(ctx).Error()
-}
-
-func (v *vm) Migrate(ctx context.Context, name string, migrateOptions *v1.MigrateOptions) error {
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "migrate")
-	optsJson, err := json.Marshal(migrateOptions)
-	if err != nil {
-		return err
-	}
-	return v.restClient.Put().AbsPath(uri).Body(optsJson).Do(ctx).Error()
-}
-
-func (v *vm) MemoryDump(ctx context.Context, name string, memoryDumpRequest *v1.VirtualMachineMemoryDumpRequest) error {
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "memorydump")
-
-	JSON, err := json.Marshal(memoryDumpRequest)
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(ctx).Error()
-}
-
-func (v *vm) RemoveMemoryDump(ctx context.Context, name string) error {
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "removememorydump")
-
-	return v.restClient.Put().AbsPath(uri).Do(ctx).Error()
-}
-
-func (v *vm) AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error {
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "addvolume")
-
-	JSON, err := json.Marshal(addVolumeOptions)
-
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(ctx).Error()
-}
-
-func (v *vm) RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error {
-	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "removevolume")
-
-	JSON, err := json.Marshal(removeVolumeOptions)
-
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(ctx).Error()
 }
 
 func (v *vm) PortForward(name string, port int, protocol string) (kvcorev1.StreamInterface, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -21,7 +21,6 @@ package kubecli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -31,16 +30,12 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	v1 "kubevirt.io/api/core/v1"
 	kvcorev1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1"
-	"kubevirt.io/client-go/log"
 )
-
-const vmiSubresourceURL = "/apis/subresources.kubevirt.io/%s/namespaces/%s/virtualmachineinstances/%s/%s"
 
 func (k *kubevirt) VirtualMachineInstance(namespace string) VirtualMachineInstanceInterface {
 	return &vmis{
@@ -137,54 +132,6 @@ func (v *vmis) SerialConsole(name string, options *kvcorev1.SerialConsoleOptions
 	}
 }
 
-func (v *vmis) Freeze(ctx context.Context, name string, unfreezeTimeout time.Duration) error {
-	log.Log.Infof("Freeze VMI %s", name)
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "freeze")
-
-	freezeUnfreezeTimeout := &v1.FreezeUnfreezeTimeout{
-		UnfreezeTimeout: &metav1.Duration{
-			Duration: unfreezeTimeout,
-		},
-	}
-
-	JSON, err := json.Marshal(freezeUnfreezeTimeout)
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(ctx).Error()
-}
-
-func (v *vmis) Unfreeze(ctx context.Context, name string) error {
-	log.Log.Infof("Unfreeze VMI %s", name)
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "unfreeze")
-	return v.restClient.Put().AbsPath(uri).Do(ctx).Error()
-}
-
-func (v *vmis) SoftReboot(ctx context.Context, name string) error {
-	log.Log.Infof("SoftReboot VMI")
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "softreboot")
-	return v.restClient.Put().AbsPath(uri).Do(ctx).Error()
-}
-
-func (v *vmis) Pause(ctx context.Context, name string, pauseOptions *v1.PauseOptions) error {
-	body, err := json.Marshal(pauseOptions)
-	if err != nil {
-		return fmt.Errorf("Cannot Marshal to json: %s", err)
-	}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "pause")
-	return v.restClient.Put().AbsPath(uri).Body(body).Do(ctx).Error()
-}
-
-func (v *vmis) Unpause(ctx context.Context, name string, unpauseOptions *v1.UnpauseOptions) error {
-	body, err := json.Marshal(unpauseOptions)
-	if err != nil {
-		return fmt.Errorf("Cannot Marshal to json: %s", err)
-	}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "unpause")
-	return v.restClient.Put().AbsPath(uri).Body(body).Do(ctx).Error()
-}
-
 func (v *vmis) Get(ctx context.Context, name string, options metav1.GetOptions) (vmi *v1.VirtualMachineInstance, err error) {
 	vmi, err = v.VirtualMachineInstanceInterface.Get(ctx, name, options)
 	vmi.SetGroupVersionKind(v1.VirtualMachineInstanceGroupVersionKind)
@@ -219,97 +166,6 @@ func (v *vmis) Patch(ctx context.Context, name string, pt types.PatchType, data 
 	return v.VirtualMachineInstanceInterface.Patch(ctx, name, pt, data, patchOptions, subresources...)
 }
 
-func (v *vmis) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-	return v.VirtualMachineInstanceInterface.Watch(ctx, opts)
-}
-
-func (v *vmis) GuestOsInfo(ctx context.Context, name string) (v1.VirtualMachineInstanceGuestAgentInfo, error) {
-	guestInfo := v1.VirtualMachineInstanceGuestAgentInfo{}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "guestosinfo")
-
-	// WORKAROUND:
-	// When doing v.restClient.Get().RequestURI(uri).Do(ctx).Into(guestInfo)
-	// k8s client-go requires the object to have metav1.ObjectMeta inlined and deepcopy generated
-	// without deepcopy the Into does not work.
-	// With metav1.ObjectMeta added the openapi validation fails on pkg/virt-api/api.go:310
-	// When returning object the openapi schema validation fails on invalid type field for
-	// metav1.ObjectMeta.CreationTimestamp of type time (the schema validation fails, not the object validation).
-	// In our schema we implemented workaround to have multiple types for this field (null, string), which is causing issues
-	// with deserialization.
-	// The issue popped up for this code since this is the first time anything is returned.
-	//
-	// The issue is present because KubeVirt have to support multiple k8s version. In newer k8s version (1.17+)
-	// this issue should be solved.
-	// This workaround can go away once the least supported k8s version is the working one.
-	// The issue has been described in: https://github.com/kubevirt/kubevirt/issues/3059
-	res := v.restClient.Get().AbsPath(uri).Do(ctx)
-	rawInfo, err := res.Raw()
-	if err != nil {
-		log.Log.Errorf("Cannot retrieve GuestOSInfo: %s", err.Error())
-		return guestInfo, err
-	}
-
-	err = json.Unmarshal(rawInfo, &guestInfo)
-	if err != nil {
-		log.Log.Errorf("Cannot unmarshal GuestOSInfo response: %s", err.Error())
-	}
-
-	return guestInfo, err
-}
-
-func (v *vmis) UserList(ctx context.Context, name string) (v1.VirtualMachineInstanceGuestOSUserList, error) {
-	userList := v1.VirtualMachineInstanceGuestOSUserList{}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "userlist")
-	err := v.restClient.Get().AbsPath(uri).Do(ctx).Into(&userList)
-	return userList, err
-}
-
-func (v *vmis) FilesystemList(ctx context.Context, name string) (v1.VirtualMachineInstanceFileSystemList, error) {
-	fsList := v1.VirtualMachineInstanceFileSystemList{}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "filesystemlist")
-	err := v.restClient.Get().AbsPath(uri).Do(ctx).Into(&fsList)
-	return fsList, err
-}
-
-func (v *vmis) Screenshot(ctx context.Context, name string, screenshotOptions *v1.ScreenshotOptions) ([]byte, error) {
-	moveCursor := "false"
-	if screenshotOptions.MoveCursor == true {
-		moveCursor = "true"
-	}
-
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "vnc/screenshot")
-	res := v.restClient.Get().AbsPath(uri).Param("moveCursor", moveCursor).Do(ctx)
-	raw, err := res.Raw()
-	if err != nil {
-		return nil, res.Error()
-	}
-	return raw, nil
-}
-
-func (v *vmis) AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error {
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "addvolume")
-
-	JSON, err := json.Marshal(addVolumeOptions)
-
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(ctx).Error()
-}
-
-func (v *vmis) RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error {
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "removevolume")
-
-	JSON, err := json.Marshal(removeVolumeOptions)
-
-	if err != nil {
-		return err
-	}
-
-	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(ctx).Error()
-}
-
 func (v *vmis) VSOCK(name string, options *v1.VSOCKOptions) (kvcorev1.StreamInterface, error) {
 	if options == nil || options.TargetPort == 0 {
 		return nil, fmt.Errorf("target port is required but not provided")
@@ -322,36 +178,4 @@ func (v *vmis) VSOCK(name string, options *v1.VSOCKOptions) (kvcorev1.StreamInte
 	}
 	queryParams.Add("tls", strconv.FormatBool(useTLS))
 	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vsock", queryParams)
-}
-
-func (v *vmis) SEVFetchCertChain(ctx context.Context, name string) (v1.SEVPlatformInfo, error) {
-	sevPlatformInfo := v1.SEVPlatformInfo{}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "sev/fetchcertchain")
-	err := v.restClient.Get().AbsPath(uri).Do(ctx).Into(&sevPlatformInfo)
-	return sevPlatformInfo, err
-}
-
-func (v *vmis) SEVQueryLaunchMeasurement(ctx context.Context, name string) (v1.SEVMeasurementInfo, error) {
-	sevMeasurementInfo := v1.SEVMeasurementInfo{}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "sev/querylaunchmeasurement")
-	err := v.restClient.Get().AbsPath(uri).Do(ctx).Into(&sevMeasurementInfo)
-	return sevMeasurementInfo, err
-}
-
-func (v *vmis) SEVSetupSession(ctx context.Context, name string, sevSessionOptions *v1.SEVSessionOptions) error {
-	body, err := json.Marshal(sevSessionOptions)
-	if err != nil {
-		return fmt.Errorf("Cannot Marshal to json: %s", err)
-	}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "sev/setupsession")
-	return v.restClient.Put().AbsPath(uri).Body(body).Do(ctx).Error()
-}
-
-func (v *vmis) SEVInjectLaunchSecret(ctx context.Context, name string, sevSecretOptions *v1.SEVSecretOptions) error {
-	body, err := json.Marshal(sevSecretOptions)
-	if err != nil {
-		return fmt.Errorf("Cannot Marshal to json: %s", err)
-	}
-	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "sev/injectlaunchsecret")
-	return v.restClient.Put().AbsPath(uri).Body(body).Do(ctx).Error()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
##### Before this PR:
Our `vm`,  `vmi`, `kv`, `vmirs` structs respectively embed generated
`VirtualMachineInterface`, `VirtualMachineInstanceInterface`,
`KubeVirtInterface` and  `VirtualMachineInstanceResplicasetInterface`.
The latter define the custom methods but do not
implement them, which are only defined in the custom structs.

##### After this PR:
We can move the expanded methods implementations
in the `virtualmachine_expansion`, `virtualmachineinstance_expansion`,
`kubevirt_expansion`, `virtualmachineinstancereplicaset_expansion` files so that our custom structs
can simply inherit them.

Also, switched to using full `AbsPath` with fmt.Sprintf()
to request composition with `Namespace()`, `Resource()`,
`Name()` and `SubResource()`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

### Special notes for your reviewer
N.B. methods that require clientConfig, like `PortForward`, remain implemented only 
in our custom structs because we still cannot implement them in the
expansion files, due to the lack of the clientConfig.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

