### PR TITLE
[BugFix] Configure a single vGPU display with ramfb

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -52,9 +52,30 @@ func CreatePCIHostDevices(hostDevicesData []HostDeviceMetaData, pciAddrPool Addr
 	return createHostDevices(hostDevicesData, pciAddrPool, createPCIHostDevice)
 }
 
+func isVgpuDisplaySet(hostDevicesData []HostDeviceMetaData) bool {
+	for _, hostDeviceData := range hostDevicesData {
+		if hostDeviceData.VirtualGPUOptions != nil &&
+			hostDeviceData.VirtualGPUOptions.Display != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func CreateMDEVHostDevices(hostDevicesData []HostDeviceMetaData, mdevAddrPool AddressPooler, enableDefaultDisplay bool) ([]api.HostDevice, error) {
 	if enableDefaultDisplay {
-		return createHostDevices(hostDevicesData, mdevAddrPool, createMDEVHostDeviceWithDisplay)
+		devices, err := createHostDevices(hostDevicesData, mdevAddrPool, createMDEVHostDeviceWithDisplay)
+		if err != nil {
+			return devices, err
+		}
+		// add a default single display option with enabled ramfb
+		// only if no vgpuDisplay option was configured.
+		if !isVgpuDisplaySet(hostDevicesData) && len(devices) > 0 {
+			devices[0].Display = "on"
+			devices[0].RamFB = "on"
+		}
+		return devices, nil
+
 	}
 	return createHostDevices(hostDevicesData, mdevAddrPool, createMDEVHostDevice)
 }
@@ -130,9 +151,6 @@ func createMDEVHostDeviceWithDisplay(hostDeviceData HostDeviceMetaData, mdevUUID
 				}
 			}
 		}
-	} else {
-		mdev.Display = "on"
-		mdev.RamFB = "on"
 	}
 	return mdev, nil
 }


### PR DESCRIPTION
### What this PR does
Before this PR:
VMs would fail to start VM when multiple vGPUs are configured with ramfb.

After this PR:
Only a single vgpu display option with ramfb will be configured per VMI.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # CNV-42218

### Release note
```release-note
Only a single vgpu display option with ramfb will be configured per VMI.
```

