### PR TITLE
[Tests]postcopy.go: Remove use of RunVMAndExpectLaunchWithRunStrategy func

### DIFF
--- a/pkg/libvmi/vm.go
+++ b/pkg/libvmi/vm.go
@@ -65,6 +65,13 @@ func WithRunning() VMOption {
 	}
 }
 
+func WithRunStrategy(strategy v1.VirtualMachineRunStrategy) VMOption {
+	return func(vm *v1.VirtualMachine) {
+		vm.Spec.RunStrategy = &strategy
+		vm.Spec.Running = nil
+	}
+}
+
 func WithDataVolumeTemplate(datavolume *v1beta1.DataVolume) VMOption {
 	return func(vm *v1.VirtualMachine) {
 		vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates,

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libdv"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
+	"kubevirt.io/kubevirt/tests/util"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
@@ -249,7 +250,7 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 							libnet.WithMasqueradeNetworking(),
 							libvmi.WithResourceMemory("3Gi"),
 							libvmi.WithRng(),
-							libvmi.WithNamespace(testsuite.NamespacePrivileged),
+							libvmi.WithNamespace(util.NamespaceTestDefault),
 						)
 						vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyRerunOnFailure))
 


### PR DESCRIPTION
Add WithRunStrategy func to libvmi
WithRunStrategy is the correct way to choose
How vmi should behave and libvmi should include
option for RunStrategy setting.

postcopy.go: Remove use of RunVMAndExpectLaunchWithRunStrategy func
RunVMAndExpectLaunchWithRunStrategy should be deprecated as it is part
of tests_utils.go and use expensive get and update API calls

Instead of Updating VM runStrategy in postcopy.go create vm with
with the desired runStrategy.

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

