### PR TITLE
Network Binding Plugin: Decouple memory overhead calculation

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/monitoring/metrics/virt-handler:go_default_library",
         "//pkg/monitoring/metrics/virt-handler/handler:go_default_library",
         "//pkg/monitoring/profiler:go_default_library",
+        "//pkg/network/netbinding:go_default_library",
         "//pkg/safepath:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/util:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -74,6 +74,7 @@ import (
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler"
 	metricshandler "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/handler"
 	"kubevirt.io/kubevirt/pkg/monitoring/profiler"
+	"kubevirt.io/kubevirt/pkg/network/netbinding"
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -346,6 +347,7 @@ func (app *virtHandlerApp) Run() {
 		downwardMetricsManager,
 		capabilities,
 		hostCpuModel,
+		netbinding.MemoryCalculator{},
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/network/netbinding/memory.go
+++ b/pkg/network/netbinding/memory.go
@@ -27,8 +27,10 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-func CalculateMemoryOverhead(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) resource.Quantity {
-	return sumPluginsMemoryOverhead(
+type MemoryCalculator struct{}
+
+func (mc MemoryCalculator) Calculate(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) resource.Quantity {
+	return sumPluginsMemoryRequests(
 		filterUniquePlugins(vmi.Spec.Domain.Devices.Interfaces, registeredPlugins),
 	)
 }
@@ -60,7 +62,7 @@ func filterUniquePlugins(interfaces []v1.Interface, registeredPlugins map[string
 	return uniquePlugins
 }
 
-func sumPluginsMemoryOverhead(uniquePlugins []v1.InterfaceBindingPlugin) resource.Quantity {
+func sumPluginsMemoryRequests(uniquePlugins []v1.InterfaceBindingPlugin) resource.Quantity {
 	result := resource.Quantity{}
 
 	for _, plugin := range uniquePlugins {

--- a/pkg/network/netbinding/memory_test.go
+++ b/pkg/network/netbinding/memory_test.go
@@ -42,7 +42,9 @@ var _ = Describe("Network Binding plugin compute resource overhead", func() {
 	)
 
 	DescribeTable("Memory overhead should be zero", func(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) {
-		actualResult := netbinding.CalculateMemoryOverhead(vmi, registeredPlugins)
+		memoryCalculator := netbinding.MemoryCalculator{}
+
+		actualResult := memoryCalculator.Calculate(vmi, registeredPlugins)
 		Expect(actualResult.Value()).To(BeZero())
 	},
 		Entry("when the VMI does not have NICs and there aren't any registered plugins", libvmi.New(), nil),
@@ -87,7 +89,9 @@ var _ = Describe("Network Binding plugin compute resource overhead", func() {
 	)
 
 	DescribeTable("It should calculate memory overhead", func(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin, expectedValue resource.Quantity) {
-		actualResult := netbinding.CalculateMemoryOverhead(vmi, registeredPlugins)
+		memoryCalculator := netbinding.MemoryCalculator{}
+
+		actualResult := memoryCalculator.Calculate(vmi, registeredPlugins)
 		Expect(actualResult.Value()).To(Equal(expectedValue.Value()))
 	},
 		Entry("when there is a single interface using a binding plugin",

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/network/downwardapi:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/namescheme:go_default_library",
-        "//pkg/network/netbinding:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -133,6 +133,7 @@ var _ = Describe("Template", func() {
 					func(vmi *v1.VirtualMachineInstance, _ *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
 						return hooks.UnmarshalHookSidecarList(vmi)
 					}),
+				WithNetBindingPluginMemoryCalculator(&stubNetBindingPluginMemoryCalculator{}),
 			)
 			// Set up mock clients
 			networkClient := fakenetworkclient.NewSimpleClientset()
@@ -2928,6 +2929,7 @@ var _ = Describe("Template", func() {
 				resourceQuotaStore,
 				namespaceStore,
 				WithSidecarCreator(testSidecarCreator),
+				WithNetBindingPluginMemoryCalculator(&stubNetBindingPluginMemoryCalculator{}),
 			)
 			vmi := v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{
 				Name: "testvmi", Namespace: "default", UID: "1234",
@@ -5048,46 +5050,53 @@ var _ = Describe("Template", func() {
 			const (
 				iface1name  = "iface1"
 				plugin1name = "plugin1"
-				iface2name  = "iface2"
-				plugin2name = "plugin2"
 			)
 
-			bindingPlugins := map[string]v1.InterfaceBindingPlugin{
-				plugin1name: {
-					ComputeResourceOverhead: &k8sv1.ResourceRequirements{
-						Requests: map[k8sv1.ResourceName]resource.Quantity{
-							k8sv1.ResourceMemory: resource.MustParse("500Mi"),
-						},
-					},
-				},
-				plugin2name: {
-					ComputeResourceOverhead: &k8sv1.ResourceRequirements{
-						Requests: map[k8sv1.ResourceName]resource.Quantity{
-							k8sv1.ResourceMemory: resource.MustParse("600Mi"),
+			kvConfig := kv.DeepCopy()
+			kvConfig.Spec.Configuration.NetworkConfiguration = &v1.NetworkConfiguration{
+				Binding: map[string]v1.InterfaceBindingPlugin{
+					plugin1name: {
+						ComputeResourceOverhead: &k8sv1.ResourceRequirements{
+							Requests: map[k8sv1.ResourceName]resource.Quantity{
+								k8sv1.ResourceMemory: resource.MustParse("500Mi"),
+							},
 						},
 					},
 				},
 			}
 
-			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.NetworkConfiguration = &v1.NetworkConfiguration{Binding: bindingPlugins}
-			_, kvStore, svc = configFactory(defaultArch)
-			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
+			config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&kvConfig.Spec.Configuration)
+
+			netBindingPluginMemoryOverheadCalculator := &stubNetBindingPluginMemoryCalculator{}
+			svc = NewTemplateService("kubevirt/virt-launcher",
+				240,
+				"/var/run/kubevirt",
+				"/var/lib/kubevirt",
+				"/var/run/kubevirt-ephemeral-disks",
+				"/var/run/kubevirt/container-disks",
+				v1.HotplugDiskDir,
+				"pull-secret-1",
+				pvcCache,
+				virtClient,
+				config,
+				qemuGid,
+				"kubevirt/vmexport",
+				resourceQuotaStore,
+				namespaceStore,
+				WithSidecarCreator(testSidecarCreator),
+				WithNetBindingPluginMemoryCalculator(netBindingPluginMemoryOverheadCalculator),
+			)
 
 			vmi := libvmi.New(
 				libvmi.WithNamespace("default"),
 				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),
 				libvmi.WithNetwork(&v1.Network{Name: iface1name}),
-				libvmi.WithInterface(v1.Interface{Name: iface2name, Binding: &v1.PluginBinding{Name: plugin2name}}),
-				libvmi.WithNetwork(&v1.Network{Name: iface2name}),
 			)
 
-			pod, err := svc.RenderLaunchManifest(vmi)
+			_, err := svc.RenderLaunchManifest(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
-			expectedMemory := GetMemoryOverhead(vmi, defaultArch, nil)
-			expectedMemory.Add(resource.MustParse("1100Mi"))
-			Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(expectedMemory.Value()))
+			Expect(netBindingPluginMemoryOverheadCalculator.calculatedMemoryOverhead).To(BeTrue())
 		})
 	})
 })
@@ -5214,4 +5223,14 @@ func validateAndExtractQemuTimeoutArg(args []string) string {
 	Expect(failMsg).To(Equal(""))
 
 	return timeoutString
+}
+
+type stubNetBindingPluginMemoryCalculator struct {
+	calculatedMemoryOverhead bool
+}
+
+func (smc *stubNetBindingPluginMemoryCalculator) Calculate(_ *v1.VirtualMachineInstance, _ map[string]v1.InterfaceBindingPlugin) resource.Quantity {
+	smc.calculatedMemoryOverhead = true
+
+	return resource.Quantity{}
 }

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -617,6 +617,7 @@ func (vca *VirtControllerApp) initCommon() {
 				return hooks.UnmarshalHookSidecarList(vmi)
 			}),
 		services.WithSidecarCreator(netbinding.NetBindingPluginSidecarList),
+		services.WithNetBindingPluginMemoryCalculator(netbinding.MemoryCalculator{}),
 	)
 
 	topologyHinter := topology.NewTopologyHinter(vca.nodeInformer.GetStore(), vca.vmiInformer.GetStore(), vca.clusterConfig)

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/network/domainspec:go_default_library",
         "//pkg/network/errors:go_default_library",
         "//pkg/network/namescheme:go_default_library",
-        "//pkg/network/netbinding:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -71,7 +71,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	netcache "kubevirt.io/kubevirt/pkg/network/cache"
-	"kubevirt.io/kubevirt/pkg/network/netbinding"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -218,6 +217,7 @@ func NewController(
 	downwardMetricsManager downwardMetricsManager,
 	capabilities *nodelabellerapi.Capabilities,
 	hostCpuModel string,
+	netBindingPluginMemoryCalculator netBindingPluginMemoryCalculator,
 ) (*VirtualMachineController, error) {
 
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-handler-vm")
@@ -233,27 +233,28 @@ func NewController(
 	}
 
 	c := &VirtualMachineController{
-		queue:                       queue,
-		recorder:                    recorder,
-		clientset:                   clientset,
-		host:                        host,
-		migrationIpAddress:          migrationIpAddress,
-		virtShareDir:                virtShareDir,
-		vmiSourceStore:              vmiSourceInformer.GetStore(),
-		vmiTargetStore:              vmiTargetInformer.GetStore(),
-		domainStore:                 domainInformer.GetStore(),
-		heartBeatInterval:           1 * time.Minute,
-		migrationProxy:              migrationProxy,
-		podIsolationDetector:        podIsolationDetector,
-		containerDiskMounter:        container_disk.NewMounter(podIsolationDetector, containerDiskState, clusterConfig),
-		hotplugVolumeMounter:        hotplug_volume.NewVolumeMounter(hotplugState, kubeletPodsDir),
-		clusterConfig:               clusterConfig,
-		virtLauncherFSRunDirPattern: "/proc/%d/root/var/run",
-		capabilities:                capabilities,
-		hostCpuModel:                hostCpuModel,
-		vmiExpectations:             controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		sriovHotplugExecutorPool:    executor.NewRateLimitedExecutorPool(executor.NewExponentialLimitedBackoffCreator()),
-		ioErrorRetryManager:         NewFailRetryManager("io-error-retry", 10*time.Second, 3*time.Minute, 30*time.Second),
+		queue:                            queue,
+		recorder:                         recorder,
+		clientset:                        clientset,
+		host:                             host,
+		migrationIpAddress:               migrationIpAddress,
+		virtShareDir:                     virtShareDir,
+		vmiSourceStore:                   vmiSourceInformer.GetStore(),
+		vmiTargetStore:                   vmiTargetInformer.GetStore(),
+		domainStore:                      domainInformer.GetStore(),
+		heartBeatInterval:                1 * time.Minute,
+		migrationProxy:                   migrationProxy,
+		podIsolationDetector:             podIsolationDetector,
+		containerDiskMounter:             container_disk.NewMounter(podIsolationDetector, containerDiskState, clusterConfig),
+		hotplugVolumeMounter:             hotplug_volume.NewVolumeMounter(hotplugState, kubeletPodsDir),
+		clusterConfig:                    clusterConfig,
+		virtLauncherFSRunDirPattern:      "/proc/%d/root/var/run",
+		capabilities:                     capabilities,
+		hostCpuModel:                     hostCpuModel,
+		vmiExpectations:                  controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		sriovHotplugExecutorPool:         executor.NewRateLimitedExecutorPool(executor.NewExponentialLimitedBackoffCreator()),
+		ioErrorRetryManager:              NewFailRetryManager("io-error-retry", 10*time.Second, 3*time.Minute, 30*time.Second),
+		netBindingPluginMemoryCalculator: netBindingPluginMemoryCalculator,
 	}
 
 	c.hasSynced = func() bool {
@@ -320,6 +321,10 @@ func NewController(
 	return c, nil
 }
 
+type netBindingPluginMemoryCalculator interface {
+	Calculate(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) resource.Quantity
+}
+
 type VirtualMachineController struct {
 	recorder                 record.EventRecorder
 	clientset                kubecli.KubevirtClient
@@ -342,8 +347,9 @@ type VirtualMachineController struct {
 	sriovHotplugExecutorPool *executor.RateLimitedExecutorPool
 	downwardMetricsManager   downwardMetricsManager
 
-	netConf netconf
-	netStat netstat
+	netConf                          netconf
+	netStat                          netstat
+	netBindingPluginMemoryCalculator netBindingPluginMemoryCalculator
 
 	domainNotifyPipes           map[string]string
 	virtLauncherFSRunDirPattern string
@@ -3629,7 +3635,9 @@ func (d *VirtualMachineController) hotplugMemory(vmi *v1.VirtualMachineInstance,
 
 	overheadRatio := vmi.Labels[v1.MemoryHotplugOverheadRatioLabel]
 	requiredMemory := services.GetMemoryOverhead(vmi, runtime.GOARCH, &overheadRatio)
-	requiredMemory.Add(netbinding.CalculateMemoryOverhead(vmi, d.clusterConfig.GetNetworkBindings()))
+	requiredMemory.Add(
+		d.netBindingPluginMemoryCalculator.Calculate(vmi, d.clusterConfig.GetNetworkBindings()),
+	)
 
 	requiredMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -126,6 +126,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 	var certDir string
 
+	var networkBindingPluginMemoryCalculator *stubNetBindingPluginMemoryCalculator
+
 	const migratableNetworkBindingPlugin = "mig_plug"
 
 	getCgroupManager = func(_ *v1.VirtualMachineInstance) (cgroup.Manager, error) {
@@ -213,6 +215,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, config)
 		fakeDownwardMetricsManager := newFakeManager()
 
+		networkBindingPluginMemoryCalculator = &stubNetBindingPluginMemoryCalculator{}
+
 		controller, _ = NewController(recorder,
 			virtClient,
 			host,
@@ -230,6 +234,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			fakeDownwardMetricsManager,
 			nil,
 			"",
+			networkBindingPluginMemoryCalculator,
 		)
 		controller.hotplugVolumeMounter = mockHotplugVolumeMounter
 		controller.virtLauncherFSRunDirPattern = filepath.Join(shareDir, "%d")
@@ -2047,6 +2052,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(conditionManager.HasCondition(vmi, v1.VirtualMachineInstanceMemoryChange)).To(BeFalse())
 			Expect(v1.VirtualMachinePodMemoryRequestsLabel).ToNot(BeKeyOf(vmi.Labels))
 			Expect(vmi.Status.Memory.GuestRequested).To(Equal(vmi.Spec.Domain.Memory.Guest))
+			Expect(networkBindingPluginMemoryCalculator.calculatedMemoryOverhead).To(BeTrue())
 		})
 
 		It("should not hotplug memory if target pod does not have enough memory", func() {
@@ -3583,3 +3589,13 @@ func (*fakeManager) StartServer(_ *v1.VirtualMachineInstance, _ int) error {
 	return nil
 }
 func (*fakeManager) StopServer(_ *v1.VirtualMachineInstance) {}
+
+type stubNetBindingPluginMemoryCalculator struct {
+	calculatedMemoryOverhead bool
+}
+
+func (smc *stubNetBindingPluginMemoryCalculator) Calculate(_ *v1.VirtualMachineInstance, _ map[string]v1.InterfaceBindingPlugin) resource.Quantity {
+	smc.calculatedMemoryOverhead = true
+
+	return resource.Quantity{}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Following PR #12235, it is possible to specify memory overhead for the compute container when registering a network binding plugin.

Decouple the memory overhead calculation when:
1. Calculating the compute container's memory overhead.
2. Calculating if there is enough memory in a memory hotplug scenario.

Introduce the `netBindingPluginMemoryCalculator` interface to:
1. templateService
2. VirtualMachineController

Expect the network binding plugin memory overhead calculation to be called in unit tests.

There is a check in `template.go` to see if the newly introduced interface is not `nil` in order to not break existing unit tests that use the real `templateService` struct:
- VMI controller
- Migration controller

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

