### PR TITLE
fix: execution order of multiple sidecars

### DIFF
--- a/pkg/hooks/info/api_info.pb.go
+++ b/pkg/hooks/info/api_info.pb.go
@@ -85,7 +85,7 @@ func (m *InfoResult) GetVersions() []string {
 type HookPoint struct {
 	// name represents name of the subscribed hook point
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	// priority is used to sort hooks prior to their execution (second key is the name)
+	// priority is used to sort hooks prior to their execution
 	Priority int32 `protobuf:"varint,2,opt,name=priority" json:"priority,omitempty"`
 }
 

--- a/pkg/hooks/info/api_info.proto
+++ b/pkg/hooks/info/api_info.proto
@@ -21,6 +21,6 @@ message InfoResult {
 message HookPoint {
     // name represents name of the subscribed hook point
     string name = 1;
-    // priority is used to sort hooks prior to their execution (second key is the name)
+    // priority is used to sort hooks prior to their execution
     int32 priority = 2;
 }


### PR DESCRIPTION
### What this PR does
Before this PR: Can't control the execution order of multiple hook sidecars

After this PR: Can control the execution order of multiple hook sidecars

Fixes #11940

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note

```release-note
fix: execution order of multiple sidecars
```