### PR TITLE
Simplify and improve how RerunOnFailure works

### DIFF
--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -6239,10 +6239,6 @@ var _ = Describe("VirtualMachine", func() {
 
 			BeforeEach(func() {
 				vm, vmi = DefaultVirtualMachine(true)
-				vm.Status.Conditions = append(vm.Status.Conditions, v1.VirtualMachineCondition{
-					Type:   v1.VirtualMachineInitialized,
-					Status: k8sv1.ConditionTrue,
-				})
 				vm.ObjectMeta.UID = types.UID(uuid.NewString())
 				vmi.ObjectMeta.UID = vm.ObjectMeta.UID
 				vm.Generation = 1
@@ -6454,7 +6450,7 @@ var _ = Describe("VirtualMachine", func() {
 		It("should sync appropriate conditions and ignore others", func() {
 			fromCondList := []v1.VirtualMachineConditionType{
 				v1.VirtualMachineReady, v1.VirtualMachineFailure, v1.VirtualMachinePaused,
-				v1.VirtualMachineInitialized, v1.VirtualMachineRestartRequired,
+				v1.VirtualMachineRestartRequired,
 			}
 			toCondList := []v1.VirtualMachineConditionType{
 				v1.VirtualMachineReady, v1.VirtualMachinePaused,

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1683,9 +1683,6 @@ const (
 	// signals with its own condition that it is paused.
 	VirtualMachinePaused VirtualMachineConditionType = "Paused"
 
-	// VirtualMachineInitialized means the virtual machine object has been seen by the VM controller
-	VirtualMachineInitialized VirtualMachineConditionType = "Initialized"
-
 	// VirtualMachineRestartRequired is added when changes made to the VM can't be live-propagated to the VMI
 	VirtualMachineRestartRequired VirtualMachineConditionType = "RestartRequired"
 )


### PR DESCRIPTION
### What this PR does
Before this PR:
RerunOnFailure needs an additional VM condition
RerunOnFailure, when added after VM creation, doesn't trigger a VM start

After this PR:
!Before

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

