### PR TITLE
instancetype: Improve error message when rejecting Matcher with InferFromVolume, Name and Kind all set

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -76,10 +76,10 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}
-		if causes := validateInstancetypeMatcherUpdate(newVM.Spec.Instancetype, oldVM.Spec.Instancetype); len(causes) > 0 {
+		if causes := validateInstancetypeMatcherUpdate(oldVM.Spec.Instancetype, newVM.Spec.Instancetype); len(causes) > 0 {
 			return webhookutils.ToAdmissionResponse(causes)
 		}
-		if causes := validatePreferenceMatcherUpdate(newVM.Spec.Preference, oldVM.Spec.Preference); len(causes) > 0 {
+		if causes := validatePreferenceMatcherUpdate(oldVM.Spec.Preference, newVM.Spec.Preference); len(causes) > 0 {
 			return webhookutils.ToAdmissionResponse(causes)
 		}
 	}
@@ -228,7 +228,7 @@ func (mutator *VMsMutator) setDefaultPreferenceKind(vm *v1.VirtualMachine) {
 	}
 }
 
-func validateInstancetypeMatcherUpdate(oldInstancetypeMatcher *v1.InstancetypeMatcher, newInstancetypeMatcher *v1.InstancetypeMatcher) []metav1.StatusCause {
+func validateInstancetypeMatcherUpdate(oldInstancetypeMatcher, newInstancetypeMatcher *v1.InstancetypeMatcher) []metav1.StatusCause {
 	// Allow updates introducing or removing the matchers
 	if oldInstancetypeMatcher == nil || newInstancetypeMatcher == nil {
 		return nil
@@ -243,7 +243,7 @@ func validateInstancetypeMatcherUpdate(oldInstancetypeMatcher *v1.InstancetypeMa
 	return nil
 }
 
-func validatePreferenceMatcherUpdate(oldPreferenceMatcher *v1.PreferenceMatcher, newPreferenceMatcher *v1.PreferenceMatcher) []metav1.StatusCause {
+func validatePreferenceMatcherUpdate(oldPreferenceMatcher, newPreferenceMatcher *v1.PreferenceMatcher) []metav1.StatusCause {
 	// Allow updates introducing or removing the matchers
 	if oldPreferenceMatcher == nil || newPreferenceMatcher == nil {
 		return nil

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -258,7 +258,16 @@ func validatePreferenceMatcherUpdate(oldPreferenceMatcher, newPreferenceMatcher 
 	return nil
 }
 
+const (
+	matcherUpdateInferFromVolumeSetErr = "InferFromVolume already set, should be cleared before setting Name or Kind"
+)
+
 func validateMatcherUpdate(oldMatcher, newMatcher v1.Matcher) error {
+	// Provide a meaningful error if the user mistaken sets inferFromVolume, name and kind
+	if oldMatcher.GetInferFromVolume() != "" && newMatcher.GetInferFromVolume() != "" && (newMatcher.GetName() != "" || newMatcher.GetKind() != "") {
+		return fmt.Errorf(matcherUpdateInferFromVolumeSetErr)
+	}
+
 	// Do not check anything when the original matcher didn't have a revisionName as this is likely the VM Controller updating the matcher
 	if oldMatcher.GetRevisionName() == "" {
 		return nil

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -589,6 +589,19 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				resp := getResponseFromVMUpdate(oldVM, newVM)
 				Expect(resp.Allowed).To(BeFalse())
 			})
+			It("should reject update request providing InferFromVolume, Name and Kind", func() {
+				oldVM.Spec.Instancetype = &v1.InstancetypeMatcher{
+					InferFromVolume: "foo",
+				}
+				newVM.Spec.Instancetype = &v1.InstancetypeMatcher{
+					InferFromVolume: "foo",
+					Name:            "foo",
+					Kind:            apiinstancetype.ClusterSingularResourceName,
+				}
+				resp := getResponseFromVMUpdate(oldVM, newVM)
+				Expect(resp.Allowed).To(BeFalse())
+				Expect(resp.Result.Message).To(ContainSubstring(matcherUpdateInferFromVolumeSetErr))
+			})
 		})
 		Context("of PreferenceMatcher", func() {
 			const (
@@ -683,6 +696,19 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				}
 				resp := getResponseFromVMUpdate(oldVM, newVM)
 				Expect(resp.Allowed).To(BeFalse())
+			})
+			It("should reject update request providing InferFromVolume, Name and Kind", func() {
+				oldVM.Spec.Preference = &v1.PreferenceMatcher{
+					InferFromVolume: "foo",
+				}
+				newVM.Spec.Preference = &v1.PreferenceMatcher{
+					InferFromVolume: "foo",
+					Name:            "foo",
+					Kind:            apiinstancetype.ClusterSingularPreferenceResourceName,
+				}
+				resp := getResponseFromVMUpdate(oldVM, newVM)
+				Expect(resp.Allowed).To(BeFalse())
+				Expect(resp.Result.Message).To(ContainSubstring(matcherUpdateInferFromVolumeSetErr))
 			})
 		})
 	})

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2894,7 +2894,9 @@ type ClusterProfilerRequest struct {
 
 type Matcher interface {
 	GetName() string
+	GetKind() string
 	GetRevisionName() string
+	GetInferFromVolume() string
 }
 
 type InferFromVolumeFailurePolicy string
@@ -2944,8 +2946,16 @@ func (i InstancetypeMatcher) GetName() string {
 	return i.Name
 }
 
+func (i InstancetypeMatcher) GetKind() string {
+	return i.Kind
+}
+
 func (i InstancetypeMatcher) GetRevisionName() string {
 	return i.RevisionName
+}
+
+func (i InstancetypeMatcher) GetInferFromVolume() string {
+	return i.InferFromVolume
 }
 
 // PreferenceMatcher references a set of preference that is used to fill fields in the VMI template.
@@ -2988,8 +2998,16 @@ func (p PreferenceMatcher) GetName() string {
 	return p.Name
 }
 
+func (p PreferenceMatcher) GetKind() string {
+	return p.Kind
+}
+
 func (p PreferenceMatcher) GetRevisionName() string {
 	return p.RevisionName
+}
+
+func (p PreferenceMatcher) GetInferFromVolume() string {
+	return p.InferFromVolume
 }
 
 type LiveUpdateConfiguration struct {


### PR DESCRIPTION
/area instancetype

### What this PR does

Users who accidentally resubmitted manifests requesting `InferFromVolume` would have a slightly confusing set of errors returned:

```
The request is invalid: 
* spec.instancetype.name: Name should not be provided when InferFromVolume is used within the InstancetypeMatcher
* spec.instancetype.kind: Kind should not be provided when InferFromVolume is used within the InstancetypeMatcher
```

This PR now improves this to the following:

```
The request is invalid: 
* InferFromVolume already set, should be cleared before setting Name or Kind
```

This PR also fixes an argument ordering issue with the initial call to `validateInstancetypeMatcherUpdate`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Ultimately we need to stop mutating the `VirtualMachineSpec` when inferring default instance types and preferences but for now this PR improves the error UX with the current approach.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

