### PR TITLE
[release-1.2] virt-launcher: Fix SSH propagation command check for AgentVersionNotSupported condition

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -173,6 +173,12 @@ var RequiredGuestAgentCommands = []string{
 }
 
 var SSHRelatedGuestAgentCommands = []string{
+	"guest-ssh-get-authorized-keys",
+	"guest-ssh-add-authorized-keys",
+	"guest-ssh-remove-authorized-keys",
+}
+
+var OldSSHRelatedGuestAgentCommands = []string{
 	"guest-exec-status",
 	"guest-exec",
 	"guest-file-open",
@@ -1519,7 +1525,7 @@ func isGuestAgentSupported(vmi *v1.VirtualMachineInstance, commands []v1.GuestAg
 		}
 	}
 
-	if checkSSH && !_guestAgentCommandSubsetSupported(SSHRelatedGuestAgentCommands, commands) {
+	if checkSSH && !sshRelatedCommandsSupported(commands) {
 		return false, "This guest agent doesn't support required public key commands"
 	}
 
@@ -1528,6 +1534,11 @@ func isGuestAgentSupported(vmi *v1.VirtualMachineInstance, commands []v1.GuestAg
 	}
 
 	return true, "This guest agent is supported"
+}
+
+func sshRelatedCommandsSupported(commands []v1.GuestAgentCommandInfo) bool {
+	return _guestAgentCommandSubsetSupported(SSHRelatedGuestAgentCommands, commands) ||
+		_guestAgentCommandSubsetSupported(OldSSHRelatedGuestAgentCommands, commands)
 }
 
 func calculatePausedCondition(vmi *v1.VirtualMachineInstance, reason api.StateChangeReason) {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3188,7 +3188,9 @@ var _ = Describe("VirtualMachineInstance", func() {
 		var vmiWithPassword *v1.VirtualMachineInstance
 		var vmiWithSSH *v1.VirtualMachineInstance
 		var basicCommands []v1.GuestAgentCommandInfo
-		var allCommands []v1.GuestAgentCommandInfo
+		var sshCommands []v1.GuestAgentCommandInfo
+		var oldSshCommands []v1.GuestAgentCommandInfo
+		var passwordCommands []v1.GuestAgentCommandInfo
 		const agentSupported = "This guest agent is supported"
 
 		BeforeEach(func() {
@@ -3219,30 +3221,37 @@ var _ = Describe("VirtualMachineInstance", func() {
 					},
 				},
 			}
-			basicCommands = []v1.GuestAgentCommandInfo{}
-			allCommands = []v1.GuestAgentCommandInfo{}
 
+			basicCommands = []v1.GuestAgentCommandInfo{}
 			for _, cmdName := range RequiredGuestAgentCommands {
-				cmd := v1.GuestAgentCommandInfo{
+				basicCommands = append(basicCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,
-				}
-				basicCommands = append(basicCommands, cmd)
-				allCommands = append(allCommands, cmd)
+				})
 			}
+
+			sshCommands = []v1.GuestAgentCommandInfo{}
 			for _, cmdName := range SSHRelatedGuestAgentCommands {
-				cmd := v1.GuestAgentCommandInfo{
+				sshCommands = append(sshCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,
-				}
-				allCommands = append(allCommands, cmd)
+				})
 			}
-			for _, cmdName := range PasswordRelatedGuestAgentCommands {
-				cmd := v1.GuestAgentCommandInfo{
+
+			oldSshCommands = []v1.GuestAgentCommandInfo{}
+			for _, cmdName := range OldSSHRelatedGuestAgentCommands {
+				oldSshCommands = append(oldSshCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,
-				}
-				allCommands = append(allCommands, cmd)
+				})
+			}
+
+			passwordCommands = []v1.GuestAgentCommandInfo{}
+			for _, cmdName := range PasswordRelatedGuestAgentCommands {
+				passwordCommands = append(passwordCommands, v1.GuestAgentCommandInfo{
+					Name:    cmdName,
+					Enabled: true,
+				})
 			}
 		})
 
@@ -3253,7 +3262,12 @@ var _ = Describe("VirtualMachineInstance", func() {
 		})
 
 		It("should succeed with empty VMI and all commands", func() {
-			result, reason := isGuestAgentSupported(vmi, allCommands)
+			var commands []v1.GuestAgentCommandInfo
+			commands = append(commands, basicCommands...)
+			commands = append(commands, sshCommands...)
+			commands = append(commands, passwordCommands...)
+
+			result, reason := isGuestAgentSupported(vmi, commands)
 			Expect(result).To(BeTrue())
 			Expect(reason).To(Equal(agentSupported))
 		})
@@ -3264,8 +3278,12 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(reason).To(Equal("This guest agent doesn't support required password commands"))
 		})
 
-		It("should succeed with password and all commands", func() {
-			result, reason := isGuestAgentSupported(vmiWithPassword, allCommands)
+		It("should succeed with password and required commands", func() {
+			var commands []v1.GuestAgentCommandInfo
+			commands = append(commands, basicCommands...)
+			commands = append(commands, passwordCommands...)
+
+			result, reason := isGuestAgentSupported(vmiWithPassword, commands)
 			Expect(result).To(BeTrue())
 			Expect(reason).To(Equal(agentSupported))
 		})
@@ -3276,8 +3294,22 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(reason).To(Equal("This guest agent doesn't support required public key commands"))
 		})
 
-		It("should succeed with SSH and all commands", func() {
-			result, reason := isGuestAgentSupported(vmiWithSSH, allCommands)
+		It("should succeed with SSH and required commands", func() {
+			var commands []v1.GuestAgentCommandInfo
+			commands = append(commands, basicCommands...)
+			commands = append(commands, sshCommands...)
+
+			result, reason := isGuestAgentSupported(vmiWithSSH, commands)
+			Expect(result).To(BeTrue())
+			Expect(reason).To(Equal(agentSupported))
+		})
+
+		It("should succeed with SSH and old required commands", func() {
+			var commands []v1.GuestAgentCommandInfo
+			commands = append(commands, basicCommands...)
+			commands = append(commands, oldSshCommands...)
+
+			result, reason := isGuestAgentSupported(vmiWithSSH, commands)
 			Expect(result).To(BeTrue())
 			Expect(reason).To(Equal(agentSupported))
 		})

--- a/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
-        "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -22,7 +22,6 @@ package accesscredentials
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,16 +29,12 @@ import (
 	"sync"
 	"time"
 
-	"libvirt.org/go/libvirt"
-
-	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
-
 	"github.com/fsnotify/fsnotify"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/config"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
@@ -320,12 +315,24 @@ func (l *AccessCredentialManager) agentSetAuthorizedKeys(domName string, user st
 		// Zero flags argument means that the authorized_keys file is overwritten with the authorizedKeys
 		return domain.AuthorizedSSHKeysSet(user, authorizedKeys, 0)
 	}()
-	if errors.Is(err, libvirt.ERR_NO_SUPPORT) {
-		// If AuthorizedSSHKeysSet method is not supported, use the old method
-		desiredAuthorizedKeys := strings.Join(authorizedKeys, "\n")
-		return l.agentWriteAuthorizedKeysFile(domName, user, desiredAuthorizedKeys)
+	if err == nil {
+		return nil
 	}
-	return err
+
+	log.Log.V(4).Infof("Could not set SSH key using guest-ssh-add-authorized-keys: %v", err)
+
+	// If AuthorizedSSHKeysSet method failed, use the old method
+	desiredAuthorizedKeys := strings.Join(authorizedKeys, "\n")
+	secondErr := l.agentWriteAuthorizedKeysFile(domName, user, desiredAuthorizedKeys)
+	if secondErr == nil {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"failed to set SSH keys: error from guest-ssh-add-authorized-keys: %w; error from using guest-file-write: %w",
+		err,
+		secondErr,
+	)
 }
 
 func (l *AccessCredentialManager) agentWriteAuthorizedKeysFile(domName string, user string, desiredAuthorizedKeys string) (err error) {

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -126,6 +126,105 @@ var _ = Describe("AccessCredentials", func() {
 		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
 	})
 
+	It("should dynamically update ssh key with old qemu agent", func() {
+		domName := "some-domain"
+		user := "someowner"
+		filePath := "/home/someowner/.ssh"
+
+		authorizedKeys := []string{"ssh some injected key"}
+
+		mockConn.EXPECT().LookupDomainByName(domName).Return(mockDomain, nil).Times(1)
+		// The AuthorizedSSHKeysSet method fails so a backward compatible code will be used.
+		mockDomain.EXPECT().AuthorizedSSHKeysSet(user, authorizedKeys, gomock.Any()).Return(libvirt.ERR_INTERNAL_ERROR).Times(1)
+		mockDomain.EXPECT().Free().Times(1)
+
+		expectedOpenCmd := fmt.Sprintf(`{"execute": "guest-file-open", "arguments": { "path": "%s/authorized_keys", "mode":"r" } }`, filePath)
+		expectedWriteOpenCmd := fmt.Sprintf(`{"execute": "guest-file-open", "arguments": { "path": "%s/authorized_keys", "mode":"w" } }`, filePath)
+		expectedOpenCmdRes := `{"return":1000}`
+
+		existingKey := base64.StdEncoding.EncodeToString([]byte("ssh some existing key"))
+		expectedReadCmd := `{"execute": "guest-file-read", "arguments": { "handle": 1000 } }`
+		expectedReadCmdRes := fmt.Sprintf(`{"return":{"count":24,"buf-b64": "%s"}}`, existingKey)
+
+		mergedKeys := base64.StdEncoding.EncodeToString([]byte(strings.Join(authorizedKeys, "\n")))
+		expectedWriteCmd := fmt.Sprintf(`{"execute": "guest-file-write", "arguments": { "handle": 1000, "buf-b64": "%s" } }`, mergedKeys)
+
+		expectedCloseCmd := `{"execute": "guest-file-close", "arguments": { "handle": 1000 } }`
+
+		expectedExecReturn := `{"return":{"pid":789}}`
+		expectedStatusCmd := `{"execute": "guest-exec-status", "arguments": { "pid": 789 } }`
+
+		getentBase64Str := base64.StdEncoding.EncodeToString([]byte("someowner:x:1111:2222:Some Owner:/home/someowner:/bin/bash"))
+		expectedHomeDirCmd := `{"execute": "guest-exec", "arguments": { "path": "getent", "arg": [ "passwd", "someowner" ], "capture-output":true } }`
+		expectedHomeDirCmdRes := fmt.Sprintf(`{"return":{"exitcode":0,"out-data":"%s","exited":true}}`, getentBase64Str)
+
+		expectedMkdirCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "mkdir", "arg": [ "-p", "%s" ], "capture-output":true } }`, filePath)
+		expectedMkdirRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
+
+		expectedParentChownCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "chown", "arg": [ "1111:2222", "%s" ], "capture-output":true } }`, filePath)
+		expectedParentChownRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
+
+		expectedParentChmodCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "chmod", "arg": [ "700", "%s" ], "capture-output":true } }`, filePath)
+		expectedParentChmodRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
+
+		expectedFileChownCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "chown", "arg": [ "1111:2222", "%s/authorized_keys" ], "capture-output":true } }`, filePath)
+		expectedFileChownRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
+
+		expectedFileChmodCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "chmod", "arg": [ "600", "%s/authorized_keys" ], "capture-output":true } }`, filePath)
+		expectedFileChmodRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
+
+		// Detect user home dir
+		mockConn.EXPECT().QemuAgentCommand(expectedHomeDirCmd, domName).Return(expectedExecReturn, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedHomeDirCmdRes, nil).Times(1)
+
+		// Expected Read File
+		mockConn.EXPECT().QemuAgentCommand(expectedOpenCmd, domName).Return(expectedOpenCmdRes, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedReadCmd, domName).Return(expectedReadCmdRes, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedCloseCmd, domName).Return("", nil).Times(1)
+
+		// Expected prepare directory
+		mockConn.EXPECT().QemuAgentCommand(expectedMkdirCmd, domName).Return(expectedExecReturn, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedMkdirRes, nil).Times(1)
+
+		mockConn.EXPECT().QemuAgentCommand(expectedParentChownCmd, domName).Return(expectedExecReturn, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedParentChownRes, nil).Times(1)
+
+		mockConn.EXPECT().QemuAgentCommand(expectedParentChmodCmd, domName).Return(expectedExecReturn, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedParentChmodRes, nil).Times(1)
+
+		// Expected Write file
+		mockConn.EXPECT().QemuAgentCommand(expectedWriteOpenCmd, domName).Return(expectedOpenCmdRes, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedWriteCmd, domName).Return("", nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedCloseCmd, domName).Return("", nil).Times(1)
+
+		// Expected set file permissions
+		mockConn.EXPECT().QemuAgentCommand(expectedFileChownCmd, domName).Return(expectedExecReturn, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedFileChownRes, nil).Times(1)
+
+		mockConn.EXPECT().QemuAgentCommand(expectedFileChmodCmd, domName).Return(expectedExecReturn, nil).Times(1)
+		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedFileChmodRes, nil).Times(1)
+
+		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
+	})
+
+	It("should fail to update ssh key if both methods return error", func() {
+		domName := "some-domain"
+		user := "someowner"
+
+		authorizedKeys := []string{"ssh some injected key"}
+
+		mockConn.EXPECT().LookupDomainByName(domName).Return(mockDomain, nil).Times(1)
+		// The AuthorizedSSHKeysSet method fails so a backward compatible code will be used.
+		mockDomain.EXPECT().AuthorizedSSHKeysSet(user, authorizedKeys, gomock.Any()).Return(libvirt.ERR_INTERNAL_ERROR).Times(1)
+		mockDomain.EXPECT().Free().Times(1)
+
+		// Detect user home dir
+		mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return("", libvirt.ERR_INTERNAL_ERROR).AnyTimes()
+
+		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).
+			To(MatchError(ContainSubstring("failed to set SSH keys")))
+	})
+
 	It("should support multiple ssh keys in one secret value", func() {
 		secretID := "some-secret-123"
 		user := "fakeuser"

--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -153,7 +153,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			vmi := libvmi.NewFedora(
 				withSSHPK(secretID, withQuestAgentPropagationMethod),
 				libvmi.WithCloudInitNoCloudUserData(
-					tests.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec"),
+					tests.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec,guest-ssh-add-authorized-keys"),
 				),
 			)
 


### PR DESCRIPTION
This is a manual backport of: https://github.com/kubevirt/kubevirt/pull/11652 .
There were no changes, only the bot could not cherry-pick it automatically.

### What this PR does
This PR fixes a bug where virt-handler was checking availability of incorrect guest agent commands.

Fixes: https://issues.redhat.com/browse/CNV-38523

### Release note
```release-note
None
```

