### PR TITLE
Add memory/cpu utilization of components to kubevirt benchmarks

### DIFF
--- a/tools/perfscale-audit/api/api.go
+++ b/tools/perfscale-audit/api/api.go
@@ -105,6 +105,18 @@ const (
 	ResultTypeVMIDeletionToFailedP99    ResultType = "vmiDeletionToFailedSecondsP99"
 	ResultTypeVMIDeletionToFailedP95    ResultType = "vmiDeletionToFailedSecondsP95"
 	ResultTypeVMIDeletionToFailedP50    ResultType = "vmiDeletionToFailedSecondsP50"
+
+	// container_memory_rss
+	ResultTypeAvgVirtAPIMemoryUsageInMB        ResultType = "avgVirtAPIMemoryUsageInMB"
+	ResultTypeAvgVirtControllerMemoryUsageInMB ResultType = "avgVirtControllerMemoryUsageInMB"
+	ResultTypeMinVirtAPIMemoryUsageInMB        ResultType = "minVirtAPIMemoryUsageInMB"
+	ResultTypeMaxVirtAPIMemoryUsageInMB        ResultType = "maxVirtAPIMemoryUsageInMB"
+	ResultTypeMinVirtControllerMemoryUsageInMB ResultType = "minVirtControllerMemoryUsageInMB"
+	ResultTypeMaxVirtControllerMemoryUsageInMB ResultType = "maxVirtControllerMemoryUsageInMB"
+
+	// container_cpu_usage_seconds_total
+	ResultTypeAvgVirtAPICPUUsage        ResultType = "avgVirtAPICPUUsage"
+	ResultTypeAvgVirtControllerCPUUsage ResultType = "avgVirtControllerCPUUsage"
 )
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: There are no benchmarks for cpu/memory utilization

After this PR: Added cpu/memory utilisation of virt api and virt controller benchamarks

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add CPU/Memory utilization of components metrics to kubevirt benchmarks
```

