### PR TITLE
Refactor unit tests to use libvmi for resource creation in expose

### DIFF
--- a/pkg/virtctl/expose/BUILD.bazel
+++ b/pkg/virtctl/expose/BUILD.bazel
@@ -28,8 +28,8 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//tests/clientcmd:go_default_library",

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -19,11 +19,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 
-	"kubevirt.io/client-go/api"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
@@ -44,9 +43,11 @@ var _ = Describe("Expose", func() {
 	var obtainedService *k8sv1.Service
 
 	BeforeEach(func() {
-		vmi = api.NewMinimalVMI(vmName)
-		vmNoLabel = api.NewMinimalVMI(vmNoLabelName)
-		vm = kubecli.NewMinimalVM(vmName)
+		vmi = libvmi.New(libvmi.WithLabel("key", "value"))
+		vmi.Name = vmName
+		vmNoLabel = libvmi.New()
+		vmNoLabel.Name = vmNoLabelName
+		vm = libvmi.NewVirtualMachine(vmi)
 		vmrs = kubecli.NewMinimalVirtualMachineInstanceReplicaSet(vmName)
 
 		// create the wrapping environment that would retur the mock virt client
@@ -72,10 +73,7 @@ var _ = Describe("Expose", func() {
 		kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(kubeclient.CoreV1()).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().DiscoveryClient().Return(discovery).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().DynamicClient().Return(dynamic).AnyTimes()
-		// set labels on vm, vm and vmrs
-		vmi.ObjectMeta.Labels = map[string]string{"key": "value"}
-		vmNoLabel.ObjectMeta.Labels = map[string]string{}
-		vm.Spec = v1.VirtualMachineSpec{Template: &v1.VirtualMachineInstanceTemplateSpec{ObjectMeta: vmi.ObjectMeta}}
+		// set vmrs
 		vmrs.Spec = v1.VirtualMachineInstanceReplicaSetSpec{Selector: &k8smetav1.LabelSelector{MatchLabels: vmi.ObjectMeta.Labels}, Template: &v1.VirtualMachineInstanceTemplateSpec{}}
 		// set up mock interface behavior
 		vmiInterface.EXPECT().Get(context.Background(), vmi.Name, gomock.Any()).Return(vmi, nil).AnyTimes()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
- Unit tests directly created and modified VM and VMI resources by manipulating their fields.
After this PR:
- Unit tests have been refactored to use the `libvmi` package for creating and modifying VM and VMI resources, promoting readability and standardization.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially address: https://github.com/kubevirt/kubevirt/issues/12059

### Why we need it and why it was done in this way
 - Using the libvmi package simplifies the unit tests and makes them more readable.
 - This approach ensures a standard way of creating VM and VMI resources across tests.
 
The following tradeoffs were made:
  - Direct manipulation of resources was replaced with utility functions, which may introduce minor overhead but enhances readability and maintainability.

The following alternatives were considered:
 - Continuing with direct manipulation of resources in tests, which was deemed less maintainable.
Links to places where the discussion took place: Issue discussion: [#12059](https://github.com/kubevirt/kubevirt/issues/12059)

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```