### PR TITLE
validating webhooks: Unexport the Admitter interface

### DIFF
--- a/pkg/util/webhooks/validating-webhooks/validating-webhook.go
+++ b/pkg/util/webhooks/validating-webhooks/validating-webhook.go
@@ -14,7 +14,7 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-type Admitter interface {
+type admitter interface {
 	Admit(*admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
 }
 
@@ -55,7 +55,7 @@ func NewAdmissionResponse(causes []v1.StatusCause) *admissionv1.AdmissionRespons
 	}
 }
 
-func Serve(resp http.ResponseWriter, req *http.Request, admitter Admitter) {
+func Serve(resp http.ResponseWriter, req *http.Request, admitter admitter) {
 	review, err := webhooks.GetAdmissionReview(req)
 	if err != nil {
 		resp.WriteHeader(http.StatusBadRequest)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter.go
@@ -15,7 +15,6 @@ import (
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
-	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )
 
 const percentValueMustBeInRangeMessagePattern = "%s '%d': must be in range between 0 and 100."
@@ -27,8 +26,6 @@ var supportedInstancetypeVersions = []string{
 }
 
 type InstancetypeAdmitter struct{}
-
-var _ validating_webhooks.Admitter = &InstancetypeAdmitter{}
 
 func (f *InstancetypeAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return admitInstancetype(ar.Request, instancetype.PluralResourceName)
@@ -69,8 +66,6 @@ func validateMemoryOvercommitPercentNoHugepages(field *k8sfield.Path, spec *inst
 }
 
 type ClusterInstancetypeAdmitter struct{}
-
-var _ validating_webhooks.Admitter = &ClusterInstancetypeAdmitter{}
 
 func (f *ClusterInstancetypeAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return admitInstancetype(ar.Request, instancetype.ClusterPluralResourceName)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/preference-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/preference-admitter.go
@@ -14,20 +14,15 @@ import (
 
 	instancetype "kubevirt.io/kubevirt/pkg/instancetype"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
-	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )
 
 type PreferenceAdmitter struct{}
-
-var _ validating_webhooks.Admitter = &PreferenceAdmitter{}
 
 func (f *PreferenceAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return admitPreference(ar.Request, instancetypeapi.PluralPreferenceResourceName)
 }
 
 type ClusterPreferenceAdmitter struct{}
-
-var _ validating_webhooks.Admitter = &ClusterPreferenceAdmitter{}
 
 func (f *ClusterPreferenceAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return admitPreference(ar.Request, instancetypeapi.ClusterPluralPreferenceResourceName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the `Admitter` interface is exported and the following structs (validating webhooks [1]) are "explicitly declaring" that they implement the `Admitter` interface:
- InstancetypeAdmitter
- ClusterInstancetypeAdmitter
- PreferenceAdmitter
- ClusterPreferenceAdmitter

This explicit declaration makes them dependent on the following package: "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"

Unexport the `Admitter` interface in order to decouple usage from implementation.

In case one of the admitters will accidentally stop implementing the `admitter` interface, the `Serve` [2] function will not accept it as an admitter and the compilation will break.

This change is also aligned with the `mutator` [3] interface which represents mutating webhooks [4].

[1] https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook

[2] https://github.com/kubevirt/kubevirt/blob/b5d3131f96a965e1cbd0e72d1e303146cdf2d5e1/pkg/util/webhooks/validating-webhooks/validating-webhook.go#L58

[3] https://github.com/kubevirt/kubevirt/blob/3bb20aa5d029cd667057d6445a07a0185d482b01/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go#L40

[4] https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

