### PR TITLE
bump Cirros OS container-disk base image to 0.6.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,10 +119,9 @@ http_file(
 
 http_file(
     name = "cirros_image",
-    sha256 = "932fcae93574e242dc3d772d5235061747dfe537668443a1f0567d893614b464",
+    sha256 = "07e44a73e54c94d988028515403c1ed762055e01b83a767edf3c2b387f78ce00",
     urls = [
-        "https://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img",
-        "https://storage.googleapis.com/builddeps/932fcae93574e242dc3d772d5235061747dfe537668443a1f0567d893614b464",
+        "https://github.com/cirros-dev/cirros/releases/download/0.6.2/cirros-0.6.2-x86_64-disk.img",
     ],
 )
 

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -89,7 +89,7 @@ const (
 	DefaultVirtWebhookClientBurst         = 400
 
 	DefaultMaxHotplugRatio   = 4
-	DefaultVMRolloutStrategy = v1.VMRolloutStrategyStage
+	DefaultVMRolloutStrategy = v1.VMRolloutStrategyLiveUpdate
 )
 
 func IsAMD64(arch string) bool {


### PR DESCRIPTION
Previous version 0.5.2 had older kernel version 5.3 which doesn't support virtio-mem hotplug

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Cirros OS Guest OS didn't support virtio-mem 

After this PR:
Cirros OS Guest OS supports virtio-mem 

Fixes #
Issues with testing VM rollout strategy in LiveUpdate mode


```release-note
NONE
```

