### PR TITLE
[tests] replace the cirrosMemory function with an interface

### DIFF
--- a/tests/libvmifact/architecture.go
+++ b/tests/libvmifact/architecture.go
@@ -81,6 +81,7 @@ const (
 func (defaultMemProvider) getMinimalMemory() string {
 	return defaultMinimalMemory
 }
+
 func (defaultMemProvider) getQemuMinimalMemory() string {
 	return defaultMinimalBootableMemory
 }

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -52,7 +52,7 @@ func NewFedora(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 func NewCirros(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	cirrosOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
-		libvmi.WithResourceMemory(cirrosMemory()),
+		libvmi.WithResourceMemory(GetMinimalMemory()),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)
 	vmi := libvmi.New(cirrosOpts...)
@@ -67,10 +67,9 @@ func NewCirros(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 
 // NewAlpine instantiates a new Alpine based VMI configuration
 func NewAlpine(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
-	alpineMemory := cirrosMemory
 	alpineOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskAlpine)),
-		libvmi.WithResourceMemory(alpineMemory()),
+		libvmi.WithResourceMemory(GetMinimalMemory()),
 		libvmi.WithRng(),
 	}
 	alpineOpts = append(alpineOpts, opts...)
@@ -78,10 +77,9 @@ func NewAlpine(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 }
 
 func NewAlpineWithTestTooling(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
-	alpineMemory := cirrosMemory
 	alpineOpts := []libvmi.Option{
 		libvmi.WithContainerDisk("disk0", cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
-		libvmi.WithResourceMemory(alpineMemory()),
+		libvmi.WithResourceMemory(GetMinimalMemory()),
 		libvmi.WithRng(),
 	}
 	alpineOpts = append(alpineOpts, opts...)
@@ -97,26 +95,9 @@ func NewAlpineWithTestTooling(opts ...libvmi.Option) *kvirtv1.VirtualMachineInst
 
 func NewGuestless(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {
 	opts = append(
-		[]libvmi.Option{libvmi.WithResourceMemory(qemuMinimumMemory())},
+		[]libvmi.Option{libvmi.WithResourceMemory(GetQemuMinimalMemory())},
 		opts...)
 	return libvmi.New(opts...)
-}
-
-func qemuMinimumMemory() string {
-	if isARM64() {
-		// required to start qemu on ARM with UEFI firmware
-		// https://github.com/kubevirt/kubevirt/pull/11366#issuecomment-1970247448
-		const armMinimalBootableMemory = "128Mi"
-		return armMinimalBootableMemory
-	}
-	return "1Mi"
-}
-
-func cirrosMemory() string {
-	if isARM64() {
-		return "256Mi"
-	}
-	return "128Mi"
 }
 
 func NewWindows(opts ...libvmi.Option) *kvirtv1.VirtualMachineInstance {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/tests/framework/checks"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1203,12 +1201,8 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 				originalPVCName := dv.Name
 
-				memory := "128Mi"
-				if checks.IsARM64(testsuite.Arch) {
-					memory = "256Mi"
-				}
 				vmi = libstorage.RenderVMIWithDataVolume(originalPVCName, testsuite.GetTestNamespace(nil),
-					libvmi.WithResourceMemory(memory), libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(bashHelloScript)))
+					libvmi.WithResourceMemory(libvmifact.GetMinimalMemory()), libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(bashHelloScript)))
 				vm, vmi = createAndStartVM(libvmi.NewVirtualMachine(vmi))
 
 				doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))


### PR DESCRIPTION
### What this PR does
Before this PR:
The architecture can't be changed on runtime, so there is no point to check it each time in order to decide about minimal memory required for VMIs.

Also, the `cirrosMemory` function is private and can't be used outside of the `libvmifact` package, but it is needed in other places.

After this PR:
Added a new private interface to the `libvmifact` package:
```go
type minimalMemoryProvider interface {
	getMinimalMemory() string
	getQemuMinimalMemory() string
}
```

Also, added two new functions to retrieve the minimal memory sizes from the right implementation, based on the current architecture, so the user can do:
```go
mem := libvmifact.GetMinimalMemory()

// OR

mem := libvmifact.GetQemuMinimalMemory()
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

