### PR TITLE
Introduce libvmi.NewReplicaSet builder

### DIFF
--- a/pkg/libvmi/BUILD.bazel
+++ b/pkg/libvmi/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "cpu.go",
         "memory.go",
         "network.go",
+        "replicaset.go",
         "selector.go",
         "storage.go",
         "vm.go",

--- a/pkg/libvmi/replicaset.go
+++ b/pkg/libvmi/replicaset.go
@@ -28,17 +28,17 @@ import (
 func NewReplicaSet(vmi *v1.VirtualMachineInstance, replicas int) *v1.VirtualMachineInstanceReplicaSet {
 	const taillength = 5
 	replicas32 := int32(replicas)
-	name := "replicaset" + rand.String(taillength)
+	rsselector := "rsselector" + rand.String(taillength)
 	rs := &v1.VirtualMachineInstanceReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(taillength)},
 		Spec: v1.VirtualMachineInstanceReplicaSetSpec{
 			Replicas: &replicas32,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"name": name},
+				MatchLabels: map[string]string{"rsslector": rsselector},
 			},
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"name": name},
+					Labels: map[string]string{"rsslector": rsselector},
 					Name:   vmi.ObjectMeta.Name,
 				},
 				Spec: vmi.Spec,

--- a/pkg/libvmi/replicaset.go
+++ b/pkg/libvmi/replicaset.go
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Authors.
+ *
+ */
+
+package libvmi
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func NewReplicaSet(vmi *v1.VirtualMachineInstance, replicas int) *v1.VirtualMachineInstanceReplicaSet {
+	const taillength = 5
+	replicas32 := int32(replicas)
+	name := "replicaset" + rand.String(taillength)
+	rs := &v1.VirtualMachineInstanceReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(taillength)},
+		Spec: v1.VirtualMachineInstanceReplicaSetSpec{
+			Replicas: &replicas32,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": name},
+			},
+			Template: &v1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"name": name},
+					Name:   vmi.ObjectMeta.Name,
+				},
+				Spec: vmi.Spec,
+			},
+		},
+	}
+	return rs
+}

--- a/tests/infrastructure/k8s-client-changes.go
+++ b/tests/infrastructure/k8s-client-changes.go
@@ -69,7 +69,7 @@ var _ = DescribeInfra("changes to the kubernetes client", func() {
 
 	It("on the controller rate limiter should lead to delayed VMI starts", func() {
 		By("first getting the basetime for a replicaset")
-		replicaset := tests.NewRandomReplicaSetFromVMI(libvmifact.NewCirros(libvmi.WithResourceMemory("1Mi")), int32(0))
+		replicaset := libvmi.NewReplicaSet(libvmifact.NewCirros(libvmi.WithResourceMemory("1Mi")), 0)
 		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(context.Background(), replicaset, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		start := time.Now()
@@ -105,7 +105,7 @@ var _ = DescribeInfra("changes to the kubernetes client", func() {
 			libvmi.WithNodeSelectorFor(&targetNode),
 		)
 
-		replicaset := tests.NewRandomReplicaSetFromVMI(vmi, 0)
+		replicaset := libvmi.NewReplicaSet(vmi, 0)
 		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(context.Background(), replicaset, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 10)

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -486,7 +486,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		var vmrs *v1.VirtualMachineInstanceReplicaSet
 		BeforeEach(func() {
 			By("Creating a VMRS object with 2 replicas")
-			vmrs = tests.NewRandomReplicaSetFromVMI(newLabeledVMI("vmirs"), int32(numberOfVMs))
+			vmrs = libvmi.NewReplicaSet(newLabeledVMI("vmirs"), numberOfVMs)
 			vmrs.Labels = map[string]string{"expose": "vmirs"}
 
 			By("Start the replica set")

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -120,7 +120,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	}
 
 	newReplicaSetWithTemplate := func(template *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceReplicaSet {
-		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(0))
+		newRS := libvmi.NewReplicaSet(template, 0)
 		newRS, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(template)).Create(context.Background(), newRS, v12.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return newRS
@@ -161,7 +161,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
-		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(1))
+		newRS := libvmi.NewReplicaSet(template, 1)
 		newRS, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(newRS)).Create(context.Background(), newRS, v12.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		doScaleWithHPA(newRS.ObjectMeta.Name, int32(startScale), int32(startScale), int32(startScale))

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -111,27 +111,6 @@ func RunVMIAndExpectSchedulingWithWarningPolicy(vmi *v1.VirtualMachineInstance, 
 	)
 }
 
-func NewRandomReplicaSetFromVMI(vmi *v1.VirtualMachineInstance, replicas int32) *v1.VirtualMachineInstanceReplicaSet {
-	name := "replicaset" + rand.String(5)
-	rs := &v1.VirtualMachineInstanceReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(5)},
-		Spec: v1.VirtualMachineInstanceReplicaSetSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"name": name},
-			},
-			Template: &v1.VirtualMachineInstanceTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"name": name},
-					Name:   vmi.ObjectMeta.Name,
-				},
-				Spec: vmi.Spec,
-			},
-		},
-	}
-	return rs
-}
-
 func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (string, error) {
 	// get current vmi
 	freshVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})


### PR DESCRIPTION
Move tests.NewRandomReplicaSetFromVMI from test/utils to a properly-named new file

```release-note
NONE
```
