### PR TITLE
[release-1.2] preference: Only apply PreferredDiskDedicatedIoThread to virtio disks

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -22843,7 +22843,7 @@
       "type": "string"
      },
      "preferredDiskDedicatedIoThread": {
-      "description": "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices.",
+      "description": "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices using the virtio bus.",
       "type": "boolean"
      },
      "preferredDiskIO": {

--- a/pkg/instancetype/BUILD.bazel
+++ b/pkg/instancetype/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",

--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -1304,7 +1304,7 @@ func applyDiskPreferences(preferenceSpec *instancetypev1beta1.VirtualMachinePref
 				vmiDisk.IO = preferenceSpec.Devices.PreferredDiskIO
 			}
 
-			if preferenceSpec.Devices.PreferredDiskDedicatedIoThread != nil && vmiDisk.DedicatedIOThread == nil {
+			if preferenceSpec.Devices.PreferredDiskDedicatedIoThread != nil && vmiDisk.DedicatedIOThread == nil && vmiDisk.DiskDevice.Disk.Bus == virtv1.DiskBusVirtio {
 				vmiDisk.DedicatedIOThread = ptr.To(*preferenceSpec.Devices.PreferredDiskDedicatedIoThread)
 			}
 		} else if vmiDisk.DiskDevice.CDRom != nil {

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -28,6 +28,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/instancetype"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -1507,10 +1508,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 				vmi.Spec.Domain.Devices.AutoattachMemBalloon = ptr.To(false)
 				vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 					{
-						Cache:             v1.CacheWriteBack,
-						IO:                v1.IONative,
-						DedicatedIOThread: ptr.To(false),
-						BlockSize:         userDefinedBlockSize,
+						Cache:     v1.CacheWriteBack,
+						IO:        v1.IONative,
+						BlockSize: userDefinedBlockSize,
 						DiskDevice: v1.DiskDevice{
 							Disk: &v1.DiskTarget{
 								Bus: v1.DiskBusSCSI,
@@ -1635,7 +1635,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(*vmi.Spec.Domain.Devices.AutoattachInputDevice).To(BeTrue())
 				Expect(vmi.Spec.Domain.Devices.Disks[0].Cache).To(Equal(v1.CacheWriteBack))
 				Expect(vmi.Spec.Domain.Devices.Disks[0].IO).To(Equal(v1.IONative))
-				Expect(*vmi.Spec.Domain.Devices.Disks[0].DedicatedIOThread).To(BeFalse())
 				Expect(*vmi.Spec.Domain.Devices.Disks[0].BlockSize).To(Equal(*userDefinedBlockSize))
 				Expect(vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus).To(Equal(v1.DiskBusSCSI))
 				Expect(vmi.Spec.Domain.Devices.Disks[2].DiskDevice.CDRom.Bus).To(Equal(v1.DiskBusSATA))
@@ -1651,7 +1650,6 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(*vmi.Spec.Domain.Devices.UseVirtioTransitional).To(Equal(*preferenceSpec.Devices.PreferredUseVirtioTransitional))
 				Expect(vmi.Spec.Domain.Devices.Disks[1].Cache).To(Equal(preferenceSpec.Devices.PreferredDiskCache))
 				Expect(vmi.Spec.Domain.Devices.Disks[1].IO).To(Equal(preferenceSpec.Devices.PreferredDiskIO))
-				Expect(*vmi.Spec.Domain.Devices.Disks[1].DedicatedIOThread).To(Equal(*preferenceSpec.Devices.PreferredDiskDedicatedIoThread))
 				Expect(*vmi.Spec.Domain.Devices.Disks[1].BlockSize).To(Equal(*preferenceSpec.Devices.PreferredDiskBlockSize))
 				Expect(vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(preferenceSpec.Devices.PreferredDiskBus))
 				Expect(vmi.Spec.Domain.Devices.Disks[3].DiskDevice.CDRom.Bus).To(Equal(preferenceSpec.Devices.PreferredCdromBus))
@@ -1683,6 +1681,43 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(diskTypeForTest))
+			})
+
+			Context("PreferredDiskDedicatedIoThread", func() {
+				DescribeTable("should be ignored when", func(preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec) {
+					Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
+					for _, disk := range vmi.Spec.Domain.Devices.Disks {
+						if disk.DiskDevice.Disk != nil {
+							Expect(disk.DedicatedIOThread).To(BeNil())
+						}
+					}
+				},
+					Entry("unset", &instancetypev1beta1.VirtualMachinePreferenceSpec{
+						Devices: &instancetypev1beta1.DevicePreferences{},
+					}),
+					Entry("false", &instancetypev1beta1.VirtualMachinePreferenceSpec{
+						Devices: &instancetypev1beta1.DevicePreferences{
+							PreferredDiskDedicatedIoThread: pointer.P(false),
+						},
+					}),
+				)
+				It("should only apply to virtio disk devices", func() {
+					preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
+						Devices: &instancetypev1beta1.DevicePreferences{
+							PreferredDiskDedicatedIoThread: pointer.P(true),
+						},
+					}
+					Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
+					for _, disk := range vmi.Spec.Domain.Devices.Disks {
+						if disk.DiskDevice.Disk != nil {
+							if disk.DiskDevice.Disk.Bus == v1.DiskBusVirtio {
+								Expect(disk.DedicatedIOThread).To(HaveValue(BeTrue()))
+							} else {
+								Expect(disk.DedicatedIOThread).To(BeNil())
+							}
+						}
+					}
+				})
 			})
 		})
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8459,7 +8459,7 @@ var CRDsValidation map[string]string = map[string]string{
               type: string
             preferredDiskDedicatedIoThread:
               description: PreferredDedicatedIoThread optionally enables dedicated
-                IO threads for Disk devices.
+                IO threads for Disk devices using the virtio bus.
               type: boolean
             preferredDiskIO:
               description: PreferredIo optionally defines the QEMU disk IO mode to
@@ -21794,7 +21794,7 @@ var CRDsValidation map[string]string = map[string]string{
               type: string
             preferredDiskDedicatedIoThread:
               description: PreferredDedicatedIoThread optionally enables dedicated
-                IO threads for Disk devices.
+                IO threads for Disk devices using the virtio bus.
               type: boolean
             preferredDiskIO:
               description: PreferredIo optionally defines the QEMU disk IO mode to

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -409,7 +409,7 @@ type DevicePreferences struct {
 	// +optional
 	PreferredCdromBus v1.DiskBus `json:"preferredCdromBus,omitempty"`
 
-	// PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices.
+	// PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices using the virtio bus.
 	//
 	// +optional
 	PreferredDiskDedicatedIoThread *bool `json:"preferredDiskDedicatedIoThread,omitempty"`

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -141,7 +141,7 @@ func (DevicePreferences) SwaggerDoc() map[string]string {
 		"preferredDiskBus":                    "PreferredDiskBus optionally defines the preferred bus for Disk Disk devices.\n\n+optional",
 		"preferredLunBus":                     "PreferredLunBus optionally defines the preferred bus for Lun Disk devices.\n\n+optional",
 		"preferredCdromBus":                   "PreferredCdromBus optionally defines the preferred bus for Cdrom Disk devices.\n\n+optional",
-		"preferredDiskDedicatedIoThread":      "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices.\n\n+optional",
+		"preferredDiskDedicatedIoThread":      "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices using the virtio bus.\n\n+optional",
 		"preferredDiskCache":                  "PreferredCache optionally defines the DriverCache to be used by Disk devices.\n\n+optional",
 		"preferredDiskIO":                     "PreferredIo optionally defines the QEMU disk IO mode to be used by Disk devices.\n\n+optional",
 		"preferredDiskBlockSize":              "PreferredBlockSize optionally defines the block size of Disk devices.\n\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -28153,7 +28153,7 @@ func schema_kubevirtio_api_instancetype_v1beta1_DevicePreferences(ref common.Ref
 					},
 					"preferredDiskDedicatedIoThread": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices.",
+							Description: "PreferredDedicatedIoThread optionally enables dedicated IO threads for Disk devices using the virtio bus.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
/cc @alicefr 
/cc @0xFelix 

### What this PR does

54ae532f7241edf393ed79882010fe7f73af7bdf recently started to reject requests containing all non-virtio disks with dedicatedIoThreads enabled. This expanded on the previous check on SATA disks.

This change brings the PreferredDiskDedicatedIoThread preference in line with this and ensures that we only apply the preference to virtio disks.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
https://issues.redhat.com/browse/CNV-42700

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`PreferredDiskDedicatedIoThread` is now only applied to `virtio` disk devices
```

