### PR TITLE
Refactor unit tests to use libvmi for resource creation in credentials

### DIFF
--- a/pkg/libvmi/BUILD.bazel
+++ b/pkg/libvmi/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "accesscredentials.go",
         "cloudinit.go",
         "config.go",
         "cpu.go",

--- a/pkg/libvmi/accesscredentials.go
+++ b/pkg/libvmi/accesscredentials.go
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package libvmi
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func WithUserPasswordAccessCredential(secretName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.AccessCredentials = append(vmi.Spec.AccessCredentials, v1.AccessCredential{
+			UserPassword: &v1.UserPasswordAccessCredential{
+				Source: v1.UserPasswordAccessCredentialSource{
+					Secret: &v1.AccessCredentialSecretSource{
+						SecretName: secretName,
+					},
+				},
+				PropagationMethod: v1.UserPasswordAccessCredentialPropagationMethod{
+					QemuGuestAgent: &v1.QemuGuestAgentUserPasswordAccessCredentialPropagation{},
+				},
+			},
+		})
+	}
+}
+
+func WithSSHPublicKeyAccessCredential(secretName string, users []string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.AccessCredentials = append(vmi.Spec.AccessCredentials, v1.AccessCredential{
+			SSHPublicKey: &v1.SSHPublicKeyAccessCredential{
+				Source: v1.SSHPublicKeyAccessCredentialSource{
+					Secret: &v1.AccessCredentialSecretSource{
+						SecretName: secretName,
+					},
+				},
+				PropagationMethod: v1.SSHPublicKeyAccessCredentialPropagationMethod{
+					QemuGuestAgent: &v1.QemuGuestAgentSSHPublicKeyAccessCredentialPropagation{
+						Users: users,
+					},
+				},
+			},
+		})
+	}
+}

--- a/pkg/virtctl/credentials/addkey/BUILD.bazel
+++ b/pkg/virtctl/credentials/addkey/BUILD.bazel
@@ -28,10 +28,10 @@ go_test(
         "addkey_test.go",
     ],
     deps = [
+        "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",

--- a/pkg/virtctl/credentials/addkey/addkey_test.go
+++ b/pkg/virtctl/credentials/addkey/addkey_test.go
@@ -23,16 +23,15 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"kubevirt.io/api/core"
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 )
 
 var _ = Describe("Credentials add-ssh-key", func() {
 	const (
-		vmName     = "test-vm"
 		secretName = "test-secret"
 		userName   = "test-user"
 	)
@@ -40,8 +39,9 @@ var _ = Describe("Credentials add-ssh-key", func() {
 	var (
 		kubeClient *fake.Clientset
 
-		vmi *v1.VirtualMachineInstance
-		vm  *v1.VirtualMachine
+		vmi    *v1.VirtualMachineInstance
+		vm     *v1.VirtualMachine
+		vmName string
 	)
 
 	BeforeEach(func() {
@@ -59,27 +59,13 @@ var _ = Describe("Credentials add-ssh-key", func() {
 			return false, secret, nil
 		})
 
-		vmi = api.NewMinimalVMI(vmName)
-		vmi.Spec.AccessCredentials = []v1.AccessCredential{{
-			SSHPublicKey: &v1.SSHPublicKeyAccessCredential{
-				Source: v1.SSHPublicKeyAccessCredentialSource{
-					Secret: &v1.AccessCredentialSecretSource{
-						SecretName: secretName,
-					},
-				},
-				PropagationMethod: v1.SSHPublicKeyAccessCredentialPropagationMethod{
-					QemuGuestAgent: &v1.QemuGuestAgentSSHPublicKeyAccessCredentialPropagation{
-						Users: []string{userName},
-					},
-				},
-			},
-		}}
+		vmi = libvmi.New(
+			libvmi.WithNamespace(metav1.NamespaceDefault),
+			libvmi.WithSSHPublicKeyAccessCredential(secretName, []string{userName}),
+		)
+		vmName = vmi.Name
 
-		vm = kubecli.NewMinimalVM(vmName)
-		vm.Namespace = metav1.NamespaceDefault
-		vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{
-			Spec: vmi.Spec,
-		}
+		vm = libvmi.NewVirtualMachine(vmi)
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virtctl/credentials/password/BUILD.bazel
+++ b/pkg/virtctl/credentials/password/BUILD.bazel
@@ -24,10 +24,10 @@ go_test(
         "password_test.go",
     ],
     deps = [
+        "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/pkg/virtctl/credentials/removekey/BUILD.bazel
+++ b/pkg/virtctl/credentials/removekey/BUILD.bazel
@@ -24,10 +24,10 @@ go_test(
         "removekey_test.go",
     ],
     deps = [
+        "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
- Unit tests directly created and modified VM and VMI resources by manipulating their fields.
After this PR:
- Unit tests have been refactored to use the `libvmi` package for creating and modifying VM and VMI resources, promoting readability and standardization.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially address: https://github.com/kubevirt/kubevirt/issues/12059

### Why we need it and why it was done in this way
 - Using the libvmi package simplifies the unit tests and makes them more readable.
 - This approach ensures a standard way of creating VM and VMI resources across tests.
 
The following tradeoffs were made:
  - Direct manipulation of resources was replaced with utility functions, which may introduce minor overhead but enhances readability and maintainability.

The following alternatives were considered:
 - Continuing with direct manipulation of resources in tests, which was deemed less maintainable.
Links to places where the discussion took place: Issue discussion: [#12059](https://github.com/kubevirt/kubevirt/issues/12059)

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```