### PR TITLE
virt-api: fix panic

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -478,7 +478,9 @@ func validateLiveUpdateFeatures(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 		return causes
 	}
 
-	causes = append(causes, validateLiveUpdateCPU(field, &spec.Template.Spec.Domain)...)
+	if spec.Template.Spec.Domain.CPU != nil {
+		causes = append(causes, validateLiveUpdateCPU(field, &spec.Template.Spec.Domain)...)
+	}
 
 	if spec.Template.Spec.Domain.Memory != nil && spec.Template.Spec.Domain.Memory.MaxGuest != nil {
 		causes = append(causes, validateLiveUpdateMemory(field, &spec.Template.Spec.Domain, spec.Template.Spec.Architecture)...)


### PR DESCRIPTION
Fix panic when creating a VMPool with vmRolloutStrategy set to 'LiveUpdate'.

```
{"component":"virt-api","level":"info","msg":"http: panic serving 192.168.66.101:28276: runtime error: invalid memory address or nil pointer dereference\ngoroutine 654 [running]:\nnet/http.(*conn).serve.func1()\n\tGOROOT/src/net/http/server.go:1898 +0xbe\npanic({0x21d51e0?, 0x3e47530?})\n\tGOROOT/src/ru
ntime/panic.go:770 +0x132\nkubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters.validateLiveUpdateCPU(0xc000cac120?, 0x0?)\n\tpkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go:509 +0x1e\nkubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters.validateL
iveUpdateFeatures(0xc003604120, 0xc00044aae8, 0xc000cac120)\n\tpkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go:478 +0x6a\nkubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters.ValidateVirtualMachineSpec(0xc003604120, 0xc00044aae8, 0xc000cac120, {0xc004fd2170, 0x10})\
n\tpkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go:396 +0x713\nkubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters.ValidateVMPoolSpec(0xc006e48b40, 0xc003604090, 0xc000b8c420, 0xc000cac120)\n\tpkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go:11
6 +0x365\nkubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters.(*VMPoolAdmitter).Admit(0xc00007a110, 0xc006e48b40)\n\tpkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go:80 +0x2f2\nkubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks.Serve({0x2a9bca0, 0xc0055dc
0e0}, 0x0?, {0x2a870c0, 0xc00007a110})\n\tpkg/util/webhooks/validating-webhooks/validating-webhook.go:73 +0xb4\nkubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook.ServeVMPool(...)\n\tpkg/virt-api/webhooks/validating-webhook/validating-webhook.go:51\nkubevirt.io/kubevirt/pkg/virt-api.(*virtAPI
App).registerValidatingWebhooks.func5({0x2a9bca0, 0xc0055dc0e0}, 0xc003722360)\n\tpkg/virt-api/api.go:882 +0x74\nnet/http.HandlerFunc.ServeHTTP(0x3fa36c0?, {0x2a9bca0?, 0xc0055dc0e0?}, 0x10?)\n\tGOROOT/src/net/http/server.go:2166 +0x29\nnet/http.(*ServeMux).ServeHTTP(0x413845?, {0x2a9bca0, 0xc0055dc0e0}
, 0xc003722360)\n\tGOROOT/src/net/http/server.go:2683 +0x1ad\nnet/http.serverHandler.ServeHTTP({0x2a8fca8?}, {0x2a9bca0?, 0xc0055dc0e0?}, 0x6?)\n\tGOROOT/src/net/http/server.go:3137 +0x8e\nnet/http.(*conn).serve(0xc006fb8090, {0x2aaaf38, 0xc0054e38f0})\n\tGOROOT/src/net/http/server.go:2039 +0x5e8\ncreat
ed by net/http.(*Server).Serve in goroutine 202\n\tGOROOT/src/net/http/server.go:3285 +0x4b4\n","pos":"server.go:3413","timestamp":"2024-06-13T21:09:29.297366Z"}
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Creating a VMPool when `vmRolloutStrategy` set to `LiveUpdate` crashes virt-api.

After this PR:
Creating a VMPool when `vmRolloutStrategy` set to `LiveUpdate` successfully creates a VMPool.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix VMPools when `LiveUpdate` as `vmRolloutStrategy` is used.
```

