### PR TITLE
Fix RerunOnFailure RunStrategy

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20996,6 +20996,10 @@
       "description": "RestoreInProgress is the name of the VirtualMachineRestore currently executing",
       "type": "string"
      },
+     "runStrategy": {
+      "description": "RunStrategy tracks the last recorded RunStrategy used by the VM. This is needed to correctly process the next strategy (for now only the RerunOnFailure)",
+      "type": "string"
+     },
      "snapshotInProgress": {
       "description": "SnapshotInProgress is the name of the VirtualMachineSnapshot currently executing",
       "type": "string"

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -965,7 +965,7 @@ func (c *VMController) addStartRequest(vm *virtv1.VirtualMachine) error {
 	return nil
 }
 
-func (c *VMController) startStop(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, syncError) {
+func (c *VMController) syncRunStrategy(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, syncError) {
 	runStrategy, err := vm.RunStrategy()
 	if err != nil {
 		return vm, &syncErrorImpl{fmt.Errorf(fetchingRunStrategyErrFmt, err), FailedCreateReason}
@@ -3059,6 +3059,9 @@ func (c *VMController) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.Virtual
 }
 
 func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, key string, dataVolumes []*cdiv1.DataVolume) (*virtv1.VirtualMachine, syncError, error) {
+
+	defer virtControllerVMWorkQueueTracer.StepTrace(key, "sync", trace.Field{Key: "VM Name", Value: vm.Name})
+
 	var (
 		syncErr     syncError
 		err         error
@@ -3131,111 +3134,103 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 	if err != nil {
 		log.Log.Object(vm).Infof("Failed to store Instancetype ControllerRevisions for VirtualMachine: %s/%s", vm.Namespace, vm.Name)
 		c.recorder.Eventf(vm, k8score.EventTypeWarning, FailedCreateVirtualMachineReason, "Error encountered while storing Instancetype ControllerRevisions: %v", err)
-		syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while storing Instancetype ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}
+		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while storing Instancetype ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}, err
 	}
 
 	// Once we have ControllerRevisions make sure they are fully up to date before proceeding
 	if err := c.instancetypeMethods.Upgrade(vm); err != nil {
 		log.Log.Object(vm).Reason(err).Errorf("failed to upgrade instancetype.kubevirt.io ControllerRevisions for VirtualMachine: %s/%s", vm.Namespace, vm.Name)
 		c.recorder.Eventf(vm, k8score.EventTypeWarning, FailedCreateVirtualMachineReason, "error encountered while upgrading instancetype.kubevirt.io ControllerRevisions: %v", err)
-		syncErr = &syncErrorImpl{fmt.Errorf("error encountered while upgrading instancetype.kubevirt.io ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}
+		return vm, &syncErrorImpl{fmt.Errorf("error encountered while upgrading instancetype.kubevirt.io ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}, nil
 	}
 
-	if syncErr == nil {
-		dataVolumesReady, err := c.handleDataVolumes(vm, dataVolumes)
-		if err != nil {
-			syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}
-		} else if dataVolumesReady || runStrategy == virtv1.RunStrategyHalted {
-			vm, syncErr = c.startStop(vm, vmi)
-		} else {
-			log.Log.Object(vm).V(3).Infof("Waiting on DataVolumes to be ready. %d datavolumes found", len(dataVolumes))
-		}
+	dataVolumesReady, err := c.handleDataVolumes(vm, dataVolumes)
+	if err != nil {
+		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}, err
+	}
+
+	if !dataVolumesReady && runStrategy != virtv1.RunStrategyHalted {
+		log.Log.Object(vm).V(3).Infof("Waiting on DataVolumes to be ready. %d datavolumes found", len(dataVolumes))
+		return vm, nil, nil
+	}
+
+	vm, syncErr = c.syncRunStrategy(vm, vmi)
+	if syncErr != nil {
+		return vm, syncErr, nil
 	}
 
 	vm, restartRequired := c.addRestartRequiredIfNeeded(startVMSpec, vm)
 
+	if !c.needsSync(key) {
+		return vm, nil, nil
+	}
+
 	// Must check needsSync again here because a VMI can be created or
 	// deleted in the startStop function which impacts how we process
 	// hotplugged volumes and interfaces
-	if c.needsSync(key) && syncErr == nil {
-		vmCopy := vm.DeepCopy()
-		if c.clusterConfig.HotplugNetworkInterfacesEnabled() &&
-			vmi != nil && vmi.DeletionTimestamp == nil {
-			vmiCopy := vmi.DeepCopy()
+	vmCopy := vm.DeepCopy()
 
-			indexedStatusIfaces := vmispec.IndexInterfaceStatusByName(vmi.Status.Interfaces,
-				func(ifaceStatus virtv1.VirtualMachineInstanceNetworkInterface) bool { return true })
+	if c.clusterConfig.HotplugNetworkInterfacesEnabled() &&
+		vmi != nil && vmi.DeletionTimestamp == nil {
+		vmiCopy := vmi.DeepCopy()
 
-			ifaces, networks := network.ClearDetachedInterfaces(vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces, vmCopy.Spec.Template.Spec.Networks, indexedStatusIfaces)
-			vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces = ifaces
-			vmCopy.Spec.Template.Spec.Networks = networks
+		indexedStatusIfaces := vmispec.IndexInterfaceStatusByName(vmi.Status.Interfaces,
+			func(ifaceStatus virtv1.VirtualMachineInstanceNetworkInterface) bool { return true })
 
-			ifaces, networks = network.ClearDetachedInterfaces(vmiCopy.Spec.Domain.Devices.Interfaces, vmiCopy.Spec.Networks, indexedStatusIfaces)
-			vmiCopy.Spec.Domain.Devices.Interfaces = ifaces
-			vmiCopy.Spec.Networks = networks
+		ifaces, networks := network.ClearDetachedInterfaces(vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces, vmCopy.Spec.Template.Spec.Networks, indexedStatusIfaces)
+		vmCopy.Spec.Template.Spec.Domain.Devices.Interfaces = ifaces
+		vmCopy.Spec.Template.Spec.Networks = networks
 
-			if hasOrdinalIfaces, err := c.hasOrdinalNetworkInterfaces(vmi); err != nil {
-				syncErr = &syncErrorImpl{fmt.Errorf("Error encountered when trying to check if VMI has interface with ordinal names (e.g.: eth1, eth2..): %v", err), HotPlugNetworkInterfaceErrorReason}
-			} else {
-				updatedVmiSpec := network.ApplyDynamicIfaceRequestOnVMI(vmCopy, vmiCopy, hasOrdinalIfaces)
-				vmiCopy.Spec = *updatedVmiSpec
-			}
+		ifaces, networks = network.ClearDetachedInterfaces(vmiCopy.Spec.Domain.Devices.Interfaces, vmiCopy.Spec.Networks, indexedStatusIfaces)
+		vmiCopy.Spec.Domain.Devices.Interfaces = ifaces
+		vmiCopy.Spec.Networks = networks
 
-			if syncErr == nil {
-				if err = c.vmiInterfacesPatch(&vmiCopy.Spec, vmi); err != nil {
-					syncErr = &syncErrorImpl{fmt.Errorf("Error encountered when trying to patch vmi: %v", err), FailedUpdateErrorReason}
-				}
-			}
-		}
-
-		err = c.handleVolumeRequests(vmCopy, vmi)
-		if err != nil {
-			syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling volume hotplug requests: %v", err), HotPlugVolumeErrorReason}
+		if hasOrdinalIfaces, err := c.hasOrdinalNetworkInterfaces(vmi); err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to check if VMI has interface with ordinal names (e.g.: eth1, eth2..): %v", err), HotPlugNetworkInterfaceErrorReason}, err
 		} else {
-			err = c.handleMemoryDumpRequest(vmCopy, vmi)
-			if err != nil {
-				syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling memory dump request: %v", err), MemoryDumpErrorReason}
-			}
+			updatedVmiSpec := network.ApplyDynamicIfaceRequestOnVMI(vmCopy, vmiCopy, hasOrdinalIfaces)
+			vmiCopy.Spec = *updatedVmiSpec
 		}
 
-		if c.clusterConfig.IsVMRolloutStrategyLiveUpdate() && !restartRequired && !conditionManager.HasCondition(vm, virtv1.VirtualMachineRestartRequired) {
-			err = c.handleCPUChangeRequest(vmCopy, vmi)
-			if err != nil {
-				syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling CPU change request: %v", err), HotPlugCPUErrorReason}
-			}
-
-			if err := c.handleAffinityChangeRequest(vmCopy, vmi); err != nil {
-				syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling node affinity change request: %v", err), AffinityChangeErrorReason}
-			}
-
-			if err := c.handleMemoryHotplugRequest(vmCopy, vmi); err != nil {
-				syncErr = &syncErrorImpl{
-					err:    fmt.Errorf("error encountered while handling memory hotplug requests: %v", err),
-					reason: HotPlugMemoryErrorReason,
-				}
-			}
-
-			if err := c.handleVolumeUpdateRequest(vmCopy, vmi); err != nil {
-				syncErr = &syncErrorImpl{
-					err:    fmt.Errorf("error encountered while handling volumes update requests: %v", err),
-					reason: VolumesUpdateErrorReason,
-				}
-			}
-		}
-
-		if syncErr == nil {
-			if !equality.Semantic.DeepEqual(vm, vmCopy) {
-				updatedVm, err := c.clientset.VirtualMachine(vmCopy.Namespace).Update(context.Background(), vmCopy, metav1.UpdateOptions{})
-				if err != nil {
-					syncErr = &syncErrorImpl{fmt.Errorf("Error encountered when trying to update vm according to add volume and/or memory dump requests: %v", err), FailedUpdateErrorReason}
-				} else {
-					vm = updatedVm
-				}
-			}
+		if err := c.vmiInterfacesPatch(&vmiCopy.Spec, vmi); err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to patch vmi: %v", err), FailedUpdateErrorReason}, err
 		}
 	}
 
-	virtControllerVMWorkQueueTracer.StepTrace(key, "sync", trace.Field{Key: "VM Name", Value: vm.Name})
+	if err := c.handleVolumeRequests(vmCopy, vmi); err != nil {
+		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling volume hotplug requests: %v", err), HotPlugVolumeErrorReason}, err
+	}
+
+	if err := c.handleMemoryDumpRequest(vmCopy, vmi); err != nil {
+		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling memory dump request: %v", err), MemoryDumpErrorReason}, err
+	}
+
+	conditionManager := controller.NewVirtualMachineConditionManager()
+	if c.clusterConfig.IsVMRolloutStrategyLiveUpdate() && !restartRequired && !conditionManager.HasCondition(vm, virtv1.VirtualMachineRestartRequired) {
+		if err := c.handleCPUChangeRequest(vmCopy, vmi); err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling CPU change request: %v", err), HotPlugCPUErrorReason}, err
+		}
+
+		if err := c.handleAffinityChangeRequest(vmCopy, vmi); err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling node affinity change request: %v", err), AffinityChangeErrorReason}, err
+		}
+
+		if err := c.handleMemoryHotplugRequest(vmCopy, vmi); err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("error encountered while handling memory hotplug requests: %v", err), HotPlugMemoryErrorReason}, err
+		}
+
+		if err := c.handleVolumeUpdateRequest(vmCopy, vmi); err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("error encountered while handling volumes update requests: %v", err), VolumesUpdateErrorReason}, err
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(vm, vmCopy) {
+		updatedVm, err := c.clientset.VirtualMachine(vmCopy.Namespace).Update(context.Background(), vmCopy, metav1.UpdateOptions{})
+		if err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to update vm according to add volume and/or memory dump requests: %v", err), FailedUpdateErrorReason}, err
+		}
+		vm = updatedVm
+	}
 
 	return vm, syncErr, nil
 }

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7608,6 +7608,11 @@ var CRDsValidation map[string]string = map[string]string{
           description: RestoreInProgress is the name of the VirtualMachineRestore
             currently executing
           type: string
+        runStrategy:
+          description: |-
+            RunStrategy tracks the last recorded RunStrategy used by the VM.
+            This is needed to correctly process the next strategy (for now only the RerunOnFailure)
+          type: string
         snapshotInProgress:
           description: SnapshotInProgress is the name of the VirtualMachineSnapshot
             currently executing
@@ -27089,6 +27094,11 @@ var CRDsValidation map[string]string = map[string]string{
                     restoreInProgress:
                       description: RestoreInProgress is the name of the VirtualMachineRestore
                         currently executing
+                      type: string
+                    runStrategy:
+                      description: |-
+                        RunStrategy tracks the last recorded RunStrategy used by the VM.
+                        This is needed to correctly process the next strategy (for now only the RerunOnFailure)
                       type: string
                     snapshotInProgress:
                       description: SnapshotInProgress is the name of the VirtualMachineSnapshot

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1627,6 +1627,10 @@ type VirtualMachineStatus struct {
 	// updated through an Update() before ObservedGeneration in Status.
 	// +optional
 	DesiredGeneration int64 `json:"desiredGeneration,omitempty" optional:"true"`
+
+	// RunStrategy tracks the last recorded RunStrategy used by the VM.
+	// This is needed to correctly process the next strategy (for now only the RerunOnFailure)
+	RunStrategy VirtualMachineRunStrategy `json:"runStrategy,omitempty" optional:"true"`
 }
 
 type VolumeSnapshotStatus struct {
@@ -1682,9 +1686,6 @@ const (
 	// VirtualMachinePaused is added in a virtual machine when its vmi
 	// signals with its own condition that it is paused.
 	VirtualMachinePaused VirtualMachineConditionType = "Paused"
-
-	// VirtualMachineInitialized means the virtual machine object has been seen by the VM controller
-	VirtualMachineInitialized VirtualMachineConditionType = "Initialized"
 
 	// VirtualMachineRestartRequired is added when changes made to the VM can't be live-propagated to the VMI
 	VirtualMachineRestartRequired VirtualMachineConditionType = "RestartRequired"

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -391,6 +391,7 @@ func (VirtualMachineStatus) SwaggerDoc() map[string]string {
 		"memoryDumpRequest":      "MemoryDumpRequest tracks memory dump request phase and info of getting a memory\ndump to the given pvc\n+nullable\n+optional",
 		"observedGeneration":     "ObservedGeneration is the generation observed by the vmi when started.\n+optional",
 		"desiredGeneration":      "DesiredGeneration is the generation which is desired for the VMI.\nThis will be used in comparisons with ObservedGeneration to understand when\nthe VMI is out of sync. This will be changed at the same time as\nObservedGeneration to remove errors which could occur if Generation is\nupdated through an Update() before ObservedGeneration in Status.\n+optional",
+		"runStrategy":            "RunStrategy tracks the last recorded RunStrategy used by the VM.\nThis is needed to correctly process the next strategy (for now only the RerunOnFailure)",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25112,6 +25112,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineStatus(ref common.ReferenceCall
 							Format:      "int64",
 						},
 					},
+					"runStrategy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RunStrategy tracks the last recorded RunStrategy used by the VM. This is needed to correctly process the next strategy (for now only the RerunOnFailure)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
When switching to the `RerunOnFailure` RunStrategy the VM does not get started

After this PR:
When switching to the `RerunOnFailure` RunStrategy the VM does get started

This PR also slightly refactors vm-controller sync() loop and removes the `VirtualMachineInitialized` condition.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix RerunOnFailure RunStrategy
```

