### PR TITLE
[release-1.2] mem-hotplug: enable only for VMs with memory >= 1Gi

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,19 +96,19 @@ http_archive(
 # Disk images
 http_file(
     name = "alpine_image",
-    sha256 = "a90150589e493d5b7e87297056b6e124d8af1b91fa2eb92bab61a839839e287b",
+    sha256 = "f87a0fd3ab0e65d2a84acd5dad5f8b6afce51cb465f65dd6f8a3810a3723b6e4",
     urls = [
-        "https://dl-cdn.alpinelinux.org/alpine/v3.16/releases/x86_64/alpine-virt-3.16.3-x86_64.iso",
-        "https://storage.googleapis.com/builddeps/a90150589e493d5b7e87297056b6e124d8af1b91fa2eb92bab61a839839e287b",
+        "https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-virt-3.20.1-x86_64.iso",
+        "https://storage.googleapis.com/builddeps/f87a0fd3ab0e65d2a84acd5dad5f8b6afce51cb465f65dd6f8a3810a3723b6e4",
     ],
 )
 
 http_file(
     name = "alpine_image_aarch64",
-    sha256 = "f3510fa675a6480a5f86b3325e97ca764368a8138d95fc4ba2efaebb41f8e325",
+    sha256 = "ca2f0e8aa7a1d7917bce7b9e7bd413772b64ec529a1938d20352558f90a5035a",
     urls = [
-        "https://dl-cdn.alpinelinux.org/alpine/v3.16/releases/aarch64/alpine-virt-3.16.3-aarch64.iso",
-        "https://storage.googleapis.com/builddeps/f3510fa675a6480a5f86b3325e97ca764368a8138d95fc4ba2efaebb41f8e325",
+        "https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/aarch64/alpine-virt-3.20.1-aarch64.iso",
+        "https://storage.googleapis.com/builddeps/ca2f0e8aa7a1d7917bce7b9e7bd413772b64ec529a1938d20352558f90a5035a",
     ],
 )
 

--- a/pkg/liveupdate/memory/memory_test.go
+++ b/pkg/liveupdate/memory/memory_test.go
@@ -36,7 +36,7 @@ var _ = Describe("LiveUpdate Memory", func() {
 
 	Context("Memory", func() {
 		Context("Validation", func() {
-			maxGuest := resource.MustParse("128Mi")
+			maxGuest := resource.MustParse("4Gi")
 
 			DescribeTable("should reject VM creation if", func(vmSetup func(*v1.VirtualMachine)) {
 
@@ -47,7 +47,7 @@ var _ = Describe("LiveUpdate Memory", func() {
 								Architecture: "amd64",
 								Domain: v1.DomainSpec{
 									Memory: &v1.Memory{
-										Guest: pointer.P(resource.MustParse("64Mi")),
+										Guest: pointer.P(resource.MustParse("1Gi")),
 									},
 								},
 							},
@@ -108,6 +108,9 @@ var _ = Describe("LiveUpdate Memory", func() {
 				}),
 				Entry("architecture is not amd64 or arm64", func(vm *v1.VirtualMachine) {
 					vm.Spec.Template.Spec.Architecture = "risc-v"
+				}),
+				Entry("guest memory is less than 1Gi", func(vm *v1.VirtualMachine) {
+					vm.Spec.Template.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("1022Mi"))
 				}),
 			)
 		})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1900,8 +1900,8 @@ var _ = Describe("Validating VM Admitter", func() {
 			var maxGuest resource.Quantity
 
 			BeforeEach(func() {
-				guest := resource.MustParse("64Mi")
-				maxGuest = resource.MustParse("128Mi")
+				guest := resource.MustParse("1Gi")
+				maxGuest = resource.MustParse("4Gi")
 
 				vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
 					Guest:    &guest,
@@ -1979,7 +1979,7 @@ var _ = Describe("Validating VM Admitter", func() {
 					Message: "Guest memory is greater than the configured maxGuest memory",
 				}),
 				Entry("maxGuest is not properly aligned", func(vm *v1.VirtualMachine) {
-					unAlignedMemory := resource.MustParse("333Mi")
+					unAlignedMemory := resource.MustParse("2049Mi")
 					vm.Spec.Template.Spec.Domain.Memory.MaxGuest = &unAlignedMemory
 				}, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
@@ -1987,7 +1987,7 @@ var _ = Describe("Validating VM Admitter", func() {
 					Message: fmt.Sprintf("MaxGuest must be %s aligned", resource.NewQuantity(memory.HotplugBlockAlignmentBytes, resource.BinarySI)),
 				}),
 				Entry("guest memory is not properly aligned", func(vm *v1.VirtualMachine) {
-					unAlignedMemory := resource.MustParse("123")
+					unAlignedMemory := resource.MustParse("1025Mi")
 					vm.Spec.Template.Spec.Domain.Memory.Guest = &unAlignedMemory
 				}, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
@@ -2010,6 +2010,13 @@ var _ = Describe("Validating VM Admitter", func() {
 					Type:    metav1.CauseTypeFieldValueInvalid,
 					Field:   "spec.template.spec.domain.memory.guest",
 					Message: "Memory hotplug is only available for x86_64 and arm64 VMs",
+				}),
+				Entry("guest memory is less than 1Gi", func(vm *v1.VirtualMachine) {
+					vm.Spec.Template.Spec.Domain.Memory.Guest = pointer.P(resource.MustParse("512Mi"))
+				}, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Field:   "spec.template.spec.domain.memory.guest",
+					Message: "Memory hotplug is only available for VMs with at least 1Gi of guest memory",
 				}),
 			)
 		})

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5641,8 +5641,8 @@ var _ = Describe("VirtualMachine", func() {
 		Context("Live update features", func() {
 			const maxSocketsFromSpec uint32 = 24
 			const maxSocketsFromConfig uint32 = 48
-			maxGuestFromSpec := resource.MustParse("128Mi")
-			maxGuestFromConfig := resource.MustParse("256Mi")
+			maxGuestFromSpec := resource.MustParse("4Gi")
+			maxGuestFromConfig := resource.MustParse("8Gi")
 
 			Context("CPU", func() {
 				It("should honour the maximum CPU sockets from VM spec", func() {
@@ -5920,7 +5920,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				It("should use maxGuest configured in cluster config when its not set in VM spec", func() {
 					vm, _ := DefaultVirtualMachine(true)
-					guestMemory := resource.MustParse("64Mi")
+					guestMemory := resource.MustParse("1Gi")
 					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 					vm.Spec.Template.Spec.Architecture = "amd64"
 
@@ -5945,7 +5945,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				It("should calculate maxGuest to be `MaxHotplugRatio` times the configured guest memory when no maxGuest is defined", func() {
 					vm, _ := DefaultVirtualMachine(true)
-					guestMemory := resource.MustParse("64Mi")
+					guestMemory := resource.MustParse("1Gi")
 					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 					vm.Spec.Template.Spec.Architecture = "amd64"
 
@@ -5967,13 +5967,13 @@ var _ = Describe("VirtualMachine", func() {
 
 				DescribeTable("should patch VMI when memory hotplug is requested", func(resources v1.ResourceRequirements) {
 					vm, _ := DefaultVirtualMachine(true)
-					newMemory := resource.MustParse("128Mi")
+					newMemory := resource.MustParse("2Gi")
 					vm.Spec.Template.Spec.Domain.Resources = resources
 					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &newMemory}
 					vm.Spec.Template.Spec.Architecture = "amd64"
 
 					vmi := api.NewMinimalVMI(vm.Name)
-					guestMemory := resource.MustParse("64Mi")
+					guestMemory := resource.MustParse("1Gi")
 					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory, MaxGuest: &maxGuestFromSpec}
 					vmi.Spec.Domain.Resources = resources
 
@@ -6003,15 +6003,15 @@ var _ = Describe("VirtualMachine", func() {
 				},
 					Entry("with memory request set", v1.ResourceRequirements{
 						Requests: k8sv1.ResourceList{
-							k8sv1.ResourceMemory: resource.MustParse("128Mi"),
+							k8sv1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					}),
 					Entry("with memory request and limits set", v1.ResourceRequirements{
 						Requests: k8sv1.ResourceList{
-							k8sv1.ResourceMemory: resource.MustParse("128Mi"),
+							k8sv1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 						Limits: k8sv1.ResourceList{
-							k8sv1.ResourceMemory: resource.MustParse("512Mi"),
+							k8sv1.ResourceMemory: resource.MustParse("4Gi"),
 						},
 					}),
 				)
@@ -6023,7 +6023,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm.Spec.Template.Spec.Architecture = "amd64"
 
 					vmi := api.NewMinimalVMI(vm.Name)
-					guestMemory := resource.MustParse("64Mi")
+					guestMemory := resource.MustParse("1Gi")
 					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory, MaxGuest: &maxGuestFromSpec}
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = guestMemory
 					vmi.Status.Memory = &v1.MemoryStatus{
@@ -6049,7 +6049,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm.Spec.Template.Spec.Architecture = "amd64"
 
 					vmi := api.NewMinimalVMI(vm.Name)
-					guestMemory := resource.MustParse("64Mi")
+					guestMemory := resource.MustParse("1Gi")
 					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory, MaxGuest: &maxGuestFromSpec}
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = guestMemory
 					vmi.Status.Memory = &v1.MemoryStatus{
@@ -6068,7 +6068,7 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				It("should not patch VMI if guest memory did not change", func() {
-					guestMemory := resource.MustParse("64Mi")
+					guestMemory := resource.MustParse("1Gi")
 					vm, _ := DefaultVirtualMachine(true)
 					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 					vm.Spec.Template.Spec.Architecture = "amd64"
@@ -6087,8 +6087,8 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				It("should set a restartRequired condition if the memory decreased from start", func() {
-					guestMemory := resource.MustParse("64Mi")
-					newMemory := resource.MustParse("32Mi")
+					guestMemory := resource.MustParse("2Gi")
+					newMemory := resource.MustParse("1Gi")
 					vm, _ := DefaultVirtualMachine(true)
 					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &newMemory}
 					vm.Spec.Template.Spec.Architecture = "amd64"
@@ -6149,11 +6149,11 @@ var _ = Describe("VirtualMachine", func() {
 				)
 
 				It("should set a restartRequired condition if VM does not support memory hotplug", func() {
-					guestMemory := resource.MustParse("64Mi")
-					newMemory := resource.MustParse("128M")
+					guestMemory := resource.MustParse("2Gi")
+					newMemory := resource.MustParse("4Gi")
 					vm, _ := DefaultVirtualMachine(true)
 					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &newMemory}
-					vm.Spec.Template.Spec.Architecture = "amd64"
+					vm.Spec.Template.Spec.Architecture = "risc-v"
 
 					vmi := api.NewMinimalVMI(vm.Name)
 					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory, MaxGuest: &maxGuestFromSpec}
@@ -6189,7 +6189,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				DescribeTable("should leave MaxGuest empty when memory hotplug is incompatible", func(vmSetup func(*v1.VirtualMachineInstanceSpec)) {
 					vm, _ := DefaultVirtualMachine(false)
-					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: kvpointer.P(resource.MustParse("128Mi"))}
+					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: kvpointer.P(resource.MustParse("1Gi"))}
 
 					vmSetup(&vm.Spec.Template.Spec)
 
@@ -6241,11 +6241,14 @@ var _ = Describe("VirtualMachine", func() {
 					Entry("architecture is not amd64 or arm64", func(vmiSpec *v1.VirtualMachineInstanceSpec) {
 						vmiSpec.Architecture = "risc-v"
 					}),
+					Entry("guest memory is less than 1Gi", func(vmiSpec *v1.VirtualMachineInstanceSpec) {
+						vmiSpec.Domain.Memory.Guest = kvpointer.P(resource.MustParse("512Mi"))
+					}),
 				)
 
 				It("should set a restartRequired condition if memory hotplug failed", func() {
-					guestMemory := resource.MustParse("64Mi")
-					newMemory := resource.MustParse("128Mi")
+					guestMemory := resource.MustParse("1Gi")
+					newMemory := resource.MustParse("2Gi")
 					vm, _ := DefaultVirtualMachine(true)
 					vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{Guest: &newMemory}
 					vm.Spec.Template.Spec.Architecture = "amd64"
@@ -6427,7 +6430,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm.Spec.Template.Spec.Domain.Memory = nil
 					vm.Spec.Template.Spec.Domain.Resources = v1.ResourceRequirements{}
 
-					instancetypeMemoryGuest := resource.MustParse("128Mi")
+					instancetypeMemoryGuest := resource.MustParse("1Gi")
 					instancetype := &instancetypev1beta1.VirtualMachineInstancetype{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "instancetype",

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -57,9 +57,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 		createHotplugVM := func(sockets *uint32, maxSockets uint32, opts ...libvmi.Option) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
 			vmiOpts := append(libvmi.WithMasqueradeNetworking(), libvmi.WithResourceMemory("1Gi"))
 			vmiOpts = append(vmiOpts, opts...)
-
-			vmi := libvmi.NewAlpineWithTestTooling(vmiOpts...)
-
+			vmi := libvmi.NewAlpine(vmiOpts...)
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)
 			vmi.Spec.Domain.Memory = &v1.Memory{
 				Guest: pointer.P(resource.MustParse("1Gi")),
@@ -254,7 +252,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 		It("should successfully hotplug memory when adding guest.memory to a VM", func() {
 			By("Creating a VM")
 			guest := resource.MustParse("1Gi")
-			vmi := libvmi.NewAlpineWithTestTooling(append(
+			vmi := libvmi.NewAlpine(append(
 				libvmi.WithMasqueradeNetworking(),
 				libvmi.WithResourceMemory(guest.String()))...,
 			)
@@ -401,7 +399,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 		It("should detect a failed memory hotplug", func() {
 			By("Creating a VM")
 			guest := resource.MustParse("1Gi")
-			vmi := libvmi.NewAlpineWithTestTooling(append(
+			vmi := libvmi.NewAlpine(append(
 				libvmi.WithMasqueradeNetworking(),
 				libvmi.WithAnnotation(v1.FuncTestMemoryHotplugFailAnnotation, ""),
 				libvmi.WithResourceMemory(guest.String()))...,

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -54,15 +54,15 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 
 	Context("A VM with memory liveUpdate enabled", func() {
 
-		createHotplugVM := func(guest *resource.Quantity, sockets *uint32, maxSockets uint32, opts ...libvmi.Option) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
-			vmiOpts := append(libvmi.WithMasqueradeNetworking(), libvmi.WithResourceMemory(guest.String()))
+		createHotplugVM := func(sockets *uint32, maxSockets uint32, opts ...libvmi.Option) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
+			vmiOpts := append(libvmi.WithMasqueradeNetworking(), libvmi.WithResourceMemory("1Gi"))
 			vmiOpts = append(vmiOpts, opts...)
 
 			vmi := libvmi.NewAlpineWithTestTooling(vmiOpts...)
 
 			vmi.Namespace = testsuite.GetTestNamespace(vmi)
 			vmi.Spec.Domain.Memory = &v1.Memory{
-				Guest: guest,
+				Guest: pointer.P(resource.MustParse("1Gi")),
 			}
 
 			if sockets != nil {
@@ -94,8 +94,8 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 
 		DescribeTable("[test_id:10823]should successfully hotplug memory", func(opts ...libvmi.Option) {
 			By("Creating a VM")
-			guest := resource.MustParse("128Mi")
-			vm, vmi := createHotplugVM(&guest, nil, 0, opts...)
+			guest := resource.MustParse("1Gi")
+			vm, vmi := createHotplugVM(nil, 0, opts...)
 
 			By("Limiting the bandwidth of migrations in the test namespace")
 			migrationBandwidthLimit := resource.MustParse("1Ki")
@@ -109,8 +109,8 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			Expect(reqMemory).To(BeNumerically(">=", guest.Value()))
 
 			By("Hotplug additional memory")
-			newGuestMemory := resource.MustParse("256Mi")
-			patchData, err := patch.GenerateTestReplacePatch("/spec/template/spec/domain/memory/guest", "128Mi", newGuestMemory.String())
+			newGuestMemory := resource.MustParse("1042Mi")
+			patchData, err := patch.GenerateTestReplacePatch("/spec/template/spec/domain/memory/guest", guest.String(), newGuestMemory.String())
 			Expect(err).NotTo(HaveOccurred())
 			_, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchData, k8smetav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -159,11 +159,11 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 
 		It("after a hotplug memory and a restart the new memory value should be the base for the VM", func() {
 			By("Creating a VM")
-			guest := resource.MustParse("128Mi")
-			vm, vmi := createHotplugVM(&guest, nil, 0)
+			guest := resource.MustParse("1Gi")
+			vm, vmi := createHotplugVM(nil, 0)
 
-			By("Hotplug 128Mi of memory")
-			newGuestMemory := resource.MustParse("256Mi")
+			By("Hotplug additional memory")
+			newGuestMemory := resource.MustParse("1042Mi")
 			patchData, err := patch.GenerateTestReplacePatch("/spec/template/spec/domain/memory/guest", guest.String(), newGuestMemory.String())
 			Expect(err).NotTo(HaveOccurred())
 			_, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchData, k8smetav1.PatchOptions{})
@@ -199,12 +199,12 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 
 		It("should successfully hotplug Memory and CPU in parallel", func() {
 			By("Creating a VM")
-			guest := resource.MustParse("128Mi")
+			guest := resource.MustParse("1Gi")
 			newSockets := uint32(2)
-			vm, vmi := createHotplugVM(&guest, pointer.P(uint32(1)), newSockets)
+			vm, vmi := createHotplugVM(pointer.P(uint32(1)), newSockets)
 
 			By("Hotplug Memory and CPU")
-			newGuestMemory := resource.MustParse("256Mi")
+			newGuestMemory := resource.MustParse("1042Mi")
 			patchData, err := patch.GeneratePatchPayload(
 				patch.PatchOperation{
 					Op:    patch.PatchTestOp,
@@ -253,7 +253,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 
 		It("should successfully hotplug memory when adding guest.memory to a VM", func() {
 			By("Creating a VM")
-			guest := resource.MustParse("128Mi")
+			guest := resource.MustParse("1Gi")
 			vmi := libvmi.NewAlpineWithTestTooling(append(
 				libvmi.WithMasqueradeNetworking(),
 				libvmi.WithResourceMemory(guest.String()))...,
@@ -276,7 +276,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			Expect(reqMemory).To(BeNumerically(">=", guest.Value()))
 
 			By("Hotplug additional memory")
-			newMemory := resource.MustParse("256Mi")
+			newMemory := resource.MustParse("1042Mi")
 			patchBytes, err := patch.GeneratePatchPayload(
 				patch.PatchOperation{
 					Op:    patch.PatchAddOp,
@@ -333,10 +333,9 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 		// both cases
 		It("should successfully hotplug memory twice", func() {
 			By("Creating a VM")
-			guest := resource.MustParse("128Mi")
-			vm, vmi := createHotplugVM(&guest, nil, 0)
+			vm, vmi := createHotplugVM(nil, 0)
 
-			for _, newMemory := range []*resource.Quantity{pointer.P(resource.MustParse("256Mi")), pointer.P(resource.MustParse("512Mi"))} {
+			for _, newMemory := range []*resource.Quantity{pointer.P(resource.MustParse("1028Mi")), pointer.P(resource.MustParse("1042Mi"))} {
 				oldGuestMemory := vm.Spec.Template.Spec.Domain.Memory.Guest
 
 				By("Ensuring the compute container has the expected memory")
@@ -401,7 +400,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 
 		It("should detect a failed memory hotplug", func() {
 			By("Creating a VM")
-			guest := resource.MustParse("128Mi")
+			guest := resource.MustParse("1Gi")
 			vmi := libvmi.NewAlpineWithTestTooling(append(
 				libvmi.WithMasqueradeNetworking(),
 				libvmi.WithAnnotation(v1.FuncTestMemoryHotplugFailAnnotation, ""),
@@ -418,7 +417,7 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 			vmi = libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Hotplug additional memory")
-			newMemory := resource.MustParse("256Mi")
+			newMemory := resource.MustParse("1042Mi")
 			patchBytes, err := patch.GenerateTestReplacePatch("/spec/template/spec/domain/memory/guest", guest.String(), newMemory.String())
 			Expect(err).NotTo(HaveOccurred())
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -209,7 +209,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Requests: kubev1.ResourceList{},
 				Limits: kubev1.ResourceList{
 					kubev1.ResourceCPU:    resource.MustParse("1"),
-					kubev1.ResourceMemory: resource.MustParse("64M"),
+					kubev1.ResourceMemory: resource.MustParse("128Mi"),
 				},
 			}
 
@@ -307,7 +307,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				}
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("100M"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 					},
 				}
 
@@ -326,7 +326,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				}, 15)).To(Succeed(), "should report number of cores")
 
 				By("Checking the requested amount of memory allocated for a guest")
-				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("100M"))
+				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("128Mi"))
 
 				readyPod := tests.GetRunningPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
 				var computeContainer *kubev1.Container
@@ -339,17 +339,17 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(371)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(406)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("[test_id:4624]should set a correct memory units", func() {
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64Mi"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 					},
 				}
-				expectedMemoryInKiB := 64 * 1024
+				expectedMemoryInKiB := 128 * 1024
 				expectedMemoryXMLStr := fmt.Sprintf("unit='KiB'>%d", expectedMemoryInKiB)
 
 				By("Starting a VirtualMachineInstance")
@@ -369,7 +369,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				}
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("120M"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 					},
 				}
 
@@ -393,7 +393,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
 						kubev1.ResourceCPU:    resource.MustParse("1200m"),
-						kubev1.ResourceMemory: resource.MustParse("100M"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 					},
 				}
 
@@ -416,7 +416,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				vmi.Spec.Domain.CPU = nil
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("100M"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 					},
 					Limits: kubev1.ResourceList{
 						kubev1.ResourceCPU: resource.MustParse("1200m"),
@@ -469,7 +469,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				_true := true
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 						kubev1.ResourceCPU:    resource.MustParse("3"),
 					},
 				}
@@ -494,7 +494,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				_false := false
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 						kubev1.ResourceCPU:    resource.MustParse("3"),
 					},
 				}
@@ -518,7 +518,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				_false := false
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 					},
 				}
 				vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
@@ -1036,7 +1036,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				vmi.Namespace = testsuite.NamespaceTestAlternative
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
+						kubev1.ResourceMemory: resource.MustParse("128Mi"),
 					},
 					Limits: kubev1.ResourceList{
 						kubev1.ResourceCPU: resource.MustParse("1000m"),


### PR DESCRIPTION
Manual backport of https://github.com/kubevirt/kubevirt/pull/12212.

The 1GiB mark is chosen as a tradeoff, it is enough memory for the guest kernel to allocate its internal data structures and to allocate the SWIOTLB.
It also means we can memory map all PCI devices
as they're memory mapped in the first 1Gi (PCI hole).

If there are 32bit devices that need to do DMA,
the kernel will allocate memory for the SWIOTLB, which is a bounce buffer to address memory after the 4Gi Mark, the SWIOTLB in Linux at the moment of this commit is 64MB and this causes an issue for the kernel with VMs with very small amounts of memory, if not enough memory is available this can lead to the guest kernel panicking while trying to allocate memory.

This SWIOTLB issue is present when setting `maxMemory` (which is set in all VMs when `LiveUpdate` is used as the `vmRolloutStrategy`) in the XML domain of the VM because the kernel will have to allow DMA to happen also for virtio-mem hotplugged memory, which is always mapped after the 4Gi mark and thus always needs SWIOTLB for devices that use 32bit addresses.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
VMs with less that 1GiB of guest memory might see the guest kernel panicking at boot.

After this PR:
VMs with less that 1GiB of guest memory work as expected but cannot hotplug memory.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
enable only for VMs with memory >= 1Gi
```