### PR TITLE
[release-1.1] Remove redundant DeepCopy calls

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -308,7 +308,6 @@ func (c *VMController) execute(key string) error {
 	// this must be first step in execution. Writing the object
 	// when api version changes ensures our api stored version is updated.
 	if !controller.ObservedLatestApiVersionAnnotation(vm) {
-		vm := vm.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(vm)
 		_, err = c.clientset.VirtualMachine(vm.Namespace).Update(context.Background(), vm)
 
@@ -706,8 +705,7 @@ func (c *VMController) VMIAffinityPatch(vm *virtv1.VirtualMachine, vmi *virtv1.V
 	var ops []string
 
 	if vm.Spec.Template.Spec.Affinity != nil {
-		vmAffinity := vm.Spec.Template.Spec.Affinity.DeepCopy()
-		vmAffinityJson, err := json.Marshal(vmAffinity)
+		vmAffinityJson, err := json.Marshal(vm.Spec.Template.Spec.Affinity)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5252,6 +5252,68 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
+
+			Context("Affinity", func() {
+				It("should be live-updated", func() {
+					testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
+						Spec: v1.KubeVirtSpec{
+							Configuration: v1.KubeVirtConfiguration{
+								DeveloperConfiguration: &v1.DeveloperConfiguration{
+									FeatureGates: []string{virtconfig.VMLiveUpdateFeaturesGate},
+								},
+							},
+						},
+					})
+
+					vm, vmi := DefaultVirtualMachine(true)
+					vm.Spec.LiveUpdateFeatures = &virtv1.LiveUpdateFeatures{
+						Affinity: &virtv1.LiveUpdateAffinity{},
+					}
+					addVirtualMachine(vm)
+
+					affinity := k8sv1.Affinity{
+						PodAffinity: &k8sv1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"test": "nmc",
+										},
+									},
+								},
+							},
+						},
+					}
+					vm.Spec.Template.Spec.Affinity = affinity.DeepCopy()
+					Expect(vmiInformer.GetIndexer().Add(vmi)).To(Succeed())
+
+					By("Expecting to see patch for the VMI with new affinity")
+					vmiInterface.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_, _, _ any, data []byte, _ any, _ ...any) (*virtv1.VirtualMachineInstance, error) {
+							// Don't try to change this as long as you want to use equality.Semantic.DeepEqual
+							type P struct {
+								Op    string
+								Path  string
+								Value k8sv1.Affinity
+							}
+
+							patches := []P{}
+
+							Expect(json.Unmarshal(data, &patches)).To(Succeed())
+							Expect(patches).To(HaveLen(1), "Expecting one patch adding new affinity")
+							Expect(equality.Semantic.DeepEqual(affinity, patches[0].Value)).To(BeTrue(), "Expecting the affinity to equal")
+
+							return nil, nil
+						},
+					)
+
+					// Do not care
+					vmInterface.EXPECT().UpdateStatus(gomock.Any(), gomock.Any())
+
+					sanityExecute(vm)
+				})
+
+			})
 		})
 
 		Context("CPU topology", func() {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/11341

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

