### PR TITLE
api: rename the io option for the driver

### DIFF
--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1794,7 +1794,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 					{
 						Cache:             v1.CacheWriteBack,
-						IO:                v1.IONative,
+						IO:                v1.DriverIONative,
 						DedicatedIOThread: ptr.To(false),
 						BlockSize:         userDefinedBlockSize,
 						DiskDevice: v1.DiskDevice{
@@ -1870,7 +1870,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 							},
 						},
 						PreferredDiskCache:           v1.CacheWriteThrough,
-						PreferredDiskIO:              v1.IONative,
+						PreferredDiskIO:              v1.DriverIONative,
 						PreferredDiskBus:             v1.DiskBusVirtio,
 						PreferredCdromBus:            v1.DiskBusSCSI,
 						PreferredLunBus:              v1.DiskBusSATA,
@@ -1920,7 +1920,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(*vmi.Spec.Domain.Devices.AutoattachMemBalloon).To(BeFalse())
 				Expect(*vmi.Spec.Domain.Devices.AutoattachInputDevice).To(BeTrue())
 				Expect(vmi.Spec.Domain.Devices.Disks[0].Cache).To(Equal(v1.CacheWriteBack))
-				Expect(vmi.Spec.Domain.Devices.Disks[0].IO).To(Equal(v1.IONative))
+				Expect(vmi.Spec.Domain.Devices.Disks[0].IO).To(Equal(v1.DriverIONative))
 				Expect(*vmi.Spec.Domain.Devices.Disks[0].DedicatedIOThread).To(BeFalse())
 				Expect(*vmi.Spec.Domain.Devices.Disks[0].BlockSize).To(Equal(*userDefinedBlockSize))
 				Expect(vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus).To(Equal(v1.DiskBusSCSI))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -2037,7 +2037,7 @@ func validateCacheMode(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.Sta
 
 func validateIOMode(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
 	var causes []metav1.StatusCause
-	if disk.IO != "" && disk.IO != v1.IONative && disk.IO != v1.IOThreads {
+	if disk.IO != "" && disk.IO != v1.DriverIONative && disk.IO != v1.DriverIOThreads {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueNotSupported,
 			Message: fmt.Sprintf("Disk IO mode for %s is not supported. Supported modes are: native, threads.", field),

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -501,7 +501,7 @@ func SetOptimalIOMode(disk *api.Disk) error {
 	if v1.DriverCache(disk.Driver.Cache) == v1.CacheNone {
 		// set native for block device or pre-allocateed image file
 		if (disk.Source.Dev != "") || IsPreAllocated(disk.Source.File) {
-			disk.Driver.IO = v1.IONative
+			disk.Driver.IO = v1.DriverIONative
 		}
 	}
 	// For now we don't explicitly set io=threads even for sparse files as it's
@@ -1642,7 +1642,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 
 			// We can find a workaround by adding IOThreads to the SCSI controller
 			case v1.DiskBusSCSI:
-				newDisk.Driver.IO = v1.IOThreads
+				newDisk.Driver.IO = v1.DriverIOThreads
 
 			default:
 				// TODO: if possible, find a workaround for SATA and USB buses.

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -3030,7 +3030,7 @@ func addCloudInitDisk(vmi *v1.VirtualMachineInstance, userData string, networkDa
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name:  "cloudinit",
 		Cache: v1.CacheWriteThrough,
-		IO:    v1.IONative,
+		IO:    v1.DriverIONative,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
 				Bus: v1.DiskBusVirtio,

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1758,12 +1758,12 @@ const (
 	// CacheWriteBack - I/O from the guest is cached on the host.
 	CacheWriteBack DriverCache = "writeback"
 
-	// IOThreads - User mode based threads with a shared lock that perform I/O tasks. Can impact performance but offers
+	// DriveIOThreads - User mode based threads with a shared lock that perform I/O tasks. Can impact performance but offers
 	// more predictable behaviour. This method is also takes fewer CPU cycles to submit I/O requests.
-	IOThreads DriverIO = "threads"
-	// IONative - Kernel native I/O tasks (AIO) offer a better performance but can block the VM if the file is not fully
+	DriverIOThreads DriverIO = "threads"
+	// DriveIONative - Kernel native I/O tasks (AIO) offer a better performance but can block the VM if the file is not fully
 	// allocated so this method recommended only when the backing file/disk/etc is fully preallocated.
-	IONative DriverIO = "native"
+	DriverIONative DriverIO = "native"
 )
 
 // Handler defines a specific action that should be taken

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2219,7 +2219,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			// disk[0]cache=none
 			vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
 			vmi.Spec.Domain.Devices.Disks[3].Cache = v1.CacheNone
-			vmi.Spec.Domain.Devices.Disks[3].IO = v1.IOThreads
+			vmi.Spec.Domain.Devices.Disks[3].IO = v1.DriverIOThreads
 
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
@@ -2229,8 +2229,8 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			By("checking if number of attached disks is equal to real disks number")
 			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
 
-			ioNative := v1.IONative
-			ioThreads := v1.IOThreads
+			ioNative := v1.DriverIONative
+			ioThreads := v1.DriverIOThreads
 			ioNone := ""
 
 			By("checking if default io has not been set for sparsed file")


### PR DESCRIPTION
Rename IONative and IOThreads with the prefix Driver. Letting the variable IOThreads create confusion with the option for the iothreads.

Please, note that this doesn't change anything on the API.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

