### PR TITLE
Allow infra components to be scheduled to master nodes

### DIFF
--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -157,6 +157,14 @@ func InjectPlacementMetadata(componentConfig *v1.ComponentConfig, podSpec *corev
 											},
 										},
 									},
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "node-role.kubernetes.io/master",
+												Operator: corev1.NodeSelectorOpExists,
+											},
+										},
+									},
 								},
 							},
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{


### PR DESCRIPTION
In many environments the `master` key is still being used (e.g. [1]).

[1] https://docs.openshift.com/container-platform/4.15/nodes/scheduling/nodes-scheduler-taints-tolerations.html

Therefore, allow infra pods to be scheduled to such nodes as well.

### Special notes for your reviewer
Follow-up to: https://github.com/kubevirt/kubevirt/pull/11659
See this comment especially: https://github.com/kubevirt/kubevirt/pull/11659#discussion_r1555270580

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

