### PR TITLE
Add a metric that reports the VMI last connection timestamp

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -117,6 +117,9 @@ Used VM filesystem capacity in bytes. Type: Gauge.
 ### kubevirt_vmi_info
 Information about VirtualMachineInstances. Type: Gauge.
 
+### kubevirt_vmi_last_api_connection_timestamp_seconds
+Virtual Machine Instance last API connection timestamp. Including VNC, console, portforward, SSH and usbredir connections. Type: Gauge.
+
 ### kubevirt_vmi_memory_actual_balloon_bytes
 Current balloon size in bytes. Type: Gauge.
 

--- a/hack/prom-metric-linter/metric_name_linter.sh
+++ b/hack/prom-metric-linter/metric_name_linter.sh
@@ -20,7 +20,7 @@
 
 set -e
 
-linter_image_tag="v0.0.1"
+linter_image_tag="v0.0.6"
 
 source $(dirname "$0")/../common.sh
 

--- a/pkg/monitoring/metrics/virt-api/connection_metrics.go
+++ b/pkg/monitoring/metrics/virt-api/connection_metrics.go
@@ -18,7 +18,11 @@
 
 package virt_api
 
-import "github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+import (
+	"time"
+
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+)
 
 var (
 	connectionMetrics = []operatormetrics.Metric{
@@ -26,6 +30,7 @@ var (
 		activeVNCConnections,
 		activeConsoleConnections,
 		activeUSBRedirConnections,
+		vmiLastConnectionTimestamp,
 	}
 
 	namespaceAndVMILabels = []string{"namespace", "vmi"}
@@ -58,6 +63,14 @@ var (
 		operatormetrics.MetricOpts{
 			Name: "kubevirt_usbredir_active_connections",
 			Help: "Amount of active USB redirection connections, broken down by namespace and vmi name.",
+		},
+		namespaceAndVMILabels,
+	)
+
+	vmiLastConnectionTimestamp = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_last_api_connection_timestamp_seconds",
+			Help: "Virtual Machine Instance last API connection timestamp. Including VNC, console, portforward, SSH and usbredir connections.",
 		},
 		namespaceAndVMILabels,
 	)
@@ -97,4 +110,8 @@ func NewActiveUSBRedirConnection(namespace, name string) Decrementer {
 	recorder := activeUSBRedirConnections.WithLabelValues(namespace, name)
 	recorder.Inc()
 	return recorder
+}
+
+func SetVMILastConnectionTimestamp(namespace, name string) {
+	vmiLastConnectionTimestamp.WithLabelValues(namespace, name).Set(float64(time.Now().Unix()))
 }

--- a/pkg/virt-api/rest/console.go
+++ b/pkg/virt-api/rest/console.go
@@ -17,6 +17,8 @@ func (app *SubresourceAPIApp) ConsoleRequestHandler(request *restful.Request, re
 	activeConnectionMetric := apimetrics.NewActiveConsoleConnection(request.PathParameter("namespace"), request.PathParameter("name"))
 	defer activeConnectionMetric.Dec()
 
+	defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
+
 	streamer := NewRawStreamer(
 		app.FetchVirtualMachineInstance,
 		validateVMIForConsole,

--- a/pkg/virt-api/rest/portforward.go
+++ b/pkg/virt-api/rest/portforward.go
@@ -17,6 +17,8 @@ func (app *SubresourceAPIApp) PortForwardRequestHandler(fetcher vmiFetcher) rest
 		activeTunnelMetric := apimetrics.NewActivePortForwardTunnel(request.PathParameter("namespace"), request.PathParameter("name"))
 		defer activeTunnelMetric.Dec()
 
+		defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
+
 		streamer := NewWebsocketStreamer(
 			fetcher,
 			validateVMIForPortForward,

--- a/pkg/virt-api/rest/usbredir.go
+++ b/pkg/virt-api/rest/usbredir.go
@@ -16,6 +16,8 @@ func (app *SubresourceAPIApp) USBRedirRequestHandler(request *restful.Request, r
 	activeConnectionMetric := apimetrics.NewActiveUSBRedirConnection(request.PathParameter("namespace"), request.PathParameter("name"))
 	defer activeConnectionMetric.Dec()
 
+	defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
+
 	streamer := NewRawStreamer(
 		app.FetchVirtualMachineInstance,
 		validateVMIForUSBRedir,

--- a/pkg/virt-api/rest/vnc.go
+++ b/pkg/virt-api/rest/vnc.go
@@ -27,6 +27,8 @@ func (app *SubresourceAPIApp) VNCRequestHandler(request *restful.Request, respon
 	activeConnectionMetric := apimetrics.NewActiveVNCConnection(request.PathParameter("namespace"), request.PathParameter("name"))
 	defer activeConnectionMetric.Dec()
 
+	defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
+
 	streamer := NewRawStreamer(
 		app.FetchVirtualMachineInstance,
 		validateVMIForVNC,
@@ -44,6 +46,8 @@ func (app *SubresourceAPIApp) VNCRequestHandler(request *restful.Request, respon
 func (app *SubresourceAPIApp) VNCScreenshotRequestHandler(request *restful.Request, response *restful.Response) {
 	activeConnectionMetric := apimetrics.NewActiveVNCConnection(request.PathParameter("namespace"), request.PathParameter("name"))
 	defer activeConnectionMetric.Dec()
+
+	defer apimetrics.SetVMILastConnectionTimestamp(request.PathParameter("namespace"), request.PathParameter("name"))
 
 	dialer := NewDirectDialer(
 		app.FetchVirtualMachineInstance,

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
         "//tests/clientcmd:go_default_library",
+        "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -61,10 +61,11 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 		var excludedMetrics = map[string]bool{
 			// virt-api
 			// can later be added in pre-existing feature tests
-			"kubevirt_portforward_active_tunnels":  true,
-			"kubevirt_usbredir_active_connections": true,
-			"kubevirt_vnc_active_connections":      true,
-			"kubevirt_console_active_connections":  true,
+			"kubevirt_portforward_active_tunnels":                true,
+			"kubevirt_usbredir_active_connections":               true,
+			"kubevirt_vnc_active_connections":                    true,
+			"kubevirt_console_active_connections":                true,
+			"kubevirt_vmi_last_api_connection_timestamp_seconds": true,
 
 			// virt-controller
 			// needs a migration - ignoring since already tested in - VM Monitoring, VM migration metrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Add `kubevirt_vmi_last_api_connection_timestamp_seconds` metric, which reports the last connection timestamp per VMI. Connections covered: console, vnc, usbredir, portforward and SSH.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-14659

### Why we need it and why it was done in this way
This metric will help users to identify VMs that have not been logged into for a long time and have allocated resources but are not actually being used.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vmi_last_connection_timestamp_seconds metric
```

