### PR TITLE
Fix flaky mem hotplug test

### DIFF
--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",


### PR DESCRIPTION
### What this PR does
Flake:
```
{ Failure tests/hotplug/memory.go:322
Unexpected error:
    <*errors.errorString | 0xc0014dbb90>: 
    could not dump libvirt domxml (remotely on pod virt-launcher-testvmi-wrnv8-6pnmg): command terminated with exit code 1: 
    , error: failed to get domain 'kubevirt-test-default1_testvmi-wrnv8'
    
    {
        s: "could not dump libvirt domxml (remotely on pod virt-launcher-testvmi-wrnv8-6pnmg): command terminated with exit code 1: \n, error: failed to get domain 'kubevirt-test-default1_testvmi-wrnv8'\n",
    }
occurred
tests/hotplug/memory.go:352}
```


Use gomega in Eventually in order to prevent
transient errors


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

