### PR TITLE
kubevirt, ci: add GitHub issue template for flaky tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test_report.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test_report.md
@@ -49,6 +49,6 @@ Add any other context about the problem here.
 An infra issue is anything "below" the testcase
 
 * Add label commenting `/triage not-reproducible`
-* Move the issue to "Obsolete"
+* Close the issue, adding a comment with details about the infrastructure issue.
 
 After the flake has been fixed, document the learning from it inside the fix PR

--- a/.github/ISSUE_TEMPLATE/flaky_test_report.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test_report.md
@@ -1,0 +1,54 @@
+---
+name: Flake Report
+about: Report a flaky test in KubeVirt
+title: 'test_name'
+labels: kind/flake
+assignees: ''
+---
+
+# What happened
+
+<!-- insert test name -->
+Flaky test detected: {test_name} [1]
+
+<!-- labels for flaky tests -->
+/kind flake
+/priority critical-urgent
+
+<!-- sig assignment
+     all tests contain a sig identifier, please assign the corresponding SIG to the issue, i.e.
+     for a test name containing [sig-compute] or [sig-operator]
+-->
+/sig compute
+
+<!-- note: the flakefinder url needs to be a stable one, i.e. instead of the moving latest report use any with a date instead -->
+[1]: {flakefinder_url}
+
+## Additional context
+Add any other context about the problem here.
+
+# Flake Action Plan
+
+**As the assignee**, **thoroughly review the issue** and put the resulting report as comment into this issue.
+
+## Then decide on one of the following actions:
+
+### **The flake is a critical bug**
+
+* Add label commenting `/triage accepted`
+* **Create a PR to fix the bug**
+* Reference this issue in the PR
+* Keep this issue open until the testcase does not fail anymore
+
+### **The flake is non-critical or an issue that is hard to fix**
+* **Quarantine the test** by creating a pull request assigning [QUARANTINE] tag to test name
+* Reference this issue on the PR
+
+### There was an infrastructure issue
+
+An infra issue is anything "below" the testcase
+
+* Add label commenting `/triage not-reproducible`
+* Move the issue to "Obsolete"
+
+After the flake has been fixed, document the learning from it inside the fix PR

--- a/.github/ISSUE_TEMPLATE/flaky_test_report.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test_report.md
@@ -41,7 +41,7 @@ Add any other context about the problem here.
 * Keep this issue open until the testcase does not fail anymore
 
 ### **The flake is non-critical or an issue that is hard to fix**
-* **Quarantine the test** by creating a pull request assigning [QUARANTINE] tag to test name
+* **Quarantine the test** by creating a pull request assigning [QUARANTINE] tag to test name and [Quarantine decorator](https://github.com/kubevirt/kubevirt/blob/f85a8117b8a90fd913ec0719faae9506866d1525/tests/decorators/decorators.go#L7) to the test
 * Reference this issue on the PR
 
 ### There was an infrastructure issue

--- a/.github/ISSUE_TEMPLATE/flaky_test_report.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test_report.md
@@ -33,7 +33,7 @@ Add any other context about the problem here.
 
 ## Then decide on one of the following actions:
 
-### **The flake is a critical bug**
+### **The flake is a bug**
 
 * Add label commenting `/triage accepted`
 * **Create a PR to fix the bug**

--- a/.github/ISSUE_TEMPLATE/flaky_test_report.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test_report.md
@@ -48,7 +48,7 @@ Add any other context about the problem here.
 
 An infra issue is anything "below" the testcase
 
-* Add label commenting `/triage not-reproducible`
+* Add label commenting `/triage infra-issue`
 * Close the issue, adding a comment with details about the infrastructure issue.
 
 After the flake has been fixed, document the learning from it inside the fix PR


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Flaky tests had to be reported with the standard issue templates.

After this PR:
Adds a template with which flaky tests can be reported.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
/cc @brianmcarey @xpivarc 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

