### PR TITLE
tests, libstorage: Patch CDI instead of Update

### DIFF
--- a/tests/libstorage/BUILD.bazel
+++ b/tests/libstorage/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libstorage",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util/net/ip:go_default_library",
@@ -38,6 +39,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",


### PR DESCRIPTION
### What this PR does
Before this PR: CDI is updated
After this PR: CDI is patched

jira-ticket: https://issues.redhat.com/browse/CNV-44575

### Why we need it and why it was done in this way
Use Patch instead of Update whenever possible for shortening the tests and reducing potential conflicts.

### Release note
```release-note
NONE
```

