### PR TITLE
api, defaults: Remove SetDefaults_NetworkInterface

### DIFF
--- a/staging/src/kubevirt.io/api/core/v1/defaults.go
+++ b/staging/src/kubevirt.io/api/core/v1/defaults.go
@@ -168,19 +168,6 @@ func SetDefaults_Probe(probe *Probe) {
 	}
 }
 
-func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
-	autoAttach := obj.Spec.Domain.Devices.AutoattachPodInterface
-	if autoAttach != nil && *autoAttach == false {
-		return
-	}
-
-	// Override only when nothing is specified
-	if len(obj.Spec.Networks) == 0 {
-		obj.Spec.Domain.Devices.Interfaces = []Interface{*DefaultBridgeNetworkInterface()}
-		obj.Spec.Networks = []Network{*DefaultPodNetwork()}
-	}
-}
-
 func DefaultBridgeNetworkInterface() *Interface {
 	iface := &Interface{
 		Name: "default",

--- a/staging/src/kubevirt.io/client-go/api/defaults_test.go
+++ b/staging/src/kubevirt.io/client-go/api/defaults_test.go
@@ -277,6 +277,25 @@ var _ = Describe("Defaults", func() {
 		v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 		Expect(vmi.Spec.Domain.IOThreadsPolicy).To(BeNil(), "Default IOThreadsPolicy should be nil")
 	})
+
+	It("should default probes", func() {
+		vmi := &v1.VirtualMachineInstance{
+			Spec: v1.VirtualMachineInstanceSpec{
+				ReadinessProbe: &v1.Probe{},
+				LivenessProbe:  &v1.Probe{},
+			},
+		}
+		v1.SetDefaults_VirtualMachineInstance(vmi)
+
+		validateProbe := func(probe *v1.Probe) {
+			Expect(probe.TimeoutSeconds).To(BeEquivalentTo(1))
+			Expect(probe.PeriodSeconds).To(BeEquivalentTo(10))
+			Expect(probe.SuccessThreshold).To(BeEquivalentTo(1))
+			Expect(probe.FailureThreshold).To(BeEquivalentTo(3))
+		}
+		validateProbe(vmi.Spec.ReadinessProbe)
+		validateProbe(vmi.Spec.LivenessProbe)
+	})
 })
 
 var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
@@ -325,24 +344,5 @@ var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("default"))
 		Expect(vmi.Spec.Networks[0].Name).To(Equal("default"))
 		Expect(vmi.Spec.Networks[0].Pod).ToNot(BeNil())
-	})
-
-	It("should default probes", func() {
-		vmi := &v1.VirtualMachineInstance{
-			Spec: v1.VirtualMachineInstanceSpec{
-				ReadinessProbe: &v1.Probe{},
-				LivenessProbe:  &v1.Probe{},
-			},
-		}
-		v1.SetDefaults_VirtualMachineInstance(vmi)
-
-		validateProbe := func(probe *v1.Probe) {
-			Expect(probe.TimeoutSeconds).To(BeEquivalentTo(1))
-			Expect(probe.PeriodSeconds).To(BeEquivalentTo(10))
-			Expect(probe.SuccessThreshold).To(BeEquivalentTo(1))
-			Expect(probe.FailureThreshold).To(BeEquivalentTo(3))
-		}
-		validateProbe(vmi.Spec.ReadinessProbe)
-		validateProbe(vmi.Spec.LivenessProbe)
 	})
 })

--- a/staging/src/kubevirt.io/client-go/api/defaults_test.go
+++ b/staging/src/kubevirt.io/client-go/api/defaults_test.go
@@ -41,13 +41,6 @@ var _ = Describe("Defaults", func() {
 		Expect(vmi.Spec.Domain.Features.SMM).To(BeNil())
 	})
 
-	It("should add interface and pod network by default", func() {
-		vmi := &v1.VirtualMachineInstance{}
-		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(vmi.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
-		Expect(vmi.Spec.Networks).NotTo(BeEmpty())
-	})
-
 	It("should default to true to all defined features", func() {
 		vmi := &v1.VirtualMachineInstance{
 			Spec: v1.VirtualMachineInstanceSpec{
@@ -295,54 +288,5 @@ var _ = Describe("Defaults", func() {
 		}
 		validateProbe(vmi.Spec.ReadinessProbe)
 		validateProbe(vmi.Spec.LivenessProbe)
-	})
-})
-
-var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
-
-	It("should append pod interface if interface is not defined", func() {
-		vmi := &v1.VirtualMachineInstance{}
-		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
-		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("default"))
-		Expect(vmi.Spec.Networks[0].Name).To(Equal("default"))
-		Expect(vmi.Spec.Networks[0].Pod).ToNot(BeNil())
-	})
-
-	It("should not append pod interface if interface is defined", func() {
-		vmi := &v1.VirtualMachineInstance{}
-		net := v1.Network{
-			Name: "testnet",
-		}
-		iface := v1.Interface{Name: net.Name}
-		vmi.Spec.Networks = []v1.Network{net}
-		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface}
-
-		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
-		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("testnet"))
-		Expect(vmi.Spec.Networks[0].Name).To(Equal("testnet"))
-		Expect(vmi.Spec.Networks[0].Pod).To(BeNil())
-	})
-
-	It("should not append pod interface if it's explicitly disabled", func() {
-		autoAttach := false
-		vmi := &v1.VirtualMachineInstance{}
-		vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
-
-		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(vmi.Spec.Domain.Devices.Interfaces).To(BeEmpty())
-		Expect(vmi.Spec.Networks).To(BeEmpty())
-	})
-
-	It("should append pod interface if auto attach is true", func() {
-		autoAttach := true
-		vmi := &v1.VirtualMachineInstance{}
-		vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
-		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
-		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("default"))
-		Expect(vmi.Spec.Networks[0].Name).To(Equal("default"))
-		Expect(vmi.Spec.Networks[0].Pod).ToNot(BeNil())
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
PR https://github.com/kubevirt/kubevirt/pull/2405 removed this function from the default VMI configuration and moved its usage to another place.

It had only two usages left in the network e2e tests.

After this PR:
- The last two usages of the function are removed from network e2e tests.
- The function and its unit tests are removed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

