### PR TITLE
Spell ppc64le correctly

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -175,14 +175,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		}
 	})
 
-	DescribeTable("should apply configurable defaults on VM create", func(arch string, amd64MachineType string, arm64MachineType string, ppcle64MachineType string, result string) {
+	DescribeTable("should apply configurable defaults on VM create", func(arch string, amd64MachineType string, arm64MachineType string, ppc64leMachineType string, result string) {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					ArchitectureConfiguration: &v1.ArchConfiguration{
 						Amd64:   &v1.ArchSpecificConfiguration{MachineType: amd64MachineType},
 						Arm64:   &v1.ArchSpecificConfiguration{MachineType: arm64MachineType},
-						Ppc64le: &v1.ArchSpecificConfiguration{MachineType: ppcle64MachineType},
+						Ppc64le: &v1.ArchSpecificConfiguration{MachineType: ppc64leMachineType},
 					},
 				},
 			},

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -213,7 +213,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 	},
 		Entry("when architecture is amd64", "amd64", v1.DefaultCPUModel),
 		Entry("when architecture is arm64", "arm64", v1.CPUModeHostPassthrough),
-		Entry("when architecture is ppcle64", "ppcle64", v1.DefaultCPUModel),
+		Entry("when architecture is ppc64le", "ppc64le", v1.DefaultCPUModel),
 		Entry("when architecture is not specified", "", v1.DefaultCPUModel))
 
 	DescribeTable("should apply configurable defaults on VMI create", func(arch string, cpuModel string) {


### PR DESCRIPTION
Just fixing a few instances in which the architecture name was misspelled.

### Release note

```release-note
NONE
```
