### PR TITLE
Update virtctl to use v1beta1 endpoint

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -76,10 +76,10 @@ const (
 	processingWaitTotal    = 24 * time.Hour
 
 	//UploadProxyURIAsync is a URI of the upload proxy, the endpoint is asynchronous
-	UploadProxyURIAsync = "/v1alpha1/upload-async"
+	UploadProxyURIAsync = "/v1beta1/upload-async"
 
 	//UploadProxyURI is a URI of the upload proxy, the endpoint is synchronous for backwards compatibility
-	UploadProxyURI = "/v1alpha1/upload"
+	UploadProxyURI = "/v1beta1/upload"
 
 	configName = "config"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Signed-off-by: Ido Aharon <iaharon@redhat.com>

**What this PR does / why we need it**:
Currently virtctl has a hard coded `v1alpha1` endpoint for both regular and async image upload. We no longer support v1alpha1, so we should update the endpoint to `v1beta1`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [CNV-41625](https://issues.redhat.com/browse/CNV-41625)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update virtctl to use v1beta1 endpoint for both regular and async image upload
```

