### PR TITLE
instancetype: Attempt to find ClusterPreferences when kind missing

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -540,7 +540,7 @@ func (m *InstancetypeMethods) FindPreferenceSpec(vm *virtv1.VirtualMachine) (*in
 		}
 		return &preference.Spec, nil
 
-	case apiinstancetype.ClusterSingularPreferenceResourceName, apiinstancetype.ClusterPluralPreferenceResourceName:
+	case apiinstancetype.ClusterSingularPreferenceResourceName, apiinstancetype.ClusterPluralPreferenceResourceName, "":
 		clusterPreference, err := m.findClusterPreference(vm)
 		if err != nil {
 			return nil, err

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -200,6 +200,13 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(*instancetypeSpec).To(Equal(clusterInstancetype.Spec))
 			})
 
+			It("find returns expected instancetype spec with no kind provided", func() {
+				vm.Spec.Instancetype.Kind = ""
+				instancetypeSpec, err := instancetypeMethods.FindInstancetypeSpec(vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*instancetypeSpec).To(Equal(clusterInstancetype.Spec))
+			})
+
 			It("uses client when instancetype not found within informer", func() {
 				err := clusterInstancetypeInformerStore.Delete(clusterInstancetype)
 				Expect(err).ToNot(HaveOccurred())
@@ -642,6 +649,13 @@ var _ = Describe("Instancetype and Preferences", func() {
 			})
 
 			It("find returns expected preference spec", func() {
+				s, err := instancetypeMethods.FindPreferenceSpec(vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*s).To(Equal(clusterPreference.Spec))
+			})
+
+			It("find returns expected preference spec with no kind provided", func() {
+				vm.Spec.Preference.Kind = ""
 				s, err := instancetypeMethods.FindPreferenceSpec(vm)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(*s).To(Equal(clusterPreference.Spec))


### PR DESCRIPTION
### What this PR does

This change brings `FindPreferenceSpec` in-line with `FindInstancetypeSpec` where by default we attempt to lookup the cluster resource when kind is missing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12375

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

