### PR TITLE
monitoring: Fix wrong calculation for `KubeVirtVMIExcessiveMigrations` in an edge case

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -743,6 +743,41 @@ tests:
         alertname: KubeVirtVMIExcessiveMigrations
         exp_alerts: []
 
+  - interval: 1h
+    input_series:
+    # the same migration is being reported by different virt-controllers
+      - series: 'kubevirt_vmi_migration_succeeded{vmi="vmi-example-1", namespace="namespace-example-1"}'
+        # time:  0 1 2 3 4 5  6
+        values: "_ 1 2 3 8 10 10" # total: 10
+      - series: 'kubevirt_vmi_migration_succeeded{vmi="vmi-example-1", namespace="namespace-example-1", vmim="same-migration", pod="virt-controller-1"}'
+        # time:  0 1 2 3 4 5 6
+        values: "_ _ _ 1 1 1 2"
+      - series: 'kubevirt_vmi_migration_succeeded{vmi="vmi-example-1", namespace="namespace-example-1", vmim="same-migration", pod="virt-controller-2"}'
+        # time:  0 1 2 3 4 5 6
+        values: "_ _ _ 1 1 1 2"
+    alert_rule_test:
+      # at 5h, there are total of 11 different migrations made on a single VMI, so the alert should not be fired.
+      # the two reports by virt-controller-1 and virt-controller-2 for the same migration are being considered as one.
+      - eval_time: 5h
+        alertname: KubeVirtVMIExcessiveMigrations
+        exp_alerts: []
+      # at 6h, there are total of 13 different migrations made on a single VMI, so the alert is expected to be fired.
+      - eval_time: 6h
+        alertname: KubeVirtVMIExcessiveMigrations
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachineInstance vmi-example-1 in namespace namespace-example-1 has been migrated more than 12 times during the last 24 hours"
+              summary: "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMIExcessiveMigrations"
+            exp_labels:
+              severity: "warning"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              vmi: vmi-example-1
+              namespace: namespace-example-1
+
+
   # No nodes are available to host VMs
   - interval: 1m
     input_series:

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -69,7 +69,7 @@ var (
 		},
 		{
 			Alert: "KubeVirtVMIExcessiveMigrations",
-			Expr:  intstr.FromString("sum by (vmi, namespace) (max_over_time(kubevirt_vmi_migration_succeeded[1d])) >= 12"),
+			Expr:  intstr.FromString("sum by (vmi, namespace) (topk by (vmi, namespace, vmim) (1, max_over_time(kubevirt_vmi_migration_succeeded[1d]))) >= 12"),
 			Annotations: map[string]string{
 				"description": "VirtualMachineInstance {{ $labels.vmi }} in namespace {{ $labels.namespace }} has been migrated more than 12 times during the last 24 hours",
 				"summary":     "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours.",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
There is an edge case, usually during an upgrade, in which two or more different virt-controllers are reporting the `kubevirt_vmi_migration_succeeded` metric for the same migration (VMIM) on the same VMI. In that case, we need to count that migration only once regardless of it being reported multiple times for the purpose of firing the alert about excessive amount of migrations in the last 24 hours. The new PromQL isolates the entries with different VMIMs, then sets the value of '1' to all of them, and then we're summing by the pair of vmi and its namespace.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Jira-ticket: https://issues.redhat.com/browse/CNV-40981

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix wrong KubeVirtVMIExcessiveMigrations alert calculation in an upgrade scenario.
```

