### PR TITLE
libvmi: Introduce new common libvmi Option for cloud init

### DIFF
--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -60,12 +60,6 @@ func WithCloudInitNoCloudEncodedNetworkData(networkData string) Option {
 	return WithCloudInitVolume(b)
 }
 
-// WithCloudInitConfigDriveUserData adds cloud-init config-drive user data.
-func WithCloudInitConfigDriveUserData(data string) Option {
-	b := NewConfigDriveResourceBuilder().WithUserData(data)
-	return WithCloudInitVolume(b)
-}
-
 func addCloudInitDiskAndVolume(vmi *v1.VirtualMachineInstance, diskName string, bus v1.DiskBus, v v1.Volume) {
 	addDisk(vmi, newDisk(diskName, bus))
 	addVolume(vmi, v)

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -60,12 +60,6 @@ func WithCloudInitNoCloudEncodedNetworkData(networkData string) Option {
 	return WithCloudInitVolume(b)
 }
 
-// WithCloudInitNoCloudNetworkDataSecretName adds cloud-init no-cloud network data from secret.
-func WithCloudInitNoCloudNetworkDataSecretName(secretName string) Option {
-	b := NewNoCloudResourceBuilder().WithNetworkSecretName(secretName)
-	return WithCloudInitVolume(b)
-}
-
 // WithCloudInitConfigDriveUserData adds cloud-init config-drive user data.
 func WithCloudInitConfigDriveUserData(data string) Option {
 	b := NewConfigDriveResourceBuilder().WithUserData(data)

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -54,12 +54,6 @@ func WithCloudInitNoCloudNetworkData(data string) Option {
 	return WithCloudInitVolume(b)
 }
 
-// WithCloudInitNoCloudEncodedNetworkData adds cloud-init no-cloud base64 encoded network data.
-func WithCloudInitNoCloudEncodedNetworkData(networkData string) Option {
-	b := NewNoCloudResourceBuilder().WithNetworkEncodedData(networkData)
-	return WithCloudInitVolume(b)
-}
-
 func addCloudInitDiskAndVolume(vmi *v1.VirtualMachineInstance, diskName string, bus v1.DiskBus, v v1.Volume) {
 	addDisk(vmi, newDisk(diskName, bus))
 	addVolume(vmi, v)

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -27,12 +27,12 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-const cloudInitDiskName = "disk1"
+const CloudInitDiskName = "disk1"
 
 // WithCloudInitVolume adds cloudInit volume and disk
 func WithCloudInitVolume(volumeBuilder CloudInitBuilder) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addCloudInitDiskAndVolume(vmi, cloudInitDiskName, v1.DiskBusVirtio, volumeBuilder.build(cloudInitDiskName))
+		addCloudInitDiskAndVolume(vmi, CloudInitDiskName, v1.DiskBusVirtio, volumeBuilder.build(CloudInitDiskName))
 	}
 }
 
@@ -145,6 +145,7 @@ type ConfigDriveResource struct {
 func NewConfigDriveResourceBuilder() *ConfigDriveResource {
 	return &ConfigDriveResource{src: &v1.CloudInitConfigDriveSource{}}
 }
+
 func (r *ConfigDriveResource) WithUserData(data string) CloudInitBuilder {
 	r.src.UserData = data
 	return r

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -138,7 +138,8 @@ func addFilesystem(vmi *v1.VirtualMachineInstance, filesystem v1.Filesystem) {
 	vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, filesystem)
 }
 
-func getVolume(vmi *v1.VirtualMachineInstance, name string) *v1.Volume {
+// GetVolume returns a volume by name, from a VMI, or nil if the volume does not exist
+func GetVolume(vmi *v1.VirtualMachineInstance, name string) *v1.Volume {
 	for i := range vmi.Spec.Volumes {
 		if vmi.Spec.Volumes[i].Name == name {
 			return &vmi.Spec.Volumes[i]
@@ -213,10 +214,6 @@ func newLun(name string, reservation bool) v1.Disk {
 			},
 		},
 	}
-}
-
-func newVolume(name string) v1.Volume {
-	return v1.Volume{Name: name}
 }
 
 func newContainerVolume(name, image string) v1.Volume {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1675,7 +1675,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 	Context("with AccessCredentials", func() {
 		It("should accept a valid ssh access credential with configdrive propagation", func() {
-			vmi := newBaseVmi(libvmi.WithCloudInitConfigDriveUserData(" "))
+			vmi := newBaseVmi(
+				libvmi.WithCloudInitVolume(libvmi.NewConfigDriveResourceBuilder().WithUserData(" ")),
+			)
 
 			vmi.Spec.AccessCredentials = []v1.AccessCredential{
 				{

--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -222,10 +222,10 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			}, 3*time.Minute)).To(Succeed())
 		}
 
-		DescribeTable("should have ssh-key under authorized keys added ", func(volumeCreationOption func(data string) libvmi.Option, propagationMethod v1.SSHPublicKeyAccessCredentialPropagationMethod) {
+		DescribeTable("should have ssh-key under authorized keys added ", func(volumeBuilder libvmi.CloudInitBuilder, propagationMethod v1.SSHPublicKeyAccessCredentialPropagationMethod) {
 			By("Creating a secret with three ssh keys")
 			vmi := libvmifact.NewFedora(
-				volumeCreationOption(userData),
+				libvmi.WithCloudInitVolume(volumeBuilder.WithUserData(userData)),
 				withSSHPK(secretID, propagationMethod))
 			createNewSecret(testsuite.GetTestNamespace(vmi), secretID, map[string][]byte{
 				"my-key1": []byte("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key1"),
@@ -236,10 +236,10 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			vmi = tests.RunVMIAndExpectLaunch(vmi, fedoraRunningTimeout)
 			verifySSHKeys(vmi)
 		},
-			Entry("[test_id:6224]using configdrive", libvmi.WithCloudInitConfigDriveUserData, v1.SSHPublicKeyAccessCredentialPropagationMethod{
+			Entry("[test_id:6224]using configdrive", libvmi.NewConfigDriveResourceBuilder(), v1.SSHPublicKeyAccessCredentialPropagationMethod{
 				ConfigDrive: &v1.ConfigDriveSSHPublicKeyAccessCredentialPropagation{},
 			}),
-			Entry("using nocloud", libvmi.WithCloudInitNoCloudUserData, v1.SSHPublicKeyAccessCredentialPropagationMethod{
+			Entry("using nocloud", libvmi.NewNoCloudResourceBuilder(), v1.SSHPublicKeyAccessCredentialPropagationMethod{
 				NoCloud: &v1.NoCloudSSHPublicKeyAccessCredentialPropagation{},
 			}),
 		)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -198,7 +198,9 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						sshAuthorizedKey,
 					)
 					vmi := libvmifact.NewFedora(
-						libvmi.WithCloudInitConfigDriveUserData(userData),
+						libvmi.WithCloudInitVolume(
+							libvmi.NewConfigDriveResourceBuilder().WithUserData(userData),
+						),
 					)
 
 					vmi = LaunchVMI(vmi)
@@ -228,8 +230,12 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					"#cloud-config\npassword: %s\nchpasswd: { expire: False }",
 					fedoraPassword,
 				)
-				vmi := libvmifact.NewFedora(libvmi.WithCloudInitConfigDriveUserData(userData))
-				// runStrategy := v1.RunStrategyManual
+				vmi := libvmifact.NewFedora(
+					libvmi.WithCloudInitVolume(
+						libvmi.NewConfigDriveResourceBuilder().WithUserData(userData),
+					),
+				)
+
 				vm := &v1.VirtualMachine{
 					ObjectMeta: vmi.ObjectMeta,
 					Spec: v1.VirtualMachineSpec{

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -388,7 +388,9 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := libvmifact.NewCirros(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudNetworkDataSecretName(secretID),
+					libvmi.WithCloudInitVolume(
+						libvmi.NewNoCloudResourceBuilder().WithNetworkSecretName(secretID),
+					),
 				)
 
 				By("Creating a secret with network data")

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -374,7 +374,9 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := libvmifact.NewCirros(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudEncodedNetworkData(testNetworkData),
+					libvmi.WithCloudInitVolume(
+						libvmi.NewNoCloudResourceBuilder().WithNetworkEncodedData(testNetworkData),
+					),
 				)
 				vmi = LaunchVMI(vmi)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)


### PR DESCRIPTION
To reduce the number of potential forms of cloud init options, this commit introduces new common Option: `WithCloudInitVolume`, to create custom cloud init volumes.

This new option, receives `CloudInitBuilder` as a parameter.

The new `CloudInitBuilder` interface defines the following methods:
* `WithUserData(string) CloudInitBuilder`
* `WithEncodedData(string) CloudInitBuilder`
* `WithSecretName(string) CloudInitBuilder`
* `WithNetworkData(string) CloudInitBuilder`
* `WithNetworkEncodedData(string) CloudInitBuilder`
* `WithNetworkSecretName(string) CloudInitBuilder`

There are two builders, to build the cloudInit volume:
* `NewNoCloudResourceBuilder`
* `NewConfigDriveResourceBuilder`

Example:
```golang
vmi := libvmi.New(
    libvmi.WithCloudInitVolume(
        NewNoCloudResourceBuilder().WithUserData("user data"),
    ),
)
```


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

