### PR TITLE
passt, sidecar: Look for optional link

### DIFF
--- a/cmd/sidecars/network-passt-binding/domain/BUILD.bazel
+++ b/cmd/sidecars/network-passt-binding/domain/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/cmd/sidecars/network-passt-binding/domain",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/driver/netlink:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/vmispec:go_default_library",
@@ -13,6 +14,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )
 
@@ -29,5 +31,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )

--- a/cmd/sidecars/network-passt-binding/domain/configurator_test.go
+++ b/cmd/sidecars/network-passt-binding/domain/configurator_test.go
@@ -22,6 +22,9 @@ package domain_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	vishnetlink "github.com/vishvananda/netlink"
+
 	vmschema "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/cmd/sidecars/network-passt-binding/domain"
@@ -29,11 +32,23 @@ import (
 	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+type defaultNetLinkStub struct{}
+
+func (nl defaultNetLinkStub) LinkByName(name string) (vishnetlink.Link, error) {
+	return nil, vishnetlink.LinkNotFoundError{}
+}
+
+type netLinkStub struct{}
+
+func (nl netLinkStub) LinkByName(name string) (vishnetlink.Link, error) {
+	return &vishnetlink.Veth{LinkAttrs: vishnetlink.LinkAttrs{Name: name}}, nil
+}
+
 var _ = Describe("pod network configurator", func() {
 	Context("generate domain spec interface", func() {
 		DescribeTable("should fail to create configurator given",
 			func(ifaces []vmschema.Interface, networks []vmschema.Network) {
-				_, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{})
+				_, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{}, &defaultNetLinkStub{})
 
 				Expect(err).To(HaveOccurred())
 			},
@@ -60,7 +75,7 @@ var _ = Describe("pod network configurator", func() {
 				PciAddress: "invalid-pci-address"}}
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
 
-			testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{})
+			testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{}, &defaultNetLinkStub{})
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = testMutator.Mutate(&domainschema.DomainSpec{})
@@ -72,7 +87,7 @@ var _ = Describe("pod network configurator", func() {
 				ifaces := []vmschema.Interface{*iface}
 				networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
 
-				testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{})
+				testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{}, &defaultNetLinkStub{})
 				Expect(err).ToNot(HaveOccurred())
 
 				mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
@@ -215,7 +230,7 @@ var _ = Describe("pod network configurator", func() {
 				ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}}
 				networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
 
-				testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, *opts)
+				testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, *opts, &defaultNetLinkStub{})
 				Expect(err).ToNot(HaveOccurred())
 
 				mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
@@ -272,7 +287,7 @@ var _ = Describe("pod network configurator", func() {
 				Model:       &domainschema.Model{Type: "virtio-non-transitional"},
 			}
 
-			testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{})
+			testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{}, &defaultNetLinkStub{})
 			Expect(err).ToNot(HaveOccurred())
 
 			existingIface := &domainschema.Interface{Alias: domainschema.NewUserDefinedAlias("existing-iface")}
@@ -298,7 +313,7 @@ var _ = Describe("pod network configurator", func() {
 				Model:       &domainschema.Model{Type: "virtio-non-transitional"},
 			}
 
-			testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{})
+			testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{}, &defaultNetLinkStub{})
 			Expect(err).ToNot(HaveOccurred())
 
 			testDomSpec := &domainschema.DomainSpec{}
@@ -309,5 +324,29 @@ var _ = Describe("pod network configurator", func() {
 
 			Expect(testMutator.Mutate(mutatedDomSpec)).To(Equal(mutatedDomSpec))
 		})
+		It("should set domain interface source link to the optional one if exists", func() {
+			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}}
+
+			expectedDomainIface := &domainschema.Interface{
+				Alias:       domainschema.NewUserDefinedAlias("default"),
+				Type:        "user",
+				Source:      domainschema.InterfaceSource{Device: "ovn-udn1"},
+				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
+				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+				Model:       &domainschema.Model{Type: "virtio-non-transitional"},
+			}
+			testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, domain.NetworkConfiguratorOptions{}, &netLinkStub{})
+			Expect(err).ToNot(HaveOccurred())
+
+			testDomSpec := &domainschema.DomainSpec{}
+
+			mutatedDomSpec, err := testMutator.Mutate(testDomSpec)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*expectedDomainIface}))
+
+			Expect(testMutator.Mutate(mutatedDomSpec)).To(Equal(mutatedDomSpec))
+		})
+
 	})
 })

--- a/cmd/sidecars/network-passt-binding/server/server.go
+++ b/cmd/sidecars/network-passt-binding/server/server.go
@@ -88,7 +88,7 @@ func (s V1alpha3Server) OnDefineDomain(_ context.Context, params *hooksV1alpha3.
 		IstioProxyInjectionEnabled: istioProxyInjectionEnabled,
 	}
 
-	passtConfigurator, err := domain.NewPasstNetworkConfigurator(vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, opts)
+	passtConfigurator, err := domain.NewPasstNetworkConfigurator(vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, opts, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create passt configurator: %v", err)
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Passt uses the source device "eth0" for domain xml

After this PR:
At some enviroments that should be "ovn-udn1" this PR try this first, if it do not exist do a fallback to eth0.

ovn-kubernetes place where the interface is not eth0:
- https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/cni/udn/primary_network.go#L30

### Why we need it and why it was done in this way
The following tradeoffs were made:
Using harcoded value is not flexible, but we plan to make it configurable in the future.

The following alternatives were considered:
Try to find the interface that has the default gw, problem is that at multus you can configure de default network at other interfaces.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use optional interface at passt binding sidecar
```

