### PR TITLE
virt-operator: replace hardcoded patch operations 

### DIFF
--- a/pkg/virt-operator/resource/apply/apiservices.go
+++ b/pkg/virt-operator/resource/apply/apiservices.go
@@ -2,7 +2,6 @@ package apply
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -13,6 +12,8 @@ import (
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 )
 
 func (r *Reconciler) createOrUpdateAPIServices(caBundle []byte) error {
@@ -72,17 +73,12 @@ func (r *Reconciler) createOrUpdateAPIService(apiService *apiregv1.APIService, c
 		return nil
 	}
 
-	spec, err := json.Marshal(apiService.Spec)
+	patchBytes, err := patch.New(getPatchWithObjectMetaAndSpec([]patch.PatchOption{}, &apiService.ObjectMeta, apiService.Spec)...).GeneratePayload()
 	if err != nil {
 		return err
 	}
 
-	ops, err := getPatchWithObjectMetaAndSpec([]string{}, &apiService.ObjectMeta, spec)
-	if err != nil {
-		return err
-	}
-
-	_, err = r.aggregatorclient.Patch(context.Background(), apiService.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+	_, err = r.aggregatorclient.Patch(context.Background(), apiService.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to patch apiservice %+v: %v", apiService, err)
 	}

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -2,7 +2,6 @@ package apply
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -18,6 +17,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
@@ -98,11 +98,6 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 		return deployment, nil
 	}
 
-	newSpec, err := json.Marshal(deployment.Spec)
-	if err != nil {
-		return nil, err
-	}
-
 	const revisionAnnotation = "deployment.kubernetes.io/revision"
 	if val, ok := existingCopy.ObjectMeta.Annotations[revisionAnnotation]; ok {
 		if deployment.ObjectMeta.Annotations == nil {
@@ -111,14 +106,14 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 		deployment.ObjectMeta.Annotations[revisionAnnotation] = val
 	}
 
-	ops, err := getPatchWithObjectMetaAndSpec([]string{
-		fmt.Sprintf(testGenerationJSONPatchTemplate, cachedDeployment.ObjectMeta.Generation),
-	}, &deployment.ObjectMeta, newSpec)
+	ops, err := patch.New(getPatchWithObjectMetaAndSpec([]patch.PatchOption{
+		patch.WithTest("/metadata/generation", cachedDeployment.ObjectMeta.Generation)},
+		&deployment.ObjectMeta, deployment.Spec)...).GeneratePayload()
 	if err != nil {
 		return nil, err
 	}
 
-	deployment, err = apps.Deployments(kv.Namespace).Patch(context.Background(), deployment.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+	deployment, err = apps.Deployments(kv.Namespace).Patch(context.Background(), deployment.Name, types.JSONPatchType, ops, metav1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to update deployment %+v: %v", deployment, err)
 	}
@@ -136,18 +131,10 @@ func setMaxUnavailable(daemonSet *appsv1.DaemonSet, maxUnavailable intstr.IntOrS
 }
 
 func generateDaemonSetPatch(oldDs, newDs *appsv1.DaemonSet) ([]byte, error) {
-	newSpec, err := json.Marshal(newDs.Spec)
-	if err != nil {
-		return nil, err
-	}
-
-	ops, err := getPatchWithObjectMetaAndSpec([]string{
-		fmt.Sprintf(testGenerationJSONPatchTemplate, oldDs.ObjectMeta.Generation),
-	}, &newDs.ObjectMeta, newSpec)
-	if err != nil {
-		return nil, err
-	}
-	return generatePatchBytes(ops), nil
+	return patch.New(
+		getPatchWithObjectMetaAndSpec([]patch.PatchOption{
+			patch.WithTest("/metadata/generation", oldDs.ObjectMeta.Generation)},
+			&newDs.ObjectMeta, newDs.Spec)...).GeneratePayload()
 }
 
 func (r *Reconciler) patchDaemonSet(oldDs, newDs *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
@@ -386,18 +373,12 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 		return nil
 	}
 
-	// Add Spec Patch
-	newSpec, err := json.Marshal(podDisruptionBudget.Spec)
+	patchBytes, err := patch.New(getPatchWithObjectMetaAndSpec([]patch.PatchOption{}, &podDisruptionBudget.ObjectMeta, podDisruptionBudget.Spec)...).GeneratePayload()
 	if err != nil {
 		return err
 	}
 
-	ops, err := getPatchWithObjectMetaAndSpec([]string{}, &podDisruptionBudget.ObjectMeta, newSpec)
-	if err != nil {
-		return err
-	}
-
-	podDisruptionBudget, err = pdbClient.Patch(context.Background(), podDisruptionBudget.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+	podDisruptionBudget, err = pdbClient.Patch(context.Background(), podDisruptionBudget.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to patch/delete poddisruptionbudget %+v: %v", podDisruptionBudget, err)
 	}

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -20,6 +20,7 @@ import (
 
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
@@ -124,17 +125,17 @@ func (r *Reconciler) createOrUpdateService(service *corev1.Service) (bool, error
 		return true, nil
 	}
 
-	patchOps, err := generateServicePatch(cachedService, service)
+	patchBytes, err := generateServicePatch(cachedService, service)
 	if err != nil {
 		return false, fmt.Errorf("unable to generate service endpoint patch operations for %+v: %v", service, err)
 	}
 
-	if len(patchOps) == 0 {
+	if len(patchBytes) == 0 {
 		log.Log.V(4).Infof("service %v is up-to-date", service.GetName())
 		return false, nil
 	}
 
-	_, err = core.Services(service.Namespace).Patch(context.Background(), service.Name, types.JSONPatchType, generatePatchBytes(patchOps), metav1.PatchOptions{})
+	_, err = core.Services(service.Namespace).Patch(context.Background(), service.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return false, fmt.Errorf("unable to patch service %+v: %v", service, err)
 	}
@@ -265,12 +266,12 @@ func (r *Reconciler) createOrUpdateCertificateSecret(queue workqueue.RateLimitin
 		return crt, nil
 	}
 
-	ops, err := createSecretPatch(secret)
+	patchBytes, err := createSecretPatch(secret)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = r.clientset.CoreV1().Secrets(secret.Namespace).Patch(context.Background(), secret.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+	_, err = r.clientset.CoreV1().Secrets(secret.Namespace).Patch(context.Background(), secret.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to patch secret %+v: %v", secret, err)
 	}
@@ -280,26 +281,12 @@ func (r *Reconciler) createOrUpdateCertificateSecret(queue workqueue.RateLimitin
 	return crt, nil
 }
 
-func createSecretPatch(secret *corev1.Secret) ([]string, error) {
-	// Add Spec Patch
-	data, err := json.Marshal(secret.Data)
-	if err != nil {
-		return nil, err
-	}
-
-	// Patch if old version
-	var ops []string
-
+func createSecretPatch(secret *corev1.Secret) ([]byte, error) {
 	// Add Labels and Annotations Patches
-	labelAnnotationPatch, err := createLabelsAndAnnotationsPatch(&secret.ObjectMeta)
-	if err != nil {
-		return nil, err
-	}
-	ops = append(ops, labelAnnotationPatch...)
+	ops := createLabelsAndAnnotationsPatch(&secret.ObjectMeta)
+	ops = append(ops, patch.WithReplace("/data", secret.Data))
 
-	ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/data", "value": %s }`, string(data)))
-
-	return ops, nil
+	return patch.New(ops...).GeneratePayload()
 }
 
 func (r *Reconciler) createOrUpdateCertificateSecrets(queue workqueue.RateLimitingInterface, caCert *tls.Certificate, duration *metav1.Duration, renewBefore *metav1.Duration, caRenewBefore *metav1.Duration) error {
@@ -392,23 +379,16 @@ func shouldEnforceClusterIP(desired, current string) bool {
 	return desired != current
 }
 
-func getObjectMetaPatch(desired, current metav1.ObjectMeta) ([]string, error) {
+func getObjectMetaPatch(desired, current metav1.ObjectMeta) []patch.PatchOption {
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := current.DeepCopy()
 	resourcemerge.EnsureObjectMeta(modified, existingCopy, desired)
-
-	labelAnnotationPatch := []string{}
-	var err error
-
 	if *modified {
 		// labels and/or annotations modified add patch
-		labelAnnotationPatch, err = createLabelsAndAnnotationsPatch(&desired)
-		if err != nil {
-			return labelAnnotationPatch, err
-		}
+		return createLabelsAndAnnotationsPatch(&desired)
 	}
 
-	return labelAnnotationPatch, nil
+	return nil
 }
 
 func hasImmutableFieldChanged(service, cachedService *corev1.Service) bool {
@@ -424,12 +404,9 @@ func hasImmutableFieldChanged(service, cachedService *corev1.Service) bool {
 
 func generateServicePatch(
 	cachedService *corev1.Service,
-	service *corev1.Service) ([]string, error) {
+	service *corev1.Service) ([]byte, error) {
 
-	patchOps, err := getObjectMetaPatch(service.ObjectMeta, cachedService.ObjectMeta)
-	if err != nil {
-		return patchOps, err
-	}
+	patchOps := getObjectMetaPatch(service.ObjectMeta, cachedService.ObjectMeta)
 
 	// set these values in the case they are empty
 	service.Spec.ClusterIP = cachedService.Spec.ClusterIP
@@ -440,16 +417,13 @@ func generateServicePatch(
 
 	// If the Specs don't equal each other, replace it
 	if !equality.Semantic.DeepEqual(cachedService.Spec, service.Spec) {
-		// add Spec Patch
-		newSpec, err := json.Marshal(service.Spec)
-		if err != nil {
-			return patchOps, err
-		}
-
-		patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/spec", "value": %s }`, string(newSpec)))
+		patchOps = append(patchOps, patch.WithReplace("/spec", service.Spec))
 	}
-
-	return patchOps, nil
+	patchset := patch.New(patchOps...)
+	if patchset.IsEmpty() {
+		return nil, nil
+	}
+	return patchset.GeneratePayload()
 }
 
 func (r *Reconciler) createOrUpdateServiceAccount(sa *corev1.ServiceAccount) error {
@@ -481,12 +455,12 @@ func (r *Reconciler) createOrUpdateServiceAccount(sa *corev1.ServiceAccount) err
 	}
 
 	// Patch Labels and Annotations
-	labelAnnotationPatch, err := createLabelsAndAnnotationsPatch(&sa.ObjectMeta)
+	labelAnnotationPatch, err := patch.New(createLabelsAndAnnotationsPatch(&sa.ObjectMeta)...).GeneratePayload()
 	if err != nil {
 		return err
 	}
 
-	_, err = core.ServiceAccounts(r.kv.Namespace).Patch(context.Background(), sa.Name, types.JSONPatchType, generatePatchBytes(labelAnnotationPatch), metav1.PatchOptions{})
+	_, err = core.ServiceAccounts(r.kv.Namespace).Patch(context.Background(), sa.Name, types.JSONPatchType, labelAnnotationPatch, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to patch serviceaccount %+v: %v", sa, err)
 	}
@@ -621,12 +595,12 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.RateLimit
 		return []byte(configMap.Data[components.CABundleKey]), nil
 	}
 
-	ops, err := createConfigMapPatch(configMap)
+	patchBytes, err := createConfigMapPatch(configMap)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Patch(context.Background(), configMap.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+	_, err = r.clientset.CoreV1().ConfigMaps(configMap.Namespace).Patch(context.Background(), configMap.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to patch configMap %+v: %v", configMap, err)
 	}
@@ -636,25 +610,12 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.RateLimit
 	return []byte(configMap.Data[components.CABundleKey]), nil
 }
 
-func createConfigMapPatch(configMap *corev1.ConfigMap) ([]string, error) {
-	// Patch if old version
-	var ops []string
-
+func createConfigMapPatch(configMap *corev1.ConfigMap) ([]byte, error) {
 	// Add Labels and Annotations Patches
-	labelAnnotationPatch, err := createLabelsAndAnnotationsPatch(&configMap.ObjectMeta)
-	if err != nil {
-		return ops, err
-	}
-	ops = append(ops, labelAnnotationPatch...)
+	ops := createLabelsAndAnnotationsPatch(&configMap.ObjectMeta)
+	ops = append(ops, patch.WithReplace("/data", configMap.Data))
 
-	// Add Spec Patch
-	data, err := json.Marshal(configMap.Data)
-	if err != nil {
-		return ops, err
-	}
-	ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/data", "value": %s }`, string(data)))
-
-	return ops, nil
+	return patch.New(ops...).GeneratePayload()
 }
 
 func (r *Reconciler) createOrUpdateCACertificateSecret(queue workqueue.RateLimitingInterface, name string, duration *metav1.Duration, renewBefore *metav1.Duration) (caCert *tls.Certificate, err error) {

--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -22,7 +22,6 @@ package apply
 import (
 	"crypto/tls"
 	"encoding/json"
-	"strings"
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -396,23 +395,17 @@ var _ = Describe("Apply", func() {
 				Expect(hasImmutableFieldChanged(targetService, cachedService)).To(BeFalse())
 				ops, err := generateServicePatch(cachedService, targetService)
 				Expect(err).ToNot(HaveOccurred())
-
-				hasSubstring := func(ops []string, substring string) bool {
-					for _, op := range ops {
-						if strings.Contains(op, substring) {
-							return true
-						}
-					}
-					return false
+				if !expectLabelsAnnotationsPatch && !expectSpecPatch {
+					Expect(ops).To(BeEmpty())
 				}
 
 				if expectLabelsAnnotationsPatch {
-					Expect(hasSubstring(ops, "/metadata/labels")).To(BeTrue())
-					Expect(hasSubstring(ops, "/metadata/annotations")).To(BeTrue())
+					Expect(string(ops)).To(ContainSubstring("/metadata/labels"))
+					Expect(string(ops)).To(ContainSubstring("/metadata/annotations"))
 				}
 
 				if expectSpecPatch {
-					Expect(hasSubstring(ops, "/spec")).To(BeTrue())
+					Expect(string(ops)).To(ContainSubstring("/spec"))
 				}
 
 				if !expectSpecPatch && !expectLabelsAnnotationsPatch {

--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -2,7 +2,6 @@ package apply
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -13,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 )
 
 func getSubresourcesForVersion(crd *extv1.CustomResourceDefinition, version string) *extv1.CustomResourceSubresources {
@@ -44,16 +45,14 @@ func needsSubresourceStatusDisable(crdTargetVersion *extv1.CustomResourceDefinit
 		(crdTargetVersion.Subresources != nil && crdTargetVersion.Subresources.Status != nil)
 }
 
-func patchCRD(client clientset.Interface, crd *extv1.CustomResourceDefinition, ops []string) (*extv1.CustomResourceDefinition, error) {
+func patchCRD(client clientset.Interface, crd *extv1.CustomResourceDefinition, ops []patch.PatchOption) (*extv1.CustomResourceDefinition, error) {
 	name := crd.GetName()
-	newSpec, err := json.Marshal(crd.Spec)
+	ops = append(ops, patch.WithReplace("/spec", crd.Spec))
+	patchBytes, err := patch.New(ops...).GeneratePayload()
 	if err != nil {
 		return nil, err
 	}
-
-	ops = append(ops, fmt.Sprintf(replaceSpecPatchTemplate, string(newSpec)))
-
-	crd, err = client.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+	crd, err = client.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("unable to patch crd %+v: %v", crd, err)
 	}
@@ -113,13 +112,8 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1.CustomResourceDefinition) erro
 		}
 	}
 	// Add Labels and Annotations Patches
-	var ops []string
-	labelAnnotationPatch, err := createLabelsAndAnnotationsPatch(&crd.ObjectMeta)
+	crd, err := patchCRD(client, crd, createLabelsAndAnnotationsPatch(&crd.ObjectMeta))
 	if err != nil {
-		return err
-	}
-	ops = append(ops, labelAnnotationPatch...)
-	if crd, err = patchCRD(client, crd, ops); err != nil {
 		return err
 	}
 
@@ -158,7 +152,7 @@ func (r *Reconciler) rolloutNonCompatibleCRDChange(crd *extv1.CustomResourceDefi
 			return nil
 		}
 		// enable the status subresources now, in case that they were disabled before
-		if _, err := patchCRD(client, crd, []string{}); err != nil {
+		if _, err := patchCRD(client, crd, []patch.PatchOption{}); err != nil {
 			return err
 		}
 

--- a/pkg/virt-operator/resource/apply/routes.go
+++ b/pkg/virt-operator/resource/apply/routes.go
@@ -2,7 +2,6 @@ package apply
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -13,6 +12,7 @@ import (
 
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )
@@ -77,17 +77,12 @@ func (r *Reconciler) syncRoute(route *routev1.Route, caBundle []byte) error {
 		return nil
 	}
 
-	spec, err := json.Marshal(route.Spec)
+	patchBytes, err := patch.New(getPatchWithObjectMetaAndSpec([]patch.PatchOption{}, &route.ObjectMeta, route.Spec)...).GeneratePayload()
 	if err != nil {
 		return err
 	}
 
-	ops, err := getPatchWithObjectMetaAndSpec([]string{}, &route.ObjectMeta, spec)
-	if err != nil {
-		return err
-	}
-
-	_, err = r.clientset.RouteClient().Routes(route.Namespace).Patch(context.Background(), route.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+	_, err = r.clientset.RouteClient().Routes(route.Namespace).Patch(context.Background(), route.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to patch route %+v: %v", route, err)
 	}


### PR DESCRIPTION
Use the patch package to replace the hardcoded patch operations. This improves the readability and make the code more cohesive.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Hardcoded operation in virt-operator/apply

After this PR:
Replaced all the patch operation with the patch packge
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
Partially fix: https://github.com/kubevirt/kubevirt/issues/11654

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```