### PR TITLE
Report global metrics only by leader pods

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "component_metrics.go",
+        "leader_metrics.go",
         "metrics.go",
         "migration_metrics.go",
         "migrationstats_collector.go",

--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -88,6 +88,14 @@ func SetupMetrics(
 	)
 }
 
+func RegisterLeaderMetrics() error {
+	if err := operatormetrics.RegisterMetrics(leaderMetrics); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func UpdateVMIMigrationInformer(informer cache.SharedIndexInformer) {
 	vmiMigrationInformer = informer
 }

--- a/pkg/monitoring/metrics/virt-operator/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-operator/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "configuration_metrics.go",
+        "leader_metrics.go",
         "metrics.go",
         "operator_metrics.go",
     ],

--- a/pkg/monitoring/metrics/virt-operator/leader_metrics.go
+++ b/pkg/monitoring/metrics/virt-operator/leader_metrics.go
@@ -22,7 +22,7 @@ package virt_operator
 import "github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 
 var (
-	configurationMetrics = []operatormetrics.Metric{
+	leaderMetrics = []operatormetrics.Metric{
 		emulationEnabled,
 	}
 

--- a/pkg/monitoring/metrics/virt-operator/metrics.go
+++ b/pkg/monitoring/metrics/virt-operator/metrics.go
@@ -36,9 +36,16 @@ func SetupMetrics() error {
 	}
 
 	return operatormetrics.RegisterMetrics(
-		configurationMetrics,
 		operatorMetrics,
 	)
+}
+
+func RegisterLeaderMetrics() error {
+	if err := operatormetrics.RegisterMetrics(leaderMetrics); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ListMetrics() []operatormetrics.Metric {

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -528,6 +528,10 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 			vca.vmControllerThreads, vca.migrationControllerThreads, vca.evacuationControllerThreads,
 			vca.disruptionBudgetControllerThreads)
 
+		if err := metrics.RegisterLeaderMetrics(); err != nil {
+			golog.Fatalf("failed to register leader metrics: %v", err)
+		}
+
 		if err := metrics.AddVMIPhaseTransitionHandlers(vca.vmiInformer); err != nil {
 			golog.Fatalf("failed to add vmi phase transition handler: %v", err)
 		}

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Workload Updater", func() {
 
 		expectedImage = "cur-image"
 
-		err := metrics.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil)
+		err := metrics.RegisterLeaderMetrics()
 		Expect(err).ToNot(HaveOccurred())
 		metrics.SetOutdatedVirtualMachineInstanceWorkloads(0)
 

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -439,6 +439,9 @@ func (app *VirtOperatorApp) Run() {
 			RetryPeriod:   app.LeaderElection.RetryPeriod.Duration,
 			Callbacks: leaderelection.LeaderCallbacks{
 				OnStartedLeading: func(ctx context.Context) {
+					if err := metrics.RegisterLeaderMetrics(); err != nil {
+						golog.Fatalf("failed to register leader metrics: %v", err)
+					}
 					metrics.SetLeader(true)
 					log.Log.Infof("Started leading")
 

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -82,10 +82,16 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			err := virtoperator.SetupMetrics()
 			Expect(err).ToNot(HaveOccurred())
 
+			err = virtoperator.RegisterLeaderMetrics()
+			Expect(err).ToNot(HaveOccurred())
+
 			err = virtapi.SetupMetrics()
 			Expect(err).ToNot(HaveOccurred())
 
 			err = virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = virtcontroller.RegisterLeaderMetrics()
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, metric := range operatormetrics.ListMetrics() {

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -45,11 +45,19 @@ func main() {
 		panic(err)
 	}
 
+	if err := virtcontroller.RegisterLeaderMetrics(); err != nil {
+		panic(err)
+	}
+
 	if err := virtapi.SetupMetrics(); err != nil {
 		panic(err)
 	}
 
 	if err := virtoperator.SetupMetrics(); err != nil {
+		panic(err)
+	}
+
+	if err := virtoperator.RegisterLeaderMetrics(); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Global metrics were reported more than once, per virt-controller/virt-operator pod.
After this PR:
Global metrics are reported only by the virt-controller/virt-operator leader pods.

Affected metrics:
- kubevirt_vmi_number_of_outdated
- kubevirt_configuration_emulation_enabled


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-42007


<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
None
```

