### PR TITLE
Remove "Snapshot" Feature Gate

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -887,7 +887,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeMigrationUpdate(w, r)
 	})
 	http.HandleFunc(components.VMSnapshotValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMSnapshots(w, r, app.clusterConfig, app.virtCli)
+		validating_webhook.ServeVMSnapshots(w, r, app.virtCli)
 	})
 	http.HandleFunc(components.VMRestoreValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMRestores(w, r, app.clusterConfig, app.virtCli, informers)

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -890,7 +890,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMSnapshots(w, r, app.virtCli)
 	})
 	http.HandleFunc(components.VMRestoreValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMRestores(w, r, app.clusterConfig, app.virtCli, informers)
+		validating_webhook.ServeVMRestores(w, r, app.virtCli, informers)
 	})
 	http.HandleFunc(components.VMExportValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMExports(w, r, app.clusterConfig)

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -173,7 +173,7 @@ func fuzzKubeVirtConfig(seed int64) *virtconfig.ClusterConfig {
 				virtconfig.SidecarGate,
 				virtconfig.GPUGate,
 				virtconfig.HostDevicesGate,
-				virtconfig.SnapshotGate,
+				deprecation.SnapshotGate,
 				virtconfig.VMExportGate,
 				virtconfig.HotplugVolumesGate,
 				virtconfig.HostDiskGate,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -71,10 +71,6 @@ func (admitter *VirtualMachineCloneAdmitter) Admit(ar *admissionv1.AdmissionRevi
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource: %+v. Expected resource: %+v", ar.Request.Resource.Resource, clone.ResourceVMClonePlural))
 	}
 
-	if ar.Request.Operation == admissionv1.Create && !admitter.Config.SnapshotEnabled() {
-		return webhookutils.ToAdmissionResponseError(fmt.Errorf("snapshot feature gate is not enabled"))
-	}
-
 	vmClone := &clonev1alpha1.VirtualMachineClone{}
 	err := json.Unmarshal(ar.Request.Object.Raw, vmClone)
 	if err != nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -290,11 +290,6 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		})
 	})
 
-	It("Should reject if snapshot feature gate is not enabled", func() {
-		disableFeatureGates()
-		admitter.admitAndExpect(vmClone, false)
-	})
-
 	DescribeTable("Should reject a source volume not Snapshot-able", func(index int) {
 		vm.Status.VolumeSnapshotStatuses[index].Enabled = false
 		admitter.admitAndExpect(vmClone, false)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -66,10 +66,6 @@ func (admitter *VMRestoreAdmitter) Admit(ar *admissionv1.AdmissionReview) *admis
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource %+v", ar.Request.Resource))
 	}
 
-	if ar.Request.Operation == admissionv1.Create && !admitter.Config.SnapshotEnabled() {
-		return webhookutils.ToAdmissionResponseError(fmt.Errorf("Snapshot/Restore feature gate not enabled"))
-	}
-
 	vmRestore := &snapshotv1.VirtualMachineRestore{}
 	// TODO ideally use UniversalDeserializer here
 	err := json.Unmarshal(ar.Request.Object.Raw, vmRestore)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -40,20 +40,17 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 // VMRestoreAdmitter validates VirtualMachineRestores
 type VMRestoreAdmitter struct {
-	Config            *virtconfig.ClusterConfig
 	Client            kubecli.KubevirtClient
 	VMRestoreInformer cache.SharedIndexInformer
 }
 
 // NewVMRestoreAdmitter creates a VMRestoreAdmitter
-func NewVMRestoreAdmitter(config *virtconfig.ClusterConfig, client kubecli.KubevirtClient, vmRestoreInformer cache.SharedIndexInformer) *VMRestoreAdmitter {
+func NewVMRestoreAdmitter(client kubecli.KubevirtClient, vmRestoreInformer cache.SharedIndexInformer) *VMRestoreAdmitter {
 	return &VMRestoreAdmitter{
-		Config:            config,
 		Client:            client,
 		VMRestoreInformer: vmRestoreInformer,
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -72,23 +72,6 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 
 	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
-	Context("Without feature gate enabled", func() {
-		It("should reject anything", func() {
-			restore := &snapshotv1.VirtualMachineRestore{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "restore",
-					Namespace: "default",
-				},
-				Spec: snapshotv1.VirtualMachineRestoreSpec{},
-			}
-
-			ar := createRestoreAdmissionReview(restore)
-			resp := createTestVMRestoreAdmitter(config, nil).Admit(ar)
-			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Message).Should(Equal("Snapshot/Restore feature gate not enabled"))
-		})
-	})
-
 	Context("With feature gate enabled", func() {
 		enableFeatureGate := func(featureGate string) {
 			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
@@ -38,19 +38,16 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 // VMSnapshotAdmitter validates VirtualMachineSnapshots
 type VMSnapshotAdmitter struct {
-	Config *virtconfig.ClusterConfig
 	Client kubecli.KubevirtClient
 }
 
 // NewVMSnapshotAdmitter creates a VMSnapshotAdmitter
-func NewVMSnapshotAdmitter(config *virtconfig.ClusterConfig, client kubecli.KubevirtClient) *VMSnapshotAdmitter {
+func NewVMSnapshotAdmitter(client kubecli.KubevirtClient) *VMSnapshotAdmitter {
 	return &VMSnapshotAdmitter{
-		Config: config,
 		Client: client,
 	}
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
@@ -62,10 +62,6 @@ func (admitter *VMSnapshotAdmitter) Admit(ar *admissionv1.AdmissionReview) *admi
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource %+v", ar.Request.Resource))
 	}
 
-	if ar.Request.Operation == admissionv1.Create && !admitter.Config.SnapshotEnabled() {
-		return webhookutils.ToAdmissionResponseError(fmt.Errorf("snapshot feature gate not enabled"))
-	}
-
 	vmSnapshot := &snapshotv1.VirtualMachineSnapshot{}
 	// TODO ideally use UniversalDeserializer here
 	err := json.Unmarshal(ar.Request.Object.Raw, vmSnapshot)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
@@ -51,19 +51,6 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 
 	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
-	Context("Without feature gate enabled", func() {
-		It("should reject anything", func() {
-			snapshot := &snapshotv1.VirtualMachineSnapshot{
-				Spec: snapshotv1.VirtualMachineSnapshotSpec{},
-			}
-
-			ar := createSnapshotAdmissionReview(snapshot)
-			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
-			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Message).Should(Equal("snapshot feature gate not enabled"))
-		})
-	})
-
 	Context("With feature gate enabled", func() {
 		enableFeatureGate := func(featureGate string) {
 			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -67,8 +67,8 @@ func ServeVMSnapshots(resp http.ResponseWriter, req *http.Request, virtCli kubec
 	validating_webhooks.Serve(resp, req, admitters.NewVMSnapshotAdmitter(virtCli))
 }
 
-func ServeVMRestores(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
-	validating_webhooks.Serve(resp, req, admitters.NewVMRestoreAdmitter(clusterConfig, virtCli, informers.VMRestoreInformer))
+func ServeVMRestores(resp http.ResponseWriter, req *http.Request, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMRestoreAdmitter(virtCli, informers.VMRestoreInformer))
 }
 
 func ServeVMExports(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -63,8 +63,8 @@ func ServeMigrationUpdate(resp http.ResponseWriter, req *http.Request) {
 	validating_webhooks.Serve(resp, req, &admitters.MigrationUpdateAdmitter{})
 }
 
-func ServeVMSnapshots(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, admitters.NewVMSnapshotAdmitter(clusterConfig, virtCli))
+func ServeVMSnapshots(resp http.ResponseWriter, req *http.Request, virtCli kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMSnapshotAdmitter(virtCli))
 }
 
 func ServeVMRestores(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -43,6 +43,7 @@ const (
 	NonRoot                = "NonRoot"            // GA
 	PSA                    = "PSA"                // GA
 	CPUNodeDiscoveryGate   = "CPUNodeDiscovery"   // GA
+	SnapshotGate           = "Snapshot"           // GA
 	PasstGate              = "Passt"              // Deprecated
 	MacvtapGate            = "Macvtap"            // Deprecated
 )
@@ -60,6 +61,7 @@ var featureGates = [...]FeatureGate{
 	{Name: NonRoot, State: GA},
 	{Name: PSA, State: GA},
 	{Name: CPUNodeDiscoveryGate, State: GA},
+	{Name: SnapshotGate, State: GA},
 	{Name: PasstGate, State: Deprecated, Message: PasstDeprecationMessage, VmiSpecUsed: passtApiUsed},
 	{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed},
 }

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -34,7 +34,6 @@ const (
 	SidecarGate           = "Sidecar"
 	GPUGate               = "GPU"
 	HostDevicesGate       = "HostDevices"
-	SnapshotGate          = "Snapshot"
 	VMExportGate          = "VMExport"
 	HotplugVolumesGate    = "HotplugVolumes"
 	HostDiskGate          = "HostDisk"
@@ -139,10 +138,6 @@ func (config *ClusterConfig) SidecarEnabled() bool {
 
 func (config *ClusterConfig) GPUPassthroughEnabled() bool {
 	return config.isFeatureGateEnabled(GPUGate)
-}
-
-func (config *ClusterConfig) SnapshotEnabled() bool {
-	return config.isFeatureGateEnabled(SnapshotGate)
 }
 
 func (config *ClusterConfig) VMExportEnabled() bool {

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -312,6 +312,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			Entry("with CPUNodeDiscoveryGate", deprecation.CPUNodeDiscoveryGate, fmt.Sprintf(deprecation.WarningPattern, deprecation.CPUNodeDiscoveryGate, deprecation.GA)),
 			Entry("with Passt", deprecation.PasstGate, deprecation.PasstDeprecationMessage),
 			Entry("with MacvtapGate", deprecation.MacvtapGate, deprecation.MacvtapDiscontinueMessage),
+			Entry("with SnapshotGate", deprecation.SnapshotGate, fmt.Sprintf(deprecation.WarningPattern, deprecation.SnapshotGate, deprecation.GA)),
 		)
 	})
 })

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -32,7 +32,6 @@ import (
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
@@ -51,8 +50,6 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		EnableFeatureGate(virtconfig.SnapshotGate)
 
 		format.MaxLength = 0
 	})

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -47,7 +47,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -541,8 +540,6 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		var snap *snapshotv1.VirtualMachineSnapshot
 
 		BeforeEach(func() {
-			tests.EnableFeatureGate(virtconfig.SnapshotGate)
-
 			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
 			vm := libvmi.NewVirtualMachine(vmi)
@@ -632,8 +629,6 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		var restore *snapshotv1.VirtualMachineRestore
 
 		BeforeEach(func() {
-			tests.EnableFeatureGate(virtconfig.SnapshotGate)
-
 			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
 			vm := libvmi.NewVirtualMachine(vmi)

--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-config/deprecation:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/deprecation"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/util"
@@ -95,8 +96,9 @@ func AdjustKubeVirtResource() {
 	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
 		virtconfig.CPUManager,
 		virtconfig.IgnitionGate,
+		// need SnapshotGate for upgrade test [test_id:3145]
+		deprecation.SnapshotGate,
 		virtconfig.SidecarGate,
-		virtconfig.SnapshotGate,
 		virtconfig.HostDiskGate,
 		virtconfig.VirtIOFSGate,
 		virtconfig.HotplugVolumesGate,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Had to enable "Snapshot" feature gate in order to use "snapshot.kubevirt.io" API group

After this PR:

Feature gate is deleted and snapshot API is enabled by default as the API is now beta:  #11955

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

https://issues.redhat.com/browse/CNV-41868

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Snapshot feature gate removed and snapshot API group is enabled by default
```

