### PR TITLE
mem-hotplug: fix flaky test and small issues

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3294,6 +3294,11 @@ func (c *VMController) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi
 		return nil
 	}
 
+	if !vmi.IsMigratable() {
+		setRestartRequired(vm, "memory updated in template spec. Memory-hotplug is only available for migratable VMs")
+		return nil
+	}
+
 	if vmi.Spec.Domain.Memory.MaxGuest == nil {
 		setRestartRequired(vm, "memory updated in template spec. Memory-hotplug is not available for this VM configuration")
 		return nil

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -6015,6 +6015,44 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(cond).To(Not(BeNil()))
 					Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 						"Type":    Equal(v1.VirtualMachineRestartRequired),
+						"Message": ContainSubstring("memory updated in template spec. Memory-hotplug failed and is not available for this VM configuration"),
+						"Status":  Equal(k8sv1.ConditionTrue),
+					}))
+				})
+
+				It("should set a restartRequired condition if memory hotplug is incompatible with the VM configuration", func() {
+					guestMemory := resource.MustParse("64Mi")
+					newMemory := resource.MustParse("128Mi")
+					vm, _ := DefaultVirtualMachine(true)
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &newMemory}
+					vm.Spec.Template.Spec.Architecture = "risc-v"
+
+					vmi := api.NewMinimalVMI(vm.Name)
+					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory, MaxGuest: nil}
+					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = guestMemory
+					vmi.Status.Memory = &v1.MemoryStatus{
+						GuestAtBoot:  &guestMemory,
+						GuestCurrent: &guestMemory,
+					}
+
+					err := controller.handleMemoryHotplugRequest(vm, vmi)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(virtFakeClient.Actions()).To(WithTransform(func(actions []testing.Action) []testing.Action {
+						var patchActions []testing.Action
+						for _, action := range actions {
+							if action.GetVerb() == "patch" && action.GetResource().Resource == "virtualmachineinstances" {
+								patchActions = append(patchActions, action)
+							}
+						}
+						return patchActions
+					}, BeEmpty()))
+
+					vmCondManager := virtcontroller.NewVirtualMachineConditionManager()
+					cond := vmCondManager.GetCondition(vm, v1.VirtualMachineRestartRequired)
+					Expect(cond).To(Not(BeNil()))
+					Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Type":    Equal(v1.VirtualMachineRestartRequired),
 						"Message": ContainSubstring("memory updated in template spec. Memory-hotplug is not available for this VM configuration"),
 						"Status":  Equal(k8sv1.ConditionTrue),
 					}))

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -287,6 +287,24 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			_, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchBytes, k8smetav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
+			By("Waiting for HotMemoryChange condition to appear")
+			Eventually(ThisVMI(vmi), 1*time.Minute, 2*time.Second).Should(HaveConditionTrue(v1.VirtualMachineInstanceMemoryChange))
+
+			By("Ensuring live-migration started")
+			var migration *v1.VirtualMachineInstanceMigration
+			Eventually(func() bool {
+				migrations, err := virtClient.VirtualMachineInstanceMigration(vm.Namespace).List(context.Background(), k8smetav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, mig := range migrations.Items {
+					if mig.Spec.VMIName == vmi.Name {
+						migration = mig.DeepCopy()
+						return true
+					}
+				}
+				return false
+			}, 30*time.Second, time.Second).Should(BeTrue())
+			libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration)
+
 			By("Ensuring the libvirt domain has more available guest memory")
 			Eventually(func() int64 {
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, k8smetav1.GetOptions{})
@@ -337,6 +355,24 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 
 				vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchBytes, k8smetav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for HotMemoryChange condition to appear")
+				Eventually(ThisVMI(vmi), 1*time.Minute, 2*time.Second).Should(HaveConditionTrue(v1.VirtualMachineInstanceMemoryChange))
+
+				By("Ensuring live-migration started")
+				var migration *v1.VirtualMachineInstanceMigration
+				Eventually(func() bool {
+					migrations, err := virtClient.VirtualMachineInstanceMigration(vm.Namespace).List(context.Background(), k8smetav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for _, mig := range migrations.Items {
+						if mig.Spec.VMIName == vmi.Name {
+							migration = mig.DeepCopy()
+							return true
+						}
+					}
+					return false
+				}, 30*time.Second, time.Second).Should(BeTrue())
+				libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration)
 
 				By("Ensuring the libvirt domain has more available guest memory")
 				Eventually(func() int64 {


### PR DESCRIPTION
This test proved to be a bit flaky
https://search.ci.kubevirt.io/?search=Memory+Hotplug+A+VM+with+memory+liveUpdate+enabled+should+successfully+hotplug+memory+twice&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job.

This makes sure we wait for the migration to have succeeded before inspecting the domain XML, otherwise the domain might not be running yet.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

