### PR TITLE
backendstorage: use fixed volume name

### DIFF
--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -368,7 +368,7 @@ func withBackendStorage(vmi *v1.VirtualMachineInstance) VolumeRendererOption {
 			return nil
 		}
 
-		volumeName := vmi.Name + "-state"
+		volumeName := "vm-state"
 		pvcName := backendstorage.PVCForVMI(vmi)
 		renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
 			Name: volumeName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the backend storage state pod volume
name is generated from the vmi name.
Pod Volume names must respect [RFC 1123 Label Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names).
Using the vmi name is not correct since the latter must respect [DNS Subdomain Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names),
which is more relaxed compared with the first one.
This can cause an unschedulable pod in the following cases:
- the vmi name contains dots(".")
- the resulting volume name has a length > 63

Besides that, there is no reason to reference the vmi name inside the pod volume name,
since they must be unique just inside the container pod.

Let's just use a fixed name `vm-state`, as we already do, for example, for `private-libvirt`.

Before this PR:
Using tpm results in an unschedulable pod if the vmi name contains dots(".")

After this PR:
tpm can be used with vmis containing dots in their names.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: persistent tpm can be used with vmis containing dots in their name
```

