### PR TITLE
virt-controller, template: Move network related code to pkg/network

### DIFF
--- a/pkg/network/istio/annotations.go
+++ b/pkg/network/istio/annotations.go
@@ -21,4 +21,7 @@ package istio
 
 const (
 	ISTIO_INJECT_ANNOTATION = "sidecar.istio.io/inject"
+
+	// Istio list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound traffic in envoy
+	ISTIO_KUBEVIRT_ANNOTATION = "traffic.sidecar.istio.io/kubevirtInterfaces"
 )

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -188,3 +188,13 @@ func HasBindingPluginDeviceInfo(iface v1.Interface, bindingPlugins map[string]v1
 	}
 	return false
 }
+
+func HaveMasqueradeInterface(interfaces []v1.Interface) bool {
+	for _, iface := range interfaces {
+		if iface.Masquerade != nil {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/network/vmispec/interface_test.go
+++ b/pkg/network/vmispec/interface_test.go
@@ -270,6 +270,20 @@ var _ = Describe("VMI network spec", func() {
 			Expect(netvmispec.BindingPluginNetworkWithDeviceInfoExist(ifaces, bindingPlugins)).To(BeTrue())
 		})
 	})
+
+	Context("HaveMasqueradeInterface", func() {
+		DescribeTable("It should return false", func(interfaces []v1.Interface) {
+			Expect(netvmispec.HaveMasqueradeInterface(interfaces)).To(BeFalse())
+		},
+			Entry("when interfaces slice is nil", nil),
+			Entry("when interfaces slice is empty", []v1.Interface{}),
+			Entry("When there is no interface with masquerade binding", []v1.Interface{interfaceWithBridgeBinding(iface1)}),
+		)
+
+		It("Should return true when there is an interface with masquerade binding", func() {
+			Expect(netvmispec.HaveMasqueradeInterface([]v1.Interface{interfaceWithBridgeBinding(iface1), interfaceWithMasqueradeBinding(iface2)})).To(BeTrue())
+		})
+	})
 })
 
 func podNetwork(name string) v1.Network {

--- a/pkg/network/vmispec/network.go
+++ b/pkg/network/vmispec/network.go
@@ -85,3 +85,12 @@ func FilterNetworksByInterfaces(networks []v1.Network, interfaces []v1.Interface
 	}
 	return nets
 }
+
+func LookupMultusDefaultNetworkName(networks []v1.Network) string {
+	for _, network := range networks {
+		if network.Multus != nil && network.Multus.Default {
+			return network.Multus.NetworkName
+		}
+	}
+	return ""
+}

--- a/pkg/network/vmispec/network_test.go
+++ b/pkg/network/vmispec/network_test.go
@@ -84,6 +84,18 @@ var _ = Describe("Network", func() {
 			&multusDefaultNetwork,
 		),
 	)
+
+	DescribeTable("should return an empty string", func(networks []v1.Network) {
+		Expect(vmispec.LookupMultusDefaultNetworkName(networks)).To(Equal(""))
+	},
+		Entry("when networks slice is nil", nil),
+		Entry("when networks slice is empty", []v1.Network{}),
+		Entry("when networks does not contain a default Multus network", []v1.Network{multusSecondaryNetwork1, multusSecondaryNetwork2}),
+	)
+
+	It("should return default Multus network name", func() {
+		Expect(vmispec.LookupMultusDefaultNetworkName([]v1.Network{multusDefaultNetwork, multusSecondaryNetwork1})).To(Equal(multusDefaultNetwork.Multus.NetworkName))
+	})
 })
 
 func createMultusSecondaryNetwork(name, networkName string) v1.Network {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -96,9 +96,6 @@ const LibvirtStartupDelay = 10
 
 const IntelVendorName = "Intel"
 
-// Istio list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound traffic in envoy
-const ISTIO_KUBEVIRT_ANNOTATION = "traffic.sidecar.istio.io/kubevirtInterfaces"
-
 const VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION = "pre.hook.backup.velero.io/container"
 const VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION = "pre.hook.backup.velero.io/command"
 const VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION = "post.hook.backup.velero.io/container"
@@ -1350,7 +1347,7 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 	}
 
 	if HaveMasqueradeInterface(vmi.Spec.Domain.Devices.Interfaces) {
-		annotationsSet[ISTIO_KUBEVIRT_ANNOTATION] = "k6t-eth0"
+		annotationsSet[istio.ISTIO_KUBEVIRT_ANNOTATION] = "k6t-eth0"
 	}
 	annotationsSet[VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
 	annotationsSet[VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1342,7 +1342,7 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 		annotationsSet[networkv1.NetworkAttachmentAnnot] = multusAnnotation
 	}
 
-	if multusDefaultNetwork := lookupMultusDefaultNetworkName(vmi.Spec.Networks); multusDefaultNetwork != "" {
+	if multusDefaultNetwork := vmispec.LookupMultusDefaultNetworkName(vmi.Spec.Networks); multusDefaultNetwork != "" {
 		annotationsSet[network.MULTUS_DEFAULT_NETWORK_CNI_ANNOTATION] = multusDefaultNetwork
 	}
 
@@ -1366,15 +1366,6 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 	annotationsSet[descheduler.EvictOnlyAnnotation] = ""
 
 	return annotationsSet, nil
-}
-
-func lookupMultusDefaultNetworkName(networks []v1.Network) string {
-	for _, network := range networks {
-		if network.Multus != nil && network.Multus.Default {
-			return network.Multus.NetworkName
-		}
-	}
-	return ""
 }
 
 func filterVMIAnnotationsForPod(vmiAnnotations map[string]string) map[string]string {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1171,16 +1171,6 @@ func addProbeOverhead(probe *v1.Probe, to *resource.Quantity) bool {
 	return false
 }
 
-func HaveMasqueradeInterface(interfaces []v1.Interface) bool {
-	for _, iface := range interfaces {
-		if iface.Masquerade != nil {
-			return true
-		}
-	}
-
-	return false
-}
-
 func HaveContainerDiskVolume(volumes []v1.Volume) bool {
 	for _, volume := range volumes {
 		if volume.ContainerDisk != nil {
@@ -1346,7 +1336,7 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 		annotationsSet[network.MULTUS_DEFAULT_NETWORK_CNI_ANNOTATION] = multusDefaultNetwork
 	}
 
-	if HaveMasqueradeInterface(vmi.Spec.Domain.Devices.Interfaces) {
+	if vmispec.HaveMasqueradeInterface(vmi.Spec.Domain.Devices.Interfaces) {
 		annotationsSet[istio.ISTIO_KUBEVIRT_ANNOTATION] = "k6t-eth0"
 	}
 	annotationsSet[VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1186,7 +1186,7 @@ var _ = Describe("Template", func() {
 
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
-				value, ok := pod.Annotations[ISTIO_KUBEVIRT_ANNOTATION]
+				value, ok := pod.Annotations[istio.ISTIO_KUBEVIRT_ANNOTATION]
 				Expect(ok).To(BeTrue())
 				Expect(value).To(Equal("k6t-eth0"))
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:


After this PR:
- `ISTIO_KUBEVIRT_ANNOTATION`
- `lookupMultusDefaultNetworkName`
- `HaveMasqueradeInterface`

were moved to `pkg/network` in order for them to be under sig-network's ownership.
Unit tests were added for the moved functions.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

