### PR TITLE
Fix flaky connection metric test

### DIFF
--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -277,17 +277,13 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 			vmi = libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Validating the metric gets updated with the last connection timestamp")
-			initialTimestamp := float64(time.Now().Unix())
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-			initialMetricValue := validateLastConnectionMetricValue(vmi, initialTimestamp)
+			initialMetricValue := validateLastConnectionMetricValue(vmi, 0)
 
 			time.Sleep(1 * time.Minute)
 
-			secondaryTimestamp := float64(time.Now().Unix())
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-			secondaryMetricValue := validateLastConnectionMetricValue(vmi, secondaryTimestamp)
-
-			Expect(secondaryMetricValue).To(BeNumerically(">", initialMetricValue))
+			validateLastConnectionMetricValue(vmi, initialMetricValue)
 		})
 	})
 
@@ -368,7 +364,7 @@ func createAgentVMI() *v1.VirtualMachineInstance {
 	return agentVMI
 }
 
-func validateLastConnectionMetricValue(vmi *v1.VirtualMachineInstance, timestamp float64) float64 {
+func validateLastConnectionMetricValue(vmi *v1.VirtualMachineInstance, formerValue float64) float64 {
 	var err error
 	var metricValue float64
 	virtClient := kubevirt.Client()
@@ -380,7 +376,7 @@ func validateLastConnectionMetricValue(vmi *v1.VirtualMachineInstance, timestamp
 			return -1
 		}
 		return metricValue
-	}, 3*time.Minute, 20*time.Second).Should(BeNumerically(">=", timestamp))
+	}, 3*time.Minute, 20*time.Second).Should(BeNumerically(">", formerValue))
 
 	return metricValue
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Remove any synchronization assumptions from `kubevirt_vmi_last_api_connection_timestamp_seconds` e2e test, which introduced flakiness. Change the test to only check that the metric value gets increased when a connection is being made.

Before this PR:
`kubevirt_vmi_last_api_connection_timestamp_seconds` e2e test was flaky.
After this PR:
`kubevirt_vmi_last_api_connection_timestamp_seconds` e2e test is no longer flaky.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->


### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

