### PR TITLE
[Clone][Bugfix] Handle source VM with unbounded volumes

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -730,7 +730,7 @@ func (t *vmRestoreTarget) createDataVolume(dvt kubevirtv1.DataVolumeTemplateSpec
 	if err != nil {
 		return false, err
 	}
-	if pvc.Annotations[populatedForPVCAnnotation] != dvt.Name || len(pvc.OwnerReferences) > 0 {
+	if pvc != nil && (pvc.Annotations[populatedForPVCAnnotation] != dvt.Name || len(pvc.OwnerReferences) > 0) {
 		return false, nil
 	}
 

--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
@@ -65,5 +66,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/clone/clone.go
+++ b/pkg/virt-controller/watch/clone/clone.go
@@ -217,7 +217,7 @@ func (ctrl *VMCloneController) syncTargetVM(vmCloneInfo *vmCloneInfo) syncInfoTy
 				return syncInfo
 			}
 
-			syncInfo = ctrl.createRestoreFromVm(vmClone, vm, vmCloneInfo.snapshotName, syncInfo)
+			syncInfo = ctrl.createRestoreFromVm(vmClone, vm, vmCloneInfo.snapshot, syncInfo)
 			return syncInfo
 		}
 
@@ -409,9 +409,9 @@ func (ctrl *VMCloneController) getSnapshot(snapshotName string, sourceNamespace 
 	return snapshot, syncInfo
 }
 
-func (ctrl *VMCloneController) createRestoreFromVm(vmClone *clonev1alpha1.VirtualMachineClone, vm *k6tv1.VirtualMachine, snapshotName string, syncInfo syncInfoType) syncInfoType {
-	patches := generatePatches(vm, &vmClone.Spec)
-	restore := generateRestore(vmClone.Spec.Target, vm.Name, vmClone.Namespace, vmClone.Name, snapshotName, vmClone.UID, patches)
+func (ctrl *VMCloneController) createRestoreFromVm(vmClone *clonev1alpha1.VirtualMachineClone, vm *k6tv1.VirtualMachine, snapshot *snapshotv1.VirtualMachineSnapshot, syncInfo syncInfoType) syncInfoType {
+	patches := generatePatches(vm, &vmClone.Spec, snapshot)
+	restore := generateRestore(vmClone.Spec.Target, vm.Name, vmClone.Namespace, vmClone.Name, snapshot.Name, vmClone.UID, patches)
 	log.Log.Object(vmClone).Infof("creating restore %s for clone %s", restore.Name, vmClone.Name)
 	createdRestore, err := ctrl.client.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, v1.CreateOptions{})
 	if err != nil {

--- a/pkg/virt-controller/watch/clone/util.go
+++ b/pkg/virt-controller/watch/clone/util.go
@@ -49,7 +49,7 @@ func generateNameWithRandomSuffix(names ...string) string {
 	// Kubernetes' object names have limit of 252 characters.
 	// For more info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
 	if len(generatedName) > 252 {
-		generatedName = "clone-object"
+		generatedName = "clone-" + rand.String(randomStringLength)
 	}
 
 	generatedName = fmt.Sprintf("%s-%s", generatedName, rand.String(randomStringLength))


### PR DESCRIPTION
### What this PR does

**Bug:**
This PR addresses a bug in the clone API.

If a VM with an unbound DV is being snapshotted, the DV is skipped and is not being snapshotted [1][2].
This makes sense for "regular" snapshots (i.e. that are not being created for cloning). Since the DV was not bounded there is nothing to snapshot, and when the VM is being restored all needs to be done is to restore the original spec with the DV volumes and possibly DV templates defined.

However, for cloning this might result with the following bug:
1. A stopped VM is being created with a DV template with a WFFC binding mode.
2. A clone is being created.
3. The clone controller snapshots the VM and the DV/DV template are skipped.
4. The clone controller restores the VM into a new instance.
5. The new instance points to the same DV.

The scenario where the target and source VMs point to the same DV is a bug.
The above can occur with a WFFC PVC as well, not necessarily a DV.

**Solution:**
Now the clone controller handles this situation in the following way:
* If the unbounded volume is a DV backed with a DV template: the DV's and DV template's names are changed, which will result in a distinct DV.
* If the unbounded volume is a PVC: the PVC's name is changed, which will result in a distinct PVC.
* If the unbounded volume is a DV that is **not** backed with a DV template: ignore the DV and drop it from the target.

[1] https://github.com/kubevirt/kubevirt/blob/cd6d77a5f96fcea1765583fa9bdb0bfe754386ef/pkg/storage/snapshot/snapshot.go#L614-L617
[2] https://github.com/kubevirt/kubevirt/blob/cd6d77a5f96fcea1765583fa9bdb0bfe754386ef/pkg/storage/snapshot/snapshot.go#L551-L554

Before this PR:
In some situations (see above), source and target VMs point to the save volume.

After this PR:
In some situations (see above), source and target VMs point to different volumes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-38559

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
7. If no release note is required, just write "NONE".
-->
```release-note
[Clone][Bugfix] Handle source VM with unbounded DataVolumes
```

/kind bug
/area clone

