### PR TITLE
virt-api: replace hardcoded patch operations with patchset

### DIFF
--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -211,61 +211,31 @@ func (app *SubresourceAPIApp) getVirtHandlerConnForVMI(vmi *v1.VirtualMachineIns
 	return kubecli.NewVirtHandlerClient(app.virtCli, app.handlerHttpClient).Port(app.consoleServerPort).ForNode(vmi.Status.NodeName), nil
 }
 
-func getChangeRequestJson(vm *v1.VirtualMachine, changes ...v1.VirtualMachineStateChangeRequest) (string, error) {
-
-	var ops []string
-
-	verb := "add"
+func getChangeRequestJson(vm *v1.VirtualMachine, changes ...v1.VirtualMachineStateChangeRequest) ([]byte, error) {
+	patchSet := patch.New()
 	// Special case: if there's no status field at all, add one.
 	newStatus := v1.VirtualMachineStatus{}
 	if equality.Semantic.DeepEqual(vm.Status, newStatus) {
 		newStatus.StateChangeRequests = append(newStatus.StateChangeRequests, changes...)
-		statusJson, err := json.Marshal(newStatus)
-		if err != nil {
-			return "", err
-		}
-		ops = append(ops, fmt.Sprintf(`{ "op": "%s", "path": "/status", "value": %s}`, verb, string(statusJson)))
+		patchSet.AddOption(patch.WithAdd("/status", newStatus))
 	} else {
-
-		failOnConflict := true
-		if len(changes) == 1 && changes[0].Action == v1.StopRequest {
+		patchSet.AddOption(patch.WithTest("/status/stateChangeRequests", vm.Status.StateChangeRequests))
+		switch {
+		case len(vm.Status.StateChangeRequests) == 0:
+			patchSet.AddOption(patch.WithAdd("/status/stateChangeRequests", changes))
+		case len(changes) == 1 && changes[0].Action == v1.StopRequest:
 			// If this is a stopRequest, replace all existing StateChangeRequests.
-			failOnConflict = false
+			patchSet.AddOption(patch.WithReplace("/status/stateChangeRequests", changes))
+		default:
+			return nil, fmt.Errorf("unable to complete request: stop/start already underway")
 		}
-
-		if len(vm.Status.StateChangeRequests) != 0 {
-			if failOnConflict {
-				return "", fmt.Errorf("unable to complete request: stop/start already underway")
-			} else {
-				verb = "replace"
-			}
-		}
-
-		changeRequests := []v1.VirtualMachineStateChangeRequest{}
-		changeRequests = append(changeRequests, changes...)
-
-		oldChangeRequestsJson, err := json.Marshal(vm.Status.StateChangeRequests)
-		if err != nil {
-			return "", err
-		}
-
-		newChangeRequestsJson, err := json.Marshal(changeRequests)
-		if err != nil {
-			return "", err
-		}
-
-		test := fmt.Sprintf(`{ "op": "test", "path": "/status/stateChangeRequests", "value": %s}`, string(oldChangeRequestsJson))
-		update := fmt.Sprintf(`{ "op": "%s", "path": "/status/stateChangeRequests", "value": %s}`, verb, string(newChangeRequestsJson))
-
-		ops = append(ops, test)
-		ops = append(ops, update)
 	}
 
 	if vm.Status.StartFailure != nil {
-		ops = append(ops, `{ "op": "remove", "path": "/status/startFailure" }`)
+		patchSet.AddOption(patch.WithRemove("/status/startFailure"))
 	}
 
-	return string(controller.GeneratePatchBytes(ops)), nil
+	return patchSet.GeneratePayload()
 }
 
 func getRunningJson(vm *v1.VirtualMachine, running bool) string {
@@ -285,14 +255,14 @@ func getUpdateTerminatingSecondsGracePeriod(gracePeriod int64) string {
 }
 
 func (app *SubresourceAPIApp) patchVMStatusStopped(vmi *v1.VirtualMachineInstance, vm *v1.VirtualMachine, response *restful.Response, bodyStruct *v1.StopOptions) (error, error) {
-	bodyString, err := getChangeRequestJson(vm,
+	patchBytes, err := getChangeRequestJson(vm,
 		v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID})
 	if err != nil {
 		writeError(errors.NewInternalError(err), response)
 		return nil, err
 	}
-	log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, bodyString)
-	return app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun}), nil
+	log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, string(patchBytes))
+	return app.statusUpdater.PatchStatus(vm, types.JSONPatchType, patchBytes, &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun}), nil
 }
 
 func (app *SubresourceAPIApp) MigrateVMRequestHandler(request *restful.Request, response *restful.Response) {
@@ -407,7 +377,7 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 		return
 	}
 
-	bodyString, err := getChangeRequestJson(vm,
+	patchBytes, err := getChangeRequestJson(vm,
 		v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID},
 		v1.VirtualMachineStateChangeRequest{Action: v1.StartRequest})
 	if err != nil {
@@ -415,8 +385,8 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 		return
 	}
 
-	log.Log.Object(vm).V(4).Infof(patchingVMFmt, bodyString)
-	err = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
+	log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
+	err = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, patchBytes, &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	if err != nil {
 		if strings.Contains(err.Error(), jsonpatchTestErr) {
 			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, err), response)
@@ -542,7 +512,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 		// Send start request if VM should start paused. virt-controller will update RunStrategy upon this request.
 		// No need to send the request if StartStrategy is already set to Paused in VMI Spec.
 		if startPaused && (vm.Spec.Template == nil || vm.Spec.Template.Spec.StartStrategy != &pausedStartStrategy) {
-			patchString, err := getChangeRequestJson(vm, v1.VirtualMachineStateChangeRequest{
+			patchBytes, err := getChangeRequestJson(vm, v1.VirtualMachineStateChangeRequest{
 				Action: v1.StartRequest,
 				Data:   startChangeRequestData,
 			})
@@ -550,8 +520,8 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 				writeError(errors.NewInternalError(err), response)
 				return
 			}
-			log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, patchString)
-			patchErr = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patchString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
+			log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, string(patchBytes))
+			patchErr = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, patchBytes, &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 		} else {
 			patchString := getRunningJson(vm, true)
 			log.Log.Object(vm).V(4).Infof(patchingVMFmt, patchString)
@@ -568,21 +538,21 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 			return
 		}
 
-		var bodyString string
+		var patchBytes []byte
 		if needsRestart {
-			bodyString, err = getChangeRequestJson(vm,
+			patchBytes, err = getChangeRequestJson(vm,
 				v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID},
 				v1.VirtualMachineStateChangeRequest{Action: v1.StartRequest, Data: startChangeRequestData})
 		} else {
-			bodyString, err = getChangeRequestJson(vm,
+			patchBytes, err = getChangeRequestJson(vm,
 				v1.VirtualMachineStateChangeRequest{Action: v1.StartRequest, Data: startChangeRequestData})
 		}
 		if err != nil {
 			writeError(errors.NewInternalError(err), response)
 			return
 		}
-		log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, bodyString)
-		patchErr = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
+		log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, string(patchBytes))
+		patchErr = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, patchBytes, &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	case v1.RunStrategyAlways, v1.RunStrategyOnce:
 		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v does not support manual start requests", runStrategy)), response)
 		return
@@ -958,7 +928,7 @@ func (app *SubresourceAPIApp) FilesystemList(request *restful.Request, response 
 	app.httpGetRequestHandler(request, response, validate, getURL, v1.VirtualMachineInstanceFileSystemList{})
 }
 
-func generateVMVolumeRequestPatch(vm *v1.VirtualMachine, volumeRequest *v1.VirtualMachineVolumeRequest) (string, error) {
+func generateVMVolumeRequestPatch(vm *v1.VirtualMachine, volumeRequest *v1.VirtualMachineVolumeRequest) ([]byte, error) {
 	vmCopy := vm.DeepCopy()
 
 	// We only validate the list against other items in the list at this point.
@@ -966,36 +936,24 @@ func generateVMVolumeRequestPatch(vm *v1.VirtualMachine, volumeRequest *v1.Virtu
 	// during the Patch command
 	if volumeRequest.AddVolumeOptions != nil {
 		if err := addAddVolumeRequests(vm, volumeRequest, vmCopy); err != nil {
-			return "", err
+			return nil, err
 		}
 	} else if volumeRequest.RemoveVolumeOptions != nil {
 		if err := addRemoveVolumeRequests(vm, volumeRequest, vmCopy); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
-	patchBytes, err := patch.GeneratePatchPayload(
-		patch.PatchOperation{
-			Op:    patch.PatchTestOp,
-			Path:  "/status/volumeRequests",
-			Value: vm.Status.VolumeRequests,
-		},
-		patch.PatchOperation{
-			Op:    getPatchVerb(vm.Status.VolumeRequests),
-			Path:  "/status/volumeRequests",
-			Value: vmCopy.Status.VolumeRequests,
-		},
+	patchSet := patch.New(
+		patch.WithTest("/status/volumeRequests", vm.Status.VolumeRequests),
 	)
 
-	return string(patchBytes), err
-}
-
-func getPatchVerb(requests []v1.VirtualMachineVolumeRequest) string {
-	verb := "add"
-	if len(requests) > 0 {
-		verb = "replace"
+	if len(vm.Status.VolumeRequests) > 0 {
+		patchSet.AddOption(patch.WithReplace("/status/volumeRequests", vmCopy.Status.VolumeRequests))
+	} else {
+		patchSet.AddOption(patch.WithAdd("/status/volumeRequests", vmCopy.Status.VolumeRequests))
 	}
-	return verb
+	return patchSet.GeneratePayload()
 }
 
 func addAddVolumeRequests(vm *v1.VirtualMachine, volumeRequest *v1.VirtualMachineVolumeRequest, vmCopy *v1.VirtualMachine) error {
@@ -1099,51 +1057,28 @@ func verifyVolumeOption(volumes []v1.Volume, volumeRequest *v1.VirtualMachineVol
 	return nil
 }
 
-func generateVMIVolumeRequestPatch(vmi *v1.VirtualMachineInstance, volumeRequest *v1.VirtualMachineVolumeRequest) (string, error) {
-
-	volumeVerb := "add"
-	diskVerb := "add"
-
-	if len(vmi.Spec.Volumes) > 0 {
-		volumeVerb = "replace"
-	}
-
-	if len(vmi.Spec.Domain.Devices.Disks) > 0 {
-		diskVerb = "replace"
-	}
-
+func generateVMIVolumeRequestPatch(vmi *v1.VirtualMachineInstance, volumeRequest *v1.VirtualMachineVolumeRequest) ([]byte, error) {
 	vmiCopy := vmi.DeepCopy()
 	vmiCopy.Spec = *controller.ApplyVolumeRequestOnVMISpec(&vmiCopy.Spec, volumeRequest)
 
-	oldVolumesJson, err := json.Marshal(vmi.Spec.Volumes)
-	if err != nil {
-		return "", err
+	patchSet := patch.New(
+		patch.WithTest("/spec/volumes", vmi.Spec.Volumes),
+		patch.WithTest("/spec/domain/devices/disks", vmi.Spec.Domain.Devices.Disks),
+	)
+
+	if len(vmi.Spec.Volumes) > 0 {
+		patchSet.AddOption(patch.WithReplace("/spec/volumes", vmiCopy.Spec.Volumes))
+	} else {
+		patchSet.AddOption(patch.WithAdd("/spec/volumes", vmiCopy.Spec.Volumes))
 	}
 
-	newVolumesJson, err := json.Marshal(vmiCopy.Spec.Volumes)
-	if err != nil {
-		return "", err
+	if len(vmi.Spec.Domain.Devices.Disks) > 0 {
+		patchSet.AddOption(patch.WithReplace("/spec/domain/devices/disks", vmiCopy.Spec.Domain.Devices.Disks))
+	} else {
+		patchSet.AddOption(patch.WithAdd("/spec/domain/devices/disks", vmiCopy.Spec.Domain.Devices.Disks))
 	}
 
-	oldDisksJson, err := json.Marshal(vmi.Spec.Domain.Devices.Disks)
-	if err != nil {
-		return "", err
-	}
-
-	newDisksJson, err := json.Marshal(vmiCopy.Spec.Domain.Devices.Disks)
-	if err != nil {
-		return "", err
-	}
-
-	testVolumes := fmt.Sprintf(`{ "op": "test", "path": "/spec/volumes", "value": %s}`, string(oldVolumesJson))
-	updateVolumes := fmt.Sprintf(`{ "op": "%s", "path": "/spec/volumes", "value": %s}`, volumeVerb, string(newVolumesJson))
-
-	testDisks := fmt.Sprintf(`{ "op": "test", "path": "/spec/domain/devices/disks", "value": %s}`, string(oldDisksJson))
-	updateDisks := fmt.Sprintf(`{ "op": "%s", "path": "/spec/domain/devices/disks", "value": %s}`, diskVerb, string(newDisksJson))
-
-	patch := fmt.Sprintf("[%s, %s, %s, %s]", testVolumes, testDisks, updateVolumes, updateDisks)
-
-	return patch, nil
+	return patchSet.GeneratePayload()
 }
 
 func (app *SubresourceAPIApp) addVolumeRequestHandler(request *restful.Request, response *restful.Response, ephemeral bool) {
@@ -1274,14 +1209,14 @@ func (app *SubresourceAPIApp) vmiVolumePatch(name, namespace string, volumeReque
 		return errors.NewConflict(v1.Resource("virtualmachineinstance"), name, err)
 	}
 
-	patch, err := generateVMIVolumeRequestPatch(vmi, volumeRequest)
+	patchBytes, err := generateVMIVolumeRequestPatch(vmi, volumeRequest)
 	if err != nil {
 		return errors.NewConflict(v1.Resource("virtualmachineinstance"), name, err)
 	}
 
 	dryRunOption := app.getDryRunOption(volumeRequest)
-	log.Log.Object(vmi).V(4).Infof("Patching VMI: %s", patch)
-	if _, err := app.virtCli.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), k8smetav1.PatchOptions{DryRun: dryRunOption}); err != nil {
+	log.Log.Object(vmi).V(4).Infof("Patching VMI: %s", string(patchBytes))
+	if _, err := app.virtCli.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, k8smetav1.PatchOptions{DryRun: dryRunOption}); err != nil {
 		log.Log.Object(vmi).Errorf("unable to patch vmi: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {
@@ -1304,14 +1239,14 @@ func (app *SubresourceAPIApp) vmVolumePatchStatus(name, namespace string, volume
 		return errors.NewConflict(v1.Resource("virtualmachine"), name, err)
 	}
 
-	patch, err := generateVMVolumeRequestPatch(vm, volumeRequest)
+	patchBytes, err := generateVMVolumeRequestPatch(vm, volumeRequest)
 	if err != nil {
 		return errors.NewConflict(v1.Resource("virtualmachine"), name, err)
 	}
 
 	dryRunOption := app.getDryRunOption(volumeRequest)
-	log.Log.Object(vm).V(4).Infof(patchingVMFmt, patch)
-	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &k8smetav1.PatchOptions{DryRun: dryRunOption}); err != nil {
+	log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
+	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, patchBytes, &k8smetav1.PatchOptions{DryRun: dryRunOption}); err != nil {
 		log.Log.Object(vm).Errorf("unable to patch vm status: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {
@@ -1353,14 +1288,6 @@ func (app *SubresourceAPIApp) VMIRemoveVolumeRequestHandler(request *restful.Req
 	app.removeVolumeRequestHandler(request, response, true)
 }
 
-func getMemoryDumpPatchVerb(request *v1.VirtualMachineMemoryDumpRequest) string {
-	verb := "add"
-	if request != nil {
-		verb = "replace"
-	}
-	return verb
-}
-
 func addMemoryDumpRequest(vm, vmCopy *v1.VirtualMachine, memoryDumpReq *v1.VirtualMachineMemoryDumpRequest) error {
 	claimName := memoryDumpReq.ClaimName
 	if vm.Status.MemoryDumpRequest != nil {
@@ -1389,34 +1316,27 @@ func removeMemoryDumpRequest(vm, vmCopy *v1.VirtualMachine, memoryDumpReq *v1.Vi
 	return nil
 }
 
-func generateVMMemoryDumpRequestPatch(vm *v1.VirtualMachine, memoryDumpReq *v1.VirtualMachineMemoryDumpRequest, removeRequest bool) (string, error) {
-	verb := getMemoryDumpPatchVerb(vm.Status.MemoryDumpRequest)
+func generateVMMemoryDumpRequestPatch(vm *v1.VirtualMachine, memoryDumpReq *v1.VirtualMachineMemoryDumpRequest, removeRequest bool) ([]byte, error) {
 	vmCopy := vm.DeepCopy()
 
 	if !removeRequest {
 		if err := addMemoryDumpRequest(vm, vmCopy, memoryDumpReq); err != nil {
-			return "", err
+			return nil, err
 		}
 	} else {
 		if err := removeMemoryDumpRequest(vm, vmCopy, memoryDumpReq); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
-	oldJson, err := json.Marshal(vm.Status.MemoryDumpRequest)
-	if err != nil {
-		return "", err
-	}
-	newJson, err := json.Marshal(vmCopy.Status.MemoryDumpRequest)
-	if err != nil {
-		return "", err
+	patchSet := patch.New(patch.WithTest("/status/memoryDumpRequest", vm.Status.MemoryDumpRequest))
+	if vm.Status.MemoryDumpRequest != nil {
+		patchSet.AddOption(patch.WithReplace("/status/memoryDumpRequest", vmCopy.Status.MemoryDumpRequest))
+	} else {
+		patchSet.AddOption(patch.WithAdd("/status/memoryDumpRequest", vmCopy.Status.MemoryDumpRequest))
 	}
 
-	test := fmt.Sprintf(`{ "op": "test", "path": "/status/memoryDumpRequest", "value": %s}`, string(oldJson))
-	update := fmt.Sprintf(`{ "op": "%s", "path": "/status/memoryDumpRequest", "value": %s}`, verb, string(newJson))
-	patch := fmt.Sprintf("[%s, %s]", test, update)
-
-	return patch, nil
+	return patchSet.GeneratePayload()
 }
 
 func (app *SubresourceAPIApp) fetchPersistentVolumeClaim(name string, namespace string) (*v12.PersistentVolumeClaim, *errors.StatusError) {
@@ -1520,13 +1440,13 @@ func (app *SubresourceAPIApp) vmMemoryDumpRequestPatchStatus(name, namespace str
 		}
 	}
 
-	patch, err := generateVMMemoryDumpRequestPatch(vm, memoryDumpReq, removeRequest)
+	patchBytes, err := generateVMMemoryDumpRequestPatch(vm, memoryDumpReq, removeRequest)
 	if err != nil {
 		return errors.NewConflict(v1.Resource("virtualmachine"), name, err)
 	}
 
-	log.Log.Object(vm).V(4).Infof(patchingVMFmt, patch)
-	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &k8smetav1.PatchOptions{}); err != nil {
+	log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
+	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, patchBytes, &k8smetav1.PatchOptions{}); err != nil {
 		log.Log.Object(vm).Errorf("unable to patch vm status: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
@@ -78,16 +78,8 @@ func (mutator *CloneCreateMutator) Mutate(ar *admissionv1.AdmissionReview) *admi
 		}
 	}
 
-	var patchOps []patch.PatchOperation
-	var value interface{}
-	value = vmClone.Spec
-	patchOps = append(patchOps, patch.PatchOperation{
-		Op:    "replace",
-		Path:  "/spec",
-		Value: value,
-	})
+	patchBytes, err := patch.New(patch.WithReplace("/spec", vmClone.Spec)).GeneratePayload()
 
-	patchBytes, err := json.Marshal(patchOps)
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -133,11 +133,11 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		patchOps := []patch.PatchOperation{
 			{Value: vmiStatus},
 		}
-		err = json.Unmarshal(resp.Patch, &patchOps)
-		Expect(err).ToNot(HaveOccurred())
-		if len(patchOps) == 0 {
+		if resp.Patch == nil {
 			return &newVMI.Status
 		}
+		err = json.Unmarshal(resp.Patch, &patchOps)
+		Expect(err).ToNot(HaveOccurred())
 
 		return vmiStatus
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/downwardmetrics:go_default_library",
         "//pkg/hooks:go_default_library",
@@ -103,6 +104,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/libvmi:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -41,6 +41,7 @@ import (
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -563,8 +564,10 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					}
 				})
 
-				DescribeTable("should reject patching elements not under /spec/:", func(patch string) {
-					restore.Spec.Patches = []string{patch}
+				DescribeTable("should reject patching elements not under /spec/:", func(patchSet *patch.PatchSet) {
+					patchBytes, err := patchSet.GeneratePayload()
+					Expect(err).To(Not(HaveOccurred()))
+					restore.Spec.Patches = []string{string(patchBytes)}
 
 					ar := createRestoreAdmissionReview(restore)
 					resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
@@ -572,26 +575,28 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					Expect(resp.Result.Details.Causes).To(HaveLen(1))
 					Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.patches"))
 				},
-					Entry("patch to replace metadata", `{"op": "replace", "path": "/metadata", "value": "some-value"}`),
-					Entry("patch to replace name", `{"op": "replace", "path": "/metadata/name", "value": "some-value"}`),
-					Entry("patch to replace kind", `{"op": "replace", "path": "/kind", "value": "some-value"}`),
-					Entry("patch to remove api version", `{"op": "remove", "path": "/apiVersion"`),
-					Entry("patch to replace status", `{"op": "replace", "path": "/status", "value": "some-value"}`),
-					Entry("patch to add ready status", `{"op": "add", "path": "/status/ready", "value": "some-value"}`),
+					Entry("patch to replace metadata", patch.New(patch.WithReplace("/metadata", "some-value"))),
+					Entry("patch to replace name", patch.New(patch.WithReplace("/metadata/name", "some-value"))),
+					Entry("patch to replace kind", patch.New(patch.WithReplace("/kind", "some-value"))),
+					Entry("patch to remove api version", patch.New(patch.WithRemove("/apiVersion"))),
+					Entry("patch to replace status", patch.New(patch.WithReplace("/status", "some-value"))),
+					Entry("patch to add ready status", patch.New(patch.WithAdd("/status/ready", "some-value"))),
 				)
 
-				DescribeTable("should allow patching elements under /spec/:", func(patch string) {
-					restore.Spec.Patches = []string{patch}
+				DescribeTable("should allow patching elements under /spec/:", func(patchSet *patch.PatchSet) {
+					patchBytes, err := patchSet.GeneratePayload()
+					Expect(err).To(Not(HaveOccurred()))
+					restore.Spec.Patches = []string{string(patchBytes)}
 
 					ar := createRestoreAdmissionReview(restore)
 					resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
 					Expect(resp.Allowed).To(BeTrue())
 				},
-					Entry("patch to replace MAC", `{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "some-value"}`),
-					Entry("patch to add running", `{"op": "add", "path": "/spec/running", "value": "some-value"}`),
-					Entry("patch to remove instancetype", `{"op": "remove", "path": "/spec/instancetype"`),
-					Entry("patch to replace a label", `{"op": "replace", "path": "/metadata/labels/key", "value": "some-value"`),
-					Entry("patch to remove an annotation", `{"op": "remove", "path": "/metadata/annotations/key"`),
+					Entry("patch to replace MAC", patch.New(patch.WithReplace("/spec/template/spec/domain/devices/interfaces/0/macAddress", "some-value"))),
+					Entry("patch to add running", patch.New(patch.WithAdd("/spec/running", "some-value"))),
+					Entry("patch to remove instancetype", patch.New(patch.WithRemove("/spec/instancetype"))),
+					Entry("patch to replace a label", patch.New(patch.WithReplace("/metadata/labels/key", "some-value"))),
+					Entry("patch to remove an annotation", patch.New(patch.WithRemove("/metadata/annotations/key"))),
 				)
 
 				It("should reject an invalid patch", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Use the patch package to replace the hardcoded patch operations. This improves the readability and make the code more cohesive.

#### Before this PR:

Hardcoded operation in virt-api package.

#### After this PR:
Replaced all the patch operations with the `patch.PatchSet` in the virt-api package.

Fixes #
Partially address: https://github.com/kubevirt/kubevirt/issues/11654

**N.B.**
The vmi mutation webhook now does not return the patch
field if no patch are requested. Previously, it always
returns a patch, eventually "null".

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @alicefr @0xFelix 
