### PR TITLE
Collect component Role rules under operator Role instead of ClusterRole

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -467,14 +467,6 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - configmaps
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
           - namespaces
           verbs:
           - get
@@ -722,42 +714,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          verbs:
-          - list
-          - get
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - secrets
-          verbs:
-          - list
-          - get
-          - watch
-        - apiGroups:
-          - networking.k8s.io
-          resources:
-          - ingresses
-          verbs:
-          - list
-          - get
-          - watch
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - get
-          - list
-          - watch
-          - delete
-          - update
-          - create
-          - patch
-        - apiGroups:
           - kubevirt.io
           resources:
           - virtualmachineinstances
@@ -814,14 +770,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - export.kubevirt.io
           resources:
           - virtualmachineexports
@@ -834,16 +782,6 @@ spec:
           resources:
           - kubevirts
           verbs:
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resourceNames:
-          - kubevirt-export-ca
-          resources:
-          - configmaps
-          verbs:
-          - get
           - list
           - watch
         - apiGroups:
@@ -1447,6 +1385,68 @@ spec:
           - update
           - create
           - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - list
+          - get
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - list
+          - get
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - list
+          - get
+          - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resourceNames:
+          - kubevirt-export-ca
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: kubevirt-operator
     strategy: deployment
   installModes:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -75,6 +75,68 @@ rules:
   - update
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - update
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - kubevirt-export-ca
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -407,14 +469,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - get
@@ -662,42 +716,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - list
-  - get
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - list
-  - get
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - list
-  - get
-  - watch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-  - update
-  - create
-  - patch
-- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachineinstances
@@ -754,14 +772,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - export.kubevirt.io
   resources:
   - virtualmachineexports
@@ -774,16 +784,6 @@ rules:
   resources:
   - kubevirts
   verbs:
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resourceNames:
-  - kubevirt-export-ca
-  resources:
-  - configmaps
-  verbs:
-  - get
   - list
   - watch
 - apiGroups:

--- a/pkg/virt-operator/resource/generate/rbac/operator.go
+++ b/pkg/virt-operator/resource/generate/rbac/operator.go
@@ -317,15 +317,14 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 	}
 
 	// now append all rules needed by KubeVirt's components
-	operatorRole.Rules = append(operatorRole.Rules, getKubeVirtComponentsRules()...)
+	operatorRole.Rules = append(operatorRole.Rules, getKubeVirtComponentsClusterRules()...)
 	return operatorRole
 }
 
-func getKubeVirtComponentsRules() []rbacv1.PolicyRule {
-
+func getKubeVirtComponentsClusterRules() []rbacv1.PolicyRule {
 	var rules []rbacv1.PolicyRule
 
-	// namespace doesn't matter, we are only interested in the rules of both Roles and ClusterRoles
+	// namespace doesn't matter, we are only interested in the rules of ClusterRoles
 	all := GetAllApiServer("")
 	all = append(all, GetAllController("")...)
 	all = append(all, GetAllHandler("")...)
@@ -336,9 +335,6 @@ func getKubeVirtComponentsRules() []rbacv1.PolicyRule {
 		switch resource.(type) {
 		case *rbacv1.ClusterRole:
 			role, _ := resource.(*rbacv1.ClusterRole)
-			rules = append(rules, role.Rules...)
-		case *rbacv1.Role:
-			role, _ := resource.(*rbacv1.Role)
 			rules = append(rules, role.Rules...)
 		}
 	}
@@ -371,6 +367,27 @@ func getKubeVirtComponentsRules() []rbacv1.PolicyRule {
 		},
 	}
 	rules = append(rules, authDelegationRules...)
+
+	return rules
+}
+
+func getKubeVirtComponentsRules() []rbacv1.PolicyRule {
+	var rules []rbacv1.PolicyRule
+
+	// namespace doesn't matter, we are only interested in the rules
+	all := GetAllApiServer("")
+	all = append(all, GetAllController("")...)
+	all = append(all, GetAllHandler("")...)
+	all = append(all, GetAllExportProxy("")...)
+	all = append(all, GetAllCluster()...)
+
+	for _, resource := range all {
+		switch resource.(type) {
+		case *rbacv1.Role:
+			role, _ := resource.(*rbacv1.Role)
+			rules = append(rules, role.Rules...)
+		}
+	}
 
 	return rules
 }
@@ -432,7 +449,7 @@ func newOperatorRoleBinding(namespace string) *rbacv1.RoleBinding {
 
 // NewOperatorRole creates a Role object for kubevirt-operator.
 func NewOperatorRole(namespace string) *rbacv1.Role {
-	return &rbacv1.Role{
+	operatorRole := &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: VersionNamev1,
 			Kind:       "Role",
@@ -527,6 +544,8 @@ func NewOperatorRole(namespace string) *rbacv1.Role {
 			},
 		},
 	}
+	operatorRole.Rules = append(operatorRole.Rules, getKubeVirtComponentsRules()...)
+	return operatorRole
 }
 
 func GetKubevirtComponentsServiceAccounts(namespace string) map[string]bool {


### PR DESCRIPTION
### What this PR does
Before this PR:
virt-operator collects rules from virt-* Roles and ClusterRoles under its ClusterRole

After this PR:
virt-operator collects rules from virt-* Roles under its Role and ClusterRoles under its ClusterRole

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Less privileged virt-operator ClusterRole
```

