### PR TITLE
controller: fix bug when limits are used with CPU hotplug

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -654,7 +654,7 @@ func (c *VMController) VMICPUsPatch(vm *virtv1.VirtualMachine, vmi *virtv1.Virtu
 	logMsg := fmt.Sprintf("hotplugging cpu to %v sockets", vm.Spec.Template.Spec.Domain.CPU.Sockets)
 
 	if !vm.Spec.Template.Spec.Domain.Resources.Requests.Cpu().IsZero() {
-		newCpuReq := vm.Spec.Template.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
+		newCpuReq := vmi.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
 		newCpuReq.Add(*resourcesDelta)
 
 		patchSet.AddOption(
@@ -665,7 +665,7 @@ func (c *VMController) VMICPUsPatch(vm *virtv1.VirtualMachine, vmi *virtv1.Virtu
 		logMsg = fmt.Sprintf("%s, setting requests to %s", logMsg, newCpuReq.String())
 	}
 	if !vm.Spec.Template.Spec.Domain.Resources.Limits.Cpu().IsZero() {
-		newCpuLimit := vm.Spec.Template.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
+		newCpuLimit := vmi.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
 		newCpuLimit.Add(*resourcesDelta)
 
 		patchSet.AddOption(
@@ -682,7 +682,7 @@ func (c *VMController) VMICPUsPatch(vm *virtv1.VirtualMachine, vmi *virtv1.Virtu
 	}
 
 	_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
-	if err != nil {
+	if err == nil {
 		log.Log.Object(vmi).Infof(logMsg)
 	}
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5754,22 +5754,22 @@ var _ = Describe("VirtualMachine", func() {
 					err = controller.handleCPUChangeRequest(vm, vmi)
 					Expect(err).ToNot(HaveOccurred())
 
-					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+					updatedVMI, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Sockets))
+					Expect(updatedVMI.Spec.Domain.CPU.Sockets).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Sockets))
 
 					if !resources.Requests.Cpu().IsZero() {
 						expectedCpuReq := vmi.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
 						expectedCpuReq.Add(*resourcesDelta)
 
-						Expect(vmi.Spec.Domain.Resources.Requests.Cpu().Value()).To(Equal(expectedCpuReq.Value()))
+						Expect(updatedVMI.Spec.Domain.Resources.Requests.Cpu().String()).To(Equal(expectedCpuReq.String()))
 					}
 
 					if !resources.Limits.Cpu().IsZero() {
 						expectedCpuLim := vmi.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
 						expectedCpuLim.Add(*resourcesDelta)
 
-						Expect(vmi.Spec.Domain.Resources.Limits.Cpu().Value()).To(Equal(expectedCpuLim.Value()))
+						Expect(updatedVMI.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal(expectedCpuLim.String()))
 					}
 				},
 					Entry("with no resources set", v1.ResourceRequirements{}),

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5787,6 +5787,61 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					}),
 				)
+
+				It("should correctly bump requests and limits when multiple hotplugs are performed", func() {
+					resources := v1.ResourceRequirements{
+						Requests: k8sv1.ResourceList{
+							k8sv1.ResourceCPU: resource.MustParse("100m"),
+						},
+						Limits: k8sv1.ResourceList{
+							k8sv1.ResourceCPU: resource.MustParse("200m"),
+						},
+					}
+
+					vm, _ := DefaultVirtualMachine(true)
+					vm.Spec.Template.Spec.Domain.Resources = resources
+					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{
+						Sockets: 2,
+					}
+
+					vmi := api.NewMinimalVMI(vm.Name)
+					vmi.Spec.Domain.CPU = &v1.CPU{
+						Sockets:    1,
+						MaxSockets: 4,
+					}
+					vmi.Spec.Domain.Resources = resources
+
+					originalVMI, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					By("first hotplug")
+					err = controller.handleCPUChangeRequest(vm, vmi)
+					Expect(err).ToNot(HaveOccurred())
+
+					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Sockets))
+
+					By("second hotplug")
+					vm.Spec.Template.Spec.Domain.CPU.Sockets = 3
+					vcpusDelta := int64(vm.Spec.Template.Spec.Domain.CPU.Sockets - originalVMI.Spec.Domain.CPU.Sockets)
+					resourcesDelta := resource.NewMilliQuantity(vcpusDelta*int64(1000*(1.0/float32(config.GetCPUAllocationRatio()))), resource.DecimalSI)
+
+					err = controller.handleCPUChangeRequest(vm, vmi)
+					Expect(err).ToNot(HaveOccurred())
+
+					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Sockets))
+
+					expectedCpuReq := originalVMI.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
+					expectedCpuReq.Add(*resourcesDelta)
+					Expect(vmi.Spec.Domain.Resources.Requests.Cpu().String()).To(Equal(expectedCpuReq.String()))
+
+					expectedCpuLim := originalVMI.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
+					expectedCpuLim.Add(*resourcesDelta)
+					Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal(expectedCpuLim.String()))
+				})
 			})
 
 			Context("Memory", func() {


### PR DESCRIPTION
The delta calculation was based on the VM instead of the VMI, this caused a miscalculation of the delta when multiple hotplug were requested.

Before this patch:
    T0: VM has  `limits.cpu: 1` and `sockets: 1`
    T1: hotplug 1 more socket
    T2: VM has  `limits.cpu: 1100m` and `sockets: 2`
    T1: hotplug 1 more socket
    T2: VM has  `limits.cpu: 1100m` and `sockets: 3`

After this patch:
    T0: VM has  `limits.cpu: 1` and `sockets: 1`
    T1: hotplug 1 more socket
    T2: VM has  `limits.cpu: 1100m` and `sockets: 2`
    T1: hotplug 1 more socket
    T2: VM has  `limits.cpu: 1200m` and `sockets: 3`

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

