### PR TITLE
acpiIndex support for hostDev interfaces

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17330,6 +17330,11 @@
       "type": "string",
       "default": ""
      },
+     "acpiIndex": {
+      "description": "If specified, the ACPI index is used to provide network interface device naming, that is stable across changes in PCI addresses assigned to the device. This value is required to be unique across all devices and be between 1 and (16*1024-1).",
+      "type": "integer",
+      "format": "int32"
+     },
      "name": {
       "type": "string",
       "default": ""

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -615,7 +615,12 @@ type HostDevice struct {
 	DeviceName string `json:"deviceName"`
 	// If specified, the virtual network interface address and its tag will be provided to the guest via config drive
 	// +optional
-	Tag string `json:"tag,omitempty"`
+	// If specified, the ACPI index is used to provide network interface device naming, that is stable across changes
+	// in PCI addresses assigned to the device.
+	// This value is required to be unique across all devices and be between 1 and (16*1024-1).
+	// +optional
+	ACPIIndex int    `json:"acpiIndex,omitempty"`
+	Tag       string `json:"tag,omitempty"`
 }
 
 type Disk struct {

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -335,6 +335,7 @@ func (VGPUDisplayOptions) SwaggerDoc() map[string]string {
 func (HostDevice) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"deviceName": "DeviceName is the resource name of the host device exposed by a device plugin",
+		"acpiIndex":  "If specified, the ACPI index is used to provide network interface device naming, that is stable across changes\nin PCI addresses assigned to the device.\nThis value is required to be unique across all devices and be between 1 and (16*1024-1).\n+optional",
 		"tag":        "If specified, the virtual network interface address and its tag will be provided to the guest via config drive\n+optional",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18285,6 +18285,13 @@ func schema_kubevirtio_api_core_v1_HostDevice(ref common.ReferenceCallback) comm
 							Format:      "",
 						},
 					},
+					"acpiIndex": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, the ACPI index is used to provide network interface device naming, that is stable across changes in PCI addresses assigned to the device. This value is required to be unique across all devices and be between 1 and (16*1024-1).",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"tag": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",


### PR DESCRIPTION
acpiIndex support for hostDev interfaces to pass XML with acpiIndex information to libvirt.
As of today, it is supported for v1.Interfaces only.

Signed-off-by: Nikhil Sharma <v-sharmanikh@microsoft.com>

**What type of PR is this?**

**What this PR does / why we need it**:

acpiIndex support for hostDev interfaces io pass XML with acpiIndex information to libvirt.
It has swagger and Schema changes to accommodate acpiIndex for hostDevices.

**swagger**:
     "acpiIndex": {
      "description": "If specified, the ACPI index is used to provide network interface device naming, that is stable across changes in PCI addresses assigned to the device. This value is required to be unique across all devices and be between 1 and (16*1024-1).",
      "type": "integer",
      "format": "int32"
     },

**schema**:
// If specified, the ACPI index is used to provide network interface device naming, that is stable across changes
	// in PCI addresses assigned to the device.
	// This value is required to be unique across all devices and be between 1 and (16*1024-1).
	// +optional
	ACPIIndex int `json:"acpiIndex,omitempty"`

Signed-off-by: Nikhil Sharma <v-sharmanikh@microsoft.com>

**Which issue(s) this PR fixes**:

As of today, acpiIndex is supported for v1.,Interfaces only. The effort is to have this optional selector work for hostDevoce interface. The domain configuration for interface and hostDevices are in sync with libvirt.

**Special notes for your reviewer**:
The domain configuration for interface and hostDevices are in sync with libvirt.

**Does this PR introduce a user-facing change**?

`NONE`

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc**.:

Changes for "acpiIndex support for hostDevice"
      - `DomainSpec`: The domain configuration spec structure, which is in sync
        with [libvirt domain configuration](https://libvirt.org/formatdomain.html).
        - `Devices`:
          - `Interface`: The network interface configuration spec.
          - `HostDevice`: The general host device configuration spec.
            The host-device is used to pass-through devices from the host to the domain.
            SR-IOV virtual functions are a classic example for networking.
    
    Signed-off-by: Nikhil Sharma <v-sharmanikh@microsoft.com>

