### PR TITLE
Use context in validation webhooks

### DIFF
--- a/pkg/util/webhooks/validating-webhooks/validating-webhook.go
+++ b/pkg/util/webhooks/validating-webhooks/validating-webhook.go
@@ -19,15 +19,8 @@ type admitter interface {
 	Admit(context.Context, *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
 }
 
-type AlwaysPassAdmitter struct {
-}
-
 func NewPassingAdmissionResponse() *admissionv1.AdmissionResponse {
 	return &admissionv1.AdmissionResponse{Allowed: true}
-}
-
-func (*AlwaysPassAdmitter) Admit(*admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	return NewPassingAdmissionResponse()
 }
 
 func NewAdmissionResponse(causes []v1.StatusCause) *admissionv1.AdmissionResponse {

--- a/pkg/util/webhooks/validating-webhooks/validating-webhook.go
+++ b/pkg/util/webhooks/validating-webhooks/validating-webhook.go
@@ -1,6 +1,7 @@
 package validating_webhooks
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,7 +16,7 @@ import (
 )
 
 type admitter interface {
-	Admit(*admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
+	Admit(context.Context, *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
 }
 
 type AlwaysPassAdmitter struct {
@@ -70,7 +71,8 @@ func Serve(resp http.ResponseWriter, req *http.Request, admitter admitter) {
 			Kind:       "AdmissionReview",
 		},
 	}
-	reviewResponse := admitter.Admit(review)
+
+	reviewResponse := admitter.Admit(req.Context(), review)
 	if reviewResponse != nil {
 		response.Response = reviewResponse
 		response.Response.UID = review.Request.UID

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -1,6 +1,7 @@
 package fuzz
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -44,7 +45,7 @@ func FuzzAdmitter(f *testing.F) {
 			objType: &v1.VirtualMachineInstance{},
 			admit: func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 				adm := &admitters.VMICreateAdmitter{ClusterConfig: config}
-				return adm.Admit(request)
+				return adm.Admit(context.Background(), request)
 			},
 			fuzzFuncs: fuzzFuncs(withSyntaxErrors),
 		},
@@ -54,7 +55,7 @@ func FuzzAdmitter(f *testing.F) {
 			objType: &v1.VirtualMachineInstance{},
 			admit: func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 				adm := &admitters.VMICreateAdmitter{ClusterConfig: config}
-				return adm.Admit(request)
+				return adm.Admit(context.Background(), request)
 			},
 			fuzzFuncs: fuzzFuncs(),
 		},
@@ -67,7 +68,7 @@ func FuzzAdmitter(f *testing.F) {
 					ClusterConfig:       config,
 					InstancetypeMethods: testutils.NewMockInstancetypeMethods(),
 				}
-				return adm.Admit(request)
+				return adm.Admit(context.Background(), request)
 			},
 			fuzzFuncs: fuzzFuncs(withSyntaxErrors),
 		},
@@ -80,7 +81,7 @@ func FuzzAdmitter(f *testing.F) {
 					ClusterConfig:       config,
 					InstancetypeMethods: testutils.NewMockInstancetypeMethods(),
 				}
-				return adm.Admit(request)
+				return adm.Admit(context.Background(), request)
 			},
 			fuzzFuncs: fuzzFuncs(),
 		},

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter.go
@@ -1,6 +1,7 @@
 package admitters
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -27,7 +28,7 @@ var supportedInstancetypeVersions = []string{
 
 type InstancetypeAdmitter struct{}
 
-func (f *InstancetypeAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (f *InstancetypeAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return admitInstancetype(ar.Request, instancetype.PluralResourceName)
 }
 
@@ -67,7 +68,7 @@ func validateMemoryOvercommitPercentNoHugepages(field *k8sfield.Path, spec *inst
 
 type ClusterInstancetypeAdmitter struct{}
 
-func (f *ClusterInstancetypeAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (f *ClusterInstancetypeAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return admitInstancetype(ar.Request, instancetype.ClusterPluralResourceName)
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter_test.go
@@ -1,12 +1,12 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +36,7 @@ var _ = Describe("Validating Instancetype Admitter", func() {
 
 	DescribeTable("should accept valid instancetype", func(version string) {
 		ar := createInstancetypeAdmissionReview(instancetypeObj, version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeTrue(), "Expected instancetype to be allowed.")
 	},
@@ -47,7 +47,7 @@ var _ = Describe("Validating Instancetype Admitter", func() {
 
 	It("should reject unsupported version", func() {
 		ar := createInstancetypeAdmissionReview(instancetypeObj, "unsupportedversion")
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
 		Expect(response.Result.Code).To(Equal(int32(http.StatusBadRequest)), "Expected error 400: BadRequest")
@@ -65,7 +65,7 @@ var _ = Describe("Validating Instancetype Admitter", func() {
 			},
 		}
 		ar := createInstancetypeAdmissionReview(instancetypeObj, version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
 	},
@@ -88,7 +88,7 @@ var _ = Describe("Validating Instancetype Admitter", func() {
 			},
 		}
 		ar := createInstancetypeAdmissionReview(instancetypeObj, version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
 		Expect(response.Result.Code).To(Equal(int32(http.StatusUnprocessableEntity)), "overCommitPercent and hugepages should not be requested together.")
@@ -114,7 +114,7 @@ var _ = Describe("Validating ClusterInstancetype Admitter", func() {
 
 	DescribeTable("should accept valid instancetype", func(version string) {
 		ar := createClusterInstancetypeAdmissionReview(clusterInstancetypeObj, version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeTrue(), "Expected instancetype to be allowed.")
 	},
@@ -137,7 +137,7 @@ var _ = Describe("Validating ClusterInstancetype Admitter", func() {
 			},
 		}
 		ar := createClusterInstancetypeAdmissionReview(clusterInstancetypeObj, version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
 		Expect(response.Result.Code).To(Equal(int32(http.StatusUnprocessableEntity)), "overCommitPercent and hugepages should not be requested together.")
@@ -145,7 +145,7 @@ var _ = Describe("Validating ClusterInstancetype Admitter", func() {
 
 	It("should reject unsupported version", func() {
 		ar := createClusterInstancetypeAdmissionReview(clusterInstancetypeObj, "unsupportedversion")
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
 		Expect(response.Result.Code).To(Equal(int32(http.StatusBadRequest)), "Expected error 400: BadRequest")

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -54,12 +54,12 @@ func isMigratable(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-func EnsureNoMigrationConflict(virtClient kubecli.KubevirtClient, vmiName string, namespace string) error {
+func ensureNoMigrationConflict(ctx context.Context, virtClient kubecli.KubevirtClient, vmiName string, namespace string) error {
 	labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", v1.MigrationSelectorLabel, vmiName))
 	if err != nil {
 		return err
 	}
-	list, err := virtClient.VirtualMachineInstanceMigration(namespace).List(context.Background(), metav1.ListOptions{
+	list, err := virtClient.VirtualMachineInstanceMigration(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	})
 	if err != nil {
@@ -77,7 +77,7 @@ func EnsureNoMigrationConflict(virtClient kubecli.KubevirtClient, vmiName string
 	return nil
 }
 
-func (admitter *MigrationCreateAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *MigrationCreateAdmitter) Admit(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	migration, _, err := getAdmissionReviewMigration(ar)
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
@@ -92,7 +92,7 @@ func (admitter *MigrationCreateAdmitter) Admit(_ context.Context, ar *admissionv
 		return webhookutils.ToAdmissionResponse(causes)
 	}
 
-	vmi, err := admitter.VirtClient.VirtualMachineInstance(migration.Namespace).Get(context.Background(), migration.Spec.VMIName, metav1.GetOptions{})
+	vmi, err := admitter.VirtClient.VirtualMachineInstance(migration.Namespace).Get(ctx, migration.Spec.VMIName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// ensure VMI exists for the migration
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("the VMI \"%s/%s\" does not exist", migration.Namespace, migration.Spec.VMIName))
@@ -113,7 +113,7 @@ func (admitter *MigrationCreateAdmitter) Admit(_ context.Context, ar *admissionv
 
 	// Don't allow new migration jobs to be introduced when previous migration jobs
 	// are already in flight.
-	err = EnsureNoMigrationConflict(admitter.VirtClient, migration.Spec.VMIName, migration.Namespace)
+	err = ensureNoMigrationConflict(ctx, admitter.VirtClient, migration.Spec.VMIName, migration.Namespace)
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -77,7 +77,7 @@ func EnsureNoMigrationConflict(virtClient kubecli.KubevirtClient, vmiName string
 	return nil
 }
 
-func (admitter *MigrationCreateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *MigrationCreateAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	migration, _, err := getAdmissionReviewMigration(ar)
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
@@ -20,6 +20,8 @@
 package admitters
 
 import (
+	"context"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +62,7 @@ func ensureSelectorLabelSafe(newMigration *v1.VirtualMachineInstanceMigration, o
 	return []metav1.StatusCause{}
 }
 
-func (admitter *MigrationUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *MigrationUpdateAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	// Get new migration from admission response
 	newMigration, oldMigration, err := getAdmissionReviewMigration(ar)
 	if err != nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -100,7 +101,7 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(ar)
+		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 	})
 
@@ -133,7 +134,7 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(ar)
+		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 
@@ -176,7 +177,7 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(ar)
+		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 	})
 
@@ -219,7 +220,7 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(ar)
+		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 	})
 
@@ -262,7 +263,7 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(ar)
+		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -45,7 +46,7 @@ func NewMigrationPolicyAdmitter() *MigrationPolicyAdmitter {
 }
 
 // Admit validates an AdmissionReview
-func (admitter *MigrationPolicyAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *MigrationPolicyAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if ar.Request.Resource.Group != migrationsv1.MigrationPolicyKind.Group ||
 		ar.Request.Resource.Resource != migrations.ResourceMigrationPolicies {
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource %+v", ar.Request.Resource))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -116,6 +117,6 @@ func createPolicyAdmissionReview(policy *migrationsv1.MigrationPolicy, namespace
 
 func (admitter *MigrationPolicyAdmitter) admitAndExpect(policy *migrationsv1.MigrationPolicy, expectAllowed bool) {
 	ar := createPolicyAdmissionReview(policy, policy.Namespace)
-	resp := admitter.Admit(ar)
+	resp := admitter.Admit(context.Background(), ar)
 	Expect(resp.Allowed).To(Equal(expectAllowed))
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -34,7 +34,7 @@ func NewPodEvictionAdmitter(clusterConfig *virtconfig.ClusterConfig, kubeClient 
 	}
 }
 
-func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *PodEvictionAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	pod, err := admitter.kubeClient.CoreV1().Pods(ar.Request.Namespace).Get(context.Background(), ar.Request.Name, metav1.GetOptions{})
 	if err != nil {
 		return validating_webhooks.NewPassingAdmissionResponse()

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -20,6 +20,7 @@
 package admitters_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -78,6 +79,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(evictedPod.Namespace, evictedPod.Name, !isDryRun),
 		)
 
@@ -100,6 +102,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(testNamespace, "does-not-exist", !isDryRun),
 		)
 
@@ -122,6 +125,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(pod.Namespace, pod.Name, !isDryRun),
 		)
 
@@ -153,6 +157,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, !isDryRun),
 		)
 
@@ -215,6 +220,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, !isDryRun),
 		)
 
@@ -274,6 +280,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, !isDryRun),
 		)
 
@@ -313,6 +320,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, !isDryRun),
 		)
 
@@ -349,6 +357,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, !isDryRun),
 		)
 
@@ -380,6 +389,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, !isDryRun),
 		)
 
@@ -411,6 +421,7 @@ var _ = Describe("Pod eviction admitter", func() {
 		)
 
 		actualAdmissionResponse := admitter.Admit(
+			context.Background(),
 			newAdmissionReview(evictedVirtLauncherPod.Namespace, evictedVirtLauncherPod.Name, isDryRun),
 		)
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/preference-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/preference-admitter.go
@@ -1,6 +1,7 @@
 package admitters
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
@@ -18,13 +19,13 @@ import (
 
 type PreferenceAdmitter struct{}
 
-func (f *PreferenceAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (f *PreferenceAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return admitPreference(ar.Request, instancetypeapi.PluralPreferenceResourceName)
 }
 
 type ClusterPreferenceAdmitter struct{}
 
-func (f *ClusterPreferenceAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (f *ClusterPreferenceAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return admitPreference(ar.Request, instancetypeapi.ClusterPluralPreferenceResourceName)
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/preference-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/preference-admitter_test.go
@@ -1,6 +1,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,7 +39,7 @@ var _ = Describe("Validating Preference Admitter", func() {
 
 	DescribeTable("should accept valid preference", func(version string) {
 		ar := createPreferenceAdmissionReview(preferenceObj, version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeTrue(), "Expected preference to be allowed.")
 	},
@@ -49,7 +50,7 @@ var _ = Describe("Validating Preference Admitter", func() {
 
 	It("should reject unsupported version", func() {
 		ar := createPreferenceAdmissionReview(preferenceObj, "unsupportedversion")
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
 		Expect(response.Result.Code).To(Equal(int32(http.StatusBadRequest)), "Expected error 400: BadRequest")
@@ -65,7 +66,7 @@ var _ = Describe("Validating Preference Admitter", func() {
 			},
 		}
 		ar := createPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
 		Expect(response.Result.Details.Causes).To(HaveLen(1))
@@ -88,7 +89,7 @@ var _ = Describe("Validating Preference Admitter", func() {
 			},
 		}
 		ar := createPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
 		Expect(response.Result.Details.Causes).To(HaveLen(1))
@@ -102,7 +103,7 @@ var _ = Describe("Validating Preference Admitter", func() {
 
 	DescribeTable("should reject when spreading vCPUs across CoresThreads with a ratio higher than 2 set through", func(preferenceObj instancetypev1beta1.VirtualMachinePreference) {
 		ar := createPreferenceAdmissionReview(&preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
 		Expect(response.Result.Details.Causes).To(HaveLen(1))
 		Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
@@ -172,7 +173,7 @@ var _ = Describe("Validating Preference Admitter", func() {
 			},
 		}
 		ar := createPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 		Expect(response.Allowed).To(BeTrue())
 		Expect(response.Warnings).To(HaveLen(1))
 		Expect(response.Warnings[0]).To(ContainSubstring(fmt.Sprintf(deprecatedPreferredCPUTopologyErrFmt, deprecatedTopology, expectedAlternativeTopology)))
@@ -204,7 +205,7 @@ var _ = Describe("Validating ClusterPreference Admitter", func() {
 
 	DescribeTable("should accept valid preference", func(version string) {
 		ar := createClusterPreferenceAdmissionReview(clusterPreferenceObj, version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeTrue(), "Expected preference to be allowed.")
 	},
@@ -215,7 +216,7 @@ var _ = Describe("Validating ClusterPreference Admitter", func() {
 
 	It("should reject unsupported version", func() {
 		ar := createClusterPreferenceAdmissionReview(clusterPreferenceObj, "unsupportedversion")
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
 		Expect(response.Result.Code).To(Equal(int32(http.StatusBadRequest)), "Expected error 400: BadRequest")
@@ -235,7 +236,7 @@ var _ = Describe("Validating ClusterPreference Admitter", func() {
 			},
 		}
 		ar := createClusterPreferenceAdmissionReview(clusterPreferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 
 		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
 		Expect(response.Result.Details.Causes).To(HaveLen(1))
@@ -249,7 +250,7 @@ var _ = Describe("Validating ClusterPreference Admitter", func() {
 
 	DescribeTable("should reject when spreading vCPUs across CoresThreads with a ratio higher than 2 set through", func(clusterPreferenceObj instancetypev1beta1.VirtualMachineClusterPreference) {
 		ar := createClusterPreferenceAdmissionReview(&clusterPreferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
 		Expect(response.Result.Details.Causes).To(HaveLen(1))
 		Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
@@ -319,7 +320,7 @@ var _ = Describe("Validating ClusterPreference Admitter", func() {
 			},
 		}
 		ar := createClusterPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
-		response := admitter.Admit(ar)
+		response := admitter.Admit(context.Background(), ar)
 		Expect(response.Allowed).To(BeTrue())
 		Expect(response.Warnings).To(HaveLen(1))
 		Expect(response.Warnings[0]).To(ContainSubstring(fmt.Sprintf(deprecatedPreferredCPUTopologyErrFmt, deprecatedTopology, expectedAlternativeTopology)))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/status-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/status-admitter.go
@@ -1,6 +1,8 @@
 package admitters
 
 import (
+	"context"
+
 	admissionv1 "k8s.io/api/admission/v1"
 
 	webhooks2 "kubevirt.io/kubevirt/pkg/virt-api/webhooks"
@@ -12,7 +14,7 @@ type StatusAdmitter struct {
 	VmsAdmitter *VMsAdmitter
 }
 
-func (s *StatusAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (s *StatusAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if resp := webhooks.ValidateStatus(ar.Request.Object.Raw); resp != nil {
 		return resp
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/status-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/status-admitter.go
@@ -14,13 +14,13 @@ type StatusAdmitter struct {
 	VmsAdmitter *VMsAdmitter
 }
 
-func (s *StatusAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (s *StatusAdmitter) Admit(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if resp := webhooks.ValidateStatus(ar.Request.Object.Raw); resp != nil {
 		return resp
 	}
 
 	if webhooks.ValidateRequestResource(ar.Request.Resource, webhooks2.VirtualMachineGroupVersionResource.Group, webhooks2.VirtualMachineGroupVersionResource.Resource) {
-		return s.VmsAdmitter.AdmitStatus(ar)
+		return s.VmsAdmitter.AdmitStatus(ctx, ar)
 	}
 
 	reviewResponse := admissionv1.AdmissionResponse{}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -65,7 +65,7 @@ func NewVMCloneAdmitter(config *virtconfig.ClusterConfig, client kubecli.Kubevir
 }
 
 // Admit validates an AdmissionReview
-func (admitter *VirtualMachineCloneAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VirtualMachineCloneAdmitter) Admit(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if ar.Request.Resource.Group != clonev1alpha1.VirtualMachineCloneKind.Group {
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected group: %+v. Expected group: %+v", ar.Request.Resource.Group, clonev1alpha1.VirtualMachineCloneKind.Group))
 	}
@@ -102,7 +102,7 @@ func (admitter *VirtualMachineCloneAdmitter) Admit(_ context.Context, ar *admiss
 		causes = append(causes, newCauses...)
 	}
 
-	if newCauses := validateSource(admitter.Client, vmClone); newCauses != nil {
+	if newCauses := validateSource(ctx, admitter.Client, vmClone); newCauses != nil {
 		causes = append(causes, newCauses...)
 	}
 
@@ -190,7 +190,7 @@ func validateSourceAndTargetKind(vmClone *clonev1alpha1.VirtualMachineClone) []m
 	return causes
 }
 
-func validateSource(client kubecli.KubevirtClient, vmClone *clonev1alpha1.VirtualMachineClone) []metav1.StatusCause {
+func validateSource(ctx context.Context, client kubecli.KubevirtClient, vmClone *clonev1alpha1.VirtualMachineClone) []metav1.StatusCause {
 	var causes []metav1.StatusCause = nil
 	sourceField := k8sfield.NewPath("spec")
 	source := vmClone.Spec.Source
@@ -227,9 +227,9 @@ func validateSource(client kubecli.KubevirtClient, vmClone *clonev1alpha1.Virtua
 	if source.Kind != "" && source.Name != "" {
 		switch source.Kind {
 		case virtualMachineKind:
-			causes = append(causes, validateCloneSourceVM(client, source.Name, vmClone.Namespace, sourceField.Child("Source"))...)
+			causes = append(causes, validateCloneSourceVM(ctx, client, source.Name, vmClone.Namespace, sourceField.Child("Source"))...)
 		case virtualMachineSnapshotKind:
-			causes = append(causes, validateCloneSourceSnapshot(client, source.Name, vmClone.Namespace, sourceField.Child("Source"))...)
+			causes = append(causes, validateCloneSourceSnapshot(ctx, client, source.Name, vmClone.Namespace, sourceField.Child("Source"))...)
 		default:
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
@@ -313,8 +313,8 @@ func validateCloneSourceExists(clientGetErr error, sourceField *k8sfield.Path, k
 	return nil
 }
 
-func validateCloneSourceVM(client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
-	vm, err := client.VirtualMachine(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func validateCloneSourceVM(ctx context.Context, client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
+	vm, err := client.VirtualMachine(namespace).Get(ctx, name, metav1.GetOptions{})
 	causes := validateCloneSourceExists(err, sourceField, virtualMachineKind, name, namespace)
 
 	if causes != nil {
@@ -330,8 +330,8 @@ func validateCloneSourceVM(client kubecli.KubevirtClient, name, namespace string
 	return causes
 }
 
-func validateCloneSourceSnapshot(client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
-	vmSnapshot, err := client.VirtualMachineSnapshot(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func validateCloneSourceSnapshot(ctx context.Context, client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
+	vmSnapshot, err := client.VirtualMachineSnapshot(namespace).Get(ctx, name, metav1.GetOptions{})
 	causes := validateCloneSourceExists(err, sourceField, virtualMachineSnapshotKind, name, namespace)
 	if causes != nil {
 		return causes

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -65,7 +65,7 @@ func NewVMCloneAdmitter(config *virtconfig.ClusterConfig, client kubecli.Kubevir
 }
 
 // Admit validates an AdmissionReview
-func (admitter *VirtualMachineCloneAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VirtualMachineCloneAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if ar.Request.Resource.Group != clonev1alpha1.VirtualMachineCloneKind.Group {
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected group: %+v. Expected group: %+v", ar.Request.Resource.Group, clonev1alpha1.VirtualMachineCloneKind.Group))
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -160,8 +160,8 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		admitter = &VirtualMachineCloneAdmitter{Config: config, Client: virtClient}
 		vmClone = newValidClone()
 		vm = newValidVM(vmClone.Namespace, vmClone.Spec.Source.Name)
-		vmInterface.EXPECT().Get(context.Background(), vmClone.Spec.Source.Name, gomock.Any()).Return(vm, nil).AnyTimes()
-		vmInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("does-not-exist")).AnyTimes()
+		vmInterface.EXPECT().Get(gomock.Any(), vmClone.Spec.Source.Name, gomock.Any()).Return(vm, nil).AnyTimes()
+		vmInterface.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("does-not-exist")).AnyTimes()
 
 		kubevirtClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			Expect(action).To(BeNil())
@@ -438,7 +438,7 @@ func createCloneAdmissionReview(vmClone *clonev1lpha1.VirtualMachineClone) *admi
 
 func (admitter *VirtualMachineCloneAdmitter) admitAndExpect(clone *clonev1lpha1.VirtualMachineClone, expectAllowed bool) {
 	ar := createCloneAdmissionReview(clone)
-	resp := admitter.Admit(ar)
+	resp := admitter.Admit(context.Background(), ar)
 	Expect(resp.Allowed).To(Equal(expectAllowed))
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -55,7 +56,7 @@ func NewVMExportAdmitter(config *virtconfig.ClusterConfig) *VMExportAdmitter {
 }
 
 // Admit validates an AdmissionReview
-func (admitter *VMExportAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMExportAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if ar.Request.Resource.Group != exportv1.SchemeGroupVersion.Group ||
 		ar.Request.Resource.Resource != "virtualmachineexports" {
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource %+v", ar.Request.Resource))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter_test.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -52,7 +53,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(ar)
+			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(Equal("vm export feature gate not enabled"))
 		})
@@ -97,7 +98,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 
-			resp := createTestVMExportAdmitter(config).Admit(ar)
+			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("unexpected resource"))
 		})
@@ -133,7 +134,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(ar)
+			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring(errorString))
 		},
@@ -154,7 +155,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(ar)
+			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.kind"))
@@ -182,7 +183,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportUpdateAdmissionReview(oldExport, export)
-			resp := createTestVMExportAdmitter(config).Admit(ar)
+			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
@@ -213,7 +214,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportUpdateAdmissionReview(oldExport, export)
-			resp := createTestVMExportAdmitter(config).Admit(ar)
+			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -229,7 +230,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(ar)
+			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue(), "should allow APIGroup: %s, Kind: %s", apiGroup, kind)
 		},
 			Entry("persistent volume claim blank", "", pvc),
@@ -249,7 +250,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(ar)
+			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse(), "should reject APIGroup: %s, Kind: %s", apiGroup, kind)
 		},
 			Entry("persistent volume claim", "invalid", pvc),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -99,7 +100,7 @@ type VMICreateAdmitter struct {
 	ClusterConfig *virtconfig.ClusterConfig
 }
 
-func (admitter *VMICreateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMICreateAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if resp := webhookutils.ValidateSchema(v1.VirtualMachineInstanceGroupVersionKind, ar.Request.Object.Raw); resp != nil {
 		return resp
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -114,7 +115,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			},
 		}
 
-		resp := vmiCreateAdmitter.Admit(ar)
+		resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Details.Causes).To(HaveLen(1))
 		Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[0].name"))
@@ -132,7 +133,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			},
 		}
-		resp := vmiCreateAdmitter.Admit(ar)
+		resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Details.Causes).To(HaveLen(1))
 		Expect(resp.Result.Message).To(ContainSubstring("no memory requested"))
@@ -157,7 +158,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			},
 		}
-		resp := vmiCreateAdmitter.Admit(ar)
+		resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 
@@ -234,7 +235,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).To(Equal(`either spec.readinessProbe.tcpSocket, spec.readinessProbe.exec or spec.readinessProbe.httpGet must be set if a spec.readinessProbe is specified, either spec.livenessProbe.tcpSocket, spec.livenessProbe.exec or spec.livenessProbe.httpGet must be set if a spec.livenessProbe is specified`))
 		})
@@ -270,7 +271,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).To(Equal(`spec.readinessProbe must have exactly one probe type set, spec.livenessProbe must have exactly one probe type set`))
 		})
@@ -301,7 +302,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 		It("should reject properly configured network-based readiness and liveness probes if no Pod Network is present", func() {
@@ -329,7 +330,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).To(Equal(`spec.readinessProbe.tcpSocket is only allowed if the Pod Network is attached, spec.livenessProbe.httpGet is only allowed if the Pod Network is attached`))
 		})
@@ -347,7 +348,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			},
 		}
-		resp := vmiCreateAdmitter.Admit(ar)
+		resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 
@@ -360,12 +361,12 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			},
 		}
-		resp := vmiCreateAdmitter.Admit(ar)
+		resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Message).To(Equal(`.very in body is a forbidden property, spec.extremely in body is a forbidden property, spec.domain in body is required`))
 	})
 
-	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
+	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
 		input := map[string]interface{}{}
 		json.Unmarshal([]byte(data), &input)
 
@@ -377,7 +378,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			},
 		}
-		resp := review(ar)
+		resp := review(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Message).To(Equal(validationResult))
 	},
@@ -406,7 +407,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 						},
 					},
 				}
-				resp := vmiCreateAdmitter.Admit(ar)
+				resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 				if positive {
 					Expect(resp.Allowed).To(BeTrue())
 				} else {
@@ -1151,7 +1152,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Object: runtime.RawExtension{
 						Raw: vmiJSON}}}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 			Expect(resp.Result).To(BeNil())
 			Expect(resp.Warnings).To(HaveLen(1))
@@ -3112,7 +3113,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3132,7 +3133,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3163,7 +3164,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(3))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey"))
@@ -3202,7 +3203,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(3))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey"))
@@ -3241,7 +3242,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(2))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values"))
@@ -3278,7 +3279,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(4))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values"))
@@ -3314,7 +3315,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight"))
@@ -3337,7 +3338,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3369,7 +3370,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(3))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey"))
@@ -3411,7 +3412,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3443,7 +3444,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(2))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values"))
@@ -3480,7 +3481,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(4))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values"))
@@ -3509,7 +3510,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3530,7 +3531,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			// webhookutils.ValidateSchema will take over so result will be only a message
@@ -3560,7 +3561,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3591,7 +3592,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3622,7 +3623,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].key"))
 			Expect(resp.Result.Details.Causes[0].Message).To(Equal("spec.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].key: Invalid value: \"key\": not a valid field selector key"))
@@ -3655,7 +3656,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].values[0]"))
@@ -3690,7 +3691,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3718,7 +3719,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		It("Allow to create when spec.topologySpreadConstraints set to nil", func() {
 			ar := vmiAdmissionReviewFromTopologyConstraints(vmi, nil)
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3732,7 +3733,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3754,7 +3755,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -3768,7 +3769,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.topologySpreadConstraints[0].topologyKey"))
@@ -3785,7 +3786,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.topologySpreadConstraints[0].topologyKey"))
@@ -3802,7 +3803,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.topologySpreadConstraints[0].maxSkew"))
@@ -3827,7 +3828,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.topologySpreadConstraints.labelSelector.matchExpressions[0].values"))
@@ -3965,7 +3966,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				}
 
-				resp := vmiCreateAdmitter.Admit(ar)
+				resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.domain.cpu.sockets"))
@@ -3999,7 +4000,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			resp := vmiCreateAdmitter.Admit(ar)
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 
 			if expectValid {
 				Expect(resp.Allowed).To(BeTrue())

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -36,7 +37,7 @@ import (
 type VMIPresetAdmitter struct {
 }
 
-func (admitter *VMIPresetAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMIPresetAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if !webhookutils.ValidateRequestResource(ar.Request.Resource, webhooks.VirtualMachineInstancePresetGroupVersionResource.Group, webhooks.VirtualMachineInstancePresetGroupVersionResource.Resource) {
 		err := fmt.Errorf("expect resource to be '%s'", webhooks.VirtualMachineInstancePresetGroupVersionResource.Resource)
 		return webhookutils.ToAdmissionResponseError(err)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,7 +39,7 @@ import (
 var _ = Describe("Validating VMIPreset Admitter", func() {
 	vmiPresetAdmitter := &VMIPresetAdmitter{}
 
-	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
+	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
 		input := map[string]interface{}{}
 		json.Unmarshal([]byte(data), &input)
 
@@ -50,7 +51,7 @@ var _ = Describe("Validating VMIPreset Admitter", func() {
 				},
 			},
 		}
-		resp := review(ar)
+		resp := review(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Message).To(Equal(validationResult))
 	},
@@ -90,7 +91,7 @@ var _ = Describe("Validating VMIPreset Admitter", func() {
 			},
 		}
 
-		resp := vmiPresetAdmitter.Admit(ar)
+		resp := vmiPresetAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Details.Causes).To(HaveLen(1))
 		Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[0]"))
@@ -117,7 +118,7 @@ var _ = Describe("Validating VMIPreset Admitter", func() {
 			},
 		}
 
-		resp := vmiPresetAdmitter.Admit(ar)
+		resp := vmiPresetAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"fmt"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -42,7 +43,7 @@ type VMIUpdateAdmitter struct {
 	ClusterConfig *virtconfig.ClusterConfig
 }
 
-func (admitter *VMIUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMIUpdateAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if resp := webhookutils.ValidateSchema(v1.VirtualMachineInstanceGroupVersionKind, ar.Request.Object.Raw); resp != nil {
 		return resp
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -41,7 +42,7 @@ type VMIRSAdmitter struct {
 	ClusterConfig *virtconfig.ClusterConfig
 }
 
-func (admitter *VMIRSAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMIRSAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if !webhookutils.ValidateRequestResource(ar.Request.Resource, webhooks.VirtualMachineInstanceReplicaSetGroupVersionResource.Group, webhooks.VirtualMachineInstanceReplicaSetGroupVersionResource.Resource) {
 		err := fmt.Errorf("expect resource to be '%s'", webhooks.VirtualMachineInstanceReplicaSetGroupVersionResource.Resource)
 		return webhookutils.ToAdmissionResponseError(err)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,7 +41,7 @@ var _ = Describe("Validating VMIRS Admitter", func() {
 	config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 	vmirsAdmitter := &VMIRSAdmitter{ClusterConfig: config}
 
-	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
+	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
 		input := map[string]interface{}{}
 		json.Unmarshal([]byte(data), &input)
 
@@ -52,7 +53,7 @@ var _ = Describe("Validating VMIRS Admitter", func() {
 				},
 			},
 		}
-		resp := review(ar)
+		resp := review(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Message).To(Equal(validationResult))
 	},
@@ -75,7 +76,7 @@ var _ = Describe("Validating VMIRS Admitter", func() {
 			},
 		}
 
-		resp := vmirsAdmitter.Admit(ar)
+		resp := vmirsAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Details.Causes).To(HaveLen(len(causes)))
 		for i, cause := range causes {
@@ -137,7 +138,7 @@ var _ = Describe("Validating VMIRS Admitter", func() {
 			},
 		}
 
-		resp := vmirsAdmitter.Admit(ar)
+		resp := vmirsAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -43,7 +44,7 @@ type VMPoolAdmitter struct {
 	ClusterConfig *virtconfig.ClusterConfig
 }
 
-func (admitter *VMPoolAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMPoolAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 
 	if ar.Request == nil {
 		err := fmt.Errorf("Empty request for virtual machine pool validation")

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter_test.go
@@ -20,6 +20,7 @@
 package admitters
 
 import (
+	"context"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -42,7 +43,7 @@ var _ = Describe("Validating Pool Admitter", func() {
 
 	always := v1.RunStrategyAlways
 
-	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
+	DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
 		input := map[string]interface{}{}
 		json.Unmarshal([]byte(data), &input)
 
@@ -54,7 +55,7 @@ var _ = Describe("Validating Pool Admitter", func() {
 				},
 			},
 		}
-		resp := review(ar)
+		resp := review(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Message).To(Equal(validationResult))
 	},
@@ -77,7 +78,7 @@ var _ = Describe("Validating Pool Admitter", func() {
 			},
 		}
 
-		resp := poolAdmitter.Admit(ar)
+		resp := poolAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 		Expect(resp.Result.Details.Causes).To(HaveLen(len(causes)))
 		for i, cause := range causes {
@@ -171,7 +172,7 @@ var _ = Describe("Validating Pool Admitter", func() {
 			},
 		}
 
-		resp := poolAdmitter.Admit(ar)
+		resp := poolAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -60,7 +60,7 @@ func NewVMRestoreAdmitter(config *virtconfig.ClusterConfig, client kubecli.Kubev
 }
 
 // Admit validates an AdmissionReview
-func (admitter *VMRestoreAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMRestoreAdmitter) Admit(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if ar.Request.Resource.Group != snapshotv1.SchemeGroupVersion.Group ||
 		ar.Request.Resource.Resource != "virtualmachinerestores" {
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource %+v", ar.Request.Resource))
@@ -98,7 +98,7 @@ func (admitter *VMRestoreAdmitter) Admit(_ context.Context, ar *admissionv1.Admi
 			case core.GroupName:
 				switch vmRestore.Spec.Target.Kind {
 				case "VirtualMachine":
-					causes, targetUID, targetVMExists, err = admitter.validateCreateVM(k8sfield.NewPath("spec"), vmRestore)
+					causes, targetUID, targetVMExists, err = admitter.validateCreateVM(ctx, k8sfield.NewPath("spec"), vmRestore)
 					if err != nil {
 						return webhookutils.ToAdmissionResponseError(err)
 					}
@@ -123,6 +123,7 @@ func (admitter *VMRestoreAdmitter) Admit(_ context.Context, ar *admissionv1.Admi
 		}
 
 		snapshotCauses, err := admitter.validateSnapshot(
+			ctx,
 			k8sfield.NewPath("spec", "virtualMachineSnapshotName"),
 			ar.Request.Namespace,
 			vmRestore.Spec.VirtualMachineSnapshotName,
@@ -183,13 +184,13 @@ func (admitter *VMRestoreAdmitter) Admit(_ context.Context, ar *admissionv1.Admi
 	return &reviewResponse
 }
 
-func (admitter *VMRestoreAdmitter) validateCreateVM(field *k8sfield.Path, vmRestore *snapshotv1.VirtualMachineRestore) (causes []metav1.StatusCause, uid *types.UID, targetVMExists bool, err error) {
+func (admitter *VMRestoreAdmitter) validateCreateVM(ctx context.Context, field *k8sfield.Path, vmRestore *snapshotv1.VirtualMachineRestore) (causes []metav1.StatusCause, uid *types.UID, targetVMExists bool, err error) {
 	vmName := vmRestore.Spec.Target.Name
 	namespace := vmRestore.Namespace
 
 	causes = admitter.validatePatches(vmRestore.Spec.Patches, field.Child("patches"))
 
-	vm, err := admitter.Client.VirtualMachine(namespace).Get(context.Background(), vmName, metav1.GetOptions{})
+	vm, err := admitter.Client.VirtualMachine(namespace).Get(ctx, vmName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// If the target VM does not exist it would be automatically created by the restore controller
 		return nil, nil, false, nil
@@ -263,8 +264,8 @@ func (admitter *VMRestoreAdmitter) validatePatches(patches []string, field *k8sf
 	return causes
 }
 
-func (admitter *VMRestoreAdmitter) validateSnapshot(field *k8sfield.Path, namespace, name string, targetUID *types.UID, targetVMExists bool) ([]metav1.StatusCause, error) {
-	snapshot, err := admitter.Client.VirtualMachineSnapshot(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func (admitter *VMRestoreAdmitter) validateSnapshot(ctx context.Context, field *k8sfield.Path, namespace, name string, targetUID *types.UID, targetVMExists bool) ([]metav1.StatusCause, error) {
+	snapshot, err := admitter.Client.VirtualMachineSnapshot(namespace).Get(ctx, name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return []metav1.StatusCause{
 			{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -60,7 +60,7 @@ func NewVMRestoreAdmitter(config *virtconfig.ClusterConfig, client kubecli.Kubev
 }
 
 // Admit validates an AdmissionReview
-func (admitter *VMRestoreAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMRestoreAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if ar.Request.Resource.Group != snapshotv1.SchemeGroupVersion.Group ||
 		ar.Request.Resource.Resource != "virtualmachinerestores" {
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource %+v", ar.Request.Resource))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			}
 
 			ar := createRestoreAdmissionReview(restore)
-			resp := createTestVMRestoreAdmitter(config, nil).Admit(ar)
+			resp := createTestVMRestoreAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(Equal("Snapshot/Restore feature gate not enabled"))
 		})
@@ -129,7 +129,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				},
 			}
 
-			resp := createTestVMRestoreAdmitter(config, nil).Admit(ar)
+			resp := createTestVMRestoreAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("unexpected resource"))
 		})
@@ -150,7 +150,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			}
 
 			ar := createRestoreAdmissionReview(restore)
-			resp := createTestVMRestoreAdmitter(config, nil, snapshot).Admit(ar)
+			resp := createTestVMRestoreAdmitter(config, nil, snapshot).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target.apiGroup"))
@@ -173,7 +173,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			}
 
 			ar := createRestoreAdmissionReview(restore)
-			resp := createTestVMRestoreAdmitter(config, nil).Admit(ar)
+			resp := createTestVMRestoreAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
@@ -211,7 +211,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			}
 
 			ar := createRestoreUpdateAdmissionReview(oldRestore, restore)
-			resp := createTestVMRestoreAdmitter(config, nil).Admit(ar)
+			resp := createTestVMRestoreAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
@@ -248,7 +248,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			}
 
 			ar := createRestoreUpdateAdmissionReview(oldRestore, restore)
-			resp := createTestVMRestoreAdmitter(config, nil).Admit(ar)
+			resp := createTestVMRestoreAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -283,7 +283,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				vm.Spec.Running = &t
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
@@ -308,7 +308,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				vm.Spec.RunStrategy = &runStrategyManual
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
@@ -334,7 +334,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				vm.Spec.Running = &f
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
@@ -361,7 +361,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				s.Status.Phase = snapshotv1.Failed
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, s).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, s).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("VirtualMachineSnapshot %q has failed and is invalid to use", vmSnapshotName)))
@@ -388,7 +388,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				s.Status.ReadyToUse = &f
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, s).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, s).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
@@ -413,7 +413,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				vm.Spec.Running = &t
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target.kind"))
@@ -439,7 +439,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				vm.Spec.Running = &t
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target.apiGroup"))
@@ -480,7 +480,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				}
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot, restoreInProcess).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, snapshot, restoreInProcess).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
@@ -502,7 +502,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				vm.Spec.Running = &f
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeTrue())
 			})
 
@@ -528,7 +528,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				}
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, targetVM, snapshot).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, targetVM, snapshot).Admit(context.Background(), ar)
 
 				if doesTargetExist {
 					Expect(resp.Allowed).To(BeFalse())
@@ -570,7 +570,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					restore.Spec.Patches = []string{string(patchBytes)}
 
 					ar := createRestoreAdmissionReview(restore)
-					resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+					resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 					Expect(resp.Allowed).To(BeFalse())
 					Expect(resp.Result.Details.Causes).To(HaveLen(1))
 					Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.patches"))
@@ -589,7 +589,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					restore.Spec.Patches = []string{string(patchBytes)}
 
 					ar := createRestoreAdmissionReview(restore)
-					resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+					resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 					Expect(resp.Allowed).To(BeTrue())
 				},
 					Entry("patch to replace MAC", patch.New(patch.WithReplace("/spec/template/spec/domain/devices/interfaces/0/macAddress", "some-value"))),
@@ -604,7 +604,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					restore.Spec.Patches = []string{invalidPatch}
 
 					ar := createRestoreAdmissionReview(restore)
-					resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+					resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 					Expect(resp.Allowed).To(BeFalse())
 					Expect(resp.Result.Details.Causes).To(HaveLen(1))
 					Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.patches"))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -115,7 +115,7 @@ func NewVMsAdmitter(clusterConfig *virtconfig.ClusterConfig, client kubecli.Kube
 	}
 }
 
-func (admitter *VMsAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMsAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if !webhookutils.ValidateRequestResource(ar.Request.Resource, webhooks.VirtualMachineGroupVersionResource.Group, webhooks.VirtualMachineGroupVersionResource.Resource) {
 		err := fmt.Errorf("expect resource to be '%s'", webhooks.VirtualMachineGroupVersionResource.Resource)
 		return webhookutils.ToAdmissionResponseError(err)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1438,7 +1438,7 @@ var _ = Describe("Validating VM Admitter", func() {
 
 			vmsAdmitter.cloneAuthFunc = makeCloneAdmitFunc(k8sClient, expectedSourceNamespace, "whocares",
 				expectedTargetNamespace, expectedServiceAccount)
-			causes, err := vmsAdmitter.authorizeVirtualMachineSpec(ar, vm)
+			causes, err := vmsAdmitter.authorizeVirtualMachineSpec(context.Background(), ar, vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(causes).To(BeEmpty())
 		},
@@ -1529,7 +1529,7 @@ var _ = Describe("Validating VM Admitter", func() {
 				expectedTargetNamespace,
 				expectedServiceAccount)
 
-			causes, err := vmsAdmitter.authorizeVirtualMachineSpec(ar, vm)
+			causes, err := vmsAdmitter.authorizeVirtualMachineSpec(context.Background(), ar, vm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(causes).To(BeEmpty())
 		},
@@ -1569,7 +1569,7 @@ var _ = Describe("Validating VM Admitter", func() {
 			ar := &admissionv1.AdmissionRequest{}
 
 			vmsAdmitter.cloneAuthFunc = makeCloneAdmitFailFunc(failMessage, failErr)
-			causes, err := vmsAdmitter.authorizeVirtualMachineSpec(ar, vm)
+			causes, err := vmsAdmitter.authorizeVirtualMachineSpec(context.Background(), ar, vm)
 			if failErr != nil {
 				Expect(err).To(Equal(failErr))
 			} else {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
@@ -56,7 +56,7 @@ func NewVMSnapshotAdmitter(config *virtconfig.ClusterConfig, client kubecli.Kube
 }
 
 // Admit validates an AdmissionReview
-func (admitter *VMSnapshotAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMSnapshotAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if ar.Request.Resource.Group != snapshotv1.SchemeGroupVersion.Group ||
 		ar.Request.Resource.Resource != "virtualmachinesnapshots" {
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource %+v", ar.Request.Resource))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
@@ -56,7 +56,7 @@ func NewVMSnapshotAdmitter(config *virtconfig.ClusterConfig, client kubecli.Kube
 }
 
 // Admit validates an AdmissionReview
-func (admitter *VMSnapshotAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *VMSnapshotAdmitter) Admit(ctx context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if ar.Request.Resource.Group != snapshotv1.SchemeGroupVersion.Group ||
 		ar.Request.Resource.Resource != "virtualmachinesnapshots" {
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("unexpected resource %+v", ar.Request.Resource))
@@ -94,7 +94,7 @@ func (admitter *VMSnapshotAdmitter) Admit(_ context.Context, ar *admissionv1.Adm
 		case core.GroupName:
 			switch vmSnapshot.Spec.Source.Kind {
 			case "VirtualMachine":
-				causes, err = admitter.validateCreateVM(sourceField.Child("name"), ar.Request.Namespace, vmSnapshot.Spec.Source.Name)
+				causes, err = admitter.validateCreateVM(ctx, sourceField.Child("name"), ar.Request.Namespace, vmSnapshot.Spec.Source.Name)
 				if err != nil {
 					return webhookutils.ToAdmissionResponseError(err)
 				}
@@ -147,8 +147,8 @@ func (admitter *VMSnapshotAdmitter) Admit(_ context.Context, ar *admissionv1.Adm
 	return &reviewResponse
 }
 
-func (admitter *VMSnapshotAdmitter) validateCreateVM(field *k8sfield.Path, namespace, name string) ([]metav1.StatusCause, error) {
-	vm, err := admitter.Client.VirtualMachine(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func (admitter *VMSnapshotAdmitter) validateCreateVM(ctx context.Context, field *k8sfield.Path, namespace, name string) ([]metav1.StatusCause, error) {
+	vm, err := admitter.Client.VirtualMachine(namespace).Get(ctx, name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return []metav1.StatusCause{
 			{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			}
 
 			ar := createSnapshotAdmissionReview(snapshot)
-			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
+			resp := createTestVMSnapshotAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(Equal("snapshot feature gate not enabled"))
 		})
@@ -103,7 +103,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				},
 			}
 
-			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
+			resp := createTestVMSnapshotAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("unexpected resource"))
 		})
@@ -114,7 +114,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			}
 
 			ar := createSnapshotAdmissionReview(snapshot)
-			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
+			resp := createTestVMSnapshotAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.apiGroup"))
@@ -132,7 +132,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			}
 
 			ar := createSnapshotAdmissionReview(snapshot)
-			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
+			resp := createTestVMSnapshotAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.name"))
@@ -160,7 +160,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			}
 
 			ar := createSnapshotUpdateAdmissionReview(oldSnapshot, snapshot)
-			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
+			resp := createTestVMSnapshotAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
@@ -191,7 +191,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			}
 
 			ar := createSnapshotUpdateAdmissionReview(oldSnapshot, snapshot)
-			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
+			resp := createTestVMSnapshotAdmitter(config, nil).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -221,7 +221,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				vm.Spec.Running = &t
 
 				ar := createSnapshotAdmissionReview(snapshot)
-				resp := createTestVMSnapshotAdmitter(config, vm).Admit(ar)
+				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeTrue())
 			})
 
@@ -240,7 +240,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				vm.Spec.Running = &t
 
 				ar := createSnapshotAdmissionReview(snapshot)
-				resp := createTestVMSnapshotAdmitter(config, vm).Admit(ar)
+				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.kind"))
@@ -262,7 +262,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				vm.Spec.Running = &t
 
 				ar := createSnapshotAdmissionReview(snapshot)
-				resp := createTestVMSnapshotAdmitter(config, vm).Admit(ar)
+				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.apiGroup"))
@@ -291,7 +291,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				}
 
 				ar := createSnapshotAdmissionReview(snapshot)
-				resp := createTestVMSnapshotAdmitter(config, vm).Admit(ar)
+				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.name"))
@@ -313,7 +313,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				vm.Spec.Running = &f
 
 				ar := createSnapshotAdmissionReview(snapshot)
-				resp := createTestVMSnapshotAdmitter(config, vm).Admit(ar)
+				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeTrue())
 			})
 		})
@@ -371,9 +371,9 @@ func createTestVMSnapshotAdmitter(config *virtconfig.ClusterConfig, vm *v1.Virtu
 	virtClient.EXPECT().VirtualMachine(gomock.Any()).Return(vmInterface).AnyTimes()
 	if vm == nil {
 		err := errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, "foo")
-		vmInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).Return(nil, err).AnyTimes()
+		vmInterface.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, err).AnyTimes()
 	} else {
-		vmInterface.EXPECT().Get(context.Background(), vm.Name, gomock.Any()).Return(vm, nil).AnyTimes()
+		vmInterface.EXPECT().Get(gomock.Any(), vm.Name, gomock.Any()).Return(vm, nil).AnyTimes()
 	}
 	return &VMSnapshotAdmitter{Config: config, Client: virtClient}
 }

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
@@ -51,7 +51,7 @@ type kubeVirtCreateAdmitter struct {
 // check for creation of a new KubeVirt CR (rejecting it), no validation can be done here
 // as that is done in the 'kubevirt-update-validator.kubevirt.io' webhook
 
-func (k *kubeVirtCreateAdmitter) Admit(review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (k *kubeVirtCreateAdmitter) Admit(_ context.Context, review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	log.Log.Info("Trying to create KV")
 	if resp := webhooks.ValidateSchema(v1.KubeVirtGroupVersionKind, review.Request.Object.Raw); resp != nil {
 		return resp

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter.go
@@ -51,7 +51,7 @@ type kubeVirtCreateAdmitter struct {
 // check for creation of a new KubeVirt CR (rejecting it), no validation can be done here
 // as that is done in the 'kubevirt-update-validator.kubevirt.io' webhook
 
-func (k *kubeVirtCreateAdmitter) Admit(_ context.Context, review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (k *kubeVirtCreateAdmitter) Admit(ctx context.Context, review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	log.Log.Info("Trying to create KV")
 	if resp := webhooks.ValidateSchema(v1.KubeVirtGroupVersionKind, review.Request.Object.Raw); resp != nil {
 		return resp
@@ -59,7 +59,7 @@ func (k *kubeVirtCreateAdmitter) Admit(_ context.Context, review *admissionv1.Ad
 	//TODO: Do we want semantic validation
 
 	// Best effort
-	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	list, err := k.client.KubeVirt(k8sv1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return webhooks.ToAdmissionResponseError(err)
 	}

--- a/pkg/virt-operator/webhooks/kubevirt-create-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-create-admitter_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Validating KubeVirtCreate Admitter", func() {
 				Name:      "Existing",
 			},
 		}
-		kvInterface.EXPECT().List(context.Background(), gomock.Any()).
+		kvInterface.EXPECT().List(gomock.Any(), gomock.Any()).
 			Return(&v1.KubeVirtList{Items: []v1.KubeVirt{alreadyExistingKv}}, nil).AnyTimes()
 
 		newKv := v1.KubeVirt{
@@ -55,12 +55,12 @@ var _ = Describe("Validating KubeVirtCreate Admitter", func() {
 			},
 		}
 
-		response := admitter.Admit(review)
+		response := admitter.Admit(context.Background(), review)
 		Expect(response.Allowed).To(BeFalse(), "Additional attempts to create Kubevirt should fail")
 	})
 
 	It("should allow creating new Kubevirt resource", func() {
-		kvInterface.EXPECT().List(context.Background(), gomock.Any()).
+		kvInterface.EXPECT().List(gomock.Any(), gomock.Any()).
 			Return(&v1.KubeVirtList{Items: []v1.KubeVirt{}}, nil).AnyTimes()
 
 		newKv := v1.KubeVirt{
@@ -81,7 +81,7 @@ var _ = Describe("Validating KubeVirtCreate Admitter", func() {
 			},
 		}
 
-		response := admitter.Admit(review)
+		response := admitter.Admit(context.Background(), review)
 		Expect(response.Allowed).To(BeTrue(), "Create Kubevirt should be allowed")
 	})
 })

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -63,7 +63,7 @@ func NewKubeVirtUpdateAdmitter(client kubecli.KubevirtClient, clusterConfig *vir
 	}
 }
 
-func (admitter *KubeVirtUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (admitter *KubeVirtUpdateAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	// Get new and old KubeVirt from admission response
 	newKV, currKV, err := getAdmissionReviewKubeVirt(ar)
 	if err != nil {

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -20,6 +20,7 @@
 package webhooks
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -172,7 +173,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			admitter = NewKubeVirtUpdateAdmitter(nil, clusterConfig)
 		})
 
-		admit := func(kubevirt v1.KubeVirt) *admissionv1.AdmissionResponse {
+		admit := func(ctx context.Context, kubevirt v1.KubeVirt) *admissionv1.AdmissionResponse {
 			kvBytes, err := json.Marshal(kubevirt)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -188,7 +189,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 					Operation: admissionv1.Update,
 				},
 			}
-			return admitter.Admit(request)
+			return admitter.Admit(ctx, request)
 		}
 
 		const warn = true
@@ -206,7 +207,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				},
 			}
 
-			response := admit(kvObject)
+			response := admit(context.Background(), kvObject)
 			Expect(response).NotTo(BeNil())
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
@@ -241,7 +242,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				},
 			}
 
-			response := admit(kvObject)
+			response := admit(context.Background(), kvObject)
 			Expect(response).NotTo(BeNil())
 			if shouldWarn {
 				Expect(response.Warnings).NotTo(BeEmpty())
@@ -298,7 +299,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				},
 			}
 
-			Expect(admitter.Admit(request)).To(Equal(&admissionv1.AdmissionResponse{
+			Expect(admitter.Admit(context.Background(), request)).To(Equal(&admissionv1.AdmissionResponse{
 				Allowed: true,
 				Warnings: []string{
 					expectedWarning,

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -32,7 +32,7 @@ type KubeVirtDeletionAdmitter struct {
 	client kubecli.KubevirtClient
 }
 
-func (k *KubeVirtDeletionAdmitter) Admit(review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (k *KubeVirtDeletionAdmitter) Admit(_ context.Context, review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	var kv *v1.KubeVirt
 	var err error
 	if review.Request.Name != "" {

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -32,16 +32,16 @@ type KubeVirtDeletionAdmitter struct {
 	client kubecli.KubevirtClient
 }
 
-func (k *KubeVirtDeletionAdmitter) Admit(_ context.Context, review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func (k *KubeVirtDeletionAdmitter) Admit(ctx context.Context, review *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	var kv *v1.KubeVirt
 	var err error
 	if review.Request.Name != "" {
-		kv, err = k.client.KubeVirt(review.Request.Namespace).Get(context.Background(), review.Request.Name, metav1.GetOptions{})
+		kv, err = k.client.KubeVirt(review.Request.Namespace).Get(ctx, review.Request.Name, metav1.GetOptions{})
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}
 	} else {
-		list, err := k.client.KubeVirt(review.Request.Namespace).List(context.Background(), metav1.ListOptions{})
+		list, err := k.client.KubeVirt(review.Request.Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}
@@ -60,7 +60,7 @@ func (k *KubeVirtDeletionAdmitter) Admit(_ context.Context, review *admissionv1.
 		return validating_webhooks.NewPassingAdmissionResponse()
 	}
 
-	vmis, err := k.client.VirtualMachineInstance(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{Limit: 2})
+	vmis, err := k.client.VirtualMachineInstance(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 2})
 
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
@@ -70,7 +70,7 @@ func (k *KubeVirtDeletionAdmitter) Admit(_ context.Context, review *admissionv1.
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf(uninstallErrorMsg, "Virtual Machine Instances"))
 	}
 
-	vms, err := k.client.VirtualMachine(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{Limit: 2})
+	vms, err := k.client.VirtualMachine(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 2})
 
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
@@ -80,7 +80,7 @@ func (k *KubeVirtDeletionAdmitter) Admit(_ context.Context, review *admissionv1.
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf(uninstallErrorMsg, "Virtual Machines"))
 	}
 
-	vmirs, err := k.client.ReplicaSet(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{Limit: 2})
+	vmirs, err := k.client.ReplicaSet(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 2})
 
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)

--- a/pkg/virt-operator/webhooks/webhook_test.go
+++ b/pkg/virt-operator/webhooks/webhook_test.go
@@ -56,14 +56,14 @@ var _ = Describe("Webhook", func() {
 			vmInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineList{}, nil)
 			vmirsInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{}, nil)
 
-			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeTrue())
 		})
 
 		It("should deny the deletion if a VMI exists", func() {
 			vmiInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceList{Items: []k6tv1.VirtualMachineInstance{{}}}, nil)
 
-			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
@@ -71,7 +71,7 @@ var _ = Describe("Webhook", func() {
 			vmiInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceList{}, nil)
 			vmInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineList{Items: []k6tv1.VirtualMachine{{}}}, nil)
 
-			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
@@ -80,14 +80,14 @@ var _ = Describe("Webhook", func() {
 			vmInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineList{}, nil)
 			vmirsInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{Items: []k6tv1.VirtualMachineInstanceReplicaSet{{}}}, nil)
 
-			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
 		It("should deny the deletion if checking VMIs fails", func() {
 			vmiInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceList{}, fmt.Errorf("whatever"))
 
-			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("Webhook", func() {
 			vmiInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceList{}, nil)
 			vmInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineList{}, fmt.Errorf("whatever"))
 
-			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeFalse())
 		})
 
@@ -104,33 +104,33 @@ var _ = Describe("Webhook", func() {
 			vmInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineList{}, nil)
 			vmirsInterface.EXPECT().List(context.Background(), gomock.Any()).Return(&k6tv1.VirtualMachineInstanceReplicaSetList{}, fmt.Errorf("whatever"))
 
-			response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+			response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 			Expect(response.Allowed).To(BeFalse())
 		})
 	})
 
 	It("should allow the deletion if the strategy is empty", func() {
 		kv.Spec.UninstallStrategy = ""
-		response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 		Expect(response.Allowed).To(BeTrue())
 	})
 
 	It("should allow the deletion if the strategy is set to RemoveWorkloads", func() {
 		kv.Spec.UninstallStrategy = k6tv1.KubeVirtUninstallStrategyRemoveWorkloads
-		response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 		Expect(response.Allowed).To(BeTrue())
 	})
 
 	It("should allow the deletion of namespaces, where it gets an admission request without a resource name", func() {
 		kv.Spec.UninstallStrategy = k6tv1.KubeVirtUninstallStrategyRemoveWorkloads
-		response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: ""}})
+		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: ""}})
 		Expect(response.Allowed).To(BeTrue())
 	})
 
 	DescribeTable("should not check for workloads if kubevirt phase is", func(phase k6tv1.KubeVirtPhase) {
 		kv.Spec.UninstallStrategy = k6tv1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
 		kv.Status.Phase = phase
-		response := admitter.Admit(&admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
+		response := admitter.Admit(context.Background(), &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{Namespace: "test", Name: "kubevirt"}})
 		Expect(response.Allowed).To(BeTrue())
 	},
 		Entry("unset", k6tv1.KubeVirtPhase("")),


### PR DESCRIPTION
### What this PR does

webhooks are sometimes making k8s calls using the virtClient. These calls are not preferred, because they break the eventual consistency concept of K8s, by checking the current status of the cluster, that may later be fixed.

The current k8s calls are done with a new context - this is useless, because it only satisfy the client api, but we still can't cancel the i/o operations (both manually, or with timeout). If an i/o operation does not return, it may cause goroutine leaks.

After this PR:
Now all the k8s calls are using a context that is sent from the Serve function, and may be canceled if needed.

### Why we need it and why it was done in this way
Prevent potential memory leak (goroutine leak).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add timeout to validation webhooks
```

