### PR TITLE
e2e,quarantine: Quarantine flaky test using RunStrategyManual with a failing VMI

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1349,7 +1349,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							Should(Equal(k8sv1.PodFailed))
 					}
 				},
-					Entry("[test_id:7164]VMI launcher pod should fail", "false"),
+					Entry("[test_id:7164][QUARANTINE]VMI launcher pod should fail", "false", decorators.Quarantine),
 					Entry("[test_id:6993][QUARANTINE]VMI launcher pod compute container should keep running", "true", decorators.Quarantine),
 				)
 			})


### PR DESCRIPTION
### What this PR does

This test is causing 24% impact to the 1.30 sig-compute lane[1] - it qualifies for quarantine.

This flake is likely related to the flake in the adjacent test[2]

[1] https://search.ci.kubevirt.io/?search=A+valid+VirtualMachine+given+Using+virtctl+interface+Using+RunStrategyManual+with+a+failing+VMI&maxAge=48h&context=1&type=all&name=pull-kubevirt-e2e-k8s-1.30-sig-compute&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
[2] https://github.com/kubevirt/kubevirt/pull/11953

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
/cc @acardace @xpivarc @EdDev 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

