### PR TITLE
tests, utils: Move GetVMPodName to libpod

### DIFF
--- a/tests/libpod/query.go
+++ b/tests/libpod/query.go
@@ -25,8 +25,6 @@ import (
 	"sort"
 	"strings"
 
-	"kubevirt.io/client-go/kubecli"
-
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -92,12 +90,12 @@ func vmiFieldSelector(vmi *v1.VirtualMachineInstance) string {
 	return strings.Join(fieldSelectors, ",")
 }
 
-func GetVmPodName(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (string, error) {
+func GetVmPodName(vmi *v1.VirtualMachineInstance) (string, error) {
 	namespace := vmi.GetObjectMeta().GetNamespace()
 	uid := vmi.GetObjectMeta().GetUID()
 	labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
 
-	pods, err := virtCli.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+	pods, err := kubevirt.Client().CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return "", err
 	}

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -171,7 +171,7 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 				serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
 
 				Expect(serverVMI.Status.Interfaces).NotTo(BeEmpty(), "a migrate-able VMI must have network interfaces")
-				serverVMIPodName, err = libpod.GetVmPodName(kubevirt.Client(), serverVMI)
+				serverVMIPodName, err = libpod.GetVmPodName(serverVMI)
 				Expect(err).ToNot(HaveOccurred())
 
 				serverIP, err = waitVMMacvtapIfaceIPReport(serverVMI, serverMAC, macvtapIfaceIPReportTimeout)

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -46,6 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -170,7 +171,7 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 				serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
 
 				Expect(serverVMI.Status.Interfaces).NotTo(BeEmpty(), "a migrate-able VMI must have network interfaces")
-				serverVMIPodName = tests.GetVmPodName(kubevirt.Client(), serverVMI)
+				serverVMIPodName = libpod.GetVmPodName(kubevirt.Client(), serverVMI)
 
 				serverIP, err = waitVMMacvtapIfaceIPReport(serverVMI, serverMAC, macvtapIfaceIPReportTimeout)
 				Expect(err).NotTo(HaveOccurred(), "should have managed to figure out the IP of the server VMI")

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -171,7 +171,8 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 				serverVMI = libwait.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
 
 				Expect(serverVMI.Status.Interfaces).NotTo(BeEmpty(), "a migrate-able VMI must have network interfaces")
-				serverVMIPodName = libpod.GetVmPodName(kubevirt.Client(), serverVMI)
+				serverVMIPodName, err = libpod.GetVmPodName(kubevirt.Client(), serverVMI)
+				Expect(err).ToNot(HaveOccurred())
 
 				serverIP, err = waitVMMacvtapIfaceIPReport(serverVMI, serverMAC, macvtapIfaceIPReportTimeout)
 				Expect(err).NotTo(HaveOccurred(), "should have managed to figure out the IP of the server VMI")

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -190,7 +190,9 @@ var istioTests = func(vmType VmType) {
 				checks.SkipIfMigrationIsNotPossible()
 			})
 			JustBeforeEach(func() {
-				sourcePodName = libpod.GetVmPodName(virtClient, vmi)
+				sourcePodName, err = libpod.GetVmPodName(virtClient, vmi)
+				Expect(err).ToNot(HaveOccurred())
+
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 				libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 			})

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -57,6 +57,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet/job"
 	netservice "kubevirt.io/kubevirt/tests/libnet/service"
 	"kubevirt.io/kubevirt/tests/libnet/vmnetserver"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libregistry"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -189,7 +190,7 @@ var istioTests = func(vmType VmType) {
 				checks.SkipIfMigrationIsNotPossible()
 			})
 			JustBeforeEach(func() {
-				sourcePodName = tests.GetVmPodName(virtClient, vmi)
+				sourcePodName = libpod.GetVmPodName(virtClient, vmi)
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 				libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 			})

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -190,7 +190,7 @@ var istioTests = func(vmType VmType) {
 				checks.SkipIfMigrationIsNotPossible()
 			})
 			JustBeforeEach(func() {
-				sourcePodName, err = libpod.GetVmPodName(virtClient, vmi)
+				sourcePodName, err = libpod.GetVmPodName(vmi)
 				Expect(err).ToNot(HaveOccurred())
 
 				migration := libmigration.New(vmi.Name, vmi.Namespace)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -461,26 +461,6 @@ func EnableFeatureGate(feature string) *v1.KubeVirt {
 	return UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
 }
 
-func GetVmPodName(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
-	namespace := vmi.GetObjectMeta().GetNamespace()
-	uid := vmi.GetObjectMeta().GetUID()
-	labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
-
-	pods, err := virtCli.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
-	Expect(err).ToNot(HaveOccurred())
-
-	podName := ""
-	for _, pod := range pods.Items {
-		if pod.ObjectMeta.DeletionTimestamp == nil {
-			podName = pod.ObjectMeta.Name
-			break
-		}
-	}
-	Expect(podName).ToNot(BeEmpty())
-
-	return podName
-}
-
 func GetRunningVMIDomainSpec(vmi *v1.VirtualMachineInstance) (*launcherApi.DomainSpec, error) {
 	runningVMISpec := launcherApi.DomainSpec{}
 	cli := kubevirt.Client()

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -58,7 +58,7 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", decorators.SigCompute, fu
 
 	GetCloudInitHookSidecarLogs := func(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 		namespace := vmi.GetObjectMeta().GetNamespace()
-		podName, err := libpod.GetVmPodName(virtCli, vmi)
+		podName, err := libpod.GetVmPodName(vmi)
 		Expect(err).ToNot(HaveOccurred())
 
 		var tailLines int64 = 100

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -37,10 +37,10 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libregistry"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -58,7 +58,7 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", decorators.SigCompute, fu
 
 	GetCloudInitHookSidecarLogs := func(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 		namespace := vmi.GetObjectMeta().GetNamespace()
-		podName := tests.GetVmPodName(virtCli, vmi)
+		podName := libpod.GetVmPodName(virtCli, vmi)
 
 		var tailLines int64 = 100
 		logsRaw, err := virtCli.CoreV1().

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -58,7 +58,8 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", decorators.SigCompute, fu
 
 	GetCloudInitHookSidecarLogs := func(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 		namespace := vmi.GetObjectMeta().GetNamespace()
-		podName := libpod.GetVmPodName(virtCli, vmi)
+		podName, err := libpod.GetVmPodName(virtCli, vmi)
+		Expect(err).ToNot(HaveOccurred())
 
 		var tailLines int64 = 100
 		logsRaw, err := virtCli.CoreV1().

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -330,7 +330,8 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 
 func getHookSidecarLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	namespace := vmi.GetObjectMeta().GetNamespace()
-	podName := libpod.GetVmPodName(virtCli, vmi)
+	podName, err := libpod.GetVmPodName(virtCli, vmi)
+	Expect(err).ToNot(HaveOccurred())
 
 	var tailLines int64 = 100
 	logsRaw, err := virtCli.CoreV1().

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -330,7 +330,7 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 
 func getHookSidecarLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	namespace := vmi.GetObjectMeta().GetNamespace()
-	podName, err := libpod.GetVmPodName(virtCli, vmi)
+	podName, err := libpod.GetVmPodName(vmi)
 	Expect(err).ToNot(HaveOccurred())
 
 	var tailLines int64 = 100

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -330,7 +330,7 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 
 func getHookSidecarLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	namespace := vmi.GetObjectMeta().GetNamespace()
-	podName := tests.GetVmPodName(virtCli, vmi)
+	podName := libpod.GetVmPodName(virtCli, vmi)
 
 	var tailLines int64 = 100
 	logsRaw, err := virtCli.CoreV1().


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The helper `GetVMPodName` lives at test/utils.

After this PR:
`GetVMPodName` moved to libpod.

The `GetVMPodName` function is also refactored to address the following issues:
- Return error instead of assert the error
- Fetch virt client using the tests framework singleton

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

