### PR TITLE
net, admitter: Extract the mac-address validation for reuse

### DIFF
--- a/pkg/network/admitter/netiface_test.go
+++ b/pkg/network/admitter/netiface_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		Entry(
 			"too long address",
 			"de:ad:00:00:be:af:be:af",
-			"interface fake.domain.devices.interfaces[0].name has MAC address (de:ad:00:00:be:af:be:af) that is too long.",
+			"interface fake.domain.devices.interfaces[0].name has too long MAC address (de:ad:00:00:be:af:be:af).",
 		),
 	)
 

--- a/pkg/network/link/BUILD.bazel
+++ b/pkg/network/link/BUILD.bazel
@@ -5,8 +5,8 @@ go_library(
     srcs = [
         "address.go",
         "discovery.go",
+        "mac.go",
         "names.go",
-        "reserved_macs.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/network/link",
     visibility = ["//visibility:public"],

--- a/pkg/network/link/mac.go
+++ b/pkg/network/link/mac.go
@@ -19,8 +19,30 @@
 
 package link
 
+import (
+	"fmt"
+	"net"
+)
+
 const StaticMasqueradeBridgeMAC = "02:00:00:00:00:00"
 
 func IsReserved(mac string) bool {
 	return mac == StaticMasqueradeBridgeMAC
+}
+
+// ValidateMacAddress performs a validation of the address validity in terms of format and size.
+// An empty mac address input is ignored (i.e. is considered valid).
+func ValidateMacAddress(macAddress string) error {
+	if macAddress == "" {
+		return nil
+	}
+	mac, err := net.ParseMAC(macAddress)
+	if err != nil {
+		return fmt.Errorf("malformed MAC address (%s)", macAddress)
+	}
+	const macLen = 6
+	if len(mac) > macLen {
+		return fmt.Errorf("too long MAC address (%s)", macAddress)
+	}
+	return nil
 }


### PR DESCRIPTION
### What this PR does

The mac address validation is currently embedded in the VMI Spec admitter. In order to allow reuse of the mac validation for other specs, the validation logic is extracted out.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

