### PR TITLE
ctrl: fix starting VM with Manual RunStrategy

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1601,6 +1601,10 @@ func (c *VMController) stopVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMac
 	return vm, nil
 }
 
+func popStateChangeRequest(vm *virtv1.VirtualMachine) {
+	vm.Status.StateChangeRequests = vm.Status.StateChangeRequests[1:]
+}
+
 func vmRevisionName(vmUID types.UID) string {
 	return fmt.Sprintf("revision-start-vm-%s", vmUID)
 }
@@ -2470,7 +2474,7 @@ func (c *VMController) updateStatus(vm, vmOrig *virtv1.VirtualMachine, vmi *virt
 	c.updateMemoryDumpRequest(vm, vmi)
 
 	if c.isTrimFirstChangeRequestNeeded(vm, vmi) {
-		vm.Status.StateChangeRequests = vm.Status.StateChangeRequests[1:]
+		popStateChangeRequest(vm)
 	}
 
 	syncStartFailureStatus(vm, vmi)
@@ -2791,14 +2795,9 @@ func (c *VMController) isTrimFirstChangeRequestNeeded(vm *virtv1.VirtualMachine,
 	switch stateChange.Action {
 	case virtv1.StopRequest:
 		if vmi == nil {
-			// because either the VM or VMI informers can trigger processing here
-			// double check the state of the cluster before taking action
-			_, err := c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Get(context.Background(), vm.GetName(), metav1.GetOptions{})
-			if err != nil && apiErrors.IsNotFound(err) {
-				// If there's no VMI, then the VMI was stopped, and the stopRequest can be cleared
-				log.Log.Object(vm).V(4).Infof("No VMI. Clearing stop request")
-				return true
-			}
+			// If there's no VMI, then the VMI was stopped, and the stopRequest can be cleared
+			log.Log.Object(vm).V(4).Infof("No VMI. Clearing stop request")
+			return true
 		} else {
 			if stateChange.UID == nil {
 				// It never makes sense to have a request to stop a VMI that doesn't
@@ -2820,9 +2819,7 @@ func (c *VMController) isTrimFirstChangeRequestNeeded(vm *virtv1.VirtualMachine,
 		// If we do not update `vmi` by asking the API Server this function could
 		// erroneously trim the just added StartRequest because it would see a running
 		// vmi with no DeletionTimestamp
-		vmi, _ := c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Get(context.Background(), vm.GetName(), metav1.GetOptions{})
-		// If the current VMI is running, then it has been started.
-		if vmi != nil && vmi.DeletionTimestamp == nil {
+		if vmi != nil && vmi.DeletionTimestamp == nil && !vmi.IsFinal() {
 			log.Log.Object(vm).V(4).Infof("VMI exists. clearing start request")
 			return true
 		}

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -6556,6 +6556,56 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(vmi).ToNot(BeNil())
 			})
 
+			It("when starting a VM with Manual and DVs are not ready the start request should not get trimmed", func() {
+				vm, _ := DefaultVirtualMachine(true)
+				vm.Spec.Running = nil
+				vm.Spec.RunStrategy = kvpointer.P(v1.RunStrategyManual)
+				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+					Name: "test1",
+					VolumeSource: v1.VolumeSource{
+						DataVolume: &v1.DataVolumeSource{
+							Name: "dv1",
+						},
+					},
+				})
+				vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dv1",
+					},
+				})
+
+				shouldFailDataVolumeCreationNoResourceFound()
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				addVirtualMachine(vm)
+
+				sanityExecute(vm)
+
+				// update VM from the store
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+
+				By("Add Start Request")
+				startRequest := v1.VirtualMachineStateChangeRequest{Action: v1.StartRequest}
+				vm.Status.StateChangeRequests = append(vm.Status.StateChangeRequests, startRequest)
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).UpdateStatus(context.TODO(), vm, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				addVirtualMachine(vm)
+
+				sanityExecute(vm)
+
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vm).ToNot(BeNil())
+
+				Expect(vm.Status.StateChangeRequests).ToNot(BeEmpty())
+				Expect(vm.Status.StateChangeRequests).To(ContainElement(startRequest))
+			})
+
 			DescribeTable("The VM should get started when switching to RerunOnFailure from", func(runStrategy v1.VirtualMachineRunStrategy) {
 				vm, _ := DefaultVirtualMachine(true)
 				vm.Spec.Running = nil
@@ -6640,6 +6690,81 @@ var _ = Describe("VirtualMachine", func() {
 				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi).ToNot(BeNil())
+			})
+
+			It("when issuing a restart a VM with Always should get restarted", func() {
+				vm, _ := DefaultVirtualMachine(true)
+				vm.Spec.Running = nil
+				vm.Spec.RunStrategy = kvpointer.P(v1.RunStrategyAlways)
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				addVirtualMachine(vm)
+				sanityExecute(vm)
+
+				crSource.Add(createVMRevision(vm))
+				syncCache(controller.crIndexer, 1)
+
+				vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				// let the controller pick up the creation
+				vmiFeeder.Add(vmi)
+				sanityExecute(vm)
+
+				// update VM from the store
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Add a stop and start Request")
+				vm.Status.StateChangeRequests = append(vm.Status.StateChangeRequests, v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID})
+				vm.Status.StateChangeRequests = append(vm.Status.StateChangeRequests, v1.VirtualMachineStateChangeRequest{Action: v1.StartRequest})
+
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).UpdateStatus(context.TODO(), vm, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("VM should get stopped")
+				addVirtualMachine(vm)
+				sanityExecute(vm)
+
+				_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+
+				By("VM should get now restarted")
+				// pick up deletion
+				crSource.Delete(createVMRevision(vm))
+				syncCache(controller.crIndexer, 0)
+				vmiFeeder.Delete(vmi)
+				sanityExecute(vm)
+
+				// check for VMI existence
+				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi).ToNot(BeNil())
+
+				// update VM from Store
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(vm.Status.StateChangeRequests).ToNot(ContainElement(v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID}))
+				Expect(vm.Status.StateChangeRequests).ToNot(BeEmpty())
+
+				// let the controller pick up the creation
+				vmiSource.Add(vmi)
+				syncCache(controller.vmiIndexer, 1)
+				addVirtualMachine(vm)
+				sanityExecute(vm)
+
+				// update VM from Store
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vm.Status.StateChangeRequests).To(BeEmpty())
+
+				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(vmi).ToNot(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+
 			})
 		})
 


### PR DESCRIPTION
check for the returned error as the `vmi` variable being not nil does not necessarily mean that the VMI actually exists.

Because of this bug if you had a VM with `Manual` RunStrategy and you were to start the VM while the DataVolumes were not ready the just issued StartRequest would get trimmed by the virt-controller. To workaround this you'd have to issue a second start request when the DVs would get ready.

Unfortunately, our production and test code differ in this behavior as the production code always returns `vmi != nil` and the fake client returns the `vmi == nil` if the VMI does not exist.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
 If you had a VM with `Manual` RunStrategy and you were to start the VM while the DataVolumes were not ready the just issued StartRequest would get trimmed by the virt-controller.

After this PR:
Start requests are never trimmed if the VMI doesn't exist.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix starting VM with Manual RunStrategy
```

