### PR TITLE
Fix flaky cpu hotplug test

### DIFF
--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",


### PR DESCRIPTION
### What this PR does
Flake
```
Unexpected error:
    <*errors.errorString | 0xc00602dad0>: 
    could not dump libvirt domxml (remotely on pod virt-launcher-testvmi-pffvl-8j4kh): command terminated with exit code 1: 
    , error: failed to get domain 'kubevirt-test-default1_testvmi-pffvl'
    
    {
        s: "could not dump libvirt domxml (remotely on pod virt-launcher-testvmi-pffvl-8j4kh): command terminated with exit code 1: \n, error: failed to get domain 'kubevirt-test-default1_testvmi-pffvl'\n",
    }
occurred
```


Move GetRunningVMIDomainSpec out of
the countDomCPUs as that is the only
thing that can have transient errors.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

