### PR TITLE
Fix missing performance metrics for VMI resources

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
         "//pkg/monitoring/domainstats/downwardmetrics:go_default_library",
+        "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-handler:go_default_library",
         "//pkg/monitoring/metrics/virt-handler/handler:go_default_library",
         "//pkg/monitoring/profiler:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -70,6 +70,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/controller"
+	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler"
 	metricshandler "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/handler"
 	"kubevirt.io/kubevirt/pkg/monitoring/profiler"
@@ -212,6 +213,7 @@ func (app *virtHandlerApp) Run() {
 	}
 
 	app.reloadableRateLimiter = ratelimiter.NewReloadableRateLimiter(flowcontrol.NewTokenBucketRateLimiter(virtconfig.DefaultVirtHandlerQPS, virtconfig.DefaultVirtHandlerBurst))
+	clientmetrics.RegisterRestConfigHooks()
 	clientConfig, err := kubecli.GetKubevirtClientConfig()
 	if err != nil {
 		panic(err)

--- a/pkg/monitoring/metrics/common/client/client_test.go
+++ b/pkg/monitoring/metrics/common/client/client_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 var _ = BeforeSuite(func() {
+	RegisterRestConfigHooks()
 	err := SetupMetrics()
 	Expect(err).ToNot(HaveOccurred())
 })

--- a/pkg/monitoring/metrics/common/client/metrics.go
+++ b/pkg/monitoring/metrics/common/client/metrics.go
@@ -31,10 +31,13 @@ import (
 
 var resourceParsingRegexs []*regexp.Regexp
 
-func SetupMetrics() error {
+// RegisterRestConfigHooks adds hooks to the KubeVirt client and should be executed before building its config
+func RegisterRestConfigHooks() {
 	setupResourcesToWatch()
 	kubecli.RegisterRestConfigHook(addHTTPRoundTripClientMonitoring)
+}
 
+func SetupMetrics() error {
 	metrics.Register(metrics.RegisterOpts{
 		RequestLatency:     &latencyAdapter{requestLatency},
 		RateLimiterLatency: &latencyAdapter{rateLimiterLatency},

--- a/pkg/virt-api/BUILD.bazel
+++ b/pkg/virt-api/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
+        "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-api:go_default_library",
         "//pkg/monitoring/profiler:go_default_library",
         "//pkg/rest:go_default_library",

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -60,6 +60,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/healthz"
+	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-api"
 	"kubevirt.io/kubevirt/pkg/monitoring/profiler"
 	mime "kubevirt.io/kubevirt/pkg/rest"
@@ -163,6 +164,7 @@ func (app *virtAPIApp) Execute() {
 	app.reloadableRateLimiter = ratelimiter.NewReloadableRateLimiter(flowcontrol.NewTokenBucketRateLimiter(virtconfig.DefaultVirtAPIQPS, virtconfig.DefaultVirtAPIBurst))
 	app.reloadableWebhookRateLimiter = ratelimiter.NewReloadableRateLimiter(flowcontrol.NewTokenBucketRateLimiter(virtconfig.DefaultVirtWebhookClientQPS, virtconfig.DefaultVirtWebhookClientBurst))
 
+	clientmetrics.RegisterRestConfigHooks()
 	clientConfig, err := kubecli.GetKubevirtClientConfig()
 	if err != nil {
 		panic(err)

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/hooks:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/liveupdate/memory:go_default_library",
+        "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",
         "//pkg/monitoring/profiler:go_default_library",
         "//pkg/network/admitter:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -74,6 +74,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
 
+	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/storage/export/export"
@@ -279,6 +280,7 @@ func Execute() {
 	log.InitializeLogging("virt-controller")
 
 	app.reloadableRateLimiter = ratelimiter.NewReloadableRateLimiter(flowcontrol.NewTokenBucketRateLimiter(virtconfig.DefaultVirtControllerQPS, virtconfig.DefaultVirtControllerBurst))
+	clientmetrics.RegisterRestConfigHooks()
 	clientConfig, err := kubecli.GetKubevirtClientConfig()
 	if err != nil {
 		panic(err)

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-operator:go_default_library",
         "//pkg/monitoring/profiler:go_default_library",
         "//pkg/service:go_default_library",

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -55,6 +55,7 @@ import (
 	clientutil "kubevirt.io/client-go/util"
 
 	"kubevirt.io/kubevirt/pkg/controller"
+	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-operator"
 	"kubevirt.io/kubevirt/pkg/monitoring/profiler"
 	"kubevirt.io/kubevirt/pkg/service"
@@ -139,6 +140,7 @@ func Execute() {
 		os.Setenv(k, v)
 	}
 
+	clientmetrics.RegisterRestConfigHooks()
 	config, err := kubecli.GetKubevirtClientConfig()
 	if err != nil {
 		panic(err)

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -111,6 +111,16 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 				Expect(metrics.Data.Result).To(ContainElement(gomegaContainsMetricMatcher(metric, labels)))
 			}
 		})
+
+		It("should have kubevirt_rest_client_requests_total for the 'virtualmachineinstances' resource", func() {
+			metric := operatormetrics.NewCounter(
+				operatormetrics.MetricOpts{Name: "kubevirt_rest_client_requests_total"},
+			)
+
+			labels := map[string]string{"resource": "virtualmachineinstances"}
+
+			Expect(metrics.Data.Result).To(ContainElement(gomegaContainsMetricMatcher(metric, labels)))
+		})
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

`kubevirt_rest_client_requests_total` was missing datapoints for some resources such as VMIs

After this PR:

`kubevirt_rest_client_requests_total` has data for all tracked resources

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix missing performance metrics for VMI resources
```

