### PR TITLE
[release-1.2] instancetype: Allow `VirtualMachines` referencing instance types when `LiveUpdate` is enabled and trigger the `RestartRequired` condition if changed

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -432,14 +432,6 @@ func validateLiveUpdateFeatures(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 		return causes
 	}
 
-	if spec.Instancetype != nil {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueNotSupported,
-			Message: fmt.Sprintf("Cannot configure instance type when the vmRolloutStrategy is LiveUpdate"),
-			Field:   field.Child("instancetype").String(),
-		})
-	}
-
 	causes = append(causes, validateLiveUpdateCPU(field, &spec.Template.Spec.Domain)...)
 
 	if hasCPURequestsOrLimits(&spec.Template.Spec.Domain.Resources) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1872,17 +1872,6 @@ var _ = Describe("Validating VM Admitter", func() {
 			disableFeatureGates()
 		})
 
-		Context("Instance type", func() {
-			It("should reject VM creation", func() {
-				vm.Spec.Instancetype = &v1.InstancetypeMatcher{
-					Name: "test",
-					Kind: instancetypeapi.SingularResourceName,
-				}
-				response := admitVm(vmsAdmitter, vm)
-				Expect(response.Allowed).To(BeFalse())
-			})
-		})
-
 		Context("CPU", func() {
 			const maximumSockets uint32 = 24
 

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2989,6 +2989,17 @@ func (c *VMController) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.Virtual
 		return vm, true
 	}
 
+	if !equality.Semantic.DeepEqual(lastSeenVMSpec.Instancetype, vm.Spec.Instancetype) || !equality.Semantic.DeepEqual(lastSeenVMSpec.Preference, vm.Spec.Preference) {
+		vmConditionManager := controller.NewVirtualMachineConditionManager()
+		vmConditionManager.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
+			Type:               virtv1.VirtualMachineRestartRequired,
+			LastTransitionTime: metav1.Now(),
+			Status:             k8score.ConditionTrue,
+			Message:            "the instance type or preference matcher of the VM was changed",
+		})
+		return vm, true
+	}
+
 	return vm, false
 }
 


### PR DESCRIPTION
/area instancetype
/cc @jean-edouard 
/cc @enp0s3 

### What this PR does
Any VMs referencing an instance type were rejected by the validation webhooks when LiveUpdate was enabled.

After this PR:

VMs referencing an instance type are now allowed when LiveUpdate is enabled. Additionally any changes to the {Instancetype,Preference}Matcher of the VM will result in the RestartRequired condition being added.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Manual backport of https://github.com/kubevirt/kubevirt/pull/11962

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`VirtualMachines` referencing an instance type are now allowed when the `LiveUpdate` feature is enabled and will trigger the `RestartRequired` condition if the reference within the `VirtualMachine` is changed.
```

