### PR TITLE
More control over when DataVolumeTemplates are created

### DIFF
--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -159,7 +159,7 @@ func GetDataVolumeFromCache(namespace, name string, dataVolumeStore cache.Store)
 		return nil, fmt.Errorf("error converting object to DataVolume: object is of type %T", obj)
 	}
 
-	return dv, nil
+	return dv.DeepCopy(), nil
 }
 
 func HasDataVolumeErrors(namespace string, volumes []virtv1.Volume, dataVolumeStore cache.Store) error {

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -176,7 +176,7 @@ func GetPersistentVolumeClaimFromCache(namespace, name string, pvcStore cache.St
 		return nil, fmt.Errorf("error converting object to PersistentVolumeClaim: object is of type %T", obj)
 	}
 
-	return pvc, nil
+	return pvc.DeepCopy(), nil
 }
 
 func HasUnboundPVC(namespace string, volumes []virtv1.Volume, pvcStore cache.Store) bool {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1092,6 +1092,10 @@ const (
 	// VolumesUpdateMigration indicates that the migration copies and update
 	// the volumes
 	VolumesUpdateMigration string = "kubevirt.io/volume-update-migration"
+
+	// ImmediateDataVolumeCreation indicates that the data volumes should be created immediately
+	// Even if the VM is halted
+	ImmediateDataVolumeCreation string = "kubevirt.io/immediate-data-volume-creation"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Currently, virt-controller will create DataVolumeTemplates once the VM is created.  Even if the VM is stopped.  It also continually ensures that DataVolumeTemplates exist whenever a VM is reconciled.  Even if the VM is stopped.  This has a couple drawbacks:

1.  If the VM is never started, the underlying PVC (if on immediate bind StorageClass) was allocated unnecessarily
2. It is hard for the user or third party backup software to replace a DataVolume's underlying PVC.  See #11637 

After this PR:

User may add `kubevirt.io/immediate-data-volume-creation: "false"` annotation to the VM and it will only reconcile DataVolumeTemplates when the VM is running

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11637

https://issues.redhat.com/browse/CNV-42076

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
VM supports kubevirt.io/immediate-data-volume-creation: "false" which delays creating DataVolumeTemplates until VM is started
```

