### PR TITLE
tests, network:  Move helper function from the network tests to `libnet`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ linters-settings:
         ignored-functions:
           - '^Eventually$'
           - '^EventuallyWithOffset$'
+          - '^ExpectWithOffset$'
           - '^console\.ExpectBatch$'
           - '^console\.RunCommand$'
   govet:

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "expose_util.go",
         "interface.go",
         "ipaddress.go",
+        "mac.go",
         "namespace.go",
         "network_attachment_definition.go",
         "ping.go",

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "expose_util.go",
+        "hotplug.go",
         "interface.go",
         "ipaddress.go",
         "mac.go",
@@ -18,7 +19,9 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libnet",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/virtctl/expose:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/libnet/mac.go
+++ b/tests/libnet/mac.go
@@ -1,4 +1,4 @@
-package network
+package libnet
 
 import (
 	cryptorand "crypto/rand"
@@ -7,7 +7,8 @@ import (
 
 func GenerateRandomMac() (net.HardwareAddr, error) {
 	prefix := net.HardwareAddr{0x02, 0x00, 0x00} // local unicast prefix
-	suffix := make(net.HardwareAddr, 3)
+	const macByteSize = 3
+	suffix := make(net.HardwareAddr, macByteSize)
 	_, err := cryptorand.Read(suffix)
 	if err != nil {
 		return nil, err

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "hotplug_bridge.go",
         "hotplug_sriov.go",
         "kubectl.go",
-        "mac.go",
         "networkpolicy.go",
         "port_forward.go",
         "primary_pod_network.go",

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "dual_stack_cluster.go",
         "expose.go",
         "framework.go",
-        "hotplug.go",
         "hotplug_bridge.go",
         "hotplug_sriov.go",
         "kubectl.go",

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -120,7 +120,7 @@ var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCust
 			var vmi *v1.VirtualMachineInstance
 			var chosenMAC string
 
-			chosenMACHW, err := GenerateRandomMac()
+			chosenMACHW, err := libnet.GenerateRandomMac()
 			Expect(err).ToNot(HaveOccurred())
 			chosenMAC = chosenMACHW.String()
 

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -77,10 +77,10 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 
 	var serverMAC, clientMAC string
 	BeforeEach(func() {
-		mac, err := GenerateRandomMac()
+		mac, err := libnet.GenerateRandomMac()
 		serverMAC = mac.String()
 		Expect(err).NotTo(HaveOccurred())
-		mac, err = GenerateRandomMac()
+		mac, err = libnet.GenerateRandomMac()
 		Expect(err).NotTo(HaveOccurred())
 		clientMAC = mac.String()
 	})

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -161,15 +161,3 @@ func patchVMWithNewInterface(vm *v1.VirtualMachine, newNetwork v1.Network, newIf
 	_, err = kubevirt.Client().VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 	return err
 }
-
-func removeInterface(vm *v1.VirtualMachine, name string) error {
-	specCopy := vm.Spec.Template.Spec.DeepCopy()
-	ifaceToRemove := vmispec.LookupInterfaceByName(specCopy.Domain.Devices.Interfaces, name)
-	ifaceToRemove.State = v1.InterfaceStateAbsent
-	patchData, err := patch.GenerateTestReplacePatch("/spec/template/spec/domain/devices/interfaces", vm.Spec.Template.Spec.Domain.Devices.Interfaces, specCopy.Domain.Devices.Interfaces)
-	if err != nil {
-		return err
-	}
-	_, err = kubevirt.Client().VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
-	return err
-}

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -43,13 +43,6 @@ const (
 	nadName   = "skynet"
 )
 
-type hotplugMethod string
-
-const (
-	migrationBased hotplugMethod = "migrationBased"
-	inPlace        hotplugMethod = "inPlace"
-)
-
 func verifyDynamicInterfaceChange(vmi *v1.VirtualMachineInstance, queueCount int32) *v1.VirtualMachineInstance {
 	vmi, err := kubevirt.Client().VirtualMachineInstance(vmi.GetNamespace()).Get(context.Background(), vmi.GetName(), metav1.GetOptions{})
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -38,11 +38,6 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 )
 
-const (
-	ifaceName = "iface1"
-	nadName   = "skynet"
-)
-
 func verifyDynamicInterfaceChange(vmi *v1.VirtualMachineInstance, queueCount int32) *v1.VirtualMachineInstance {
 	vmi, err := kubevirt.Client().VirtualMachineInstance(vmi.GetNamespace()).Get(context.Background(), vmi.GetName(), metav1.GetOptions{})
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -66,7 +61,7 @@ func verifyDynamicInterfaceChange(vmi *v1.VirtualMachineInstance, queueCount int
 	return vmi
 }
 
-func waitForSingleHotPlugIfaceOnVMISpec(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+func waitForSingleHotPlugIfaceOnVMISpec(vmi *v1.VirtualMachineInstance, ifaceName, nadName string) *v1.VirtualMachineInstance {
 	EventuallyWithOffset(1, func() []v1.Network {
 		var err error
 		vmi, err = kubevirt.Client().VirtualMachineInstance(vmi.GetNamespace()).Get(context.Background(), vmi.GetName(), metav1.GetOptions{})

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
-	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 
 	. "github.com/onsi/gomega"
@@ -37,7 +36,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/libvmifact"
 )
 
 const (
@@ -143,13 +141,6 @@ func interfaceStatusFromInterfaceNames(queueCount int32, ifaceNames ...string) [
 		})
 	}
 	return ifaceStatus
-}
-
-func newVMWithOneInterface() *v1.VirtualMachine {
-	vm := libvmi.NewVirtualMachine(libvmifact.NewAlpineWithTestTooling(), libvmi.WithRunning())
-	vm.Spec.Template.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-	vm.Spec.Template.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
-	return vm
 }
 
 func patchVMWithNewInterface(vm *v1.VirtualMachine, newNetwork v1.Network, newIface v1.Interface) error {

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -39,9 +39,8 @@ import (
 )
 
 const (
-	ifaceName   = "iface1"
-	nadName     = "skynet"
-	vmIfaceName = "eth1"
+	ifaceName = "iface1"
+	nadName   = "skynet"
 )
 
 type hotplugMethod string

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -51,6 +51,13 @@ import (
 
 const linuxBridgeName = "supadupabr"
 
+type hotplugMethod string
+
+const (
+	migrationBased hotplugMethod = "migrationBased"
+	inPlace        hotplugMethod = "inPlace"
+)
+
 var _ = SIGDescribe("bridge nic-hotplug", func() {
 
 	BeforeEach(func() {

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -411,7 +411,12 @@ func removeInterface(vm *v1.VirtualMachine, name string) error {
 	specCopy := vm.Spec.Template.Spec.DeepCopy()
 	ifaceToRemove := vmispec.LookupInterfaceByName(specCopy.Domain.Devices.Interfaces, name)
 	ifaceToRemove.State = v1.InterfaceStateAbsent
-	patchData, err := patch.GenerateTestReplacePatch("/spec/template/spec/domain/devices/interfaces", vm.Spec.Template.Spec.Domain.Devices.Interfaces, specCopy.Domain.Devices.Interfaces)
+	const interfacesPath = "/spec/template/spec/domain/devices/interfaces"
+	patchSet := patch.New(
+		patch.WithTest(interfacesPath, vm.Spec.Template.Spec.Domain.Devices.Interfaces),
+		patch.WithAdd(interfacesPath, specCopy.Domain.Devices.Interfaces),
+	)
+	patchData, err := patchSet.GeneratePayload()
 	if err != nil {
 		return err
 	}

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -101,7 +101,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		})
 
 		DescribeTable("can be hotplugged a network interface", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
+			libnet.WaitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 			Expect(libnet.InterfaceExists(hotPluggedVMI, guestSecondaryIfaceName)).To(Succeed())
 
@@ -128,7 +128,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		)
 
 		DescribeTable("hotplugged interfaces are available after the VM is restarted", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
+			libnet.WaitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 			By("restarting the VM")
 			Expect(kubevirt.Client().VirtualMachine(hotPluggedVM.GetNamespace()).Restart(
@@ -160,7 +160,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		)
 
 		DescribeTable("can migrate a VMI with hotplugged interfaces", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
+			libnet.WaitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 
 			By("migrating the VMI")
@@ -174,7 +174,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		)
 
 		DescribeTable("has connectivity over the secondary network", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
+			libnet.WaitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 
 			const subnetMask = "/24"
@@ -221,7 +221,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		)
 
 		DescribeTable("is able to hotplug multiple network interfaces", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
+			libnet.WaitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 			By("hotplugging the second interface")
 			var err error
@@ -404,7 +404,7 @@ func newBridgeNetworkInterface(name, netAttachDefName string) (v1.Network, v1.In
 
 func addBridgeInterface(vm *v1.VirtualMachine, name, netAttachDefName string) error {
 	newNetwork, newIface := newBridgeNetworkInterface(name, netAttachDefName)
-	return patchVMWithNewInterface(vm, newNetwork, newIface)
+	return libnet.PatchVMWithNewInterface(vm, newNetwork, newIface)
 }
 
 func removeInterface(vm *v1.VirtualMachine, name string) error {
@@ -426,7 +426,7 @@ func verifyBridgeDynamicInterfaceChange(vmi *v1.VirtualMachineInstance, plugMeth
 		libmigration.ConfirmVMIPostMigration(kubevirt.Client(), vmi, migrationUID)
 	}
 	const queueCount = 1
-	return verifyDynamicInterfaceChange(vmi, queueCount)
+	return libnet.VerifyDynamicInterfaceChange(vmi, queueCount)
 }
 
 func verifyUnpluggedIfaceClearedFromVMandVMI(namespace, vmName, netName string) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -59,6 +59,10 @@ const (
 )
 
 var _ = SIGDescribe("bridge nic-hotplug", func() {
+	const (
+		ifaceName = "iface1"
+		nadName   = "skynet"
+	)
 
 	BeforeEach(func() {
 		Expect(checks.HasFeature(virtconfig.HotplugNetworkIfacesGate)).To(BeTrue())
@@ -95,7 +99,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		})
 
 		DescribeTable("can be hotplugged a network interface", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI)
+			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 			Expect(libnet.InterfaceExists(hotPluggedVMI, guestSecondaryIfaceName)).To(Succeed())
 
@@ -122,7 +126,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		)
 
 		DescribeTable("hotplugged interfaces are available after the VM is restarted", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI)
+			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 			By("restarting the VM")
 			Expect(kubevirt.Client().VirtualMachine(hotPluggedVM.GetNamespace()).Restart(
@@ -154,7 +158,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		)
 
 		DescribeTable("can migrate a VMI with hotplugged interfaces", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI)
+			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 
 			By("migrating the VMI")
@@ -168,7 +172,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		)
 
 		DescribeTable("has connectivity over the secondary network", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI)
+			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 
 			const subnetMask = "/24"
@@ -215,7 +219,7 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		)
 
 		DescribeTable("is able to hotplug multiple network interfaces", func(plugMethod hotplugMethod) {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI)
+			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 			hotPluggedVMI = verifyBridgeDynamicInterfaceChange(hotPluggedVMI, plugMethod)
 			By("hotplugging the second interface")
 			var err error
@@ -259,6 +263,8 @@ var _ = SIGDescribe("bridge nic-hotunplug", func() {
 	const (
 		linuxBridgeNetworkName1 = "red"
 		linuxBridgeNetworkName2 = "blue"
+
+		nadName = "skynet"
 	)
 
 	BeforeEach(func() {

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -63,7 +63,11 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 
 		BeforeEach(func() {
 			By("Creating a VM")
-			hotPluggedVM = newVMWithOneInterface()
+			vmi := libvmifact.NewAlpineWithTestTooling(
+				libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			hotPluggedVM = libvmi.NewVirtualMachine(vmi, libvmi.WithRunning())
 			var err error
 			hotPluggedVM, err = kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), hotPluggedVM, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -65,6 +65,11 @@ var _ = SIGDescribe("[Serial] SRIOV nic-hotplug", Serial, decorators.SRIOV, func
 	})
 
 	Context("a running VM", func() {
+		const (
+			ifaceName = "iface1"
+			nadName   = "skynet"
+		)
+
 		var hotPluggedVM *v1.VirtualMachine
 		var hotPluggedVMI *v1.VirtualMachineInstance
 
@@ -93,7 +98,7 @@ var _ = SIGDescribe("[Serial] SRIOV nic-hotplug", Serial, decorators.SRIOV, func
 		})
 
 		It("can hotplug a network interface", func() {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI)
+			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 
 			migration := libmigration.New(hotPluggedVMI.Name, hotPluggedVMI.Namespace)
 			migrationUID := libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests/console"
@@ -41,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libmigration"
+	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -68,7 +70,11 @@ var _ = SIGDescribe("[Serial] SRIOV nic-hotplug", Serial, decorators.SRIOV, func
 
 		BeforeEach(func() {
 			By("Creating a VM")
-			hotPluggedVM = newVMWithOneInterface()
+			vmi := libvmifact.NewAlpineWithTestTooling(
+				libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			hotPluggedVM = libvmi.NewVirtualMachine(vmi, libvmi.WithRunning())
 			var err error
 			hotPluggedVM, err = kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), hotPluggedVM, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -136,7 +136,7 @@ func newSRIOVNetworkInterface(name, netAttachDefName string) (v1.Network, v1.Int
 
 func addSRIOVInterface(vm *v1.VirtualMachine, name, netAttachDefName string) error {
 	newNetwork, newIface := newSRIOVNetworkInterface(name, netAttachDefName)
-	mac, err := GenerateRandomMac()
+	mac, err := libnet.GenerateRandomMac()
 	if err != nil {
 		return err
 	}

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -145,6 +146,11 @@ func addSRIOVInterface(vm *v1.VirtualMachine, name, netAttachDefName string) err
 }
 
 func verifySriovDynamicInterfaceChange(vmi *v1.VirtualMachineInstance, plugMethod hotplugMethod) *v1.VirtualMachineInstance {
+	if plugMethod == migrationBased {
+		migration := libmigration.New(vmi.Name, vmi.Namespace)
+		migrationUID := libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
+		libmigration.ConfirmVMIPostMigration(kubevirt.Client(), vmi, migrationUID)
+	}
 	const queueCount = 0
-	return verifyDynamicInterfaceChange(vmi, plugMethod, queueCount)
+	return verifyDynamicInterfaceChange(vmi, queueCount)
 }

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -98,7 +98,7 @@ var _ = SIGDescribe("[Serial] SRIOV nic-hotplug", Serial, decorators.SRIOV, func
 		})
 
 		It("can hotplug a network interface", func() {
-			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
+			libnet.WaitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI, ifaceName, nadName)
 
 			migration := libmigration.New(hotPluggedVMI.Name, hotPluggedVMI.Namespace)
 			migrationUID := libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
@@ -160,10 +160,10 @@ func addSRIOVInterface(vm *v1.VirtualMachine, name, netAttachDefName string) err
 		return err
 	}
 	newIface.MacAddress = mac.String()
-	return patchVMWithNewInterface(vm, newNetwork, newIface)
+	return libnet.PatchVMWithNewInterface(vm, newNetwork, newIface)
 }
 
 func verifySriovDynamicInterfaceChange(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 	const queueCount = 0
-	return verifyDynamicInterfaceChange(vmi, queueCount)
+	return libnet.VerifyDynamicInterfaceChange(vmi, queueCount)
 }

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -95,7 +95,8 @@ var _ = SIGDescribe("[Serial] SRIOV nic-hotplug", Serial, decorators.SRIOV, func
 		It("can hotplug a network interface", func() {
 			waitForSingleHotPlugIfaceOnVMISpec(hotPluggedVMI)
 			hotPluggedVMI = verifySriovDynamicInterfaceChange(hotPluggedVMI, migrationBased)
-			Expect(libnet.InterfaceExists(hotPluggedVMI, vmIfaceName)).To(Succeed())
+			const guestSecondaryIfaceName = "eth1"
+			Expect(libnet.InterfaceExists(hotPluggedVMI, guestSecondaryIfaceName)).To(Succeed())
 
 			updatedVM, err := kubevirt.Client().VirtualMachine(hotPluggedVM.Namespace).Get(context.Background(), hotPluggedVM.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -762,7 +762,7 @@ func createSRIOVVmiOnNode(nodeName, networkName, cidr string) (*v1.VirtualMachin
 	//
 	// This step is needed to guarantee that no VFs on the PF carry a duplicate MAC address that may affect
 	// ability of VMIs to send and receive ICMP packets on their ports.
-	mac, err := GenerateRandomMac()
+	mac, err := libnet.GenerateRandomMac()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -620,11 +620,11 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 					bridgeSubnetMask     = "/24"
 				)
 
-				initialMacAddress, err := GenerateRandomMac()
+				initialMacAddress, err := libnet.GenerateRandomMac()
 				Expect(err).NotTo(HaveOccurred())
 				initialMacAddressStr := initialMacAddress.String()
 
-				spoofedMacAddress, err := GenerateRandomMac()
+				spoofedMacAddress, err := libnet.GenerateRandomMac()
 				Expect(err).NotTo(HaveOccurred())
 				spoofedMacAddressStr := spoofedMacAddress.String()
 


### PR DESCRIPTION
### What this PR does
Move helper function from the network tests to `libnet`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

