### PR TITLE
[release-1.1] Fix tests to pass with snapshotable wffc storage

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -556,7 +556,13 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 				})
 
 				It("with a simple clone", func() {
-					sourceVM = createVMWithStorageClass(snapshotStorageClass, false)
+					running := false
+					if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(snapshotStorageClass) {
+						// with wffc need to start the virtual machine
+						// in order for the pvc to be populated
+						running = true
+					}
+					sourceVM = createVMWithStorageClass(snapshotStorageClass, running)
 					vmClone = generateCloneFromVM()
 
 					createCloneAndWaitForFinish(vmClone)
@@ -682,7 +688,14 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 						return vmclone
 					}
 
-					sourceVM = createVMWithStorageClass(snapshotStorageClass, false)
+					running := false
+					wffcSC := libstorage.IsStorageClassBindingModeWaitForFirstConsumer(snapshotStorageClass)
+					if wffcSC {
+						// with wffc need to start the virtual machine
+						// in order for the pvc to be populated
+						running = true
+					}
+					sourceVM = createVMWithStorageClass(snapshotStorageClass, running)
 					vmClone = generateCloneWithFilters(sourceVM, targetVMName)
 
 					createCloneAndWaitForFinish(vmClone)
@@ -690,6 +703,10 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 					By(fmt.Sprintf("Getting the target VM %s", targetVMName))
 					targetVM, err = virtClient.VirtualMachine(sourceVM.Namespace).Get(context.Background(), targetVMName, &v1.GetOptions{})
 					Expect(err).ShouldNot(HaveOccurred())
+					if wffcSC {
+						// run the virtual machine for the clone dv to be populated
+						expectVMRunnable(targetVM)
+					}
 
 					By("Creating another clone from the target VM")
 					const cloneFromCloneName = "vm-clone-from-clone"

--- a/tests/framework/matcher/phase.go
+++ b/tests/framework/matcher/phase.go
@@ -27,6 +27,12 @@ func HaveSucceeded() types.GomegaMatcher {
 	}
 }
 
+func PendingPopulation() types.GomegaMatcher {
+	return phaseMatcher{
+		expectedPhase: "PendingPopulation",
+	}
+}
+
 func BeInPhase(phase interface{}) types.GomegaMatcher {
 	return phaseMatcher{
 		expectedPhase: phase,

--- a/tests/framework/matcher/phase.go
+++ b/tests/framework/matcher/phase.go
@@ -33,6 +33,10 @@ func PendingPopulation() types.GomegaMatcher {
 	}
 }
 
+func WaitForFirstConsumer() types.GomegaMatcher {
+	return Or(BeInPhase("WaitForFirstConsumer"), PendingPopulation())
+}
+
 func BeInPhase(phase interface{}) types.GomegaMatcher {
 	return phaseMatcher{
 		expectedPhase: phase,

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2144,7 +2144,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libstorage.EventuallyDV(dv, 600, HaveSucceeded())
+				libstorage.EventuallyDV(dv, 600, Or(HaveSucceeded(), PendingPopulation()))
 				vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
 				tests.AddUserData(vmi, "disk1", "#!/bin/bash\n echo hello\n")
 				return vmi

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1049,7 +1049,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -246,7 +246,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				// This will only work on storage with binding mode WaitForFirstConsumer,
 				if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-					Eventually(ThisDV(dataVolume), 40).Should(Or(BeInPhase(cdiv1.WaitForFirstConsumer), BeInPhase(cdiv1.PendingPopulation)))
+					Eventually(ThisDV(dataVolume), 40).Should(WaitForFirstConsumer())
 				}
 				num := 2
 				By("Starting and stopping the VirtualMachineInstance a number of times")
@@ -327,7 +327,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Expect(err).ToNot(HaveOccurred())
 				// This will only work on storage with binding mode WaitForFirstConsumer,
 				if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-					Eventually(ThisDV(dataVolume), 40).Should(Or(BeInPhase(cdiv1.WaitForFirstConsumer), BeInPhase(cdiv1.PendingPopulation)))
+					Eventually(ThisDV(dataVolume), 40).Should(WaitForFirstConsumer())
 				}
 				// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
 				// import and start

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1294,11 +1294,18 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when storage with snapshot is not present")
 		}
 
-		vm := createVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
+		vm := tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 			cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 			testsuite.GetTestNamespace(nil),
 			bashHelloScript,
-			sc))
+			sc)
+		if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+			// In WFFC need to start the VM in order for the
+			// dv to get populated
+			vm.Spec.Running = pointer.Bool(true)
+		}
+		vm = createVM(vm)
+		stopVM(vm)
 		snapshot := createAndVerifyVMSnapshot(vm)
 		Expect(snapshot).ToNot(BeNil())
 		defer deleteSnapshot(snapshot)
@@ -1373,6 +1380,11 @@ var _ = SIGDescribe("Export", func() {
 			sc)
 		libstorage.AddDataVolumeTemplate(vm, blankDv)
 		addDataVolumeDisk(vm, "blankdisk", blankDv.Name)
+		if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+			// In WFFC need to start the VM in order for the
+			// dv to get populated
+			vm.Spec.Running = pointer.Bool(true)
+		}
 		vm = createVM(vm)
 		stopVM(vm)
 		snapshot := createAndVerifyVMSnapshot(vm)
@@ -2149,7 +2161,13 @@ var _ = SIGDescribe("Export", func() {
 				sc)
 			libstorage.AddDataVolumeTemplate(vm, blankDv)
 			addDataVolumeDisk(vm, "blankdisk", blankDv.Name)
+			if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+				// In WFFC need to start the VM in order for the
+				// dv to get populated
+				vm.Spec.Running = pointer.Bool(true)
+			}
 			vm = createVM(vm)
+			vm = stopVM(vm)
 			snapshot := createAndVerifyVMSnapshot(vm)
 			Expect(snapshot).ToNot(BeNil())
 			defer deleteSnapshot(snapshot)
@@ -2299,7 +2317,13 @@ var _ = SIGDescribe("Export", func() {
 					sc)
 				libstorage.AddDataVolumeTemplate(vm, blankDv)
 				addDataVolumeDisk(vm, "blankdisk", blankDv.Name)
+				if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+					// In WFFC need to start the VM in order for the
+					// dv to get populated
+					vm.Spec.Running = pointer.Bool(true)
+				}
 				vm = createVM(vm)
+				vm = stopVM(vm)
 				snapshot := createAndVerifyVMSnapshot(vm)
 				Expect(snapshot).ToNot(BeNil())
 				defer deleteSnapshot(snapshot)

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -172,7 +172,8 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 				"--image-path", imagePath,
 				sizeArg, pvcSize,
 				"--storage-class", sc,
-				"--block-volume",
+				"--force-bind",
+				"--volume-mode", "block",
 				insecureArg)
 			err := virtctlCmd()
 			if err != nil {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -878,7 +878,7 @@ var _ = SIGDescribe("Storage", func() {
 					Skip("Skip test when Block storage is not present")
 				}
 
-				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), PendingPopulation(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 			})
 
 			AfterEach(func() {
@@ -1021,7 +1021,7 @@ var _ = SIGDescribe("Storage", func() {
 					Skip("Skip test when Block storage is not present")
 				}
 
-				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), PendingPopulation(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 				vmi = nil
 			})
 

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -878,7 +878,7 @@ var _ = SIGDescribe("Storage", func() {
 					Skip("Skip test when Block storage is not present")
 				}
 
-				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), PendingPopulation(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 			})
 
 			AfterEach(func() {
@@ -1021,7 +1021,7 @@ var _ = SIGDescribe("Storage", func() {
 					Skip("Skip test when Block storage is not present")
 				}
 
-				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), PendingPopulation(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 				vmi = nil
 			})
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -521,7 +521,7 @@ func NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc string, acc
 	var err error
 	dv, err = virtCli.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	libstorage.EventuallyDV(dv, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer), BeInPhase(cdiv1.PendingPopulation)))
+	libstorage.EventuallyDV(dv, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 	return NewRandomVMIWithDataVolume(dv.Name), dv
 }
 

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -44,6 +44,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -282,7 +283,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			Expect(err).ToNot(HaveOccurred())
 			By("Waiting until the DataVolume is ready")
 			if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-				Eventually(ThisDV(dataVolume), 30).Should(Or(BeInPhase(cdiv1.WaitForFirstConsumer), BeInPhase(cdiv1.PendingPopulation)))
+				Eventually(ThisDV(dataVolume), 30).Should(WaitForFirstConsumer())
 			}
 
 			virtiofsMountPath := fmt.Sprintf("/mnt/virtiofs_%s", dataVolume.Name)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2077,7 +2077,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Skip("Skip test when Block storage is not present")
 			}
 
-			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 		})
 
 		AfterEach(func() {
@@ -2209,7 +2209,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Skip("Skip test when Block storage is not present")
 			}
 
-			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 
 			vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
 
@@ -2247,7 +2247,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Skip("Skip test when Block storage is not present")
 			}
 
-			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 
 			vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

Manual backport of #11478

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

