### PR TITLE
Infra components control-plane nodes NoSchedule toleration

### DIFF
--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -174,6 +174,18 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 							},
 						},
 					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/control-plane",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
 				},
 			}
 

--- a/pkg/virt-operator/resource/apply/reconcile_test.go
+++ b/pkg/virt-operator/resource/apply/reconcile_test.go
@@ -556,6 +556,20 @@ var _ = Describe("Apply", func() {
 				matchExpression := preferredSchedulingTerm.Preference.MatchExpressions[0]
 				Expect(matchExpression.Key).To(Equal(workerLabel))
 				Expect(matchExpression.Operator).To(Equal(corev1.NodeSelectorOpDoesNotExist))
+
+				Expect(podSpec.Tolerations).ToNot(BeEmpty())
+				Expect(podSpec.Tolerations).To(ContainElements(
+					corev1.Toleration{
+						Key:      "node-role.kubernetes.io/control-plane",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+					corev1.Toleration{
+						Key:      "node-role.kubernetes.io/master",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				))
 			},
 				Entry("nil component config", nil),
 				Entry("nil node placement", &v1.ComponentConfig{}),


### PR DESCRIPTION
### What this PR does
In many environments, the control-plane nodes are tainted with a NoSchedule effect. Therefore, by default infra pods should tolerate it.

In many environments the `master` key is still being used (e.g. [1]), so I'm adding a toleration for that as well.

[1] https://docs.openshift.com/container-platform/4.15/nodes/scheduling/nodes-scheduler-taints-tolerations.html

Before this PR:
Infra components do not tolerate by default control-plane nodes with a NoSchedule taint.

After this PR:
Infra components do tolerate by default control-plane nodes with a NoSchedule taint.

### Special notes for your reviewer
A follow-up to https://github.com/kubevirt/kubevirt/pull/11659

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Infra components control-plane nodes NoSchedule toleration
```

