### PR TITLE
libinstancetype clean ups

### DIFF
--- a/tests/instancetype/upgrade.go
+++ b/tests/instancetype/upgrade.go
@@ -124,7 +124,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		// creation of a ControllerRevision later on in the test to use the now
 		// created VirtualMachine as an OwnerReference.
 		instancetype := builder.NewInstancetype(
-			builder.WithCPUs(uint32(1)),
+			builder.WithCPUs(1),
 			builder.WithMemory("128Mi"),
 		)
 		instancetype, err := virtClient.VirtualMachineInstancetype(testsuite.GetTestNamespace(instancetype)).Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -187,7 +187,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetype from v1beta1 without labels to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builder.NewInstancetype(
-					builder.WithCPUs(uint32(1)),
+					builder.WithCPUs(1),
 					builder.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.VirtualMachineInstancetype(instancetype.Namespace).Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -200,7 +200,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetype from v1beta1 with labels to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builder.NewInstancetype(
-					builder.WithCPUs(uint32(1)),
+					builder.WithCPUs(1),
 					builder.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.VirtualMachineInstancetype(instancetype.Namespace).Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -213,7 +213,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetype from v1alpha2 to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha2.NewInstancetype(
-					builderv1alpha2.WithCPUs(uint32(1)),
+					builderv1alpha2.WithCPUs(1),
 					builderv1alpha2.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.GeneratedKubeVirtClient().InstancetypeV1alpha2().VirtualMachineInstancetypes(instancetype.Namespace).Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -226,7 +226,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetype from v1alpha1 to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha1.NewInstancetype(
-					builderv1alpha1.WithCPUs(uint32(1)),
+					builderv1alpha1.WithCPUs(1),
 					builderv1alpha1.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.GeneratedKubeVirtClient().InstancetypeV1alpha1().VirtualMachineInstancetypes(instancetype.Namespace).Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -239,7 +239,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetypeSpecRevision v1alpha1 to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha1.NewInstancetype(
-					builderv1alpha1.WithCPUs(uint32(1)),
+					builderv1alpha1.WithCPUs(1),
 					builderv1alpha1.WithMemory("128Mi"),
 				)
 				specBytes, err := json.Marshal(&instancetype.Spec)
@@ -269,7 +269,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineClusterInstancetype from v1beta1 without labels to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builder.NewClusterInstancetype(
-					builder.WithCPUs(uint32(1)),
+					builder.WithCPUs(1),
 					builder.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.VirtualMachineClusterInstancetype().Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -282,7 +282,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineClusterInstancetype from v1beta1 with labels to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builder.NewClusterInstancetype(
-					builder.WithCPUs(uint32(1)),
+					builder.WithCPUs(1),
 					builder.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.VirtualMachineClusterInstancetype().Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -295,7 +295,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineClusterInstancetype from v1alpha2 to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha2.NewClusterInstancetype(
-					builderv1alpha2.WithCPUs(uint32(1)),
+					builderv1alpha2.WithCPUs(1),
 					builderv1alpha2.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.GeneratedKubeVirtClient().InstancetypeV1alpha2().VirtualMachineClusterInstancetypes().Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -308,7 +308,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineClusterInstancetype from v1alpha1 to latest",
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha1.NewClusterInstancetype(
-					builderv1alpha1.WithCPUs(uint32(1)),
+					builderv1alpha1.WithCPUs(1),
 					builderv1alpha1.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.GeneratedKubeVirtClient().InstancetypeV1alpha1().VirtualMachineClusterInstancetypes().Create(context.Background(), instancetype, metav1.CreateOptions{})

--- a/tests/instancetype/upgrade.go
+++ b/tests/instancetype/upgrade.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -126,7 +125,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		// created VirtualMachine as an OwnerReference.
 		instancetype := builder.NewInstancetype(
 			builder.WithCPUs(uint32(1)),
-			builder.WithMemory(resource.MustParse("128Mi")),
+			builder.WithMemory("128Mi"),
 		)
 		instancetype, err := virtClient.VirtualMachineInstancetype(testsuite.GetTestNamespace(instancetype)).Create(context.Background(), instancetype, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -189,7 +188,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builder.NewInstancetype(
 					builder.WithCPUs(uint32(1)),
-					builder.WithMemory(resource.MustParse("128Mi")),
+					builder.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.VirtualMachineInstancetype(instancetype.Namespace).Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -202,7 +201,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builder.NewInstancetype(
 					builder.WithCPUs(uint32(1)),
-					builder.WithMemory(resource.MustParse("128Mi")),
+					builder.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.VirtualMachineInstancetype(instancetype.Namespace).Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -215,7 +214,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha2.NewInstancetype(
 					builderv1alpha2.WithCPUs(uint32(1)),
-					builderv1alpha2.WithMemory(resource.MustParse("128Mi")),
+					builderv1alpha2.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.GeneratedKubeVirtClient().InstancetypeV1alpha2().VirtualMachineInstancetypes(instancetype.Namespace).Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -228,7 +227,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha1.NewInstancetype(
 					builderv1alpha1.WithCPUs(uint32(1)),
-					builderv1alpha1.WithMemory(resource.MustParse("128Mi")),
+					builderv1alpha1.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.GeneratedKubeVirtClient().InstancetypeV1alpha1().VirtualMachineInstancetypes(instancetype.Namespace).Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -241,7 +240,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha1.NewInstancetype(
 					builderv1alpha1.WithCPUs(uint32(1)),
-					builderv1alpha1.WithMemory(resource.MustParse("128Mi")),
+					builderv1alpha1.WithMemory("128Mi"),
 				)
 				specBytes, err := json.Marshal(&instancetype.Spec)
 				Expect(err).ToNot(HaveOccurred())
@@ -271,7 +270,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builder.NewClusterInstancetype(
 					builder.WithCPUs(uint32(1)),
-					builder.WithMemory(resource.MustParse("128Mi")),
+					builder.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.VirtualMachineClusterInstancetype().Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -284,7 +283,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builder.NewClusterInstancetype(
 					builder.WithCPUs(uint32(1)),
-					builder.WithMemory(resource.MustParse("128Mi")),
+					builder.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.VirtualMachineClusterInstancetype().Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -297,7 +296,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha2.NewClusterInstancetype(
 					builderv1alpha2.WithCPUs(uint32(1)),
-					builderv1alpha2.WithMemory(resource.MustParse("128Mi")),
+					builderv1alpha2.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.GeneratedKubeVirtClient().InstancetypeV1alpha2().VirtualMachineClusterInstancetypes().Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -310,7 +309,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			func() (*appsv1.ControllerRevision, error) {
 				instancetype := builderv1alpha1.NewClusterInstancetype(
 					builderv1alpha1.WithCPUs(uint32(1)),
-					builderv1alpha1.WithMemory(resource.MustParse("128Mi")),
+					builderv1alpha1.WithMemory("128Mi"),
 				)
 				instancetype, err := virtClient.GeneratedKubeVirtClient().InstancetypeV1alpha1().VirtualMachineClusterInstancetypes().Create(context.Background(), instancetype, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/libinstancetype/builder/builder.go
+++ b/tests/libinstancetype/builder/builder.go
@@ -53,9 +53,9 @@ func WithCPUs(vCPUs uint32) InstancetypeSpecOption {
 	}
 }
 
-func WithMemory(memory resource.Quantity) InstancetypeSpecOption {
+func WithMemory(memory string) InstancetypeSpecOption {
 	return func(spec *instancetypev1beta1.VirtualMachineInstancetypeSpec) {
-		spec.Memory.Guest = memory
+		spec.Memory.Guest = resource.MustParse(memory)
 	}
 }
 

--- a/tests/libinstancetype/builder/v1alpha1/builder.go
+++ b/tests/libinstancetype/builder/v1alpha1/builder.go
@@ -52,9 +52,9 @@ func WithCPUs(vCPUs uint32) InstancetypeSpecOption {
 	}
 }
 
-func WithMemory(memory resource.Quantity) InstancetypeSpecOption {
+func WithMemory(memory string) InstancetypeSpecOption {
 	return func(spec *instancetypev1alpha1.VirtualMachineInstancetypeSpec) {
-		spec.Memory.Guest = memory
+		spec.Memory.Guest = resource.MustParse(memory)
 	}
 }
 

--- a/tests/libinstancetype/builder/v1alpha2/builder.go
+++ b/tests/libinstancetype/builder/v1alpha2/builder.go
@@ -52,9 +52,9 @@ func WithCPUs(vCPUs uint32) InstancetypeSpecOption {
 	}
 }
 
-func WithMemory(memory resource.Quantity) InstancetypeSpecOption {
+func WithMemory(memory string) InstancetypeSpecOption {
 	return func(spec *instancetypev1alpha2.VirtualMachineInstancetypeSpec) {
-		spec.Memory.Guest = memory
+		spec.Memory.Guest = resource.MustParse(memory)
 	}
 }
 

--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -31,7 +31,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	audit_api "kubevirt.io/kubevirt/tools/perfscale-audit/api"
@@ -234,7 +233,7 @@ func createBatchRunningVMWithRateControl(virtClient kubecli.KubevirtClient, vmCo
 func createInstancetype(virtClient kubecli.KubevirtClient) *instancetypev1beta1.VirtualMachineInstancetype {
 	instancetype := instancetypeBuilder.NewInstancetype(
 		instancetypeBuilder.WithCPUs(1),
-		instancetypeBuilder.WithMemory(resource.MustParse("90Mi")),
+		instancetypeBuilder.WithMemory("90Mi"),
 	)
 	instancetype, err := virtClient.VirtualMachineInstancetype(util.NamespaceTestDefault).Create(context.Background(), instancetype, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -437,7 +437,7 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 
 			BeforeEach(func() {
 				instancetype = instancetypebuilder.NewInstancetype(
-					instancetypebuilder.WithCPUs(uint32(2)),
+					instancetypebuilder.WithCPUs(2),
 				)
 				instancetype, err = virtCli.VirtualMachineInstancetype(testsuite.GetTestNamespace(instancetype)).
 					Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -448,7 +448,7 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 				}
 
 				clusterInstancetype = instancetypebuilder.NewClusterInstancetype(
-					instancetypebuilder.WithCPUs(uint32(2)),
+					instancetypebuilder.WithCPUs(2),
 				)
 				clusterInstancetype, err = virtCli.VirtualMachineClusterInstancetype().
 					Create(context.Background(), clusterInstancetype, metav1.CreateOptions{})


### PR DESCRIPTION
/sig code-quality
/cc @fossedihelm

As discussed in https://github.com/kubevirt/kubevirt/pull/12248 this is the simple follow up you requested.

### What this PR does

Two simple cleanups of libinstancetype. 

* `WithMemory` is aligned with libvmi's `WithResourceMemory` and now takes a simple string
* Calls of `WithCPUs` casting arguments to `uint32` are now replaced with simple `int`s.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

