### PR TITLE
[release-1.2] Allow to set cpu reqs/limits when doing cpu hotplug

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -434,14 +434,6 @@ func validateLiveUpdateFeatures(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 
 	causes = append(causes, validateLiveUpdateCPU(field, &spec.Template.Spec.Domain)...)
 
-	if hasCPURequestsOrLimits(&spec.Template.Spec.Domain.Resources) {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("Configuration of CPU resource requirements is not allowed when CPU live update is enabled"),
-			Field:   field.Child("template", "spec", "domain", "resources").String(),
-		})
-	}
-
 	if spec.Template.Spec.Domain.Memory != nil && spec.Template.Spec.Domain.Memory.MaxGuest != nil {
 		causes = append(causes, validateLiveUpdateMemory(field, &spec.Template.Spec.Domain, spec.Template.Spec.Architecture)...)
 	}
@@ -798,15 +790,4 @@ func (admitter *VMsAdmitter) isMigrationInProgress(vmi *v1.VirtualMachineInstanc
 		return fmt.Errorf("cannot update while VMI migration is in progress: %v", err)
 	}
 	return nil
-}
-
-func hasCPURequestsOrLimits(rr *v1.ResourceRequirements) bool {
-	if _, ok := rr.Requests[corev1.ResourceCPU]; ok {
-		return true
-	}
-	if _, ok := rr.Limits[corev1.ResourceCPU]; ok {
-		return true
-	}
-
-	return false
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1889,26 +1889,6 @@ var _ = Describe("Validating VM Admitter", func() {
 				Expect(response.Result.Details.Causes[0].Message).To(ContainSubstring("Number of sockets in CPU topology is greater than the maximum sockets allowed"))
 			})
 
-			It("should reject VM creation when resource requests are configured", func() {
-				vm.Spec.Template.Spec.Domain.Resources.Requests = make(k8sv1.ResourceList)
-				vm.Spec.Template.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("400m")
-
-				response := admitVm(vmsAdmitter, vm)
-				Expect(response.Allowed).To(BeFalse())
-				Expect(response.Result.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.resources"))
-				Expect(response.Result.Details.Causes[0].Message).To(ContainSubstring("Configuration of CPU resource requirements is not allowed when CPU live update is enabled"))
-			})
-
-			It("should reject VM creation when resource limits are configured", func() {
-				vm.Spec.Template.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-				vm.Spec.Template.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("400m")
-
-				response := admitVm(vmsAdmitter, vm)
-				Expect(response.Allowed).To(BeFalse())
-				Expect(response.Result.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.resources"))
-				Expect(response.Result.Details.Causes[0].Message).To(ContainSubstring("Configuration of CPU resource requirements is not allowed when CPU live update is enabled"))
-			})
-
 			When("Hot CPU change is in progress", func() {
 				BeforeEach(func() {
 					vm.Status.Ready = true

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -641,7 +641,7 @@ func (c *VMController) VMICPUsPatch(vm *virtv1.VirtualMachine, vmi *virtv1.Virtu
 	resourcesDelta := resource.NewMilliQuantity(vcpusDelta*int64(1000/c.clusterConfig.GetCPUAllocationRatio()), resource.DecimalSI)
 
 	if !vm.Spec.Template.Spec.Domain.Resources.Requests.Cpu().IsZero() {
-		newCpuReq := vm.Spec.Template.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
+		newCpuReq := vmi.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
 		newCpuReq.Add(*resourcesDelta)
 
 		patches = append(patches, fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/requests/cpu", "value": "%s"}`, vmi.Spec.Domain.Resources.Requests.Cpu().String()))
@@ -649,7 +649,7 @@ func (c *VMController) VMICPUsPatch(vm *virtv1.VirtualMachine, vmi *virtv1.Virtu
 	}
 
 	if !vm.Spec.Template.Spec.Domain.Resources.Limits.Cpu().IsZero() {
-		newCpuLimit := vm.Spec.Template.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
+		newCpuLimit := vmi.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
 		newCpuLimit.Add(*resourcesDelta)
 
 		patches = append(patches, fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/limits/cpu", "value": "%s"}`, vmi.Spec.Domain.Resources.Limits.Cpu().String()))

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -65,6 +65,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
 	"kubevirt.io/kubevirt/pkg/util/status"
 	traceUtils "kubevirt.io/kubevirt/pkg/util/trace"
@@ -631,12 +632,33 @@ func (c *VMController) updatePVCMemoryDumpAnnotation(vm *virtv1.VirtualMachine) 
 }
 
 func (c *VMController) VMICPUsPatch(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
-	test := fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/cpu/sockets", "value": %s}`, strconv.FormatUint(uint64(vmi.Spec.Domain.CPU.Sockets), 10))
-	update := fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/cpu/sockets", "value": %s}`, strconv.FormatUint(uint64(vm.Spec.Template.Spec.Domain.CPU.Sockets), 10))
-	patch := fmt.Sprintf("[%s, %s]", test, update)
+	patches := []string{
+		fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/cpu/sockets", "value": %s}`, strconv.FormatUint(uint64(vmi.Spec.Domain.CPU.Sockets), 10)),
+		fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/cpu/sockets", "value": %s}`, strconv.FormatUint(uint64(vm.Spec.Template.Spec.Domain.CPU.Sockets), 10)),
+	}
 
-	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), v1.PatchOptions{})
+	vcpusDelta := hardware.GetNumberOfVCPUs(vm.Spec.Template.Spec.Domain.CPU) - hardware.GetNumberOfVCPUs(vmi.Spec.Domain.CPU)
+	resourcesDelta := resource.NewMilliQuantity(vcpusDelta*int64(1000/c.clusterConfig.GetCPUAllocationRatio()), resource.DecimalSI)
 
+	if !vm.Spec.Template.Spec.Domain.Resources.Requests.Cpu().IsZero() {
+		newCpuReq := vm.Spec.Template.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
+		newCpuReq.Add(*resourcesDelta)
+
+		patches = append(patches, fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/requests/cpu", "value": "%s"}`, vmi.Spec.Domain.Resources.Requests.Cpu().String()))
+		patches = append(patches, fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/resources/requests/cpu", "value": "%s"}`, newCpuReq.String()))
+	}
+
+	if !vm.Spec.Template.Spec.Domain.Resources.Limits.Cpu().IsZero() {
+		newCpuLimit := vm.Spec.Template.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
+		newCpuLimit.Add(*resourcesDelta)
+
+		patches = append(patches, fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/resources/limits/cpu", "value": "%s"}`, vmi.Spec.Domain.Resources.Limits.Cpu().String()))
+		patches = append(patches, fmt.Sprintf(`{ "op": "replace", "path": "/spec/domain/resources/limits/cpu", "value": "%s"}`, newCpuLimit.String()))
+	}
+
+	patchBytes := controller.GeneratePatchBytes(patches)
+
+	_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
 	return err
 }
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5703,6 +5703,63 @@ var _ = Describe("VirtualMachine", func() {
 					vmi := controller.setupVMIFromVM(vm)
 					Expect(vmi.Spec.Domain.CPU.MaxSockets).To(Equal(defaultSockets * 4))
 				})
+
+				DescribeTable("should patch VMI when CPU hotplug is requested", func(resources v1.ResourceRequirements) {
+					vm, _ := DefaultVirtualMachine(true)
+					vm.Spec.Template.Spec.Domain.Resources = resources
+					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{
+						Sockets: 2,
+					}
+
+					vmi := api.NewMinimalVMI(vm.Name)
+					vmi.Spec.Domain.CPU = &v1.CPU{
+						Sockets:    1,
+						MaxSockets: 4,
+					}
+					vmi.Spec.Domain.Resources = resources
+
+					vcpusDelta := int64(vm.Spec.Template.Spec.Domain.CPU.Sockets - vmi.Spec.Domain.CPU.Sockets)
+					resourcesDelta := resource.NewMilliQuantity(vcpusDelta*int64(1000*(1.0/float32(config.GetCPUAllocationRatio()))), resource.DecimalSI)
+
+					vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = controller.handleCPUChangeRequest(vm, vmi)
+					Expect(err).ToNot(HaveOccurred())
+
+					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Sockets))
+
+					if !resources.Requests.Cpu().IsZero() {
+						expectedCpuReq := vmi.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
+						expectedCpuReq.Add(*resourcesDelta)
+
+						Expect(vmi.Spec.Domain.Resources.Requests.Cpu().Value()).To(Equal(expectedCpuReq.Value()))
+					}
+
+					if !resources.Limits.Cpu().IsZero() {
+						expectedCpuLim := vmi.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
+						expectedCpuLim.Add(*resourcesDelta)
+
+						Expect(vmi.Spec.Domain.Resources.Limits.Cpu().Value()).To(Equal(expectedCpuLim.Value()))
+					}
+				},
+					Entry("with no resources set", v1.ResourceRequirements{}),
+					Entry("with cpu request set", v1.ResourceRequirements{
+						Requests: k8sv1.ResourceList{
+							k8sv1.ResourceCPU: resource.MustParse("100m"),
+						},
+					}),
+					Entry("with cpu request and limits set", v1.ResourceRequirements{
+						Requests: k8sv1.ResourceList{
+							k8sv1.ResourceCPU: resource.MustParse("100m"),
+						},
+						Limits: k8sv1.ResourceList{
+							k8sv1.ResourceCPU: resource.MustParse("400m"),
+						},
+					}),
+				)
 			})
 
 			Context("Memory", func() {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5727,22 +5727,22 @@ var _ = Describe("VirtualMachine", func() {
 					err = controller.handleCPUChangeRequest(vm, vmi)
 					Expect(err).ToNot(HaveOccurred())
 
-					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+					updatedVMI, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Sockets))
+					Expect(updatedVMI.Spec.Domain.CPU.Sockets).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Sockets))
 
 					if !resources.Requests.Cpu().IsZero() {
 						expectedCpuReq := vmi.Spec.Domain.Resources.Requests.Cpu().DeepCopy()
 						expectedCpuReq.Add(*resourcesDelta)
 
-						Expect(vmi.Spec.Domain.Resources.Requests.Cpu().Value()).To(Equal(expectedCpuReq.Value()))
+						Expect(updatedVMI.Spec.Domain.Resources.Requests.Cpu().String()).To(Equal(expectedCpuReq.String()))
 					}
 
 					if !resources.Limits.Cpu().IsZero() {
 						expectedCpuLim := vmi.Spec.Domain.Resources.Limits.Cpu().DeepCopy()
 						expectedCpuLim.Add(*resourcesDelta)
 
-						Expect(vmi.Spec.Domain.Resources.Limits.Cpu().Value()).To(Equal(expectedCpuLim.Value()))
+						Expect(updatedVMI.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal(expectedCpuLim.String()))
 					}
 				},
 					Entry("with no resources set", v1.ResourceRequirements{}),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
 A VM with cpu requests and/or limits set could not hotplug vcpus.

After this PR:
 A VM with cpu requests and/or limits set can hotplug vcpus.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow to hotplug vcpus for VMs with CPU requests and/or limits set
```