### PR TITLE
Reduce severity when VolumeSnapshotClass is absent

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -650,7 +650,7 @@ func (ctrl *VMSnapshotController) getVolumeSnapshotClass(storageClassName string
 	}
 
 	if len(matches) == 0 {
-		log.Log.Warningf("No VolumeSnapshotClass for %s", storageClassName)
+		log.Log.V(3).Infof("No VolumeSnapshotClass for %s", storageClassName)
 		return "", nil
 	}
 

--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -628,6 +628,8 @@ func (ctrl *VMSnapshotController) getSnapshotPVC(namespace, volumeName string) (
 
 	if volumeSnapshotClass != "" {
 		return pvc, nil
+	} else {
+		log.Log.Warningf("No VolumeSnapshotClass for %s", pvc.Spec.storageClassName)
 	}
 
 	return nil, nil
@@ -777,7 +779,6 @@ func updateVMSnapshotIndications(source snapshotSource) ([]snapshotv1.Indication
 
 		if ga {
 			indications = append(indications, snapshotv1.VMSnapshotGuestAgentIndication)
-
 		} else {
 			indications = append(indications, snapshotv1.VMSnapshotNoGuestAgentIndication)
 		}

--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -630,7 +630,7 @@ func (ctrl *VMSnapshotController) getSnapshotPVC(namespace, volumeName string) (
 		return pvc, nil
 	}
 
-	log.Log.Warningf("No VolumeSnapshotClass for %s", pvc.Spec.storageClassName)
+	log.Log.Warningf("No VolumeSnapshotClass for %s", *pvc.Spec.StorageClassName)
 
 	return nil, nil
 }

--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -628,9 +628,9 @@ func (ctrl *VMSnapshotController) getSnapshotPVC(namespace, volumeName string) (
 
 	if volumeSnapshotClass != "" {
 		return pvc, nil
-	} else {
-		log.Log.Warningf("No VolumeSnapshotClass for %s", pvc.Spec.storageClassName)
 	}
+
+	log.Log.Warningf("No VolumeSnapshotClass for %s", pvc.Spec.storageClassName)
 
 	return nil, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

#### Before this PR

When a volume associated with a VM is using a `StorageClass` which does not have a `VolumeSnapshotClass` associated with it, a log message is emitted at the warning level. In our environment using a CSI driver which does not support snapshots (AWS EFS), this generates excessive logs in the order of ~500k messages per day.

#### After this PR

The log message will be emitted at verbosity level 3. This level was chosen as it is above the [default level of 2](https://github.com/kubevirt/kubevirt/blob/fb7c34663c81fc5c0c49ea984b1f970b62ea042b/staging/src/kubevirt.io/client-go/log/log.go?plain=1#L101) and would therefore be avoided by default.

### Why we need it and why it was done in this way

#### The following tradeoffs were made

Although the message will not be shown in logs, it will still be shown in the `status.volumeSnapshotStatuses` field of the VM resource.

#### The following alternatives were considered

This could potentially done by more intelligently assessing the `StorageClass` in use and whether the `provisioner` supports snapshots but this would place some burden on KubeVirt to maintain a compatibility list.

### Special notes for your reviewer

None

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note

```release-note
* Reduced the severity of log messages when a `VolumeSnapshotClass` is not found. When snapshots are not enabled for a volume, the reason will still be displayed in the `status.volumeSnapshotStatuses` field of a `VirtualMachine` resource.
```

