### PR TITLE
tests: avoid a misleading variable name

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -704,12 +704,12 @@ var _ = SIGDescribe("Storage", func() {
 						diskName = fmt.Sprintf("disk-%s.img", uuid.NewString())
 						diskPath = filepath.Join(hostDiskDir, diskName)
 						// create a disk image before test
-						job := CreateDiskOnHost(diskPath)
-						job, err = virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Create(context.Background(), job, metav1.CreateOptions{})
+						pod := CreateDiskOnHost(diskPath)
+						pod, err = virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Create(context.Background(), pod, metav1.CreateOptions{})
 						Expect(err).ToNot(HaveOccurred())
 
-						Eventually(ThisPod(job), 30*time.Second, 1*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
-						pod, err := ThisPod(job)()
+						Eventually(ThisPod(pod), 30*time.Second, 1*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
+						pod, err = ThisPod(pod)()
 						Expect(err).NotTo(HaveOccurred())
 						nodeName = pod.Spec.NodeName
 					})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2374,11 +2374,11 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			tmpHostDiskDir := tests.RandTmpDir()
 			tmpHostDiskPath := filepath.Join(tmpHostDiskDir, fmt.Sprintf("disk-%s.img", uuid.NewString()))
 
-			job := storage.CreateDiskOnHost(tmpHostDiskPath)
-			job, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Create(context.Background(), job, metav1.CreateOptions{})
+			pod := storage.CreateDiskOnHost(tmpHostDiskPath)
+			pod, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Create(context.Background(), pod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisPod(job), 30*time.Second, 1*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
-			pod, err := ThisPod(job)()
+			Eventually(ThisPod(pod), 30*time.Second, 1*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
+			pod, err = ThisPod(pod)()
 			Expect(err).NotTo(HaveOccurred())
 			nodeName = pod.Spec.NodeName
 			defer tests.RemoveHostDiskImage(tmpHostDiskDir, nodeName)


### PR DESCRIPTION
Job and Pod are two distinct Kubernetes resources. When a Pod is returned, let us not call it a "job".

/sig code-quality

```release-note
NONE
```

