### PR TITLE
Use restartRequired condition when volumes cannot be updated

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -990,7 +990,7 @@ func (c *VMController) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi 
 		// Validate if the update volumes can be migrated
 		if err := volumemig.ValidateVolumes(vmi, vm); err != nil {
 			vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-				Type:               virtv1.VirtualMachineInstanceVolumesChange,
+				Type:               virtv1.VirtualMachineRestartRequired,
 				LastTransitionTime: v1.Now(),
 				Status:             k8score.ConditionTrue,
 				Message:            err.Error(),

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -6155,6 +6155,54 @@ var _ = Describe("VirtualMachine", func() {
 					Entry("with the replacement updateVolumeStrategy",
 						kvpointer.P(v1.UpdateVolumesStrategyReplacement)),
 				)
+
+				It("should set the restart condition with the Migration updateVolumeStrategy if volumes cannot be migrated", func() {
+					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
+						Spec: v1.KubeVirtSpec{
+							Configuration: v1.KubeVirtConfiguration{
+								VMRolloutStrategy: &liveUpdate,
+								DeveloperConfiguration: &v1.DeveloperConfiguration{
+									FeatureGates: []string{
+										virtconfig.VMLiveUpdateFeaturesGate,
+										virtconfig.VolumesUpdateStrategy,
+										virtconfig.VolumeMigration,
+									},
+								},
+							},
+						},
+					})
+					vm, vmi := DefaultVirtualMachine(true)
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+						Name: "vol1"})
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+						Name: "vol3",
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "updated-vol3"}},
+						},
+					})
+					vm.Spec.UpdateVolumesStrategy = kvpointer.P(v1.UpdateVolumesStrategyMigration)
+					vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems,
+						v1.Filesystem{
+							Name:     "vol3",
+							Virtiofs: &v1.FilesystemVirtiofs{},
+						})
+					vmi.Spec.Volumes = append(vmi.Spec.Volumes,
+						v1.Volume{Name: "vol2"},
+						v1.Volume{
+							Name: "vol3",
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "vol3"}},
+							},
+						},
+					)
+					controller.handleVolumeUpdateRequest(vm, vmi)
+					cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(vm, v1.VirtualMachineRestartRequired)
+					Expect(cond).ToNot(BeNil())
+					Expect(cond.Status).To(Equal(k8score.ConditionTrue))
+					Expect(cond.Message).To(ContainSubstring("invalid volumes to update with migration:"))
+				})
 			})
 
 			Context("Instance Types and Preferences", func() {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -6141,6 +6141,7 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 					vm, vmi := DefaultVirtualMachine(true)
+					vm.Spec.UpdateVolumesStrategy = strategy
 					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 						Name: "vol1"})
 					vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{Name: "vol2"})

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -556,6 +556,22 @@ const (
 
 	// Indicates whether the VMI is live migratable
 	VirtualMachineInstanceIsMigratable VirtualMachineInstanceConditionType = "LiveMigratable"
+
+	// Indicates that the VMI is in progress of Hot vCPU Plug/UnPlug
+	VirtualMachineInstanceVCPUChange VirtualMachineInstanceConditionType = "HotVCPUChange"
+
+	// Indicates that the VMI is hot(un)plugging memory
+	VirtualMachineInstanceMemoryChange VirtualMachineInstanceConditionType = "HotMemoryChange"
+
+	// Indicates that the VMI has an updates in its volume set
+	VirtualMachineInstanceVolumesChange VirtualMachineInstanceConditionType = "VolumesChange"
+
+	// Summarizes that all the DataVolumes attached to the VMI are Ready or not
+	VirtualMachineInstanceDataVolumesReady VirtualMachineInstanceConditionType = "DataVolumesReady"
+)
+
+// These are valid reasons for VMI conditions.
+const (
 	// Reason means that VMI is not live migratioable because of it's disks collection
 	VirtualMachineInstanceReasonDisksNotMigratable = "DisksNotLiveMigratable"
 	// Reason means that VMI is not live migratioable because of it's network interfaces collection
@@ -576,16 +592,6 @@ const (
 	VirtualMachineInstanceReasonHypervPassthroughNotMigratable = "HypervPassthroughNotLiveMigratable"
 	// Reason means that VMI is not live migratable because it requested SCSI persitent reservation
 	VirtualMachineInstanceReasonPRNotMigratable = "PersistentReservationNotLiveMigratable"
-	// Indicates that the VMI is in progress of Hot vCPU Plug/UnPlug
-	VirtualMachineInstanceVCPUChange = "HotVCPUChange"
-	// Indicates that the VMI is hot(un)plugging memory
-	VirtualMachineInstanceMemoryChange = "HotMemoryChange"
-	// Indicates that the VMI has an updates in its volume set
-	VirtualMachineInstanceVolumesChange = "VolumesChange"
-
-	// Summarizes that all the DataVolumes attached to the VMI are Ready or not
-	VirtualMachineInstanceDataVolumesReady = "DataVolumesReady"
-
 	// Reason means that not all of the VMI's DVs are ready
 	VirtualMachineInstanceReasonNotAllDVsReady = "NotAllDVsReady"
 	// Reason means that all of the VMI's DVs are bound and not running


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, if the volumes cannot be live updated we
are setting the `VirtualMachineInstanceVolumesChange` condition
to the vm.
This is wrong for two reasons:
- `VirtualMachineInstanceVolumesChange` is a vmi condition and not a vm condition.
- We need to specify that the vm requires a restart if validateVolume fails

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @alicefr @vladikr @mhenriks 
