### PR TITLE
chore: fix some function names

### DIFF
--- a/pkg/virt-api/webhooks/arm64.go
+++ b/pkg/virt-api/webhooks/arm64.go
@@ -134,7 +134,7 @@ func validateSoundDevice(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSp
 	}
 }
 
-// setDefaultCPUModel set default cpu model to host-passthrough
+// setDefaultArm64CPUModel set default cpu model to host-passthrough
 func setDefaultArm64CPUModel(spec *v1.VirtualMachineInstanceSpec) {
 	if spec.Domain.CPU == nil {
 		spec.Domain.CPU = &v1.CPU{}
@@ -145,7 +145,7 @@ func setDefaultArm64CPUModel(spec *v1.VirtualMachineInstanceSpec) {
 	}
 }
 
-// setDefaultBootloader set default bootloader to uefi boot
+// setDefaultArm64Bootloader set default bootloader to uefi boot
 func setDefaultArm64Bootloader(spec *v1.VirtualMachineInstanceSpec) {
 	if spec.Domain.Firmware == nil || spec.Domain.Firmware.Bootloader == nil {
 		if spec.Domain.Firmware == nil {
@@ -159,7 +159,7 @@ func setDefaultArm64Bootloader(spec *v1.VirtualMachineInstanceSpec) {
 	}
 }
 
-// setDefaultDisksBus set default Disks Bus, because sata is not supported by qemu-kvm of Arm64
+// setDefaultArm64DisksBus set default Disks Bus, because sata is not supported by qemu-kvm of Arm64
 func setDefaultArm64DisksBus(spec *v1.VirtualMachineInstanceSpec) {
 	bus := v1.DiskBusVirtio
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

 fix some function names

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

