### PR TITLE
Adding a link to our support matrix in k8s compatability doc. 

### DIFF
--- a/docs/kubernetes-compatibility.md
+++ b/docs/kubernetes-compatibility.md
@@ -1,11 +1,13 @@
 # Kubernetes Version Compatibility
 
 Kubernetes supports 3 minor release concurrently. This means if the latest
-Kubernetes release is v1.19, that v1.18 and v1.17 will remain supported for
-backport fixes but that v1.16 will lose support.
+Kubernetes release is v1.27, that v1.26 and v1.25 will remain supported for
+backport fixes but that v1.24 will lose support.
 
 Similarly, each KubeVirt release maintains compatibility with the latest 3
 Kubernetes releases that are out at the time the KubeVirt release is made.
+
+See the [KubeVirt to Kubernetes version support matrix](https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md) to see the currently supported versions of KubeVirt and their associated Kubernetes versions.
 
 # Compatibility Matrix Examples.
 
@@ -14,14 +16,14 @@ illustrate the example)
 
 ## New KubeVirt Release
 
-KubeVirt release v0.1 is cut. At that point in time the latest Kubernetes
-version is v1.3. This means KubeVirt v0.1 will forever be compatible with
-Kubernetes v1.3, v1.2, and v1.1.
+KubeVirt release v1.0 is cut. At that point in time the latest Kubernetes
+version is v1.27. This means KubeVirt v1.0 will forever be compatible with
+Kubernetes v1.27, v1.26, and v1.25.
 
 ## KubeVirt Main
 
 KubeVirt main always follows the latest 3 Kubernetes releases. If a new
-Kubernetes v1.4 release is cut, that means support for v1.1 will be dropped
+Kubernetes v1.28 release is cut, that means support for v1.25 will be dropped
 for KubeVirt main.
 
 Note that this support for the latest Kubernetes releases doesn't happen
@@ -32,11 +34,11 @@ KubeVirt release is cut.
 
 ## Old KubeVirt Release
 
-KubeVirt main supports Kubernetes releases v1.4, v1.3, and v1.2. However, the
-KubeVirt v0.1 release was cut when the latest Kubernetes release was v1.3.
+KubeVirt main supports Kubernetes releases v1.28, v1.27, and v1.26. However, the
+KubeVirt v1.0 release was cut when the latest Kubernetes release was v1.27.
 
-This means that KubeVirt v0.1 supports Kubernetes v1.3, v1.2, v1.1 while
-KubeVirt main is tracking support for Kubernetes v1.4, v1.3, v1.2.
+This means that KubeVirt v1.0 supports Kubernetes v1.27, v1.26, v1.25 while
+KubeVirt main is tracking support for Kubernetes v1.28, v1.27, v1.26.
 
 # Support Exceptions
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
We've had the KubeVirt to K8s support matrix for a while now, but it was not mentioned in our K8s compatibility doc. This was raised in the linked issue.

This PR also updates the version numbers in the explanations by about 9 years. It was confusing having k8s version of v1.0-1.3 when these are contemporary kubevirt versions. Rather than jump all the way to KubeVirt 1.2 or 1.3 I thought the doc was clearer if it was KubeVirt v1.0 to better differentiate from the k8s numbers (as v1.2 at a glance is similar to v1.2*).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11587 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

