### PR TITLE
virt-config, feature-gates: Control the addition of FGs to the FG list

### DIFF
--- a/pkg/virt-config/deprecation/BUILD.bazel
+++ b/pkg/virt-config/deprecation/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "deprecation_suite_test.go",
+        "feature-gates_test.go",
         "validator_test.go",
     ],
     embed = [":go_default_library"],

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -54,31 +54,37 @@ type FeatureGate struct {
 	Message     string
 }
 
-var featureGates = [...]FeatureGate{
-	{Name: LiveMigrationGate, State: GA},
-	{Name: SRIOVLiveMigrationGate, State: GA},
-	{Name: NonRoot, State: GA},
-	{Name: PSA, State: GA},
-	{Name: CPUNodeDiscoveryGate, State: GA},
-	{Name: PasstGate, State: Deprecated, Message: PasstDeprecationMessage, VmiSpecUsed: passtApiUsed},
-	{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed},
-}
+var featureGates = map[string]FeatureGate{}
 
 func init() {
-	for i, fg := range featureGates {
-		if fg.Message == "" {
+	RegisterFeatureGate(FeatureGate{Name: LiveMigrationGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: SRIOVLiveMigrationGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: NonRoot, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: PSA, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: CPUNodeDiscoveryGate, State: GA})
 
-			featureGates[i].Message = fmt.Sprintf(WarningPattern, fg.Name, fg.State)
-		}
+	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Deprecated, Message: PasstDeprecationMessage, VmiSpecUsed: passtApiUsed})
+	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})
+}
+
+// RegisterFeatureGate adds a given feature-gate to the FG list
+// In case the FG already exists (based on its name), it overrides the
+// existing FG.
+// If the feature-gate is missing a message, a default one is set.
+func RegisterFeatureGate(fg FeatureGate) {
+	if fg.Message == "" {
+		fg.Message = fmt.Sprintf(WarningPattern, fg.Name, fg.State)
 	}
+	featureGates[fg.Name] = fg
+}
+
+func UnregisterFeatureGate(fgName string) {
+	delete(featureGates, fgName)
 }
 
 func FeatureGateInfo(featureGate string) *FeatureGate {
-	for _, deprecatedFeature := range featureGates {
-		if featureGate == deprecatedFeature.Name {
-			deprecatedFeature := deprecatedFeature
-			return &deprecatedFeature
-		}
+	if fg, exist := featureGates[featureGate]; exist {
+		return &fg
 	}
 	return nil
 }

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -62,9 +62,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: NonRoot, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: PSA, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: CPUNodeDiscoveryGate, State: GA})
-
-	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Deprecated, Message: PasstDeprecationMessage, VmiSpecUsed: passtApiUsed})
-	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})
 }
 
 // RegisterFeatureGate adds a given feature-gate to the FG list

--- a/pkg/virt-config/deprecation/feature-gates_test.go
+++ b/pkg/virt-config/deprecation/feature-gates_test.go
@@ -1,0 +1,88 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package deprecation_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/virt-config/deprecation"
+)
+
+var _ = Describe("Feature Gate", func() {
+	It("register a simple FG, expect default warning", func() {
+		fg := deprecation.FeatureGate{Name: "my-fg", State: deprecation.GA}
+
+		deprecation.RegisterFeatureGate(fg)
+		DeferCleanup(deprecation.UnregisterFeatureGate, fg.Name)
+
+		Expect(deprecation.FeatureGateInfo(fg.Name)).To(Equal(&deprecation.FeatureGate{
+			Name:    fg.Name,
+			State:   fg.State,
+			Message: fmt.Sprintf(deprecation.WarningPattern, fg.Name, fg.State),
+		}))
+	})
+
+	It("register a FG with an explicit warning", func() {
+		const message = "my-message"
+		fg := deprecation.FeatureGate{Name: "my-fg", State: deprecation.Deprecated, Message: message}
+
+		deprecation.RegisterFeatureGate(fg)
+		DeferCleanup(deprecation.UnregisterFeatureGate, fg.Name)
+
+		Expect(deprecation.FeatureGateInfo(fg.Name)).To(Equal(&deprecation.FeatureGate{
+			Name:    fg.Name,
+			State:   fg.State,
+			Message: message,
+		}))
+	})
+
+	It("register multiple unique FGs", func() {
+		fg1 := deprecation.FeatureGate{Name: "my-fg1", State: deprecation.GA, Message: "my-message"}
+		fg2 := deprecation.FeatureGate{Name: "my-fg2", State: deprecation.GA, Message: "my-message"}
+
+		deprecation.RegisterFeatureGate(fg1)
+		deprecation.RegisterFeatureGate(fg2)
+		DeferCleanup(deprecation.UnregisterFeatureGate, fg1.Name)
+		DeferCleanup(deprecation.UnregisterFeatureGate, fg2.Name)
+
+		Expect(deprecation.FeatureGateInfo(fg1.Name)).To(Equal(&fg1))
+		Expect(deprecation.FeatureGateInfo(fg2.Name)).To(Equal(&fg2))
+	})
+
+	It("register FG that overrides an existing one", func() {
+		fg1 := deprecation.FeatureGate{Name: "my-fg1", State: deprecation.GA, Message: "my-message"}
+		fg2 := deprecation.FeatureGate{Name: "my-fg2", State: deprecation.GA, Message: "my-message"}
+		fg1clone := deprecation.FeatureGate{Name: "my-fg1", State: deprecation.GA, Message: "my-other-message"}
+
+		deprecation.RegisterFeatureGate(fg1)
+		deprecation.RegisterFeatureGate(fg2)
+		deprecation.RegisterFeatureGate(fg1clone)
+		DeferCleanup(deprecation.UnregisterFeatureGate, fg1.Name)
+		DeferCleanup(deprecation.UnregisterFeatureGate, fg2.Name)
+		DeferCleanup(deprecation.UnregisterFeatureGate, fg1clone.Name)
+
+		Expect(deprecation.FeatureGateInfo(fg1.Name)).NotTo(Equal(&fg1))
+		Expect(deprecation.FeatureGateInfo(fg1.Name)).To(Equal(&fg1clone))
+		Expect(deprecation.FeatureGateInfo(fg2.Name)).To(Equal(&fg2))
+	})
+})

--- a/pkg/virt-config/deprecation/macvtap.go
+++ b/pkg/virt-config/deprecation/macvtap.go
@@ -25,6 +25,10 @@ import (
 
 const MacvtapDiscontinueMessage = "Macvtap network binding is discontinued since v1.3. Please refer to Kubevirt user guide for alternatives."
 
+func init() {
+	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})
+}
+
 func macvtapApiUsed(spec *v1.VirtualMachineInstanceSpec) bool {
 	for _, net := range spec.Domain.Devices.Interfaces {
 		if net.DeprecatedMacvtap != nil {

--- a/pkg/virt-config/deprecation/passt.go
+++ b/pkg/virt-config/deprecation/passt.go
@@ -27,6 +27,10 @@ import (
 
 const PasstDeprecationMessage = "Passt network binding will be deprecated next release. Please refer to Kubevirt user guide for alternatives."
 
+func init() {
+	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Deprecated, Message: PasstDeprecationMessage, VmiSpecUsed: passtApiUsed})
+}
+
 func passtApiUsed(spec *v1.VirtualMachineInstanceSpec) bool {
 	return util.IsPasstVMI(spec)
 }


### PR DESCRIPTION
### What this PR does

A static FG list has been maintained, defining FGs directly into the list upon definition.

This approach has several disadvantages:
- There is no strict control on adding a new FG. E.g. an addition of two FGs with the same name is possible.
- FG have to be defined in a central place and cannot be distributed to the location that is owned by a feature.

Therefore, the current implementation is refactored to use a registration function to add FGs in a controlled manner.
Duplications is avoided by using a map instead of a list.

When `RegisterFeatureGate` is called, the inputted FG is either added to the FG list or overriding an existing FG entry.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The FG management is currently limited to "deprecation" feature-gates. I.e. the ones who are targeted for removal eventually.

But this mechanism can be extended and used to manage also active FGs.
Following work is going to generalize the current management to all FG states (i.e. to add Alpha & Beta states).
By doing so, we will be able to auto-generate the list of Feature-Gates and their state.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

