### PR TITLE
Introduce buildifier-prebuilt to reduce rules_go dependency complexity

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -95,9 +95,16 @@ gazelle(
 
 bazeldnf(name = "bazeldnf")
 
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
-buildifier(name = "buildifier")
+alias(
+    name = "buildozer",
+    actual = "@buildifier_prebuilt//:buildozer",
+)
+
+buildifier(
+    name = "buildifier",
+)
 
 genrule(
     name = "get-version",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,6 +21,20 @@ http_archive(
     ],
 )
 
+# Bazel buildtools prebuilt binaries
+http_archive(
+    name = "buildifier_prebuilt",
+    sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
+    strip_prefix = "buildifier-prebuilt-6.4.0",
+    urls = [
+        "http://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz",
+    ],
+)
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
 # Additional bazel rules
 http_archive(
     name = "rules_proto",
@@ -58,6 +72,14 @@ http_archive(
         "https://storage.googleapis.com/builddeps/c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     ],
 )
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()
 
 http_archive(
     name = "bazel_gazelle",
@@ -178,10 +200,6 @@ load(
 )
 
 gazelle_dependencies()
-
-load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
-
-buildifier_dependencies()
 
 bazeldnf_dependencies()
 

--- a/hack/bazel-generate.sh
+++ b/hack/bazel-generate.sh
@@ -15,7 +15,7 @@ bazel run \
 # inject changes to libvirt BUILD file
 bazel run \
     --config=${ARCHITECTURE} \
-    -- @com_github_bazelbuild_buildtools//buildozer 'add cdeps //:libvirt-libs' //vendor/libvirt.org/go/libvirt:go_default_library
+    -- :buildozer 'add cdeps //:libvirt-libs' //vendor/libvirt.org/go/libvirt:go_default_library
 # align BAZEL files to a single format
 bazel run \
     --config=${ARCHITECTURE} \

--- a/hack/bump-distroless.sh
+++ b/hack/bump-distroless.sh
@@ -13,12 +13,12 @@ DISTROLESS_S390X_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base:latest-
 # buildozer returns a non-zero exit code (3) if the commands were a success but did not change the file.
 # To make the command idempotent, first set the digest to a kind-of-unique number to work around this behaviour.
 # This way we can assume a zero exit code if no errors occur.
-cat <<EOF | bazel run --config=${ARCHITECTURE} -- @com_github_bazelbuild_buildtools//buildozer -f -
+cat <<EOF | bazel run --config=${ARCHITECTURE} -- :buildozer -f -
 set digest "$(date +%s)"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base_aarch64
 set digest "$(date +%s)"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base_aarch64
 EOF
 # now set the actual digest
-cat <<EOF | bazel run --config=${ARCHITECTURE} -- @com_github_bazelbuild_buildtools//buildozer -f -
+cat <<EOF | bazel run --config=${ARCHITECTURE} -- :buildozer -f -
 set digest "${DISTROLESS_AMD64_DIGEST}"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base
 set digest "${DISTROLESS_ARM64_DIGEST}"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base_aarch64
 set digest "${DISTROLESS_S390X_DIGEST}"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base_s390x


### PR DESCRIPTION
### What this PR does
Before this PR:

The buildtools repo, while already using prebuilt binaries and only depending on rules_go without any specific go dependencies, still has two caveats:

 * it requires still rules_go which can make updating more challenging
 * it downloads all binaries for all buildtools supported architectures

After this PR:

Use buildifier and buildozer as toolchain, to only use download and use the binaries from the host platform (instead of downloading all) and only make it independent of rules_go for simplifying dependency management.

buildifier-prebuilt is pretty broadly in use and I also checked that the binaries and digests in use (buildtools 6.4.0) are really coming from where it is claiming that they are coming. 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

