### PR TITLE
tests/storage: Replace hardcoded patch operations with patchset

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -147,12 +147,12 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 			By("Expanding PVC")
-			patchData, err := patch.GeneratePatchPayload(patch.PatchOperation{
-				Op:    patch.PatchAddOp,
-				Path:  "/spec/resources/requests/storage",
-				Value: resource.MustParse("2Gi"),
-			})
+			patchSet := patch.New(
+				patch.WithAdd("/spec/resources/requests/storage", resource.MustParse("2Gi")),
+			)
+			patchData, err := patchSet.GeneratePayload()
 			Expect(err).ToNot(HaveOccurred())
+
 			_, err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Patch(context.Background(), dataVolume.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -272,7 +272,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		})
 
 		It("[test_id:4610]create a snapshot when VM is running should succeed", func() {
-			patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
+			patch, err := patch.New(patch.WithReplace("/spec/running", true)).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*vm.Spec.Running).Should(BeTrue())
@@ -281,7 +283,12 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		})
 
 		It("should create a snapshot when VM runStrategy is Manual", func() {
-			patch := []byte("[{ \"op\": \"remove\", \"path\": \"/spec/running\"}, { \"op\": \"add\", \"path\": \"/spec/runStrategy\", \"value\": \"Manual\"}]")
+			patch, err := patch.New(
+				patch.WithRemove("/spec/running"),
+				patch.WithAdd("/spec/runStrategy", "Manual"),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vm.Spec.RunStrategy).ToNot(BeNil())
@@ -291,7 +298,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		})
 
 		It("VM should contain snapshot status for all volumes", func() {
-			patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
+			patch, err := patch.New(patch.WithReplace("/spec/running", true)).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
 			vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -466,7 +475,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				newMemory := resource.MustParse("1Gi")
 				Expect(newMemory).ToNot(Equal(initialMemory))
 
-				//update vm to make sure vm revision is saved in the snapshot
+				// update vm to make sure vm revision is saved in the snapshot
 				By("Updating the VM template spec")
 				patchData, err := patch.GenerateTestReplacePatch(
 					"/spec/template/spec/domain/resources/requests/"+string(corev1.ResourceMemory),


### PR DESCRIPTION
Use the PatchSet struct from the patch package to replace hardcoded jsonpatch operations to improve readability, in the tests/storage package.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Hardcoded jsonpatches in the tests/storage package.
After this PR:
All hardcoded jsonpatches were updated to use `patch.patchSet` type, for readability and maintainability .
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

