### PR TITLE
Move pod-eviction-admitter_test.go to use libvmi for VMI construction

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -57,6 +57,11 @@ var _ = Describe("Pod eviction admitter", func() {
 
 	const isDryRun = true
 
+	var defaultVMIOptions = []libvmi.Option{
+		libvmi.WithNamespace(testNamespace),
+		withStatusNodeName(testNodeName),
+	}
+
 	It("should allow the request when it refers to a non virt-launcher pod", func() {
 		virtClient := kubevirtfake.NewSimpleClientset()
 		Expect(virtClient.Fake.Resources).To(BeEmpty())
@@ -103,11 +108,8 @@ var _ = Describe("Pod eviction admitter", func() {
 		Expect(virtClient.Fake.Actions()).To(BeEmpty())
 	})
 
-	DescribeTable("should trigger VMI Evacuation and deny the request", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...libvmi.Option) {
-		vmiOptions = append(vmiOptions,
-			libvmi.WithNamespace(testNamespace),
-			withStatusNodeName(testNodeName),
-		)
+	DescribeTable("should trigger VMI Evacuation and deny the request", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, additionalVMIOptions ...libvmi.Option) {
+		vmiOptions := append(defaultVMIOptions, additionalVMIOptions...)
 
 		vmi := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
@@ -172,11 +174,8 @@ var _ = Describe("Pod eviction admitter", func() {
 		),
 	)
 
-	DescribeTable("should allow the request without triggering VMI evacuation", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...libvmi.Option) {
-		vmiOptions = append(vmiOptions,
-			libvmi.WithNamespace(testNamespace),
-			withStatusNodeName(testNodeName),
-		)
+	DescribeTable("should allow the request without triggering VMI evacuation", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, additionalVMIOptions ...libvmi.Option) {
+		vmiOptions := append(defaultVMIOptions, additionalVMIOptions...)
 
 		vmi := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
@@ -230,11 +229,8 @@ var _ = Describe("Pod eviction admitter", func() {
 		),
 	)
 
-	DescribeTable("should deny the request without triggering VMI evacuation", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...libvmi.Option) {
-		vmiOptions = append(vmiOptions,
-			libvmi.WithNamespace(testNamespace),
-			withStatusNodeName(testNodeName),
-		)
+	DescribeTable("should deny the request without triggering VMI evacuation", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, additionalVMIOptions ...libvmi.Option) {
+		vmiOptions := append(defaultVMIOptions, additionalVMIOptions...)
 
 		vmi := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
@@ -270,12 +266,7 @@ var _ = Describe("Pod eviction admitter", func() {
 	)
 
 	It("should deny the request when the admitter fails to fetch the VMI", func() {
-		vmiOptions := []libvmi.Option{
-			libvmi.WithNamespace(testNamespace),
-			withStatusNodeName(testNodeName),
-		}
-
-		vmi := libvmi.New(vmiOptions...)
+		vmi := libvmi.New(defaultVMIOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
 
 		expectedError := errors.New("some error")
@@ -306,12 +297,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should deny the request when the admitter fails to patch the VMI", func() {
-		vmiOptions := []libvmi.Option{
-			libvmi.WithNamespace(testNamespace),
+		vmiOptions := append(defaultVMIOptions,
 			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
-			withStatusNodeName(testNodeName),
 			withLiveMigratableCondition(),
-		}
+		)
 
 		migratableVMI := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)
@@ -347,13 +336,11 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should allow the request and not mark the VMI again when the VMI is already marked for evacuation", func() {
-		vmiOptions := []libvmi.Option{
-			libvmi.WithNamespace(testNamespace),
+		vmiOptions := append(defaultVMIOptions,
 			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
-			withStatusNodeName(testNodeName),
 			withLiveMigratableCondition(),
 			withEvacuationNodeName(testNodeName),
-		}
+		)
 
 		migratableVMI := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)
@@ -377,12 +364,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should deny the request and perform a dryRun patch on the VMI when the request is a dry run", func() {
-		vmiOptions := []libvmi.Option{
-			libvmi.WithNamespace(testNamespace),
+		vmiOptions := append(defaultVMIOptions,
 			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
-			withStatusNodeName(testNodeName),
 			withLiveMigratableCondition(),
-		}
+		)
 
 		migratableVMI := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -138,40 +138,36 @@ var _ = Describe("Pod eviction admitter", func() {
 	},
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is LiveMigrate and VMI is migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyLiveMigrate)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is LiveMigrateIfPossible and VMI is migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyLiveMigrateIfPossible)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrateIfPossible),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is External and VMI is not migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyExternal)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyExternal),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is External and VMI is migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyExternal)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyExternal),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is LiveMigrate, VMI eviction strategy is missing and VMI is migratable",
 			pointer.P(virtv1.EvictionStrategyLiveMigrate),
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is LiveMigrateIfPossible, VMI eviction strategy is missing and VMI is migratable",
 			pointer.P(virtv1.EvictionStrategyLiveMigrateIfPossible),
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is External, VMI eviction strategy is missing and VMI is not migratable",
 			pointer.P(virtv1.EvictionStrategyExternal),
-			withEvictionStrategy(nil),
 		),
 		Entry("When cluster-wide eviction strategy is External, VMI eviction strategy is missing and VMI is migratable",
 			pointer.P(virtv1.EvictionStrategyExternal),
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 	)
@@ -204,38 +200,33 @@ var _ = Describe("Pod eviction admitter", func() {
 	},
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is missing and VMI is not migratable",
 			nil,
-			withEvictionStrategy(nil),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is missing and VMI is migratable",
 			nil,
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is None and VMI is not migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyNone)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyNone),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is None and VMI is migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyNone)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyNone),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is LiveMigrateIfPossible and VMI is not migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyLiveMigrateIfPossible)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrateIfPossible),
 		),
 		Entry("When cluster-wide eviction strategy is None, VMI eviction strategy is missing and VMI is not migratable",
 			pointer.P(virtv1.EvictionStrategyNone),
-			withEvictionStrategy(nil),
 		),
 		Entry("When cluster-wide eviction strategy is None, VMI eviction strategy is missing and VMI is migratable",
 			pointer.P(virtv1.EvictionStrategyNone),
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is LiveMigrateIfPossible, VMI eviction strategy is missing and VMI is not migratable",
 			pointer.P(virtv1.EvictionStrategyLiveMigrateIfPossible),
-			withEvictionStrategy(nil),
 		),
 	)
 
@@ -271,11 +262,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	},
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is LiveMigrate and VMI is not migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyLiveMigrate)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 		),
 		Entry("When cluster-wide eviction strategy is LiveMigrate, VMI eviction strategy is missing and VMI is not migratable",
 			pointer.P(virtv1.EvictionStrategyLiveMigrate),
-			withEvictionStrategy(nil),
 		),
 	)
 
@@ -316,11 +306,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should deny the request when the admitter fails to patch the VMI", func() {
-		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
 		vmiOptions := []libvmi.Option{
 			libvmi.WithNamespace(testNamespace),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 			withStatusNodeName(testNodeName),
-			withEvictionStrategy(&evictionStrategy),
 			withLiveMigratableCondition(),
 		}
 
@@ -358,11 +347,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should allow the request and not mark the VMI again when the VMI is already marked for evacuation", func() {
-		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
 		vmiOptions := []libvmi.Option{
 			libvmi.WithNamespace(testNamespace),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 			withStatusNodeName(testNodeName),
-			withEvictionStrategy(&evictionStrategy),
 			withLiveMigratableCondition(),
 			withEvacuationNodeName(testNodeName),
 		}
@@ -389,11 +377,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should deny the request and perform a dryRun patch on the VMI when the request is a dry run", func() {
-		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
 		vmiOptions := []libvmi.Option{
 			libvmi.WithNamespace(testNamespace),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 			withStatusNodeName(testNodeName),
-			withEvictionStrategy(&evictionStrategy),
 			withLiveMigratableCondition(),
 		}
 
@@ -550,12 +537,6 @@ func newExpectedJSONPatchToVMI(vmi *virtv1.VirtualMachineInstance, expectedJSONP
 func withStatusNodeName(nodeName string) libvmi.Option {
 	return func(vmi *virtv1.VirtualMachineInstance) {
 		vmi.Status.NodeName = nodeName
-	}
-}
-
-func withEvictionStrategy(evictionStrategy *virtv1.EvictionStrategy) libvmi.Option {
-	return func(vmi *virtv1.VirtualMachineInstance) {
-		vmi.Spec.EvictionStrategy = evictionStrategy
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:** 
The pod-eviction-admitter tests used a scoped function `newVMI` as well as accompanying scoped types and builder functions of similar nature to [libvmi](https://github.com/kubevirt/kubevirt/tree/main/pkg/libvmi) in order to construct VMIs for the tests.

**After this PR:** 
Delegates any VMI construction logic to [libvmi](https://github.com/kubevirt/kubevirt/tree/main/pkg/libvmi) and removes redundant logic from the tests:
* Removes redundant types and VMI creation functions.
* Removes redundant option specification and sets default VMI options that are used for all tests (via `defaultVMIOptions`)
* Adds a new `withNodeName` function to compensate for the lack of VMI status update logic during construction (in accordance with the libvmi guidelines).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially addresses #12059 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

