### PR TITLE
release, verification: add source tarball signature upload

### DIFF
--- a/automation/github-source-tarball-signature.sh
+++ b/automation/github-source-tarball-signature.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
+#
+#
+
+function update_github_source_tarball_signature() {
+    local src_tarball_file
+    src_tarball_file="${DOCKER_TAG}.tar.gz"
+    src_tarball_signature_file="${src_tarball_file}.asc"
+
+    if ! gh release download "$DOCKER_TAG" --repo "$GITHUB_REPOSITORY" --pattern="${src_tarball_signature_file}" --clobber --output "/tmp/${src_tarball_signature_file}"; then
+        upload_github_source_tarball_signature
+    else
+        gh release download "$DOCKER_TAG" --repo "$GITHUB_REPOSITORY" --archive=tar.gz --clobber --output "/tmp/${src_tarball_file}"
+        if ! gpg --verify --local-user "${GPG_USER_ID}" "/tmp/${src_tarball_signature_file}" "/tmp/${src_tarball_file}"; then
+            upload_github_source_tarball_signature
+        fi
+    fi
+
+}
+
+function upload_github_source_tarball_signature() {
+    local src_tarball_file
+    src_tarball_file="${DOCKER_TAG}.tar.gz"
+
+    # 1. download source tarball
+    # example download url: https://github.com/kubevirt/kubevirt/archive/refs/tags/v1.3.0-beta.0.tar.gz
+    gh release download "$DOCKER_TAG" --repo "$GITHUB_REPOSITORY" --archive=tar.gz --clobber --output "/tmp/${src_tarball_file}"
+
+    # 2. sign with private key (to verify the signature a prerequisite is that the public key is uploaded)
+
+    [ -f "/tmp/${src_tarball_file}.asc" ] && rm "/tmp/${src_tarball_file}.asc"
+    gpg --armor --detach-sign --local-user "${GPG_USER_ID}" --output "/tmp/${src_tarball_file}.asc" "/tmp/${src_tarball_file}"
+
+    # 3. upload the detached signature
+    gh release upload --repo "$GITHUB_REPOSITORY" --clobber "$DOCKER_TAG" "/tmp/${src_tarball_file}.asc"
+}

--- a/automation/release.sh
+++ b/automation/release.sh
@@ -2,6 +2,8 @@
 
 set -exuo pipefail
 
+source automation/github-source-tarball-signature.sh
+
 function cleanup_gh_install() {
     [ -n "${gh_cli_dir}" ] && [ -d "${gh_cli_dir}" ] && rm -rf "${gh_cli_dir:?}/"
 }
@@ -110,6 +112,7 @@ function main() {
 
     build_release_artifacts
     update_github_release
+    update_github_source_tarball_signature
     upload_testing_manifests
     generate_stable_version_file
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Release source tarballs are unsigned - they don't have an external signature added as stated here: https://github.com/ossf/scorecard/blob/2ef20f17fb2e64147c83440cd2c769653454015a/docs/checks.md#signed-releases

After this PR:
Adds a step to the release creation that downloads the source tarball from the target release, generates a detached signature file, and uploads the signature file to the target release.

Requires `gh` cli tool.

The user-id to sign with is set via env GPG_USER_ID.

For successful verification on a target system the public key for the user-id used to create the signature has to be imported first. Release source tarball can be then verified using the command

```
gpg --verify ${release-tarball-file}.asc ${release-tarball-file}
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

kubevirt/project-infra#3494 is required to merge first, since it modifies the release job - it adds importing the gpg key file for signing and setting the GPG_USER_ID env var.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

