### PR TITLE
s390x: Fix unit tests on s390x for memory-hotplug and disable fuzz testing

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -65,7 +65,8 @@ if [ $# -eq 0 ]; then
             go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" --ignore=container-disk-v2alpha ./cmd/...
         )
         (
-            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race ./pkg/...
+            # Skip fuzz tests, as they are not part of regular unit testing
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race -skip FuzzAdmitter ./pkg/...
         )
     else
         (
@@ -106,7 +107,8 @@ fi
 for arg in $args; do
     if [ "${target}" = "test" ]; then
         (
-            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race ./$arg/...
+            # Skip fuzz tests, as they are not part of regular unit testing
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race -skip FuzzAdmitter ./$arg/...
         )
     elif [ "${target}" = "install" ]; then
         eval "$(go env)"

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -66,7 +66,7 @@ if [ $# -eq 0 ]; then
         )
         (
             # Skip fuzz tests, as they are not part of regular unit testing
-            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race -skip FuzzAdmitter ./pkg/...
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race -skip FuzzAdmitter -timeout 15m ./pkg/...
         )
     else
         (
@@ -108,7 +108,7 @@ for arg in $args; do
     if [ "${target}" = "test" ]; then
         (
             # Skip fuzz tests, as they are not part of regular unit testing
-            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race -skip FuzzAdmitter ./$arg/...
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race -skip FuzzAdmitter -timeout 15m ./$arg/...
         )
     elif [ "${target}" = "install" ]; then
         eval "$(go env)"

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -1432,7 +1432,11 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				}
 
 				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
-				Expect(spec.Domain.Memory.MaxGuest.Value()).To(Equal(maxGuest.Value()))
+				if rt.GOARCH != "s390x" {
+					Expect(spec.Domain.Memory.MaxGuest.Value()).To(Equal(maxGuest.Value()))
+				} else {
+					Expect(spec.Domain.Memory.MaxGuest).To(BeNil())
+				}
 			})
 			It("to prefer maxGuest from KV over MaxHotplugRatio", func() {
 				kvCR := testutils.GetFakeKubeVirtClusterConfig(kvStore)
@@ -1448,8 +1452,12 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				}
 
 				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
-				Expect(spec.Domain.Memory.Guest.Value()).To(Equal(guest.Value()))
-				Expect(spec.Domain.Memory.MaxGuest.Value()).To(Equal(maxGuest.Value()))
+				if rt.GOARCH != "s390x" {
+					Expect(spec.Domain.Memory.Guest.Value()).To(Equal(guest.Value()))
+					Expect(spec.Domain.Memory.MaxGuest.Value()).To(Equal(maxGuest.Value()))
+				} else {
+					Expect(spec.Domain.Memory.MaxGuest).To(BeNil())
+				}
 			})
 			It("to calculate maxGuest to be `MaxHotplugRatio` times the configured guest memory when no maxGuest is defined", func() {
 				guest := resource.MustParse("1Gi")
@@ -1459,7 +1467,11 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				}
 
 				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
-				Expect(spec.Domain.Memory.MaxGuest.Value()).To(Equal(expectedMaxGuest.Value()))
+				if rt.GOARCH != "s390x" {
+					Expect(spec.Domain.Memory.MaxGuest.Value()).To(Equal(expectedMaxGuest.Value()))
+				} else {
+					Expect(spec.Domain.Memory.MaxGuest).To(BeNil())
+				}
 			})
 			It("to use hot plug ratio configured in cluster config when max guest isn't provided in the VMI", func() {
 				kvCR := testutils.GetFakeKubeVirtClusterConfig(kvStore)
@@ -1474,7 +1486,11 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				}
 
 				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
-				Expect(spec.Domain.Memory.MaxGuest.Value()).To(Equal(expectedMaxGuest.Value()))
+				if rt.GOARCH != "s390x" {
+					Expect(spec.Domain.Memory.MaxGuest.Value()).To(Equal(expectedMaxGuest.Value()))
+				} else {
+					Expect(spec.Domain.Memory.MaxGuest).To(BeNil())
+				}
 			})
 
 			DescribeTable("should leave MaxGuest empty when memory hotplug is incompatible", func(vmiSetup func(*v1.VirtualMachineInstanceSpec)) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
unit tests on s390x where not working, as with `make go-test` it runs the fuzz test. Additionally memory-hotplug tests where failling
After this PR:
unit-tests are passing for s390x
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:
fuzz testing was disabled for s390x.

The following alternatives were considered:
Finding an alternative way to allow fuzz tests to run only when specifically triggered. However i did not find any method that works on both golang and bazel testing.
Additionally, simply enabling memory-hotplug on s390x would have fixed the failling tests, however the feature itself is not working on s390x, likely because it uses live-migration.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

