### PR TITLE
virt-api: fix panic in setupMemoryHotplug()

### DIFF
--- a/pkg/virt-api/webhooks/defaults.go
+++ b/pkg/virt-api/webhooks/defaults.go
@@ -76,7 +76,7 @@ func setupCPUHotplug(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMac
 }
 
 func setupMemoryHotplug(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance) {
-	if vmi.Spec.Domain.Memory == nil {
+	if vmi.Spec.Domain.Memory == nil || vmi.Spec.Domain.Memory.Guest == nil {
 		return
 	}
 	if vmi.Spec.Domain.Memory.MaxGuest == nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -254,6 +254,32 @@ var _ = Describe("Validating VM Admitter", func() {
 		Expect(resp.Allowed).To(BeTrue())
 	})
 
+	It("should accept VM requesting hugepages but missing spec.template.spec.domain.memory.guest", func() {
+		vmi := api.NewMinimalVMI("testvmi")
+		vmi.Spec.Domain.Memory = &v1.Memory{
+			Hugepages: &v1.Hugepages{
+				PageSize: "2Mi",
+			},
+		}
+		vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+			Requests: k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+
+		vm := &v1.VirtualMachine{
+			Spec: v1.VirtualMachineSpec{
+				Running: &notRunning,
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: vmi.Spec,
+				},
+			},
+		}
+
+		resp := admitVm(vmsAdmitter, vm)
+		Expect(resp.Allowed).To(BeTrue())
+	})
+
 	DescribeTable("should reject VolumeRequests on a migrating vm", func(requests []v1.VirtualMachineVolumeRequest) {
 		now := metav1.Now()
 		vmi := api.NewMinimalVMI("testvmi")

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3280,15 +3280,16 @@ func (c *VMController) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi
 		return err
 	}
 
-	if vmCopyWithInstancetype.Spec.Template.Spec.Domain.Memory == nil || vmi.Spec.Domain.Memory == nil {
+	if vmCopyWithInstancetype.Spec.Template.Spec.Domain.Memory == nil ||
+		vmCopyWithInstancetype.Spec.Template.Spec.Domain.Memory.Guest == nil ||
+		vmi.Spec.Domain.Memory == nil ||
+		vmi.Spec.Domain.Memory.Guest == nil ||
+		vmi.Status.Memory == nil ||
+		vmi.Status.Memory.GuestCurrent == nil {
 		return nil
 	}
 
-	guestMemory := vmi.Spec.Domain.Memory.Guest
-
-	if vmi.Status.Memory == nil ||
-		vmi.Status.Memory.GuestCurrent == nil ||
-		vmCopyWithInstancetype.Spec.Template.Spec.Domain.Memory.Guest.Equal(*guestMemory) {
+	if vmCopyWithInstancetype.Spec.Template.Spec.Domain.Memory.Guest.Equal(*vmi.Spec.Domain.Memory.Guest) {
 		return nil
 	}
 


### PR DESCRIPTION
Check that guest memory is set before accessing it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Creating a VM with hugepages set with no `domain.guest.memory` (so memory is set using requests) will crash virt-api. 

After this PR:

Creating a VM with hugepages set with no `domain.guest.memory` (so memory is set using requests) does not crash virt-api. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Captured panic using KubeVirt v1.2, here virt-controller crashes because the code has been moved from there

```
{"component":"virt-controller","kind":"DataVolume","level":"error","msg":"Cant find the matching VM for DataVolume: dv1-rhel-ocs","name":"dv1-rhel-ocs","namespace":"default","pos":"vm.go:2141","timestamp":"2024-06-12T14:06:56.369402Z","uid":"b56e99bf-12e8-4730-84a9-8e0ea026a823"}
{"component":"virt-controller","kind":"VirtualMachine","level":"info","msg":"Starting VM due to runStrategy: Always","name":"vm1-rhel-ocs","namespace":"default","pos":"vm.go:967","timestamp":"2024-06-12T14:06:56.466117Z","uid":"df589043-5345-483b-ad34-e3303f36652d"}
E0612 14:06:56.466402       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 1104 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1cc35e0?, 0x32bcb90})
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x14?})
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x1cc35e0?, 0x32bcb90?})
	/usr/lib/golang/src/runtime/panic.go:914 +0x21f
k8s.io/apimachinery/pkg/api/resource.(*Quantity).ScaledValue(0xc000891560?, 0x1a47b96?)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go:758 +0xe
k8s.io/apimachinery/pkg/api/resource.(*Quantity).Value(...)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go:744
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).setupMemoryHotplug(0xc000891560?, 0xc00325e000, 0x4?)
	/remote-source/app/pkg/virt-controller/watch/vm.go:1902 +0xab
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).setupHotplug(0xc00071c2d0, 0xc00356e638?, 0x1fceac9?)
	/remote-source/app/pkg/virt-controller/watch/vm.go:3399 +0x87
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).setupVMIFromVM(0xc00071c2d0, 0xc002a2a200)
	/remote-source/app/pkg/virt-controller/watch/vm.go:1791 +0x628
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).startVMI(0xc00071c2d0, 0xc003696d20?)
	/remote-source/app/pkg/virt-controller/watch/vm.go:1183 +0x59f
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).syncRunStrategy(0xc00071c2d0, 0xc002a2a200, 0x0, {0x1fc776c, 0x6})
	/remote-source/app/pkg/virt-controller/watch/vm.go:968 +0x151b
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).sync(0xc00071c2d0, 0xc002a2a200, 0x0, {0xc005090090, 0x14}, {0xc00316e040, 0x1, 0x1})
	/remote-source/app/pkg/virt-controller/watch/vm.go:3111 +0xb9a
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).execute(0xc00071c2d0, {0xc005090090, 0x14})
	/remote-source/app/pkg/virt-controller/watch/vm.go:376 +0x94e
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).Execute(0xc00071c2d0)
	/remote-source/app/pkg/virt-controller/watch/vm.go:281 +0x1fd
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).runWorker(...)
	/remote-source/app/pkg/virt-controller/watch/vm.go:261
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:157 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x32bcff0?, {0x22dc600, 0xc002f0da10}, 0x1, 0xc00364e0c0)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:158 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0040a9fb0?, 0x3b9aca00, 0x0, 0xd0?, 0x447a9c?)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:135 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(0x9a95c5?, 0x0?, 0x0?)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:92 +0x1e
created by kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).Run in goroutine 1053
	/remote-source/app/pkg/virt-controller/watch/vm.go:253 +0x3c6
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x974cae]

goroutine 1104 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x14?})
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xcd
panic({0x1cc35e0?, 0x32bcb90?})
	/usr/lib/golang/src/runtime/panic.go:914 +0x21f
k8s.io/apimachinery/pkg/api/resource.(*Quantity).ScaledValue(0xc000891560?, 0x1a47b96?)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go:758 +0xe
k8s.io/apimachinery/pkg/api/resource.(*Quantity).Value(...)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go:744
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).setupMemoryHotplug(0xc000891560?, 0xc00325e000, 0x4?)
	/remote-source/app/pkg/virt-controller/watch/vm.go:1902 +0xab
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).setupHotplug(0xc00071c2d0, 0xc00356e638?, 0x1fceac9?)
	/remote-source/app/pkg/virt-controller/watch/vm.go:3399 +0x87
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).setupVMIFromVM(0xc00071c2d0, 0xc002a2a200)
	/remote-source/app/pkg/virt-controller/watch/vm.go:1791 +0x628
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).startVMI(0xc00071c2d0, 0xc003696d20?)
	/remote-source/app/pkg/virt-controller/watch/vm.go:1183 +0x59f
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).syncRunStrategy(0xc00071c2d0, 0xc002a2a200, 0x0, {0x1fc776c, 0x6})
	/remote-source/app/pkg/virt-controller/watch/vm.go:968 +0x151b
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).sync(0xc00071c2d0, 0xc002a2a200, 0x0, {0xc005090090, 0x14}, {0xc00316e040, 0x1, 0x1})
	/remote-source/app/pkg/virt-controller/watch/vm.go:3111 +0xb9a
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).execute(0xc00071c2d0, {0xc005090090, 0x14})
	/remote-source/app/pkg/virt-controller/watch/vm.go:376 +0x94e
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).Execute(0xc00071c2d0)
	/remote-source/app/pkg/virt-controller/watch/vm.go:281 +0x1fd
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).runWorker(...)
	/remote-source/app/pkg/virt-controller/watch/vm.go:261
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:157 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x32bcff0?, {0x22dc600, 0xc002f0da10}, 0x1, 0xc00364e0c0)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:158 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0040a9fb0?, 0x3b9aca00, 0x0, 0xd0?, 0x447a9c?)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:135 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(0x9a95c5?, 0x0?, 0x0?)
	/remote-source/app/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:92 +0x1e
created by kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMController).Run in goroutine 1053
	/remote-source/app/pkg/virt-controller/watch/vm.go:253 +0x3c6
```

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

