### PR TITLE
client-go: remove `ForceRestart` and `ForceStop` duplicate methods

### DIFF
--- a/pkg/virtctl/vm/restart_test.go
+++ b/pkg/virtctl/vm/restart_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Restart command", func() {
 			GracePeriodSeconds: &gracePeriod,
 			DryRun:             nil,
 		}
-		vmInterface.EXPECT().ForceRestart(context.Background(), vm.Name, &restartOptions).Return(nil).Times(1)
+		vmInterface.EXPECT().Restart(context.Background(), vm.Name, &restartOptions).Return(nil).Times(1)
 
 		cmd := clientcmd.NewRepeatableVirtctlCommand("restart", vmName, "--force", "--grace-period=0")
 		Expect(cmd()).To(Succeed())

--- a/pkg/virtctl/vm/stop_test.go
+++ b/pkg/virtctl/vm/stop_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Stop command", func() {
 			GracePeriod: &gracePeriod,
 			DryRun:      nil,
 		}
-		vmInterface.EXPECT().ForceStop(context.Background(), vm.Name, &stopOptions).Return(nil).Times(1)
+		vmInterface.EXPECT().Stop(context.Background(), vm.Name, &stopOptions).Return(nil).Times(1)
 
 		cmd := clientcmd.NewRepeatableVirtctlCommand("stop", vmName, "--force", "--grace-period=0")
 		Expect(cmd()).To(Succeed())

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/fake/fake_virtualmachine_expansion.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/fake/fake_virtualmachine_expansion.go
@@ -52,13 +52,6 @@ func (c *FakeVirtualMachines) Restart(ctx context.Context, name string, restartO
 	return err
 }
 
-func (c *FakeVirtualMachines) ForceRestart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error {
-	_, err := c.Fake.
-		Invokes(fake2.NewPutSubresourceAction(virtualmachinesResource, c.ns, "restart", name, restartOptions), nil)
-
-	return err
-}
-
 func (c *FakeVirtualMachines) Start(ctx context.Context, name string, startOptions *v1.StartOptions) error {
 	_, err := c.Fake.
 		Invokes(fake2.NewPutSubresourceAction(virtualmachinesResource, c.ns, "start", name, startOptions), nil)
@@ -68,13 +61,6 @@ func (c *FakeVirtualMachines) Start(ctx context.Context, name string, startOptio
 
 func (c *FakeVirtualMachines) Stop(ctx context.Context, name string, stopOptions *v1.StopOptions) error {
 	_, err := c.Fake.
-		Invokes(fake2.NewPutSubresourceAction(virtualmachinesResource, c.ns, "stop", name, stopOptions), nil)
-
-	return err
-}
-
-func (c *FakeVirtualMachines) ForceStop(ctx context.Context, name string, stopOptions *v1.StopOptions) error {
-	_, err := c.Fake.Fake.
 		Invokes(fake2.NewPutSubresourceAction(virtualmachinesResource, c.ns, "stop", name, stopOptions), nil)
 
 	return err

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachine_expansion.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/virtualmachine_expansion.go
@@ -38,10 +38,8 @@ type VirtualMachineExpansion interface {
 	GetWithExpandedSpec(ctx context.Context, name string) (*v1.VirtualMachine, error)
 	PatchStatus(ctx context.Context, name string, pt types.PatchType, data []byte, patchOptions metav1.PatchOptions) (*v1.VirtualMachine, error)
 	Restart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error
-	ForceRestart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error
 	Start(ctx context.Context, name string, startOptions *v1.StartOptions) error
 	Stop(ctx context.Context, name string, stopOptions *v1.StopOptions) error
-	ForceStop(ctx context.Context, name string, stopOptions *v1.StopOptions) error
 	Migrate(ctx context.Context, name string, migrateOptions *v1.MigrateOptions) error
 	AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error
 	RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error
@@ -69,22 +67,6 @@ func (c *virtualMachines) PatchStatus(ctx context.Context, name string, pt types
 }
 
 func (c *virtualMachines) Restart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error {
-	body, err := json.Marshal(restartOptions)
-	if err != nil {
-		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
-	}
-	return c.client.Put().
-		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
-		Namespace(c.ns).
-		Resource("virtualmachines").
-		Name(name).
-		SubResource("restart").
-		Body(body).
-		Do(ctx).
-		Error()
-}
-
-func (c *virtualMachines) ForceRestart(ctx context.Context, name string, restartOptions *v1.RestartOptions) error {
 	body, err := json.Marshal(restartOptions)
 	if err != nil {
 		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
@@ -128,22 +110,6 @@ func (c *virtualMachines) Stop(ctx context.Context, name string, stopOptions *v1
 		Name(name).
 		SubResource("stop").
 		Body(optsJson).
-		Do(ctx).
-		Error()
-}
-
-func (c *virtualMachines) ForceStop(ctx context.Context, name string, stopOptions *v1.StopOptions) error {
-	body, err := json.Marshal(stopOptions)
-	if err != nil {
-		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
-	}
-	return c.client.Put().
-		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion)).
-		Namespace(c.ns).
-		Resource("virtualmachines").
-		Name(name).
-		SubResource("stop").
-		Body(body).
 		Do(ctx).
 		Error()
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1745,16 +1745,6 @@ func (_mr *_MockVirtualMachineInterfaceRecorder) Restart(arg0, arg1, arg2 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Restart", arg0, arg1, arg2)
 }
 
-func (_m *MockVirtualMachineInterface) ForceRestart(ctx context.Context, name string, restartOptions *v121.RestartOptions) error {
-	ret := _m.ctrl.Call(_m, "ForceRestart", ctx, name, restartOptions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockVirtualMachineInterfaceRecorder) ForceRestart(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ForceRestart", arg0, arg1, arg2)
-}
-
 func (_m *MockVirtualMachineInterface) Start(ctx context.Context, name string, startOptions *v121.StartOptions) error {
 	ret := _m.ctrl.Call(_m, "Start", ctx, name, startOptions)
 	ret0, _ := ret[0].(error)
@@ -1773,16 +1763,6 @@ func (_m *MockVirtualMachineInterface) Stop(ctx context.Context, name string, st
 
 func (_mr *_MockVirtualMachineInterfaceRecorder) Stop(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stop", arg0, arg1, arg2)
-}
-
-func (_m *MockVirtualMachineInterface) ForceStop(ctx context.Context, name string, stopOptions *v121.StopOptions) error {
-	ret := _m.ctrl.Call(_m, "ForceStop", ctx, name, stopOptions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockVirtualMachineInterfaceRecorder) ForceStop(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ForceStop", arg0, arg1, arg2)
 }
 
 func (_m *MockVirtualMachineInterface) Migrate(ctx context.Context, name string, migrateOptions *v121.MigrateOptions) error {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -769,7 +769,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 240*time.Second, 1*time.Second).ShouldNot(Exist())
 
 				By("Ensuring a second invocation should fail")
-				Expect(stopCommand()).To(MatchError(fmt.Sprintf(`Error stopping VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "%s": VM is not running`, vm.Name)))
+				Expect(stopCommand()).To(MatchError(fmt.Sprintf(`error stopping VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "%s": VM is not running`, vm.Name)))
 			})
 
 			It("[test_id:6310]should start a VirtualMachineInstance in paused state", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
`ForceRestart` and `ForceStop` methods are respectively duplicate of `Restart` and `Stop`.
The differences are expressed in options that the caller set.
We can drop the two methods if favor of the classic `Restart` and `Stop`


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Drop `ForceRestart` and `ForceStop` methods from client-go
```

/cc @xpivarc 