### PR TITLE
vm: fix RerunOnFailure stuck in Provisioning

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1114,7 +1114,7 @@ func (c *VMController) syncRunStrategy(vm *virtv1.VirtualMachine, vmi *virtv1.Vi
 		}
 
 		// when coming here from a different RunStrategy we have to start the VM
-		if !hasStartRequest(vm) && vm.Status.RunStrategy == *vm.Spec.RunStrategy {
+		if !hasStartRequest(vm) && vm.Status.RunStrategy == runStrategy {
 			return vm, nil
 		}
 
@@ -2443,7 +2443,11 @@ func (c *VMController) updateStatus(vm, vmOrig *virtv1.VirtualMachine, vmi *virt
 	vm.Status.Ready = ready
 
 	runStrategy, _ := vmOrig.RunStrategy()
-	vm.Status.RunStrategy = runStrategy
+	// sync for the first time only when the VMI gets created
+	// so that we can tell if the VM got started at least once
+	if vm.Status.RunStrategy != "" || vm.Status.Created {
+		vm.Status.RunStrategy = runStrategy
+	}
 
 	c.trimDoneVolumeRequests(vm)
 	c.updateMemoryDumpRequest(vm, vmi)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -1110,7 +1110,7 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvent(recorder, virtcontroller.FailedDataVolumeImportReason)
 		})
 
-		It("should start VMI once DataVolumes are complete", func() {
+		DescribeTable("should start VMI once DataVolumes are complete", func(runStrategy v1.VirtualMachineRunStrategy) {
 			vm, _ := DefaultVirtualMachine(true)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
@@ -1125,29 +1125,56 @@ var _ = Describe("VirtualMachine", func() {
 					Name: "dv1",
 				},
 			})
-
-			existingDataVolume, _ := watchutil.CreateDataVolumeManifest(virtClient, vm.Spec.DataVolumeTemplates[0], vm)
-
-			existingDataVolume.Namespace = "default"
-			existingDataVolume.Status.Phase = cdiv1.Succeeded
+			vm.Spec.Running = nil
+			vm.Spec.RunStrategy = &runStrategy
 
 			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
 			Expect(err).To(Succeed())
-			addVirtualMachine(vm)
 
-			controller.dataVolumeStore.Add(existingDataVolume)
+			shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": string(vm.UID)}, nil, pointer.P(0))
+
+			addVirtualMachine(vm)
 			sanityExecute(vm)
-			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
+			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
+
+			_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).To(MatchError(ContainSubstring("not found")))
+
+			dv, _ := watchutil.CreateDataVolumeManifest(virtClient, vm.Spec.DataVolumeTemplates[0], vm)
+			dv.Namespace = "default"
+			dv.Status.Phase = cdiv1.Succeeded
+
+			controller.dataVolumeStore.Add(dv)
+			controller.addDataVolume(dv)
+			sanityExecute(vm)
+
+			Expect(virtFakeClient.Actions()).To(WithTransform(func(actions []testing.Action) []testing.Action {
+				var patchActions []testing.Action
+				for _, action := range actions {
+					if action.GetVerb() == "update" &&
+						action.GetResource().Resource == "virtualmachines" &&
+						action.GetSubresource() == "status" {
+						patchActions = append(patchActions, action)
+					}
+				}
+				return patchActions
+			}, Not(BeEmpty())))
 
 			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
-			Expect(err).To(Succeed())
-			// TODO // expect update status is called
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(vm.Status.Created).To(BeFalse())
 			Expect(vm.Status.Ready).To(BeFalse())
 
 			_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-		})
+
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
+		},
+			Entry("with runStrategy set to Always", v1.RunStrategyAlways),
+			Entry("with runStrategy set to Once", v1.RunStrategyOnce),
+			Entry("with runStrategy set to RerunOnFailure", v1.RunStrategyRerunOnFailure),
+		)
 
 		It("should start VMI once DataVolumes (not templates) are complete", func() {
 


### PR DESCRIPTION
When a VM with RerunOnFailure as RunStrategy is created with a DataVolume the VM would get stuck in Provisioning and never start even after the DV succeeded, this patch fixes this bug.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
When a VM with RerunOnFailure as RunStrategy is created with a DataVolume the VM would get stuck in Provisioning and never start even after the DV succeeded.

After this PR:
The VM correctly starts after provisioning.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix RerunOnFailure stuck in Provisioning
```

