### PR TITLE
[release-1.2] Manual backport of implement retries in export server

### DIFF
--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/virt-controller/watch/util:go_default_library",
         "//pkg/virt-operator/resource/apply:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
+        "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -922,6 +922,8 @@ var _ = Describe("Export controller", func() {
 		Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().MilliValue()).To(Equal(int64(1000)))
 		Expect(pod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
 		Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1073741824)))
+		Expect(pod.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
+		Expect(pod.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Path).To(Equal(ReadinessPath))
 	},
 		Entry("PVC", createPVCVMExport, 3),
 		Entry("VM", populateVmExportVM, 4),

--- a/pkg/storage/export/virt-exportserver/BUILD.bazel
+++ b/pkg/storage/export/virt-exportserver/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/service:go_default_library",
+        "//pkg/storage/export/export:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -517,7 +517,7 @@ func checkDirectoryPermissions(filePath string) bool {
 		// Check if export server has permissions to manipulate the file
 		file, err := os.Open(itemPath)
 		if err != nil {
-			log.Log.Reason(err).Errorf("unable to open %s, file may lack read permissions", itemPath)
+			log.Log.Reason(err).Errorf("%s may lack read permissions", itemPath)
 			return false
 		}
 		file.Close()

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -475,6 +475,11 @@ func archiveHandler(mountPoint string) http.Handler {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
+		if hasPermissions := checkDirectoryPermissions(mountPoint); !hasPermissions {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
 		tarReader, err := newTarReader(mountPoint)
 		if err != nil {
 			log.Log.Reason(err).Error("error creating tar reader")
@@ -492,6 +497,34 @@ func archiveHandler(mountPoint string) http.Handler {
 	})
 }
 
+func checkDirectoryPermissions(filePath string) bool {
+	dir, err := os.Open(filePath)
+	if err != nil {
+		log.Log.Reason(err).Errorf("error opening %s", filePath)
+		return false
+	}
+	defer dir.Close()
+
+	// Read all filenames
+	contents, err := dir.Readdirnames(-1)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to read directory contents: %v", err)
+		return false
+	}
+
+	for _, item := range contents {
+		itemPath := filepath.Join(filePath, item)
+		// Check if export server has permissions to manipulate the file
+		file, err := os.Open(itemPath)
+		if err != nil {
+			log.Log.Reason(err).Errorf("unable to open %s, file may lack read permissions", itemPath)
+			return false
+		}
+		file.Close()
+	}
+	return true
+}
+
 func gzipHandler(filePath string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet {
@@ -501,7 +534,7 @@ func gzipHandler(filePath string) http.Handler {
 		f, err := os.Open(filePath)
 		if err != nil {
 			log.Log.Reason(err).Errorf("error opening %s", filePath)
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 		defer f.Close()

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -476,7 +476,7 @@ func archiveHandler(mountPoint string) http.Handler {
 			return
 		}
 		if hasPermissions := checkDirectoryPermissions(mountPoint); !hasPermissions {
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
@@ -534,7 +534,7 @@ func gzipHandler(filePath string) http.Handler {
 		f, err := os.Open(filePath)
 		if err != nil {
 			log.Log.Reason(err).Errorf("error opening %s", filePath)
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		defer f.Close()

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -29,6 +29,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"io"
+	golog "log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -129,6 +130,9 @@ func (er *execReader) Close() error {
 func (s *exportServer) initHandler() {
 	mux := http.NewServeMux()
 	for i, vi := range s.Volumes {
+		if hasPermissions := checkVolumePermissions(vi.Path); !hasPermissions {
+			golog.Fatalf("unable to manipulate %s's contents, exiting", vi.Path)
+		}
 		for path, handler := range s.getHandlerMap(vi) {
 			log.Log.Infof("Handling path %s\n", path)
 			mux.Handle(path, tokenChecker(s.TokenGetter, handler))
@@ -523,6 +527,24 @@ func checkDirectoryPermissions(filePath string) bool {
 		file.Close()
 	}
 	return true
+}
+
+func checkVolumePermissions(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		log.Log.Reason(err).Errorf("error statting %s", path)
+		return false
+	}
+	if !fi.IsDir() {
+		f, err := os.Open(path)
+		if err != nil {
+			log.Log.Reason(err).Errorf("error opening %s", path)
+			return false
+		}
+		f.Close()
+		return true
+	}
+	return checkDirectoryPermissions(path)
 }
 
 func gzipHandler(filePath string) http.Handler {

--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -338,6 +338,9 @@ func downloadMemoryDump(namespace, vmName string, virtClient kubecli.KubevirtCli
 		ExportSource: exportSource,
 		PortForward:  portForward,
 		LocalPort:    localPort,
+		// Using 2 as retry count to help mitigate a bug that might happen when creating the
+		// exporter pod just after the hotplug pod is deleted: https://issues.redhat.com/browse/CNV-39141
+		DownloadRetries: 2,
 	}
 
 	if portForward {

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -243,7 +243,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err.Error()).Should(ContainSubstring(expectedError))
 		})
 
-		It("VirtualMachineExport download fails if the server returns a bad status", func() {
+		It("VirtualMachineExport retries until failure if the server returns a bad status", func() {
 			testInit(http.StatusInternalServerError)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
@@ -258,7 +258,7 @@ var _ = Describe("vmexport", func() {
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(Equal("bad status: 500 Internal Server Error"))
+			Expect(err.Error()).Should(Equal("retry count reached, exiting unsuccesfully"))
 		})
 
 		It("Bad flag combination", func() {

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -56,6 +56,10 @@ var _ = Describe("vmexport", func() {
 
 	})
 
+	defaultHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
 	setflag := func(flag, parameter string) string {
 		return fmt.Sprintf("%s=%s", flag, parameter)
 	}
@@ -79,16 +83,14 @@ var _ = Describe("vmexport", func() {
 		})
 	}
 
-	testInit := func(statusCode int) {
+	testInit := func(handlerFunc func(w http.ResponseWriter, r *http.Request)) {
 		kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().StorageV1().Return(kubeClient.StorageV1()).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineExport(metav1.NamespaceDefault).Return(vmExportClient.ExportV1alpha1().VirtualMachineExports(metav1.NamespaceDefault)).AnyTimes()
 
 		addDefaultReactors()
 
-		server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(statusCode)
-		}))
+		server = httptest.NewTLSServer(http.HandlerFunc(handlerFunc))
 
 		virtctlvmexport.ExportProcessingComplete = utils.WaitExportCompleteDefault
 		virtctlvmexport.SetHTTPClientCreator(func(*http.Transport, bool) *http.Client {
@@ -109,7 +111,7 @@ var _ = Describe("vmexport", func() {
 
 	Context("VMExport fails", func() {
 		It("VirtualMachineExport already exists when using 'create'", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			utils.HandleVMExportGet(vmExportClient, vmexport, vmexportName)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"))
@@ -119,7 +121,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport doesn't exist when using 'download' without source type", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.OUTPUT_FLAG, "output.img"))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
@@ -127,7 +129,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport processing fails when using 'download'", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			virtctlvmexport.ExportProcessingComplete = utils.WaitExportCompleteError
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"), setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
@@ -136,7 +138,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when there's no volume available", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus(nil, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
@@ -149,7 +151,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when the volumes have a different name than expected", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -171,7 +173,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when there are multiple volumes and no volume name has been specified", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -193,7 +195,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when no format is available", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{{Name: volumeName}}, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
@@ -206,7 +208,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when the only available format is incompatible with download", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -224,7 +226,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download fails when the secret token is not attainable", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -244,7 +246,9 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport retries until failure if the server returns a bad status", func() {
-			testInit(http.StatusInternalServerError)
+			testInit(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			})
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -255,14 +259,39 @@ var _ = Describe("vmexport", func() {
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 			utils.HandleSecretGet(kubeClient, secretName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.RETRY_FLAG, "2"))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal("retry count reached, exiting unsuccesfully"))
 		})
 
+		It("VirtualMachineExport succeeds after retrying due to bad status", func() {
+			count := 0
+			testInit(func(w http.ResponseWriter, r *http.Request) {
+				if count == 0 {
+					w.WriteHeader(http.StatusInternalServerError)
+				} else {
+					w.WriteHeader(http.StatusOK)
+				}
+				count++
+			})
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
+			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
+				{
+					Name:    volumeName,
+					Formats: utils.GetExportVolumeFormat(server.URL, exportv1.KubeVirtRaw),
+				},
+			}, secretName)
+			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
+			utils.HandleSecretGet(kubeClient, secretName)
+
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.RETRY_FLAG, "2"))
+			err := cmd()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("Bad flag combination", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			args := []string{virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), setflag(virtctlvmexport.VM_FLAG, "test2"), setflag(virtctlvmexport.SNAPSHOT_FLAG, "test3")}
 			args = append([]string{commandName}, args...)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
@@ -272,7 +301,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		DescribeTable("Invalid arguments/flags", func(errString string, args ...string) {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			args = append([]string{commandName}, args...)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
 			err := cmd()
@@ -302,7 +331,7 @@ var _ = Describe("vmexport", func() {
 
 	Context("VMExport succeeds", func() {
 		BeforeEach(func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 		})
 
 		// Create tests
@@ -322,7 +351,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport doesn't exist when using 'delete'", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DELETE, vmexportName)
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
@@ -430,7 +459,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download succeeds when the volume has a different name than expected but there's only one volume", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -447,7 +476,7 @@ var _ = Describe("vmexport", func() {
 		})
 
 		It("VirtualMachineExport download succeeds when there's only one volume and no --volume has been specified", func() {
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
@@ -570,7 +599,7 @@ var _ = Describe("vmexport", func() {
 
 		BeforeEach(func() {
 			orgHttpFunc = virtctlvmexport.HandleHTTPRequest
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 		})
 
 		AfterEach(func() {
@@ -718,7 +747,7 @@ var _ = Describe("vmexport", func() {
 
 		BeforeEach(func() {
 			orgHttpFunc = virtctlvmexport.HandleHTTPRequest
-			testInit(http.StatusOK)
+			testInit(defaultHandler)
 			vme = utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/11911.

Couldn't create an automatic cherry-pick since I had to address some conflicts with older vmexport flags.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-43123

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Implement retry mechanism in export server and vmexport
```

