### PR TITLE
preference: Only apply PreferredDiskDedicatedIoThread to virtio disks

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18823,7 +18823,7 @@
       "type": "string"
      },
      "preferredDiskDedicatedIoThread": {
-      "description": "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices.",
+      "description": "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices using the virtio bus.",
       "type": "boolean"
      },
      "preferredDiskIO": {

--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -1361,7 +1361,7 @@ func applyDiskPreferences(preferenceSpec *instancetypev1beta1.VirtualMachinePref
 				vmiDisk.IO = preferenceSpec.Devices.PreferredDiskIO
 			}
 
-			if preferenceSpec.Devices.PreferredDiskDedicatedIoThread != nil && vmiDisk.DedicatedIOThread == nil {
+			if preferenceSpec.Devices.PreferredDiskDedicatedIoThread != nil && vmiDisk.DedicatedIOThread == nil && vmiDisk.DiskDevice.Disk.Bus == virtv1.DiskBusVirtio {
 				vmiDisk.DedicatedIOThread = ptr.To(*preferenceSpec.Devices.PreferredDiskDedicatedIoThread)
 			}
 		} else if vmiDisk.DiskDevice.CDRom != nil {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -9069,7 +9069,7 @@ var CRDsValidation map[string]string = map[string]string{
               type: string
             preferredDiskDedicatedIoThread:
               description: PreferredDedicatedIoThread optionally enables dedicated
-                IO threads for Disk devices.
+                IO threads for Disk devices using the virtio bus.
               type: boolean
             preferredDiskIO:
               description: PreferredIo optionally defines the QEMU disk IO mode to
@@ -23406,7 +23406,7 @@ var CRDsValidation map[string]string = map[string]string{
               type: string
             preferredDiskDedicatedIoThread:
               description: PreferredDedicatedIoThread optionally enables dedicated
-                IO threads for Disk devices.
+                IO threads for Disk devices using the virtio bus.
               type: boolean
             preferredDiskIO:
               description: PreferredIo optionally defines the QEMU disk IO mode to

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -454,7 +454,7 @@ type DevicePreferences struct {
 	// +optional
 	PreferredCdromBus v1.DiskBus `json:"preferredCdromBus,omitempty"`
 
-	// PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices.
+	// PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices using the virtio bus.
 	//
 	// +optional
 	PreferredDiskDedicatedIoThread *bool `json:"preferredDiskDedicatedIoThread,omitempty"`

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -151,7 +151,7 @@ func (DevicePreferences) SwaggerDoc() map[string]string {
 		"preferredDiskBus":                    "PreferredDiskBus optionally defines the preferred bus for Disk Disk devices.\n\n+optional",
 		"preferredLunBus":                     "PreferredLunBus optionally defines the preferred bus for Lun Disk devices.\n\n+optional",
 		"preferredCdromBus":                   "PreferredCdromBus optionally defines the preferred bus for Cdrom Disk devices.\n\n+optional",
-		"preferredDiskDedicatedIoThread":      "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices.\n\n+optional",
+		"preferredDiskDedicatedIoThread":      "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices using the virtio bus.\n\n+optional",
 		"preferredDiskCache":                  "PreferredCache optionally defines the DriverCache to be used by Disk devices.\n\n+optional",
 		"preferredDiskIO":                     "PreferredIo optionally defines the QEMU disk IO mode to be used by Disk devices.\n\n+optional",
 		"preferredDiskBlockSize":              "PreferredBlockSize optionally defines the block size of Disk devices.\n\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -30020,7 +30020,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_DevicePreferences(ref common.Ref
 					},
 					"preferredDiskDedicatedIoThread": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices.",
+							Description: "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices using the virtio bus.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
/cc @alromeros
/cc @alicefr

### What this PR does

54ae532f7241edf393ed79882010fe7f73af7bdf (#11219) recently started to reject requests containing all non-virtio disks with dedicatedIoThreads enabled. This expanded on the previous check on SATA disks.

This change brings the PreferredDiskDedicatedIoThread preference in line with this and ensures that we only apply the preference to virtio disks.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`PreferredDiskDedicatedIoThread` is now only applied to `virtio` disk devices
```

