### PR TITLE
 Report VM/VMI conditions as kubernetes events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ hack/builder/manifests/
 .bazeldnf/
 user.bazelrc
 .vscode/
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,3 @@ hack/builder/manifests/
 .bazeldnf/
 user.bazelrc
 .vscode/
-.envrc

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -729,7 +729,6 @@ func (c *VMController) handleCPUChangeRequest(vm *virtv1.VirtualMachine, vmi *vi
                 return nil
         }
 
-
 	if err := c.VMICPUsPatch(vmCopyWithInstancetype, vmi); err != nil {
 		log.Log.Object(vmi).Errorf("unable to patch vmi to add cpu topology status: %v", err)
 		return err
@@ -970,7 +969,7 @@ func (c *VMController) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi 
 		// Validate if the update volumes can be migrated
 		if err := volumemig.ValidateVolumes(vmi, vm); err != nil {
                         setRestartRequired(vm, err.Error())
-			return nil
+		        return nil
 		}
 
 		if err := volumemig.PatchVMIStatusWithMigratedVolumes(c.clientset, c.pvcStore, vmi, vm); err != nil {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -735,18 +735,6 @@ func (c *VMController) handleCPUChangeRequest(vm *virtv1.VirtualMachine, vmi *vi
 		return nil
 	}
 
-	networkInterfaceMultiQueue := vmCopyWithInstancetype.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
-	if networkInterfaceMultiQueue != nil && *networkInterfaceMultiQueue {
-		setRestartRequired(vm, "Changes to CPU sockets require a restart when NetworkInterfaceMultiQueue is enabled")
-                return nil
-        }
-
-	networkInterfaceMultiQueue := vmCopyWithInstancetype.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
-	if networkInterfaceMultiQueue != nil && *networkInterfaceMultiQueue {
-		setRestartRequired(vm, "Changes to CPU sockets require a restart when NetworkInterfaceMultiQueue is enabled")
-                return nil
-        }
-
 	if err := c.VMICPUsPatch(vmCopyWithInstancetype, vmi); err != nil {
 		log.Log.Object(vmi).Errorf("unable to patch vmi to add cpu topology status: %v", err)
 		return err

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -714,26 +714,21 @@ func (c *VMController) handleCPUChangeRequest(vm *virtv1.VirtualMachine, vmi *vi
 	// Since we're here, we can also assume MaxSockets was not changed in the VM spec since last boot.
 	// Therefore, bumping Sockets to a value higher than MaxSockets is fine, it just requires a reboot.
 	if vmCopyWithInstancetype.Spec.Template.Spec.Domain.CPU.Sockets > vmi.Spec.Domain.CPU.MaxSockets {
-		vmConditions := controller.NewVirtualMachineConditionManager()
-		vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-			Type:               virtv1.VirtualMachineRestartRequired,
-			LastTransitionTime: metav1.Now(),
-			Status:             k8score.ConditionTrue,
-			Message:            "CPU sockets updated in template spec to a value higher than what's available",
-		})
+                setRestartRequired(vm, "CPU sockets updated in template spec to a value higher than what's available")
 		return nil
 	}
 
 	if vmCopyWithInstancetype.Spec.Template.Spec.Domain.CPU.Sockets < vmi.Spec.Domain.CPU.Sockets {
-		vmConditions := controller.NewVirtualMachineConditionManager()
-		vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-			Type:               virtv1.VirtualMachineRestartRequired,
-			LastTransitionTime: metav1.Now(),
-			Status:             k8score.ConditionTrue,
-			Message:            "Reduction of CPU socket count requires a restart",
-		})
+		setRestartRequired(vm, "Reduction of CPU socket count requires a restart")
 		return nil
 	}
+
+	networkInterfaceMultiQueue := vmCopyWithInstancetype.Spec.Template.Spec.Domain.Devices.NetworkInterfaceMultiQueue
+	if networkInterfaceMultiQueue != nil && *networkInterfaceMultiQueue {
+		setRestartRequired(vm, "Changes to CPU sockets require a restart when NetworkInterfaceMultiQueue is enabled")
+                return nil
+        }
+
 
 	if err := c.VMICPUsPatch(vmCopyWithInstancetype, vmi); err != nil {
 		log.Log.Object(vmi).Errorf("unable to patch vmi to add cpu topology status: %v", err)
@@ -966,12 +961,7 @@ func (c *VMController) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi 
 		*vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyReplacement:
 		if !vmConditions.HasCondition(vm, virtv1.VirtualMachineRestartRequired) {
 			log.Log.Object(vm).Infof("Set restart required condition because of a volumes update")
-			vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-				Type:               virtv1.VirtualMachineRestartRequired,
-				LastTransitionTime: v1.Now(),
-				Status:             k8score.ConditionTrue,
-				Message:            "the volumes replacement is effective only after restart",
-			})
+                        setRestartRequired(vm, "the volumes replacement is effective only after restart")
 		}
 	case *vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyMigration:
 		if !c.clusterConfig.VolumeMigrationEnabled() {
@@ -979,12 +969,7 @@ func (c *VMController) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi 
 		}
 		// Validate if the update volumes can be migrated
 		if err := volumemig.ValidateVolumes(vmi, vm); err != nil {
-			vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-				Type:               virtv1.VirtualMachineRestartRequired,
-				LastTransitionTime: v1.Now(),
-				Status:             k8score.ConditionTrue,
-				Message:            err.Error(),
-			})
+                        setRestartRequired(vm, err.Error())
 			return nil
 		}
 
@@ -1102,7 +1087,7 @@ func (c *VMController) syncRunStrategy(vm *virtv1.VirtualMachine, vmi *virtv1.Vi
 		}
 
 		// when coming here from a different RunStrategy we have to start the VM
-		if !hasStartRequest(vm) && vm.Status.RunStrategy == *vm.Spec.RunStrategy {
+                if !hasStartRequest(vm) && vm.Status.RunStrategy == runStrategy {
 			return vm, nil
 		}
 
@@ -2431,7 +2416,11 @@ func (c *VMController) updateStatus(vm, vmOrig *virtv1.VirtualMachine, vmi *virt
 	vm.Status.Ready = ready
 
 	runStrategy, _ := vmOrig.RunStrategy()
-	vm.Status.RunStrategy = runStrategy
+	// sync for the first time only when the VMI gets created
+	// so that we can tell if the VM got started at least once
+	if vm.Status.RunStrategy != "" || vm.Status.Created {
+		vm.Status.RunStrategy = runStrategy
+	}
 
 	c.trimDoneVolumeRequests(vm)
 	c.updateMemoryDumpRequest(vm, vmi)
@@ -2989,6 +2978,16 @@ func validLiveUpdateDisks(oldVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.Virtu
 	return true
 }
 
+func setRestartRequired(vm *virtv1.VirtualMachine, message string) {
+	vmConditions := controller.NewVirtualMachineConditionManager()
+	vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
+		Type:               virtv1.VirtualMachineRestartRequired,
+		LastTransitionTime: metav1.Now(),
+		Status:             k8score.ConditionTrue,
+		Message:            message,
+	})
+}
+
 // addRestartRequiredIfNeeded adds the restartRequired condition to the VM if any non-live-updatable field was changed
 func (c *VMController) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.VirtualMachineSpec, vm *virtv1.VirtualMachine) bool {
 	if lastSeenVMSpec == nil {
@@ -3035,13 +3034,7 @@ func (c *VMController) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.Virtual
 	}
 
 	if !equality.Semantic.DeepEqual(lastSeenVM.Spec.Template.Spec, currentVM.Spec.Template.Spec) {
-		vmConditionManager := controller.NewVirtualMachineConditionManager()
-		vmConditionManager.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-			Type:               virtv1.VirtualMachineRestartRequired,
-			LastTransitionTime: metav1.Now(),
-			Status:             k8score.ConditionTrue,
-			Message:            "a non-live-updatable field was changed in the template spec",
-		})
+                setRestartRequired(vm, "a non-live-updatable field was changed in the template spec")
 		return true
 	}
 
@@ -3297,22 +3290,22 @@ func (c *VMController) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi
 
 	conditionManager := controller.NewVirtualMachineInstanceConditionManager()
 
-	if vmi.Spec.Domain.Memory.MaxGuest == nil ||
-		conditionManager.HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceMemoryChange, k8score.ConditionFalse) {
-		// memory hotplug either failed or is incompatible, let's trigger the restart required condition
-		// to make the memory bump effective
-
-		vmConditions := controller.NewVirtualMachineConditionManager()
-		vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-			Type:               virtv1.VirtualMachineRestartRequired,
-			LastTransitionTime: metav1.Now(),
-			Status:             k8score.ConditionTrue,
-			Message:            "memory updated in template spec. Memory-hotplug is not available for this VM configuration",
-		})
+        if conditionManager.HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceMemoryChange, k8score.ConditionFalse) {
+		setRestartRequired(vm, "memory updated in template spec. Memory-hotplug failed and is not available for this VM configuration")
 		return nil
 	}
 
 	if vmCopyWithInstancetype.Spec.Template.Spec.Domain.Memory.Guest.Equal(*vmi.Spec.Domain.Memory.Guest) {
+		return nil
+	}
+
+	if !vmi.IsMigratable() {
+		setRestartRequired(vm, "memory updated in template spec. Memory-hotplug is only available for migratable VMs")
+		return nil
+	}
+
+	if vmi.Spec.Domain.Memory.MaxGuest == nil {
+		setRestartRequired(vm, "memory updated in template spec. Memory-hotplug is not available for this VM configuration")
 		return nil
 	}
 
@@ -3326,25 +3319,13 @@ func (c *VMController) handleMemoryHotplugRequest(vm *virtv1.VirtualMachine, vmi
 	}
 
 	if err := memory.ValidateLiveUpdateMemory(&vmCopyWithInstancetype.Spec.Template.Spec, vmi.Spec.Domain.Memory.MaxGuest); err != nil {
-		vmConditions := controller.NewVirtualMachineConditionManager()
-		vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-			Type:               virtv1.VirtualMachineRestartRequired,
-			LastTransitionTime: metav1.Now(),
-			Status:             k8score.ConditionTrue,
-			Message:            fmt.Sprintf("memory hotplug not supported, %s", err.Error()),
-		})
+                setRestartRequired(vm, fmt.Sprintf("memory hotplug not supported, %s", err.Error()))
 		return nil
 	}
 
 	if vmCopyWithInstancetype.Spec.Template.Spec.Domain.Memory.Guest != nil && vmi.Status.Memory.GuestAtBoot != nil &&
 		vmCopyWithInstancetype.Spec.Template.Spec.Domain.Memory.Guest.Cmp(*vmi.Status.Memory.GuestAtBoot) == -1 {
-		vmConditions := controller.NewVirtualMachineConditionManager()
-		vmConditions.UpdateCondition(vm, &virtv1.VirtualMachineCondition{
-			Type:               virtv1.VirtualMachineRestartRequired,
-			LastTransitionTime: metav1.Now(),
-			Status:             k8score.ConditionTrue,
-			Message:            "memory updated in template spec to a value lower than what the VM started with",
-		})
+                setRestartRequired(vm, "memory updated in template spec to a value higher than what's available")
 		return nil
 	}
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -68,12 +68,6 @@ import (
 )
 
 const (
-
-	//VMIProvisioning is the reason set when a VMI is provisioning
-        VMIProvisioning = "VirtualMachineInstance provisioning."
-)
-
-const (
 	deleteNotifFailed        = "Failed to process delete notification"
 	tombstoneGetObjectErrFmt = "couldn't get object from tombstone %+v"
 )
@@ -540,7 +534,6 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 				}
 				if !conditionManager.HasCondition(vmiCopy, condition.Type) {
 					vmiCopy.Status.Conditions = append(vmiCopy.Status.Conditions, condition)
-                                        c.recorder.Event(vmi, k8sv1.EventTypeNormal, string(condition.Type), VMIProvisioning)
 				}
 				if tempPodExists {
 					// Add PodScheduled False condition to the VM
@@ -568,7 +561,6 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 					cm.RemoveCondition(vmiCopy, condition.Type)
 				}
 				vmiCopy.Status.Conditions = append(vmiCopy.Status.Conditions, condition)
-			        c.recorder.Event(vmi, k8sv1.EventTypeWarning, condition.Reason, condition.Message)
 			}
 		}
 	case vmi.IsScheduling():

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -48,7 +48,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/trace"
 
-	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -2407,14 +2406,14 @@ func (c *VMIController) aggregateDataVolumesConditions(vmiCopy *virtv1.VirtualMa
 
 
 	vmiConditions := controller.NewVirtualMachineInstanceConditionManager()
-	cond := vmiConditions.GetCondition(vmiCopy, v1.VirtualMachineInstanceDataVolumesReady)
+	cond := vmiConditions.GetCondition(vmiCopy, virtv1.VirtualMachineInstanceDataVolumesReady)
 	if !equality.Semantic.DeepEqual(cond, dvsReadyCondition) {
 	        vmiConditions.UpdateCondition(vmiCopy, &dvsReadyCondition)
 
                 if dvsReadyCondition.Status == k8sv1.ConditionTrue {
-			d.recorder.Event(vmi, k8sv1.EventTypeNormal, dvsReadyCondition.Reason, dvsReadyCondition.Message)
+			c.recorder.Event(vmiCopy, k8sv1.EventTypeNormal, dvsReadyCondition.Reason, dvsReadyCondition.Message)
                 } else {
-			d.recorder.Event(vmi, k8sv1.EventTypeWarning, dvsReadyCondition.Reason, dvsReadyCondition.Message)
+			c.recorder.Event(vmiCopy, k8sv1.EventTypeWarning, dvsReadyCondition.Reason, dvsReadyCondition.Message)
                 }
         }
 }

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/trace"
 
+	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -65,6 +66,12 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/descheduler"
+)
+
+const (
+
+	//VMIProvisioning is the reason set when a VMI is provisioning
+        VMIProvisioning = "VirtualMachineInstance provisioning."
 )
 
 const (
@@ -534,6 +541,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 				}
 				if !conditionManager.HasCondition(vmiCopy, condition.Type) {
 					vmiCopy.Status.Conditions = append(vmiCopy.Status.Conditions, condition)
+                                        c.recorder.Event(vmi, k8sv1.EventTypeNormal, string(condition.Type), VMIProvisioning)
 				}
 				if tempPodExists {
 					// Add PodScheduled False condition to the VM
@@ -561,6 +569,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 					cm.RemoveCondition(vmiCopy, condition.Type)
 				}
 				vmiCopy.Status.Conditions = append(vmiCopy.Status.Conditions, condition)
+			        c.recorder.Event(vmi, k8sv1.EventTypeWarning, condition.Reason, condition.Message)
 			}
 		}
 	case vmi.IsScheduling():
@@ -2396,8 +2405,18 @@ func (c *VMIController) aggregateDataVolumesConditions(vmiCopy *virtv1.VirtualMa
 		dvsReadyCondition.Message = "Not all of the VMI's DVs are ready"
 	}
 
+
 	vmiConditions := controller.NewVirtualMachineInstanceConditionManager()
-	vmiConditions.UpdateCondition(vmiCopy, &dvsReadyCondition)
+	cond := vmiConditions.GetCondition(vmiCopy, v1.VirtualMachineInstanceDataVolumesReady)
+	if !equality.Semantic.DeepEqual(cond, dvsReadyCondition) {
+	        vmiConditions.UpdateCondition(vmiCopy, &dvsReadyCondition)
+
+                if dvsReadyCondition.Status == k8sv1.ConditionTrue {
+			d.recorder.Event(vmi, k8sv1.EventTypeNormal, dvsReadyCondition.Reason, dvsReadyCondition.Message)
+                } else {
+			d.recorder.Event(vmi, k8sv1.EventTypeWarning, dvsReadyCondition.Reason, dvsReadyCondition.Message)
+                }
+        }
 }
 
 func statusOfReadyCondition(conditions []cdiv1.DataVolumeCondition) k8sv1.ConditionStatus {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -147,8 +147,8 @@ const (
 	VMIShutdown = "The VirtualMachineInstance was shut down."
 	//VMIPaused is the reason set when a VMI is paused
 	VMIPaused = "VirtualMachineInstance paused."
-        //VMIResumed is  the reason set when a VMI is resumed
-        VMIResumed = "VirtualMachineInstance resumed."
+	//VMIResumed is  the reason set when a VMI is resumed
+	VMIResumed = "VirtualMachineInstance resumed."
 	//VMICrashed is the reason set when a VMI crashed
 	VMICrashed = "The VirtualMachineInstance crashed."
 	//VMIAbortingMigration is the reason set when migration is being aborted
@@ -1109,18 +1109,18 @@ func (d *VirtualMachineController) updateAccessCredentialConditions(vmi *v1.Virt
 func (d *VirtualMachineController) updateLiveMigrationConditions(vmi *v1.VirtualMachineInstance, condManager *controller.VirtualMachineInstanceConditionManager) {
 	// Calculate whether the VM is migratable
 	liveMigrationCondition, isBlockMigration := d.calculateLiveMigrationCondition(vmi)
-        status := liveMigrationCondition.Status 
-        reason := liveMigrationCondition.Reason
-        message := liveMigrationCondition.Message
+	status := liveMigrationCondition.Status
+	reason := liveMigrationCondition.Reason
+	message := liveMigrationCondition.Message
 
 	if !condManager.HasCondition(vmi, v1.VirtualMachineInstanceIsMigratable) {
 		vmi.Status.Conditions = append(vmi.Status.Conditions, *liveMigrationCondition)
 
-                if status == k8sv1.ConditionTrue {
+		if status == k8sv1.ConditionTrue {
 			d.recorder.Event(vmi, k8sv1.EventTypeNormal, reason, message)
-                } else {
-                        d.recorder.Event(vmi, k8sv1.EventTypeWarning, reason, message)
-                }
+		} else {
+			d.recorder.Event(vmi, k8sv1.EventTypeWarning, reason, message)
+		}
 
 		// Set VMI Migration Method
 		if isBlockMigration {
@@ -1134,11 +1134,11 @@ func (d *VirtualMachineController) updateLiveMigrationConditions(vmi *v1.Virtual
 			condManager.RemoveCondition(vmi, v1.VirtualMachineInstanceIsMigratable)
 			vmi.Status.Conditions = append(vmi.Status.Conditions, *liveMigrationCondition)
 
-                        if status == k8sv1.ConditionTrue {
-        			d.recorder.Event(vmi, k8sv1.EventTypeNormal, reason, message)
-                        } else {
-                                d.recorder.Event(vmi, k8sv1.EventTypeWarning, reason, message)
-                        }
+			if status == k8sv1.ConditionTrue {
+				d.recorder.Event(vmi, k8sv1.EventTypeNormal, reason, message)
+			} else {
+				d.recorder.Event(vmi, k8sv1.EventTypeWarning, reason, message)
+			}
 		}
 	}
 
@@ -1149,6 +1149,7 @@ func (d *VirtualMachineController) updateLiveMigrationConditions(vmi *v1.Virtual
 }
 
 func (d *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) error {
+
 
 	// Update the condition when GA is connected
 	channelConnected := false
@@ -1174,7 +1175,7 @@ func (d *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMac
 			Status:        k8sv1.ConditionTrue,
 		}
 		vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
-        	d.recorder.Event(vmi, k8sv1.EventTypeNormal, string(v1.VirtualMachineInstanceAgentConnected), "guest agent successfully connected")
+		d.recorder.Event(vmi, k8sv1.EventTypeNormal, string(v1.VirtualMachineInstanceAgentConnected), "guest agent successfully connected")
 	case !channelConnected:
 		condManager.RemoveCondition(vmi, v1.VirtualMachineInstanceAgentConnected)
 	}
@@ -1218,7 +1219,7 @@ func (d *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMac
 					Reason:        reason,
 				}
 				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
-        	                d.recorder.Event(vmi, k8sv1.EventTypeNormal, string(v1.VirtualMachineInstanceUnsupportedAgent), reason)
+				d.recorder.Event(vmi, k8sv1.EventTypeNormal, string(v1.VirtualMachineInstanceUnsupportedAgent), reason)
 			}
 		} else {
 			condManager.RemoveCondition(vmi, v1.VirtualMachineInstanceUnsupportedAgent)
@@ -1238,7 +1239,7 @@ func (d *VirtualMachineController) updatePausedConditions(vmi *v1.VirtualMachine
 	} else if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
 		log.Log.Object(vmi).V(3).Info("Removing paused condition")
 		condManager.RemoveCondition(vmi, v1.VirtualMachineInstancePaused)
-                d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Resumed.String(), VMIResumed)
+		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Resumed.String(), VMIResumed)
 	}
 }
 
@@ -1593,7 +1594,7 @@ func (d *VirtualMachineController) calculatePausedCondition(vmi *v1.VirtualMachi
 	case api.ReasonPausedUser:
 		log.Log.Object(vmi).V(3).Info("Adding paused condition")
 		now := metav1.NewTime(time.Now())
-                condition := v1.VirtualMachineInstanceCondition{
+		condition := v1.VirtualMachineInstanceCondition{
 			Type:               v1.VirtualMachineInstancePaused,
 			Status:             k8sv1.ConditionTrue,
 			LastProbeTime:      now,
@@ -1602,11 +1603,11 @@ func (d *VirtualMachineController) calculatePausedCondition(vmi *v1.VirtualMachi
 			Message:            "VMI was paused by user",
 		}
 		vmi.Status.Conditions = append(vmi.Status.Conditions, condition)
-                d.recorder.Event(vmi, k8sv1.EventTypeNormal, condition.Reason, VMIPaused)
+		d.recorder.Event(vmi, k8sv1.EventTypeNormal, condition.Reason, VMIPaused)
 	case api.ReasonPausedIOError:
 		log.Log.Object(vmi).V(3).Info("Adding paused condition")
 		now := metav1.NewTime(time.Now())
-                condition := v1.VirtualMachineInstanceCondition{
+		condition := v1.VirtualMachineInstanceCondition{
 			Type:               v1.VirtualMachineInstancePaused,
 			Status:             k8sv1.ConditionTrue,
 			LastProbeTime:      now,
@@ -1614,8 +1615,8 @@ func (d *VirtualMachineController) calculatePausedCondition(vmi *v1.VirtualMachi
 			Reason:             "PausedIOError",
 			Message:            "VMI was paused, low-level IO error detected",
 		}
-                vmi.Status.Conditions = append(vmi.Status.Conditions, condition)
-                d.recorder.Event(vmi, k8sv1.EventTypeWarning, condition.Reason, VMIPaused)
+		vmi.Status.Conditions = append(vmi.Status.Conditions, condition)
+		d.recorder.Event(vmi, k8sv1.EventTypeWarning, condition.Reason, VMIPaused)
 	default:
 		log.Log.Object(vmi).V(3).Infof("Domain is paused for unknown reason, %s", reason)
 	}
@@ -2912,7 +2913,7 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 	if err := client.SyncMigrationTarget(vmi, options); err != nil {
 		return fmt.Errorf("syncing migration target failed: %v", err)
 	}
-	d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), VMIMigrationTargetPrepared) 
+	d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), VMIMigrationTargetPrepared)
 
 	err = d.handleTargetMigrationProxy(vmi)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**
VMI (and consequently) VM objects have many interesting status conditions that can often be of great value for event sourcing usecases. Currently only some Events are emitted for the VM/VMI objects but none of them are related to the conditions themselves (e.g. `DisksNotLiveMigratable`). Additionally, some VMI states aren't reflected as events either (e.g. `Paused`).

**After this PR:**
This PR aims to emit VM/VMI conditions and additional VMI states as Kubernetes Events.
It handles emission by adding events in codepaths where condition updates are applied to the VM/VMI objects.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/12046

### Why we need it and why it was done in this way
**The following tradeoffs were made:**

No significant tradeoffs were made as the relevant components already emit Events using their respective recorders (the PR aims to simply add more of them).

**The following alternatives were considered:**

The immediate alternative that comes to mind is to extend kubevirt metrics with information related to conditions, this however only addresses the observability aspect of the issue and not event sourcing. 

**Links to places where the discussion took place:** <!-- optional: slack, other GH issue, mailinglist, ... --> 
https://github.com/kubevirt/kubevirt/issues/12046

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

