### PR TITLE
virt-handler: Fix broken device controller unit-test

### DIFF
--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -194,12 +194,14 @@ var _ = Describe("Device Controller", func() {
 			}, 5*time.Second).Should(BeNumerically(">=", 1))
 		})
 
-		It("should remove all device plugins if permittedHostDevices is removed from the CR", func() {
+		It("Should remove device plugins if permittedHostDevices is removed from the CR", func() {
 			emptyConfigMap, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 			Expect(emptyConfigMap.GetPermittedHostDevices()).To(BeNil())
 
-			initialDevices := []Device{plugin1, plugin2}
-			deviceController := NewDeviceController(host, maxDevices, permissions, initialDevices, emptyConfigMap, clientTest.CoreV1())
+			deviceController := NewDeviceController(host, maxDevices, permissions, []Device{}, emptyConfigMap, clientTest.CoreV1())
+
+			deviceController.startDevice(deviceName1, plugin1)
+			deviceController.startDevice(deviceName2, plugin2)
 
 			go deviceController.Run(stop)
 
@@ -210,6 +212,24 @@ var _ = Describe("Device Controller", func() {
 				_, exists2 := deviceController.startedPlugins[deviceName2]
 				return exists1 || exists2
 			}, 5*time.Second).Should(BeFalse())
+		})
+
+		It("Should not remove permanent device plugins if permittedHostDevices is removed from the CR", func() {
+			emptyConfigMap, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+			Expect(emptyConfigMap.GetPermittedHostDevices()).To(BeNil())
+
+			permanentPlugins := []Device{plugin1, plugin2}
+			deviceController := NewDeviceController(host, maxDevices, permissions, permanentPlugins, emptyConfigMap, clientTest.CoreV1())
+
+			go deviceController.Run(stop)
+
+			Eventually(func() bool {
+				deviceController.startedPluginsMutex.Lock()
+				defer deviceController.startedPluginsMutex.Unlock()
+				_, exists1 := deviceController.startedPlugins[deviceName1]
+				_, exists2 := deviceController.startedPlugins[deviceName2]
+				return exists1 && exists2
+			}, 5*time.Second).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
The current unit test is only passing because timing wise it checks for the
devices to be stopped before they are even started. The actual devices are
never stopped.
This changes the behavior to ensure permanent devices are never removed while
others are removed when no longer permitted.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
s390x unit-test job sometimes fails
After this PR:
s390x unit-test job is stable
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

