### PR TITLE
Refactor validateDisks function to improve readability

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -58,6 +58,10 @@ const requiredFieldFmt = "%s is a required field"
 const (
 	maxStrLen = 256
 
+	// Should be a power of 2
+	minCustomBlockSize = 512
+	maxCustomBlockSize = 2097152 // 2 MB
+
 	// cloudInitNetworkMaxLen and CloudInitUserMaxLen are being limited
 	// to 2K to allow scaling of config as edits will cause entire object
 	// to be distributed to large no of nodes. For larger than 2K, user should
@@ -1841,242 +1845,302 @@ func getNumberOfPodInterfaces(spec *v1.VirtualMachineInstanceSpec) int {
 	return nPodInterfaces
 }
 
-func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
+func validateDiskName(field *k8sfield.Path, idx int, disks []v1.Disk) []metav1.StatusCause {
 	var causes []metav1.StatusCause
-	nameMap := make(map[string]int)
-
-	for idx, disk := range disks {
-		// verify name is unique
-		otherIdx, ok := nameMap[disk.Name]
-		if !ok {
-			nameMap[disk.Name] = idx
-		} else {
+	for otherIdx, disk := range disks {
+		if otherIdx < idx && disk.Name == disks[idx].Name {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: fmt.Sprintf("%s and %s must not have the same Name.", field.Index(idx).String(), field.Index(otherIdx).String()),
 				Field:   field.Index(idx).Child("name").String(),
 			})
 		}
+	}
+	return causes
+}
 
-		// Verify only a single device type is set.
-		deviceTargetSetCount := 0
-		var diskType string
-		var bus v1.DiskBus
-		if disk.Disk != nil {
-			deviceTargetSetCount++
-			diskType = "disk"
-			bus = disk.Disk.Bus
-		}
-		if disk.LUN != nil {
-			deviceTargetSetCount++
-			diskType = "lun"
-			bus = disk.LUN.Bus
-		}
-		if disk.CDRom != nil {
-			deviceTargetSetCount++
-			diskType = "cdrom"
-			bus = disk.CDRom.Bus
-		}
+func validateDeviceTarget(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	deviceTargetSetCount := 0
+	if disk.Disk != nil {
+		deviceTargetSetCount++
+	}
+	if disk.LUN != nil {
+		deviceTargetSetCount++
+	}
+	if disk.CDRom != nil {
+		deviceTargetSetCount++
+	}
+	// NOTE: not setting a device target is okay. We default to Disk.
+	// However, only a single device target is allowed to be set at a time.
+	if deviceTargetSetCount > 1 {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s can only have a single target type defined", field.Index(idx).String()),
+			Field:   field.Index(idx).String(),
+		})
+	}
+	return causes
+}
 
-		// NOTE: not setting a device target is okay. We default to Disk.
-		// However, only a single device target is allowed to be set at a time.
-		if deviceTargetSetCount > 1 {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s can only have a single target type defined", field.Index(idx).String()),
-				Field:   field.Index(idx).String(),
-			})
-		}
-
-		// Verify pci address
-		if disk.Disk != nil && disk.Disk.PciAddress != "" {
-			if disk.Disk.Bus != v1.DiskBusVirtio {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("disk %s - setting a PCI address is only possible with bus type virtio.", field.Child("domain", "devices", "disks", "disk").Index(idx).Child("name").String()),
-					Field:   field.Child("domain", "devices", "disks", "disk").Index(idx).Child("pciAddress").String(),
-				})
-			}
-
-			_, err := hwutil.ParsePciAddress(disk.Disk.PciAddress)
-			if err != nil {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("disk %s has malformed PCI address (%s).", field.Child("domain", "devices", "disks", "disk").Index(idx).Child("name").String(), disk.Disk.PciAddress),
-					Field:   field.Child("domain", "devices", "disks", "disk").Index(idx).Child("pciAddress").String(),
-				})
-			}
-		}
-
-		// Verify boot order is greater than 0, if provided
-		if disk.BootOrder != nil && *disk.BootOrder < 1 {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s must have a boot order > 0, if supplied", field.Index(idx).String()),
-				Field:   field.Index(idx).Child("bootOrder").String(),
-			})
-		}
-
-		// Verify bus is supported, if provided
-		if len(bus) > 0 {
-			if bus == "ide" {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: "IDE bus is not supported",
-					Field:   field.Index(idx).Child(diskType, "bus").String(),
-				})
-			} else {
-				buses := []v1.DiskBus{v1.DiskBusVirtio, v1.DiskBusSCSI, v1.DiskBusSATA, v1.DiskBusUSB}
-				validBus := false
-				for _, b := range buses {
-					if b == bus {
-						validBus = true
-					}
-				}
-				if !validBus {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("%s is set with an unrecognized bus %s, must be one of: %v", field.Index(idx).String(), bus, buses),
-						Field:   field.Index(idx).Child(diskType, "bus").String(),
-					})
-				}
-
-				// special case. virtio is incompatible with CD-ROM for q35 machine types
-				if diskType == "cdrom" && bus == v1.DiskBusVirtio {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("Bus type %s is invalid for CD-ROM device", bus),
-						Field:   field.Index(idx).Child("cdrom", "bus").String(),
-					})
-
-				}
-				// sata disks (in contrast to sata cdroms) don't support readOnly
-				if disk.Disk != nil && bus == v1.DiskBusSATA && disk.Disk.ReadOnly {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("%s hard-disks do not support read-only.", bus),
-						Field:   field.Index(idx).Child("disk", "bus").String(),
-					})
-				}
-			}
-
-			// Reject defining DedicatedIOThread to a disk without VirtIO bus since this configuration
-			// is not supported in libvirt.
-			isIOThreadsWithUnsupportedBus := disk.DedicatedIOThread != nil && *disk.DedicatedIOThread &&
-				bus != v1.DiskBusVirtio
-			if isIOThreadsWithUnsupportedBus {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueNotSupported,
-					Message: fmt.Sprintf("IOThreads are not supported for disks on a %s bus", bus),
-					Field:   field.Child("domain", "devices", "disks").Index(idx).String(),
-				})
-			}
-		}
-
-		// Verify serial number is made up of valid characters for libvirt, if provided
-		if disk.Serial != "" && !isValidExpression(disk.Serial) {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s must be made up of the following characters [A-Za-z0-9_.+-], if specified", field.Index(idx).String()),
-				Field:   field.Index(idx).Child("serial").String(),
-			})
-		}
-
-		// Verify serial number is within valid length, if provided
-		if disk.Serial != "" && len([]rune(disk.Serial)) > maxStrLen {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s must be less than or equal to %d in length, if specified", field.Index(idx).String(), maxStrLen),
-				Field:   field.Index(idx).Child("serial").String(),
-			})
-		}
-
-		// Verify if cache mode is valid
-		if disk.Cache != "" && disk.Cache != v1.CacheNone && disk.Cache != v1.CacheWriteThrough && disk.Cache != v1.CacheWriteBack {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s has invalid value %s", field.Index(idx).Child("cache").String(), disk.Cache),
-				Field:   field.Index(idx).Child("cache").String(),
-			})
-		}
-
-		if disk.IO != "" && disk.IO != v1.IONative && disk.IO != v1.IOThreads {
-			field := field.Child("domain", "devices", "disks").Index(idx).Child("io").String()
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueNotSupported,
-				Message: fmt.Sprintf("Disk IO mode for %s is not supported. Supported modes are: native, threads.", field),
-				Field:   field,
-			})
-		}
-
-		// Verify if error_policy is valid
-		if disk.ErrorPolicy != nil && *disk.ErrorPolicy != v1.DiskErrorPolicyStop && *disk.ErrorPolicy != v1.DiskErrorPolicyIgnore && *disk.ErrorPolicy != v1.DiskErrorPolicyReport && *disk.ErrorPolicy != v1.DiskErrorPolicyEnospace {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s has invalid value \"%s\"", field.Index(idx).Child("errorPolicy").String(), *disk.ErrorPolicy),
-				Field:   field.Index(idx).Child("errorPolicy").String(),
-			})
-		}
-
-		// Verify disk and volume name can be a valid container name since disk
-		// name can become a container name which will fail to schedule if invalid
-		errs := validation.IsDNS1123Label(disk.Name)
-
-		for _, err := range errs {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: err,
-				Field:   field.Child("domain", "devices", "disks").Index(idx).Child("name").String(),
-			})
-		}
-
-		if disk.BlockSize != nil {
-			hasCustomBlockSize := disk.BlockSize.Custom != nil
-			hasVolumeMatchingEnabled := disk.BlockSize.MatchVolume != nil && (disk.BlockSize.MatchVolume.Enabled == nil || *disk.BlockSize.MatchVolume.Enabled)
-			if hasCustomBlockSize && hasVolumeMatchingEnabled {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: "Block size matching can't be enabled together with a custom value",
-					Field:   field.Index(idx).Child("blockSize").String(),
-				})
-			} else if hasCustomBlockSize {
-				customSize := disk.BlockSize.Custom
-				if customSize.Logical > customSize.Physical {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("Logical size %d must be the same or less than the physical size of %d", customSize.Logical, customSize.Physical),
-						Field:   field.Index(idx).Child("blockSize").Child("custom").Child("logical").String(),
-					})
-				} else {
-					checkSize := func(size uint) (bool, string) {
-						if size < 512 {
-							return false, fmt.Sprintf("Provided size of %d is less than the supported minimum size of 512", size)
-						} else if size > 2097152 {
-							return false, fmt.Sprintf("Provided size of %d is greater than the supported maximum size of 2 MiB", size)
-						} else if size&(size-1) != 0 {
-							return false, fmt.Sprintf("Provided size of %d is not a power of 2", size)
-						}
-						return true, ""
-					}
-					if sizeOk, reason := checkSize(customSize.Logical); !sizeOk {
-						causes = append(causes, metav1.StatusCause{
-							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: reason,
-							Field:   field.Index(idx).Child("blockSize").Child("custom").Child("logical").String(),
-						})
-					}
-					if sizeOk, reason := checkSize(customSize.Physical); !sizeOk {
-						causes = append(causes, metav1.StatusCause{
-							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: reason,
-							Field:   field.Index(idx).Child("blockSize").Child("custom").Child("physical").String(),
-						})
-					}
-				}
-			}
-		}
+func validatePciAddress(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.Disk == nil || disk.Disk.PciAddress == "" {
+		return causes
 	}
 
+	if disk.Disk.Bus != v1.DiskBusVirtio {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("disk %s - setting a PCI address is only possible with bus type virtio.", field.Child("domain", "devices", "disks", "disk").Index(idx).Child("name").String()),
+			Field:   field.Child("domain", "devices", "disks", "disk").Index(idx).Child("pciAddress").String(),
+		})
+	}
+
+	if _, err := hwutil.ParsePciAddress(disk.Disk.PciAddress); err != nil {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("disk %s has malformed PCI address (%s).", field.Child("domain", "devices", "disks", "disk").Index(idx).Child("name").String(), disk.Disk.PciAddress),
+			Field:   field.Child("domain", "devices", "disks", "disk").Index(idx).Child("pciAddress").String(),
+		})
+	}
+	return causes
+}
+
+func validateBootOrderValue(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.BootOrder != nil && *disk.BootOrder < 1 {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s must have a boot order > 0, if supplied", field.Index(idx).String()),
+			Field:   field.Index(idx).Child("bootOrder").String(),
+		})
+	}
+	return causes
+}
+
+func getDiskBus(disk v1.Disk) v1.DiskBus {
+	switch {
+	case disk.Disk != nil:
+		return disk.Disk.Bus
+	case disk.LUN != nil:
+		return disk.LUN.Bus
+	case disk.CDRom != nil:
+		return disk.CDRom.Bus
+	default:
+		return ""
+	}
+}
+
+func getDiskType(disk v1.Disk) string {
+	switch {
+	case disk.Disk != nil:
+		return "disk"
+	case disk.LUN != nil:
+		return "lun"
+	case disk.CDRom != nil:
+		return "cdrom"
+	default:
+		return ""
+	}
+}
+
+func validateBusSupport(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	bus := getDiskBus(disk)
+	diskType := getDiskType(disk)
+	if bus == "" {
+		return causes
+	}
+	switch bus {
+	case "ide":
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "IDE bus is not supported",
+			Field:   field.Index(idx).Child(diskType, "bus").String(),
+		})
+	case v1.DiskBusVirtio:
+		// special case. virtio is incompatible with CD-ROM for q35 machine types
+		if diskType == "cdrom" {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("Bus type %s is invalid for CD-ROM device", bus),
+				Field:   field.Index(idx).Child("cdrom", "bus").String(),
+			})
+		}
+	case v1.DiskBusSATA:
+		// sata disks (in contrast to sata cdroms) don't support readOnly
+		if disk.Disk != nil && disk.Disk.ReadOnly {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("%s hard-disks do not support read-only.", bus),
+				Field:   field.Index(idx).Child("disk", "bus").String(),
+			})
+		}
+	case v1.DiskBusSCSI, v1.DiskBusUSB:
+		break
+	default:
+		supportedBuses := []v1.DiskBus{v1.DiskBusVirtio, v1.DiskBusSCSI, v1.DiskBusSATA, v1.DiskBusUSB}
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s is set with an unrecognized bus %s, must be one of: %v", field.Index(idx).String(), bus, supportedBuses),
+			Field:   field.Index(idx).Child(diskType, "bus").String(),
+		})
+	}
+	// Reject defining DedicatedIOThread to a disk without VirtIO bus since this configuration
+	// is not supported in libvirt.
+	if disk.DedicatedIOThread != nil && *disk.DedicatedIOThread && bus != v1.DiskBusVirtio {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: fmt.Sprintf("IOThreads are not supported for disks on a %s bus", bus),
+			Field:   field.Child("domain", "devices", "disks").Index(idx).String(),
+		})
+	}
+	return causes
+}
+
+func validateSerialNumValue(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.Serial != "" && !isValidExpression(disk.Serial) {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s must be made up of the following characters [A-Za-z0-9_.+-], if specified", field.Index(idx).String()),
+			Field:   field.Index(idx).Child("serial").String(),
+		})
+	}
+	return causes
+}
+
+func validateSerialNumLength(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.Serial != "" && len([]rune(disk.Serial)) > maxStrLen {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s must be less than or equal to %d in length, if specified", field.Index(idx).String(), maxStrLen),
+			Field:   field.Index(idx).Child("serial").String(),
+		})
+	}
+	return causes
+}
+
+func validateCacheMode(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.Cache != "" && disk.Cache != v1.CacheNone && disk.Cache != v1.CacheWriteThrough && disk.Cache != v1.CacheWriteBack {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s has invalid value %s", field.Index(idx).Child("cache").String(), disk.Cache),
+			Field:   field.Index(idx).Child("cache").String(),
+		})
+	}
+	return causes
+}
+
+func validateIOMode(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.IO != "" && disk.IO != v1.IONative && disk.IO != v1.IOThreads {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: fmt.Sprintf("Disk IO mode for %s is not supported. Supported modes are: native, threads.", field),
+			Field:   field.Child("domain", "devices", "disks").Index(idx).Child("io").String(),
+		})
+	}
+	return causes
+}
+
+func validateErrorPolicy(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.ErrorPolicy != nil && *disk.ErrorPolicy != v1.DiskErrorPolicyStop && *disk.ErrorPolicy != v1.DiskErrorPolicyIgnore && *disk.ErrorPolicy != v1.DiskErrorPolicyReport && *disk.ErrorPolicy != v1.DiskErrorPolicyEnospace {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s has invalid value \"%s\"", field.Index(idx).Child("errorPolicy").String(), *disk.ErrorPolicy),
+			Field:   field.Index(idx).Child("errorPolicy").String(),
+		})
+	}
+	return causes
+}
+
+func validateDiskNameAsContainerName(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	for _, err := range validation.IsDNS1123Label(disk.Name) {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: err,
+			Field:   field.Child("domain", "devices", "disks").Index(idx).Child("name").String(),
+		})
+	}
+	return causes
+}
+
+func validateCustomBlockSize(field *k8sfield.Path, idx int, blockType string, size uint) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	switch {
+	case size < minCustomBlockSize:
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("Provided size of %d is less than the supported minimum size of %d", size, minCustomBlockSize),
+			Field:   field.Index(idx).Child("blockSize").Child("custom").Child(blockType).String(),
+		})
+	case size > maxCustomBlockSize:
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("Provided size of %d is greater than the supported maximum size of %d", size, maxCustomBlockSize),
+			Field:   field.Index(idx).Child("blockSize").Child("custom").Child(blockType).String(),
+		})
+	case size&(size-1) != 0:
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("Provided size of %d is not a power of 2", size),
+			Field:   field.Index(idx).Child("blockSize").Child("custom").Child(blockType).String(),
+		})
+	}
+	return causes
+}
+
+func validateBlockSize(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.BlockSize == nil || disk.BlockSize.Custom == nil {
+		return causes
+	}
+	if disk.BlockSize.MatchVolume != nil && (disk.BlockSize.MatchVolume.Enabled == nil || *disk.BlockSize.MatchVolume.Enabled) {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Block size matching can't be enabled together with a custom value",
+			Field:   field.Index(idx).Child("blockSize").String(),
+		})
+		return causes
+	}
+	customSize := disk.BlockSize.Custom
+	if customSize.Logical > customSize.Physical {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("Logical size %d must be the same or less than the physical size of %d", customSize.Logical, customSize.Physical),
+			Field:   field.Index(idx).Child("blockSize").Child("custom").Child("logical").String(),
+		})
+	} else {
+		causes = append(causes, validateCustomBlockSize(field, idx, "logical", customSize.Logical)...)
+		causes = append(causes, validateCustomBlockSize(field, idx, "physical", customSize.Physical)...)
+	}
+	return causes
+}
+
+func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	for idx, disk := range disks {
+		causes = append(causes, validateDiskName(field, idx, disks)...)
+		causes = append(causes, validateDeviceTarget(field, idx, disk)...)
+		causes = append(causes, validatePciAddress(field, idx, disk)...)
+		causes = append(causes, validateBootOrderValue(field, idx, disk)...)
+		causes = append(causes, validateBusSupport(field, idx, disk)...)
+		causes = append(causes, validateSerialNumValue(field, idx, disk)...)
+		causes = append(causes, validateSerialNumLength(field, idx, disk)...)
+		causes = append(causes, validateCacheMode(field, idx, disk)...)
+		causes = append(causes, validateIOMode(field, idx, disk)...)
+		causes = append(causes, validateErrorPolicy(field, idx, disk)...)
+		// Verify disk and volume name can be a valid container name since disk
+		// name can become a container name which will fail to schedule if invalid
+		causes = append(causes, validateDiskNameAsContainerName(field, idx, disk)...)
+		causes = append(causes, validateBlockSize(field, idx, disk)...)
+	}
 	return causes
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11305

### Why we need it and why it was done in this way
This refactoring of validateDisks function reduces the length of the function, improves readbility, improves maintainability and preserves the same functionality. It was done this way to reduce the number of nested conditions, nested loops, and code duplication.

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/11305

### Special notes for your reviewer


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

