### PR TITLE
[BUGFIX] Fix restore panic in case of volumesnapshot missing

### DIFF
--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -158,7 +158,10 @@ func (ctrl *VMExportController) getOrCreatePVCFromSnapshot(vmExport *exportv1.Vi
 	}
 
 	// leaving source name and namespace blank because we don't care in this context
-	pvc := snapshot.CreateRestorePVCDef(restorePVCName, volumeSnapshot, volumeBackup)
+	pvc, err := snapshot.CreateRestorePVCDef(restorePVCName, volumeSnapshot, volumeBackup)
+	if err != nil {
+		return nil, err
+	}
 	if volumeBackupIsKubeVirtContent(volumeBackup, sourceVm) {
 		if len(pvc.GetAnnotations()) == 0 {
 			pvc.SetAnnotations(make(map[string]string))

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -956,11 +956,17 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	if err != nil {
 		return err
 	}
+	if volumeSnapshot == nil {
+		return fmt.Errorf("missing volumeSnapshot %s", *volumeBackup.VolumeSnapshotName)
+	}
 
 	if volumeRestore == nil {
 		return fmt.Errorf("missing volumeRestore")
 	}
-	pvc := CreateRestorePVCDefFromVMRestore(vmRestore.Name, volumeRestore.PersistentVolumeClaimName, volumeSnapshot, volumeBackup, sourceVmName, sourceVmNamespace)
+	pvc, err := CreateRestorePVCDefFromVMRestore(vmRestore.Name, volumeRestore.PersistentVolumeClaimName, volumeSnapshot, volumeBackup, sourceVmName, sourceVmNamespace)
+	if err != nil {
+		return err
+	}
 	target.Own(pvc)
 
 	_, err = ctrl.Client.CoreV1().PersistentVolumeClaims(vmRestore.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
@@ -971,10 +977,9 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	return nil
 }
 
-func CreateRestorePVCDef(restorePVCName string, volumeSnapshot *vsv1.VolumeSnapshot, volumeBackup *snapshotv1.VolumeBackup) *corev1.PersistentVolumeClaim {
+func CreateRestorePVCDef(restorePVCName string, volumeSnapshot *vsv1.VolumeSnapshot, volumeBackup *snapshotv1.VolumeBackup) (*corev1.PersistentVolumeClaim, error) {
 	if volumeBackup == nil || volumeBackup.VolumeSnapshotName == nil {
-		log.Log.Errorf("VolumeSnapshot name missing %+v", volumeBackup)
-		return nil
+		return nil, fmt.Errorf("VolumeSnapshot name missing %+v", volumeBackup)
 	}
 	sourcePVC := volumeBackup.PersistentVolumeClaim.DeepCopy()
 	pvc := &corev1.PersistentVolumeClaim{
@@ -987,8 +992,7 @@ func CreateRestorePVCDef(restorePVCName string, volumeSnapshot *vsv1.VolumeSnaps
 	}
 
 	if volumeSnapshot == nil {
-		log.Log.Errorf("VolumeSnapshot missing %+v", volumeSnapshot)
-		return nil
+		return nil, fmt.Errorf("VolumeSnapshot missing %+v", volumeSnapshot)
 	}
 	if volumeSnapshot.Status != nil && volumeSnapshot.Status.RestoreSize != nil {
 		restorePVCSize, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
@@ -1023,7 +1027,7 @@ func CreateRestorePVCDef(restorePVCName string, volumeSnapshot *vsv1.VolumeSnaps
 	pvc.Spec.DataSourceRef = &dataSourceRef
 
 	pvc.Spec.VolumeName = ""
-	return pvc
+	return pvc, nil
 }
 
 func getRestoreAnnotationValue(restore *snapshotv1.VirtualMachineRestore) string {
@@ -1041,8 +1045,11 @@ func setLastRestoreAnnotation(restore *snapshotv1.VirtualMachineRestore, obj met
 	obj.GetAnnotations()[lastRestoreAnnotation] = getRestoreAnnotationValue(restore)
 }
 
-func CreateRestorePVCDefFromVMRestore(vmRestoreName, restorePVCName string, volumeSnapshot *vsv1.VolumeSnapshot, volumeBackup *snapshotv1.VolumeBackup, sourceVmName, sourceVmNamespace string) *corev1.PersistentVolumeClaim {
-	pvc := CreateRestorePVCDef(restorePVCName, volumeSnapshot, volumeBackup)
+func CreateRestorePVCDefFromVMRestore(vmRestoreName, restorePVCName string, volumeSnapshot *vsv1.VolumeSnapshot, volumeBackup *snapshotv1.VolumeBackup, sourceVmName, sourceVmNamespace string) (*corev1.PersistentVolumeClaim, error) {
+	pvc, err := CreateRestorePVCDef(restorePVCName, volumeSnapshot, volumeBackup)
+	if err != nil {
+		return nil, err
+	}
 	if pvc.Labels == nil {
 		pvc.Labels = make(map[string]string)
 	}
@@ -1053,7 +1060,7 @@ func CreateRestorePVCDefFromVMRestore(vmRestoreName, restorePVCName string, volu
 	pvc.Labels[restoreSourceNameLabel] = sourceVmName
 	pvc.Labels[restoreSourceNamespaceLabel] = sourceVmNamespace
 	pvc.Annotations[RestoreNameAnnotation] = vmRestoreName
-	return pvc
+	return pvc, nil
 }
 
 func updateRestoreCondition(r *snapshotv1.VirtualMachineRestore, c snapshotv1.Condition) {

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -624,18 +624,6 @@ func (t *vmRestoreTarget) getControllerRevision(namespace, name string) (*appsv1
 	return obj.(*appsv1.ControllerRevision), nil
 }
 
-func (t *vmRestoreTarget) getVirtualMachineSnapshot(namespace, name string) (*snapshotv1.VirtualMachineSnapshot, error) {
-	vmSnapshotKey := cacheKeyFunc(namespace, name)
-	obj, exists, err := t.controller.VMSnapshotInformer.GetStore().GetByKey(vmSnapshotKey)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, fmt.Errorf("Unable to find VirtualMachineSnapshot %s", vmSnapshotKey)
-	}
-	return obj.(*snapshotv1.VirtualMachineSnapshot), nil
-}
-
 func (t *vmRestoreTarget) restoreInstancetypeControllerRevision(vmSnapshotRevisionName, vmSnapshotName string, vm *kubevirtv1.VirtualMachine) (*appsv1.ControllerRevision, error) {
 	snapshotCR, err := t.getControllerRevision(vm.Namespace, vmSnapshotRevisionName)
 	if err != nil {

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -466,6 +466,36 @@ var _ = Describe("Restore controller", func() {
 				controller.processVMRestoreWorkItem()
 			})
 
+			It("should return error if volumesnapshot doesnt exist", func() {
+				r := createRestoreWithOwner()
+				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete: &f,
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
+					},
+				}
+				addVolumeRestores(r)
+				vm := createModifiedVM()
+				rc := r.DeepCopy()
+				rc.ResourceVersion = "1"
+				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete: &f,
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionFalse, "missing volumeSnapshot vmsnapshot-snapshot-uid-volume-disk1"),
+						newReadyCondition(corev1.ConditionFalse, "missing volumeSnapshot vmsnapshot-snapshot-uid-volume-disk1"),
+					},
+				}
+				addVolumeRestores(rc)
+
+				vmSource.Add(vm)
+				addVirtualMachineRestore(r)
+
+				expectUpdateVMRestoreInProgress(vm)
+				expectVMRestoreUpdate(kubevirtClient, rc)
+				controller.processVMRestoreWorkItem()
+			})
+
 			It("should create restore PVCs", func() {
 				r := createRestoreWithOwner()
 				vm := createModifiedVM()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
In case of volumesnapshot missing while in the restore process we are getting to a nil pointer dereference

After this PR:
Handle nil pointer and return error that volumesnapshot missing

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # jira-ticket: https://issues.redhat.com/browse/CNV-42228

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fix restore panic in case of volumesnapshot missing
```

