### PR TITLE
fix(vap test): use schedulable nodes only

### DIFF
--- a/tests/validatingadmissionpolicy/noderestrictions.go
+++ b/tests/validatingadmissionpolicy/noderestrictions.go
@@ -64,9 +64,7 @@ var _ = Describe("[Serial][sig-compute] virt-handler node restrictions via valid
 		_, err = virtClient.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(context.Background(), "kubevirt-node-restriction-binding", metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred(), "validating admission policy binding should appear")
 
-		nodesList, err := virtClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
+		nodesList := libnode.GetAllSchedulableNodes(virtClient)
 		Expect(nodesList.Items).ToNot(BeEmpty())
 		nodeName = nodesList.Items[0].Name
 		patchBytes, err := patch.New(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the VAP tests use the virt-handler token to ensure that only legit patch operations are allowed. They get all the nodes and pick a random one.
In those cases where the first node is a control-plane only node, the test fail since the virt-handler is not running there.
The virt-handler daemonset schedules virt-handler pods only in schedulable nodes.

Instead of pick a random node from the entire node list, pick a random node from the schedulable node list.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

