### PR TITLE
Remove several lambda functions from tests/operator

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -138,7 +138,6 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		generatePreviousVersionVmYamls         func(string, string)
 		generatePreviousVersionVmsnapshotYamls func()
 		generateMigratableVMIs                 func(int) []*v1.VirtualMachineInstance
-		deleteAllVMIs                          func([]*v1.VirtualMachineInstance)
 		verifyVMIsUpdated                      func([]*v1.VirtualMachineInstance)
 		verifyVMIsEvicted                      func([]*v1.VirtualMachineInstance)
 		fetchVirtHandlerCommand                func() string
@@ -288,13 +287,6 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 			)
 
 			return vmis
-		}
-
-		deleteAllVMIs = func(vmis []*v1.VirtualMachineInstance) {
-			for _, vmi := range vmis {
-				err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Delete VMI successfully")
-			}
 		}
 
 		verifyVMIsEvicted = func(vmis []*v1.VirtualMachineInstance) {
@@ -1425,7 +1417,7 @@ spec:
 			}
 
 			By("Deleting migratable VMIs")
-			deleteAllVMIs(migratableVMIs)
+			deleteVMIs(migratableVMIs)
 
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false)
@@ -1681,8 +1673,8 @@ spec:
 			verifyVMIsUpdated(vmis)
 
 			By("Deleting VMIs")
-			deleteAllVMIs(vmis)
-			deleteAllVMIs(vmisNonMigratable)
+			deleteVMIs(vmis)
+			deleteVMIs(vmisNonMigratable)
 
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false)
@@ -3352,4 +3344,11 @@ func createRunningVMIs(vmis []*v1.VirtualMachineInstance) []*v1.VirtualMachineIn
 	}
 
 	return newVMIs
+}
+
+func deleteVMIs(vmis []*v1.VirtualMachineInstance) {
+	for _, vmi := range vmis {
+		err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred(), "Delete VMI successfully")
+	}
 }

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -132,7 +132,6 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 	var vmYamls map[string]*vmYamlDefinition
 
 	var (
-		installTestingManifests                func(string)
 		deleteOperator                         func(string)
 		deleteTestingManifests                 func(string)
 		deleteAllKvAndWait                     func(bool)
@@ -155,11 +154,6 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 		aggregatorClient = aggregatorclient.NewForConfigOrDie(config)
 
 		k8sClient = clientcmd.GetK8sCmdClient()
-
-		installTestingManifests = func(manifestPath string) {
-			_, _, err = clientcmd.RunCommandWithNS(metav1.NamespaceNone, k8sClient, "apply", "-f", manifestPath)
-			Expect(err).ToNot(HaveOccurred())
-		}
 
 		deleteOperator = func(manifestPath string) {
 			_, _, err = clientcmd.RunCommandWithNS(metav1.NamespaceNone, k8sClient, "delete", "-f", manifestPath)
@@ -1304,7 +1298,9 @@ spec:
 				installOperator(flags.OperatorManifestPath)
 
 				By("Re-installing testing manifests")
-				installTestingManifests(flags.TestingManifestPath)
+				_, _, err = clientcmd.RunCommandWithNS(metav1.NamespaceNone, k8sClient, "apply", "-f", flags.TestingManifestPath)
+				Expect(err).ToNot(HaveOccurred(), "failed to re-install the testing manifests")
+
 			} else {
 				By("Updating KubeVirt object With current tag")
 				patches := patch.New(


### PR DESCRIPTION
### What this PR does
tests/operator/operator.go defines many lambda function. This can be confusing, hard to read and hard to debug.

After this PR:
Several lambdas removed and replaced with inline code, and several others moved to be regular functions.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/sig code-quality
