### PR TITLE
Use ginkgo's contexts - update the coding-conventions

### DIFF
--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -320,6 +320,98 @@ coding conventions](#detailed-coding-conventions).
       subdirectories.
 - Document directories and filenames should use dashes rather than underscores.
 
+# Writing Tests
+## Writing functional tests
+### Test Interrupts
+To make sure that any asynchronous operation is canceled when the test is
+terminated, make sure to use golang contexts properly. See more details in 
+[ginkgo documentation](https://onsi.github.io/ginkgo/#spec-timeouts-and-interruptible-nodes)
+
+Avoid using new contexts (e.g. `context.Background()` or `context.TODO()`).
+Instead, prefer using the context injected by ginkgo.
+
+First, add the `ctx` optional parameter of the anonymous functions in `It`, `BeforeEach`,
+`AfterEach` or `DescribeTable`. Then use this parameter for all the contexts in this container.
+
+By adding the `ctx` parameter, we making ginkgo to inject a context.
+
+For example:
+```go
+It("should test something", func(ctx context.Context){
+	...
+	kv, err = virtClient.KubeVirt(kvName).Update(ctx, kv, metav1.UpdateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	...
+})
+```
+
+When using asynchronous assertion, i.e. `Eventually` or `Consistently`, pass the container's context
+using the `WithContext` method, and add the context parameter to the checked function; e.g.
+```go
+It("should test something", func(ctx context.Context){
+	...
+	
+	Eventually(func(ctx context.Context) error {
+		kv, err = virtClient.KubeVirt(kvName).Update(ctx, kv, metav1.UpdateOptions{})
+		...
+		
+		return err
+	}).WithTimeout(120 * time.Seconds).
+		WithPolling(10 * time.Seconds).
+		WithContext(ctx).
+		Should(Succeed())
+	
+	...
+})
+```
+
+Notice that in case of also passing the `Gomega` parameter, the context parameter will be the second one, i.e.
+```go
+It("should test something", func (ctx context.Context){
+	...
+	
+	Eventually(func(g Gomega, ctx context.Context) {
+		kv, err = virtClient.KubeVirt(kvName).Update(ctx, kv, metav1.UpdateOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+		...
+	}).WithTimeout(120 * time.Seconds).
+		WithPolling(10 * time.Seconds).
+		WithContext(ctx).
+		Should(Succeed())
+	
+	...
+})
+```
+
+Also notice that ginkgo cancels the context when exiting the container. Avoid using the same
+context over containers. This example will fail with canceled context error:
+```go
+var _ = Describe("test something", func(){
+	var ctx context.Context
+	
+	BeforeEach(func(gctx context.Context){
+		ctx = gctx // or something like ctx = context.WithTimeout(gctx, ...)
+	})
+	
+	It(func(){
+		kv, err = virtClient.KubeVirt(kvName).Update(ctx, kv, metav1.UpdateOptions{}) // <= will fail here
+		...
+	})
+})
+```
+
+#### Bad Example
+```go
+It("should test something", func(){
+	...
+	kv, err = virtClient.KubeVirt(kvName).Update(context.Backgound(), kv, metav1.UpdateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	...
+})
+
+```
+
+See also in [kubernetes code standards](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md#interrupting-tests)
 # Additional conventions (for scripts, etc.)
 
 - Avoid relying on Docker Hub.


### PR DESCRIPTION
Update the coding conventions with the right way of using context with ginkgo.

See also #12140

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

