### PR TITLE
tests/utils: inline NewRandomVMIWithEphemeralDisk into its only user

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -140,25 +140,6 @@ func cirrosMemory() string {
 	return "128Mi"
 }
 
-// NewRandomVMIWithEphemeralDisk
-//
-// Deprecated: Use libvmi directly
-func NewRandomVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInstance {
-	opts := []libvmi.Option{
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-		libvmi.WithResourceMemory(cirrosMemory()),
-		libvmi.WithContainerDisk("disk0", containerImage),
-	}
-	if containerImage == cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling) {
-		opts = append(
-			[]libvmi.Option{libvmi.WithRng()},
-			opts...)
-	}
-	return libvmi.New(opts...)
-}
-
 // AddEphemeralDisk
 //
 // Deprecated: Use libvmi
@@ -187,10 +168,20 @@ func AddEphemeralDisk(vmi *v1.VirtualMachineInstance, name string, bus v1.DiskBu
 //
 // Deprecated: Use libvmi directly
 func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
-	cloudInitNoCloudEncodedUserData := libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(userData))
-	cloudInitNoCloudEncodedUserData(vmi)
-	return vmi
+	opts := []libvmi.Option{
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+		libvmi.WithResourceMemory(cirrosMemory()),
+		libvmi.WithContainerDisk("disk0", containerImage),
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(userData)),
+	}
+	if containerImage == cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling) {
+		opts = append(
+			[]libvmi.Option{libvmi.WithRng()},
+			opts...)
+	}
+	return libvmi.New(opts...)
 }
 
 func NewRandomReplicaSetFromVMI(vmi *v1.VirtualMachineInstance, replicas int32) *v1.VirtualMachineInstanceReplicaSet {


### PR DESCRIPTION
The deprecated `NewRandomVMIWithEphemeralDisk` function is used only once. Let us inline it, so no one is tempted to use it.

/sig code-quality

```release-note
NONE
```

