### PR TITLE
[release-1.0] backendstorage: use fixed volume name

### DIFF
--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -335,7 +335,7 @@ func withAccessCredentials(accessCredentials []v1.AccessCredential) VolumeRender
 func withTPM(vmi *v1.VirtualMachineInstance) VolumeRendererOption {
 	return func(renderer *VolumeRenderer) error {
 		if backendstorage.HasPersistentTPMDevice(&vmi.Spec) {
-			volumeName := vmi.Name + "-tpm"
+			volumeName := "vm-state"
 			pvcName := backendstorage.PVCForVMI(vmi)
 			renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
 				Name: volumeName,


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/12261

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: persistent tpm can be used with vmis containing dots in their name
```

