### PR TITLE
tests: remove partial downgrade of KubeVirt

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1604,7 +1604,7 @@ spec:
 				Skip("Skip update test when CDI is not present")
 			}
 
-			if updateOperator && flags.OperatorManifestPath == "" {
+			if flags.OperatorManifestPath == "" {
 				Skip("Skip operator update test when operator manifest path isn't configured")
 			}
 
@@ -1658,17 +1658,15 @@ spec:
 			By("Sanity Checking Deployments infrastructure is deleted")
 			sanityCheckDeploymentsDeleted()
 
-			if updateOperator {
-				By("Deleting testing manifests")
-				deleteTestingManifests(flags.TestingManifestPath)
+			By("Deleting testing manifests")
+			deleteTestingManifests(flags.TestingManifestPath)
 
-				By("Deleting virt-operator installation")
-				deleteOperator(flags.OperatorManifestPath)
+			By("Deleting virt-operator installation")
+			deleteOperator(flags.OperatorManifestPath)
 
-				By("Installing previous release of virt-operator")
-				manifestURL := getUpstreamReleaseAssetURL(previousImageTag, "kubevirt-operator.yaml")
-				installOperator(manifestURL)
-			}
+			By("Installing previous release of virt-operator")
+			manifestURL := getUpstreamReleaseAssetURL(previousImageTag, "kubevirt-operator.yaml")
+			installOperator(manifestURL)
 
 			// Install previous release of KubeVirt
 			By("Creating KubeVirt object")


### PR DESCRIPTION
Simplify the operator tests by eliminating the partial downgrade of KubeVirt.
Downgrades aren't officially supported, however, the operator tests install the previous version of KubeVirt in order to, then, test the upgrades. As part of the test preparation, we pass from the latest KubeVirt version to the previous release.

In the case of the upgrade by patching KubeVirt CR, the downgrade was partial as the operator wasn't delete. This change completly remove the latest kubevirt version, in this way, we can simulate a proper upgrade from the previous release.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

