### PR TITLE
Increase verbosity level of 1MiB-alignment log

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -223,7 +223,7 @@ func AlignImageSizeTo1MiB(size int64, logger *log.FilteredLogger) int64 {
 			if newSize == 0 {
 				logger.Errorf("disks must be at least 1MiB, %d bytes is too small", size)
 			} else {
-				logger.Warningf("disk size is not 1MiB-aligned. Adjusting from %d down to %d.", size, newSize)
+				logger.V(4).Infof("disk size is not 1MiB-aligned. Adjusting from %d down to %d.", size, newSize)
 			}
 		}
 		return newSize


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This Pull Request aims to increase the log verbosity of a log in `AlignImageSizeTo1MiB` to avoid flooding.

This log is unskippable when using a non-aligned volume size, and appears quite frequently in `virt-launcher` and `virt-handler`. We currently log it as a warning, which is overkill for this specific case. We should increase the verbosity level and let it only appear when explicitly debugging.

Some cases where the log is triggered:
- In virt-handler, every time PVC/DV volumes are converted to hostDisk in `ReplacePVCByHostDisk`.
- In virt-launcher, when we use disks that allow expansion.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-43005

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

