### PR TITLE
Support Memory Hotplug with Hugepages

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -551,15 +551,6 @@ func validateLiveUpdateMemory(field *k8sfield.Path, domain *v1.DomainSpec, archi
 		})
 	}
 
-	if domain.Memory != nil &&
-		domain.Memory.Hugepages != nil {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("Memory hotplug is not compatible with hugepages"),
-			Field:   field.Child("template", "spec", "domain", "memory", "hugepages").String(),
-		})
-	}
-
 	if domain.Memory == nil ||
 		domain.Memory.Guest == nil {
 		causes = append(causes, metav1.StatusCause{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -2028,15 +2028,6 @@ var _ = Describe("Validating VM Admitter", func() {
 				Expect(response.Allowed).To(BeFalse())
 				Expect(response.Result.Details.Causes).To(ContainElement(cause))
 			},
-				Entry("hugepages is configured", func(vm *v1.VirtualMachine) {
-					vm.Spec.Template.Spec.Domain.Memory.Hugepages = &v1.Hugepages{
-						PageSize: "2Mi",
-					}
-				}, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Field:   "spec.template.spec.domain.memory.hugepages",
-					Message: "Memory hotplug is not compatible with hugepages",
-				}),
 				Entry("realtime is configured", func(vm *v1.VirtualMachine) {
 					enableFeatureGate(virtconfig.VMLiveUpdateFeaturesGate, virtconfig.NUMAFeatureGate)
 					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -86,7 +86,10 @@ const (
 	// must be a power of 2 and at least equal
 	// to the size of a transparent hugepage (2MiB on x84_64).
 	// Recommended value by QEMU is 2MiB
-	MemoryHotplugBlockAlignmentBytes = 2097152
+	MemoryHotplugBlockAlignmentBytes = 0x200000
+
+	// 1GiB, the size of 1Gi HugePages
+	MemoryHotplug1GHugePagesBlockAlignmentBytes = 0x40000000
 )
 
 var (
@@ -1194,7 +1197,6 @@ func setupDomainMemory(vmi *v1.VirtualMachineInstance, domain *api.Domain) error
 	domain.Spec.MaxMemory = &api.MaxMemory{
 		Unit:  maxMemory.Unit,
 		Value: maxMemory.Value,
-		Slots: 1,
 	}
 
 	domain.Spec.Memory = maxMemory
@@ -1224,12 +1226,19 @@ func setupDomainMemory(vmi *v1.VirtualMachineInstance, domain *api.Domain) error
 		return err
 	}
 
+	blockAlignment := MemoryHotplugBlockAlignmentBytes
+	if vmi.Spec.Domain.Memory != nil &&
+		vmi.Spec.Domain.Memory.Hugepages != nil &&
+		vmi.Spec.Domain.Memory.Hugepages.PageSize == "1Gi" {
+		blockAlignment = MemoryHotplug1GHugePagesBlockAlignmentBytes
+	}
+
 	domain.Spec.Devices.Memory = &api.MemoryDevice{
 		Model: "virtio-mem",
 		Target: &api.MemoryTarget{
 			Size:  pluggableMemorySize,
 			Node:  "0",
-			Block: api.Memory{Unit: "b", Value: MemoryHotplugBlockAlignmentBytes},
+			Block: api.Memory{Unit: "b", Value: uint64(blockAlignment)},
 		},
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2764,6 +2764,28 @@ var _ = Describe("Converter", func() {
 				Expect(domain.Spec.Devices.Memory.Target.Block.Value).To(Equal(uint64(MemoryHotplugBlockAlignmentBytes)))
 				Expect(domain.Spec.Devices.Memory.Target.Block.Unit).To(Equal("b"))
 			})
+
+			DescribeTable("should correctly setup hotplug when hugepages are used", func(pageSize string) {
+				vmi.Spec.Domain.Memory.Hugepages = &v1.Hugepages{PageSize: pageSize}
+				err := setupDomainMemory(vmi, domain)
+				Expect(err).ToNot(HaveOccurred())
+
+				blockAlignment := MemoryHotplugBlockAlignmentBytes
+				if pageSize == "1Gi" {
+					blockAlignment = MemoryHotplug1GHugePagesBlockAlignmentBytes
+				}
+
+				Expect(domain.Spec.Devices.Memory).ToNot(BeNil())
+				Expect(domain.Spec.Devices.Memory.Model).To(Equal("virtio-mem"))
+				Expect(domain.Spec.Devices.Memory.Target).ToNot(BeNil())
+				Expect(domain.Spec.Devices.Memory.Target.Node).To(Equal("0"))
+				Expect(domain.Spec.Devices.Memory.Target.Size.Unit).To(Equal("b"))
+				Expect(domain.Spec.Devices.Memory.Target.Block.Value).To(Equal(uint64(blockAlignment)))
+				Expect(domain.Spec.Devices.Memory.Target.Block.Unit).To(Equal("b"))
+			},
+				Entry("with pages set to 2Mi", "2Mi"),
+				Entry("with pages set to 1Gi", "1Gi"),
+			)
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
A VM configured with memory hotplug and hugepages does not start

After this PR:
A VM configured with memory hotplug and hugepages starts correctly

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support Memory Hotplug with Hugepages
```

