### PR TITLE
[release-1.3] Configure a single vGPU display with ramfb

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1213,6 +1213,35 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.GPUs"))
 		})
+
+		It("should reject multiple configurations of vGPU displays with ramfb", func() {
+			enableFeatureGate(virtconfig.GPUGate)
+			vmi := api.NewMinimalVMI("testvm")
+			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
+				{
+					Name:       "gpu1",
+					DeviceName: "vendor.com/gpu_name",
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.Bool(true),
+						},
+					},
+				},
+				{
+					Name:       "gpu2",
+					DeviceName: "vendor.com/gpu_name1",
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.Bool(true),
+						},
+					},
+				},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("fake.GPUs"))
+		})
 		It("should accept legacy GPU devices if PermittedHostDevices aren't set", func() {
 			kvConfig := kv.DeepCopy()
 			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.GPUGate}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -52,9 +52,30 @@ func CreatePCIHostDevices(hostDevicesData []HostDeviceMetaData, pciAddrPool Addr
 	return createHostDevices(hostDevicesData, pciAddrPool, createPCIHostDevice)
 }
 
+func isVgpuDisplaySet(hostDevicesData []HostDeviceMetaData) bool {
+	for _, hostDeviceData := range hostDevicesData {
+		if hostDeviceData.VirtualGPUOptions != nil &&
+			hostDeviceData.VirtualGPUOptions.Display != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func CreateMDEVHostDevices(hostDevicesData []HostDeviceMetaData, mdevAddrPool AddressPooler, enableDefaultDisplay bool) ([]api.HostDevice, error) {
 	if enableDefaultDisplay {
-		return createHostDevices(hostDevicesData, mdevAddrPool, createMDEVHostDeviceWithDisplay)
+		devices, err := createHostDevices(hostDevicesData, mdevAddrPool, createMDEVHostDeviceWithDisplay)
+		if err != nil {
+			return devices, err
+		}
+		// add a default single display option with enabled ramfb
+		// only if no vgpuDisplay option was configured.
+		if !isVgpuDisplaySet(hostDevicesData) && len(devices) > 0 {
+			devices[0].Display = "on"
+			devices[0].RamFB = "on"
+		}
+		return devices, nil
+
 	}
 	return createHostDevices(hostDevicesData, mdevAddrPool, createMDEVHostDevice)
 }
@@ -130,9 +151,6 @@ func createMDEVHostDeviceWithDisplay(hostDeviceData HostDeviceMetaData, mdevUUID
 				}
 			}
 		}
-	} else {
-		mdev.Display = "on"
-		mdev.RamFB = "on"
 	}
 	return mdev, nil
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/12053

### Release note
```release-note
Only a single vgpu display option with ramfb will be configured per VMI.
```