### PR TITLE
tests/scale/virt-api.go: replace update api call with patch

### DIFF
--- a/tests/scale/BUILD.bazel
+++ b/tests/scale/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/decorators:go_default_library",
+        "//tests/flags:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/tests/scale/BUILD.bazel
+++ b/tests/scale/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/scale",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -15,5 +16,6 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )


### PR DESCRIPTION
### What this PR does
This PR enhances the efficiency and reliability of the `tests/scale/virt-api.go` by replacing the `Update` operation with the `Patch` operation.
This PR also removed redundant func `restorescc` and refactors  the `getApiReplicas` func

**Efficiency** - The `Patch` operation is more efficient for specific changes compared to the `Update` operation.

**Reliability** - Using `Patch` reduces the likelihood of conflicts and failures, especially when multiple changes are being made to the resource concurrently.

### Release note

```release-note
NONE
```
