### PR TITLE
virtctl: Prioritize specified identity file over SSH agent

### DIFF
--- a/pkg/virtctl/ssh/native.go
+++ b/pkg/virtctl/ssh/native.go
@@ -94,8 +94,8 @@ func (o *NativeSSHConnection) PrepareSSHClient(kind, namespace, name string) (*s
 func (o *NativeSSHConnection) getAuthMethods(kind, namespace, name string) []ssh.AuthMethod {
 	var methods []ssh.AuthMethod
 
-	methods = o.trySSHAgent(methods)
 	methods = o.tryPrivateKey(methods)
+	methods = o.trySSHAgent(methods)
 
 	methods = append(methods, ssh.PasswordCallback(func() (secret string, err error) {
 		password, err := readPassword(fmt.Sprintf("%s@%s/%s.%s's password: ", o.Options.SSHUsername, kind, name, namespace))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR fixes a bug in `virtctl ssh` described in https://github.com/kubevirt/kubevirt/issues/7072#issuecomment-2205078403.

Before this PR:
Even when an SSH private key is specified via `--identity-file / -i` option, `virtctl ssh` tries keys in SSH agent.
If the SSH agent has a number of keys, retries are exhausted before `virtctl ssh` uses the specified key.

After this PR:
`virtctl ssh` tries a specified SSH private key first.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:
N/A

The following alternatives were considered:
N/A

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... --> None

### Special notes for your reviewer

<!-- optional -->
None

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that `virtctl ssh` does not use specified SSH key in some cases
```

cc @0xFelix 