### PR TITLE
Remove the  deprecated function NewRandomVMIWithEphemeralDiskAndUserdata from tests/utils.go

### DIFF
--- a/pkg/libvmi/cloudinit/cloudinit.go
+++ b/pkg/libvmi/cloudinit/cloudinit.go
@@ -41,6 +41,12 @@ func WithNoCloudEncodedUserData(data string) NoCloudOption {
 	}
 }
 
+func WithNoCloudUserDataSecretName(secretName string) NoCloudOption {
+	return func(source *v1.CloudInitNoCloudSource) {
+		source.UserDataSecretRef = &k8scorev1.LocalObjectReference{Name: secretName}
+	}
+}
+
 func WithNoCloudNetworkData(data string) NoCloudOption {
 	return func(source *v1.CloudInitNoCloudSource) {
 		source.NetworkData = data

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -40,6 +40,14 @@ func WithContainerDisk(diskName, imageName string) Option {
 	}
 }
 
+// WithContainerSATADisk specifies the disk name and the name of the container image to be used.
+func WithContainerSATADisk(diskName, imageName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDisk(vmi, newDisk(diskName, v1.DiskBusSATA))
+		addVolume(vmi, newContainerVolume(diskName, imageName))
+	}
+}
+
 // WithPersistentVolumeClaim specifies the name of the PersistentVolumeClaim to be used.
 func WithPersistentVolumeClaim(diskName, pvcName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -10,8 +10,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/libvmi:go_default_library",
-        "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
@@ -19,7 +17,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//tests/console:go_default_library",
-        "//tests/containerdisk:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -50,7 +50,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/testsuite"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -149,34 +148,30 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 	})
 
 	Context("VirtualMachines", func() {
-		var vm *v1.VirtualMachine
-		resource := "virtualmachines"
-
-		newVM := func() *v1.VirtualMachine {
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
-			vm := libvmi.NewVirtualMachine(vmi)
-			return vm
-		}
+		var (
+			vm        *v1.VirtualMachine
+			namespace string
+		)
+		const resource = "virtualmachines"
 
 		BeforeEach(func() {
-			vm = newVM()
-
+			vm = libvmi.NewVirtualMachine(libvmifact.NewCirros())
+			namespace = testsuite.GetTestNamespace(vm)
 		})
 
 		It("[test_id:7631]create a VirtualMachine", func() {
 			By("Make a Dry-Run request to create a Virtual Machine")
-			err = dryRunCreate(restClient, resource, vm.Namespace, vm, nil)
+			err = dryRunCreate(restClient, resource, namespace, vm, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no Virtual Machine was actually created")
-			_, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			_, err = virtClient.VirtualMachine(namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).To(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 		})
 
 		It("[test_id:7632]delete a VirtualMachine", func() {
 			By("Create a VirtualMachine")
-			_, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+			vm, err = virtClient.VirtualMachine(namespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to delete a Virtual Machine")
@@ -195,7 +190,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		It("[test_id:7633]update a VirtualMachine", func() {
 			By("Create a VirtualMachine")
-			_, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+			vm, err = virtClient.VirtualMachine(namespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to update a Virtual Machine")
@@ -212,14 +207,14 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that no update actually took place")
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			vm, err = virtClient.VirtualMachine(namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vm.Labels["key"]).ToNot(Equal("42"))
 		})
 
 		It("[test_id:7634]patch a VirtualMachine", func() {
 			By("Create a VirtualMachine")
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+			vm, err = virtClient.VirtualMachine(namespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Make a Dry-Run request to patch a Virtual Machine")
@@ -542,11 +537,8 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 
 		BeforeEach(func() {
 			tests.EnableFeatureGate(virtconfig.SnapshotGate)
-
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
-			vm := libvmi.NewVirtualMachine(vmi)
-			_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+			vm := libvmi.NewVirtualMachine(libvmifact.NewCirros())
+			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			snap = newVMSnapshot(vm)
@@ -634,10 +626,8 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, func() 
 		BeforeEach(func() {
 			tests.EnableFeatureGate(virtconfig.SnapshotGate)
 
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
-			vm := libvmi.NewVirtualMachine(vmi)
-			_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+			vm := libvmi.NewVirtualMachine(libvmifact.NewCirros())
+			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			snap := newVMSnapshot(vm)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2427,10 +2427,11 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			// ordering:
 			// use a small disk for the other ones
 			containerImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			// virtio - added by NewRandomVMIWithEphemeralDisk
-			vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, "echo hi!\n")
-			// sata
-			tests.AddEphemeralDisk(vmi, "disk2", v1.DiskBusSATA, containerImage)
+			// virtio - added by NewCirros
+			vmi = libvmifact.NewCirros(
+				// add sata disk
+				libvmi.WithContainerSATADisk("disk2", containerImage),
+			)
 			// NOTE: we have one disk per bus, so we expect vda, sda
 		})
 		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
NewRandomVMIWithEphemeralDiskAndUserdata functions is deprecated

#### After this PR:
Replaced the deprecated functions with calls to libvmi

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

