### PR TITLE
[release-1.2] mem-hotplug: fix target pod requests calculation with hugepages

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -452,6 +452,10 @@ if [ -z "$KUBEVIRT_QUARANTINE" ]; then
   add_to_label_filter '(!QUARANTINE)' '&&'
 fi
 
+if [ -z "$KUBEVIRT_HUGEPAGES_2M" ]; then
+  add_to_label_filter '(!requireHugepages2Mi)' '&&'
+fi
+
 # Prepare RHEL PV for Template testing
 if [[ $TARGET =~ os-.* ]]; then
   ginko_params="$ginko_params|Networkpolicy"

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -2045,5 +2045,14 @@ func getTargetPodMemoryRequests(pod *k8sv1.Pod) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("Could not find memory request in VMI compute container")
 	}
+
+	if hugePagesReq, ok := cc.Resources.Requests[k8sv1.ResourceHugePagesPrefix+"2Mi"]; ok {
+		memReq.Add(hugePagesReq)
+	}
+
+	if hugePagesReq, ok := cc.Resources.Requests[k8sv1.ResourceHugePagesPrefix+"1Gi"]; ok {
+		memReq.Add(hugePagesReq)
+	}
+
 	return memReq.String(), nil
 }

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -544,11 +544,12 @@ var _ = Describe("Migration watcher", func() {
 		})
 
 		Context("Memory", func() {
-			It("should label VMI with target pod memory requests", func() {
-				guestMemory := resource.MustParse("128Mi")
+			DescribeTable("should label VMI with target pod memory requests", func(hugepages *virtv1.Hugepages, expectedRequests string) {
+				guestMemory := resource.MustParse("1Gi")
 				vmi.Spec.Domain = virtv1.DomainSpec{
 					Memory: &virtv1.Memory{
-						Guest: &guestMemory,
+						Guest:     &guestMemory,
+						Hugepages: hugepages,
 					},
 				}
 
@@ -570,6 +571,11 @@ var _ = Describe("Migration watcher", func() {
 					Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
 				}}
 
+				if hugepages != nil {
+					resourceName := k8sv1.ResourceName(k8sv1.ResourceHugePagesPrefix + hugepages.PageSize)
+					targetPod.Spec.Containers[0].Resources.Requests[resourceName] = guestMemory
+				}
+
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
 				addPod(targetPod)
@@ -584,8 +590,15 @@ var _ = Describe("Migration watcher", func() {
 					"MigrationUID": Equal(types.UID("testmigration")),
 				})))
 				expectVirtualMachineInstanceMigrationConfiguration(vmi.Namespace, vmi.Name, getMigrationConfig())
-				expectVirtualMachineInstanceLabels(vmi.Namespace, vmi.Name, HaveKeyWithValue(virtv1.MigrationTargetNodeNameLabel, "node01"), HaveKeyWithValue(virtv1.VirtualMachinePodMemoryRequestsLabel, "150Mi"))
-			})
+				expectVirtualMachineInstanceLabels(vmi.Namespace, vmi.Name,
+					HaveKeyWithValue(virtv1.MigrationTargetNodeNameLabel, "node01"),
+					HaveKeyWithValue(virtv1.VirtualMachinePodMemoryRequestsLabel, expectedRequests),
+				)
+			},
+				Entry("when using a common VM", nil, "150Mi"),
+				Entry("when using 2Mi Hugepages", &virtv1.Hugepages{PageSize: "2Mi"}, "1174Mi"),
+				Entry("when using 1Gi Hugepages", &virtv1.Hugepages{PageSize: "1Gi"}, "1174Mi"),
+			)
 
 			It("should mark migration as succeeded if memory hotplug failed", func() {
 				vmi.Status.Conditions = append(vmi.Status.Conditions,

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -50,6 +50,7 @@ var (
 	USB                                  = []interface{}{Label("USB")}
 	AutoResourceLimitsGate               = []interface{}{Label("AutoResourceLimitsGate")}
 	RequiresTwoWorkerNodesWithCPUManager = []interface{}{Label("requires-two-worker-nodes-with-cpu-manager")}
+	RequiresHugepages2Mi                 = []interface{}{Label("requireHugepages2Mi")}
 
 	// Storage classes
 	RequiresSnapshotStorageClass = []interface{}{Label("RequiresSnapshotStorageClass")}


### PR DESCRIPTION
Manual backport of https://github.com/kubevirt/kubevirt/pull/12168.

This fixes a bug where you cannot hotplug successfully when using hugepages due to virt-launcher being tricked into thinking that the target pod does not have enough memory to accomodate the new VMI with additional hotplugged memory.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Doing memory hotplug with hugepages gets the hotplug migration stuck indefinitely. 

After this PR:
Doing memory hotplug with hugepages works as expected.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```