### PR TITLE
instancetype: Introduce and enforce preference architecture requirements

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -23018,6 +23018,10 @@
    "v1beta1.PreferenceRequirements": {
     "type": "object",
     "properties": {
+     "architecture": {
+      "description": "Specifies the required architecture of the vm.",
+      "type": "string"
+     },
      "cpu": {
       "description": "Required CPU related attributes of the instancetype.",
       "$ref": "#/definitions/v1beta1.CPUPreferenceRequirement"

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8933,6 +8933,9 @@ var CRDsValidation map[string]string = map[string]string{
           description: Requirements defines the minium amount of instance type defined
             resources required by a set of preferences
           properties:
+            architecture:
+              description: Specifies the required architecture of the vm.
+              type: string
             cpu:
               description: Required CPU related attributes of the instancetype.
               properties:
@@ -22628,6 +22631,9 @@ var CRDsValidation map[string]string = map[string]string{
           description: Requirements defines the minium amount of instance type defined
             resources required by a set of preferences
           properties:
+            architecture:
+              description: Specifies the required architecture of the vm.
+              type: string
             cpu:
               description: Required CPU related attributes of the instancetype.
               properties:

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
@@ -381,6 +381,11 @@ func (in *PreferenceRequirements) DeepCopyInto(out *PreferenceRequirements) {
 		*out = new(MemoryPreferenceRequirement)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Architecture != nil {
+		in, out := &in.Architecture, &out.Architecture
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -582,7 +582,6 @@ type ClockPreferences struct {
 }
 
 type PreferenceRequirements struct {
-
 	// Required CPU related attributes of the instancetype.
 	//
 	//+optional
@@ -592,6 +591,11 @@ type PreferenceRequirements struct {
 	//
 	//+optional
 	Memory *MemoryPreferenceRequirement `json:"memory,omitempty"`
+
+	// Specifies the required architecture of the vm.
+	//
+	//+optional
+	Architecture *string `json:"architecture,omitempty"`
 }
 
 type CPUPreferenceRequirement struct {

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -201,8 +201,9 @@ func (ClockPreferences) SwaggerDoc() map[string]string {
 
 func (PreferenceRequirements) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"cpu":    "Required CPU related attributes of the instancetype.\n\n+optional",
-		"memory": "Required Memory related attributes of the instancetype.\n\n+optional",
+		"cpu":          "Required CPU related attributes of the instancetype.\n\n+optional",
+		"memory":       "Required Memory related attributes of the instancetype.\n\n+optional",
+		"architecture": "Specifies the required architecture of the vm.\n\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -28454,6 +28454,13 @@ func schema_kubevirtio_api_instancetype_v1beta1_PreferenceRequirements(ref commo
 							Ref:         ref("kubevirt.io/api/instancetype/v1beta1.MemoryPreferenceRequirement"),
 						},
 					},
+					"architecture": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies the required architecture of the vm.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
/area instancetype

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

