### PR TITLE
vmclone: use patchset and remove informers from struct

### DIFF
--- a/pkg/apimachinery/patch/patch.go
+++ b/pkg/apimachinery/patch/patch.go
@@ -77,6 +77,10 @@ func New(opts ...PatchOption) *PatchSet {
 	return p
 }
 
+func (p *PatchSet) GetPatches() []PatchOperation {
+	return p.patches
+}
+
 func (p *PatchSet) AddOption(opts ...PatchOption) {
 	for _, f := range opts {
 		f(p)

--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/clone",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/util/status:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",
@@ -42,6 +43,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/clone/clone_base.go
+++ b/pkg/virt-controller/watch/clone/clone_base.go
@@ -41,14 +41,14 @@ const (
 )
 
 type VMCloneController struct {
-	client                  kubecli.KubevirtClient
-	vmCloneInformer         cache.SharedIndexInformer
-	snapshotInformer        cache.SharedIndexInformer
-	restoreInformer         cache.SharedIndexInformer
-	vmInformer              cache.SharedIndexInformer
-	snapshotContentInformer cache.SharedIndexInformer
-	pvcInformer             cache.SharedIndexInformer
-	recorder                record.EventRecorder
+	client               kubecli.KubevirtClient
+	vmCloneIndexer       cache.Indexer
+	snapshotStore        cache.Store
+	restoreStore         cache.Store
+	vmStore              cache.Store
+	snapshotContentStore cache.Store
+	pvcStore             cache.Store
+	recorder             record.EventRecorder
 
 	vmCloneQueue       workqueue.RateLimitingInterface
 	vmStatusUpdater    *status.VMStatusUpdater
@@ -58,21 +58,22 @@ type VMCloneController struct {
 
 func NewVmCloneController(client kubecli.KubevirtClient, vmCloneInformer, snapshotInformer, restoreInformer, vmInformer, snapshotContentInformer, pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder) (*VMCloneController, error) {
 	ctrl := VMCloneController{
-		client:                  client,
-		vmCloneInformer:         vmCloneInformer,
-		snapshotInformer:        snapshotInformer,
-		restoreInformer:         restoreInformer,
-		vmInformer:              vmInformer,
-		snapshotContentInformer: snapshotContentInformer,
-		pvcInformer:             pvcInformer,
-		recorder:                recorder,
-		vmCloneQueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-vmclone"),
-		vmStatusUpdater:         status.NewVMStatusUpdater(client),
-		cloneStatusUpdater:      status.NewCloneStatusUpdater(client),
+		client:               client,
+		vmCloneIndexer:       vmCloneInformer.GetIndexer(),
+		snapshotStore:        snapshotInformer.GetStore(),
+		restoreStore:         restoreInformer.GetStore(),
+		vmStore:              vmInformer.GetStore(),
+		snapshotContentStore: snapshotContentInformer.GetStore(),
+		pvcStore:             pvcInformer.GetStore(),
+		recorder:             recorder,
+		vmCloneQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-vmclone"),
+		vmStatusUpdater:      status.NewVMStatusUpdater(client),
+		cloneStatusUpdater:   status.NewCloneStatusUpdater(client),
 	}
 
 	ctrl.hasSynced = func() bool {
-		return vmCloneInformer.HasSynced() && snapshotInformer.HasSynced() && restoreInformer.HasSynced() && vmInformer.HasSynced()
+		return vmCloneInformer.HasSynced() && snapshotInformer.HasSynced() && restoreInformer.HasSynced() &&
+			vmInformer.HasSynced() && snapshotInformer.HasSynced() && pvcInformer.HasSynced()
 	}
 
 	_, err := vmCloneInformer.AddEventHandler(
@@ -177,13 +178,13 @@ func (ctrl *VMCloneController) handleSnapshot(obj interface{}) {
 		return
 	}
 
-	snapshotSourceKeys, err := ctrl.vmCloneInformer.GetIndexer().IndexKeys("snapshotSource", snapshotKey)
+	snapshotSourceKeys, err := ctrl.vmCloneIndexer.IndexKeys("snapshotSource", snapshotKey)
 	if err != nil {
 		log.Log.Object(snapshot).Reason(err).Error("cannot get clone snapshotSourceKeys from snapshotSource indexer")
 		return
 	}
 
-	snapshotWaitingKeys, err := ctrl.vmCloneInformer.GetIndexer().IndexKeys(string(clonev1alpha1.SnapshotInProgress), snapshotKey)
+	snapshotWaitingKeys, err := ctrl.vmCloneIndexer.IndexKeys(string(clonev1alpha1.SnapshotInProgress), snapshotKey)
 	if err != nil {
 		log.Log.Object(snapshot).Reason(err).Error("cannot get clone snapshotWaitingKeys from " + string(clonev1alpha1.SnapshotInProgress) + " indexer")
 		return
@@ -215,7 +216,7 @@ func (ctrl *VMCloneController) handleRestore(obj interface{}) {
 		return
 	}
 
-	restoreWaitingKeys, err := ctrl.vmCloneInformer.GetIndexer().IndexKeys(string(clonev1alpha1.RestoreInProgress), restoreKey)
+	restoreWaitingKeys, err := ctrl.vmCloneIndexer.IndexKeys(string(clonev1alpha1.RestoreInProgress), restoreKey)
 	if err != nil {
 		log.Log.Object(restore).Reason(err).Error("cannot get clone restoreWaitingKeys from " + string(clonev1alpha1.RestoreInProgress) + " indexer")
 		return
@@ -252,7 +253,7 @@ func (ctrl *VMCloneController) handlePVC(obj interface{}) {
 
 	restoreKey := getKey(restoreName, pvc.Namespace)
 
-	succeededWaitingKeys, err := ctrl.vmCloneInformer.GetIndexer().IndexKeys(string(clonev1alpha1.Succeeded), restoreKey)
+	succeededWaitingKeys, err := ctrl.vmCloneIndexer.IndexKeys(string(clonev1alpha1.Succeeded), restoreKey)
 	if err != nil {
 		log.Log.Object(pvc).Reason(err).Error("cannot get clone succeededWaitingKeys from " + string(clonev1alpha1.Succeeded) + " indexer")
 		return
@@ -353,7 +354,7 @@ func (ctrl *VMCloneController) listVmCloneMatchingVM(namespace, name string) ([]
 }
 
 func (ctrl *VMCloneController) filterVmClone(namespace string, filter func(*clonev1alpha1.VirtualMachineClone) bool) ([]*clonev1alpha1.VirtualMachineClone, error) {
-	objs, err := ctrl.vmCloneInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	objs, err := ctrl.vmCloneIndexer.ByIndex(cache.NamespaceIndex, namespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
vmclone controller pkg cleanup:
1. Use the patch package to replace the hardcoded patch operations. This improves the readability and make the code more cohesive.
2. Remove the usage of the informers in the vmclone controller.
There is no need to hold informers, narrowing down
the interface can decrease the probability of making
a mistake.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially address: https://github.com/kubevirt/kubevirt/issues/11654

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

