### PR TITLE
skip memory hot plug tests for s390x.

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -135,6 +135,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/framework/checks:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -58,6 +58,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-config/deprecation"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 
 	rt "runtime"
 )
@@ -2034,6 +2035,7 @@ var _ = Describe("Validating VM Admitter", func() {
 			var maxGuest resource.Quantity
 
 			BeforeEach(func() {
+				checks.SkipIfS390X(rt.GOARCH, "Memory hotplug is not supported for s390x")
 				guest := resource.MustParse("1Gi")
 				maxGuest = resource.MustParse("4Gi")
 

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -82,6 +82,10 @@ func IsARM64(arch string) bool {
 	return arch == "arm64"
 }
 
+func IsS390X(arch string) bool {
+	return arch == "s390x"
+}
+
 func HasLiveMigration() bool {
 	return HasFeature("LiveMigration")
 }

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -224,6 +224,12 @@ func SkipIfARM64(arch string, message string) {
 	}
 }
 
+func SkipIfS390X(arch string, message string) {
+	if IsS390X(arch) {
+		ginkgo.Skip("Skip test on s390x: " + message)
+	}
+}
+
 func SkipIfRunningOnKindInfra(message string) {
 	if IsRunningOnKindInfra() {
 		ginkgo.Skip("Skip test on kind infra: " + message)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The memory hot plug feature is not available for s390x. This is causing unit tests to fail when running them on s390x.  The vm's architecutre is getting set using the runtime.GOARCH here: https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go#L2044 So it is getting set as s390x when we are running unit tests on s390x. Since the feature is not supported on s390x. It is throwing the error expected as `Memory hotplug is only available for x86_64 and arm64 VMs`  instead of failing with the below mentioned error. Failure logs here: 
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-unit-test-s390x/1808521224393854976
```
[FAILED] Expected
      <[]v1.StatusCause | len:1, cap:1>: [
          {
              Type: "FieldValueInvalid",
              Message: "Memory hotplug is only available for x86_64 and arm64 VMs",
              Field: "spec.template.spec.domain.memory.guest",
          },
      ]
  to contain element matching
      <v1.StatusCause>: {
          Type: "FieldValueInvalid",
          Message: "Memory hotplug is only available for VMs with at least 1Gi of guest memory",
          Field: "spec.template.spec.domain.memory.guest",
      }
```

After this PR:
The memory hot plug tests will be skipped if the architecture is s390x.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
    NONE

```

