### PR TITLE
tests: Introduce new libclient package

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -199,6 +199,7 @@ go_test(
         "//tests/infrastructure:go_default_library",
         "//tests/instancetype:go_default_library",
         "//tests/launchsecurity:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libconfigmap:go_default_library",
         "//tests/libdv:go_default_library",
         "//tests/libinfra:go_default_library",

--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//tests/decorators:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libnet/cloudinit:go_default_library",
         "//tests/libsecret:go_default_library",
         "//tests/libvmifact:go_default_library",

--- a/tests/compute/console.go
+++ b/tests/compute/console.go
@@ -35,9 +35,9 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -64,7 +64,7 @@ var _ = SIGDescribe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@re
 		Context("with a serial console", func() {
 			It("[test_id:1588]should return OS login", func() {
 				vmi := libvmifact.NewCirros()
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 				expectConsoleOutput(
 					vmi,
 					"login as 'cirros' user",
@@ -72,7 +72,7 @@ var _ = SIGDescribe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@re
 			})
 			It("[test_id:1590]should be able to reconnect to console multiple times", func() {
 				vmi := libvmifact.NewAlpine()
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				for i := 0; i < 5; i++ {
 					expectConsoleOutput(vmi, "login")
@@ -80,7 +80,7 @@ var _ = SIGDescribe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@re
 			})
 
 			It("[test_id:1591]should close console connection when new console connection is opened", func() {
-				vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
+				vmi := libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 				By("opening 1st console connection")
 				stream, err := virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kvcorev1.SerialConsoleOptions{})
@@ -135,7 +135,7 @@ var _ = SIGDescribe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@re
 		Context("without a serial console", func() {
 			It("[test_id:4118]should run but not be connectable via the serial console", func() {
 				vmi := libvmifact.NewAlpine(libvmi.WithoutSerialConsole())
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				By("failing to connect to serial console")
 				_, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).SerialConsole(vmi.ObjectMeta.Name, &kvcorev1.SerialConsoleOptions{})

--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -35,10 +35,10 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libsecret"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -90,7 +90,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 				"my-key3": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key3"),
 			})
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi), guestAgentConnetTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -129,7 +129,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 				"fedora": []byte(customPassword),
 			})
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi), guestAgentConnetTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -165,7 +165,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 				"my-key1": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key1"),
 			})
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi), guestAgentConnetTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -187,7 +187,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			createNewSecret(testsuite.GetTestNamespace(vmi), secretID, map[string][]byte{
 				"fedora": []byte(customPassword),
 			})
-			vmi = tests.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
 
 			By("Waiting for agent to connect")
 			Eventually(matcher.ThisVMI(vmi), guestAgentConnetTimeout, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -233,7 +233,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 				"my-key3": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key3"),
 			})
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
 			verifySSHKeys(vmi)
 		},
 			Entry("[test_id:6224]using configdrive", libvmi.WithCloudInitConfigDriveUserData, v1.SSHPublicKeyAccessCredentialPropagationMethod{

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -41,11 +41,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libconfigmap"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libsecret"
@@ -113,7 +113,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				By("Running VMI")
 				vmi := libvmifact.NewAlpine(libvmi.WithConfigMapDisk(configMapName, configMapName))
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				CheckIsoVolumeSizes(vmi)
@@ -178,7 +178,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					libvmi.WithConfigMapDisk(configMaps[1], configMaps[1]),
 					libvmi.WithConfigMapDisk(configMaps[2], configMaps[2]))
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 				CheckIsoVolumeSizes(vmi)
 			})
 		})
@@ -214,7 +214,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				By("Running VMI")
 				vmi := libvmifact.NewAlpine(libvmi.WithSecretDisk(secretName, secretName))
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				CheckIsoVolumeSizes(vmi)
@@ -280,7 +280,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					libvmi.WithSecretDisk(secrets[1], secrets[1]),
 					libvmi.WithSecretDisk(secrets[2], secrets[2]))
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 				CheckIsoVolumeSizes(vmi)
 			})
 		})
@@ -294,7 +294,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		It("[test_id:998]Should be the namespace and token the same for a pod and vmi", func() {
 			By("Running VMI")
 			vmi := libvmifact.NewAlpine(libvmi.WithServiceAccountDisk("default"))
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 			CheckIsoVolumeSizes(vmi)
@@ -401,7 +401,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					}
 				}
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				CheckIsoVolumeSizes(vmi)
@@ -510,7 +510,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				By("Running VMI")
 				vmi := libvmifact.NewAlpine(libvmi.WithSecretDisk(secretName, secretName))
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				CheckIsoVolumeSizes(vmi)
@@ -571,7 +571,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			vmi := libvmifact.NewAlpine(
 				libvmi.WithLabel(testLabelKey, testLabelVal),
 				libvmi.WithDownwardAPIDisk(downwardAPIName))
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 			CheckIsoVolumeSizes(vmi)

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -25,11 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,19 +32,23 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"kubevirt.io/kubevirt/tests/exec"
-	"kubevirt.io/kubevirt/tests/testsuite"
-	"kubevirt.io/kubevirt/tests/util"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]ContainerDisk", decorators.SigCompute, func() {
@@ -183,7 +182,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					}
 				}
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 			})
 		})
 
@@ -195,7 +194,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				vmi := libvmifact.NewAlpine(
 					libvmi.WithEphemeralCDRom("disk4", v1.DiskBusSATA, cd.ContainerDiskFor(cd.ContainerDiskVirtio)),
 				)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 				By("Checking whether the second disk really contains virtio drivers")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed(), "expected alpine to login properly")
@@ -221,7 +220,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		Context("with ephemeral registry disk", func() {
 			It("[test_id:4299]should not have world write permissions", func() {
 				vmi := libvmifact.NewAlpine()
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 				By("Ensuring VMI is running by logging in")
 				libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)

--- a/tests/guestlog/BUILD.bazel
+++ b/tests/guestlog/BUILD.bazel
@@ -8,12 +8,12 @@ go_library(
     deps = [
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//tests:go_default_library",
         "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/testsuite:go_default_library",

--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/tests/exec"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -21,11 +19,13 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/tests"
+
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -52,7 +52,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				By("Starting a VMI")
 				cirrosVmi.Spec.Domain.Devices.AutoattachSerialConsole = pointer.P(autoattachSerialConsole)
 				cirrosVmi.Spec.Domain.Devices.LogSerialConsole = pointer.P(logSerialConsole)
-				vmi := tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
+				vmi := libclient.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")
 				virtlauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
@@ -81,7 +81,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 
 			It("it should exit cleanly when the shutdown is initiated by the guest", func() {
 				By("Starting a VMI")
-				vmi := tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
+				vmi := libclient.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")
 				virtlauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
@@ -124,7 +124,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 `
 
 			It("it should fetch logs for a running VM with logs API", func() {
-				vmi = tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")
 				virtlauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
@@ -173,7 +173,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 			})
 
 			It("it should rotate the internal log files", func() {
-				vmi = tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")
 				virtlauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
@@ -203,7 +203,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 						k8sv1.ResourceMemory: resource.MustParse("256M"),
 					},
 				}
-				vmi = tests.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 				Expect(vmi.Status.QOSClass).ToNot(BeNil())
 				Expect(*vmi.Status.QOSClass).To(Equal(k8sv1.PodQOSGuaranteed))
 

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -7,28 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
-	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
-	"kubevirt.io/kubevirt/tests/framework/matcher"
-
-	"kubevirt.io/kubevirt/tests/libnet"
-
-	"kubevirt.io/kubevirt/tests/libmigration"
-
-	"kubevirt.io/kubevirt/tests/libinfra"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
-	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
-	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/libnode"
-	"kubevirt.io/kubevirt/tests/testsuite"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -40,11 +18,28 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libclient"
+	"kubevirt.io/kubevirt/tests/libinfra"
+	"kubevirt.io/kubevirt/tests/libmigration"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -256,7 +251,7 @@ var _ = Describe("[sig-compute] Hyper-V enlightenments", decorators.SigCompute, 
 					EVMCS: featureState,
 				},
 			}
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 			var err error
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
@@ -287,7 +282,7 @@ var _ = Describe("[sig-compute] Hyper-V enlightenments", decorators.SigCompute, 
 	Context("VMI with HyperV passthrough", func() {
 		It("should be usable and non-migratable", func() {
 			vmi := libvmifact.NewCirros(withHypervPassthrough())
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libinfra:go_default_library",
         "//tests/libmonitoring:go_default_library",
         "//tests/libnet:go_default_library",

--- a/tests/infrastructure/certificates.go
+++ b/tests/infrastructure/certificates.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libinfra"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -130,7 +131,7 @@ var _ = DescribeInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][leve
 
 		By("checking that we can still start virtual machines and connect to the VMI")
 		vmi := libvmifact.NewAlpine()
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 		Expect(console.LoginToAlpine(vmi)).To(Succeed())
 	})
 
@@ -146,7 +147,7 @@ var _ = DescribeInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][leve
 		By("repeatedly starting VMIs until virt-api and virt-handler certificates are updated")
 		Eventually(func() (rotated bool) {
 			vmi := libvmifact.NewAlpine()
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/infrastructure/downward-metrics.go
+++ b/tests/infrastructure/downward-metrics.go
@@ -23,10 +23,6 @@ import (
 	"context"
 	"time"
 
-	"kubevirt.io/kubevirt/tests/libinfra"
-
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,10 +30,11 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests/libvmifact"
-
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
+	"kubevirt.io/kubevirt/tests/libinfra"
+	"kubevirt.io/kubevirt/tests/libvmifact"
 )
 
 var _ = DescribeInfra("downwardMetrics", func() {
@@ -51,7 +48,7 @@ var _ = DescribeInfra("downwardMetrics", func() {
 	DescribeTable("should start a vmi and get the metrics", func(via libvmi.Option, metricsGetter libinfra.MetricsGetter) {
 
 		vmi := libvmifact.NewFedora(via)
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 		Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 		metrics, err := metricsGetter(vmi)
@@ -74,7 +71,7 @@ var _ = DescribeInfra("downwardMetrics", func() {
 
 	It("metric ResourceProcessorLimit should be present", func() {
 		vmi := libvmifact.NewFedora(libvmi.WithCPUCount(1, 1, 1), libvmi.WithDownwardMetricsVolume("vhostmd"))
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 		Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 		metrics, err := libinfra.GetDownwardMetricsDisk(vmi)

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -28,26 +28,11 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
-	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
-
-	"kubevirt.io/kubevirt/tests/libinfra"
-	"kubevirt.io/kubevirt/tests/libvmifact"
-
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
-	"kubevirt.io/kubevirt/tests/exec"
-	"kubevirt.io/kubevirt/tests/testsuite"
-
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	netutils "k8s.io/utils/net"
-
-	"kubevirt.io/kubevirt/tests/libnode"
-
-	"kubevirt.io/kubevirt/tests/libwait"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -56,11 +41,21 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
+
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
+	"kubevirt.io/kubevirt/tests/libinfra"
 	"kubevirt.io/kubevirt/tests/libmonitoring"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnode"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 const (
@@ -238,7 +233,7 @@ var _ = DescribeInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][leve
 				libvmi.WithNodeSelectorFor(&k8sv1.Node{ObjectMeta: metav1.ObjectMeta{Name: preferredNodeName}}))
 		}
 
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 		nodeName := vmi.Status.NodeName
 
 		By("Expecting the VirtualMachineInstance console")

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libpod"
 
@@ -182,7 +183,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, libmigration.MigrationWaitTime)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, libmigration.MigrationWaitTime)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -236,7 +237,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 
 		It("oc/kubectl logs <vmi-pod> return default container log", func() {
 			vm = libvmifact.NewCirros()
-			vm = tests.RunVMIAndExpectLaunch(vm, 30)
+			vm = libclient.RunVMIAndExpectLaunch(vm, 30)
 
 			k8sClient := clientcmd.GetK8sCmdClient()
 			pod, err := libpod.GetPodByVirtualMachineInstance(vm, vm.Namespace)

--- a/tests/launchsecurity/BUILD.bazel
+++ b/tests/launchsecurity/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/libwait:go_default_library",

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	expect "github.com/google/goexpect"
@@ -322,7 +323,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 					checks.SkipTestIfNotSEVESCapable()
 				}
 				vmi := newSEVFedora(withES)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Expecting the VirtualMachineInstance console")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())

--- a/tests/libclient/BUILD.bazel
+++ b/tests/libclient/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["libclient.go"],
+    importpath = "kubevirt.io/kubevirt/tests/libclient",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//tests/framework/kubevirt:go_default_library",
+        "//tests/libwait:go_default_library",
+        "//tests/testsuite:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/tests/libclient/libclient.go
+++ b/tests/libclient/libclient.go
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package libclient
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+const waitingVMInstanceStart = "Waiting until the VirtualMachineInstance will start"
+
+func RunVMIAndExpectLaunch(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
+	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	By(waitingVMInstanceStart)
+	return libwait.WaitForVMIPhase(vmi,
+		[]v1.VirtualMachineInstancePhase{v1.Running},
+		libwait.WithTimeout(timeout),
+	)
+}

--- a/tests/migration/BUILD.bazel
+++ b/tests/migration/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//tests/framework/cleanup:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libconfigmap:go_default_library",
         "//tests/libdv:go_default_library",
         "//tests/libinfra:go_default_library",

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
@@ -79,7 +80,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 			})
 
 			It("[test_id:3242]should block the eviction api and migrate", func() {
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 				vmiNodeOrig := vmi.Status.NodeName
 				pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -193,7 +194,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 				vmi = fedoraVMIWithEvictionStrategy()
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -331,7 +332,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 					vmi.Spec.Affinity = &k8sv1.Affinity{NodeAffinity: nodeAffinity}
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
@@ -357,7 +358,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 					vmi.Spec.Affinity = &k8sv1.Affinity{NodeAffinity: nodeAffinity}
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 					By("Checking that the VirtualMachineInstance console has expected output")
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -383,7 +384,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 					tests.UpdateKubeVirtConfigValueAndWait(cfg)
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 					node := vmi.Status.NodeName
 					temporaryNodeDrain(node)
@@ -601,7 +602,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					)
 
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 					vmiNodeOrig := vmi.Status.NodeName
 					pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Expect(err).NotTo(HaveOccurred())
@@ -642,7 +643,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						libvmi.WithEvictionStrategy(v1.EvictionStrategyNone),
 					)
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 					pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Expect(err).NotTo(HaveOccurred())
 					err = virtClient.CoreV1().Pods(vmi.Namespace).EvictV1beta1(context.Background(), &policyv1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
@@ -219,7 +220,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Starting hello world in the VM")
 			vmnetserver.StartTCPServer(vmi, port, console.LoginToCirros)
@@ -259,7 +260,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("default")),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 				// after being restarted multiple times
@@ -311,7 +312,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					libnet.WithMasqueradeNetworking()...,
 				)
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				durationLowBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "10Mi", 3)
 				durationHighBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "128Mi", 3)
@@ -332,7 +333,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -351,7 +352,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheWriteBack
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -381,7 +382,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -403,7 +404,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.EvictionStrategy = &strategy
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -475,7 +476,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					via,
 				)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("starting the migration")
@@ -516,7 +517,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
 				)
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the TSC frequency on the Domain XML")
@@ -557,7 +558,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -591,7 +592,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -611,7 +612,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -651,7 +652,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -698,7 +699,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -725,7 +726,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -780,7 +781,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// execute a migration that is expected to fail
 				By("Starting the Migration")
@@ -835,7 +836,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// execute a migration that is expected to fail
 				By("Starting the Migration")
@@ -899,7 +900,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// Need to wait for cloud init to finnish and start the agent inside the vmi.
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -925,7 +926,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -999,7 +1000,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 				// after being restarted multiple times
@@ -1020,7 +1021,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), testsuite.GetTestNamespace(nil), k8sv1.ReadWriteMany)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 300)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 300)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -1037,7 +1038,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// Need to wait for cloud init to finish and start the agent inside the vmi.
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -1082,7 +1083,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				tests.AddEphemeralDisk(vmi, "myephemeral", v1.VirtIO, image)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -1097,7 +1098,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			It("[release-blocker][test_id:1377]should be successfully migrated multiple times", func() {
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), testsuite.GetTestNamespace(nil), k8sv1.ReadWriteMany)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -1116,7 +1117,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), testsuite.GetTestNamespace(nil), k8sv1.ReadWriteMany)
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 				vmi.Spec.Hostname = fmt.Sprintf("%s", cd.ContainerDiskCirros)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -1420,7 +1421,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					)
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					By("Checking that the VirtualMachineInstance console has expected output")
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -1442,7 +1443,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					// Need to wait for cloud init to finish and start the agent inside the vmi.
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -1523,7 +1524,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					CreateMigrationPolicy(virtClient, PreparePolicyAndVMIWithBandwidthLimitation(vmi, migrationBandwidthLimit))
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					// Need to wait for cloud init to finish and start the agent inside the vmi.
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -1634,7 +1635,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					By("Checking that the VirtualMachineInstance console has expected output")
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -1660,7 +1661,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -1748,7 +1749,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Annotations = map[string]string{v1.FuncTestForceLauncherMigrationFailureAnnotation: ""}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				for i := 0; i < 10; i++ {
 					// execute a migration, wait for finalized state
@@ -1789,7 +1790,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Annotations = map[string]string{v1.FuncTestForceLauncherMigrationFailureAnnotation: ""}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
@@ -1823,7 +1824,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Annotations = map[string]string{v1.FuncTestBlockLauncherPrepareMigrationTargetAnnotation: ""}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// execute a migration
 				By("Starting the Migration")
@@ -1906,7 +1907,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Annotations = map[string]string{v1.FuncTestBlockLauncherPrepareMigrationTargetAnnotation: ""}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				// execute a migration
 				By("Starting the Migration")
@@ -1971,7 +1972,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), testsuite.GetTestNamespace(nil), k8sv1.ReadWriteOnce)
 				vmi.Spec.Hostname = string(cd.ContainerDiskAlpine)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -2036,7 +2037,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				CreateMigrationPolicy(virtClient, PreparePolicyAndVMIWithBandwidthLimitation(vmi, migrationBandwidthLimit))
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Starting the Migration")
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -2062,7 +2063,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				CreateMigrationPolicy(virtClient, PreparePolicyAndVMIWithBandwidthLimitation(vmi, migrationBandwidthLimit))
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 				sourcePod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2121,7 +2122,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				CreateMigrationPolicy(virtClient, PreparePolicyAndVMIWithBandwidthLimitation(vmi, migrationBandwidthLimit))
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 				vmiOriginalNode := vmi.Status.NodeName
 
 				// execute a migration, wait for finalized state
@@ -2192,7 +2193,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					)
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					By("Trying to migrate VM and expect for the migration to get stuck")
 					migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -2325,7 +2326,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 				Expect(vmi.Spec.Domain.CPU.Model).To(Equal(v1.CPUModeHostModel))
 
 				By("Fetching original host CPU model & supported CPU features")
@@ -2368,7 +2369,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					By("Saving the original node's state")
 					node, err = virtClient.CoreV1().Nodes().Get(context.Background(), vmi.Status.NodeName, metav1.GetOptions{})
@@ -2427,7 +2428,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					for indx, node := range nodes {
 						patchedNode := libinfra.ExpectStoppingNodeLabellerToSucceed(node.Name, virtClient)
@@ -2501,7 +2502,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					setParallelMigration(vmi)
 
 					By("Running vmi %s" + vmi.Name)
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					By("Starting the Migration")
 					migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -2548,7 +2549,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				}
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Starting the Migration")
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -2585,7 +2586,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -2620,7 +2621,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(7))
 			Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 			// execute a migration, wait for finalized state
 			By("Starting the Migration")
@@ -2641,7 +2642,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			CreateMigrationPolicy(virtClient, PreparePolicyAndVMIWithBandwidthLimitation(vmi, migrationBandwidthLimit))
 
 			By("Starting the VirtualMachineInstance")
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -2794,7 +2795,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				NodeAffinity: nodeAffinityRule,
 			}
 			By("Starting the VirtualMachineInstance")
-			vmiToMigrate = tests.RunVMIAndExpectLaunch(vmiToMigrate, 240)
+			vmiToMigrate = libclient.RunVMIAndExpectLaunch(vmiToMigrate, 240)
 			Expect(vmiToMigrate.Status.NodeName).To(Equal(sourceNode.Name))
 			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
 
@@ -2857,7 +2858,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				NodeAffinity: nodeAffinityRule,
 			}
 			By("Starting the VirtualMachineInstance")
-			vmiToMigrate = tests.RunVMIAndExpectLaunch(vmiToMigrate, 240)
+			vmiToMigrate = libclient.RunVMIAndExpectLaunch(vmiToMigrate, 240)
 			Expect(vmiToMigrate.Status.NodeName).To(Equal(sourceNode.Name))
 			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
 
@@ -3097,7 +3098,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Starting the migration")
 			migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -3116,7 +3117,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 		By("Starting a Migration")
 		migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -3137,7 +3138,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Checking that there always is at most one migration running")
 			Consistently(func() int {
@@ -3185,7 +3186,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					libvmi.WithResourceMemory("1Mi"),
 					libvmi.WithCPUFeature("invtsc", "require"),
 				)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				expectTopologyHintsToBeSet(vmi)
 			})
@@ -3195,7 +3196,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
 				vmi.Spec.Volumes = []v1.Volume{}
 				vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 				expectTopologyHintsToBeSet(vmi)
 			})
@@ -3225,7 +3226,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 		It("retrying immediately should be blocked by the migration backoff", func() {
 			By("Starting the VirtualMachineInstance")
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Waiting for the migration to fail")
 			migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -3242,7 +3243,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 		It("after a successful migration backoff should be cleared", func() {
 			By("Starting the VirtualMachineInstance")
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Waiting for the migration to fail")
 			migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -3298,7 +3299,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			_ = createResourceQuota(resourceQuota)
 
 			By("Starting the VirtualMachineInstance")
-			_ = tests.RunVMIAndExpectLaunch(vmi, 240)
+			_ = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Trying to migrate the VirtualMachineInstance")
 			migration := libmigration.New(vmi.Name, testsuite.GetTestNamespace(vmi))

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
@@ -172,7 +173,7 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 					}
 
 					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					By("Checking that the VirtualMachineInstance console has expected output")
 					Expect(console.LoginToFedora(vmi)).To(Succeed())

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libmigration:go_default_library",
         "//tests/libmonitoring:go_default_library",
         "//tests/libnet:go_default_library",

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libnet"
 
 	"kubevirt.io/kubevirt/tests/libmigration"
@@ -43,7 +44,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -97,7 +97,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			By("Starting the VirtualMachineInstance")
 			opts := append(libnet.WithMasqueradeNetworking(), libvmi.WithResourceMemory("2Mi"))
 			vmi := libvmi.New(opts...)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Migrating the VMI 13 times")
 			for i := 0; i < 13; i++ {

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -161,7 +162,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		It("Should correctly update metrics on successful VMIM", func() {
 			By("Creating VMIs")
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Migrating VMIs")
 			migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -189,7 +190,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
 			)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 			labels := map[string]string{
 				"vmi":       vmi.Name,
 				"namespace": vmi.Namespace,
@@ -306,7 +307,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		It("should fire KubevirtVmHighMemoryUsage alert", func() {
 			By("starting VMI")
 			vmi := libvmifact.NewGuestless()
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("fill up the vmi pod memory")
 			vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -326,7 +327,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 		It("[test_id:9260] should fire OrphanedVirtualMachineInstances alert", func() {
 			By("starting VMI")
 			vmi := libvmifact.NewGuestless()
-			tests.RunVMIAndExpectLaunch(vmi, 240)
+			libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("delete virt-handler daemonset")
 			err = virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Delete(context.Background(), virtHandler.deploymentName, metav1.DeleteOptions{})
@@ -351,7 +352,7 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 func createAgentVMI() *v1.VirtualMachineInstance {
 	virtClient := kubevirt.Client()
 	vmiAgentConnectedConditionMatcher := MatchFields(IgnoreExtras, Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})
-	vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...), 180)
+	vmi := libclient.RunVMIAndExpectLaunch(libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...), 180)
 
 	var err error
 	var agentVMI *v1.VirtualMachineInstance

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libkvconfig:go_default_library",
         "//tests/libmigration:go_default_library",
         "//tests/libnet:go_default_library",

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -9,6 +9,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/exec"
@@ -127,7 +128,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		var tcpVM *v1.VirtualMachineInstance
 		BeforeEach(func() {
 			tcpVM = newLabeledVMI("vm")
-			tcpVM = tests.RunVMIAndExpectLaunch(tcpVM, 180)
+			tcpVM = libclient.RunVMIAndExpectLaunch(tcpVM, 180)
 			generateHelloWorldServer(tcpVM, testPort, "tcp", console.LoginToAlpine, false)
 		})
 
@@ -392,7 +393,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		var udpVM *v1.VirtualMachineInstance
 		BeforeEach(func() {
 			udpVM = newLabeledVMI("udp-vm")
-			udpVM = tests.RunVMIAndExpectLaunch(udpVM, 180)
+			udpVM = libclient.RunVMIAndExpectLaunch(udpVM, 180)
 			generateHelloWorldServer(udpVM, testPort, "udp", console.LoginToAlpine, false)
 		})
 

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -43,6 +43,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/network/istio"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -353,7 +354,7 @@ var istioTests = func(vmType VmType) {
 					libvmi.WithNamespace(namespace),
 				)
 				By("Starting VirtualMachineInstance")
-				serverVMI = tests.RunVMIAndExpectLaunch(serverVMI, 240)
+				serverVMI = libclient.RunVMIAndExpectLaunch(serverVMI, 240)
 
 				serverVMIService := netservice.BuildSpec("vmi-server", vmiServerTestPort, vmiServerTestPort, vmiAppSelectorKey, vmiServerAppSelectorValue)
 				_, err = virtClient.CoreV1().Services(namespace).Create(context.Background(), serverVMIService, metav1.CreateOptions{})

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -72,7 +73,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewCirros(), cirrosStartupTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewCirros(), cirrosStartupTimeout)
 		})
 
 		When("paused via API", func() {
@@ -148,7 +149,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						SuccessThreshold:    1,
 						FailureThreshold:    1,
 					}
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+					libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 					By("Pausing it")
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
@@ -438,7 +439,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		BeforeEach(func() {
 			By("Starting a Cirros VMI")
-			vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewCirros(), cirrosStartupTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewCirros(), cirrosStartupTimeout)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(console.LoginToCirros(vmi)).To(Succeed())

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -38,7 +39,6 @@ import (
 	virtctlpause "kubevirt.io/kubevirt/pkg/virtctl/pause"
 	virtctlsoftreboot "kubevirt.io/kubevirt/pkg/virtctl/softreboot"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -85,7 +85,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi with agent connected via API", func() {
 			It("should succeed", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewFedora(withoutACPI()), vmiLaunchTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewFedora(withoutACPI()), vmiLaunchTimeout)
 
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
@@ -98,7 +98,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi with ACPI feature enabled via API", func() {
 			It("should succeed", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewCirros(), vmiLaunchTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewCirros(), vmiLaunchTimeout)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
@@ -112,7 +112,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi with agent connected via virtctl", func() {
 			It("should succeed", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewFedora(withoutACPI()), vmiLaunchTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewFedora(withoutACPI()), vmiLaunchTimeout)
 
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
@@ -125,7 +125,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi with ACPI feature enabled via virtctl", func() {
 			It("should succeed", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewCirros(), vmiLaunchTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewCirros(), vmiLaunchTimeout)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
@@ -139,7 +139,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi neither have the agent connected nor the ACPI feature enabled via virtctl", func() {
 			It("should failed", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewCirros(withoutACPI()), vmiLaunchTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewCirros(withoutACPI()), vmiLaunchTimeout)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
@@ -153,7 +153,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi after paused and unpaused via virtctl", func() {
 			It("should failed to soft reboot a paused vmi", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewFedora(), vmiLaunchTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewFedora(), vmiLaunchTimeout)
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				command := clientcmd.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_PAUSE, "vmi", "--namespace", testsuite.GetTestNamespace(vmi), vmi.Name)

--- a/tests/stability_test.go
+++ b/tests/stability_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/gmeasure"
 
-	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 )
 
@@ -19,7 +19,7 @@ var _ = PDescribe("Ensure stable functionality", func() {
 
 		experiment.Sample(func(idx int) {
 			experiment.MeasureDuration("Create VM", func() {
-				tests.RunVMIAndExpectLaunch(libvmifact.NewCirros(), 30)
+				libclient.RunVMIAndExpectLaunch(libvmifact.NewCirros(), 30)
 			})
 		}, gmeasure.SamplingConfig{N: 15, Duration: 10 * time.Minute})
 	})

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/framework/storage:go_default_library",
+        "//tests/libclient:go_default_library",
         "//tests/libdv:go_default_library",
         "//tests/libinstancetype:go_default_library",
         "//tests/libkvconfig:go_default_library",

--- a/tests/storage/backendstorage.go
+++ b/tests/storage/backendstorage.go
@@ -22,21 +22,22 @@ package storage
 import (
 	"context"
 
-	"kubevirt.io/kubevirt/pkg/controller"
-
-	"kubevirt.io/kubevirt/tests/libnet"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
+	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -90,7 +91,7 @@ var _ = SIGDescribe("[Serial]Backend Storage", Serial, func() {
 			libnet.WithMasqueradeNetworking()...,
 		)
 		vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 		By("Expecting the creation of a backend storage PVC with the right storage class")
 		pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).Get(context.Background(), backendstorage.PVCForVMI(vmi), metav1.GetOptions{})

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -28,6 +28,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	expect "github.com/google/goexpect"
 	storagev1 "k8s.io/api/storage/v1"
@@ -136,7 +137,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				libvmi.WithResourceMemory("1Gi"),
 				libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n"),
 			)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 500)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 500)
 
 			By("Expecting the VirtualMachineInstance console")
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -227,7 +228,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 120)
 
 				By(checkingVMInstanceConsoleExpectedOut)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -56,6 +56,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libdv"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnode"
@@ -1191,7 +1192,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			DescribeTable("should allow live migration with attached hotplug volumes", func(vmiFunc func() *v1.VirtualMachineInstance) {
 				vmi = vmiFunc()
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 				volumeName := "testvolume"
 				volumeMode := corev1.PersistentVolumeBlock
 				addVolumeFunc := addDVVolumeVMI

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -283,7 +284,7 @@ var _ = SIGDescribe("Storage", func() {
 					if storageEngine == "nfs" {
 						vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 					} else {
-						vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
+						vmi = libclient.RunVMIAndExpectLaunch(vmi, 180)
 					}
 
 					By(checkingVMInstanceConsoleOut)
@@ -303,7 +304,7 @@ var _ = SIGDescribe("Storage", func() {
 				num := 3
 				By("Starting and stopping the VirtualMachineInstance number of times")
 				for i := 1; i <= num; i++ {
-					vmi := tests.RunVMIAndExpectLaunch(vmi, 90)
+					vmi := libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 					// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 					// after being restarted multiple times
@@ -331,7 +332,7 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithResourceMemory("512M"),
 					libvmi.WithEmptyDisk("emptydisk1", v1.DiskBusVirtio, resource.MustParse("1G")),
 				)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
@@ -377,7 +378,7 @@ var _ = SIGDescribe("Storage", func() {
 						},
 					},
 				})
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
@@ -443,7 +444,7 @@ var _ = SIGDescribe("Storage", func() {
 					if storageEngine == "nfs" {
 						vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 120)
 					} else {
-						vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
+						vmi = libclient.RunVMIAndExpectLaunch(vmi, 120)
 					}
 
 					By(checkingVMInstanceConsoleOut)
@@ -468,7 +469,7 @@ var _ = SIGDescribe("Storage", func() {
 				if isRunOnKindInfra {
 					createdVMI = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 90)
 				} else {
-					createdVMI = tests.RunVMIAndExpectLaunch(vmi, 90)
+					createdVMI = libclient.RunVMIAndExpectLaunch(vmi, 90)
 				}
 
 				By("Writing an arbitrary file to it's EFI partition")
@@ -496,7 +497,7 @@ var _ = SIGDescribe("Storage", func() {
 				if isRunOnKindInfra {
 					tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 90)
 				} else {
-					tests.RunVMIAndExpectLaunch(vmi, 90)
+					libclient.RunVMIAndExpectLaunch(vmi, 90)
 				}
 
 				By("Making sure that the previously written file is not present")
@@ -534,7 +535,7 @@ var _ = SIGDescribe("Storage", func() {
 				num := 3
 				By("Starting and stopping the VirtualMachineInstance number of times")
 				for i := 1; i <= num; i++ {
-					obj := tests.RunVMIAndExpectLaunch(vmi, 240)
+					obj := libclient.RunVMIAndExpectLaunch(vmi, 240)
 
 					// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 					// after being restarted multiple times
@@ -624,7 +625,7 @@ var _ = SIGDescribe("Storage", func() {
 						)
 						vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = driver
 
-						vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+						vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 						By("Checking if disk.img has been created")
 						vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -654,7 +655,7 @@ var _ = SIGDescribe("Storage", func() {
 							// hostdisk needs a privileged namespace
 							libvmi.WithNamespace(testsuite.NamespacePrivileged),
 						)
-						vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+						vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 						By("Checking if another.img has been created")
 						vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -709,7 +710,7 @@ var _ = SIGDescribe("Storage", func() {
 							// hostdisk needs a privileged namespace
 							libvmi.WithNamespace(testsuite.NamespacePrivileged),
 						)
-						vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+						vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 						By("Checking if disk.img exists")
 						vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -796,7 +797,7 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 							libvmi.WithNodeSelectorFor(&k8sv1.Node{ObjectMeta: metav1.ObjectMeta{Name: node}}))
-						vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+						vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 						By("Checking if disk.img exists")
 						vmiPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -916,7 +917,7 @@ var _ = SIGDescribe("Storage", func() {
 						libvmi.WithNamespace(testsuite.NamespacePrivileged),
 					)
 					vmi.Spec.Volumes[0].HostDisk.Capacity = resource.MustParse(strconv.Itoa(int(float64(diskSize) * 1.2)))
-					tests.RunVMIAndExpectLaunch(vmi, 30)
+					libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 					By("Checking events")
 					objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(30) * time.Second)
@@ -956,7 +957,7 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithPersistentVolumeClaim("disk0", dataVolume.Name),
 					libvmi.WithCloudInitNoCloudEncodedUserData(cirrosUserData),
 				)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 				By(checkingVMInstanceConsoleOut)
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -970,7 +971,7 @@ var _ = SIGDescribe("Storage", func() {
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), testsuite.GetTestNamespace(nil), k8sv1.ReadWriteMany)
 				By("Launching a VMI with PVC ")
-				tests.RunVMIAndExpectLaunch(vmi, 180)
+				libclient.RunVMIAndExpectLaunch(vmi, 180)
 
 				By(checkingVMInstanceConsoleOut)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -1030,7 +1031,7 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithEmptyDisk("emptydisk1", v1.DiskBusSCSI, resource.MustParse("1Gi")),
 					libvmi.WithEmptyDisk("emptydisk2", v1.DiskBusSATA, resource.MustParse("1Gi")),
 				)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
@@ -1052,7 +1053,7 @@ var _ = SIGDescribe("Storage", func() {
 					vmi = libvmifact.NewAlpine(
 						libvmi.WithEmptyDisk("emptydisk1", v1.DiskBusUSB, resource.MustParse("128Mi")),
 					)
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+					vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 					By("Checking that /dev/sda has a capacity of 128Mi")
@@ -1096,7 +1097,7 @@ var _ = SIGDescribe("Storage", func() {
 				)
 
 				By("Initializing the VM")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -1116,7 +1117,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				By("Initializing the VM")
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 				runningPod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1241,8 +1242,8 @@ var _ = SIGDescribe("Storage", func() {
 				setShareable(vmi2, diskName)
 
 				By("Starting the VirtualMachineInstances")
-				vmi1 = tests.RunVMIAndExpectLaunch(vmi1, 500)
-				vmi2 = tests.RunVMIAndExpectLaunch(vmi2, 500)
+				vmi1 = libclient.RunVMIAndExpectLaunch(vmi1, 500)
+				vmi2 = libclient.RunVMIAndExpectLaunch(vmi2, 500)
 				By("Write data from the first VMI")
 				Expect(console.LoginToAlpine(vmi1)).To(Succeed())
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libclient"
 	instancetypebuilder "kubevirt.io/kubevirt/tests/libinstancetype/builder"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -193,7 +194,7 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 
 			It("[test_id:2265][posneg:negative] should return an error when VM has not been found but VMI is running", func() {
 				vmi := libvmifact.NewGuestless()
-				tests.RunVMIAndExpectLaunch(vmi, 60)
+				libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 				err := virtCli.VirtualMachine(testsuite.GetTestNamespace(vmi)).Restart(context.Background(), vmi.Name, &v1.RestartOptions{})
 				Expect(err).To(HaveOccurred())

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -27,38 +27,32 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/pointer"
-
-	"kubevirt.io/kubevirt/tests/libmigration"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-
-	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
 	expect "github.com/google/goexpect"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "k8s.io/api/core/v1"
-
-	"kubevirt.io/kubevirt/tests/console"
-
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	virtv1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/client-go/kubecli"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
+	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
-
-	"kubevirt.io/client-go/kubecli"
-
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -122,7 +116,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			vmi.Spec.Domain.Memory = &virtv1.Memory{Guest: &vmiMemSizeMi}
 
 			By("Starting the VirtualMachineInstance")
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 240)
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 			By("Consume more memory than the node's memory")
 			err = fillMemWithStressFedoraVMI(vmi, memToUseInTheVmKib)
@@ -176,7 +170,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			vmiToFillTargetNodeMem.Spec.Domain.Resources.Requests["memory"] = vmiMemReq
 
 			By("Starting the VirtualMachineInstance")
-			vmiToFillTargetNodeMem = tests.RunVMIAndExpectLaunch(vmiToFillTargetNodeMem, 240)
+			vmiToFillTargetNodeMem = libclient.RunVMIAndExpectLaunch(vmiToFillTargetNodeMem, 240)
 			Expect(console.LoginToFedora(vmiToFillTargetNodeMem)).To(Succeed())
 
 			By("reaching memory overcommitment in the target node")
@@ -193,7 +187,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			//add label the source node to make sure that the vm we want to migrate will be scheduled to the source node
 
 			By("Starting the VirtualMachineInstance that we should migrate to the target node")
-			vmiToMigrate = tests.RunVMIAndExpectLaunch(vmiToMigrate, 240)
+			vmiToMigrate = libclient.RunVMIAndExpectLaunch(vmiToMigrate, 240)
 			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
 
 			// execute a migration, wait for finalized state

--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +35,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 )
 
@@ -70,7 +70,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		var vmi *v1.VirtualMachineInstance
 		BeforeEach(func() {
 			vmi = libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation))
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 		})
 
 		It("should fail to connect to VMI's usbredir socket", func() {
@@ -85,7 +85,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		var vmi *v1.VirtualMachineInstance
 		BeforeEach(func() {
 			vmi = libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation), withClientPassthrough())
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 90)
 		})
 
 		Context("with an usbredir connection", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -91,16 +91,6 @@ const (
 	DiskCustomHostPath     = "disk-custom-host-path"
 )
 
-func RunVMIAndExpectLaunch(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
-	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	By(waitingVMInstanceStart)
-	return libwait.WaitForVMIPhase(vmi,
-		[]v1.VirtualMachineInstancePhase{v1.Running},
-		libwait.WithTimeout(timeout),
-	)
-}
-
 func RunVMIAndExpectLaunchWithDataVolume(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume, timeout int) *v1.VirtualMachineInstance {
 	vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -29,11 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/pointer"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-
 	expect "github.com/google/goexpect"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -41,23 +36,27 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libsecret"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
-
-	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
-
-	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
-	"kubevirt.io/kubevirt/pkg/util/net/dns"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
-	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
 const (
@@ -143,7 +142,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					libvmi.WithCloudInitNoCloudEncodedUserData(userData),
 				)
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -182,7 +181,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -274,7 +273,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 
 			runTest := func(vmi *v1.VirtualMachineInstance, dsType cloudinit.DataSourceType) {
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 				By("waiting until login appears")
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
@@ -330,7 +329,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				break
 			}
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 			CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)

--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,7 +29,7 @@ var _ = Describe("[sig-compute]Controller devices", decorators.SigCompute, func(
 		DescribeTable("a scsi controller", func(enabled bool) {
 			vmi := libvmifact.NewCirros()
 			vmi.Spec.Domain.Devices.DisableHotplug = !enabled
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			domSpec := &api.DomainSpec{}

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -26,31 +26,29 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libnode"
-
-	virt_api "kubevirt.io/kubevirt/pkg/virt-api"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"kubevirt.io/kubevirt/tests/testsuite"
-
 	v1 "kubevirt.io/api/core/v1"
 	kvcorev1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+	virt_api "kubevirt.io/kubevirt/pkg/virt-api"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, func() {
@@ -73,11 +71,11 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 			})
 
 			It("[test_id:707]should create headless vmi without any issue", func() {
-				tests.RunVMIAndExpectLaunch(vmi, 30)
+				libclient.RunVMIAndExpectLaunch(vmi, 30)
 			})
 
 			It("[test_id:714][posneg:positive]should not have vnc graphic device in xml", func() {
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should get vmi spec without problem")
@@ -92,7 +90,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 					},
 					OvercommitGuestOverhead: true,
 				}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 				readyPod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
@@ -107,7 +105,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 						kubev1.ResourceMemory: resource.MustParse("100M"),
 					},
 				}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 				readyPod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
@@ -119,8 +117,8 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 			It("[test_id:713]should have more memory on pod when headless", func() {
 				normalVmi := libvmifact.NewAlpine()
 
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
-				normalVmi = tests.RunVMIAndExpectLaunch(normalVmi, 30)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
+				normalVmi = libclient.RunVMIAndExpectLaunch(normalVmi, 30)
 
 				readyPod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				Expect(err).ToNot(HaveOccurred())
@@ -140,7 +138,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 			})
 
 			It("[test_id:738][posneg:negative]should not connect to VNC", func() {
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 				_, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
 
@@ -148,7 +146,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 			})
 
 			It("[test_id:709][posneg:positive]should connect to console", func() {
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 				By("checking that console works")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -159,7 +157,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 		Context("without headless", func() {
 
 			It("[test_id:714][posneg:negative]should have one vnc graphic device in xml", func() {
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should get vmi spec without problem")
@@ -221,7 +219,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", decorators.SigCompute, 
 
 				By("Running the VMI")
 				vmi = libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 30)
 
 				By("VMI has the guest agent connected condition")
 				Eventually(matcher.ThisVMI(vmi), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected), "should have agent connected condition")

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -41,16 +41,17 @@ import (
 	hooksv1alpha3 "kubevirt.io/kubevirt/pkg/hooks/v1alpha3"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/tests/libvmifact"
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libregistry"
+	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 	"kubevirt.io/kubevirt/tests/util"
@@ -214,7 +215,7 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 
 		Context("with sidecar-shim", func() {
 			It("should receive Terminal signal on VMI deletion", func() {
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 360)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 360)
 
 				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -243,7 +244,7 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 				checks.SkipIfMigrationIsNotPossible()
 
 				vmi.ObjectMeta.Annotations = RenderSidecar(hookVersion)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 360)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 360)
 
 				sourcePod, exists, err := getVMIPod(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -301,7 +302,7 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 				} else {
 					vmi.ObjectMeta.Annotations = RenderSidecarWithConfigMapWithoutImage(hooksv1alpha2.Version, cm.Name)
 				}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 360)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 360)
 				domainXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(domainXml).Should(ContainSubstring("<sysinfo type='smbios'>"))

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -24,16 +24,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/kubevirt/tests/decorators"
-
-	"kubevirt.io/kubevirt/tests/framework/checks"
-
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 )
 
@@ -50,7 +48,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Context("with injected data", func() {
 				It("[test_id:1616]should have injected data under firmware directory", func() {
 					ignitionData := "ignition injected"
-					vmi := tests.RunVMIAndExpectLaunch(
+					vmi := libclient.RunVMIAndExpectLaunch(
 						libvmifact.NewFedora(libvmi.WithAnnotation(v1.IgnitionAnnotation, ignitionData)),
 						240)
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -62,6 +62,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libsecret"
@@ -126,12 +127,12 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:1620]should start it", func() {
-			tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
+			libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 		})
 
 		It("[test_id:6095]should start in paused state if start strategy set to paused", func() {
 			vmi := libvmifact.NewAlpine(libvmi.WithStartStrategy(v1.StartStrategyPaused))
-			vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 			By("Unpausing VMI")
@@ -141,7 +142,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:1621]should attach virt-launcher to it", func() {
-			vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
+			vmi := libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 			By("Getting virt-launcher logs")
 			logs := func() string { return getVirtLauncherLogs(kubevirt.Client(), vmi) }
@@ -152,7 +153,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:3195]should carry annotations to pod", func() {
-			vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(
+			vmi := libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(
 				libvmi.WithAnnotation("testannotation", "annotation from vmi")),
 				startupTimeout)
 
@@ -163,7 +164,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:3196]should carry kubernetes and kubevirt annotations to pod", func() {
-			vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(
+			vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(
 				libvmi.WithAnnotation("kubevirt.io/test", "test"),
 				libvmi.WithAnnotation("kubernetes.io/test", "test")),
 				startupTimeout)
@@ -177,7 +178,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 		It("Should prevent eviction when EvictionStratgy: External", func() {
 			vmi := libvmifact.NewAlpine(libvmi.WithEvictionStrategy(v1.EvictionStrategyExternal))
-			vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 			pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(err).NotTo(HaveOccurred())
@@ -204,7 +205,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		It("[test_id:1622]should log libvirtd logs", func() {
-			vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
+			vmi := libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 			By("Getting virt-launcher logs")
 			logs := func() string { return getVirtLauncherLogs(kubevirt.Client(), vmi) }
@@ -229,7 +230,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			}
 			vmi := libvmi.New(options...)
 
-			vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 			By("Getting virt-launcher logs")
 			logs := func() string { return getVirtLauncherLogs(kubevirt.Client(), vmi) }
@@ -354,7 +355,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi = addBootOrderToDisk(vmi, "disk0", &alpineBootOrder)
 				vmi = addBootOrderToDisk(vmi, "disk2", &cirrosBootOrder)
 				By("starting VMI")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 2*startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, 2*startupTimeout)
 
 				By("Checking console text")
 				err = console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -469,7 +470,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			It("[test_id:5761]should check if vm with valid node selector is scheduled and running and node selector is not updated", func() {
 				vmi := libvmifact.NewCirros()
 				vmi.Spec.NodeSelector = map[string]string{k8sv1.LabelOSStable: "linux"}
-				tests.RunVMIAndExpectLaunch(vmi, 60)
+				libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 				pods, err := kubevirt.Client().CoreV1().Pods(testsuite.GetTestNamespace(vmi)).List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -792,7 +793,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			It("[test_id:1635]the vmi with tolerations should be scheduled", func() {
 				vmi := libvmifact.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmi.Spec.Tolerations = []k8sv1.Toleration{{Key: "test", Value: "123"}}
-				tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 			})
 
 			It("[test_id:1636]the vmi without tolerations should not be scheduled", func() {
@@ -823,7 +824,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 			It("[test_id:1637]the vmi with node affinity and no conflicts should be scheduled", func() {
 				vmi := libvmifact.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 				Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "Updated VMI name run on the same node")
@@ -832,7 +833,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 			It("[test_id:1638]the vmi with node affinity and anti-pod affinity should not be scheduled", func() {
 				vmi := libvmifact.NewCirros(libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 				Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "VMI should run on the same node")
@@ -904,7 +905,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				tests.UpdateKubeVirtConfigValueAndWait(*config)
 
 				vmi := libvmifact.NewCirros()
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 				Expect(curVMI.Spec.Domain.CPU.Model).To(Equal(defaultCPUModel), "Expected default CPU model")
@@ -920,7 +921,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Model: vmiCPUModel,
 				}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
@@ -930,7 +931,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 			It("[sig-compute][test_id:3201]should set cpu model to default when vmi does not have it set and default cpu model is not set", func() {
 				vmi := libvmifact.NewCirros()
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				curVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
@@ -948,7 +949,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				tests.UpdateKubeVirtConfigValueAndWait(*config)
 
 				newVMI := libvmifact.NewCirros()
-				newVMI = tests.RunVMIAndExpectLaunch(newVMI, 90)
+				newVMI = libclient.RunVMIAndExpectLaunch(newVMI, 90)
 				By("Fetching virt-launcher pod")
 				virtLauncherPod, err := libpod.GetPodByVirtualMachineInstance(newVMI, newVMI.Namespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -970,7 +971,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				newVMI.Spec.Domain.CPU = &v1.CPU{
 					Model: vmiCPUModel,
 				}
-				newVMI = tests.RunVMIAndExpectLaunch(newVMI, 90)
+				newVMI = libclient.RunVMIAndExpectLaunch(newVMI, 90)
 				By("Fetching virt-launcher pod")
 				virtLauncherPod, err := libpod.GetPodByVirtualMachineInstance(newVMI, newVMI.Namespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -1021,7 +1022,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					Cores: 1,
 					Model: supportedCPU,
 				}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				By("Verifying VirtualMachineInstance's status is Succeeded")
 				Eventually(func() v1.VirtualMachineInstancePhase {
@@ -1083,7 +1084,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 						},
 					},
 				}
-				tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 			})
 
 			It("[test_id:3203]the vmi with cpu.features that cannot match nfd labels on a node should not be scheduled", func() {
@@ -1407,7 +1408,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:1646]should request a KVM and TUN device", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 				pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1428,7 +1429,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:1647]should not enable emulation in virt-launcher", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 				pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1484,7 +1485,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance's Pod", func() {
 		It("[test_id:1650]should result in the VirtualMachineInstance moving to a finalized state", func() {
 			By("Creating the VirtualMachineInstance")
-			vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
+			vmi := libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 			By("Verifying VirtualMachineInstance's pod is active")
 			pods, err := kubevirt.Client().CoreV1().Pods(vmi.Namespace).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
@@ -1516,7 +1517,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			It("[test_id:1651]should result in pod being terminated", func() {
 
 				By("Creating the VirtualMachineInstance")
-				vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
+				vmi := libclient.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 				podSelector := tests.UnfinishedVMIPodSelector(vmi)
 				By("Verifying VirtualMachineInstance's pod is active")
@@ -1592,7 +1593,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi.Spec.NodeSelector = map[string]string{k8sv1.LabelHostname: node}
 
 				By("Creating the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
+				vmi = libclient.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
 				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
 				By("Deleting the VirtualMachineInstance")

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libclient"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
@@ -35,7 +36,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -51,7 +51,7 @@ var _ = Describe("[sig-compute]Health Monitoring", decorators.SigCompute, func()
 
 	Describe("A VirtualMachineInstance with a watchdog device", func() {
 		It("[test_id:4641]should be shut down when the watchdog expires", func() {
-			vmi := tests.RunVMIAndExpectLaunch(
+			vmi := libclient.RunVMIAndExpectLaunch(
 				libvmifact.NewAlpine(libvmi.WithWatchdog(v1.WatchdogActionPoweroff)), 360)
 
 			By("Expecting the VirtualMachineInstance console")

--- a/tests/vmi_tpm_test.go
+++ b/tests/vmi_tpm_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -37,7 +38,6 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 )
 
@@ -54,7 +54,7 @@ var _ = Describe("[sig-compute]vTPM", decorators.SigCompute, decorators.Requires
 			By("Creating a VMI with TPM enabled")
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...)
 			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{}
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 			By("Logging in as root")
 			err = console.LoginToFedora(vmi)

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libclient"
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -73,7 +74,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...)
 			vmi.Spec.Domain.Devices.UseVirtioTransitional = &useVirtioTransitional
 			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(vmi.Status.VSOCKCID).NotTo(BeNil())
 
 			By("creating valid libvirt domain")
@@ -130,7 +131,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			By("Creating a VMI with VSOCK enabled")
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...)
 			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+			vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(vmi.Status.VSOCKCID).NotTo(BeNil())
 
 			By("creating valid libvirt domain")
@@ -146,7 +147,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			vmi2 := libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...)
 			vmi2.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 			vmi2.Spec.Affinity = affinity(node)
-			vmi2 = tests.RunVMIAndExpectLaunch(vmi2, 60)
+			vmi2 = libclient.RunVMIAndExpectLaunch(vmi2, 60)
 			Expect(vmi2.Status.VSOCKCID).NotTo(BeNil())
 
 			By("creating valid libvirt domain")
@@ -184,7 +185,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			libvmi.WithCloudInitNoCloudUserData(userData),
 		)
 		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 		By("Logging in as root")
 		err = console.LoginToFedora(vmi)
@@ -249,7 +250,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		By("Creating a VMI with VSOCK enabled")
 		vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...)
 		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 		By("Connect to the guest on invalide port")
 		_, err = virtClient.VirtualMachineInstance(vmi.Namespace).VSOCK(vmi.Name, &v1.VSOCKOptions{TargetPort: uint32(0)})
@@ -262,7 +263,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		By("Creating a VMI with VSOCK enabled")
 		vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking()...)
 		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+		vmi = libclient.RunVMIAndExpectLaunch(vmi, 60)
 
 		By("Connect to the guest on the unused port")
 		cliConn, svrConn := net.Pipe()


### PR DESCRIPTION
### What this PR does
This PR creates a new libclient package and moves vmi related function `RunVMIAndExpectLaunch` to it.
libclient package is meant to hold functions that mainly use the go clientset in order to perform various actions on objects such as VMIs.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

