### PR TITLE
[release-0.59] Manual backport of implement retries in export server

### DIFF
--- a/cmd/virt-exportserver/BUILD.bazel
+++ b/cmd/virt-exportserver/BUILD.bazel
@@ -31,10 +31,10 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 passwd_entry(
     name = "nonroot-user",
-    gid = 1001,
+    gid = 107,
     home = "/home/nonroot-user",
     shell = "/bin/bash",
-    uid = 1001,
+    uid = 107,
     username = "nonroot-user",
 )
 

--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/virt-controller/watch/util:go_default_library",
         "//pkg/virt-operator/resource/apply:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
+        "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -63,6 +63,7 @@ import (
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/apply"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+	optutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
 
 const (
@@ -125,6 +126,9 @@ const (
 	internalHostKey        = "internal_host"
 	externalCaConfigMapKey = "external_ca_cm"
 	internalCaConfigMapKey = "internal_ca_cm"
+
+	// ReadinessPath is the endpoint used to check the readiness probe
+	ReadinessPath = "/exportready"
 )
 
 // variable so can be overridden in tests
@@ -920,6 +924,21 @@ func (ctrl *VMExportController) createExporterPodManifest(vmExport *exportv1.Vir
 		MountPath: "/token",
 	})
 
+	podManifest.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Scheme: corev1.URISchemeHTTPS,
+				Path:   ReadinessPath,
+				Port: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8443,
+				},
+			},
+		},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       5,
+	}
+
 	if vm, err := ctrl.getVmFromExport(vmExport); err != nil {
 		return nil, err
 	} else {
@@ -1125,7 +1144,7 @@ func (ctrl *VMExportController) updateCommonVMExportStatusFields(vmExport, vmExp
 		vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newReadyCondition(corev1.ConditionFalse, inUseReason, sourceVolumes.availableMessage))
 		vmExportCopy.Status.Phase = exportv1.Pending
 	} else {
-		if exporterPod.Status.Phase == corev1.PodRunning {
+		if optutil.PodIsReady(exporterPod) {
 			vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newReadyCondition(corev1.ConditionTrue, podReadyReason, ""))
 			vmExportCopy.Status.Phase = exportv1.Ready
 			vmExportCopy.Status.Links.Internal, err = ctrl.getInteralLinks(sourceVolumes.volumes, exporterPod, service, getVolumeName, vmExport)

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -913,6 +913,8 @@ var _ = Describe("Export controller", func() {
 		Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().Value()).To(Equal(int64(1)))
 		Expect(pod.Spec.Containers[0].Resources.Limits.Memory()).ToNot(BeNil())
 		Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(Equal(int64(1024 * 1024 * 1024)))
+		Expect(pod.Spec.Containers[0].ReadinessProbe).ToNot(BeNil())
+		Expect(pod.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Path).To(Equal(ReadinessPath))
 	},
 		Entry("PVC", createPVCVMExport, 3),
 		Entry("VM", populateVmExportVM, 4),

--- a/pkg/storage/export/virt-exportserver/BUILD.bazel
+++ b/pkg/storage/export/virt-exportserver/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/service:go_default_library",
+        "//pkg/storage/export/export:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -28,6 +28,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"io"
+	golog "log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -128,6 +129,9 @@ func (er *execReader) Close() error {
 func (s *exportServer) initHandler() {
 	mux := http.NewServeMux()
 	for i, vi := range s.Volumes {
+		if hasPermissions := checkVolumePermissions(vi.Path); !hasPermissions {
+			golog.Fatalf("unable to manipulate %s's contents, exiting", vi.Path)
+		}
 		for path, handler := range s.getHandlerMap(vi) {
 			log.Log.Infof("Handling path %s\n", path)
 			mux.Handle(path, tokenChecker(s.TokenGetter, handler))
@@ -472,7 +476,7 @@ func archiveHandler(mountPoint string) http.Handler {
 			return
 		}
 		if hasPermissions := checkDirectoryPermissions(mountPoint); !hasPermissions {
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
@@ -521,6 +525,24 @@ func checkDirectoryPermissions(filePath string) bool {
 	return true
 }
 
+func checkVolumePermissions(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		log.Log.Reason(err).Errorf("error statting %s", path)
+		return false
+	}
+	if !fi.IsDir() {
+		f, err := os.Open(path)
+		if err != nil {
+			log.Log.Reason(err).Errorf("error opening %s", path)
+			return false
+		}
+		f.Close()
+		return true
+	}
+	return checkDirectoryPermissions(path)
+}
+
 func gzipHandler(filePath string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet {
@@ -530,7 +552,7 @@ func gzipHandler(filePath string) http.Handler {
 		f, err := os.Open(filePath)
 		if err != nil {
 			log.Log.Reason(err).Errorf("error opening %s", filePath)
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		defer f.Close()

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -50,6 +50,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/service"
+	"kubevirt.io/kubevirt/pkg/storage/export/export"
 )
 
 const (
@@ -149,6 +150,8 @@ func (s *exportServer) initHandler() {
 			}
 		}
 	}
+	// Readiness probe
+	mux.HandleFunc(export.ReadinessPath, s.readyHandler)
 
 	s.handler = mux
 }
@@ -531,16 +534,16 @@ func checkVolumePermissions(path string) bool {
 		log.Log.Reason(err).Errorf("error statting %s", path)
 		return false
 	}
-	if !fi.IsDir() {
-		f, err := os.Open(path)
-		if err != nil {
-			log.Log.Reason(err).Errorf("error opening %s", path)
-			return false
-		}
-		f.Close()
-		return true
+	if fi.IsDir() {
+		return checkDirectoryPermissions(path)
 	}
-	return checkDirectoryPermissions(path)
+	f, err := os.Open(path)
+	if err != nil {
+		log.Log.Reason(err).Errorf("error opening %s", path)
+		return false
+	}
+	f.Close()
+	return true
 }
 
 func gzipHandler(filePath string) http.Handler {
@@ -766,4 +769,8 @@ func secretHandler(tokenGetter TokenGetterFunc) http.Handler {
 		}
 		log.Log.Infof("Wrote %d bytes\n", n)
 	})
+}
+
+func (s *exportServer) readyHandler(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, "OK")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/11911.

The vmexport integration has been removed from this backport since it's just an additional flag that helps mitigate transient server errors. This backport only covers the readiness probe and retry mechanism in export server.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-43126

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Implement retry mechanism in export server
```

