### PR TITLE
virt-exportproxy: use stores instead of informers

### DIFF
--- a/pkg/storage/backend-storage/backend-storage_test.go
+++ b/pkg/storage/backend-storage/backend-storage_test.go
@@ -41,7 +41,7 @@ import (
 var _ = Describe("Backend Storage", func() {
 	var backendStorage *BackendStorage
 	var config *virtconfig.ClusterConfig
-	var kvInformer cache.SharedIndexInformer
+	var kvStore cache.Store
 	var storageClassInformer cache.SharedIndexInformer
 	var storageProfileInformer cache.SharedIndexInformer
 
@@ -49,7 +49,7 @@ var _ = Describe("Backend Storage", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient := kubecli.NewMockKubevirtClient(ctrl)
 		kubevirtFakeConfig := &virtv1.KubeVirtConfiguration{}
-		config, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
+		config, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		storageClassInformer, _ = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		storageProfileInformer, _ = testutils.NewFakeInformerFor(&v1beta1.StorageProfile{})
 		pvcInformer, _ := testutils.NewFakeInformerFor(&v1.PersistentVolumeClaim{})
@@ -60,9 +60,9 @@ var _ = Describe("Backend Storage", func() {
 	Context("Storage class", func() {
 		It("Should return VMStateStorageClass and RWX when set", func() {
 			By("Setting a VM state storage class in the CR")
-			kvCR := testutils.GetFakeKubeVirtClusterConfig(kvInformer)
+			kvCR := testutils.GetFakeKubeVirtClusterConfig(kvStore)
 			kvCR.Spec.Configuration.VMStateStorageClass = "myfave"
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvCR)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvCR)
 
 			By("Expecting getStorageClass() to return that one")
 			sc, err := backendStorage.getStorageClass()

--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -20,11 +20,11 @@ const (
 	kvObjectName      = "kubevirt"
 )
 
-func NewFakeClusterConfigUsingKV(kv *KVv1.KubeVirt) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.SharedIndexInformer) {
+func NewFakeClusterConfigUsingKV(kv *KVv1.KubeVirt) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.Store) {
 	return NewFakeClusterConfigUsingKVWithCPUArch(kv, runtime.GOARCH)
 }
 
-func NewFakeClusterConfigUsingKVWithCPUArch(kv *KVv1.KubeVirt, CPUArch string) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.SharedIndexInformer) {
+func NewFakeClusterConfigUsingKVWithCPUArch(kv *KVv1.KubeVirt, CPUArch string) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.Store) {
 	kv.ResourceVersion = rand.String(10)
 	kv.Status.Phase = "Deployed"
 	crdInformer, _ := NewFakeInformerFor(&extv1.CustomResourceDefinition{})
@@ -34,10 +34,10 @@ func NewFakeClusterConfigUsingKVWithCPUArch(kv *KVv1.KubeVirt, CPUArch string) (
 
 	AddDataVolumeAPI(crdInformer)
 	cfg, _ := virtconfig.NewClusterConfigWithCPUArch(crdInformer, kubeVirtInformer, kvObjectNamespace, CPUArch)
-	return cfg, crdInformer, kubeVirtInformer
+	return cfg, crdInformer, kubeVirtInformer.GetStore()
 }
 
-func NewFakeClusterConfigUsingKVConfig(config *KVv1.KubeVirtConfiguration) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.SharedIndexInformer) {
+func NewFakeClusterConfigUsingKVConfig(config *KVv1.KubeVirtConfiguration) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.Store) {
 	kv := &KVv1.KubeVirt{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kvObjectName,
@@ -95,8 +95,8 @@ func AddDataVolumeAPI(crdInformer cache.SharedIndexInformer) {
 	})
 }
 
-func GetFakeKubeVirtClusterConfig(kubeVirtInformer cache.SharedIndexInformer) *KVv1.KubeVirt {
-	obj, _, _ := kubeVirtInformer.GetStore().GetByKey(kvObjectNamespace + "/" + kvObjectName)
+func GetFakeKubeVirtClusterConfig(kubeVirtStore cache.Store) *KVv1.KubeVirt {
+	obj, _, _ := kubeVirtStore.GetByKey(kvObjectNamespace + "/" + kvObjectName)
 	return obj.(*KVv1.KubeVirt)
 
 }

--- a/pkg/util/tls/tls.go
+++ b/pkg/util/tls/tls.go
@@ -58,7 +58,7 @@ func SetupPromTLS(certManager certificate.Manager, clusterConfig *virtconfig.Clu
 	return tlsConfig
 }
 
-func SetupExportProxyTLS(certManager certificate.Manager, kubeVirtInformer cache.SharedIndexInformer) *tls.Config {
+func SetupExportProxyTLS(certManager certificate.Manager, kubeVirtStore cache.Store) *tls.Config {
 	tlsConfig := &tls.Config{
 		GetCertificate: func(info *tls.ClientHelloInfo) (certificate *tls.Certificate, err error) {
 			cert := certManager.Current()
@@ -74,7 +74,7 @@ func SetupExportProxyTLS(certManager certificate.Manager, kubeVirtInformer cache
 				return nil, fmt.Errorf(noSrvCertMessage)
 			}
 
-			kv := getKubevirt(kubeVirtInformer)
+			kv := getKubevirt(kubeVirtStore)
 			tlsConfig := getTLSConfiguration(kv)
 			ciphers := CipherSuiteIds(tlsConfig.Ciphers)
 			minTLSVersion := TLSVersion(tlsConfig.MinTLSVersion)
@@ -328,8 +328,8 @@ func createIntermediatePool(externallyManaged bool, rawIntermediates [][]byte) *
 	return intermediatePool
 }
 
-func getKubevirt(kubeVirtInformer cache.SharedIndexInformer) *v1.KubeVirt {
-	objects := kubeVirtInformer.GetStore().List()
+func getKubevirt(kubeVirtStore cache.Store) *v1.KubeVirt {
+	objects := kubeVirtStore.List()
 	for _, obj := range objects {
 		if kv, ok := obj.(*v1.KubeVirt); ok && kv.DeletionTimestamp == nil {
 			if kv.Status.Phase != "" {

--- a/pkg/util/tls/tls_test.go
+++ b/pkg/util/tls/tls_test.go
@@ -108,9 +108,7 @@ var _ = Describe("TLS", func() {
 				},
 			},
 		}
-		config, _, kubeVirtInformer := testutils.NewFakeClusterConfigUsingKV(kv)
-		clusterConfig = config
-		kubeVirtStore = kubeVirtInformer.GetStore()
+		clusterConfig, _, kubeVirtStore = testutils.NewFakeClusterConfigUsingKV(kv)
 	})
 
 	DescribeTable("on virt-handler with self-signed CA should", func(serverSecret, clientSecret string, errStr string) {

--- a/pkg/util/tls/tls_test.go
+++ b/pkg/util/tls/tls_test.go
@@ -71,7 +71,7 @@ var _ = Describe("TLS", func() {
 	var caManager kvtls.ClientCAManager
 	var certmanagers map[string]certificate.Manager
 	var clusterConfig *virtconfig.ClusterConfig
-	var kubeVirtInformer cache.SharedIndexInformer
+	var kubeVirtStore cache.Store
 
 	BeforeEach(func() {
 		// Bootstrap TLS for kubevirt
@@ -108,7 +108,9 @@ var _ = Describe("TLS", func() {
 				},
 			},
 		}
-		clusterConfig, _, kubeVirtInformer = testutils.NewFakeClusterConfigUsingKV(kv)
+		config, _, kubeVirtInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+		clusterConfig = config
+		kubeVirtStore = kubeVirtInformer.GetStore()
 	})
 
 	DescribeTable("on virt-handler with self-signed CA should", func(serverSecret, clientSecret string, errStr string) {
@@ -216,7 +218,7 @@ var _ = Describe("TLS", func() {
 			return kvtls.SetupPromTLS(certmanagers[components.VirtHandlerServerCertSecretName], clusterConfig)
 		}),
 		Entry("to exportproxy endpoints", func() *tls.Config {
-			return kvtls.SetupExportProxyTLS(certmanagers[components.VirtHandlerServerCertSecretName], kubeVirtInformer)
+			return kvtls.SetupExportProxyTLS(certmanagers[components.VirtHandlerServerCertSecretName], kubeVirtStore)
 		}),
 	)
 
@@ -331,7 +333,7 @@ var _ = Describe("TLS", func() {
 		kvConfig.Spec.Configuration.TLSConfiguration = &v12.TLSConfiguration{
 			MinTLSVersion: "VersionTLS13",
 		}
-		testutils.UpdateFakeKubeVirtClusterConfig(kubeVirtInformer.GetStore(), kvConfig)
+		testutils.UpdateFakeKubeVirtClusterConfig(kubeVirtStore, kvConfig)
 		client = &http.Client{Transport: &http.Transport{TLSClientConfig: clientTLSConfig}}
 		resp, err = client.Get(srv.URL)
 		Expect(err).To(HaveOccurred())
@@ -356,7 +358,7 @@ var _ = Describe("TLS", func() {
 		),
 		Entry("on exportproxy endpoint",
 			func() *tls.Config {
-				return kvtls.SetupExportProxyTLS(certmanagers[components.VirtHandlerServerCertSecretName], kubeVirtInformer)
+				return kvtls.SetupExportProxyTLS(certmanagers[components.VirtHandlerServerCertSecretName], kubeVirtStore)
 			},
 			func() *tls.Config {
 				return &tls.Config{InsecureSkipVerify: true}

--- a/pkg/virt-api/rest/profiler_test.go
+++ b/pkg/virt-api/rest/profiler_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Cluster Profiler Subresources", func() {
 		},
 	}
 
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 
 	app := SubresourceAPIApp{}
 	BeforeEach(func() {
@@ -102,10 +102,10 @@ var _ = Describe("Cluster Profiler Subresources", func() {
 	enableFeatureGate := func(featureGate string) {
 		kvConfig := kv.DeepCopy()
 		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 
 	expectPodList := func() {

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -116,7 +116,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 		},
 	}
 
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 
 	app := SubresourceAPIApp{}
 	BeforeEach(func() {
@@ -166,10 +166,10 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 	enableFeatureGate := func(featureGate string) {
 		kvConfig := kv.DeepCopy()
 		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 
 	expectHandlerPod := func() {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -56,7 +56,7 @@ import (
 
 var _ = Describe("VirtualMachine Mutator", func() {
 	var vm *v1.VirtualMachine
-	var kvInformer cache.SharedIndexInformer
+	var kvStore cache.Store
 	var mutator *VMsMutator
 	var ctrl *gomock.Controller
 	var virtClient *kubecli.MockKubevirtClient
@@ -137,7 +137,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{}
 
 		mutator = &VMsMutator{}
-		mutator.ClusterConfig, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+		mutator.ClusterConfig, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
@@ -179,7 +179,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 	})
 
 	DescribeTable("should apply configurable defaults on VM create", func(arch string, amd64MachineType string, arm64MachineType string, ppc64leMachineType string, s390xMachineType string, result string) {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					ArchitectureConfiguration: &v1.ArchConfiguration{
@@ -202,7 +202,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 	)
 
 	It("should not override default architecture with defaults on VM create", func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Status: v1.KubeVirtStatus{
 				DefaultArchitecture: "arm64",
 			},
@@ -214,7 +214,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 	})
 
 	It("should not override specified properties with defaults on VM create", func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					MachineType: machineTypeFromConfig,
@@ -252,7 +252,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			Kind: apiinstancetype.SingularPreferenceResourceName,
 		}
 
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					MachineType: machineTypeFromConfig,
@@ -287,7 +287,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			Kind: apiinstancetype.SingularPreferenceResourceName,
 		}
 
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					MachineType: machineTypeFromConfig,
@@ -305,7 +305,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			Kind: apiinstancetype.SingularPreferenceResourceName,
 		}
 
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					ArchitectureConfiguration: &v1.ArchConfiguration{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 var _ = Describe("Validating MigrationCreate Admitter", func() {
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
 	// Mock VirtualMachineInstanceMigration
 	var ctrl *gomock.Controller
@@ -52,7 +52,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 	var mockVMIClient *kubecli.MockVirtualMachineInstanceInterface
 
 	enableFeatureGate := func(featureGate string) {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					DeveloperConfiguration: &v1.DeveloperConfiguration{
@@ -63,7 +63,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 		})
 	}
 	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					DeveloperConfiguration: &v1.DeveloperConfiguration{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
@@ -39,10 +39,10 @@ import (
 
 var _ = Describe("Validating MigrationUpdate Admitter", func() {
 	migrationUpdateAdmitter := &MigrationUpdateAdmitter{}
-	_, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+	_, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
 	enableFeatureGate := func(featureGate string) {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					DeveloperConfiguration: &v1.DeveloperConfiguration{
@@ -53,7 +53,7 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 		})
 	}
 	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					DeveloperConfiguration: &v1.DeveloperConfiguration{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -57,12 +57,12 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 	var admitter *VirtualMachineCloneAdmitter
 	var vmClone *clonev1lpha1.VirtualMachineClone
 	var config *virtconfig.ClusterConfig
-	var kvInformer cache.SharedIndexInformer
+	var kvStore cache.Store
 	var vmInterface *kubecli.MockVirtualMachineInterface
 	var vm *v1.VirtualMachine
 
 	enableFeatureGate := func(featureGate string) {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					DeveloperConfiguration: &v1.DeveloperConfiguration{
@@ -74,7 +74,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 	}
 
 	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					DeveloperConfiguration: &v1.DeveloperConfiguration{
@@ -139,7 +139,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
-		config, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+		config, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 		vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
 		kubevirtClient = fake.NewSimpleClientset()
 		virtClient.

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 	snapshotApiGroup := "snapshot.kubevirt.io"
 	kubevirtApiGroup := "kubevirt.io"
 
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
 	Context("With feature gate disabled", func() {
 		It("should reject anything", func() {
@@ -60,7 +60,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 
 	Context("With feature gate enabled", func() {
 		enableFeatureGate := func(featureGate string) {
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
@@ -71,7 +71,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			})
 		}
 		disableFeatureGates := func() {
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -72,17 +72,17 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			DefaultArchitecture: "amd64",
 		},
 	}
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 	vmiCreateAdmitter := &VMICreateAdmitter{ClusterConfig: config}
 
 	dnsConfigTestOption := "test"
 	enableFeatureGate := func(featureGate string) {
 		kvConfig := kv.DeepCopy()
 		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 
 	updateDefaultArchitecture := func(defaultArchitecture string) {
@@ -90,7 +90,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.MultiArchitecture}
 		kvConfig.Status.DefaultArchitecture = defaultArchitecture
 
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 
 	AfterEach(func() {
@@ -860,7 +860,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			kvConfig := kv.DeepCopy()
 			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.VMLiveUpdateFeaturesGate}
 			kvConfig.Spec.Configuration.VMRolloutStrategy = ptr.To(v1.VMRolloutStrategyLiveUpdate)
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 
 			vmi := api.NewMinimalVMI("testvmi")
 			guestMemory := resource.MustParse("128Mi")
@@ -1216,7 +1216,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		It("should accept legacy GPU devices if PermittedHostDevices aren't set", func() {
 			kvConfig := kv.DeepCopy()
 			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.GPUGate}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
@@ -1239,7 +1239,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
@@ -1275,7 +1275,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.HostDevices = []v1.HostDevice{
 				{
@@ -1297,7 +1297,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.HostDevices = []v1.HostDevice{
 				{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -61,16 +61,16 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			Phase: v1.KubeVirtPhaseDeploying,
 		},
 	}
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 	vmiUpdateAdmitter := &VMIUpdateAdmitter{config}
 
 	enableFeatureGate := func(featureGate string) {
 		kvConfig := kv.DeepCopy()
 		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 
 	AfterEach(func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 		},
 	}
 
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
 	Context("Without feature gate enabled", func() {
 		It("should reject anything", func() {
@@ -92,7 +92,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 
 	Context("With feature gate enabled", func() {
 		enableFeatureGate := func(featureGate string) {
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
@@ -103,7 +103,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			})
 		}
 		disableFeatureGates := func() {
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -63,7 +63,7 @@ import (
 )
 
 var _ = Describe("Validating VM Admitter", func() {
-	config, crdInformer, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+	config, crdInformer, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 	var (
 		vmsAdmitter         *VMsAdmitter
 		dataSourceInformer  cache.SharedIndexInformer
@@ -75,7 +75,7 @@ var _ = Describe("Validating VM Admitter", func() {
 	)
 
 	enableFeatureGate := func(featureGates ...string) {
-		kv := testutils.GetFakeKubeVirtClusterConfig(kvInformer)
+		kv := testutils.GetFakeKubeVirtClusterConfig(kvStore)
 		if kv.Spec.Configuration.DeveloperConfiguration == nil {
 			kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
 		}
@@ -84,24 +84,24 @@ var _ = Describe("Validating VM Admitter", func() {
 		} else {
 			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, featureGates...)
 		}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 	disableFeatureGates := func() {
-		kv := testutils.GetFakeKubeVirtClusterConfig(kvInformer)
+		kv := testutils.GetFakeKubeVirtClusterConfig(kvStore)
 		if kv.Spec.Configuration.DeveloperConfiguration != nil {
 			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = make([]string, 0)
 		}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 	enableLiveUpdate := func() {
-		kv := testutils.GetFakeKubeVirtClusterConfig(kvInformer)
+		kv := testutils.GetFakeKubeVirtClusterConfig(kvStore)
 		kv.Spec.Configuration.VMRolloutStrategy = pointer.P(v1.VMRolloutStrategyLiveUpdate)
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 	disableLiveUpdate := func() {
-		kv := testutils.GetFakeKubeVirtClusterConfig(kvInformer)
+		kv := testutils.GetFakeKubeVirtClusterConfig(kvStore)
 		kv.Spec.Configuration.VMRolloutStrategy = nil
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 
 	notRunning := false

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 	vmName := "vm"
 	apiGroup := "kubevirt.io"
 
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
 	Context("Without feature gate enabled", func() {
 		It("should reject anything", func() {
@@ -66,7 +66,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 
 	Context("With feature gate enabled", func() {
 		enableFeatureGate := func(featureGate string) {
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
@@ -77,7 +77,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			})
 		}
 		disableFeatureGates := func() {
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -413,7 +413,7 @@ var _ = Describe("test configuration", func() {
 
 	It("Should update the config if a newer version is available", func() {
 		oldValue := uint32(10)
-		clusterConfig, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
+		clusterConfig, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 			MigrationConfiguration: &v1.MigrationConfiguration{
 				ParallelOutboundMigrationsPerNode: &oldValue,
 			},
@@ -438,7 +438,7 @@ var _ = Describe("test configuration", func() {
 				Phase: "Deployed",
 			},
 		}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 		Eventually(func() uint32 {
 			return *clusterConfig.GetMigrationConfiguration().ParallelOutboundMigrationsPerNode
 		}).Should(BeEquivalentTo(9))
@@ -446,7 +446,7 @@ var _ = Describe("test configuration", func() {
 
 	It("Should stick with the last good config", func() {
 
-		clusterConfig, _, kvInformer := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
+		clusterConfig, _, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 			ImagePullPolicy: kubev1.PullAlways,
 		})
 		Expect(clusterConfig.GetImagePullPolicy()).To(Equal(kubev1.PullAlways))
@@ -465,7 +465,7 @@ var _ = Describe("test configuration", func() {
 				Phase: "Deployed",
 			},
 		}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 
 		Consistently(func() kubev1.PullPolicy {
 			return clusterConfig.GetImagePullPolicy()
@@ -574,7 +574,7 @@ var _ = Describe("test configuration", func() {
 				Phase: v1.KubeVirtPhaseDeploying,
 			},
 		}
-		clusterConfig, _, kubeVirtInformer := testutils.NewFakeClusterConfigUsingKV(KV)
+		clusterConfig, _, kvStore := testutils.NewFakeClusterConfigUsingKV(KV)
 		callbackSet1 = false
 		callbackSet2 = false
 		clusterConfig.SetConfigModifiedCallback(callback1)
@@ -582,7 +582,7 @@ var _ = Describe("test configuration", func() {
 
 		Expect(clusterConfig.GetVirtLauncherVerbosity()).To(Equal(uint(3)))
 		KV.Spec.Configuration.DeveloperConfiguration.LogVerbosity.VirtLauncher = 6
-		testutils.UpdateFakeKubeVirtClusterConfig(kubeVirtInformer.GetStore(), KV)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, KV)
 		Expect(clusterConfig.GetVirtLauncherVerbosity()).To(Equal(uint(6)))
 		Eventually(func() bool {
 			lock.Lock()

--- a/pkg/virt-controller/services/virtiofs_test.go
+++ b/pkg/virt-controller/services/virtiofs_test.go
@@ -29,10 +29,10 @@ var _ = Describe("virtiofs container", func() {
 			DefaultArchitecture: "amd64",
 		},
 	}
-	config, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 
 	enableFeatureGate := func(featureGate string) {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					DeveloperConfiguration: &v1.DeveloperConfiguration{
@@ -44,7 +44,7 @@ var _ = Describe("virtiofs container", func() {
 	}
 
 	disableFeatureGates := func() {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
 
 	AfterEach(func() {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -68,7 +68,7 @@ var _ = Describe("VirtualMachine", func() {
 		var k8sClient *k8sfake.Clientset
 		var virtClient *kubecli.MockKubevirtClient
 		var config *virtconfig.ClusterConfig
-		var kvInformer cache.SharedIndexInformer
+		var kvStore cache.Store
 		var virtFakeClient *fake.Clientset
 
 		BeforeEach(func() {
@@ -124,7 +124,7 @@ var _ = Describe("VirtualMachine", func() {
 			recorder = record.NewFakeRecorder(100)
 			recorder.IncludeObject = true
 
-			config, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+			config, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
 			controller, _ = NewVMController(vmiInformer,
 				vmInformer,
@@ -5442,7 +5442,7 @@ var _ = Describe("VirtualMachine", func() {
 			func(iface string, field gstruct.Fields) {
 				vm, _ := DefaultVirtualMachine(true)
 
-				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 					Spec: v1.KubeVirtSpec{
 						Configuration: v1.KubeVirtConfiguration{
 							NetworkConfiguration: &v1.NetworkConfiguration{
@@ -5475,7 +5475,7 @@ var _ = Describe("VirtualMachine", func() {
 		It("should reject adding a default deprecated slirp interface", func() {
 			vm, _ := DefaultVirtualMachine(true)
 
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						NetworkConfiguration: &v1.NetworkConfiguration{
@@ -5598,7 +5598,7 @@ var _ = Describe("VirtualMachine", func() {
 				It("should prefer maximum CPU sockets from VM spec rather than from cluster config", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{MaxSockets: maxSocketsFromSpec}
-					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
 								LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{
@@ -5774,7 +5774,7 @@ var _ = Describe("VirtualMachine", func() {
 						Guest:    &guestMemory,
 						MaxGuest: &maxGuestFromSpec,
 					}
-					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
 								LiveUpdateConfiguration: &v1.LiveUpdateConfiguration{
@@ -6023,7 +6023,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			Context("Affinity", func() {
 				It("should be live-updated", func() {
-					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
 								VMRolloutStrategy: &liveUpdate,
@@ -6073,7 +6073,7 @@ var _ = Describe("VirtualMachine", func() {
 
 			Context("Volumes", func() {
 				DescribeTable("should set the restart condition", func(strategy *v1.UpdateVolumesStrategy) {
-					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
 								VMRolloutStrategy: &liveUpdate,
@@ -6103,7 +6103,7 @@ var _ = Describe("VirtualMachine", func() {
 				)
 
 				It("should set the restart condition with the Migration updateVolumeStrategy if volumes cannot be migrated", func() {
-					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
 								VMRolloutStrategy: &liveUpdate,
@@ -6209,7 +6209,7 @@ var _ = Describe("VirtualMachine", func() {
 						Clientset:               virtClient,
 					}
 
-					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), &v1.KubeVirt{
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
 								VMRolloutStrategy: &liveUpdate,
@@ -6331,13 +6331,13 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					},
 				}
-				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 
 				var maxSockets uint32 = 8
 
 				By("Setting a cluster-wide CPU maxSockets value")
 				kv.Spec.Configuration.LiveUpdateConfiguration.MaxCpuSockets = pointer.P(maxSockets)
-				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 
 				By("Creating a VM with CPU sockets set to the cluster maxiumum")
 				vm.Spec.Template.Spec.Domain.CPU.Sockets = maxSockets
@@ -6371,7 +6371,7 @@ var _ = Describe("VirtualMachine", func() {
 			})
 
 			It("should appear when changing a non-live-updatable field", func() {
-				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 
 				By("Creating a VMI with hostname 'a'")
 				vm.Spec.Template.Spec.Hostname = "a"
@@ -6486,7 +6486,7 @@ var _ = Describe("VirtualMachine", func() {
 				})
 				kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = fgs
 				kv.Spec.Configuration.VMRolloutStrategy = strat
-				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kv)
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 
 				By("Creating a VM with CPU sockets set to 2")
 				vm.Spec.Template.Spec.Domain.CPU.Sockets = 2

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -96,7 +96,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var storageClassInformer cache.SharedIndexInformer
 	var rqInformer cache.SharedIndexInformer
 	var nsInformer cache.SharedIndexInformer
-	var kvInformer cache.SharedIndexInformer
+	var kvStore cache.Store
 
 	var dataVolumeInformer cache.SharedIndexInformer
 	var cdiInformer cache.SharedIndexInformer
@@ -270,7 +270,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			},
 		}
 
-		config, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
+		config, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		storageClassInformer, _ = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		cdiInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
@@ -2123,10 +2123,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Guest:    &requestedGuestMemory,
 					MaxGuest: &requestedGuestMemory,
 				}
-				kvCR := testutils.GetFakeKubeVirtClusterConfig(kvInformer)
+				kvCR := testutils.GetFakeKubeVirtClusterConfig(kvStore)
 				overheadRatio := "2"
 				kvCR.Spec.Configuration.AdditionalGuestMemoryOverheadRatio = &overheadRatio
-				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvCR)
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvCR)
 
 				controller.syncMemoryHotplug(vmi)
 

--- a/pkg/virt-handler/device-manager/mediated_device_test.go
+++ b/pkg/virt-handler/device-manager/mediated_device_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Mediated Device", func() {
 					Phase: v1.KubeVirtPhaseDeploying,
 				},
 			}
-			fakeClusterConfig, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+			fakeClusterConfig, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 
 			By("creating an empty device controller")
 			var noDevices []Device
@@ -196,7 +196,7 @@ var _ = Describe("Mediated Device", func() {
 					},
 				},
 			}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			permittedDevices := fakeClusterConfig.GetPermittedHostDevices()
 			Expect(permittedDevices).ToNot(BeNil(), "something went wrong while parsing the configmap(s)")
 			Expect(permittedDevices.MediatedDevices).To(HaveLen(1), "the fake device was not found")
@@ -215,7 +215,7 @@ var _ = Describe("Mediated Device", func() {
 
 			By("deletting the device from the configmap")
 			kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			permittedDevices = fakeClusterConfig.GetPermittedHostDevices()
 			Expect(permittedDevices).ToNot(BeNil(), "something went wrong while parsing the configmap(s)")
 			Expect(permittedDevices.MediatedDevices).To(BeEmpty(), "the fake device was not deleted")

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -353,7 +353,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 					Phase: v1.KubeVirtPhaseDeploying,
 				},
 			}
-			fakeClusterConfig, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+			fakeClusterConfig, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 
 			kvConfig := kv.DeepCopy()
 			kvConfig.Spec.Configuration.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{
@@ -391,7 +391,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 					},
 				},
 			}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			node := &kubev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testNode",
@@ -449,7 +449,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 
 			By("removing all created mdevs")
 			kvConfig.Spec.Configuration.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			deviceController.refreshMediatedDeviceTypes()
 			files, err := os.ReadDir(fakeMdevDevicesPath)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -126,7 +126,7 @@ pciHostDevices:
 				Phase: v1.KubeVirtPhaseDeploying,
 			},
 		}
-		fakeClusterConfig, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
+		fakeClusterConfig, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 
 		By("creating an empty device controller")
 		var noDevices []Device
@@ -143,7 +143,7 @@ pciHostDevices:
 				},
 			},
 		}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 		permittedDevices := fakeClusterConfig.GetPermittedHostDevices()
 		Expect(permittedDevices).ToNot(BeNil(), "something went wrong while parsing the configmap(s)")
 		Expect(permittedDevices.PciHostDevices).To(HaveLen(1), "the fake device was not found")
@@ -160,7 +160,7 @@ pciHostDevices:
 
 		By("deletting the device from the configmap")
 		kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer.GetStore(), kvConfig)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 		permittedDevices = fakeClusterConfig.GetPermittedHostDevices()
 		Expect(permittedDevices).ToNot(BeNil(), "something went wrong while parsing the configmap(s)")
 		Expect(permittedDevices.PciHostDevices).To(BeEmpty(), "the fake device was not deleted")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

virt-exportproxy does not need the informers, but the stores are enough.
Simplifies the interface used to the bare minimum.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

 This PR also addresses https://github.com/kubevirt/kubevirt/pull/12047#pullrequestreview-2110264819 
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @xpivarc @alicefr 