### PR TITLE
api: Add preference enum validation

### DIFF
--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -9031,6 +9031,17 @@ var CRDsValidation map[string]string = map[string]string{
             preferredCPUTopology:
               description: PreferredCPUTopology optionally defines the preferred guest
                 visible CPU topology, defaults to PreferSockets.
+              enum:
+              - preferCores
+              - preferSockets
+              - preferThreads
+              - preferSpread
+              - preferAny
+              - cores
+              - sockets
+              - threads
+              - spread
+              - any
               type: string
             spreadOptions:
               properties:
@@ -9038,6 +9049,10 @@ var CRDsValidation map[string]string = map[string]string{
                   description: |-
                     Across optionally defines how to spread vCPUs across the guest visible topology.
                     Default: SocketsCores
+                  enum:
+                  - SocketsCoresThreads
+                  - SocketsCores
+                  - CoresThreads
                   type: string
                 ratio:
                   description: |-
@@ -23384,6 +23399,17 @@ var CRDsValidation map[string]string = map[string]string{
             preferredCPUTopology:
               description: PreferredCPUTopology optionally defines the preferred guest
                 visible CPU topology, defaults to PreferSockets.
+              enum:
+              - preferCores
+              - preferSockets
+              - preferThreads
+              - preferSpread
+              - preferAny
+              - cores
+              - sockets
+              - threads
+              - spread
+              - any
               type: string
             spreadOptions:
               properties:
@@ -23391,6 +23417,10 @@ var CRDsValidation map[string]string = map[string]string{
                   description: |-
                     Across optionally defines how to spread vCPUs across the guest visible topology.
                     Default: SocketsCores
+                  enum:
+                  - SocketsCoresThreads
+                  - SocketsCores
+                  - CoresThreads
                   type: string
                 ratio:
                   description: |-

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -353,6 +353,7 @@ type CPUPreferences struct {
 	// PreferredCPUTopology optionally defines the preferred guest visible CPU topology, defaults to PreferSockets.
 	//
 	//+optional
+	//+kubebuilder:validation:Enum=preferCores;preferSockets;preferThreads;preferSpread;preferAny;cores;sockets;threads;spread;any
 	PreferredCPUTopology *PreferredCPUTopology `json:"preferredCPUTopology,omitempty"`
 
 	//
@@ -383,6 +384,7 @@ type SpreadOptions struct {
 	// Default: SocketsCores
 	//
 	//+optional
+	//+kubebuilder:validation:Enum=SocketsCoresThreads;SocketsCores;CoresThreads
 	Across *SpreadAcross `json:"across,omitempty"`
 
 	// Ratio optionally defines the ratio to spread vCPUs across the guest visible topology:

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -121,7 +121,7 @@ func (VolumePreferences) SwaggerDoc() map[string]string {
 func (CPUPreferences) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                     "CPUPreferences contains various optional CPU preferences.",
-		"preferredCPUTopology": "PreferredCPUTopology optionally defines the preferred guest visible CPU topology, defaults to PreferSockets.\n\n+optional",
+		"preferredCPUTopology": "PreferredCPUTopology optionally defines the preferred guest visible CPU topology, defaults to PreferSockets.\n\n+optional\n+kubebuilder:validation:Enum=preferCores;preferSockets;preferThreads;preferSpread;preferAny;cores;sockets;threads;spread;any",
 		"spreadOptions":        "+optional",
 		"preferredCPUFeatures": "PreferredCPUFeatures optionally defines a slice of preferred CPU features.\n\n+optional",
 	}
@@ -129,7 +129,7 @@ func (CPUPreferences) SwaggerDoc() map[string]string {
 
 func (SpreadOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"across": "Across optionally defines how to spread vCPUs across the guest visible topology.\nDefault: SocketsCores\n\n+optional",
+		"across": "Across optionally defines how to spread vCPUs across the guest visible topology.\nDefault: SocketsCores\n\n+optional\n+kubebuilder:validation:Enum=SocketsCoresThreads;SocketsCores;CoresThreads",
 		"ratio":  "Ratio optionally defines the ratio to spread vCPUs across the guest visible topology:\n\nCoresThreads        - 1:2   - Controls the ratio of cores to threads. Only a ratio of 2 is currently accepted.\nSocketsCores        - 1:N   - Controls the ratio of socket to cores.\nSocketsCoresThreads - 1:N:2 - Controls the ratio of socket to cores. Each core providing 2 threads.\n\nDefault: 2\n\n+optional",
 	}
 }

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -109,6 +109,22 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				Create(context.Background(), preference, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should reject unsupported PreferredCPUTopolgy value", func() {
+			preference := builder.NewPreference(
+				builder.WithPreferredCPUTopology(instancetypev1beta1.PreferredCPUTopology("foo")),
+			)
+			_, err := virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(preference)).Create(context.Background(), preference, metav1.CreateOptions{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject unsupported SpreadOptions.Across value", func() {
+			preference := builder.NewPreference(
+				builder.WithSpreadAcross(instancetypev1beta1.SpreadAcross("foo")),
+			)
+			_, err := virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(preference)).Create(context.Background(), preference, metav1.CreateOptions{})
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Context("VM with invalid InstancetypeMatcher", func() {

--- a/tests/libinstancetype/builder/builder.go
+++ b/tests/libinstancetype/builder/builder.go
@@ -139,3 +139,16 @@ func WithPreferredDiskBus(bus v1.DiskBus) PreferenceSpecOption {
 		spec.Devices.PreferredDiskBus = bus
 	}
 }
+
+func WithSpreadAcross(across instancetypev1beta1.SpreadAcross) PreferenceSpecOption {
+	return func(spec *instancetypev1beta1.VirtualMachinePreferenceSpec) {
+		if spec.CPU == nil {
+			spec.CPU = &instancetypev1beta1.CPUPreferences{}
+		}
+		if spec.CPU.SpreadOptions == nil {
+			spec.CPU.SpreadOptions = &instancetypev1beta1.SpreadOptions{}
+		}
+		spec.CPU.PreferredCPUTopology = pointer.P(instancetypev1beta1.Spread)
+		spec.CPU.SpreadOptions.Across = pointer.P(across)
+	}
+}


### PR DESCRIPTION
/area instancetype

### What this PR does

This change adds API validation for the enums allowed by a preference for `PreferredCPUTopology` and `SpreadAcross` options. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

