### PR TITLE
workload-updater: avoid cancelling the migration when the migration has finished

### DIFF
--- a/pkg/virt-controller/watch/workload-updater/BUILD.bazel
+++ b/pkg/virt-controller/watch/workload-updater/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -357,6 +357,9 @@ func (c *WorkloadUpdateController) shouldAbortMigration(vmi *virtv1.VirtualMachi
 	if isVolumesUpdateInProgress(vmi) {
 		return false
 	}
+	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
+		return false
+	}
 	return numMig > 0
 }
 

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -17,6 +17,8 @@ import (
 
 	"kubevirt.io/client-go/api"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -518,6 +520,28 @@ var _ = Describe("Workload Updater", func() {
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, FailedChangeAbortionReason)
+		})
+
+		It("shouldn't cancel the migration if the migration object is still in running phase but the domain is ready on the target", func() {
+			vmi := api.NewMinimalVMI("testvm")
+			vmi.Namespace = k8sv1.NamespaceDefault
+			vmi.Status.Phase = v1.Running
+			vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
+				Type: v1.VirtualMachineInstanceIsMigratable, Status: k8sv1.ConditionTrue})
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				StartTimestamp:                 pointer.P(metav1.Now()),
+				Completed:                      false,
+				Failed:                         false,
+				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+			}
+			// Ensure that the deletion operation isn't called. The test reproduces the race when the migration operation
+			// was completed, but the migration object was still in running phase and it was accidentally deleted.
+			migrationInterface.EXPECT().Delete(gomock.Any(), gomock.Any(), metav1.DeleteOptions{}).Return(nil).Times(0)
+			controller.vmiStore.Add(vmi)
+			createMig(vmi.Name, v1.MigrationRunning)
+			controller.Execute()
+			Expect(recorder.Events).To(BeEmpty())
+
 		})
 	})
 


### PR DESCRIPTION
Make sure that the migration has completed by checking if the target domain is ready. In certain cases, the migration can be  still in running phase but the migration process has already completed and the object hasn't been updated yet. In order to prevent the race condition of deleting the migration object, we check if the target is ready.

Fixes #12297


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

