### PR TITLE
VMClone: Remove webhook that checks VM Source

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -723,6 +723,33 @@ func GetVirtualMachineCloneInformerIndexers() cache.Indexers {
 
 	return cache.Indexers{
 		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		// Gets: vm key. Returns: clones that their source or target is the specified vm
+		"vmSource": func(obj interface{}) ([]string, error) {
+			vmClone, ok := obj.(*clone.VirtualMachineClone)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			source := vmClone.Spec.Source
+			if source != nil && source.APIGroup != nil && *source.APIGroup == core.GroupName && source.Kind == "VirtualMachine" {
+				return []string{getkey(vmClone, source.Name)}, nil
+			}
+
+			return nil, nil
+		},
+		"vmTarget": func(obj interface{}) ([]string, error) {
+			vmClone, ok := obj.(*clone.VirtualMachineClone)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			target := vmClone.Spec.Target
+			if target != nil && target.APIGroup != nil && *target.APIGroup == core.GroupName && target.Kind == "VirtualMachine" {
+				return []string{getkey(vmClone, target.Name)}, nil
+			}
+
+			return nil, nil
+		},
 		// Gets: snapshot key. Returns: clones that their source is the specified snapshot
 		"snapshotSource": func(obj interface{}) ([]string, error) {
 			vmClone, ok := obj.(*clone.VirtualMachineClone)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -39,7 +39,6 @@ import (
 
 	clonebase "kubevirt.io/api/clone"
 	clone "kubevirt.io/api/clone/v1beta1"
-	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
@@ -228,7 +227,6 @@ func validateSource(ctx context.Context, client kubecli.KubevirtClient, vmClone 
 	if source.Kind != "" && source.Name != "" {
 		switch source.Kind {
 		case virtualMachineKind:
-			causes = append(causes, validateCloneSourceVM(ctx, client, source.Name, vmClone.Namespace, sourceField.Child("Source"))...)
 		case virtualMachineSnapshotKind:
 			causes = append(causes, validateCloneSourceSnapshot(ctx, client, source.Name, vmClone.Namespace, sourceField.Child("Source"))...)
 		default:
@@ -314,23 +312,6 @@ func validateCloneSourceExists(clientGetErr error, sourceField *k8sfield.Path, k
 	return nil
 }
 
-func validateCloneSourceVM(ctx context.Context, client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
-	vm, err := client.VirtualMachine(namespace).Get(ctx, name, metav1.GetOptions{})
-	causes := validateCloneSourceExists(err, sourceField, virtualMachineKind, name, namespace)
-
-	if causes != nil {
-		return causes
-	}
-
-	// currently, cloning leverages vm snapshot/restore to copy volumes
-	// snapshot/restore requires that volumes support CSI snapshots
-	// this limitation should be removed eventually
-	// probably by leveraging CDI cloning
-	causes = append(causes, validateCloneVolumeSnapshotSupportVM(vm, sourceField)...)
-
-	return causes
-}
-
 func validateCloneSourceSnapshot(ctx context.Context, client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
 	vmSnapshot, err := client.VirtualMachineSnapshot(namespace).Get(ctx, name, metav1.GetOptions{})
 	causes := validateCloneSourceExists(err, sourceField, virtualMachineSnapshotKind, name, namespace)
@@ -349,51 +330,6 @@ func validateCloneSourceSnapshot(ctx context.Context, client kubecli.KubevirtCli
 
 	causes = append(causes, validateCloneVolumeSnapshotSupportVMSnapshotContent(snapshotContent, sourceField)...)
 	return causes
-}
-
-func validateCloneVolumeSnapshotSupportVM(vm *v1.VirtualMachine, sourceField *k8sfield.Path) []metav1.StatusCause {
-	var result []metav1.StatusCause
-
-	// should never happen, but don't want to NPE
-	if vm.Spec.Template == nil {
-		return result
-	}
-
-	for _, v := range vm.Spec.Template.Spec.Volumes {
-		if v.PersistentVolumeClaim != nil || v.DataVolume != nil {
-			found := false
-			for _, vss := range vm.Status.VolumeSnapshotStatuses {
-				if v.Name == vss.Name {
-					if !vss.Enabled {
-						result = append(result, metav1.StatusCause{
-							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: fmt.Sprintf("Virtual Machine volume %s does not support snapshots", v.Name),
-							Field:   sourceField.String(),
-						})
-					}
-					found = true
-					break
-				}
-			}
-			if !found {
-				result = append(result, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("Virtual Machine volume %s snapshot support unknown", v.Name),
-					Field:   sourceField.String(),
-				})
-			}
-		}
-	}
-
-	if backendstorage.IsBackendStorageNeededForVM(vm) {
-		result = append(result, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Virtual Machine requires backend storage, operation not supported",
-			Field:   sourceField.String(),
-		})
-	}
-
-	return result
 }
 
 func validateCloneVolumeSnapshotSupportVMSnapshotContent(snapshotContents *snapshotv1.VirtualMachineSnapshotContent, sourceField *k8sfield.Path) []metav1.StatusCause {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -243,11 +243,6 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		}),
 	)
 
-	It("should reject clone with source that uses backend storage", func() {
-		vm.Spec.Template.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
-		admitter.admitAndExpect(vmClone, false)
-	})
-
 	Context("source types", func() {
 
 		DescribeTable("should allow legal types", func(kind string) {
@@ -269,9 +264,9 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		admitter.admitAndExpect(vmClone, false)
 	})
 
-	It("Should reject a source VM that does not exist", func() {
+	It("Should allow source VM that does not exist", func() {
 		vmClone.Spec.Source.Name = "vm-that-doesnt-exist"
-		admitter.admitAndExpect(vmClone, false)
+		admitter.admitAndExpect(vmClone, true)
 	})
 
 	When("Both source and target kinds are VirtualMachine", func() {
@@ -299,9 +294,9 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		admitter.admitAndExpect(vmClone, false)
 	})
 
-	DescribeTable("Should reject a source volume not Snapshot-able", func(index int) {
+	DescribeTable("Should allow a source volume not Snapshot-able", func(index int) {
 		vm.Status.VolumeSnapshotStatuses[index].Enabled = false
-		admitter.admitAndExpect(vmClone, false)
+		admitter.admitAndExpect(vmClone, true)
 	},
 		Entry("DataVolume", 0),
 		Entry("PersistentVolumeClaim", 1),
@@ -330,7 +325,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			for i := range vm.Status.VolumeSnapshotStatuses {
 				vm.Status.VolumeSnapshotStatuses[i].Enabled = false
 			}
-			admitter.admitAndExpect(vmClone, false)
+			admitter.admitAndExpect(vmClone, true)
 		})
 
 		It("should reject if vmsnapshot contents don't include a volume's backup", func() {

--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1beta1:go_default_library",

--- a/pkg/virt-controller/watch/clone/clone.go
+++ b/pkg/virt-controller/watch/clone/clone.go
@@ -21,25 +21,22 @@ package clone
 
 import (
 	"context"
+	"errors"
 	"fmt"
-
-	"k8s.io/client-go/tools/cache"
-
-	virtsnapshot "kubevirt.io/kubevirt/pkg/storage/snapshot"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-
-	"kubevirt.io/kubevirt/pkg/pointer"
-
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	clone "kubevirt.io/api/clone/v1beta1"
 	k6tv1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	virtsnapshot "kubevirt.io/kubevirt/pkg/storage/snapshot"
 )
 
 type cloneSourceType string
@@ -66,9 +63,10 @@ type syncInfoType struct {
 	targetVMCreated bool
 	pvcBound        bool
 
+	event          Event
+	reason         string
 	isCloneFailing bool
-	failEvent      Event
-	failReason     string
+	isClonePending bool
 }
 
 // vmCloneInfo stores the current vmclone information
@@ -78,7 +76,6 @@ type vmCloneInfo struct {
 	snapshot     *snapshotv1.VirtualMachineSnapshot
 	snapshotName string
 	sourceVm     *k6tv1.VirtualMachine
-	restore      *snapshotv1.VirtualMachineRestore
 }
 
 func (ctrl *VMCloneController) execute(key string) error {
@@ -133,6 +130,15 @@ func (ctrl *VMCloneController) execute(key string) error {
 func (ctrl *VMCloneController) sync(vmClone *clone.VirtualMachineClone) (syncInfoType, error) {
 	cloneInfo, err := ctrl.retrieveCloneInfo(vmClone)
 	if err != nil {
+		// If source does not exist we will wait for source
+		// to be created and then vmclone will get reconciled again.
+		if errors.Unwrap(err) == ErrSourceDoesntExist {
+			return syncInfoType{
+				isClonePending: true,
+				event:          SourceDoesNotExist,
+				reason:         err.Error(),
+			}, nil
+		}
 		return syncInfoType{}, err
 	}
 
@@ -275,21 +281,28 @@ func (ctrl *VMCloneController) updateStatus(origClone *clone.VirtualMachineClone
 		phaseChanged = true
 	}
 
-	if syncInfo.isCloneFailing {
-		ctrl.logAndRecord(vmClone, syncInfo.failEvent, syncInfo.failReason)
+	switch {
+	case syncInfo.isClonePending:
+		ctrl.logAndRecord(vmClone, syncInfo.event, syncInfo.reason)
+		updateCloneConditions(vmClone,
+			newProgressingCondition(corev1.ConditionFalse, "Pending"),
+			newReadyCondition(corev1.ConditionFalse, syncInfo.reason),
+		)
+	case syncInfo.isCloneFailing:
+		ctrl.logAndRecord(vmClone, syncInfo.event, syncInfo.reason)
 		assignPhase(clone.Failed)
 		updateCloneConditions(vmClone,
 			newProgressingCondition(corev1.ConditionFalse, "Failed"),
 			newReadyCondition(corev1.ConditionFalse, "Failed"),
 		)
+	default:
+		updateCloneConditions(vmClone,
+			newProgressingCondition(corev1.ConditionTrue, "Still processing"),
+			newReadyCondition(corev1.ConditionFalse, "Still processing"),
+		)
 	}
 
-	updateCloneConditions(vmClone,
-		newProgressingCondition(corev1.ConditionTrue, "Still processing"),
-		newReadyCondition(corev1.ConditionFalse, "Still processing"),
-	)
-
-	if isInPhase(vmClone, clone.PhaseUnset) {
+	if isInPhase(vmClone, clone.PhaseUnset) && !syncInfo.isClonePending {
 		assignPhase(clone.SnapshotInProgress)
 	}
 	if isInPhase(vmClone, clone.SnapshotInProgress) {
@@ -351,7 +364,7 @@ func (ctrl *VMCloneController) createSnapshotFromVm(vmClone *clone.VirtualMachin
 
 	createdSnapshot, err := ctrl.client.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, v1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			syncInfo.setError(fmt.Errorf("failed creating snapshot %s for clone %s: %v", snapshot.Name, vmClone.Name, err))
 			return snapshot, syncInfo
 		}
@@ -397,8 +410,8 @@ func (ctrl *VMCloneController) getSnapshot(snapshotName string, sourceNamespace 
 		// At this point the snapshot is already created. If it doesn't exist it means that it's deleted for some
 		// reason and the clone should fail
 		syncInfo.isCloneFailing = true
-		syncInfo.failEvent = SnapshotDeleted
-		syncInfo.failReason = fmt.Sprintf("snapshot %s does not exist anymore", snapshotName)
+		syncInfo.event = SnapshotDeleted
+		syncInfo.reason = fmt.Sprintf("snapshot %s does not exist anymore", snapshotName)
 		return nil, syncInfo
 	}
 	if err != nil {
@@ -422,7 +435,7 @@ func (ctrl *VMCloneController) createRestoreFromVm(vmClone *clone.VirtualMachine
 	log.Log.Object(vmClone).Infof("creating restore %s for clone %s", restore.Name, vmClone.Name)
 	createdRestore, err := ctrl.client.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, v1.CreateOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			retErr := fmt.Errorf("failed creating restore %s for clone %s: %v", restore.Name, vmClone.Name, err)
 			ctrl.recorder.Event(vmClone, corev1.EventTypeWarning, string(RestoreCreationFailed), retErr.Error())
 			syncInfo.setError(retErr)
@@ -519,7 +532,7 @@ func (ctrl *VMCloneController) verifyPVCBound(vmClone *clone.VirtualMachineClone
 
 func (ctrl *VMCloneController) cleanupSnapshot(vmClone *clone.VirtualMachineClone, syncInfo syncInfoType) syncInfoType {
 	err := ctrl.client.VirtualMachineSnapshot(vmClone.Namespace).Delete(context.Background(), *vmClone.Status.SnapshotName, v1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		syncInfo.setError(fmt.Errorf("cannot clean up snapshot %s for clone %s", *vmClone.Status.SnapshotName, vmClone.Name))
 		return syncInfo
 	}
@@ -529,7 +542,7 @@ func (ctrl *VMCloneController) cleanupSnapshot(vmClone *clone.VirtualMachineClon
 
 func (ctrl *VMCloneController) cleanupRestore(vmClone *clone.VirtualMachineClone, syncInfo syncInfoType) syncInfoType {
 	err := ctrl.client.VirtualMachineRestore(vmClone.Namespace).Delete(context.Background(), *vmClone.Status.RestoreName, v1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		syncInfo.setError(fmt.Errorf("cannot clean up restore %s for clone %s", *vmClone.Status.RestoreName, vmClone.Name))
 		return syncInfo
 	}
@@ -557,17 +570,7 @@ func (ctrl *VMCloneController) getSource(vmClone *clone.VirtualMachineClone, nam
 		return nil, fmt.Errorf("error getting %s %s in namespace %s from cache: %v", sourceKind, name, namespace, err)
 	}
 	if !exists {
-		err = ctrl.updateStatus(vmClone, syncInfoType{
-			isCloneFailing: true,
-			failEvent:      SourceDoesNotExist,
-			failReason:     fmt.Sprintf("%s %s does not exist in namespace %s", sourceKind, name, namespace),
-		})
-
-		if err != nil {
-			log.Log.Errorf("updating status when source %s does not exist failed: %v", sourceKind, err)
-		}
-
-		return nil, fmt.Errorf("%s %s in namespace %s does not exist", sourceKind, name, namespace)
+		return nil, fmt.Errorf("%w: %s %s/%s", ErrSourceDoesntExist, sourceKind, namespace, name)
 	}
 
 	return obj, nil

--- a/pkg/virt-controller/watch/clone/clone_base.go
+++ b/pkg/virt-controller/watch/clone/clone_base.go
@@ -37,17 +37,19 @@ const (
 	TargetVMCreated       Event = "TargetVMCreated"
 	PVCBound              Event = "PVCBound"
 
-	SnapshotDeleted          Event = "SnapshotDeleted"
-	SourceDoesNotExist       Event = "SourceDoesNotExist"
-	VMVolumeSnapshotsInvalid Event = "VMVolumeSnapshotsInvalid"
+	SnapshotDeleted                 Event = "SnapshotDeleted"
+	SourceDoesNotExist              Event = "SourceDoesNotExist"
+	SourceWithBackendStorageInvalid Event = "SourceVMWithBackendStorageInvalid"
+	VMVolumeSnapshotsInvalid        Event = "VMVolumeSnapshotsInvalid"
 )
 
 var (
 	ErrVolumeNotSnapshotable        = "Virtual Machine volume %s does not support snapshots"
 	ErrVolumeSnapshotSupportUnknown = "Virtual Machine volume %s snapshot support unknown"
-)
 
-var ErrSourceDoesntExist = errors.New("Source doesnt exist")
+	ErrSourceDoesntExist        = errors.New("Source doesnt exist")
+	ErrSourceWithBackendStorage = errors.New("Clone of source with backendstorage is not supported")
+)
 
 type VMCloneController struct {
 	client               kubecli.KubevirtClient

--- a/pkg/virt-controller/watch/clone/clone_base.go
+++ b/pkg/virt-controller/watch/clone/clone_base.go
@@ -1,6 +1,7 @@
 package clone
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -38,6 +39,8 @@ const (
 	SnapshotDeleted    Event = "SnapshotDeleted"
 	SourceDoesNotExist Event = "SourceDoesNotExist"
 )
+
+var ErrSourceDoesntExist = errors.New("Source doesnt exist")
 
 type VMCloneController struct {
 	client               kubecli.KubevirtClient

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -256,6 +256,57 @@ var _ = Describe("Clone", func() {
 
 	Context("basic controller operations", func() {
 		Context("with source VM", func() {
+			It("should report event if source VM doesn't exist, phase shouldn't change", func() {
+				vmClone.Status.Phase = clone.PhaseUnset
+				addClone(vmClone)
+
+				controller.Execute()
+				expectEvent(SourceDoesNotExist)
+				expectCloneBeInPhase(clone.PhaseUnset)
+			})
+
+			It("should report event if VM volumeSnapshots are invalid", func() {
+				sourceVM.Spec.Template.Spec.Volumes = append(sourceVM.Spec.Template.Spec.Volumes, virtv1.Volume{
+					Name: "disk0",
+					VolumeSource: virtv1.VolumeSource{
+						DataVolume: &virtv1.DataVolumeSource{
+							Name: "testdv",
+						},
+					},
+				})
+				addVM(sourceVM)
+				vmClone.Status.Phase = clone.PhaseUnset
+				addClone(vmClone)
+
+				controller.Execute()
+				expectEvent(VMVolumeSnapshotsInvalid)
+				expectCloneBeInPhase(clone.PhaseUnset)
+			})
+
+			It("should report event if VM volumeSnapshots are not snapshotable", func() {
+				sourceVM.Spec.Template.Spec.Volumes = append(sourceVM.Spec.Template.Spec.Volumes, virtv1.Volume{
+					Name: "disk0",
+					VolumeSource: virtv1.VolumeSource{
+						DataVolume: &virtv1.DataVolumeSource{
+							Name: "testdv",
+						},
+					},
+				})
+				sourceVM.Status.VolumeSnapshotStatuses = []virtv1.VolumeSnapshotStatus{
+					{
+						Name:    "disk0",
+						Enabled: false,
+					},
+				}
+				addVM(sourceVM)
+				vmClone.Status.Phase = clone.PhaseUnset
+				addClone(vmClone)
+
+				controller.Execute()
+				expectEvent(VMVolumeSnapshotsInvalid)
+				expectCloneBeInPhase(clone.PhaseUnset)
+			})
+
 			DescribeTable("should create snapshot if not exists yet", func(phase clone.VirtualMachineClonePhase) {
 				vmClone.Status.Phase = phase
 

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -265,6 +265,19 @@ var _ = Describe("Clone", func() {
 				expectCloneBeInPhase(clone.PhaseUnset)
 			})
 
+			It("clone should fail if source VM has backendstorage", func() {
+				sourceVM.Spec.Template.Spec.Domain.Devices.TPM = &virtv1.TPMDevice{
+					Persistent: pointer.P(true),
+				}
+				addVM(sourceVM)
+				vmClone.Status.Phase = clone.PhaseUnset
+				addClone(vmClone)
+
+				controller.Execute()
+				expectEvent(SourceWithBackendStorageInvalid)
+				expectCloneBeInPhase(clone.Failed)
+			})
+
 			It("should report event if VM volumeSnapshots are invalid", func() {
 				sourceVM.Spec.Template.Spec.Volumes = append(sourceVM.Spec.Template.Spec.Volumes, virtv1.Volume{
 					Name: "disk0",

--- a/pkg/virt-controller/watch/clone/util.go
+++ b/pkg/virt-controller/watch/clone/util.go
@@ -166,7 +166,7 @@ func updateCondition(conditions []clone.Condition, c clone.Condition, includeRea
 
 func updateCloneConditions(vmClone *clone.VirtualMachineClone, conditions ...clone.Condition) {
 	for _, cond := range conditions {
-		vmClone.Status.Conditions = updateCondition(vmClone.Status.Conditions, cond, false)
+		vmClone.Status.Conditions = updateCondition(vmClone.Status.Conditions, cond, true)
 	}
 }
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -152,6 +152,7 @@ go_test(
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",
+        "//tests/events:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",


### PR DESCRIPTION
### What this PR does
Before this PR:
VMClone request is rejected in case VM source doesnt exist.
VMClone request is rejected in case a VM has a volume that its volumesnapshotstatus is `disabled`

After this PR:
In case of VM source doesnt exists VMClone will be created. We will get an event and the VMClone conditions will be updated accordingly, once VM is created the VMClone continues.
In case of a volume that its volumesnapshotstatus is `disabled` we will get an event and the VMClone conditions will be updated accordingly, once the status will change to `enabled` the clone will continue.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # jira-ticket: https://issues.redhat.com/browse/CNV-41557

### Special notes for your reviewer
This change is in order to make our product more aligned with k8s “eventual consistency” model.
We shouldn't reject requests when the rejection reason is able to change. Checking VM source existence and volumesnapshotstatus is racy an can change anytime.

Planned: remove the similar checks in VMClone webhook of snapshot source.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMClone: Remove webhook that checks VM Source
```

