### PR TITLE
handler: remove the change condition only when the migration is in complete state

### DIFF
--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -91,6 +91,14 @@ func MigrationFailed(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
+func MigrationCompleted(vmi *v1.VirtualMachineInstance) bool {
+	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.Completed {
+		return true
+	}
+
+	return false
+}
+
 func VMIEvictionStrategy(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance) *v1.EvictionStrategy {
 	if vmi != nil && vmi.Spec.EvictionStrategy != nil {
 		return vmi.Spec.EvictionStrategy

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -804,6 +804,9 @@ func (d *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 		log.Log.Object(vmi).Info("The target node received the running migrated domain")
 		now := metav1.Now()
 		vmiCopy.Status.MigrationState.TargetNodeDomainReadyTimestamp = &now
+	}
+
+	if migrations.MigrationCompleted(vmi) {
 		d.finalizeMigration(vmiCopy)
 	}
 


### PR DESCRIPTION
The workload update migration relies on the change condition on the VMI to understand if the update migration needs to be canceled. The removal of the condition and the migration set to completed are racy. This change helps to coordinates the removal of the change conditions only after the migration it has been set as final.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
No coordination between the change conditions removal and workload update migration cancellation

After this PR:
Virt-handler finalized the migration only after the status of the migration has been set to completed

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12297

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

