### PR TITLE
Report VM/VMI conditions as additional Kubernetes events

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2340,7 +2340,16 @@ func (c *VMIController) aggregateDataVolumesConditions(vmiCopy *virtv1.VirtualMa
 	}
 
 	vmiConditions := controller.NewVirtualMachineInstanceConditionManager()
-	vmiConditions.UpdateCondition(vmiCopy, &dvsReadyCondition)
+	cond := vmiConditions.GetCondition(vmiCopy, virtv1.VirtualMachineInstanceDataVolumesReady)
+	if !equality.Semantic.DeepEqual(cond, dvsReadyCondition) {
+	        vmiConditions.UpdateCondition(vmiCopy, &dvsReadyCondition)
+
+                if dvsReadyCondition.Status == k8sv1.ConditionTrue {
+			c.recorder.Event(vmiCopy, k8sv1.EventTypeNormal, dvsReadyCondition.Reason, dvsReadyCondition.Message)
+                } else {
+			c.recorder.Event(vmiCopy, k8sv1.EventTypeWarning, dvsReadyCondition.Reason, dvsReadyCondition.Message)
+                }
+        }
 }
 
 func statusOfReadyCondition(conditions []cdiv1.DataVolumeCondition) k8sv1.ConditionStatus {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -73,7 +73,6 @@ import (
 	netcache "kubevirt.io/kubevirt/pkg/network/cache"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
-	"kubevirt.io/kubevirt/pkg/util"
 
 	"kubevirt.io/kubevirt/pkg/virt-handler/heartbeat"
 
@@ -482,7 +481,7 @@ func (d *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan
 		return err
 	}
 
-	if util.IsNonRootVMI(vmi) {
+	if virtutil.IsNonRootVMI(vmi) {
 		err := diskutils.DefaultOwnershipManager.SetFileOwnership(socketPath)
 		if err != nil {
 			log.Log.Reason(err).Error("unable to change ownership for domain notify")
@@ -941,7 +940,7 @@ func needToComputeChecksums(vmi *v1.VirtualMachineInstance) bool {
 		}
 	}
 
-	if util.HasKernelBootContainerImage(vmi) {
+	if virtutil.HasKernelBootContainerImage(vmi) {
 		if vmi.Status.KernelBootStatus == nil {
 			return true
 		}
@@ -995,7 +994,7 @@ func (d *VirtualMachineController) updateChecksumInfo(vmi *v1.VirtualMachineInst
 	}
 
 	// kernelboot
-	if util.HasKernelBootContainerImage(vmi) {
+	if virtutil.HasKernelBootContainerImage(vmi) {
 		vmi.Status.KernelBootStatus = &v1.KernelBootStatus{}
 
 		if diskChecksums.KernelBootChecksum.Kernel != nil {
@@ -1642,7 +1641,7 @@ func (d *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.Virtu
 		return newNonMigratableCondition(err.Error(), v1.VirtualMachineInstanceReasonCPUModeNotMigratable), isBlockMigration
 	}
 
-	if util.IsVMIVirtiofsEnabled(vmi) {
+	if virtutil.IsVMIVirtiofsEnabled(vmi) {
 		return newNonMigratableCondition("VMI uses virtiofs", v1.VirtualMachineInstanceReasonVirtIOFSNotMigratable), isBlockMigration
 	}
 
@@ -1650,7 +1649,7 @@ func (d *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.Virtu
 		return newNonMigratableCondition("VMI uses a PCI host devices", v1.VirtualMachineInstanceReasonHostDeviceNotMigratable), isBlockMigration
 	}
 
-	if util.IsSEVVMI(vmi) {
+	if virtutil.IsSEVVMI(vmi) {
 		return newNonMigratableCondition("VMI uses SEV", v1.VirtualMachineInstanceReasonSEVNotMigratable), isBlockMigration
 	}
 
@@ -3113,7 +3112,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 			return fmt.Errorf("failed to adjust resources: %v", err)
 		}
 
-		if util.IsSEVAttestationRequested(vmi) {
+		if virtutil.IsSEVAttestationRequested(vmi) {
 			sev := vmi.Spec.Domain.LaunchSecurity.SEV
 			if sev.Session == "" || sev.DHCert == "" {
 				// Wait for the session parameters to be provided


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**
VMI (and consequently) VM objects have many interesting status conditions that can often be of great value for event sourcing usecases. Currently only some Events are emitted for the VM/VMI objects but none of them are related to the conditions themselves (e.g. `DisksNotLiveMigratable`). Additionally, some VMI states aren't reflected as events either (e.g. `Paused`).

**After this PR:**
This PR aims to emit VM/VMI conditions and additional VMI states as Kubernetes Events.
It handles emission by adding events in codepaths where condition updates are applied to the VM/VMI objects.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/12046

### Why we need it and why it was done in this way
**The following tradeoffs were made:**

No significant tradeoffs were made as the relevant components already emit Events using their respective recorders (the PR aims to simply add more of them).

**The following alternatives were considered:**

The immediate alternative that comes to mind is to extend kubevirt metrics with information related to conditions, this however only addresses the observability aspect of the issue and not event sourcing. 

**Links to places where the discussion took place:** <!-- optional: slack, other GH issue, mailinglist, ... --> 
https://github.com/kubevirt/kubevirt/issues/12046

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

