### PR TITLE
Refactor unit tests to use libvmi for resource creation in emptydisk

### DIFF
--- a/pkg/emptydisk/BUILD.bazel
+++ b/pkg/emptydisk/BUILD.bazel
@@ -22,8 +22,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
-        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/emptydisk/emptydisk_test.go
+++ b/pkg/emptydisk/emptydisk_test.go
@@ -8,32 +8,13 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"kubevirt.io/client-go/api"
-
-	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
 var _ = Describe("EmptyDisk", func() {
 
 	var emptyDiskBaseDir string
 	var creator *emptyDiskCreator
-
-	AppendEmptyDisk := func(vmi *v1.VirtualMachineInstance, diskName string) {
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-			Name: diskName,
-			DiskDevice: v1.DiskDevice{
-				Disk: &v1.DiskTarget{},
-			},
-		})
-		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-			Name: diskName,
-			VolumeSource: v1.VolumeSource{
-				EmptyDisk: &v1.EmptyDiskSource{
-					Capacity: resource.MustParse("3Gi"),
-				},
-			},
-		})
-	}
 
 	BeforeEach(func() {
 		var err error
@@ -50,8 +31,10 @@ var _ = Describe("EmptyDisk", func() {
 
 	Describe("a vmi with emptyDisks attached", func() {
 		It("should get a new qcow2 image if not already present", func() {
-			vmi := api.NewMinimalVMI("testvmi")
-			AppendEmptyDisk(vmi, "testdisk")
+			vmi := libvmi.New(
+				libvmi.WithEmptyDisk("testdisk", "", resource.MustParse("3Gi")),
+			)
+
 			err := creator.CreateTemporaryDisks(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = os.Stat(filePathForVolumeName(emptyDiskBaseDir, "testdisk"))
@@ -60,8 +43,10 @@ var _ = Describe("EmptyDisk", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("should not override ", func() {
-			vmi := api.NewMinimalVMI("testvmi")
-			AppendEmptyDisk(vmi, "testdisk")
+			vmi := libvmi.New(
+				libvmi.WithEmptyDisk("testdisk", "", resource.MustParse("3Gi")),
+			)
+
 			err := creator.CreateTemporaryDisks(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = os.Stat(filePathForVolumeName(emptyDiskBaseDir, "testdisk"))
@@ -73,8 +58,10 @@ var _ = Describe("EmptyDisk", func() {
 			Expect(NewEmptyDiskCreator().FilePathForVolumeName("volume1")).ToNot(Equal(NewEmptyDiskCreator().FilePathForVolumeName("volume2")))
 		})
 		It("should leave pre-existing disks alone", func() {
-			vmi := api.NewMinimalVMI("testvmi")
-			AppendEmptyDisk(vmi, "testdisk")
+			vmi := libvmi.New(
+				libvmi.WithEmptyDisk("testdisk", "", resource.MustParse("3Gi")),
+			)
+
 			err := os.WriteFile(filePathForVolumeName(emptyDiskBaseDir, "testdisk"), []byte("test"), 0777)
 			Expect(err).ToNot(HaveOccurred())
 			err = creator.CreateTemporaryDisks(vmi)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
- Unit tests directly created and modified VM and VMI resources by manipulating their fields.
After this PR:
- Unit tests have been refactored to use the `libvmi` package for creating and modifying VM and VMI resources, promoting readability and standardization.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially address: https://github.com/kubevirt/kubevirt/issues/12059

### Why we need it and why it was done in this way
 - Using the libvmi package simplifies the unit tests and makes them more readable.
 - This approach ensures a standard way of creating VM and VMI resources across tests.
 
The following tradeoffs were made:
  - Direct manipulation of resources was replaced with utility functions, which may introduce minor overhead but enhances readability and maintainability.

The following alternatives were considered:
 - Continuing with direct manipulation of resources in tests, which was deemed less maintainable.
Links to places where the discussion took place: Issue discussion: [#12059](https://github.com/kubevirt/kubevirt/issues/12059)

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE