### PR TITLE
Add libruntime for VM modifications in tests

### DIFF
--- a/tests/libvmruntime/BUILD.bazel
+++ b/tests/libvmruntime/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["vmruntime.go"],
+    importpath = "kubevirt.io/kubevirt/tests/libvmruntime",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apimachinery/patch:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//tests/framework/kubevirt:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+    ],
+)

--- a/tests/libvmruntime/vmruntime.go
+++ b/tests/libvmruntime/vmruntime.go
@@ -1,0 +1,37 @@
+package libvmruntime
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	_ "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+)
+
+func StopVirtualMachine(vm *v1.VirtualMachine) *v1.VirtualMachine {
+	return patchVMWithRunStrategy(vm, v1.RunStrategyHalted)
+}
+
+func StartVirtualMachine(vm *v1.VirtualMachine) *v1.VirtualMachine {
+	return patchVMWithRunStrategy(vm, v1.RunStrategyAlways)
+}
+
+func patchVMWithRunStrategy(vm *v1.VirtualMachine, rs v1.VirtualMachineRunStrategy) *v1.VirtualMachine {
+	ginkgo.By("Starting the VirtualMachineInstance")
+	virtClient := kubevirt.Client()
+	patchSet := patch.New()
+	patchSet.AddOption(
+		patch.WithAdd("/spec/runStrategy", rs),
+	)
+	payload, err := patchSet.GeneratePayload()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, payload, metav1.PatchOptions{})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	return vm
+}

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -70,6 +70,7 @@ go_library(
         "//tests/libsecret:go_default_library",
         "//tests/libstorage:go_default_library",
         "//tests/libvmifact:go_default_library",
+        "//tests/libvmruntime:go_default_library",
         "//tests/libwait:go_default_library",
         "//tests/testsuite:go_default_library",
         "//tests/util:go_default_library",

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -49,6 +49,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libvmruntime"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -562,7 +563,8 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					Expect(newVMInterfaces[0].MacAddress).ToNot(Equal(oldVMInterfaces[0].MacAddress))
 
 					By("Making sure new VM is runnable")
-					tests.RunVMAndExpectLaunchWithRunStrategy(virtClient, newVM, v1.RunStrategyAlways)
+					libvmruntime.StartVirtualMachine(newVM)
+					Eventually(ThisVM(newVM)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
 				})
 
 			})


### PR DESCRIPTION
The new libruntime library introduces functions for modifying virtual machines post-creation
using the patch API call.
    
Currently, libruntime exposes two functions:
- StopVirtualMachine
- StartVirtualMachine
    
These functions are designed to replace the following functions in tests/utils:
- StopVirtualMachine
- StartVirtualMachine
- RunVMAndExpectLaunchWithRunStrategy
    
We should replace calls to these functions only when necessary, specifically in scenarios  where we cannot create a VM with the desired run strategy initially, and need to start or stop the VM after creation.
    
Wherever possible, avoid this replacement by creating the VM with the desired run strategy from the beginning to minimize the use of expensive API calls.


restore.go:Remove use of RunVMAndExpectLaunchWithRunStrategy func RunVMAndExpectLaunchWithRunStrategy should be deprecated as it is part of tests/utils.go and use expensive get and update API calls

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

