### PR TITLE
[release-1.2] Ctrl, VM: Require restart when socket count is reduced

### DIFF
--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -6313,6 +6313,31 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue), "restart required")
 			})
 
+			It("should appear when VM sockets count is reduced", func() {
+				By("Creating a VM with two sockets")
+				vm.Spec.Template.Spec.Domain.CPU.Sockets = 2
+
+				vmi = controller.setupVMIFromVM(vm)
+				vmiSource.Add(vmi)
+				syncCache(controller.vmiInformer.GetIndexer(), 1)
+
+				By("Creating a Controller Revision with two sockets")
+				crSource.Add(createVMRevision(vm))
+				syncCache(controller.crInformer.GetIndexer(), 1)
+
+				By("Reducing the sockets count to one")
+				vm.Spec.Template.Spec.Domain.CPU.Sockets = vm.Spec.Template.Spec.Domain.CPU.Sockets - 1
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				addVirtualMachine(vm)
+
+				By("Executing the controller expecting the RestartRequired condition to appear")
+				sanityExecute(vm)
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vm.Status.Conditions).To(restartRequiredMatcher(k8sv1.ConditionTrue), "restart required")
+			})
+
 			DescribeTable("when changing a live-updatable field", func(fgs []string, strat *v1.VMRolloutStrategy, matcher gomegatypes.GomegaMatcher) {
 				// Add necessary stuff to reflect running VM
 				// TODO: This should be done in more places


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is an manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/11883

Conflicts with indexer in the test

```release-note
Restart of a VM is required when the CPU socket count is reduced
```

