### PR TITLE
Virtctl: Hot plug cpu and memory

### DIFF
--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/virtctl/pause:go_default_library",
         "//pkg/virtctl/portforward:go_default_library",
         "//pkg/virtctl/scp:go_default_library",
+        "//pkg/virtctl/set:go_default_library",
         "//pkg/virtctl/softreboot:go_default_library",
         "//pkg/virtctl/ssh:go_default_library",
         "//pkg/virtctl/templates:go_default_library",

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -25,6 +25,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/pause"
 	"kubevirt.io/kubevirt/pkg/virtctl/portforward"
 	"kubevirt.io/kubevirt/pkg/virtctl/scp"
+	"kubevirt.io/kubevirt/pkg/virtctl/set"
 	"kubevirt.io/kubevirt/pkg/virtctl/softreboot"
 	"kubevirt.io/kubevirt/pkg/virtctl/ssh"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
@@ -98,6 +99,7 @@ func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 		vm.NewAddVolumeCommand(clientConfig),
 		vm.NewRemoveVolumeCommand(clientConfig),
 		vm.NewExpandCommand(clientConfig),
+		set.NewSetCommand(clientConfig),
 		memorydump.NewMemoryDumpCommand(clientConfig),
 		pause.NewPauseCommand(clientConfig),
 		pause.NewUnpauseCommand(clientConfig),

--- a/pkg/virtctl/set/BUILD.bazel
+++ b/pkg/virtctl/set/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["set.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/set",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/virtctl/templates:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "set_suite_test.go",
+        "set_test.go",
+    ],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/clientcmd:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+    ],
+)

--- a/pkg/virtctl/set/set.go
+++ b/pkg/virtctl/set/set.go
@@ -1,0 +1,135 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Contributors
+ *
+ */
+
+package set
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+type Set struct {
+	clientConfig    clientcmd.ClientConfig
+	cpuSocketsCount uint32
+	memorySize      string
+}
+
+func NewSetCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	s := &Set{clientConfig: clientConfig}
+
+	cmd := &cobra.Command{
+		Use:     "set (VM) [--cpu=CPU_COUNT] [--memory=SIZE]",
+		Short:   "Set the number of CPUs and/or memory for a running virtual machine.",
+		Example: setUsage(),
+		Args:    templates.ExactArgs("set", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return s.Run(cmd, args)
+		},
+	}
+
+	cmd.Flags().Uint32Var(&s.cpuSocketsCount, "cpu", 0, "Number of CPUs (sockets) to set (must be greater than 0)")
+	cmd.Flags().StringVar(&s.memorySize, "memory", "", "Guest Memory size to set (e.g., 2Gi)")
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func setUsage() string {
+	return `  # Set the number of CPUs (sockets) to 2 and memory to 1Gi for VirtualMachine 'myvm':
+  {{ProgramName}} set myvm --cpu=2 --memory=1Gi`
+}
+
+func (s *Set) Run(cmd *cobra.Command, args []string) error {
+	vmName := args[0]
+	namespace, _, err := s.clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	virtCli, err := kubecli.GetKubevirtClientFromClientConfig(s.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	vm, err := virtCli.VirtualMachine(namespace).Get(context.Background(), vmName, k8smetav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	patchSet := patch.New()
+	var messages []string
+
+	if cmd.Flags().Changed("cpu") {
+		if vm.Spec.Template.Spec.Domain.CPU == nil {
+			cpuToAdd := &v1.CPU{Sockets: s.cpuSocketsCount}
+			patchSet.AddOption(patch.WithAdd("/spec/template/spec/domain/cpu", cpuToAdd))
+			messages = append(messages, fmt.Sprintf("Successfully added CPU with %d sockets for %s", s.cpuSocketsCount, vm.Name))
+		} else {
+			patchSet.AddOption(patch.WithReplace("/spec/template/spec/domain/cpu/sockets", s.cpuSocketsCount))
+			messages = append(messages, fmt.Sprintf("Successfully set CPU sockets to %d for %s", s.cpuSocketsCount, vm.Name))
+		}
+	}
+
+	if cmd.Flags().Changed("memory") {
+		guestMemorySize, err := resource.ParseQuantity(s.memorySize)
+		if err != nil {
+			return fmt.Errorf("invalid memory size: %s", s.memorySize)
+		}
+
+		if vm.Spec.Template.Spec.Domain.Memory == nil {
+			// Memory field does not exist, add the entire Memory structure
+			memoryToAdd := &v1.Memory{Guest: &guestMemorySize}
+			patchSet.AddOption(patch.WithAdd("/spec/template/spec/domain/memory", memoryToAdd))
+			messages = append(messages, fmt.Sprintf("Successfully added memory with size %s for %s", guestMemorySize.String(), vm.Name))
+		} else {
+			patchSet.AddOption(patch.WithReplace("/spec/template/spec/domain/memory/guest", guestMemorySize))
+			messages = append(messages, fmt.Sprintf("Successfully set memory to %s for %s", guestMemorySize.String(), vm.Name))
+		}
+	}
+
+	if !patchSet.IsEmpty() {
+		patchPayload, err := patchSet.GeneratePayload()
+		if err != nil {
+			return fmt.Errorf("failed to generate patch payload: %w", err)
+		}
+
+		if _, err := virtCli.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchPayload, k8smetav1.PatchOptions{}); err != nil {
+			return fmt.Errorf("could not patch the virtual machine: %w", err)
+		}
+	} else {
+		cmd.Help()
+		return fmt.Errorf("at least one of --cpu or --memory must be set")
+	}
+
+	for _, message := range messages {
+		cmd.Printf("%s\n", message)
+	}
+	return nil
+}

--- a/pkg/virtctl/set/set_suite_test.go
+++ b/pkg/virtctl/set/set_suite_test.go
@@ -1,0 +1,11 @@
+package set_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestSet(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/set/set_test.go
+++ b/pkg/virtctl/set/set_test.go
@@ -1,0 +1,141 @@
+package set_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/golang/mock/gomock"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/clientcmd"
+)
+
+var _ = Describe("Set command", func() {
+	var vmInterface *kubecli.MockVirtualMachineInterface
+	var ctrl *gomock.Controller
+	const vmName = "testvm"
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
+		kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
+		vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
+		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).AnyTimes()
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	DescribeTable("Input parameters validation without VM interaction", func(flags []string, errMsg string) {
+		cmd := clientcmd.NewRepeatableVirtctlCommand(append([]string{"set"}, flags...)...)
+		Expect(cmd()).To(MatchError(errMsg))
+	},
+		Entry("with missing input parameters", []string{}, "argument validation failed"),
+		Entry("with invalid CPU count", []string{vmName, "--cpu=invalid"}, "invalid argument \"invalid\" for \"--cpu\" flag: strconv.ParseUint: parsing \"invalid\": invalid syntax"),
+		Entry("with negative CPU count", []string{vmName, "--cpu=-1"}, "invalid argument \"-1\" for \"--cpu\" flag: strconv.ParseUint: parsing \"-1\": invalid syntax"),
+	)
+
+	DescribeTable("Input parameters validation with VM interaction", func(flags []string, errMsg string) {
+		vm := kubecli.NewMinimalVM(vmName)
+		vm.ObjectMeta.Namespace = k8smetav1.NamespaceDefault
+		vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{}
+		vmInterface.EXPECT().Get(gomock.Any(), vmName, k8smetav1.GetOptions{}).Return(vm, nil).Times(1)
+
+		cmd := clientcmd.NewRepeatableVirtctlCommand(append([]string{"set"}, flags...)...)
+		Expect(cmd()).To(MatchError(errMsg))
+	},
+		Entry("with no CPU or memory specified", []string{vmName}, "at least one of --cpu or --memory must be set"),
+		Entry("with invalid memory size", []string{vmName, "--memory=invalidSize"}, "invalid memory size: invalidSize"),
+	)
+
+	Context("Patch CPU and Memory", func() {
+		It("should succeed with valid CPU", func() {
+			vm := kubecli.NewMinimalVM(vmName)
+			vm.ObjectMeta.Namespace = k8smetav1.NamespaceDefault
+			vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{}
+			vmInterface.EXPECT().Get(gomock.Any(), vmName, k8smetav1.GetOptions{}).Return(vm, nil).Times(1)
+
+			expectedPatch := `[{"op":"add","path":"/spec/template/spec/domain/cpu","value":{"sockets":2}}]`
+			vmInterface.EXPECT().Patch(gomock.Any(), vmName, types.JSONPatchType, gomock.Any(), k8smetav1.PatchOptions{}, gomock.Any()).DoAndReturn(
+				func(ctx context.Context, name string, pt types.PatchType, data []byte, options k8smetav1.PatchOptions, subresources ...string) (*v1.VirtualMachine, error) {
+					Expect(data).To(MatchJSON(expectedPatch))
+					return vm, nil
+				}).Times(1)
+
+			cmd := clientcmd.NewRepeatableVirtctlCommand("set", vmName, "--cpu=2")
+			Expect(cmd()).To(Succeed())
+		})
+
+		It("should succeed with valid Memory", func() {
+			vm := kubecli.NewMinimalVM(vmName)
+			vm.ObjectMeta.Namespace = k8smetav1.NamespaceDefault
+			vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{}
+			vmInterface.EXPECT().Get(gomock.Any(), vmName, k8smetav1.GetOptions{}).Return(vm, nil).Times(1)
+
+			expectedPatch := `[{"op":"add","path":"/spec/template/spec/domain/memory","value":{"guest":"2Gi"}}]`
+			vmInterface.EXPECT().Patch(gomock.Any(), vmName, types.JSONPatchType, gomock.Any(), k8smetav1.PatchOptions{}, gomock.Any()).DoAndReturn(
+				func(ctx context.Context, name string, pt types.PatchType, data []byte, options k8smetav1.PatchOptions, subresources ...string) (*v1.VirtualMachine, error) {
+					Expect(data).To(MatchJSON(expectedPatch))
+					return vm, nil
+				}).Times(1)
+
+			cmd := clientcmd.NewRepeatableVirtctlCommand("set", vmName, "--memory=2048Mi")
+			Expect(cmd()).To(Succeed())
+		})
+
+		It("should succeed with existing CPU, replacing sockets", func() {
+			vm := kubecli.NewMinimalVM(vmName)
+			vm.ObjectMeta.Namespace = k8smetav1.NamespaceDefault
+			vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						CPU: &v1.CPU{Sockets: 1},
+					},
+				},
+			}
+			vmInterface.EXPECT().Get(gomock.Any(), vmName, k8smetav1.GetOptions{}).Return(vm, nil).Times(1)
+
+			expectedPatch := `[{"op":"replace","path":"/spec/template/spec/domain/cpu/sockets","value":2}]`
+			vmInterface.EXPECT().Patch(gomock.Any(), vmName, types.JSONPatchType, gomock.Any(), k8smetav1.PatchOptions{}, gomock.Any()).DoAndReturn(
+				func(ctx context.Context, name string, pt types.PatchType, data []byte, options k8smetav1.PatchOptions, subresources ...string) (*v1.VirtualMachine, error) {
+					Expect(data).To(MatchJSON(expectedPatch))
+					return vm, nil
+				}).Times(1)
+
+			cmd := clientcmd.NewRepeatableVirtctlCommand("set", vmName, "--cpu=2")
+			Expect(cmd()).To(Succeed())
+		})
+
+		It("should succeed with existing Memory, replacing guest size", func() {
+			vm := kubecli.NewMinimalVM(vmName)
+			vm.ObjectMeta.Namespace = k8smetav1.NamespaceDefault
+			vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Memory: &v1.Memory{Guest: resource.NewQuantity(1024, resource.BinarySI)},
+					},
+				},
+			}
+			vmInterface.EXPECT().Get(gomock.Any(), vmName, k8smetav1.GetOptions{}).Return(vm, nil).Times(1)
+
+			expectedPatch := `[{"op":"replace","path":"/spec/template/spec/domain/memory/guest","value":"2Gi"}]`
+			vmInterface.EXPECT().Patch(gomock.Any(), vmName, types.JSONPatchType, gomock.Any(), k8smetav1.PatchOptions{}, gomock.Any()).DoAndReturn(
+				func(ctx context.Context, name string, pt types.PatchType, data []byte, options k8smetav1.PatchOptions, subresources ...string) (*v1.VirtualMachine, error) {
+					Expect(data).To(MatchJSON(expectedPatch))
+					return vm, nil
+				}).Times(1)
+
+			cmd := clientcmd.NewRepeatableVirtctlCommand("set", vmName, "--memory=2048Mi")
+			Expect(cmd()).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does
Before this PR:

virtctl did not support hotplugging CPU and memory.

After this PR:

virtctl now supports hotplugging CPU and memory, allowing dynamic change of these resources to running virtual machines without needing a restart.

## examples

To set 3 cpus for virtual machine: `virtctl set --cpu=3 myvm`
To set memory: `virtctl set --memory=2Gi myvm`
OR: `virtctl set --memory=2Gi --cpu=3 myvm`

### Why we need it and why it was done in this way
Hotplugging CPU and memory provides a convenient way to adjust VM resources on the fly, especially for those who aren't sure how to edit VM specs.

This is implemented using the `virtctl` client that directly patches the VM resource.
### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note

```release-note
virtctl: added support for CPU and memory hotplug
```

