### PR TITLE
instancetypes: Address functional test TODOs and extend libdv

### DIFF
--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -895,14 +895,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						libdv.WithNamespace(namespace),
 						libdv.WithForceBindAnnotation(),
 						libdv.WithPVC(libdv.PVCWithAccessMode(k8sv1.ReadWriteOnce), libdv.PVCWithVolumeSize("1Gi")),
+						libdv.WithDataVolumeSourceRef("DataSource", namespace, dataSource.Name),
 					)
-
-					// TODO - Add WithDataVolumeSourceRef support to libdv and use here
-					dataVolume.Spec.SourceRef = &cdiv1beta1.DataVolumeSourceRef{
-						Kind:      "DataSource",
-						Namespace: &namespace,
-						Name:      dataSource.Name,
-					}
 
 					return generateDataVolumeTemplatesFromDataVolume(dataVolume)
 				},
@@ -949,14 +943,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						libdv.WithNamespace(namespace),
 						libdv.WithForceBindAnnotation(),
 						libdv.WithPVC(libdv.PVCWithAccessMode(k8sv1.ReadWriteOnce), libdv.PVCWithVolumeSize("1Gi")),
+						libdv.WithDataVolumeSourceRef("DataSource", namespace, dataSource.Name),
 					)
-
-					// TODO - Add WithDataVolumeSourceRef support to libdv and use here
-					dataVolume.Spec.SourceRef = &cdiv1beta1.DataVolumeSourceRef{
-						Kind:      "DataSource",
-						Namespace: &namespace,
-						Name:      dataSource.Name,
-					}
 
 					return generateDataVolumeTemplatesFromDataVolume(dataVolume)
 				},

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -787,14 +787,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				libdv.WithForceBindAnnotation(),
 				libdv.WithBlankImageSource(),
 				libdv.WithPVC(libdv.PVCWithAccessMode(k8sv1.ReadWriteOnce), libdv.PVCWithVolumeSize("1Gi")),
+				libdv.WithDefaultInstancetype(instancetypeapi.SingularResourceName, instancetype.Name),
+				libdv.WithDefaultPreference(instancetypeapi.SingularPreferenceResourceName, preference.Name),
 			)
-			// TODO - Add withDefault{Instancetype,Preference}Label support to libdv
-			sourceDV.Labels = map[string]string{
-				instancetypeapi.DefaultInstancetypeLabel:     instancetype.Name,
-				instancetypeapi.DefaultInstancetypeKindLabel: instancetypeapi.SingularResourceName,
-				instancetypeapi.DefaultPreferenceLabel:       preference.Name,
-				instancetypeapi.DefaultPreferenceKindLabel:   instancetypeapi.SingularPreferenceResourceName,
-			}
+
 			sourceDV, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), sourceDV, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			libstorage.EventuallyDV(sourceDV, 180, matcher.HaveSucceeded())

--- a/tests/libdv/BUILD.bazel
+++ b/tests/libdv/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libdv",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/tests/libdv/BUILD.bazel
+++ b/tests/libdv/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libdv",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/libdv/dv.go
+++ b/tests/libdv/dv.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	instancetypeapi "kubevirt.io/api/instancetype"
+
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -148,6 +150,26 @@ func WithForceBindAnnotation() dvOption {
 			dv.Annotations = make(map[string]string)
 		}
 		dv.Annotations["cdi.kubevirt.io/storage.bind.immediate.requested"] = "true"
+	}
+}
+
+func WithDefaultInstancetype(kind, name string) dvOption {
+	return func(dv *v1beta1.DataVolume) {
+		if dv.Labels == nil {
+			dv.Labels = map[string]string{}
+		}
+		dv.Labels[instancetypeapi.DefaultInstancetypeLabel] = name
+		dv.Labels[instancetypeapi.DefaultInstancetypeKindLabel] = kind
+	}
+}
+
+func WithDefaultPreference(kind, name string) dvOption {
+	return func(dv *v1beta1.DataVolume) {
+		if dv.Labels == nil {
+			dv.Labels = map[string]string{}
+		}
+		dv.Labels[instancetypeapi.DefaultPreferenceLabel] = name
+		dv.Labels[instancetypeapi.DefaultPreferenceKindLabel] = kind
 	}
 }
 

--- a/tests/libdv/dv.go
+++ b/tests/libdv/dv.go
@@ -28,6 +28,7 @@ import (
 
 	instancetypeapi "kubevirt.io/api/instancetype"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -170,6 +171,16 @@ func WithDefaultPreference(kind, name string) dvOption {
 		}
 		dv.Labels[instancetypeapi.DefaultPreferenceLabel] = name
 		dv.Labels[instancetypeapi.DefaultPreferenceKindLabel] = kind
+	}
+}
+
+func WithDataVolumeSourceRef(kind, namespace, name string) dvOption {
+	return func(dv *v1beta1.DataVolume) {
+		dv.Spec.SourceRef = &v1beta1.DataVolumeSourceRef{
+			Kind:      kind,
+			Namespace: pointer.P(namespace),
+			Name:      name,
+		}
 	}
 }
 


### PR DESCRIPTION
/sig code-quality

### What this PR does

This PR introduces `WithDefault{Instancetype,Preference` and `WithDataVolumeSourceRef` to `libdv` to address some basic `TODOs` within the instancetype functional tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

