### PR TITLE
[WIP] persistent reservation tests: run in ordered container

### DIFF
--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -39,7 +39,7 @@ import (
 // feature gate PersistentReservation. The enablement/disablement of this
 // feature gate redeploys virt-handler pod, and this might interfer with other
 // tests.
-var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, Ordered, func() {
+var _ = SIGDescribe("[Serial]SCSI persistent reservation", Label("kvmanualreset"), Serial, Ordered, func() {
 	const randLen = 8
 	var (
 		naa          string

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -39,7 +39,7 @@ import (
 // feature gate PersistentReservation. The enablement/disablement of this
 // feature gate redeploys virt-handler pod, and this might interfer with other
 // tests.
-var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
+var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, Ordered, func() {
 	const randLen = 8
 	var (
 		naa          string
@@ -181,7 +181,8 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 
 		}, 90*time.Second, 1*time.Second).Should(BeTrue())
 	}
-	BeforeEach(func() {
+
+	BeforeAll(func() {
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
@@ -190,11 +191,6 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 			tests.EnableFeatureGate(virtconfig.PersistentReservation)
 		}
 
-	})
-	AfterEach(func() {
-		if fgDisabled {
-			tests.DisableFeatureGate(virtconfig.PersistentReservation)
-		}
 	})
 
 	Context("Use LUN disk with presistent reservation", func() {
@@ -311,8 +307,8 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 		})
 	})
 
-	Context("with PersistentReservation feature gate toggled", func() {
-		It("should delete and recreate virt-handler", func() {
+	AfterAll(func() {
+		if fgDisabled {
 			tests.DisableFeatureGate(virtconfig.PersistentReservation)
 
 			Eventually(func() bool {
@@ -337,7 +333,6 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(BeEmpty())
 			}
-		})
+		}
 	})
-
 })

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -166,5 +166,10 @@ func resetToDefaultConfig() {
 		// we can just skip the restore step.
 		return
 	}
+	if ok, _ := CurrentSpecReport().MatchesLabelFilter("kvmanualreset"); ok {
+		// Some expensive tests (especially ordered containers) rely on restoring state themselves
+		// And not have it reverted mid-run
+		return
+	}
 	tests.UpdateKubeVirtConfigValueAndWait(testsuite.KubeVirtDefaultConfig)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Refactor the long persistent reservation suite to only perform teardown once after it's done.

This allows us to avoid re-rolling out the feature gate change for each
test. BeforeAll and AfterAll readout: https://onsi.github.io/ginkgo/#setup-in-ordered-containers-beforeall-and-afterall

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

