### PR TITLE
volume migration: improve conditions when the volume migration isn't possible

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -969,11 +969,21 @@ func (c *VMController) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi 
 		}
 		// Validate if the update volumes can be migrated
 		if err := volumemig.ValidateVolumes(vmi, vm); err != nil {
+			log.Log.Object(vm).Errorf("cannot migrate the VM. Volumes are invalid: %v", err)
 			setRestartRequired(vm, err.Error())
 			return nil
 		}
-
-		if err := volumemig.PatchVMIStatusWithMigratedVolumes(c.clientset, c.pvcStore, vmi, vm); err != nil {
+		migVols, err := volumemig.GenerateMigratedVolumes(c.pvcStore, vmi, vm)
+		if err != nil {
+			log.Log.Object(vm).Errorf("cannot generate the migrated volumes: %v", err)
+			return nil
+		}
+		if err := volumemig.ValidateVolumesUpdateMigration(vmi, vm, migVols); err != nil {
+			log.Log.Object(vm).Errorf("cannot migrate the VMI: %v", err)
+			setRestartRequired(vm, err.Error())
+			return nil
+		}
+		if err := volumemig.PatchVMIStatusWithMigratedVolumes(c.clientset, vmi, migVols); err != nil {
 			log.Log.Object(vm).Errorf("failed to update migrating volumes for vmi:%v", err)
 			return err
 		}

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -411,8 +411,12 @@ func (c *WorkloadUpdateController) getUpdateData(kv *virtv1.KubeVirt) *updateDat
 		} else if exists := lookup[vmi.Namespace+"/"+vmi.Name]; exists {
 			continue
 		}
-
-		if automatedMigrationAllowed && (vmi.IsMigratable() || volumemig.CanVolumesUpdateMigration(vmi)) {
+		volMig := false
+		errValid := volumemig.ValidateVolumesUpdateMigration(vmi, nil, vmi.Status.MigratedVolumes)
+		if len(vmi.Status.MigratedVolumes) > 0 && errValid == nil {
+			volMig = true
+		}
+		if automatedMigrationAllowed && (vmi.IsMigratable() || volMig) {
 			data.migratableOutdatedVMIs = append(data.migratableOutdatedVMIs, vmi)
 		} else if automatedShutdownAllowed {
 			data.evictOutdatedVMIs = append(data.evictOutdatedVMIs, vmi)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -20,6 +20,7 @@
 package virthandler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	goerror "errors"
@@ -1139,7 +1140,8 @@ func (d *VirtualMachineController) updateLiveMigrationConditions(vmi *v1.Virtual
 			vmi.Status.Conditions = append(vmi.Status.Conditions, *liveMigrationCondition)
 		}
 	}
-
+	storageLiveMigCond := d.calculateLiveStorageMigrationCondition(vmi)
+	condManager.UpdateCondition(vmi, storageLiveMigCond)
 	evictable := migrations.VMIMigratableOnEviction(d.clusterConfig, vmi)
 	if evictable && liveMigrationCondition.Status == k8sv1.ConditionFalse {
 		d.recorder.Eventf(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), "EvictionStrategy is set but vmi is not migratable; %s", liveMigrationCondition.Message)
@@ -1665,6 +1667,86 @@ func (d *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.Virtu
 
 func vmiContainsPCIHostDevice(vmi *v1.VirtualMachineInstance) bool {
 	return len(vmi.Spec.Domain.Devices.HostDevices) > 0 || len(vmi.Spec.Domain.Devices.GPUs) > 0
+}
+
+type multipleNonMigratableCondition struct {
+	reasons []string
+	msgs    []string
+}
+
+func newMultipleNonMigratableCondition() *multipleNonMigratableCondition {
+	return &multipleNonMigratableCondition{}
+}
+
+func (cond *multipleNonMigratableCondition) addNonMigratableCondition(reason, msg string) {
+	cond.reasons = append(cond.reasons, reason)
+	cond.msgs = append(cond.msgs, msg)
+}
+
+func (cond *multipleNonMigratableCondition) String() string {
+	var buffer bytes.Buffer
+	for i, c := range cond.reasons {
+		if i > 0 {
+			buffer.WriteString(", ")
+		}
+		buffer.WriteString(fmt.Sprintf("%s: %s", c, cond.msgs[i]))
+	}
+	return buffer.String()
+}
+
+func (cond *multipleNonMigratableCondition) generateStorageLiveMigrationCondition() *v1.VirtualMachineInstanceCondition {
+	switch len(cond.reasons) {
+	case 0:
+		return &v1.VirtualMachineInstanceCondition{
+			Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+			Status: k8sv1.ConditionTrue,
+		}
+	default:
+		return &v1.VirtualMachineInstanceCondition{
+			Type:    v1.VirtualMachineInstanceIsStorageLiveMigratable,
+			Status:  k8sv1.ConditionFalse,
+			Message: cond.String(),
+			Reason:  v1.VirtualMachineInstanceReasonNotMigratable,
+		}
+	}
+}
+
+func (d *VirtualMachineController) calculateLiveStorageMigrationCondition(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceCondition {
+	multiCond := newMultipleNonMigratableCondition()
+
+	if err := d.checkNetworkInterfacesForMigration(vmi); err != nil {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonInterfaceNotMigratable, err.Error())
+	}
+
+	if err := d.isHostModelMigratable(vmi); err != nil {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonCPUModeNotMigratable, err.Error())
+	}
+
+	if util.IsVMIVirtiofsEnabled(vmi) {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonVirtIOFSNotMigratable, "VMI uses virtiofs")
+	}
+
+	if vmiContainsPCIHostDevice(vmi) {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonHostDeviceNotMigratable, "VMI uses a PCI host devices")
+	}
+
+	if util.IsSEVVMI(vmi) {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonSEVNotMigratable, "VMI uses SEV")
+	}
+
+	if reservation.HasVMIPersistentReservation(vmi) {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonPRNotMigratable, "VMI uses SCSI persitent reservation")
+	}
+
+	if tscRequirement := topology.GetTscFrequencyRequirement(vmi); !topology.AreTSCFrequencyTopologyHintsDefined(vmi) && tscRequirement.Type == topology.RequiredForMigration {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonNoTSCFrequencyMigratable, tscRequirement.Reason)
+	}
+
+	if vmiFeatures := vmi.Spec.Domain.Features; vmiFeatures != nil && vmiFeatures.HypervPassthrough != nil && *vmiFeatures.HypervPassthrough.Enabled {
+		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonHypervPassthroughNotMigratable, "VMI uses hyperv passthrough")
+	}
+
+	return multiCond.generateStorageLiveMigrationCondition()
 }
 
 func (c *VirtualMachineController) Run(threadiness int, stopCh chan struct{}) {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -464,6 +464,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Type:   v1.VirtualMachineInstanceIsMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
 			}
 
 			vmiFeeder.Add(vmi)
@@ -612,10 +616,16 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updatedVMI.Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
 			Expect(updatedVMI.Status.Phase).To(Equal(v1.Running))
-			Expect(updatedVMI.Status.Conditions).To(ConsistOf(v1.VirtualMachineInstanceCondition{
-				Type:   v1.VirtualMachineInstanceIsMigratable,
-				Status: k8sv1.ConditionTrue,
-			}))
+			Expect(updatedVMI.Status.Conditions).To(ConsistOf(
+				v1.VirtualMachineInstanceCondition{
+					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				v1.VirtualMachineInstanceCondition{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+			))
 			Expect(updatedVMI.Status.MigrationMethod).To(Equal(v1.LiveMigration))
 			Expect(updatedVMI.Status.Interfaces).To(BeEmpty())
 		})
@@ -667,6 +677,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 				),
 				MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(v1.VirtualMachineInstanceUnsupportedAgent),
+					"Status": Equal(k8sv1.ConditionTrue)},
+				),
+				MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
 					"Status": Equal(k8sv1.ConditionTrue)},
 				),
 			))
@@ -774,6 +788,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
 					"Status": Equal(k8sv1.ConditionTrue)},
 				),
+				MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
+					"Status": Equal(k8sv1.ConditionTrue)},
+				),
 			))
 		})
 
@@ -811,6 +829,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 				),
 				MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
+					"Status": Equal(k8sv1.ConditionTrue)},
+				),
+				MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
 					"Status": Equal(k8sv1.ConditionTrue)},
 				),
 			))
@@ -901,6 +923,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					"Status":  Equal(k8sv1.ConditionFalse),
 					"Message": Equal("some message")},
 				),
+				MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
+					"Status": Equal(k8sv1.ConditionTrue)},
+				),
 			))
 		})
 
@@ -938,6 +964,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					"Type":   Equal(v1.VirtualMachineInstancePaused),
 					"Status": Equal(k8sv1.ConditionTrue)},
 				),
+				MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
+					"Status": Equal(k8sv1.ConditionTrue)},
+				),
 			))
 
 			By("unpausing domain")
@@ -958,6 +988,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(updatedVMI.Status.Conditions).To(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
+					"Status": Equal(k8sv1.ConditionTrue)},
+				),
+				MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(v1.VirtualMachineInstanceIsStorageLiveMigratable),
 					"Status": Equal(k8sv1.ConditionTrue)},
 				),
 			))
@@ -1050,7 +1084,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updatedVMI.Status.MigrationMethod).To(Equal(v1.LiveMigration))
-			Expect(updatedVMI.Status.Conditions).To(ConsistOf(
+			Expect(updatedVMI.Status.Conditions).To(ContainElement(
 				MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(v1.VirtualMachineInstanceIsMigratable),
 					"Status": Equal(k8sv1.ConditionTrue)},

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -572,6 +572,9 @@ const (
 
 	// Summarizes that all the DataVolumes attached to the VMI are Ready or not
 	VirtualMachineInstanceDataVolumesReady VirtualMachineInstanceConditionType = "DataVolumesReady"
+
+	// Indicates whether the VMI is live migratable
+	VirtualMachineInstanceIsStorageLiveMigratable VirtualMachineInstanceConditionType = "StorageLiveMigratable"
 )
 
 // These are valid reasons for VMI conditions.
@@ -600,6 +603,9 @@ const (
 	VirtualMachineInstanceReasonNotAllDVsReady = "NotAllDVsReady"
 	// Reason means that all of the VMI's DVs are bound and not running
 	VirtualMachineInstanceReasonAllDVsReady = "AllDVsReady"
+
+	// Indicates a generic reason that the VMI isn't migratable and more details are spiecified in the condition message.
+	VirtualMachineInstanceReasonNotMigratable = "NotMigratable"
 )
 
 const (

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -27,6 +27,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -387,6 +388,43 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			// increasing. Therefore, after 2 minutes we don't expect more then 6 mgration objects.
 			Expect(len(migList.Items)).Should(BeNumerically(">", 1))
 			Expect(len(migList.Items)).Should(BeNumerically("<", 56))
+		})
+
+		It("should set the restart condition since the second volume is RWO and not part of the migration", func() {
+			const volName = "vol0"
+			dv1 := createDV()
+			dv2 := createBlankDV()
+			destDV := createBlankDV()
+			vmi := libvmi.New(
+				libvmi.WithNamespace(ns),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+				libvmi.WithResourceMemory("128Mi"),
+				libvmi.WithDataVolume(volName, dv1.Name),
+				libvmi.WithDataVolume("vol1", dv2.Name),
+				libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()),
+			)
+			vm := libvmi.NewVirtualMachine(vmi,
+				libvmi.WithRunning(),
+				libvmi.WithDataVolumeTemplate(dv1),
+			)
+			vm, err := virtClient.VirtualMachine(ns).Create(context.Background(), vm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
+			libwait.WaitForSuccessfulVMIStart(vmi)
+			By("Update volumes")
+			updateVMWithDV(vm.Name, volName, destDV.Name)
+			Eventually(func() []virtv1.VirtualMachineCondition {
+				vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return vm.Status.Conditions
+			}).WithTimeout(120*time.Second).WithPolling(time.Second).Should(
+				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Type":    Equal(virtv1.VirtualMachineRestartRequired),
+					"Status":  Equal(k8sv1.ConditionTrue),
+					"Message": Equal("cannot migrate the VM. The volume vol1 is RWO and not included in the migration volumes"),
+				})), "The RestartRequired condition should be false",
+			)
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
No conditions was set if the volume migration wasn't possible because the VM isn't migratable

After this PR:
Create new condition `VMIStorageLiveMigratable` which reports if the storage of the VM can be live migrate, and if not the causes in the error message.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new condition for VMIStorageLiveMigratable
```

