### PR TITLE
virt-config: Extract pod network attachment logic

### DIFF
--- a/pkg/libvmi/network.go
+++ b/pkg/libvmi/network.go
@@ -132,3 +132,10 @@ func WithSubdomain(subdomain string) Option {
 		vmi.Spec.Subdomain = subdomain
 	}
 }
+
+// WithAutoAttachPodInterface sets the autoattachPodInterface parameter.
+func WithAutoAttachPodInterface(enabled bool) Option {
+	return func(vmi *kvirtv1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.AutoattachPodInterface = &enabled
+	}
+}

--- a/pkg/network/vmispec/BUILD.bazel
+++ b/pkg/network/vmispec/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "defaults.go",
         "hotplug.go",
         "infosource.go",
         "interface.go",
@@ -16,6 +17,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "defaults_test.go",
         "hotplug_test.go",
         "infosource_test.go",
         "interface_test.go",

--- a/pkg/network/vmispec/defaults.go
+++ b/pkg/network/vmispec/defaults.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package vmispec
+
+import (
+	"fmt"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+type netClusterConfiger interface {
+	GetDefaultNetworkInterface() string
+	IsBridgeInterfaceOnPodNetworkEnabled() bool
+}
+
+func SetDefaultNetworkInterface(config netClusterConfiger, spec *v1.VirtualMachineInstanceSpec) error {
+	autoAttach := spec.Domain.Devices.AutoattachPodInterface
+	if autoAttach != nil && !*autoAttach {
+		return nil
+	}
+
+	// Override only when nothing is specified
+	if len(spec.Networks) == 0 && len(spec.Domain.Devices.Interfaces) == 0 {
+		iface := v1.NetworkInterfaceType(config.GetDefaultNetworkInterface())
+		switch iface {
+		case v1.BridgeInterface:
+			if !config.IsBridgeInterfaceOnPodNetworkEnabled() {
+				return fmt.Errorf("Bridge interface is not enabled in kubevirt-config")
+			}
+			spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		case v1.MasqueradeInterface:
+			spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+		case v1.DeprecatedSlirpInterface:
+			return fmt.Errorf("slirp interface is deprecated as of v1.3")
+		}
+
+		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+	}
+	return nil
+}

--- a/pkg/network/vmispec/defaults_test.go
+++ b/pkg/network/vmispec/defaults_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Default pod network", func() {
 				defaultNetworkInterface:              string(v1.BridgeInterface),
 				isBridgeInterfaceEnabledOnPodNetwork: false,
 			},
-			"Bridge interface is not enabled in kubevirt-config",
+			"bridge interface is not enabled in kubevirt-config",
 		),
 		Entry("when the deprecated slirp binding is the cluster-wide default",
 			stubClusterConfig{defaultNetworkInterface: string(v1.DeprecatedSlirpInterface)},

--- a/pkg/network/vmispec/defaults_test.go
+++ b/pkg/network/vmispec/defaults_test.go
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package vmispec_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+)
+
+var _ = Describe("Default pod network", func() {
+	DescribeTable("It should not automatically add the pod network to the VMI", func(vmi *v1.VirtualMachineInstance) {
+		origSpec := vmi.Spec.DeepCopy()
+
+		Expect(vmispec.SetDefaultNetworkInterface(stubClusterConfig{}, &vmi.Spec)).To(Succeed())
+
+		Expect(vmi.Spec).To(Equal(*origSpec))
+	},
+		Entry("when AutoattachPodInterface is false", libvmi.New(libvmi.WithAutoAttachPodInterface(false))),
+		Entry("when at least one network and one interface are specified",
+			libvmi.New(
+				libvmi.WithInterface(v1.Interface{Name: "mynet"}),
+				libvmi.WithNetwork(&v1.Network{Name: "mynet"}),
+			),
+		),
+	)
+
+	DescribeTable("It should add the pod network using bridge binding", func(vmi *v1.VirtualMachineInstance) {
+		config := stubClusterConfig{
+			defaultNetworkInterface:              string(v1.BridgeInterface),
+			isBridgeInterfaceEnabledOnPodNetwork: true,
+		}
+
+		Expect(vmispec.SetDefaultNetworkInterface(config, &vmi.Spec)).To(Succeed())
+
+		Expect(vmi.Spec.Domain.Devices.Interfaces).To(Equal([]v1.Interface{*v1.DefaultBridgeNetworkInterface()}))
+		Expect(vmi.Spec.Networks).To(Equal([]v1.Network{*v1.DefaultPodNetwork()}))
+	},
+		Entry("when AutoattachPodInterface is undefined", libvmi.New()),
+		Entry("when AutoattachPodInterface is true", libvmi.New(libvmi.WithAutoAttachPodInterface(true))),
+	)
+
+	DescribeTable("It should add the pod network using masquerade binding", func(vmi *v1.VirtualMachineInstance) {
+		config := stubClusterConfig{defaultNetworkInterface: string(v1.MasqueradeInterface)}
+
+		Expect(vmispec.SetDefaultNetworkInterface(config, &vmi.Spec)).To(Succeed())
+
+		Expect(vmi.Spec.Domain.Devices.Interfaces).To(Equal([]v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}))
+		Expect(vmi.Spec.Networks).To(Equal([]v1.Network{*v1.DefaultPodNetwork()}))
+	},
+		Entry("when AutoattachPodInterface is undefined", libvmi.New()),
+		Entry("when AutoattachPodInterface is true", libvmi.New(libvmi.WithAutoAttachPodInterface(true))),
+	)
+
+	DescribeTable("It should return an error", func(config stubClusterConfig, expectedErrMsg string) {
+		Expect(vmispec.SetDefaultNetworkInterface(config, &v1.VirtualMachineInstanceSpec{})).To(MatchError(expectedErrMsg))
+	},
+		Entry("when bridge binding is the cluster-wide default, but it is disabled on pod network",
+			stubClusterConfig{
+				defaultNetworkInterface:              string(v1.BridgeInterface),
+				isBridgeInterfaceEnabledOnPodNetwork: false,
+			},
+			"Bridge interface is not enabled in kubevirt-config",
+		),
+		Entry("when the deprecated slirp binding is the cluster-wide default",
+			stubClusterConfig{defaultNetworkInterface: string(v1.DeprecatedSlirpInterface)},
+			"slirp interface is deprecated as of v1.3",
+		),
+	)
+})
+
+type stubClusterConfig struct {
+	defaultNetworkInterface              string
+	isBridgeInterfaceEnabledOnPodNetwork bool
+}
+
+func (scc stubClusterConfig) GetDefaultNetworkInterface() string {
+	return scc.defaultNetworkInterface
+}
+
+func (scc stubClusterConfig) IsBridgeInterfaceOnPodNetworkEnabled() bool {
+	return scc.isBridgeInterfaceEnabledOnPodNetwork
+}

--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/liveupdate/memory:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-api/webhooks/defaults.go
+++ b/pkg/virt-api/webhooks/defaults.go
@@ -29,6 +29,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
@@ -162,7 +163,7 @@ func setDefaultVirtualMachineInstanceSpec(clusterConfig *virtconfig.ClusterConfi
 	SetDefaultGuestCPUTopology(clusterConfig, spec)
 	setDefaultPullPoliciesOnContainerDisks(spec)
 	setDefaultEvictionStrategy(clusterConfig, spec)
-	if err := clusterConfig.SetVMISpecDefaultNetworkInterface(spec); err != nil {
+	if err := vmispec.SetDefaultNetworkInterface(clusterConfig, spec); err != nil {
 		return err
 	}
 	util.SetDefaultVolumeDisk(spec)

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -24,7 +24,6 @@ package virtconfig
 */
 
 import (
-	"fmt"
 	"strings"
 
 	"kubevirt.io/client-go/log"
@@ -199,32 +198,6 @@ func (c *ClusterConfig) GetDefaultNetworkInterface() string {
 
 func (c *ClusterConfig) GetDefaultArchitecture() string {
 	return c.GetConfig().ArchitectureConfiguration.DefaultArchitecture
-}
-
-func (c *ClusterConfig) SetVMISpecDefaultNetworkInterface(spec *v1.VirtualMachineInstanceSpec) error {
-	autoAttach := spec.Domain.Devices.AutoattachPodInterface
-	if autoAttach != nil && !*autoAttach {
-		return nil
-	}
-
-	// Override only when nothing is specified
-	if len(spec.Networks) == 0 && len(spec.Domain.Devices.Interfaces) == 0 {
-		iface := v1.NetworkInterfaceType(c.GetDefaultNetworkInterface())
-		switch iface {
-		case v1.BridgeInterface:
-			if !c.IsBridgeInterfaceOnPodNetworkEnabled() {
-				return fmt.Errorf("Bridge interface is not enabled in kubevirt-config")
-			}
-			spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-		case v1.MasqueradeInterface:
-			spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
-		case v1.DeprecatedSlirpInterface:
-			return fmt.Errorf("slirp interface is deprecated as of v1.3")
-		}
-
-		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-	}
-	return nil
 }
 
 func (c *ClusterConfig) IsSlirpInterfaceEnabled() bool {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1307,7 +1307,7 @@ func (c *VMController) startVMI(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachi
 
 	autoAttachInputDevice(vmi)
 
-	err = c.clusterConfig.SetVMISpecDefaultNetworkInterface(&vmi.Spec)
+	err = vmispec.SetDefaultNetworkInterface(c.clusterConfig, &vmi.Spec)
 	if err != nil {
 		return vm, err
 	}

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -1064,7 +1064,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			vmi := libvmifact.NewCirros()
 
 			_, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err.Error()).To(ContainSubstring("Bridge interface is not enabled in kubevirt-config"))
+			Expect(err.Error()).To(ContainSubstring("bridge interface is not enabled in kubevirt-config"))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Currently, the logic that decides whether to automatically attach the pod network to a VMI - is a method of `virtconfig.ClusterConfig`.

After this PR:
This logic was moved under sig-network's ownership.
Unit tests were added.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

