### PR TITLE
[release-1.3] Network binding plugins: Add memory overhead for compute container

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14186,6 +14186,10 @@
    "v1.InterfaceBindingPlugin": {
     "type": "object",
     "properties": {
+     "computeResourceOverhead": {
+      "description": "ComputeResourceOverhead specifies the resource overhead that should be added to the compute container when using the binding. version: v1alphav1",
+      "$ref": "#/definitions/k8s.io.api.core.v1.ResourceRequirements"
+     },
      "domainAttachmentType": {
       "description": "DomainAttachmentType is a standard domain network attachment method kubevirt supports. Supported values: \"tap\". The standard domain attachment can be used instead or in addition to the sidecarImage. version: 1alphav1",
       "type": "string"

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -636,6 +636,64 @@ spec:
                       binding:
                         additionalProperties:
                           properties:
+                            computeResourceOverhead:
+                              description: |-
+                                ComputeResourceOverhead specifies the resource overhead that should be added to the compute container when using the binding.
+                                version: v1alphav1
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
                             domainAttachmentType:
                               description: |-
                                 DomainAttachmentType is a standard domain network attachment method kubevirt supports.
@@ -3863,6 +3921,64 @@ spec:
                       binding:
                         additionalProperties:
                           properties:
+                            computeResourceOverhead:
+                              description: |-
+                                ComputeResourceOverhead specifies the resource overhead that should be added to the compute container when using the binding.
+                                version: v1alphav1
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
                             domainAttachmentType:
                               description: |-
                                 DomainAttachmentType is a standard domain network attachment method kubevirt supports.

--- a/pkg/network/netbinding/BUILD.bazel
+++ b/pkg/network/netbinding/BUILD.bazel
@@ -2,18 +2,24 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["netbinding.go"],
+    srcs = [
+        "memory.go",
+        "netbinding.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/network/netbinding",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/hooks:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = [
+        "memory_test.go",
         "netbinding_suite_test.go",
         "netbinding_test.go",
     ],
@@ -25,5 +31,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )

--- a/pkg/network/netbinding/memory.go
+++ b/pkg/network/netbinding/memory.go
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package netbinding
+
+import (
+	k8scorev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func CalculateMemoryOverhead(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) resource.Quantity {
+	return sumPluginsMemoryOverhead(
+		filterUniquePlugins(vmi.Spec.Domain.Devices.Interfaces, registeredPlugins),
+	)
+}
+
+func filterUniquePlugins(interfaces []v1.Interface, registeredPlugins map[string]v1.InterfaceBindingPlugin) []v1.InterfaceBindingPlugin {
+	var uniquePlugins []v1.InterfaceBindingPlugin
+
+	uniquePluginsSet := map[string]struct{}{}
+
+	for _, iface := range interfaces {
+		if iface.Binding == nil {
+			continue
+		}
+
+		pluginName := iface.Binding.Name
+		if _, seen := uniquePluginsSet[pluginName]; seen {
+			continue
+		}
+
+		plugin, exists := registeredPlugins[pluginName]
+		if !exists {
+			continue
+		}
+
+		uniquePluginsSet[pluginName] = struct{}{}
+		uniquePlugins = append(uniquePlugins, plugin)
+	}
+
+	return uniquePlugins
+}
+
+func sumPluginsMemoryOverhead(uniquePlugins []v1.InterfaceBindingPlugin) resource.Quantity {
+	result := resource.Quantity{}
+
+	for _, plugin := range uniquePlugins {
+		if plugin.ComputeResourceOverhead == nil {
+			continue
+		}
+
+		requests := plugin.ComputeResourceOverhead.Requests
+		if requests == nil {
+			continue
+		}
+
+		result.Add(requests[k8scorev1.ResourceMemory])
+	}
+
+	return result
+}

--- a/pkg/network/netbinding/memory_test.go
+++ b/pkg/network/netbinding/memory_test.go
@@ -1,0 +1,200 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package netbinding_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8scorev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/network/netbinding"
+)
+
+var _ = Describe("Network Binding plugin compute resource overhead", func() {
+	const (
+		iface1name  = "net1"
+		iface2name  = "net2"
+		plugin1name = "plugin1"
+		plugin2name = "plugin2"
+	)
+
+	DescribeTable("Memory overhead should be zero", func(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) {
+		actualResult := netbinding.CalculateMemoryOverhead(vmi, registeredPlugins)
+		Expect(actualResult.Value()).To(BeZero())
+	},
+		Entry("when the VMI does not have NICs and there aren't any registered plugins", libvmi.New(), nil),
+		Entry("when no binding plugin is used on the VMI and there aren't any registered plugins",
+			libvmi.New(
+				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			),
+			nil,
+		),
+		Entry("when no binding plugin is used on the VMI and there are registered plugins",
+			libvmi.New(
+				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			),
+			map[string]v1.InterfaceBindingPlugin{plugin1name: newPlugin(nil)},
+		),
+		Entry("when binding plugin is used on the VMI, but it does not require compute overhead",
+			libvmi.New(
+				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface1name}),
+			),
+			map[string]v1.InterfaceBindingPlugin{
+				plugin1name: newPlugin(nil),
+			},
+		),
+		Entry("when binding plugin is used on the VMI, but it does not require memory overhead",
+			libvmi.New(
+				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface1name}),
+			),
+			map[string]v1.InterfaceBindingPlugin{
+				plugin1name: newPlugin(
+					&k8scorev1.ResourceRequirements{
+						Requests: map[k8scorev1.ResourceName]resource.Quantity{
+							k8scorev1.ResourceCPU: resource.MustParse("100m"),
+						},
+					},
+				),
+			},
+		),
+	)
+
+	DescribeTable("It should calculate memory overhead", func(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin, expectedValue resource.Quantity) {
+		actualResult := netbinding.CalculateMemoryOverhead(vmi, registeredPlugins)
+		Expect(actualResult.Value()).To(Equal(expectedValue.Value()))
+	},
+		Entry("when there is a single interface using a binding plugin",
+			libvmi.New(
+				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface1name}),
+			),
+			map[string]v1.InterfaceBindingPlugin{
+				plugin1name: newPlugin(
+					&k8scorev1.ResourceRequirements{
+						Requests: map[k8scorev1.ResourceName]resource.Quantity{
+							k8scorev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+					},
+				),
+			},
+			resource.MustParse("500Mi"),
+		),
+		Entry("when there are two interfaces using the same binding plugin",
+			libvmi.New(
+				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface1name}),
+				libvmi.WithInterface(v1.Interface{Name: iface2name, Binding: &v1.PluginBinding{Name: plugin1name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface2name}),
+			),
+			map[string]v1.InterfaceBindingPlugin{
+				plugin1name: newPlugin(
+					&k8scorev1.ResourceRequirements{
+						Requests: map[k8scorev1.ResourceName]resource.Quantity{
+							k8scorev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+					},
+				),
+			},
+			resource.MustParse("500Mi"),
+		),
+		Entry("when there are two interfaces using different binding plugins",
+			libvmi.New(
+				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface1name}),
+				libvmi.WithInterface(v1.Interface{Name: iface2name, Binding: &v1.PluginBinding{Name: plugin2name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface2name}),
+			),
+			map[string]v1.InterfaceBindingPlugin{
+				plugin1name: newPlugin(
+					&k8scorev1.ResourceRequirements{
+						Requests: map[k8scorev1.ResourceName]resource.Quantity{
+							k8scorev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+					},
+				),
+				plugin2name: newPlugin(
+					&k8scorev1.ResourceRequirements{
+						Requests: map[k8scorev1.ResourceName]resource.Quantity{
+							k8scorev1.ResourceMemory: resource.MustParse("600Mi"),
+						},
+					},
+				),
+			},
+			resource.MustParse("1100Mi"),
+		),
+		Entry("when there are two interfaces and just one is using a binding plugin",
+			libvmi.New(
+				libvmi.WithInterface(v1.Interface{Name: iface1name}),
+				libvmi.WithNetwork(&v1.Network{Name: iface1name}),
+				libvmi.WithInterface(v1.Interface{Name: iface2name, Binding: &v1.PluginBinding{Name: plugin2name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface2name}),
+			),
+			map[string]v1.InterfaceBindingPlugin{
+				plugin1name: newPlugin(
+					&k8scorev1.ResourceRequirements{
+						Requests: map[k8scorev1.ResourceName]resource.Quantity{
+							k8scorev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+					},
+				),
+				plugin2name: newPlugin(
+					&k8scorev1.ResourceRequirements{
+						Requests: map[k8scorev1.ResourceName]resource.Quantity{
+							k8scorev1.ResourceMemory: resource.MustParse("600Mi"),
+						},
+					},
+				),
+			},
+			resource.MustParse("600Mi"),
+		),
+		Entry("when there is a non-registered plugin, it should not be taken into account",
+			libvmi.New(
+				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface1name}),
+				libvmi.WithInterface(v1.Interface{Name: iface2name, Binding: &v1.PluginBinding{Name: "non existent"}}),
+				libvmi.WithNetwork(&v1.Network{Name: iface2name}),
+			),
+			map[string]v1.InterfaceBindingPlugin{
+				plugin1name: newPlugin(
+					&k8scorev1.ResourceRequirements{
+						Requests: map[k8scorev1.ResourceName]resource.Quantity{
+							k8scorev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+					},
+				),
+			},
+			resource.MustParse("500Mi"),
+		),
+	)
+})
+
+func newPlugin(computeResourceOverhead *k8scorev1.ResourceRequirements) v1.InterfaceBindingPlugin {
+	return v1.InterfaceBindingPlugin{ComputeResourceOverhead: computeResourceOverhead}
+}

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/network/downwardapi:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/namescheme:go_default_library",
+        "//pkg/network/netbinding:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -49,6 +49,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/downwardapi"
 	"kubevirt.io/kubevirt/pkg/network/istio"
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
+	"kubevirt.io/kubevirt/pkg/network/netbinding"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
 	"kubevirt.io/kubevirt/pkg/storage/types"
@@ -1456,6 +1457,8 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 		vmiCPUArch = t.clusterConfig.GetClusterCPUArch()
 	}
 	memoryOverhead := GetMemoryOverhead(vmi, vmiCPUArch, t.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
+	memoryOverhead.Add(netbinding.CalculateMemoryOverhead(vmi, t.clusterConfig.GetNetworkBindings()))
+
 	metrics.SetVmiLaucherMemoryOverhead(vmi, memoryOverhead)
 	withCPULimits := t.doesVMIRequireAutoCPULimits(vmi)
 	return VMIResourcePredicates{

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/network/domainspec:go_default_library",
         "//pkg/network/errors:go_default_library",
         "//pkg/network/namescheme:go_default_library",
+        "//pkg/network/netbinding:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -71,6 +71,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	netcache "kubevirt.io/kubevirt/pkg/network/cache"
+	"kubevirt.io/kubevirt/pkg/network/netbinding"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -3656,6 +3657,8 @@ func (d *VirtualMachineController) hotplugMemory(vmi *v1.VirtualMachineInstance,
 
 	overheadRatio := vmi.Labels[v1.MemoryHotplugOverheadRatioLabel]
 	requiredMemory := services.GetMemoryOverhead(vmi, runtime.GOARCH, &overheadRatio)
+	requiredMemory.Add(netbinding.CalculateMemoryOverhead(vmi, d.clusterConfig.GetNetworkBindings()))
+
 	requiredMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
 
 	if podMemReq.Cmp(requiredMemory) < 0 {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1257,6 +1257,63 @@ var CRDsValidation map[string]string = map[string]string{
                 binding:
                   additionalProperties:
                     properties:
+                      computeResourceOverhead:
+                        description: |-
+                          ComputeResourceOverhead specifies the resource overhead that should be added to the compute container when using the binding.
+                          version: v1alphav1
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
                       domainAttachmentType:
                         description: |-
                           DomainAttachmentType is a standard domain network attachment method kubevirt supports.

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -2211,6 +2211,11 @@ func (in *InterfaceBindingPlugin) DeepCopyInto(out *InterfaceBindingPlugin) {
 		*out = new(InterfaceBindingMigration)
 		**out = **in
 	}
+	if in.ComputeResourceOverhead != nil {
+		in, out := &in.ComputeResourceOverhead, &out.ComputeResourceOverhead
+		*out = new(corev1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2832,6 +2832,11 @@ type InterfaceBindingPlugin struct {
 	// version: v1alphav1
 	// +optional
 	DownwardAPI NetworkBindingDownwardAPIType `json:"downwardAPI,omitempty"`
+
+	// ComputeResourceOverhead specifies the resource overhead that should be added to the compute container when using the binding.
+	// version: v1alphav1
+	// +optional
+	ComputeResourceOverhead *k8sv1.ResourceRequirements `json:"computeResourceOverhead,omitempty"`
 }
 
 type DomainAttachmentType string

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -938,6 +938,7 @@ func (InterfaceBindingPlugin) SwaggerDoc() map[string]string {
 		"domainAttachmentType":        "DomainAttachmentType is a standard domain network attachment method kubevirt supports.\nSupported values: \"tap\".\nThe standard domain attachment can be used instead or in addition to the sidecarImage.\nversion: 1alphav1",
 		"migration":                   "Migration means the VM using the plugin can be safely migrated\nversion: 1alphav1",
 		"downwardAPI":                 "DownwardAPI specifies what kind of data should be exposed to the binding plugin sidecar.\nSupported values: \"device-info\"\nversion: v1alphav1\n+optional",
+		"computeResourceOverhead":     "ComputeResourceOverhead specifies the resource overhead that should be added to the compute container when using the binding.\nversion: v1alphav1\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20099,11 +20099,17 @@ func schema_kubevirtio_api_core_v1_InterfaceBindingPlugin(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"computeResourceOverhead": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ComputeResourceOverhead specifies the resource overhead that should be added to the compute container when using the binding. version: v1alphav1",
+							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"kubevirt.io/api/core/v1.InterfaceBindingMigration"},
+			"k8s.io/api/core/v1.ResourceRequirements", "kubevirt.io/api/core/v1.InterfaceBindingMigration"},
 	}
 }
 

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -62,12 +63,20 @@ var _ = SIGDescribe("[Serial] VirtualMachineInstance with passt network binding 
 
 	BeforeEach(func() {
 		const passtBindingName = "passt"
+
+		var passtComputeMemoryOverheadWhenAllPortsAreForwarded = resource.MustParse("500Mi")
+
 		passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")
 
 		err := libkvconfig.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
 			SidecarImage:                passtSidecarImage,
 			NetworkAttachmentDefinition: libnet.PasstNetAttDef,
 			Migration:                   &v1.InterfaceBindingMigration{Method: v1.LinkRefresh},
+			ComputeResourceOverhead: &k8sv1.ResourceRequirements{
+				Requests: map[k8sv1.ResourceName]resource.Quantity{
+					k8sv1.ResourceMemory: passtComputeMemoryOverheadWhenAllPortsAreForwarded,
+				},
+			},
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:
Manual cherrypick of #12235.
The PR is backported in order to fix a bug that impacts users of the [passt network binding plugin](https://kubevirt.io/user-guide/network/net_binding_plugins/passt/).


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network binding plugins: Enable the ability to specify compute memory overhead
```

