### PR TITLE
[release-1.2] Fix RerunOnFailure RunStrategy

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20974,6 +20974,10 @@
       "description": "RestoreInProgress is the name of the VirtualMachineRestore currently executing",
       "type": "string"
      },
+     "runStrategy": {
+      "description": "RunStrategy tracks the last recorded RunStrategy used by the VM. This is needed to correctly process the next strategy (for now only the RerunOnFailure)",
+      "type": "string"
+     },
      "snapshotInProgress": {
       "description": "SnapshotInProgress is the name of the VirtualMachineSnapshot currently executing",
       "type": "string"

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -887,11 +887,7 @@ func (c *VMController) addStartRequest(vm *virtv1.VirtualMachine) error {
 	return nil
 }
 
-func (c *VMController) syncRunStrategy(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, syncError) {
-	runStrategy, err := vm.RunStrategy()
-	if err != nil {
-		return vm, &syncErrorImpl{fmt.Errorf(fetchingRunStrategyErrFmt, err), FailedCreateReason}
-	}
+func (c *VMController) syncRunStrategy(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, runStrategy virtv1.VirtualMachineRunStrategy) (*virtv1.VirtualMachine, syncError) {
 	vmKey, err := controller.KeyFunc(vm)
 	if err != nil {
 		log.Log.Object(vm).Errorf(fetchingVMKeyErrFmt, err)
@@ -962,8 +958,7 @@ func (c *VMController) syncRunStrategy(vm *virtv1.VirtualMachine, vmi *virtv1.Vi
 				}
 
 				if vmiFailed {
-					err = c.addStartRequest(vm)
-					if err != nil {
+					if err := c.addStartRequest(vm); err != nil {
 						return vm, &syncErrorImpl{fmt.Errorf("failed to patch VM with start action: %v", err), VMIFailedDeleteReason}
 					}
 				}
@@ -972,7 +967,8 @@ func (c *VMController) syncRunStrategy(vm *virtv1.VirtualMachine, vmi *virtv1.Vi
 			return vm, nil
 		}
 
-		if !hasStartRequest(vm) {
+		// when coming here from a different RunStrategy we have to start the VM
+		if !hasStartRequest(vm) && vm.Status.RunStrategy == *vm.Spec.RunStrategy {
 			return vm, nil
 		}
 
@@ -2400,6 +2396,9 @@ func (c *VMController) updateStatus(vmOrig *virtv1.VirtualMachine, vmi *virtv1.V
 	}
 	vm.Status.Ready = ready
 
+	runStrategy, _ := vmOrig.RunStrategy()
+	vm.Status.RunStrategy = runStrategy
+
 	c.trimDoneVolumeRequests(vm)
 	c.updateMemoryDumpRequest(vm, vmi)
 
@@ -2658,7 +2657,6 @@ func syncConditions(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstanc
 	syncIgnoreMap := map[string]interface{}{
 		string(virtv1.VirtualMachineReady):           nil,
 		string(virtv1.VirtualMachineFailure):         nil,
-		string(virtv1.VirtualMachineInitialized):     nil,
 		string(virtv1.VirtualMachineRestartRequired): nil,
 	}
 	vmiCondMap := make(map[string]interface{})
@@ -2751,6 +2749,13 @@ func (c *VMController) isTrimFirstChangeRequestNeeded(vm *virtv1.VirtualMachine,
 			}
 		}
 	case virtv1.StartRequest:
+		// Update VMI as the runStrategy might have started/stopped the VM.
+		// Example: if the runStrategy is `RerunOnFailure` and the VMI just failed
+		// `syncRunStrategy()` will delete the VMI object and enqueue a StartRequest.
+		// If we do not update `vmi` by asking the API Server this function could
+		// erroneously trim the just added StartRequest because it would see a running
+		// vmi with no DeletionTimestamp
+		vmi, _ := c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Get(context.Background(), vm.GetName(), metav1.GetOptions{})
 		// If the current VMI is running, then it has been started.
 		if vmi != nil && vmi.DeletionTimestamp == nil {
 			log.Log.Object(vm).V(4).Infof("VMI exists. clearing start request")
@@ -3024,25 +3029,6 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		}
 	}
 
-	conditionManager := controller.NewVirtualMachineConditionManager()
-	if !conditionManager.HasCondition(vm, virtv1.VirtualMachineInitialized) {
-		runStrategy, err := vm.RunStrategy()
-		if err != nil {
-			return vm, nil, err
-		}
-		if runStrategy == virtv1.RunStrategyRerunOnFailure {
-			// VM just got created with RerunOnFailure runStrategy, it needs to auto-start
-			err = c.addStartRequest(vm)
-			if err != nil {
-				return vm, nil, err
-			}
-		}
-		vm.Status.Conditions = append(vm.Status.Conditions, virtv1.VirtualMachineCondition{
-			Type:   virtv1.VirtualMachineInitialized,
-			Status: k8score.ConditionTrue,
-		})
-	}
-
 	if vm.DeletionTimestamp != nil {
 		if vmi == nil || controller.HasFinalizer(vm, v1.FinalizerOrphanDependents) {
 			vm, err = c.removeVMFinalizer(vm)
@@ -3071,7 +3057,7 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 	// Scale up or down, if all expected creates and deletes were report by the listener
 	runStrategy, err := vm.RunStrategy()
 	if err != nil {
-		return vm, nil, err
+		return vm, &syncErrorImpl{fmt.Errorf(fetchingRunStrategyErrFmt, err), FailedCreateReason}, err
 	}
 
 	// Ensure we have ControllerRevisions of any instancetype or preferences referenced by the VM
@@ -3079,12 +3065,12 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 	if err != nil {
 		log.Log.Object(vm).Infof("Failed to store Instancetype ControllerRevisions for VirtualMachine: %s/%s", vm.Namespace, vm.Name)
 		c.recorder.Eventf(vm, k8score.EventTypeWarning, FailedCreateVirtualMachineReason, "Error encountered while storing Instancetype ControllerRevisions: %v", err)
-		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while storing Instancetype ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}, err
+		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while storing Instancetype ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}, nil
 	}
 
 	dataVolumesReady, err := c.handleDataVolumes(vm, dataVolumes)
 	if err != nil {
-		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}, err
+		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}, nil
 	}
 
 	if !dataVolumesReady && runStrategy != virtv1.RunStrategyHalted {
@@ -3092,7 +3078,7 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		return vm, nil, nil
 	}
 
-	vm, syncErr = c.syncRunStrategy(vm, vmi)
+	vm, syncErr = c.syncRunStrategy(vm, vmi, runStrategy)
 	if syncErr != nil {
 		return vm, syncErr, nil
 	}
@@ -3123,50 +3109,50 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		vmiCopy.Spec.Domain.Devices.Interfaces = ifaces
 		vmiCopy.Spec.Networks = networks
 
-		if hasOrdinalIfaces, err := c.hasOrdinalNetworkInterfaces(vmi); err != nil {
-			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to check if VMI has interface with ordinal names (e.g.: eth1, eth2..): %v", err), HotPlugNetworkInterfaceErrorReason}, err
-		} else {
-			updatedVmiSpec := applyDynamicIfaceRequestOnVMI(vmCopy, vmiCopy, hasOrdinalIfaces)
-			vmiCopy.Spec = *updatedVmiSpec
+		hasOrdinalIfaces, err := c.hasOrdinalNetworkInterfaces(vmi)
+		if err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to check if VMI has interface with ordinal names (e.g.: eth1, eth2..): %v", err), HotPlugNetworkInterfaceErrorReason}, nil
 		}
+		updatedVmiSpec := applyDynamicIfaceRequestOnVMI(vmCopy, vmiCopy, hasOrdinalIfaces)
+		vmiCopy.Spec = *updatedVmiSpec
 
 		if err := c.vmiInterfacesPatch(&vmiCopy.Spec, vmi); err != nil {
-			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to patch vmi: %v", err), FailedUpdateErrorReason}, err
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to patch vmi: %v", err), FailedUpdateErrorReason}, nil
 		}
 	}
 
 	if err := c.handleVolumeRequests(vmCopy, vmi); err != nil {
-		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling volume hotplug requests: %v", err), HotPlugVolumeErrorReason}, err
+		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling volume hotplug requests: %v", err), HotPlugVolumeErrorReason}, nil
 	}
 
 	if err := c.handleMemoryDumpRequest(vmCopy, vmi); err != nil {
-		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling memory dump request: %v", err), MemoryDumpErrorReason}, err
+		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling memory dump request: %v", err), MemoryDumpErrorReason}, nil
 	}
 
 	conditionManager := controller.NewVirtualMachineConditionManager()
 	if c.clusterConfig.IsVMRolloutStrategyLiveUpdate() && !restartRequired && !conditionManager.HasCondition(vm, virtv1.VirtualMachineRestartRequired) {
 		if err := c.handleCPUChangeRequest(vmCopy, vmi); err != nil {
-			return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling CPU change request: %v", err), HotPlugCPUErrorReason}, err
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling CPU change request: %v", err), HotPlugCPUErrorReason}, nil
 		}
 
 		if err := c.handleAffinityChangeRequest(vmCopy, vmi); err != nil {
-			return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling node affinity change request: %v", err), AffinityChangeErrorReason}, err
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered while handling node affinity change request: %v", err), AffinityChangeErrorReason}, nil
 		}
 
 		if err := c.handleMemoryHotplugRequest(vmCopy, vmi); err != nil {
-			return vm, &syncErrorImpl{fmt.Errorf("error encountered while handling memory hotplug requests: %v", err), HotPlugMemoryErrorReason}, err
+			return vm, &syncErrorImpl{fmt.Errorf("error encountered while handling memory hotplug requests: %v", err), HotPlugMemoryErrorReason}, nil
 		}
 	}
 
 	if !equality.Semantic.DeepEqual(vm, vmCopy) {
 		updatedVm, err := c.clientset.VirtualMachine(vmCopy.Namespace).Update(context.Background(), vmCopy, metav1.UpdateOptions{})
 		if err != nil {
-			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to update vm according to add volume and/or memory dump requests: %v", err), FailedUpdateErrorReason}, err
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered when trying to update vm according to add volume and/or memory dump requests: %v", err), FailedUpdateErrorReason}, nil
 		}
 		vm = updatedVm
 	}
 
-	return vm, syncErr, nil
+	return vm, nil, nil
 }
 
 // resolveControllerRef returns the controller referenced by a ControllerRef,

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -261,7 +261,7 @@ func (c *VMController) runWorker() {
 	}
 }
 
-func (c *VMController) needsSync(key string) bool {
+func (c *VMController) satisfiedExpectations(key string) bool {
 	return c.expectations.SatisfiedExpectations(key) && c.dataVolumeExpectations.SatisfiedExpectations(key)
 }
 
@@ -3018,7 +3018,7 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		startVMSpec *virtv1.VirtualMachineSpec
 	)
 
-	if !c.needsSync(key) {
+	if !c.satisfiedExpectations(key) {
 		return vm, nil, nil
 	}
 
@@ -3085,13 +3085,13 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 
 	vm, restartRequired := c.addRestartRequiredIfNeeded(startVMSpec, vm)
 
-	if !c.needsSync(key) {
+	// Must check satisfiedExpectations again here because a VMI can be created or
+	// deleted in the startStop function which impacts how we process
+	// hotplugged volumes and interfaces
+	if !c.satisfiedExpectations(key) {
 		return vm, nil, nil
 	}
 
-	// Must check needsSync again here because a VMI can be created or
-	// deleted in the startStop function which impacts how we process
-	// hotplugged volumes and interfaces
 	vmCopy := vm.DeepCopy()
 
 	if c.clusterConfig.HotplugNetworkInterfacesEnabled() &&

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -16,6 +16,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1955,10 +1956,10 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(vm.Status.Created).To(BeFalse())
 				Expect(vm.Status.Ready).To(BeFalse())
 
-				if runStrategy == v1.RunStrategyRerunOnFailure {
-					Expect(vm.Status.StateChangeRequests).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action": Equal(v1.StateChangeRequestAction("Start")),
-					})))
+				if runStrategy == v1.RunStrategyRerunOnFailure || runStrategy == v1.RunStrategyAlways {
+					vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+					Expect(vmi).ToNot(BeNil())
 				}
 
 				testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
@@ -2482,10 +2483,10 @@ var _ = Describe("VirtualMachine", func() {
 			//TODO expect update status is called
 			Expect(vm.Status.Created).To(BeFalse())
 			Expect(vm.Status.Ready).To(BeFalse())
-			if runStrategy == v1.RunStrategyRerunOnFailure {
-				Expect(vm.Status.StateChangeRequests).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-					"Action": Equal(v1.StateChangeRequestAction("Start")),
-				})))
+			if runStrategy == v1.RunStrategyRerunOnFailure || runStrategy == v1.RunStrategyAlways {
+				vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(vmi).ToNot(BeNil())
 			}
 
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
@@ -3621,12 +3622,6 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(vm.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusCrashLoopBackOff))
 				} else {
 					Expect(vm.Status.PrintableStatus).ToNot(Equal(v1.VirtualMachineStatusCrashLoopBackOff))
-				}
-
-				if runStrategy == v1.RunStrategyRerunOnFailure {
-					Expect(vm.Status.StateChangeRequests).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Action": Equal(v1.StateChangeRequestAction("Start")),
-					})))
 				}
 			},
 
@@ -6139,10 +6134,6 @@ var _ = Describe("VirtualMachine", func() {
 
 			BeforeEach(func() {
 				vm, vmi = DefaultVirtualMachine(true)
-				vm.Status.Conditions = append(vm.Status.Conditions, v1.VirtualMachineCondition{
-					Type:   v1.VirtualMachineInitialized,
-					Status: k8sv1.ConditionTrue,
-				})
 				vm.ObjectMeta.UID = types.UID(uuid.NewString())
 				vmi.ObjectMeta.UID = vm.ObjectMeta.UID
 				vm.Generation = 1
@@ -6317,6 +6308,112 @@ var _ = Describe("VirtualMachine", func() {
 					[]string{virtconfig.VMLiveUpdateFeaturesGate}, &liveUpdate, Not(restartRequiredMatcher(k8sv1.ConditionTrue))),
 			)
 		})
+
+		Context("RunStrategy", func() {
+
+			It("when starting a VM with RerunOnFailure the VM should get started", func() {
+				vm, _ := DefaultVirtualMachine(true)
+				vm.Spec.Running = nil
+				vm.Spec.RunStrategy = kvpointer.P(v1.RunStrategyRerunOnFailure)
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				addVirtualMachine(vm)
+
+				sanityExecute(vm)
+
+				vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi).ToNot(BeNil())
+			})
+
+			DescribeTable("The VM should get started when switching to RerunOnFailure from", func(runStrategy v1.VirtualMachineRunStrategy) {
+				vm, _ := DefaultVirtualMachine(true)
+				vm.Spec.Running = nil
+				vm.Spec.RunStrategy = kvpointer.P(runStrategy)
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				addVirtualMachine(vm)
+
+				sanityExecute(vm)
+
+				_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+
+				By("Change RunStrategy")
+				vm.Spec.RunStrategy = kvpointer.P(v1.RunStrategyRerunOnFailure)
+
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Update(context.TODO(), vm, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				addVirtualMachine(vm)
+
+				sanityExecute(vm)
+
+				vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi).ToNot(BeNil())
+			},
+				Entry("Halted", v1.RunStrategyHalted),
+				Entry("Manual", v1.RunStrategyManual),
+			)
+
+			It("The VM should get restarted when doing RerunOnFailure -> Halted -> RerunOnFailure", func() {
+				vm, _ := DefaultVirtualMachine(true)
+				vm.Spec.Running = nil
+				vm.Spec.RunStrategy = kvpointer.P(v1.RunStrategyRerunOnFailure)
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				addVirtualMachine(vm)
+				sanityExecute(vm)
+
+				crSource.Add(createVMRevision(vm))
+				syncCache(controller.crInformer.GetIndexer())
+
+				vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi).ToNot(BeNil())
+
+				// let the controller pick up the creation
+				vmiFeeder.Add(vmi)
+				sanityExecute(vm)
+
+				By("Change RunStrategy to Halted")
+				vm.Spec.RunStrategy = kvpointer.P(v1.RunStrategyHalted)
+
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Update(context.TODO(), vm, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				addVirtualMachine(vm)
+				sanityExecute(vm)
+
+				crSource.Delete(createVMRevision(vm))
+				syncCache(controller.crInformer.GetIndexer())
+
+				// let the controller pick up the deletion
+				vmiFeeder.Delete(vmi)
+				sanityExecute(vm)
+
+				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+
+				By("Change RunStrategy back to RerunOnFailure")
+				vm.Spec.RunStrategy = kvpointer.P(v1.RunStrategyRerunOnFailure)
+
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Update(context.TODO(), vm, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				addVirtualMachine(vm)
+				sanityExecute(vm)
+
+				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi).ToNot(BeNil())
+			})
+		})
+
 	})
 	Context("syncConditions", func() {
 		var vm *v1.VirtualMachine
@@ -6353,8 +6450,8 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should sync appropriate conditions and ignore others", func() {
 			fromCondList := []v1.VirtualMachineConditionType{
-				v1.VirtualMachineReady, v1.VirtualMachineFailure, v1.VirtualMachinePaused,
-				v1.VirtualMachineInitialized, v1.VirtualMachineRestartRequired,
+				v1.VirtualMachineReady, v1.VirtualMachineFailure,
+				v1.VirtualMachinePaused, v1.VirtualMachineRestartRequired,
 			}
 			toCondList := []v1.VirtualMachineConditionType{
 				v1.VirtualMachineReady, v1.VirtualMachinePaused,

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7579,6 +7579,11 @@ var CRDsValidation map[string]string = map[string]string{
           description: RestoreInProgress is the name of the VirtualMachineRestore
             currently executing
           type: string
+        runStrategy:
+          description: RunStrategy tracks the last recorded RunStrategy used by the
+            VM. This is needed to correctly process the next strategy (for now only
+            the RerunOnFailure)
+          type: string
         snapshotInProgress:
           description: SnapshotInProgress is the name of the VirtualMachineSnapshot
             currently executing
@@ -26843,6 +26848,11 @@ var CRDsValidation map[string]string = map[string]string{
                     restoreInProgress:
                       description: RestoreInProgress is the name of the VirtualMachineRestore
                         currently executing
+                      type: string
+                    runStrategy:
+                      description: RunStrategy tracks the last recorded RunStrategy
+                        used by the VM. This is needed to correctly process the next
+                        strategy (for now only the RerunOnFailure)
                       type: string
                     snapshotInProgress:
                       description: SnapshotInProgress is the name of the VirtualMachineSnapshot

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1610,6 +1610,10 @@ type VirtualMachineStatus struct {
 	// updated through an Update() before ObservedGeneration in Status.
 	// +optional
 	DesiredGeneration int64 `json:"desiredGeneration,omitempty" optional:"true"`
+
+	// RunStrategy tracks the last recorded RunStrategy used by the VM.
+	// This is needed to correctly process the next strategy (for now only the RerunOnFailure)
+	RunStrategy VirtualMachineRunStrategy `json:"runStrategy,omitempty" optional:"true"`
 }
 
 type VolumeSnapshotStatus struct {
@@ -1665,9 +1669,6 @@ const (
 	// VirtualMachinePaused is added in a virtual machine when its vmi
 	// signals with its own condition that it is paused.
 	VirtualMachinePaused VirtualMachineConditionType = "Paused"
-
-	// VirtualMachineInitialized means the virtual machine object has been seen by the VM controller
-	VirtualMachineInitialized VirtualMachineConditionType = "Initialized"
 
 	// VirtualMachineRestartRequired is added when changes made to the VM can't be live-propagated to the VMI
 	VirtualMachineRestartRequired VirtualMachineConditionType = "RestartRequired"

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -390,6 +390,7 @@ func (VirtualMachineStatus) SwaggerDoc() map[string]string {
 		"memoryDumpRequest":      "MemoryDumpRequest tracks memory dump request phase and info of getting a memory\ndump to the given pvc\n+nullable\n+optional",
 		"observedGeneration":     "ObservedGeneration is the generation observed by the vmi when started.\n+optional",
 		"desiredGeneration":      "DesiredGeneration is the generation which is desired for the VMI.\nThis will be used in comparisons with ObservedGeneration to understand when\nthe VMI is out of sync. This will be changed at the same time as\nObservedGeneration to remove errors which could occur if Generation is\nupdated through an Update() before ObservedGeneration in Status.\n+optional",
+		"runStrategy":            "RunStrategy tracks the last recorded RunStrategy used by the VM.\nThis is needed to correctly process the next strategy (for now only the RerunOnFailure)",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25069,6 +25069,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineStatus(ref common.ReferenceCall
 							Format:      "int64",
 						},
 					},
+					"runStrategy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RunStrategy tracks the last recorded RunStrategy used by the VM. This is needed to correctly process the next strategy (for now only the RerunOnFailure)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/11963

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix RerunOnFailure RunStrategy
```

/cc @acardace 