### PR TITLE
Add the VMI namespace to migration succeeded/failed metrics

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/migrationstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/migrationstats_collector.go
@@ -62,7 +62,7 @@ var (
 			Name: "kubevirt_vmi_migration_succeeded",
 			Help: "Indicates if the VMI migration succeeded.",
 		},
-		[]string{"vmi", "vmim"},
+		[]string{"vmi", "vmim", "namespace"},
 	)
 
 	failedMigration = operatormetrics.NewGaugeVec(
@@ -70,7 +70,7 @@ var (
 			Name: "kubevirt_vmi_migration_failed",
 			Help: "Indicates if the VMI migration failed.",
 		},
-		[]string{"vmi", "vmim"},
+		[]string{"vmi", "vmim", "namespace"},
 	)
 )
 
@@ -100,9 +100,9 @@ func reportMigrationStats(vmims []*k6tv1.VirtualMachineInstanceMigration) []oper
 		case k6tv1.MigrationRunning, k6tv1.MigrationScheduled, k6tv1.MigrationPreparingTarget, k6tv1.MigrationTargetReady:
 			runningCount++
 		case k6tv1.MigrationSucceeded:
-			cr = append(cr, operatormetrics.CollectorResult{Metric: succeededMigration, Value: 1, Labels: []string{vmim.Spec.VMIName, vmim.Name}})
+			cr = append(cr, operatormetrics.CollectorResult{Metric: succeededMigration, Value: 1, Labels: []string{vmim.Spec.VMIName, vmim.Name, vmim.Namespace}})
 		default:
-			cr = append(cr, operatormetrics.CollectorResult{Metric: failedMigration, Value: 1, Labels: []string{vmim.Spec.VMIName, vmim.Name}})
+			cr = append(cr, operatormetrics.CollectorResult{Metric: failedMigration, Value: 1, Labels: []string{vmim.Spec.VMIName, vmim.Name, vmim.Namespace}})
 		}
 	}
 

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -172,7 +172,8 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_running_phase", 0)
 
 			labels := map[string]string{
-				"vmi": vmi.Name,
+				"vmi":       vmi.Name,
+				"namespace": vmi.Namespace,
 			}
 			libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_migration_succeeded", 1, labels, 1)
 
@@ -190,7 +191,8 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 			)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 			labels := map[string]string{
-				"vmi": vmi.Name,
+				"vmi":       vmi.Name,
+				"namespace": vmi.Namespace,
 			}
 
 			By("Starting the Migration")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
`kubevirt_vmi_migration_succeeded` and `kubevirt_vmi_migration_failed` metrics didn't have the VMI namespace label.
After this PR:
`kubevirt_vmi_migration_succeeded` and `kubevirt_vmi_migration_failed` metrics have the VMI namespace label.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://issues.redhat.com/browse/CNV-42622

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

