### PR TITLE
 libvmi: Refactor cloudinit buiders

### DIFF
--- a/pkg/libvmi/BUILD.bazel
+++ b/pkg/libvmi/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/libvmi",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -40,14 +40,16 @@ func WithCloudInitNoCloud(opts ...cloudinit.NoCloudOption) Option {
 	}
 }
 
-// WithCloudInitConfigDriveUserData adds cloud-init config-drive user data.
-func WithCloudInitConfigDriveUserData(data string) Option {
+// WithCloudInitConfigDrive adds cloud-init config-drive sources.
+func WithCloudInitConfigDrive(opts ...cloudinit.ConfigDriveOption) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
-		volume.CloudInitConfigDrive.UserData = data
-		volume.CloudInitConfigDrive.UserDataBase64 = ""
+
+		for _, f := range opts {
+			f(volume.CloudInitConfigDrive)
+		}
 	}
 }
 

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -44,18 +44,6 @@ func WithCloudInitNoCloud(opts ...cloudinit.NoCloudOption) Option {
 	}
 }
 
-// WithCloudInitNoCloudEncodedUserData adds cloud-init no-cloud base64-encoded user data
-func WithCloudInitNoCloudEncodedUserData(data string) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
-
-		volume := getVolume(vmi, cloudInitDiskName)
-		encodedData := base64.StdEncoding.EncodeToString([]byte(data))
-		volume.CloudInitNoCloud.UserData = ""
-		volume.CloudInitNoCloud.UserDataBase64 = encodedData
-	}
-}
-
 // WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data.
 func WithCloudInitNoCloudNetworkData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -22,8 +22,6 @@ package libvmi
 import (
 	"kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
-	k8scorev1 "k8s.io/api/core/v1"
-
 	v1 "kubevirt.io/api/core/v1"
 )
 
@@ -39,18 +37,6 @@ func WithCloudInitNoCloud(opts ...cloudinit.NoCloudOption) Option {
 		for _, f := range opts {
 			f(volume.CloudInitNoCloud)
 		}
-	}
-}
-
-// WithCloudInitNoCloudNetworkDataSecretName adds cloud-init no-cloud network data from secret.
-func WithCloudInitNoCloudNetworkDataSecretName(secretName string) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
-
-		volume := getVolume(vmi, cloudInitDiskName)
-		volume.CloudInitNoCloud.NetworkDataSecretRef = &k8scorev1.LocalObjectReference{Name: secretName}
-		volume.CloudInitNoCloud.NetworkData = ""
-		volume.CloudInitNoCloud.NetworkDataBase64 = ""
 	}
 }
 

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -20,8 +20,6 @@
 package libvmi
 
 import (
-	"encoding/base64"
-
 	"kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	k8scorev1 "k8s.io/api/core/v1"
@@ -41,18 +39,6 @@ func WithCloudInitNoCloud(opts ...cloudinit.NoCloudOption) Option {
 		for _, f := range opts {
 			f(volume.CloudInitNoCloud)
 		}
-	}
-}
-
-// WithCloudInitNoCloudEncodedNetworkData adds cloud-init no-cloud base64 encoded network data.
-func WithCloudInitNoCloudEncodedNetworkData(networkData string) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
-
-		volume := getVolume(vmi, cloudInitDiskName)
-		volume.CloudInitNoCloud.NetworkDataBase64 = base64.StdEncoding.EncodeToString([]byte(networkData))
-		volume.CloudInitNoCloud.NetworkData = ""
-		volume.CloudInitNoCloud.NetworkDataSecretRef = nil
 	}
 }
 

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -22,6 +22,8 @@ package libvmi
 import (
 	"encoding/base64"
 
+	"kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+
 	k8scorev1 "k8s.io/api/core/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -29,14 +31,16 @@ import (
 
 const cloudInitDiskName = "disk1"
 
-// WithCloudInitNoCloudUserData adds cloud-init no-cloud user data.
-func WithCloudInitNoCloudUserData(data string) Option {
+// WithCloudInitNoCloud adds cloud-init no-cloud sources.
+func WithCloudInitNoCloud(opts ...cloudinit.NoCloudOption) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
-		volume.CloudInitNoCloud.UserData = data
-		volume.CloudInitNoCloud.UserDataBase64 = ""
+
+		for _, f := range opts {
+			f(volume.CloudInitNoCloud)
+		}
 	}
 }
 

--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -44,18 +44,6 @@ func WithCloudInitNoCloud(opts ...cloudinit.NoCloudOption) Option {
 	}
 }
 
-// WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data.
-func WithCloudInitNoCloudNetworkData(data string) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
-
-		volume := getVolume(vmi, cloudInitDiskName)
-		volume.CloudInitNoCloud.NetworkData = data
-		volume.CloudInitNoCloud.NetworkDataBase64 = ""
-		volume.CloudInitNoCloud.NetworkDataSecretRef = nil
-	}
-}
-
 // WithCloudInitNoCloudEncodedNetworkData adds cloud-init no-cloud base64 encoded network data.
 func WithCloudInitNoCloudEncodedNetworkData(networkData string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/pkg/libvmi/cloudinit/BUILD.bazel
+++ b/pkg/libvmi/cloudinit/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cloudinit.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/libvmi/cloudinit",
+    visibility = ["//visibility:public"],
+    deps = ["//staging/src/kubevirt.io/api/core/v1:go_default_library"],
+)

--- a/pkg/libvmi/cloudinit/BUILD.bazel
+++ b/pkg/libvmi/cloudinit/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["cloudinit.go"],
     importpath = "kubevirt.io/kubevirt/pkg/libvmi/cloudinit",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/api/core/v1:go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
 )

--- a/pkg/libvmi/cloudinit/cloudinit.go
+++ b/pkg/libvmi/cloudinit/cloudinit.go
@@ -38,3 +38,9 @@ func WithNoCloudEncodedUserData(data string) NoCloudOption {
 		source.UserDataBase64 = base64.StdEncoding.EncodeToString([]byte(data))
 	}
 }
+
+func WithNoCloudNetworkData(data string) NoCloudOption {
+	return func(source *v1.CloudInitNoCloudSource) {
+		source.NetworkData = data
+	}
+}

--- a/pkg/libvmi/cloudinit/cloudinit.go
+++ b/pkg/libvmi/cloudinit/cloudinit.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package cloudinit
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
+
+type NoCloudOption func(*v1.CloudInitNoCloudSource)
+
+func WithNoCloudUserData(data string) NoCloudOption {
+	return func(source *v1.CloudInitNoCloudSource) {
+		source.UserData = data
+	}
+}

--- a/pkg/libvmi/cloudinit/cloudinit.go
+++ b/pkg/libvmi/cloudinit/cloudinit.go
@@ -58,3 +58,11 @@ func WithNoCloudNetworkDataSecretName(secretName string) NoCloudOption {
 		source.NetworkDataSecretRef = &k8scorev1.LocalObjectReference{Name: secretName}
 	}
 }
+
+type ConfigDriveOption func(*v1.CloudInitConfigDriveSource)
+
+func WithConfigDriveUserData(data string) ConfigDriveOption {
+	return func(source *v1.CloudInitConfigDriveSource) {
+		source.UserData = data
+	}
+}

--- a/pkg/libvmi/cloudinit/cloudinit.go
+++ b/pkg/libvmi/cloudinit/cloudinit.go
@@ -20,6 +20,8 @@
 package cloudinit
 
 import (
+	"encoding/base64"
+
 	v1 "kubevirt.io/api/core/v1"
 )
 
@@ -28,5 +30,11 @@ type NoCloudOption func(*v1.CloudInitNoCloudSource)
 func WithNoCloudUserData(data string) NoCloudOption {
 	return func(source *v1.CloudInitNoCloudSource) {
 		source.UserData = data
+	}
+}
+
+func WithNoCloudEncodedUserData(data string) NoCloudOption {
+	return func(source *v1.CloudInitNoCloudSource) {
+		source.UserDataBase64 = base64.StdEncoding.EncodeToString([]byte(data))
 	}
 }

--- a/pkg/libvmi/cloudinit/cloudinit.go
+++ b/pkg/libvmi/cloudinit/cloudinit.go
@@ -22,6 +22,8 @@ package cloudinit
 import (
 	"encoding/base64"
 
+	k8scorev1 "k8s.io/api/core/v1"
+
 	v1 "kubevirt.io/api/core/v1"
 )
 
@@ -42,5 +44,17 @@ func WithNoCloudEncodedUserData(data string) NoCloudOption {
 func WithNoCloudNetworkData(data string) NoCloudOption {
 	return func(source *v1.CloudInitNoCloudSource) {
 		source.NetworkData = data
+	}
+}
+
+func WithNoCloudEncodedNetworkData(data string) NoCloudOption {
+	return func(source *v1.CloudInitNoCloudSource) {
+		source.NetworkDataBase64 = base64.StdEncoding.EncodeToString([]byte(data))
+	}
+}
+
+func WithNoCloudNetworkDataSecretName(secretName string) NoCloudOption {
+	return func(source *v1.CloudInitNoCloudSource) {
+		source.NetworkDataSecretRef = &k8scorev1.LocalObjectReference{Name: secretName}
 	}
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -109,6 +109,7 @@ go_test(
         "//pkg/hooks:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/liveupdate/memory:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 
@@ -1708,7 +1709,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 	Context("with AccessCredentials", func() {
 		It("should accept a valid ssh access credential with configdrive propagation", func() {
-			vmi := newBaseVmi(libvmi.WithCloudInitConfigDriveUserData(" "))
+			vmi := newBaseVmi(libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveUserData(" ")))
 
 			vmi.Spec.AccessCredentials = []v1.AccessCredential{
 				{

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -146,6 +146,7 @@ go_test(
         "//pkg/hooks/v1alpha2:go_default_library",
         "//pkg/hooks/v1alpha3:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/network/dns:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",

--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -239,7 +239,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			verifySSHKeys(vmi)
 		},
 			Entry("[test_id:6224]using configdrive", libvmifact.NewFedora(
-				libvmi.WithCloudInitConfigDriveUserData(userData),
+				libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveUserData(userData)),
 				withSSHPK(secretID, v1.SSHPublicKeyAccessCredentialPropagationMethod{
 					ConfigDrive: &v1.ConfigDriveSSHPublicKeyAccessCredentialPropagation{},
 				}),

--- a/tests/compute/credentials.go
+++ b/tests/compute/credentials.go
@@ -34,6 +34,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -155,9 +156,9 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			const secretID = "my-pub-key"
 			vmi := libvmifact.NewFedora(
 				withSSHPK(secretID, withQuestAgentPropagationMethod),
-				libvmi.WithCloudInitNoCloudUserData(
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(
 					cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec,guest-ssh-add-authorized-keys"),
-				),
+				)),
 			)
 
 			By("Creating a secret with an ssh key")
@@ -178,7 +179,9 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 			const secretID = "my-user-pass"
 			vmi := libvmifact.NewFedora(
 				withPassword(secretID),
-				libvmi.WithCloudInitNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-set-user-password")),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(
+					cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-set-user-password"),
+				)),
 			)
 
 			customPassword := "imadethisup"
@@ -242,7 +245,7 @@ var _ = SIGDescribe("Guest Access Credentials", func() {
 				}),
 			)),
 			Entry("using nocloud", libvmifact.NewFedora(
-				libvmi.WithCloudInitNoCloudUserData(userData),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData)),
 				withSSHPK(secretID, v1.SSHPublicKeyAccessCredentialPropagationMethod{
 					NoCloud: &v1.NoCloudSSHPublicKeyAccessCredentialPropagation{},
 				}),

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/virtctl/expose:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/tests/libnet/vmibuilder.go
+++ b/tests/libnet/vmibuilder.go
@@ -23,6 +23,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
 )
@@ -32,6 +33,6 @@ func WithMasqueradeNetworking(ports ...v1.Port) libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...))(vmi)
 		libvmi.WithNetwork(v1.DefaultPodNetwork())(vmi)
-		libvmi.WithCloudInitNoCloudNetworkData(networkData)(vmi)
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData))(vmi)
 	}
 }

--- a/tests/libvmifact/BUILD.bazel
+++ b/tests/libvmifact/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//tests/containerdisk:go_default_library",

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -23,6 +23,7 @@ import (
 	kvirtv1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
 
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -50,7 +51,7 @@ func NewFedora(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 // NewCirros instantiates a new CirrOS based VMI configuration
 func NewCirros(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	// Supplied with no user data, Cirros image takes 230s to allow login
-	withNonEmptyUserData := libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
+	withNonEmptyUserData := libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho hello\n"))
 
 	cirrosOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
@@ -75,7 +76,7 @@ func NewAlpine(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 
 func NewAlpineWithTestTooling(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	// Supplied with no user data, AlpimeWithTestTooling image takes more than 200s to allow login
-	withNonEmptyUserData := libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n")
+	withNonEmptyUserData := libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho hello\n"))
 	alpineMemory := cirrosMemory
 	alpineOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),

--- a/tests/migration/BUILD.bazel
+++ b/tests/migration/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libmigration"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 
@@ -167,7 +168,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			libvmi.WithSecretDisk(secret.Name, secret.Name),
 			libvmi.WithConfigMapDisk(configMapName, configMapName),
 			libvmi.WithEmptyDisk("usb-disk", v1.DiskBusUSB, resource.MustParse("64Mi")),
-			libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho 'hello'\n"),
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho 'hello'\n")),
 		)
 	}
 
@@ -1172,7 +1173,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					libvmi.WithPersistentVolumeClaim("disk0", dv.Name),
 					libvmi.WithResourceMemory(fedoraVMSize),
 					libvmi.WithRng(),
-					libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\n echo hello\n"),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\n echo hello\n")),
 				)
 
 				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
@@ -2015,7 +2016,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithDataVolume("disk0", dv.Name),
 					libvmi.WithResourceMemory("1Gi"),
-					libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\n echo hello\n"),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\n echo hello\n")),
 				)
 				return vmi
 			}

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -29,6 +29,7 @@ import (
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	kvpointer "kubevirt.io/kubevirt/pkg/pointer"
 
@@ -319,7 +320,7 @@ func VMIMigrationWithGuestAgent(virtClient kubecli.KubevirtClient, pvName string
 		libvmi.WithPersistentVolumeClaim("disk0", pvName),
 		libvmi.WithResourceMemory(memoryRequestSize),
 		libvmi.WithRng(),
-		libvmi.WithCloudInitNoCloudEncodedUserData(mountSvcAccCommands),
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(mountSvcAccCommands)),
 		libvmi.WithServiceAccountDisk("default"),
 	)
 

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/cloud-init:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -35,6 +35,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests"
@@ -401,7 +402,7 @@ func startPasstVMI(vmiBuilder func(opts ...libvmi.Option) *v1.VirtualMachineInst
 	vmi := libvmifact.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceWithPasstBindingPlugin()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData),
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 	)
 	vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -36,6 +36,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests/console"
@@ -175,7 +176,9 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithInterface(iface),
 				libvmi.WithNetwork(&net),
-				libvmi.WithCloudInitNoCloudNetworkData(cloudinit.CreateNetworkDataWithStaticIPsByIface("eth1", ip2+subnetMask)),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
+					cloudinit.CreateNetworkDataWithStaticIPsByIface("eth1", ip2+subnetMask),
+				)),
 				libvmi.WithNodeAffinityFor(hotPluggedVMI.Status.NodeName))
 			anotherVmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(anotherVmi)).Create(context.Background(), anotherVmi, metav1.CreateOptions{})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -37,6 +37,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -200,7 +201,7 @@ func newFedoraWithGuestAgentAndDefaultInterface(iface v1.Interface) (*v1.Virtual
 	vmi := libvmifact.NewFedora(
 		libvmi.WithInterface(iface),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData),
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 	)
 	return vmi, nil
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -48,6 +48,7 @@ import (
 
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
@@ -656,7 +657,7 @@ func newSRIOVVmi(networks []string, cloudInitNetworkData string) *v1.VirtualMach
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	}
 	if cloudInitNetworkData != "" {
-		cloudinitOption := libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkData)
+		cloudinitOption := libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(cloudInitNetworkData))
 		options = append(options, cloudinitOption)
 	}
 

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -36,6 +36,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	network "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 
@@ -87,7 +88,7 @@ var _ = SIGDescribe("Infosource", func() {
 				libvmi.WithInterface(*libvmi.InterfaceWithMac(&secondaryLinuxBridgeInterface2, secondaryInterface2Mac)),
 				libvmi.WithNetwork(secondaryNetwork1),
 				libvmi.WithNetwork(secondaryNetwork2),
-				libvmi.WithCloudInitNoCloudUserData(manipulateGuestLinksScript(primaryInterfaceNewMac, dummyInterfaceMac)))
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(manipulateGuestLinksScript(primaryInterfaceNewMac, dummyInterfaceMac))))
 
 			var err error
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmiSpec, metav1.CreateOptions{})

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -350,7 +350,7 @@ var istioTests = func(vmType VmType) {
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
 					libvmi.WithLabel("version", "v1"),
 					libvmi.WithLabel(vmiAppSelectorKey, vmiServerAppSelectorValue),
-					libvmi.WithCloudInitNoCloudNetworkData(networkData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 					libvmi.WithNamespace(namespace),
 				)
 				By("Starting VirtualMachineInstance")
@@ -515,8 +515,10 @@ func createMasqueradeVm(ports []v1.Port) *v1.VirtualMachineInstance {
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
 		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData),
-		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(enablePasswordAuth)),
+		libvmi.WithCloudInitNoCloud(
+			libvmici.WithNoCloudNetworkData(networkData),
+			libvmici.WithNoCloudEncodedUserData(enablePasswordAuth),
+		),
 	)
 	return vmi
 }

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -46,6 +46,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -697,7 +698,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
                     ip addr add %s dev ep1
                     ip addr add %s dev ep2
                 `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6)
-				agentVMI := libvmifact.NewFedora(libvmi.WithCloudInitNoCloudUserData(userdata))
+				agentVMI := libvmifact.NewFedora(libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userdata)))
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
 				agentVMI.Spec.Networks = networks

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -209,7 +209,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 			It("[test_id:1751]should create a virtual machine with one interface", func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
-					libvmi.WithCloudInitNoCloudNetworkData(networkData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
@@ -229,7 +229,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				checks.SkipIfOpenShift4("OpenShift 4 does not support usage of the network definition from the different namespace")
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
-					libvmi.WithCloudInitNoCloudNetworkData(networkData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
@@ -293,7 +293,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
-					libvmi.WithCloudInitNoCloudNetworkData(networkData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
@@ -449,7 +449,9 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterface),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudinit.CreateNetworkDataWithStaticIPsByIface("eth1", ptpSubnetIP2+ptpSubnetMask)),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
+						cloudinit.CreateNetworkDataWithStaticIPsByIface("eth1", ptpSubnetIP2+ptpSubnetMask),
+					)),
 					libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmiTwo, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiTwo)).Create(context.Background(), vmiTwo, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -465,7 +467,9 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudinit.CreateNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, ptpSubnetIP1+ptpSubnetMask)),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
+						cloudinit.CreateNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, ptpSubnetIP1+ptpSubnetMask),
+					)),
 					libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmiOne, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiOne)).Create(context.Background(), vmiOne, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -638,7 +642,9 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				vmiUnderTest := libvmifact.NewFedora(
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudinit.CreateNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, linuxBridgeInterfaceWithCustomMac.MacAddress, vmUnderTestIPAddress+bridgeSubnetMask)),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
+						cloudinit.CreateNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, linuxBridgeInterfaceWithCustomMac.MacAddress, vmUnderTestIPAddress+bridgeSubnetMask),
+					)),
 					libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				vmiUnderTest, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiUnderTest)).Create(context.Background(), vmiUnderTest, metav1.CreateOptions{})
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
@@ -647,7 +653,9 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				targetVmi := libvmifact.NewFedora(
 					libvmi.WithInterface(linuxBridgeInterfaceWithMACSpoofCheck),
 					libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudinit.CreateNetworkDataWithStaticIPsByIface("eth0", targetVMIPAddress+bridgeSubnetMask)),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(
+						cloudinit.CreateNetworkDataWithStaticIPsByIface("eth0", targetVMIPAddress+bridgeSubnetMask),
+					)),
 					libvmi.WithNodeAffinityFor(nodes.Items[0].Name))
 				targetVmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(targetVmi)).Create(context.Background(), targetVmi, metav1.CreateOptions{})
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -57,6 +57,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
@@ -582,7 +583,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		It("[test_id:1779]should have custom resolv.conf", func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
 			userData := "#cloud-config\n"
-			dnsVMI := libvmifact.NewCirros(libvmi.WithCloudInitNoCloudUserData(userData))
+			dnsVMI := libvmifact.NewCirros(libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData)))
 
 			dnsVMI.Spec.DNSPolicy = "None"
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -367,7 +367,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			deadbeafVMI := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(masqIface),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithCloudInitNoCloudNetworkData(networkData),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 			)
 			deadbeafVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), deadbeafVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -654,7 +654,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 				libvmi.WithNetwork(net),
-				libvmi.WithCloudInitNoCloudNetworkData(networkData),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 			)
 
 			return vmi, nil
@@ -968,7 +968,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				vmi = libvmifact.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudNetworkData(networkData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				)
 
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -582,8 +582,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	Context("VirtualMachineInstance with custom dns", func() {
 		It("[test_id:1779]should have custom resolv.conf", func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
-			userData := "#cloud-config\n"
-			dnsVMI := libvmifact.NewCirros(libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData)))
+			dnsVMI := libvmifact.NewCirros()
 
 			dnsVMI.Spec.DNSPolicy = "None"
 

--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -20,6 +20,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests/console"
@@ -65,7 +66,7 @@ var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", 
 		vmi = libvmi.New(
 			libvmi.WithRng(),
 			libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime)),
-			libvmi.WithCloudInitNoCloudEncodedUserData(tuneAdminRealtimeCloudInitData),
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(tuneAdminRealtimeCloudInitData)),
 			libvmi.WithResourceCPU("2"),
 			libvmi.WithLimitCPU("2"),
 			libvmi.WithResourceMemory(memory),

--- a/tests/realtime/BUILD.bazel
+++ b/tests/realtime/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -18,6 +18,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests"
@@ -46,7 +47,7 @@ func newFedoraRealtime(realtimeMask string) *v1.VirtualMachineInstance {
 	return libvmi.New(
 		libvmi.WithRng(),
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime)),
-		libvmi.WithCloudInitNoCloudEncodedUserData(tuneAdminRealtimeCloudInitData),
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(tuneAdminRealtimeCloudInitData)),
 		libvmi.WithLimitMemory(memory),
 		libvmi.WithLimitCPU("2"),
 		libvmi.WithResourceMemory(memory),

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -54,6 +54,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests"
@@ -140,7 +141,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, dataVolume.Namespace, libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n"))
+			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, dataVolume.Namespace, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho hello\n")))
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 500)
 
 			By("Expecting the VirtualMachineInstance console")
@@ -1151,7 +1152,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			dataVolume = dvChange(dataVolume)
 			preallocated := dataVolume.Spec.Preallocation != nil && *dataVolume.Spec.Preallocation
 
-			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, testsuite.GetTestNamespace(nil), libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\n echo hello\n"))
+			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, testsuite.GetTestNamespace(nil), libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\n echo hello\n")))
 			vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = "scsi"
 
 			dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -64,6 +64,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	certutil "kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 
 	"kubevirt.io/kubevirt/tests"
@@ -1848,7 +1849,7 @@ var _ = SIGDescribe("Export", func() {
 
 		vm := libvmi.NewVirtualMachine(
 			libstorage.RenderVMIWithDataVolume(dataVolume.Name, testsuite.GetTestNamespace(nil),
-				libvmi.WithCloudInitNoCloudEncodedUserData(bashHelloScript),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(bashHelloScript)),
 				libvmi.WithDataVolume("blankdisk", blankDv.Name),
 			),
 			libvmi.WithRunning(),

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -48,6 +48,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtctl "kubevirt.io/kubevirt/pkg/virtctl/vm"
 
 	"kubevirt.io/kubevirt/tests"
@@ -1172,7 +1173,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				vmi := libvmi.New(
 					libvmi.WithDataVolume("disk0", dataVolume.Name),
 					libvmi.WithResourceMemory("256Mi"),
-					libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\n echo hello\n"),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\n echo hello\n")),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					// Stir things up, /dev/urandom access will be needed
@@ -1327,7 +1328,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				hookSidecarsValue := fmt.Sprintf(`[{"args": ["--version", "v1alpha2"], "image": "%s", "imagePullPolicy": "IfNotPresent"}]`,
 					libregistry.GetUtilityImageFromRegistry(hookSidecarImage))
 				vmi := libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace,
-					libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho 'hello'\n"),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho 'hello'\n")),
 					libvmi.WithAnnotation("hooks.kubevirt.io/hookSidecars", hookSidecarsValue),
 					libvmi.WithAnnotation("diskimage.vm.kubevirt.io/bootImageName", newDiskImgName),
 				)

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -37,6 +37,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -182,7 +183,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 				libvmi.WithResourceMemory("128Mi"),
 				libvmi.WithDataVolume(volName, dv.Name),
-				libvmi.WithCloudInitNoCloudEncodedUserData(("#!/bin/bash\necho hello\n")),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho hello\n")),
 			)
 			vm := libvmi.NewVirtualMachine(vmi,
 				libvmi.WithRunning(),

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -37,6 +37,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	typesStorage "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -260,7 +261,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			),
 		)
 		return libvmi.NewVirtualMachine(
-			libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace, libvmi.WithCloudInitNoCloudEncodedUserData(bashHelloScript)),
+			libstorage.RenderVMIWithDataVolume(dv.Name, dv.Namespace, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(bashHelloScript))),
 			libvmi.WithDataVolumeTemplate(dv),
 		)
 	}
@@ -1207,7 +1208,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					memory = "256Mi"
 				}
 				vmi = libstorage.RenderVMIWithDataVolume(originalPVCName, testsuite.GetTestNamespace(nil),
-					libvmi.WithResourceMemory(memory), libvmi.WithCloudInitNoCloudEncodedUserData(bashHelloScript))
+					libvmi.WithResourceMemory(memory), libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(bashHelloScript)))
 				vm, vmi = createAndStartVM(libvmi.NewVirtualMachine(vmi))
 
 				doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
@@ -1763,7 +1764,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					)
 
 					return libvmi.NewVirtualMachine(
-						libstorage.RenderVMIWithDataVolume(dataVolume.Name, sourceDV.Namespace, libvmi.WithCloudInitNoCloudEncodedUserData(bashHelloScript)),
+						libstorage.RenderVMIWithDataVolume(dataVolume.Name, sourceDV.Namespace, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(bashHelloScript))),
 						libvmi.WithDataVolumeTemplate(dataVolume),
 					)
 				}

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -26,6 +26,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -756,7 +757,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					"  - sudo sed -i 's/^SELINUX=.*/SELINUX=enforcing/' /etc/selinux/config\n"
 
 				vmi := libvmifact.NewFedora(
-					libvmi.WithCloudInitNoCloudUserData(userData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData)),
 					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)))
 
 				dv := libdv.NewDataVolume(

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -54,6 +54,7 @@ import (
 
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
@@ -962,7 +963,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = libvmi.New(
 					libvmi.WithResourceMemory("256Mi"),
 					libvmi.WithPersistentVolumeClaim("disk0", dataVolume.Name),
-					libvmi.WithCloudInitNoCloudEncodedUserData(cirrosUserData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(cirrosUserData)),
 				)
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -348,7 +348,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				By("Checking that /dev/vdc has a capacity of 1G, aligned to 4k")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "sudo blockdev --getsize64 /dev/vdc\n"},
+					&expect.BSnd{S: "sudo blockdev --getsize64 /dev/vdb\n"},
 					&expect.BExp{R: "999292928"}, // 1G in bytes rounded down to nearest 1MiB boundary
 				}, 10)).To(Succeed())
 

--- a/tests/virtctl/BUILD.bazel
+++ b/tests/virtctl/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/virtctl/create/instancetype:go_default_library",
         "//pkg/virtctl/create/preference:go_default_library",
         "//pkg/virtctl/create/vm:go_default_library",

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -17,6 +17,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
@@ -91,7 +92,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 	DescribeTable("should copy a local file back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))))
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -115,7 +116,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 	DescribeTable("should copy a local directory back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))))
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -19,6 +19,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
@@ -85,7 +86,7 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 	DescribeTable("should succeed to execute a command on the VM", func(cmdFn func(string)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloudUserData(libssh.RenderUserDataWithKey(pub)))
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))))
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/virtiofs/BUILD.bazel
+++ b/tests/virtiofs/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/config:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests"
@@ -110,7 +111,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 				virtiofsMountPath(pvc2), pvc2, virtiofsMountPath(pvc2), virtiofsTestFile(virtiofsMountPath(pvc2)))
 
 			vmi = libvmifact.NewFedora(
-				libvmi.WithCloudInitNoCloudEncodedUserData(mountVirtiofsCommands),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(mountVirtiofsCommands)),
 				libvmi.WithFilesystemPVC(pvc1),
 				libvmi.WithFilesystemPVC(pvc2),
 				libvmi.WithNamespace(namespace),
@@ -224,7 +225,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
                            `, virtiofsMountPath, pvcName, virtiofsMountPath, virtiofsTestFile)
 
 			vmi = libvmifact.NewFedora(
-				libvmi.WithCloudInitNoCloudEncodedUserData(mountVirtiofsCommands),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(mountVirtiofsCommands)),
 				libvmi.WithFilesystemPVC(pvcName),
 				libvmi.WithNamespace(namespace),
 			)
@@ -313,7 +314,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
                                `, virtiofsMountPath, dataVolume.Name, virtiofsMountPath, virtiofsTestFile)
 
 			vmi = libvmifact.NewFedora(
-				libvmi.WithCloudInitNoCloudEncodedUserData(mountVirtiofsCommands),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(mountVirtiofsCommands)),
 				libvmi.WithFilesystemDV(dataVolume.Name),
 				libvmi.WithNamespace(namespace),
 			)

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -22,6 +22,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 
 	"kubevirt.io/kubevirt/tests/console"
@@ -123,7 +124,7 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithCloudInitNoCloudNetworkData(cloudinit.CreateDefaultCloudInitNetworkData()),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(cloudinit.CreateDefaultCloudInitNetworkData())),
 				libvmi.WithUefi(false),
 				libvmi.WithResourceMemory("1Gi"),
 			)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -56,6 +56,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtctl "kubevirt.io/kubevirt/pkg/virtctl/vm"
 
 	"kubevirt.io/kubevirt/tests"
@@ -191,7 +192,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				libvmi.WithDataVolume("disk0", dataVolume.Name),
 				libvmi.WithResourceMemory("256Mi"),
 				libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-				libvmi.WithCloudInitNoCloudEncodedUserData("#!/bin/bash\necho hello\n"),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho hello\n")),
 				libvmi.WithTerminationGracePeriod(30),
 			), dataVolume
 		}

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -158,7 +159,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						fedoraPassword,
 						sshAuthorizedKey,
 					)
-					vmi := libvmifact.NewFedora(libvmi.WithCloudInitNoCloudUserData(userData))
+					vmi := libvmifact.NewFedora(libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData)))
 
 					vmi = LaunchVMI(vmi)
 					CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
@@ -294,7 +295,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			It("[test_id:1617] with cloudInitNoCloud userData source", func() {
 				vmi := libvmifact.NewCirros(
-					libvmi.WithCloudInitNoCloudUserData(userData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData)),
 				)
 
 				runTest(vmi, cloudinit.DataSourceNoCloud)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -351,7 +351,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := libvmifact.NewCirros(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudNetworkData(testNetworkData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(testNetworkData)),
 				)
 				vmi = LaunchVMI(vmi)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -141,7 +141,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			It("[test_id:1615]should have cloud-init data", func() {
 				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 				vmi := libvmifact.NewCirros(
-					libvmi.WithCloudInitNoCloudEncodedUserData(userData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(userData)),
 				)
 
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -369,7 +369,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := libvmifact.NewCirros(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudEncodedNetworkData(testNetworkData),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedNetworkData(testNetworkData)),
 				)
 				vmi = LaunchVMI(vmi)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -199,7 +199,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						sshAuthorizedKey,
 					)
 					vmi := libvmifact.NewFedora(
-						libvmi.WithCloudInitConfigDriveUserData(userData),
+						libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveUserData(userData)),
 					)
 
 					vmi = LaunchVMI(vmi)
@@ -229,7 +229,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					"#cloud-config\npassword: %s\nchpasswd: { expire: False }",
 					fedoraPassword,
 				)
-				vmi := libvmifact.NewFedora(libvmi.WithCloudInitConfigDriveUserData(userData))
+				vmi := libvmifact.NewFedora(libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveUserData(userData)))
 				// runStrategy := v1.RunStrategyManual
 				vm := &v1.VirtualMachine{
 					ObjectMeta: vmi.ObjectMeta,

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -389,7 +389,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := libvmifact.NewCirros(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudNetworkDataSecretName(secretID),
+					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkDataSecretName(secretID)),
 				)
 
 				By("Creating a secret with network data")

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -31,6 +31,7 @@ import (
 	"unicode"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -1336,7 +1337,12 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				})
 
 				It("[test_id:5267]VMI condition should signal unsupported agent presence", func() {
-					agentVMI := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), libvmi.WithCloudInitNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-shutdown")))
+					agentVMI := libvmifact.NewFedora(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithCloudInitNoCloud(
+							libvmici.WithNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-shutdown")),
+						),
+					)
 					By("Starting a VirtualMachineInstance")
 					agentVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
@@ -1346,7 +1352,12 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				})
 
 				It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", func() {
-					agentVMI := libvmifact.NewFedora(libnet.WithMasqueradeNetworking(), libvmi.WithCloudInitNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec,guest-set-password")))
+					agentVMI := libvmifact.NewFedora(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithCloudInitNoCloud(
+							libvmici.WithNoCloudUserData(cloudinit.GetFedoraToolsGuestAgentBlacklistUserData("guest-exec,guest-set-password")),
+						),
+					)
 					By("Starting a VirtualMachineInstance")
 					agentVMI, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Create(context.Background(), agentVMI, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
@@ -2154,7 +2165,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				libvmi.WithContainerDisk("ephemeral-disk2", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 				libvmi.WithContainerDisk("ephemeral-disk5", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 				libvmi.WithContainerDisk("ephemeral-disk3", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
-				libvmi.WithCloudInitNoCloudUserData("#!/bin/bash\necho 'hello'\n"),
+				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData("#!/bin/bash\necho 'hello'\n")),
 				libvmi.WithHostDisk("hostdisk", filepath.Join(tmpHostDiskDir, "test-disk.img"), v1.HostDiskExistsOrCreate),
 				// hostdisk needs a privileged namespace
 				libvmi.WithNamespace(testsuite.NamespacePrivileged),

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -41,6 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libssh"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
@@ -181,7 +182,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		vmi := libvmifact.NewFedora(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			libvmi.WithCloudInitNoCloudUserData(userData),
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData)),
 		)
 		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 60)


### PR DESCRIPTION
### What this PR does

The existing cloud-init builders have too many permutations, making it
hard to maintain and use.

This change starts with having one builder per source type and the data
used is passed through a `cloudinit` dedicated builder.

The number of permutation is left to the callers now.
The library provides two libvmi main builders for cloudinit, one for NoCloud and one for ConfigDrive.
The specific building blocks of the cloudinit details are exposed through a dedicated cloudinit builders that the user can use per need.

Note, it is up to the caller to assure not to build a wrong spec.
The library does not attempt to correct it, mainly because the caller may want to build intentionally a bad configuration (e.g. for unit tests).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

