### PR TITLE
add support for enrolledKeys option when secure boot is enabled

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16946,6 +16946,10 @@
     "description": "If set, EFI will be used instead of BIOS.",
     "type": "object",
     "properties": {
+     "enrolledKeys": {
+      "description": "If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys. This is only valid if SecureBoot is enabled. Defaults to true",
+      "type": "boolean"
+     },
      "persistent": {
       "description": "If set to true, Persistent will persist the EFI NVRAM across reboots. Defaults to false",
       "type": "boolean"

--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -179,7 +179,7 @@ func WithDownwardMetricsChannel() Option {
 }
 
 // WithUefi configures EFI bootloader and SecureBoot.
-func WithUefi(secureBoot bool) Option {
+func WithUefi(secureBoot, enrolledKeys bool) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		if vmi.Spec.Domain.Firmware == nil {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{}
@@ -191,6 +191,7 @@ func WithUefi(secureBoot bool) Option {
 			vmi.Spec.Domain.Firmware.Bootloader.EFI = &v1.EFI{}
 		}
 		vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.P(secureBoot)
+		vmi.Spec.Domain.Firmware.Bootloader.EFI.EnrolledKeys = pointer.P(enrolledKeys)
 		// secureBoot Requires SMM to be enabled
 		if secureBoot {
 			if vmi.Spec.Domain.Features == nil {

--- a/pkg/virt-launcher/virtwrap/efi/efi.go
+++ b/pkg/virt-launcher/virtwrap/efi/efi.go
@@ -64,9 +64,11 @@ func (e *EFIEnvironment) EFICode(secureBoot, sev bool) string {
 	}
 }
 
-func (e *EFIEnvironment) EFIVars(secureBoot, sev bool) string {
-	if secureBoot {
+func (e *EFIEnvironment) EFIVars(secureBoot, enrolledKeys, sev bool) string {
+	if secureBoot && enrolledKeys {
 		return e.varsSecureBoot
+	} else if secureBoot && !enrolledKeys {
+		return e.vars
 	} else if sev {
 		return e.varsSEV
 	} else {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -951,16 +951,17 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 	var efiConf *converter.EFIConfiguration
 	if vmi.IsBootloaderEFI() {
 		secureBoot := vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
+		enrolledKeys := vmi.Spec.Domain.Firmware.Bootloader.EFI.EnrolledKeys == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.EnrolledKeys
 		sev := kutil.IsSEVVMI(vmi)
 
 		if !l.efiEnvironment.Bootable(secureBoot, sev) {
 			log.Log.Errorf("EFI OVMF roms missing for booting in EFI mode with SecureBoot=%v, SEV=%v", secureBoot, sev)
 			return nil, fmt.Errorf("EFI OVMF roms missing for booting in EFI mode with SecureBoot=%v, SEV=%v", secureBoot, sev)
 		}
-
+		
 		efiConf = &converter.EFIConfiguration{
 			EFICode:      l.efiEnvironment.EFICode(secureBoot, sev),
-			EFIVars:      l.efiEnvironment.EFIVars(secureBoot, sev),
+			EFIVars:      l.efiEnvironment.EFIVars(secureBoot, enrolledKeys, sev),
 			SecureLoader: secureBoot,
 		}
 	}

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6299,6 +6299,12 @@ var CRDsValidation map[string]string = map[string]string{
                             efi:
                               description: If set, EFI will be used instead of BIOS.
                               properties:
+                                enrolledKeys:
+                                  description: |-
+                                    If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys.
+                                    This is only valid if SecureBoot is enabled.
+                                    Defaults to true
+                                  type: boolean
                                 persistent:
                                   description: |-
                                     If set to true, Persistent will persist the EFI NVRAM across reboots.
@@ -11168,6 +11174,12 @@ var CRDsValidation map[string]string = map[string]string{
                     efi:
                       description: If set, EFI will be used instead of BIOS.
                       properties:
+                        enrolledKeys:
+                          description: |-
+                            If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys.
+                            This is only valid if SecureBoot is enabled.
+                            Defaults to true
+                          type: boolean
                         persistent:
                           description: |-
                             If set to true, Persistent will persist the EFI NVRAM across reboots.
@@ -14182,6 +14194,12 @@ var CRDsValidation map[string]string = map[string]string{
                     efi:
                       description: If set, EFI will be used instead of BIOS.
                       properties:
+                        enrolledKeys:
+                          description: |-
+                            If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys.
+                            This is only valid if SecureBoot is enabled.
+                            Defaults to true
+                          type: boolean
                         persistent:
                           description: |-
                             If set to true, Persistent will persist the EFI NVRAM across reboots.
@@ -16426,6 +16444,12 @@ var CRDsValidation map[string]string = map[string]string{
                             efi:
                               description: If set, EFI will be used instead of BIOS.
                               properties:
+                                enrolledKeys:
+                                  description: |-
+                                    If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys.
+                                    This is only valid if SecureBoot is enabled.
+                                    Defaults to true
+                                  type: boolean
                                 persistent:
                                   description: |-
                                     If set to true, Persistent will persist the EFI NVRAM across reboots.
@@ -20747,6 +20771,12 @@ var CRDsValidation map[string]string = map[string]string{
                                       description: If set, EFI will be used instead
                                         of BIOS.
                                       properties:
+                                        enrolledKeys:
+                                          description: |-
+                                            If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys.
+                                            This is only valid if SecureBoot is enabled.
+                                            Defaults to true
+                                          type: boolean
                                         persistent:
                                           description: |-
                                             If set to true, Persistent will persist the EFI NVRAM across reboots.
@@ -25755,6 +25785,12 @@ var CRDsValidation map[string]string = map[string]string{
                                           description: If set, EFI will be used instead
                                             of BIOS.
                                           properties:
+                                            enrolledKeys:
+                                              description: |-
+                                                If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys.
+                                                This is only valid if SecureBoot is enabled.
+                                                Defaults to true
+                                              type: boolean
                                             persistent:
                                               description: |-
                                                 If set to true, Persistent will persist the EFI NVRAM across reboots.

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -1335,6 +1335,11 @@ func (in *EFI) DeepCopyInto(out *EFI) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnrolledKeys != nil {
+		in, out := &in.EnrolledKeys, &out.EnrolledKeys
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Persistent != nil {
 		in, out := &in.Persistent, &out.Persistent
 		*out = new(bool)

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -246,6 +246,11 @@ type EFI struct {
 	// Defaults to true
 	// +optional
 	SecureBoot *bool `json:"secureBoot,omitempty"`
+	// If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys.
+	// This is only valid if SecureBoot is enabled.
+	// Defaults to true
+	// +optional
+	EnrolledKeys *bool `json:"enrolledKeys,omitempty"`
 	// If set to true, Persistent will persist the EFI NVRAM across reboots.
 	// Defaults to false
 	// +optional

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -121,9 +121,10 @@ func (BIOS) SwaggerDoc() map[string]string {
 
 func (EFI) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":           "If set, EFI will be used instead of BIOS.",
-		"secureBoot": "If set, SecureBoot will be enabled and the OVMF roms will be swapped for\nSecureBoot-enabled ones.\nRequires SMM to be enabled.\nDefaults to true\n+optional",
-		"persistent": "If set to true, Persistent will persist the EFI NVRAM across reboots.\nDefaults to false\n+optional",
+		"":             "If set, EFI will be used instead of BIOS.",
+		"secureBoot":   "If set, SecureBoot will be enabled and the OVMF roms will be swapped for\nSecureBoot-enabled ones.\nRequires SMM to be enabled.\nDefaults to true\n+optional",
+		"enrolledKeys": "If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys.\nThis is only valid if SecureBoot is enabled.\nDefaults to true\n+optional",
+		"persistent":   "If set to true, Persistent will persist the EFI NVRAM across reboots.\nDefaults to false\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17566,6 +17566,13 @@ func schema_kubevirtio_api_core_v1_EFI(ref common.ReferenceCallback) common.Open
 							Format:      "",
 						},
 					},
+					"enrolledKeys": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If set, libvirt will initialize the NVRAM file associated with the VM from a template that contains a suitable set of keys. This is only valid if SecureBoot is enabled. Defaults to true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"persistent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If set to true, Persistent will persist the EFI NVRAM across reboots. Defaults to false",

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -51,8 +51,9 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 
 	newSEVFedora := func(withES bool, opts ...libvmi.Option) *v1.VirtualMachineInstance {
 		const secureBoot = false
+		const enrolledKeys = false
 		sevOptions := []libvmi.Option{
-			libvmi.WithUefi(secureBoot),
+			libvmi.WithUefi(secureBoot, enrolledKeys),
 			libvmi.WithSEV(withES),
 		}
 		opts = append(sevOptions, opts...)

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -124,7 +124,7 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithCloudInitNoCloudNetworkData(cloudinit.CreateDefaultCloudInitNetworkData()),
-				libvmi.WithUefi(false),
+				libvmi.WithUefi(false, false),
 				libvmi.WithResourceMemory("1Gi"),
 			)
 			if withTPM {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -242,13 +242,13 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 	Describe("VirtualMachineInstance definition", func() {
 		fedoraWithUefiSecuredBoot := libvmifact.NewFedora(
 			libvmi.WithResourceMemory("1Gi"),
-			libvmi.WithUefi(true),
+			libvmi.WithUefi(true, true),
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 		alpineWithUefiWithoutSecureBoot := libvmifact.NewAlpine(
 			libvmi.WithResourceMemory("1Gi"),
-			libvmi.WithUefi(false),
+			libvmi.WithUefi(false, false),
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)

--- a/tools/util/marshaller_test.go
+++ b/tools/util/marshaller_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestMarshallObject(t *testing.T) {
 	var imagePullSecret []v1.LocalObjectReference
-	handler, err := components.NewHandlerDaemonSet("{{.Namespace}}", "", "{{.DockerPrefix}}", "{{.DockerTag}}", "", "", "", "", "", "", "", "", v1.PullIfNotPresent, imagePullSecret, nil, "2", nil, false)
+	handler, err := components.NewHandlerDaemonSet("{{.Namespace}}", "", "{{.DockerPrefix}}", "{{.DockerTag}}", "", "", "", "", "", "", "", "", "", "", v1.PullIfNotPresent, imagePullSecret, nil, "2", nil, false)
 	if err != nil {
 		t.Fatalf("error generating virt-handler deployment for marshall test %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Nianyu Shen <xiaoyu9964@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

