### PR TITLE
Remove the deprecated function NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata

### DIFF
--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -70,3 +70,7 @@ func addDiskVolumeWithCloudInitNoCloud(vmi *v1.VirtualMachineInstance, diskName 
 func setCloudInitNoCloud(volume *v1.Volume, source *v1.CloudInitNoCloudSource) {
 	volume.VolumeSource = v1.VolumeSource{CloudInitNoCloud: source}
 }
+
+func GetCloudInitVolume(vmi *v1.VirtualMachineInstance) *v1.Volume {
+	return getVolume(vmi, cloudInitDiskName)
+}

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -58,7 +58,7 @@ func NewCirros(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	vmi := libvmi.New(cirrosOpts...)
 
 	// Supplied with no user data, Cirros image takes 230s to allow login
-	if !cloudInitNoCloudExists(vmi.Spec.Volumes) {
+	if libvmi.GetCloudInitVolume(vmi) == nil {
 		withNonEmptyUserData := libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho hello\n"))
 		withNonEmptyUserData(vmi)
 	}
@@ -88,20 +88,11 @@ func NewAlpineWithTestTooling(opts ...libvmi.Option) *kvirtv1.VirtualMachineInst
 	vmi := libvmi.New(alpineOpts...)
 
 	// Supplied with no user data, AlpimeWithTestTooling image takes more than 200s to allow login
-	if !cloudInitNoCloudExists(vmi.Spec.Volumes) {
+	if libvmi.GetCloudInitVolume(vmi) == nil {
 		withNonEmptyUserData := libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData("#!/bin/bash\necho hello\n"))
 		withNonEmptyUserData(vmi)
 	}
 	return vmi
-}
-
-func cloudInitNoCloudExists(volumes []kvirtv1.Volume) bool {
-	for _, vol := range volumes {
-		if src := vol.CloudInitNoCloud; src != nil && (src.UserData != "" || src.UserDataBase64 != "" || src.UserDataSecretRef != nil) {
-			return true
-		}
-	}
-	return false
 }
 
 func NewGuestless(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -193,16 +193,6 @@ func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData st
 	return vmi
 }
 
-// NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(containerImage string, userData string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
-	cloudInitConfigDriveData := libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveUserData(userData))
-	cloudInitConfigDriveData(vmi)
-	return vmi
-}
-
 // NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData
 //
 // Deprecated: Use libvmi directly

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -54,6 +54,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
+	libcloudinit "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
@@ -181,7 +182,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Context("with cloudInitConfigDrive userDataBase64 source", func() {
 			It("[test_id:3178]should have cloud-init data", func() {
 				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+				vmi := libvmifact.NewCirros(libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveUserData(userData)))
 
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
@@ -301,9 +302,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				runTest(vmi, cloudinit.DataSourceNoCloud)
 			})
 			It("[test_id:3180] with cloudInitConfigDrive userData source", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros),
-					userData)
+				vmi := libvmifact.NewCirros(libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveUserData(userData)))
 				runTest(vmi, cloudinit.DataSourceConfigDrive)
 			})
 		})


### PR DESCRIPTION
### What this PR does
Before this PR:
The NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata is deprecated

After this PR:
NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata was removed, and replaced by calls to the libvmi functions.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/sig code-quality
