### PR TITLE
Refactor unit tests to use libvmi for resource creation in config file

### DIFF
--- a/pkg/config/config-map_test.go
+++ b/pkg/config/config-map_test.go
@@ -23,15 +23,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	k8sv1 "k8s.io/api/core/v1"
-
-	"kubevirt.io/client-go/api"
-
 	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
 var _ = Describe("ConfigMap", func() {
@@ -66,7 +64,8 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	It("Should not create a new config map iso disk without a Disk device", func() {
-		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi := libvmi.New()
+
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 			Name: "configmap-volume",
 			VolumeSource: v1.VolumeSource{

--- a/pkg/config/downwardapi_test.go
+++ b/pkg/config/downwardapi_test.go
@@ -26,11 +26,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	k8sv1 "k8s.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/client-go/api"
 
-	k8sv1 "k8s.io/api/core/v1"
-
-	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
 var _ = Describe("DownwardAPI", func() {
@@ -54,25 +55,9 @@ var _ = Describe("DownwardAPI", func() {
 	})
 
 	It("Should create a new downwardapi iso disk", func() {
-		vmi := api.NewMinimalVMI("fake-vmi")
-		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-			Name: "downwardapi-volume",
-			VolumeSource: v1.VolumeSource{
-				DownwardAPI: &v1.DownwardAPIVolumeSource{
-					Fields: []k8sv1.DownwardAPIVolumeFile{
-						{
-							Path: "labels",
-							FieldRef: &k8sv1.ObjectFieldSelector{
-								FieldPath: "metadata.labels",
-							},
-						},
-					},
-				},
-			},
-		})
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-			Name: "downwardapi-volume",
-		})
+		vmi := libvmi.New(
+			libvmi.WithDownwardAPIDisk("downwardapi-volume"),
+		)
 
 		err := CreateDownwardAPIDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/config/secret_test.go
+++ b/pkg/config/secret_test.go
@@ -23,14 +23,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/client-go/api"
-
 	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
 var _ = Describe("Secret", func() {
@@ -65,7 +63,8 @@ var _ = Describe("Secret", func() {
 	})
 
 	It("Should not create a new secret iso disk without a Disk device", func() {
-		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi := libvmi.New()
+
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 			Name: "secret-volume",
 			VolumeSource: v1.VolumeSource{

--- a/pkg/config/service-account_test.go
+++ b/pkg/config/service-account_test.go
@@ -23,14 +23,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/client-go/api"
-
 	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
 var _ = Describe("ServiceAccount", func() {
@@ -65,7 +63,7 @@ var _ = Describe("ServiceAccount", func() {
 	})
 
 	It("Should create a new service account iso disk without a Disk device", func() {
-		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi := libvmi.New()
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 			Name: "serviceaccount-volume",
 			VolumeSource: v1.VolumeSource{

--- a/pkg/config/sysprep_test.go
+++ b/pkg/config/sysprep_test.go
@@ -25,11 +25,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
-
-	"kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
 func createFiles(filenames []string) {
@@ -60,29 +59,13 @@ var _ = Describe("SysprepConfigMap", func() {
 		os.RemoveAll(SysprepDisksDir)
 	})
 
-	vmiConfigMap := api.NewMinimalVMI("fake-vmi")
-	vmiConfigMap.Spec.Volumes = append(vmiConfigMap.Spec.Volumes, v1.Volume{
-		Name: "sysprep-volume",
-		VolumeSource: v1.VolumeSource{
-			Sysprep: &v1.SysprepSource{
-				ConfigMap: &k8sv1.LocalObjectReference{
-					Name: "test-config",
-				},
-			},
-		},
-	})
+	vmiConfigMap := libvmi.New(
+		libvmi.WithSysprepConfigMap("sysprep-volume", "test-config"),
+	)
 
-	vmiSecret := api.NewMinimalVMI("fake-vmi")
-	vmiSecret.Spec.Volumes = append(vmiSecret.Spec.Volumes, v1.Volume{
-		Name: "sysprep-volume",
-		VolumeSource: v1.VolumeSource{
-			Sysprep: &v1.SysprepSource{
-				Secret: &k8sv1.LocalObjectReference{
-					Name: "secret-config",
-				},
-			},
-		},
-	})
+	vmiSecret := libvmi.New(
+		libvmi.WithSysprepSecret("sysprep-volume", "secret-config"),
+	)
 
 	DescribeTable("Assert successful sysprep ISO creation with CreateSysprepDisks",
 		func(vmi *v1.VirtualMachineInstance, filenames []string) {

--- a/pkg/libvmi/config.go
+++ b/pkg/libvmi/config.go
@@ -28,6 +28,16 @@ func WithSecretDisk(secretName, volumeName string) Option {
 	return WithLabelledSecretDisk(secretName, volumeName, "")
 }
 
+func WithSysprepSecret(volumeName, secretName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newSysprepVolume(volumeName, &v1.SysprepSource{
+			Secret: &k8sv1.LocalObjectReference{
+				Name: secretName,
+			},
+		}))
+	}
+}
+
 func WithLabelledSecretDisk(secretName, volumeName, label string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newSecretVolume(secretName, volumeName, label))
@@ -39,6 +49,16 @@ func WithLabelledSecretDisk(secretName, volumeName, label string) Option {
 
 func WithConfigMapDisk(configMapName, volumeName string) Option {
 	return WithLabelledConfigMapDisk(configMapName, volumeName, "")
+}
+
+func WithSysprepConfigMap(volumeName, configMapName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newSysprepVolume(volumeName, &v1.SysprepSource{
+			ConfigMap: &k8sv1.LocalObjectReference{
+				Name: configMapName,
+			},
+		}))
+	}
 }
 
 func WithLabelledConfigMapDisk(configMapName, volumeName, label string) Option {
@@ -105,6 +125,15 @@ func newSecretVolume(secretName, volumeName, label string) v1.Volume {
 				SecretName:  secretName,
 				VolumeLabel: label,
 			},
+		},
+	}
+}
+
+func newSysprepVolume(volumeName string, source *v1.SysprepSource) v1.Volume {
+	return v1.Volume{
+		Name: volumeName,
+		VolumeSource: v1.VolumeSource{
+			Sysprep: source,
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
- Unit tests directly created and modified VM and VMI resources by manipulating their fields.
After this PR:
- Unit tests have been refactored to use the `libvmi` package for creating and modifying VM and VMI resources, promoting readability and standardization.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially address: https://github.com/kubevirt/kubevirt/issues/12059

### Why we need it and why it was done in this way
 - Using the libvmi package simplifies the unit tests and makes them more readable.
 - This approach ensures a standard way of creating VM and VMI resources across tests.
 
The following tradeoffs were made:
  - Direct manipulation of resources was replaced with utility functions, which may introduce minor overhead but enhances readability and maintainability.

The following alternatives were considered:
 - Continuing with direct manipulation of resources in tests, which was deemed less maintainable.
Links to places where the discussion took place: Issue discussion: [#12059](https://github.com/kubevirt/kubevirt/issues/12059)

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
- Unit tests directly created and modified VM and VMI resources by manipulating their fields.
After this PR:
- Unit tests have been refactored to use the `libvmi` package for creating and modifying VM and VMI resources, promoting readability and standardization.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially address: https://github.com/kubevirt/kubevirt/issues/12059

### Why we need it and why it was done in this way
 - Using the libvmi package simplifies the unit tests and makes them more readable.
 - This approach ensures a standard way of creating VM and VMI resources across tests.
 
The following tradeoffs were made:
  - Direct manipulation of resources was replaced with utility functions, which may introduce minor overhead but enhances readability and maintainability.

The following alternatives were considered:
 - Continuing with direct manipulation of resources in tests, which was deemed less maintainable.
Links to places where the discussion took place: Issue discussion: [#12059](https://github.com/kubevirt/kubevirt/issues/12059)

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```