### PR TITLE
tests: Move cert functions

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -10,12 +10,10 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
-        "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/tests/infrastructure/certificates.go
+++ b/tests/infrastructure/certificates.go
@@ -70,7 +70,7 @@ var _ = DescribeInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][leve
 	It("[test_id:4099] should be rotated when a new CA is created", func() {
 		By("checking that the config-map gets the new CA bundle attached")
 		Eventually(func() int {
-			_, crts := libinfra.GetBundleFromConfigMap(components.KubeVirtCASecretName)
+			_, crts := libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
 			return len(crts)
 		}, 10*time.Second, 1*time.Second).Should(BeNumerically(">", 0))
 
@@ -98,7 +98,7 @@ var _ = DescribeInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][leve
 		By("checking that one of the CAs in the config-map is the new one")
 		var caBundle []byte
 		Eventually(func() bool {
-			caBundle, _ = libinfra.GetBundleFromConfigMap(components.KubeVirtCASecretName)
+			caBundle, _ = libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
 			return libinfra.ContainsCrt(caBundle, newCA)
 		}, 10*time.Second, 1*time.Second).Should(BeTrue(), "the new CA should be added to the config-map")
 

--- a/tests/infrastructure/certificates.go
+++ b/tests/infrastructure/certificates.go
@@ -70,7 +70,7 @@ var _ = DescribeInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][leve
 	It("[test_id:4099] should be rotated when a new CA is created", func() {
 		By("checking that the config-map gets the new CA bundle attached")
 		Eventually(func() int {
-			_, crts := tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
+			_, crts := libinfra.GetBundleFromConfigMap(components.KubeVirtCASecretName)
 			return len(crts)
 		}, 10*time.Second, 1*time.Second).Should(BeNumerically(">", 0))
 
@@ -98,7 +98,7 @@ var _ = DescribeInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][leve
 		By("checking that one of the CAs in the config-map is the new one")
 		var caBundle []byte
 		Eventually(func() bool {
-			caBundle, _ = tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
+			caBundle, _ = libinfra.GetBundleFromConfigMap(components.KubeVirtCASecretName)
 			return libinfra.ContainsCrt(caBundle, newCA)
 		}, 10*time.Second, 1*time.Second).Should(BeTrue(), "the new CA should be added to the config-map")
 

--- a/tests/infrastructure/certificates.go
+++ b/tests/infrastructure/certificates.go
@@ -135,8 +135,8 @@ var _ = DescribeInfra("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][leve
 	})
 
 	It("[sig-compute][test_id:4100] should be valid during the whole rotation process", func() {
-		oldAPICert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
-		oldHandlerCert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
+		oldAPICert := libinfra.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
+		oldHandlerCert := libinfra.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
 		Expect(err).ToNot(HaveOccurred())
 
 		By("destroying the CA certificate")

--- a/tests/libinfra/BUILD.bazel
+++ b/tests/libinfra/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//tests/flags:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libnode:go_default_library",
+        "//tests/libpod:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/tests/libinfra/BUILD.bazel
+++ b/tests/libinfra/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/downwardmetrics/vhostmd/api:go_default_library",
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",
+        "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",

--- a/tests/libinfra/certificates.go
+++ b/tests/libinfra/certificates.go
@@ -48,9 +48,9 @@ func ContainsCrt(bundle []byte, containedCrt []byte) bool {
 	return attached
 }
 
-func GetBundleFromConfigMap(configMapName string) ([]byte, []*x509.Certificate) {
+func GetBundleFromConfigMap(ctx context.Context, configMapName string) ([]byte, []*x509.Certificate) {
 	virtClient := kubevirt.Client()
-	configMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), configMapName, v1.GetOptions{})
+	configMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(ctx, configMapName, v1.GetOptions{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	if rawBundle, ok := configMap.Data[components.CABundleKey]; ok {
 		crts, err := cert.ParseCertsPEM([]byte(rawBundle))

--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libconfigmap:go_default_library",
+        "//tests/libinfra:go_default_library",
         "//tests/libmigration:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnode:go_default_library",

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -85,6 +85,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libconfigmap"
+	"kubevirt.io/kubevirt/tests/libinfra"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
@@ -2993,7 +2994,7 @@ func serviceMonitorEnabled() bool {
 // verifyOperatorWebhookCertificate can be used when inside tests doing reinstalls of kubevirt, to ensure that virt-operator already got the new certificate.
 // This is necessary, since it can take up to a minute to get the fresh certificates when secrets are updated.
 func verifyOperatorWebhookCertificate() {
-	caBundle, _ := tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
+	caBundle, _ := libinfra.GetBundleFromConfigMap(components.KubeVirtCASecretName)
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(caBundle)
 	// ensure that the state is fully restored before each test

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -3010,7 +3010,7 @@ func verifyOperatorWebhookCertificate() {
 	}, 90*time.Second, 1*time.Second).Should(Not(HaveOccurred()), "bundle and certificate are still not in sync after 90 seconds")
 	// we got the first pod with the new certificate, now let's wait until every pod sees it
 	// this can take additional time since nodes are not synchronizing at the same moment
-	tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-operator"), flags.KubeVirtInstallNamespace, "8444")
+	libinfra.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-operator"), flags.KubeVirtInstallNamespace, "8444")
 }
 
 func getUpstreamReleaseAssetURL(tag string, assetName string) string {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2994,7 +2994,7 @@ func serviceMonitorEnabled() bool {
 // verifyOperatorWebhookCertificate can be used when inside tests doing reinstalls of kubevirt, to ensure that virt-operator already got the new certificate.
 // This is necessary, since it can take up to a minute to get the fresh certificates when secrets are updated.
 func verifyOperatorWebhookCertificate() {
-	caBundle, _ := libinfra.GetBundleFromConfigMap(components.KubeVirtCASecretName)
+	caBundle, _ := libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(caBundle)
 	// ensure that the state is fully restored before each test

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -56,9 +56,6 @@ import (
 
 	util2 "kubevirt.io/kubevirt/tests/util"
 
-	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
-	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -707,18 +704,6 @@ func EnsurePodsCertIsSynced(labelSelector string, namespace string, port string)
 		return certs[0]
 	}
 	return nil
-}
-
-func GetBundleFromConfigMap(configMapName string) ([]byte, []*x509.Certificate) {
-	virtClient := kubevirt.Client()
-	configMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), configMapName, metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	if rawBundle, ok := configMap.Data[components.CABundleKey]; ok {
-		crts, err := cert.ParseCertsPEM([]byte(rawBundle))
-		Expect(err).ToNot(HaveOccurred())
-		return []byte(rawBundle), crts
-	}
-	return nil, nil
 }
 
 func RandTmpDir() string {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -31,7 +31,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -680,30 +679,6 @@ func callUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	return io.ReadAll(resp.Body)
-}
-
-// EnsurePodsCertIsSynced waits until new certificates are rolled out  to all pods which are matching the specified labelselector.
-// Once all certificates are in sync, the final secret is returned
-func EnsurePodsCertIsSynced(labelSelector string, namespace string, port string) []byte {
-	var certs [][]byte
-	EventuallyWithOffset(1, func() bool {
-		var err error
-		certs, err = libpod.GetCertsForPods(labelSelector, namespace, port)
-		Expect(err).ToNot(HaveOccurred())
-		if len(certs) == 0 {
-			return true
-		}
-		for _, crt := range certs {
-			if !reflect.DeepEqual(certs[0], crt) {
-				return false
-			}
-		}
-		return true
-	}, 90*time.Second, 1*time.Second).Should(BeTrue(), "certificates across '%s' pods are not in sync", labelSelector)
-	if len(certs) > 0 {
-		return certs[0]
-	}
-	return nil
 }
 
 func RandTmpDir() string {


### PR DESCRIPTION
### What this PR does
Before this PR:
cert related functions are in test.utils.

After this PR:
cert realted function moved to libinfra, following the example of https://github.com/kubevirt/kubevirt/commit/3edd103d4adeb1d8fb01b3d4c600d9076bc5a1f6

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

