### PR TITLE
[release-1.2] controller: Setup CurrentCPUTopology after applying instance types

### DIFF
--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -2563,16 +2563,19 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should have stable firmware UUIDs", func() {
 			vm1, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
-			vmi1 := controller.setupVMIFromVM(vm1)
+			vmi1, err := controller.setupVMIFromVM(vm1)
+			Expect(err).ToNot(HaveOccurred())
 
 			// intentionally use the same names
 			vm2, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
-			vmi2 := controller.setupVMIFromVM(vm2)
+			vmi2, err := controller.setupVMIFromVM(vm2)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(vmi1.Spec.Domain.Firmware.UUID).To(Equal(vmi2.Spec.Domain.Firmware.UUID))
 
 			// now we want different names
 			vm3, _ := DefaultVirtualMachineWithNames(true, "testvm3", "testvmi3")
-			vmi3 := controller.setupVMIFromVM(vm3)
+			vmi3, err := controller.setupVMIFromVM(vm3)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi3.Spec.Domain.Firmware.UUID))
 		})
 
@@ -2581,7 +2584,8 @@ var _ = Describe("VirtualMachine", func() {
 			vm1, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
 			vm1.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{UUID: types.UID(uid)}
 
-			vmi1 := controller.setupVMIFromVM(vm1)
+			vmi1, err := controller.setupVMIFromVM(vm1)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(string(vmi1.Spec.Domain.Firmware.UUID)).To(Equal(uid))
 		})
 
@@ -3494,7 +3498,8 @@ var _ = Describe("VirtualMachine", func() {
 					Phase:     phase,
 				}
 
-				vmi := controller.setupVMIFromVM(vm)
+				vmi, err := controller.setupVMIFromVM(vm)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.Spec.Volumes).To(BeEmpty())
 
 			},
@@ -5618,7 +5623,8 @@ var _ = Describe("VirtualMachine", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{MaxSockets: maxSocketsFromSpec}
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(vmi.Spec.Domain.CPU.MaxSockets).To(Equal(maxSocketsFromSpec))
 				})
 
@@ -5639,7 +5645,8 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(vmi.Spec.Domain.CPU.MaxSockets).To(Equal(maxSocketsFromSpec))
 				})
 
@@ -5659,7 +5666,8 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(vmi.Spec.Domain.CPU.MaxSockets).To(Equal(maxSocketsFromConfig))
 				})
 
@@ -5681,7 +5689,8 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(vmi.Spec.Domain.CPU.MaxSockets).To(Equal(cpuSockets * 4))
 				})
 
@@ -5700,7 +5709,8 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(vmi.Spec.Domain.CPU.MaxSockets).To(Equal(defaultSockets * 4))
 				})
 
@@ -5826,7 +5836,8 @@ var _ = Describe("VirtualMachine", func() {
 						MaxGuest: &maxGuestFromSpec,
 					}
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(*vmi.Spec.Domain.Memory.MaxGuest).To(Equal(maxGuestFromSpec))
 				})
 
@@ -5851,7 +5862,8 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(*vmi.Spec.Domain.Memory.MaxGuest).To(Equal(maxGuestFromSpec))
 				})
 
@@ -5875,7 +5887,8 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(*vmi.Spec.Domain.Memory.MaxGuest).To(Equal(maxGuestFromConfig))
 				})
 
@@ -5896,7 +5909,8 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(vmi.Spec.Domain.Memory.MaxGuest.Value()).To(Equal(guestMemory.Value() * int64(config.GetMaxHotplugRatio())))
 				})
 
@@ -6050,7 +6064,8 @@ var _ = Describe("VirtualMachine", func() {
 					vm.Spec.Template.Spec.Domain = v1.DomainSpec{}
 
 					setupVM(&vm.Spec.Template.Spec)
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(vmi.Spec.Domain.Memory.Guest).ToNot(BeNil())
 					Expect(vmi.Spec.Domain.Memory.Guest.String()).To(Equal("1Gi"))
@@ -6127,7 +6142,8 @@ var _ = Describe("VirtualMachine", func() {
 
 					vmSetup(&vm.Spec.Template.Spec)
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(vmi.Spec.Domain.Memory.MaxGuest).To(BeNil())
 				},
@@ -6344,6 +6360,51 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					),
 				)
+
+				It("setupVMIFromVM should handle vm.spec.template.spec.domain.memory being nil and populate MaxGuest", func() {
+					fakeInstancetypeClients := fake.NewSimpleClientset().InstancetypeV1beta1()
+					fakeInstancetypeClient := fakeInstancetypeClients.VirtualMachineInstancetypes(metav1.NamespaceDefault)
+					virtClient.EXPECT().VirtualMachineInstancetype(gomock.Any()).Return(fakeInstancetypeClient).AnyTimes()
+
+					controller.instancetypeMethods = &instancetype.InstancetypeMethods{
+						Clientset: virtClient,
+					}
+
+					vm, _ := DefaultVirtualMachine(true)
+					vm.Spec.Template.Spec.Architecture = "amd64"
+					vm.Spec.Template.Spec.Domain.CPU = nil
+					vm.Spec.Template.Spec.Domain.Memory = nil
+					vm.Spec.Template.Spec.Domain.Resources = v1.ResourceRequirements{}
+
+					instancetypeMemoryGuest := resource.MustParse("128Mi")
+					instancetype := &instancetypev1beta1.VirtualMachineInstancetype{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "instancetype",
+						},
+						Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
+							CPU: instancetypev1beta1.CPUInstancetype{
+								Guest: 1,
+							},
+							Memory: instancetypev1beta1.MemoryInstancetype{
+								Guest: instancetypeMemoryGuest,
+							},
+						},
+					}
+					instancetype, err := virtClient.VirtualMachineInstancetype(vm.Namespace).Create(context.TODO(), instancetype, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					vm.Spec.Instancetype = &v1.InstancetypeMatcher{
+						Name: instancetype.Name,
+						Kind: instancetypeapi.SingularResourceName,
+					}
+
+					vmi, err := controller.setupVMIFromVM(vm)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.Spec.Domain.Memory).ToNot(BeNil())
+					Expect(vmi.Spec.Domain.Memory.Guest).ToNot(BeNil())
+					Expect(vmi.Spec.Domain.Memory.Guest.Value()).To(Equal(instancetypeMemoryGuest.Value()))
+					Expect(vmi.Spec.Domain.Memory.MaxGuest).ToNot(BeNil())
+					Expect(vmi.Spec.Domain.Memory.MaxGuest.Value()).To(Equal(instancetypeMemoryGuest.Value() * int64(controller.clusterConfig.GetMaxHotplugRatio())))
+				})
 			})
 		})
 
@@ -6543,13 +6604,14 @@ var _ = Describe("VirtualMachine", func() {
 				crSource.Add(createVMRevision(vm))
 
 				By("Creating a VMI with cluster max")
-				vmi = controller.setupVMIFromVM(vm)
+				vmi, err := controller.setupVMIFromVM(vm)
+				Expect(err).ToNot(HaveOccurred())
 				vmiSource.Add(vmi)
 				syncCache(controller.vmiInformer.GetIndexer(), 1)
 
 				By("Bumping the VM sockets above the cluster maximum")
 				vm.Spec.Template.Spec.Domain.CPU.Sockets = 10
-				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
 				addVirtualMachine(vm)
 
@@ -6575,7 +6637,8 @@ var _ = Describe("VirtualMachine", func() {
 
 				By("Creating a VMI with hostname 'a'")
 				vm.Spec.Template.Spec.Hostname = "a"
-				vmi = controller.setupVMIFromVM(vm)
+				vmi, err := controller.setupVMIFromVM(vm)
+				Expect(err).ToNot(HaveOccurred())
 				vmiSource.Add(vmi)
 				syncCache(controller.vmiInformer.GetIndexer(), 1)
 
@@ -6608,7 +6671,8 @@ var _ = Describe("VirtualMachine", func() {
 				crSource.Add(createVMRevision(vm))
 
 				By("Creating a VMI with cluster max")
-				vmi = controller.setupVMIFromVM(vm)
+				vmi, err := controller.setupVMIFromVM(vm)
+				Expect(err).ToNot(HaveOccurred())
 				vmiSource.Add(vmi)
 				syncCache(controller.vmiInformer.GetIndexer(), 1)
 
@@ -6638,7 +6702,8 @@ var _ = Describe("VirtualMachine", func() {
 				syncCache(controller.crInformer.GetIndexer(), 1)
 
 				By("Creating a VMI")
-				vmi = controller.setupVMIFromVM(vm)
+				vmi, err := controller.setupVMIFromVM(vm)
+				Expect(err).ToNot(HaveOccurred())
 				markAsReady(vmi)
 				vmi.Status.Memory = &v1.MemoryStatus{
 					GuestAtBoot:  &maxGuest,
@@ -6666,7 +6731,8 @@ var _ = Describe("VirtualMachine", func() {
 				By("Creating a VM with two sockets")
 				vm.Spec.Template.Spec.Domain.CPU.Sockets = 2
 
-				vmi = controller.setupVMIFromVM(vm)
+				vmi, err := controller.setupVMIFromVM(vm)
+				Expect(err).ToNot(HaveOccurred())
 				vmiSource.Add(vmi)
 				syncCache(controller.vmiInformer.GetIndexer(), 1)
 
@@ -6707,9 +6773,10 @@ var _ = Describe("VirtualMachine", func() {
 				syncCache(controller.crInformer.GetIndexer(), 1)
 
 				By("Creating a VMI")
-				vmi = controller.setupVMIFromVM(vm)
+				vmi, err := controller.setupVMIFromVM(vm)
+				Expect(err).ToNot(HaveOccurred())
 				markAsReady(vmi)
-				vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				vmiSource.Add(vmi)
 				syncCache(controller.vmiInformer.GetIndexer(), 1)


### PR DESCRIPTION
### What this PR does

As set out in https://github.com/kubevirt/kubevirt/issues/12158 CurrentCPUTopology was previously being defined
before instance types were applied to the VMI. As a result the default
values for sockets, cores and threads of 1 would be used and could end
up with the HotVCPUChange condition later being applied if LiveUpdates
are enabled.

This change resolves this issue by breaking out the setup of
CurrentCPUTopology into a standalone function that is called once
instance types have been applied to the VMI.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12158

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This fix is based on https://github.com/kubevirt/kubevirt/pull/12152

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

