### PR TITLE
Vgpu flake

### DIFF
--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 			var latestPod k8sv1.Pod
-			err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true, waitForPod(&latestPod, ThisPod(testPod)).WithContext())
+			err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 1*time.Minute, true, waitForPod(&latestPod, ThisPod(testPod)).WithContext())
 			return &latestPod, err
 		}
 
@@ -100,7 +100,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 		var latestPod k8sv1.Pod
-		err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 2*time.Minute, true, waitForPod(&latestPod, ThisPod(testPod)).WithContext())
+		err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 1*time.Minute, true, waitForPod(&latestPod, ThisPod(testPod)).WithContext())
 		return &latestPod, err
 	}
 

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 			var latestPod k8sv1.Pod
-			err := wait.PollImmediate(5*time.Second, 3*time.Minute, waitForPod(&latestPod, ThisPod(testPod)))
+			err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 3*time.Minute, true, waitForPod(&latestPod, ThisPod(testPod)).WithContext())
 			return &latestPod, err
 		}
 
@@ -100,7 +100,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 		var latestPod k8sv1.Pod
-		err := wait.PollImmediate(time.Second, 2*time.Minute, waitForPod(&latestPod, ThisPod(testPod)))
+		err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 2*time.Minute, true, waitForPod(&latestPod, ThisPod(testPod)).WithContext())
 		return &latestPod, err
 	}
 
@@ -397,7 +397,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 			var latestPod k8sv1.Pod
-			err := wait.PollImmediate(time.Second, 2*time.Minute, waitForPod(&latestPod, ThisPod(testPod)))
+			err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 2*time.Minute, true, waitForPod(&latestPod, ThisPod(testPod)).WithContext())
 			return err
 		}
 


### PR DESCRIPTION
### What this PR does
```
Timed out after 120.013s.
The function passed to Eventually returned the following error:
    <wait.errInterrupted>: 
    timed out waiting for the condition
    {
        cause: <*errors.errorString | 0xc000292b70>{
            s: "timed out waiting for the condition",
        },
    }
tests/mdev_configuration_allocation_test.go:251}
```

This PRs decrease the waiting time for the Pod in order for the `Eventually` loop to attempt next try.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

