### PR TITLE
Use ginkgo's context in tests/compute

### DIFF
--- a/tests/compute/console.go
+++ b/tests/compute/console.go
@@ -107,10 +107,10 @@ var _ = SIGDescribe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@re
 				Eventually(firstConsoleErrChan, 1*time.Minute, 1*time.Second).Should(Receive(MatchError(ContainSubstring("EOF"))))
 			})
 
-			It("[test_id:1592]should wait until the virtual machine is in running state and return a stream interface", func() {
+			It("[test_id:1592]should wait until the virtual machine is in running state and return a stream interface", func(ctx context.Context) {
 				vmi := libvmifact.NewAlpine()
 				By("Creating a new VirtualMachineInstance")
-				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(ctx, vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("and connecting to it very quickly. Hopefully the VM is not yet up")
@@ -118,13 +118,13 @@ var _ = SIGDescribe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@re
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:1593]should not be connected if scheduled to non-existing host", func() {
+			It("[test_id:1593]should not be connected if scheduled to non-existing host", func(ctx context.Context) {
 				vmi := libvmifact.NewAlpine(
 					libvmi.WithNodeAffinityFor("nonexistent"),
 				)
 
 				By("Creating a new VirtualMachineInstance")
-				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(ctx, vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kvcorev1.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})

--- a/tests/compute/vmidefaults.go
+++ b/tests/compute/vmidefaults.go
@@ -61,12 +61,12 @@ var _ = SIGDescribe("VMIDefaults", func() {
 			)
 		})
 
-		It("[test_id:4115]Should be applied to VMIs", func() {
+		It("[test_id:4115]Should be applied to VMIs", func(ctx context.Context) {
 			// create the VMI first
-			_, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			_, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(ctx, vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			newVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			newVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(ctx, vmi.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			// check defaults
@@ -75,15 +75,15 @@ var _ = SIGDescribe("VMIDefaults", func() {
 			Expect(disk.Disk.Bus).ToNot(BeEmpty(), "DiskTarget's bus should not be empty")
 		})
 
-		It("[test_id:]Should be applied to any auto attached volume disks", func() {
+		It("[test_id:]Should be applied to any auto attached volume disks", func(ctx context.Context) {
 
 			// Drop the disks to ensure they are added in by setDefaultVolumeDisk
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
 
-			_, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			_, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(ctx, vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			newVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+			newVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(ctx, vmi.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(newVMI.Spec.Domain.Devices.Disks).To(HaveLen(1))
@@ -109,9 +109,9 @@ var _ = SIGDescribe("VMIDefaults", func() {
 			kvConfiguration = kv.Spec.Configuration
 		})
 
-		It("[test_id:4556]Should be present in domain", func() {
+		It("[test_id:4556]Should be present in domain", func(ctx context.Context) {
 			By("Creating a virtual machine")
-			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(ctx, vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for successful start")
@@ -143,7 +143,7 @@ var _ = SIGDescribe("VMIDefaults", func() {
 			Expect(*domain.Devices.Ballooning).To(Equal(expected), "Default to virtio model and 10 seconds pooling")
 		})
 
-		DescribeTable("[Serial]Should override period in domain if present in virt-config ", Serial, func(period uint32, expected api.MemBalloon) {
+		DescribeTable("[Serial]Should override period in domain if present in virt-config ", Serial, func(ctx context.Context, period uint32, expected api.MemBalloon) {
 			By("Adding period to virt-config")
 			kvConfigurationCopy := kvConfiguration.DeepCopy()
 			kvConfigurationCopy.MemBalloonStatsPeriod = &period
@@ -155,7 +155,7 @@ var _ = SIGDescribe("VMIDefaults", func() {
 			}
 
 			By("Creating a virtual machine")
-			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(ctx, vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for successful start")
@@ -193,10 +193,10 @@ var _ = SIGDescribe("VMIDefaults", func() {
 			}),
 		)
 
-		It("[test_id:4559]Should not be present in domain ", func() {
+		It("[test_id:4559]Should not be present in domain ", func(ctx context.Context) {
 			By("Creating a virtual machine with autoAttachmemballoon set to false")
 			vmi.Spec.Domain.Devices.AutoattachMemBalloon = pointer.P(false)
-			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(ctx, vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for successful start")
@@ -217,7 +217,7 @@ var _ = SIGDescribe("VMIDefaults", func() {
 
 	Context("Input defaults", func() {
 
-		It("[test_id:TODO]Should be set in VirtualMachineInstance", func() {
+		It("[test_id:TODO]Should be set in VirtualMachineInstance", func(ctx context.Context) {
 
 			By("Creating a VirtualMachineInstance with an input device without a bus or type set")
 			vmi = libvmifact.NewCirros()
@@ -225,7 +225,7 @@ var _ = SIGDescribe("VMIDefaults", func() {
 				Name: "foo-1",
 			})
 
-			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(ctx, vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(vmi.Spec.Domain.Devices.Inputs).ToNot(BeEmpty(), "There should be input devices")
@@ -235,15 +235,15 @@ var _ = SIGDescribe("VMIDefaults", func() {
 
 		})
 
-		It("[test_id:TODO]Should be applied to a device added by AutoattachInputDevice", func() {
+		It("[test_id:TODO]Should be applied to a device added by AutoattachInputDevice", func(ctx context.Context) {
 			By("Creating a VirtualMachine with AutoattachInputDevice enabled")
 			vm := libvmi.NewVirtualMachine(libvmifact.NewCirros(), libvmi.WithRunning())
 			vm.Spec.Template.Spec.Domain.Devices.AutoattachInputDevice = pointer.P(true)
-			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(ctx, vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vm)).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vm)).Get(ctx, vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(vmi.Spec.Domain.Devices.Inputs).ToNot(BeEmpty(), "There should be input devices")


### PR DESCRIPTION
### What this PR does
using ginkgo context, allow better controll over test termination. This PR start this change by replacing all context.Background() in tests/compute, with context from ginkgo containers.

This change follows the kubernetes test concept.

For more details, see here: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md#interrupting-tests

And here: https://onsi.github.io/ginkgo/#spec-timeouts-and-interruptible-nodes

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

