### PR TITLE
VM unit tests, remove informers

### DIFF
--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )
 

--- a/pkg/testutils/mock_queue.go
+++ b/pkg/testutils/mock_queue.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	v1 "kubevirt.io/api/core/v1"
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
@@ -257,36 +256,6 @@ func (v *DomainFeeder) Delete(vmi *api.Domain) {
 
 func NewDomainFeeder(queue *MockWorkQueue, source *framework.FakeControllerSource) *DomainFeeder {
 	return &DomainFeeder{
-		MockQueue: queue,
-		Source:    source,
-	}
-}
-
-type DataVolumeFeeder struct {
-	MockQueue *MockWorkQueue
-	Source    *framework.FakeControllerSource
-}
-
-func (v *DataVolumeFeeder) Add(dataVolume *cdiv1.DataVolume) {
-	v.MockQueue.ExpectAdds(1)
-	v.Source.Add(dataVolume)
-	v.MockQueue.Wait()
-}
-
-func (v *DataVolumeFeeder) Modify(dataVolume *cdiv1.DataVolume) {
-	v.MockQueue.ExpectAdds(1)
-	v.Source.Modify(dataVolume)
-	v.MockQueue.Wait()
-}
-
-func (v *DataVolumeFeeder) Delete(dataVolume *cdiv1.DataVolume) {
-	v.MockQueue.ExpectAdds(1)
-	v.Source.Delete(dataVolume)
-	v.MockQueue.Wait()
-}
-
-func NewDataVolumeFeeder(queue *MockWorkQueue, source *framework.FakeControllerSource) *DataVolumeFeeder {
-	return &DataVolumeFeeder{
 		MockQueue: queue,
 		Source:    source,
 	}

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -191,7 +191,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -65,8 +65,6 @@ var _ = Describe("VirtualMachine", func() {
 		var vmiSource *framework.FakeControllerSource
 		var vmSource *framework.FakeControllerSource
 		var vmiInformer cache.SharedIndexInformer
-
-		var pvcInformer cache.SharedIndexInformer
 		var controller *VMController
 		var recorder *record.FakeRecorder
 		var mockQueue *testutils.MockWorkQueue
@@ -99,7 +97,7 @@ var _ = Describe("VirtualMachine", func() {
 			var vmInformer cache.SharedIndexInformer
 			vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstance{}, virtcontroller.GetVMIInformerIndexers())
 			vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachine{}, virtcontroller.GetVirtualMachineInformerIndexers())
-			pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+			pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 			namespaceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 			ns1 := &k8sv1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1372,7 +1370,7 @@ var _ = Describe("VirtualMachine", func() {
 					Phase: k8sv1.ClaimBound,
 				},
 			}
-			Expect(pvcInformer.GetStore().Add(&pvc)).To(Succeed())
+			Expect(controller.pvcStore.Add(&pvc)).To(Succeed())
 
 			createCount := 0
 			if expectedCreations > 0 {
@@ -1783,7 +1781,7 @@ var _ = Describe("VirtualMachine", func() {
 					if pvc.Namespace == "" {
 						pvc.Namespace = vm.Namespace
 					}
-					Expect(pvcInformer.GetStore().Add(&pvc)).To(Succeed())
+					Expect(controller.pvcStore.Add(&pvc)).To(Succeed())
 				}
 
 				controller.cloneAuthFunc = func(dv *cdiv1.DataVolume, requestNamespace, requestName string, proxy cdiv1.AuthorizationHelperProxy, saNamespace, saName string) (bool, string, error) {
@@ -3367,7 +3365,7 @@ var _ = Describe("VirtualMachine", func() {
 						Namespace: vm.Namespace,
 					},
 				}
-				Expect(pvcInformer.GetStore().Add(&pvc)).To(Succeed())
+				Expect(controller.pvcStore.Add(&pvc)).To(Succeed())
 
 				pvcAnnotationUpdated := make(chan bool, 1)
 				defer close(pvcAnnotationUpdated)
@@ -3720,7 +3718,7 @@ var _ = Describe("VirtualMachine", func() {
 							Phase: k8sv1.ClaimPending,
 						},
 					}
-					Expect(pvcInformer.GetStore().Add(&pvc)).To(Succeed())
+					Expect(controller.pvcStore.Add(&pvc)).To(Succeed())
 
 					sanityExecute(vm)
 
@@ -3899,7 +3897,7 @@ var _ = Describe("VirtualMachine", func() {
 							Phase: pvcPhase,
 						},
 					}
-					Expect(pvcInformer.GetStore().Add(&pvc)).To(Succeed())
+					Expect(controller.pvcStore.Add(&pvc)).To(Succeed())
 
 					sanityExecute(vm)
 


### PR DESCRIPTION
### What this PR does
Remove informers in order to simplify test setup. This also improve test runtime from ~15 seconds down to ~0.2 seconds.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

