### PR TITLE
Workload updater decrease test time and complexity

### DIFF
--- a/pkg/virt-controller/watch/workload-updater/BUILD.bazel
+++ b/pkg/virt-controller/watch/workload-updater/BUILD.bazel
@@ -55,7 +55,6 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -37,8 +37,6 @@ var _ = Describe("Workload Updater", func() {
 	var migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
 	var kubeVirtInterface *kubecli.MockKubeVirtInterface
 	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
-	var vmiSource *framework.FakeControllerSource
-	var vmiInformer cache.SharedIndexInformer
 	var migrationInformer cache.SharedIndexInformer
 	var migrationSource *framework.FakeControllerSource
 	var kubeVirtSource *framework.FakeControllerSource
@@ -53,12 +51,10 @@ var _ = Describe("Workload Updater", func() {
 	var expectedImage string
 
 	syncCaches := func(stop chan struct{}) {
-		go vmiInformer.Run(stop)
 		go migrationInformer.Run(stop)
 		go kubeVirtInformer.Run(stop)
 
 		Expect(cache.WaitForCacheSync(stop,
-			vmiInformer.HasSynced,
 			migrationInformer.HasSynced,
 			kubeVirtInformer.HasSynced,
 		)).To(BeTrue())
@@ -96,7 +92,7 @@ var _ = Describe("Workload Updater", func() {
 		kubeVirtInterface = kubecli.NewMockKubeVirtInterface(ctrl)
 		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 
-		vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstance{}, cache.Indexers{
+		vmiInformer, _ := testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstance{}, cache.Indexers{
 			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
 			"node": func(obj interface{}) (strings []string, e error) {
 				return []string{obj.(*v1.VirtualMachineInstance).Status.NodeName}, nil
@@ -134,7 +130,7 @@ var _ = Describe("Workload Updater", func() {
 
 	Context("workload update in progress", func() {
 		It("should migrate the VMI", func() {
-			newVirtualMachine("testvm", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+			newVirtualMachine("testvm", true, "madeup", controller.vmiStore, controller.podIndexer)
 			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
 			kv := newKubeVirt(1)
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
@@ -147,7 +143,7 @@ var _ = Describe("Workload Updater", func() {
 		})
 
 		It("should do nothing if deployment is updating", func() {
-			newVirtualMachine("testvm", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+			newVirtualMachine("testvm", true, "madeup", controller.vmiStore, controller.podIndexer)
 			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
 			kv := newKubeVirt(1)
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
@@ -168,16 +164,16 @@ var _ = Describe("Workload Updater", func() {
 			totalVMs := 0
 			reasons := []string{}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", controller.vmiStore, controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-non-migratable-%d", i), false, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-non-migratable-%d", i), false, "madeup", controller.vmiStore, controller.podIndexer)
 				totalVMs++
 			}
 			// add vmis that are not outdated to ensure they are not counted as outdated in count
 			for i := 0; i < 100; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-%d", i), false, expectedImage, vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-%d", i), false, expectedImage, controller.vmiStore, controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < int(virtconfig.ParallelMigrationsPerClusterDefault); i++ {
@@ -219,11 +215,11 @@ var _ = Describe("Workload Updater", func() {
 			totalVMs := 0
 			reasons := []string{}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", controller.vmiStore, controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-%d", i), false, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-%d", i), false, "madeup", controller.vmiStore, controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < int(virtconfig.ParallelMigrationsPerClusterDefault); i++ {
@@ -261,7 +257,7 @@ var _ = Describe("Workload Updater", func() {
 
 			reasons := []string{}
 			for i := 0; i < desiredNumberOfVMs; i++ {
-				vmi := newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				vmi := newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", controller.vmiStore, controller.podIndexer)
 				// create enough migrations to only allow one more active one to be created
 				if i < int(virtconfig.ParallelMigrationsPerClusterDefault)-1 {
 					migrationFeeder.Add(newMigration(fmt.Sprintf("vmim-%d", i), vmi.Name, v1.MigrationRunning))
@@ -284,16 +280,16 @@ var _ = Describe("Workload Updater", func() {
 
 		It("should migrate/shutdown outdated VMIs and leave up to date VMIs alone", func() {
 			reasons := []string{}
-			newVirtualMachine("testvm-outdated-migratable", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+			newVirtualMachine("testvm-outdated-migratable", true, "madeup", controller.vmiStore, controller.podIndexer)
 			reasons = append(reasons, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 
-			newVirtualMachine("testvm-outdated-non-migratable", false, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+			newVirtualMachine("testvm-outdated-non-migratable", false, "madeup", controller.vmiStore, controller.podIndexer)
 			reasons = append(reasons, SuccessfulEvictVirtualMachineInstanceReason)
 
 			totalVMs := 2
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-migratable-%d", i), true, expectedImage, vmiInformer.GetIndexer(), controller.podIndexer)
-				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-non-migratable-%d", i), false, expectedImage, vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-migratable-%d", i), true, expectedImage, controller.vmiStore, controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-non-migratable-%d", i), false, expectedImage, controller.vmiStore, controller.podIndexer)
 				totalVMs += 2
 			}
 
@@ -314,11 +310,11 @@ var _ = Describe("Workload Updater", func() {
 		It("should do nothing if no method is set", func() {
 			totalVMs := 0
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", controller.vmiStore, controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-%d", i), false, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-%d", i), false, "madeup", controller.vmiStore, controller.podIndexer)
 				totalVMs++
 			}
 
@@ -332,7 +328,7 @@ var _ = Describe("Workload Updater", func() {
 			const desiredNumberOfVMs = 50
 			reasons := []string{}
 			for i := 0; i < desiredNumberOfVMs; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", controller.vmiStore, controller.podIndexer)
 			}
 			for i := 0; i < defaultBatchDeletionCount; i++ {
 				reasons = append(reasons, SuccessfulEvictVirtualMachineInstanceReason)
@@ -357,9 +353,9 @@ var _ = Describe("Workload Updater", func() {
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
 
-			vmi := newVirtualMachine("testvm-migratable", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+			vmi := newVirtualMachine("testvm-migratable", true, "madeup", controller.vmiStore, controller.podIndexer)
 			migrationFeeder.Add(newMigration("vmim-1", vmi.Name, v1.MigrationRunning))
-			vmi = newVirtualMachine("testvm-nonmigratable", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+			vmi = newVirtualMachine("testvm-nonmigratable", true, "madeup", controller.vmiStore, controller.podIndexer)
 			migrationFeeder.Add(newMigration("vmim-2", vmi.Name, v1.MigrationRunning))
 
 			waitForNumberOfInstancesOnVMIInformerCache(controller, desiredNumberOfVMs)
@@ -373,7 +369,7 @@ var _ = Describe("Workload Updater", func() {
 			batchDeletions := 30
 			reasons := []string{}
 			for i := 0; i < desiredNumberOfVMs; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", controller.vmiStore, controller.podIndexer)
 			}
 			for i := 0; i < batchDeletions; i++ {
 				reasons = append(reasons, SuccessfulEvictVirtualMachineInstanceReason)
@@ -402,7 +398,7 @@ var _ = Describe("Workload Updater", func() {
 			}
 
 			for i := 0; i < batchDeletions*2; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-1-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-1-%d", i), true, "madeup", controller.vmiStore, controller.podIndexer)
 			}
 			waitForNumberOfInstancesOnVMIInformerCache(controller, batchDeletions*2)
 			kv := newKubeVirt(batchDeletions * 2)
@@ -467,7 +463,7 @@ var _ = Describe("Workload Updater", func() {
 				vmi.ObjectMeta.Annotations = make(map[string]string)
 				vmi.ObjectMeta.Annotations[v1.WorkloadUpdateMigrationAbortionAnnotation] = ""
 			}
-			vmiSource.Add(vmi)
+			controller.vmiStore.Add(vmi)
 			return vmi
 		}
 		createMig := func(vmiName string, phase v1.VirtualMachineInstanceMigrationPhase) *v1.VirtualMachineInstanceMigration {
@@ -577,7 +573,7 @@ func newKubeVirt(expectedNumOutdated int) *v1.KubeVirt {
 	}
 }
 
-func newVirtualMachine(name string, isMigratable bool, image string, vmiIndexer cache.Indexer, podStore cache.Store) *v1.VirtualMachineInstance {
+func newVirtualMachine(name string, isMigratable bool, image string, vmiIndexer cache.Store, podStore cache.Store) *v1.VirtualMachineInstance {
 	vmi := api.NewMinimalVMI("testvm")
 	vmi.Name = name
 	vmi.Namespace = k8sv1.NamespaceDefault

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -30,11 +30,8 @@ import (
 )
 
 var _ = Describe("Workload Updater", func() {
-	var ctrl *gomock.Controller
-	var virtClient *kubecli.MockKubevirtClient
 	var migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
 	var kubeVirtInterface *kubecli.MockKubeVirtInterface
-	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
 	var recorder *record.FakeRecorder
 	var kubeClient *fake.Clientset
 
@@ -68,11 +65,11 @@ var _ = Describe("Workload Updater", func() {
 		Expect(err).ToNot(HaveOccurred())
 		metrics.SetOutdatedVirtualMachineInstanceWorkloads(0)
 
-		ctrl = gomock.NewController(GinkgoT())
-		virtClient = kubecli.NewMockKubevirtClient(ctrl)
+		ctrl := gomock.NewController(GinkgoT())
+		virtClient := kubecli.NewMockKubevirtClient(ctrl)
 		migrationInterface = kubecli.NewMockVirtualMachineInstanceMigrationInterface(ctrl)
 		kubeVirtInterface = kubecli.NewMockKubeVirtInterface(ctrl)
-		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		vmiInterface := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 
 		vmiInformer, _ := testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachineInstance{}, cache.Indexers{
 			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -31,7 +31,6 @@ import (
 
 var _ = Describe("Workload Updater", func() {
 	var ctrl *gomock.Controller
-	var stop chan struct{}
 	var virtClient *kubecli.MockKubevirtClient
 	var migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
 	var kubeVirtInterface *kubecli.MockKubeVirtInterface
@@ -69,7 +68,6 @@ var _ = Describe("Workload Updater", func() {
 		Expect(err).ToNot(HaveOccurred())
 		metrics.SetOutdatedVirtualMachineInstanceWorkloads(0)
 
-		stop = make(chan struct{})
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		migrationInterface = kubecli.NewMockVirtualMachineInstanceMigrationInterface(ctrl)
@@ -525,9 +523,6 @@ var _ = Describe("Workload Updater", func() {
 	})
 
 	AfterEach(func() {
-
-		close(stop)
-
 		Expect(recorder.Events).To(BeEmpty())
 	})
 })

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -37,7 +37,6 @@ var _ = Describe("Workload Updater", func() {
 	var migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
 	var kubeVirtInterface *kubecli.MockKubeVirtInterface
 	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
-	var migrationInformer cache.SharedIndexInformer
 	var kubeVirtSource *framework.FakeControllerSource
 	var kubeVirtInformer cache.SharedIndexInformer
 	var recorder *record.FakeRecorder
@@ -49,11 +48,9 @@ var _ = Describe("Workload Updater", func() {
 	var expectedImage string
 
 	syncCaches := func(stop chan struct{}) {
-		go migrationInformer.Run(stop)
 		go kubeVirtInformer.Run(stop)
 
 		Expect(cache.WaitForCacheSync(stop,
-			migrationInformer.HasSynced,
 			kubeVirtInformer.HasSynced,
 		)).To(BeTrue())
 	}
@@ -96,7 +93,7 @@ var _ = Describe("Workload Updater", func() {
 				return []string{obj.(*v1.VirtualMachineInstance).Status.NodeName}, nil
 			},
 		})
-		migrationInformer, _ = testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
+		migrationInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(200)
 		recorder.IncludeObject = true

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -562,7 +562,7 @@ var _ = Describe("Workload Updater", func() {
 
 func waitForNumberOfInstancesOnVMIInformerCache(wu *WorkloadUpdateController, vmisNo int) {
 	EventuallyWithOffset(1, func() []interface{} {
-		return wu.vmiInformer.GetStore().List()
+		return wu.vmiStore.List()
 	}, 3*time.Second, 200*time.Millisecond).Should(HaveLen(vmisNo))
 }
 

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -30,14 +30,16 @@ import (
 )
 
 var _ = Describe("Workload Updater", func() {
-	var migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
-	var kubeVirtInterface *kubecli.MockKubeVirtInterface
-	var recorder *record.FakeRecorder
-	var kubeClient *fake.Clientset
+	var (
+		migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
+		kubeVirtInterface  *kubecli.MockKubeVirtInterface
+		recorder           *record.FakeRecorder
+		kubeClient         *fake.Clientset
 
-	var controller *WorkloadUpdateController
+		controller *WorkloadUpdateController
 
-	var expectedImage string
+		expectedImage string
+	)
 
 	addKubeVirt := func(kv *v1.KubeVirt) {
 		key, err := virtcontroller.KeyFunc(kv)

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -396,8 +396,8 @@ var _ = Describe("Workload Updater", func() {
 			controller.Execute()
 			Expect(recorder.Events).To(BeEmpty())
 
-			// sleep to account for batch interval
-			time.Sleep(3 * time.Second)
+			// Shift time for batch interval
+			controller.lastDeletionBatch = time.Now().Add(-3 * time.Second)
 
 			// Should execute another batch of deletions after sleep
 			addKubeVirt(kv)

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -39,7 +39,6 @@ var _ = Describe("Workload Updater", func() {
 	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
 	var vmiSource *framework.FakeControllerSource
 	var vmiInformer cache.SharedIndexInformer
-	var podInformer cache.SharedIndexInformer
 	var migrationInformer cache.SharedIndexInformer
 	var migrationSource *framework.FakeControllerSource
 	var kubeVirtSource *framework.FakeControllerSource
@@ -55,7 +54,6 @@ var _ = Describe("Workload Updater", func() {
 
 	syncCaches := func(stop chan struct{}) {
 		go vmiInformer.Run(stop)
-		go podInformer.Run(stop)
 		go migrationInformer.Run(stop)
 		go kubeVirtInformer.Run(stop)
 
@@ -105,7 +103,7 @@ var _ = Describe("Workload Updater", func() {
 			},
 		})
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
-		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
+		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(200)
 		recorder.IncludeObject = true
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
@@ -136,7 +134,7 @@ var _ = Describe("Workload Updater", func() {
 
 	Context("workload update in progress", func() {
 		It("should migrate the VMI", func() {
-			newVirtualMachine("testvm", true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+			newVirtualMachine("testvm", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
 			kv := newKubeVirt(1)
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
@@ -149,7 +147,7 @@ var _ = Describe("Workload Updater", func() {
 		})
 
 		It("should do nothing if deployment is updating", func() {
-			newVirtualMachine("testvm", true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+			newVirtualMachine("testvm", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
 			kv := newKubeVirt(1)
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
@@ -170,16 +168,16 @@ var _ = Describe("Workload Updater", func() {
 			totalVMs := 0
 			reasons := []string{}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-non-migratable-%d", i), false, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-non-migratable-%d", i), false, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 				totalVMs++
 			}
 			// add vmis that are not outdated to ensure they are not counted as outdated in count
 			for i := 0; i < 100; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-%d", i), false, expectedImage, vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-%d", i), false, expectedImage, vmiInformer.GetIndexer(), controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < int(virtconfig.ParallelMigrationsPerClusterDefault); i++ {
@@ -221,11 +219,11 @@ var _ = Describe("Workload Updater", func() {
 			totalVMs := 0
 			reasons := []string{}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-%d", i), false, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-%d", i), false, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < int(virtconfig.ParallelMigrationsPerClusterDefault); i++ {
@@ -263,7 +261,7 @@ var _ = Describe("Workload Updater", func() {
 
 			reasons := []string{}
 			for i := 0; i < desiredNumberOfVMs; i++ {
-				vmi := newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				vmi := newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 				// create enough migrations to only allow one more active one to be created
 				if i < int(virtconfig.ParallelMigrationsPerClusterDefault)-1 {
 					migrationFeeder.Add(newMigration(fmt.Sprintf("vmim-%d", i), vmi.Name, v1.MigrationRunning))
@@ -286,16 +284,16 @@ var _ = Describe("Workload Updater", func() {
 
 		It("should migrate/shutdown outdated VMIs and leave up to date VMIs alone", func() {
 			reasons := []string{}
-			newVirtualMachine("testvm-outdated-migratable", true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+			newVirtualMachine("testvm-outdated-migratable", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			reasons = append(reasons, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 
-			newVirtualMachine("testvm-outdated-non-migratable", false, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+			newVirtualMachine("testvm-outdated-non-migratable", false, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			reasons = append(reasons, SuccessfulEvictVirtualMachineInstanceReason)
 
 			totalVMs := 2
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-migratable-%d", i), true, expectedImage, vmiInformer.GetIndexer(), podInformer.GetStore())
-				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-non-migratable-%d", i), false, expectedImage, vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-migratable-%d", i), true, expectedImage, vmiInformer.GetIndexer(), controller.podIndexer)
+				newVirtualMachine(fmt.Sprintf("testvm-up-to-date-non-migratable-%d", i), false, expectedImage, vmiInformer.GetIndexer(), controller.podIndexer)
 				totalVMs += 2
 			}
 
@@ -316,11 +314,11 @@ var _ = Describe("Workload Updater", func() {
 		It("should do nothing if no method is set", func() {
 			totalVMs := 0
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 				totalVMs++
 			}
 			for i := 0; i < 50; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-%d", i), false, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-%d", i), false, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 				totalVMs++
 			}
 
@@ -334,7 +332,7 @@ var _ = Describe("Workload Updater", func() {
 			const desiredNumberOfVMs = 50
 			reasons := []string{}
 			for i := 0; i < desiredNumberOfVMs; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			}
 			for i := 0; i < defaultBatchDeletionCount; i++ {
 				reasons = append(reasons, SuccessfulEvictVirtualMachineInstanceReason)
@@ -359,9 +357,9 @@ var _ = Describe("Workload Updater", func() {
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
 
-			vmi := newVirtualMachine("testvm-migratable", true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+			vmi := newVirtualMachine("testvm-migratable", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			migrationFeeder.Add(newMigration("vmim-1", vmi.Name, v1.MigrationRunning))
-			vmi = newVirtualMachine("testvm-nonmigratable", true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+			vmi = newVirtualMachine("testvm-nonmigratable", true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			migrationFeeder.Add(newMigration("vmim-2", vmi.Name, v1.MigrationRunning))
 
 			waitForNumberOfInstancesOnVMIInformerCache(controller, desiredNumberOfVMs)
@@ -375,7 +373,7 @@ var _ = Describe("Workload Updater", func() {
 			batchDeletions := 30
 			reasons := []string{}
 			for i := 0; i < desiredNumberOfVMs; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			}
 			for i := 0; i < batchDeletions; i++ {
 				reasons = append(reasons, SuccessfulEvictVirtualMachineInstanceReason)
@@ -404,7 +402,7 @@ var _ = Describe("Workload Updater", func() {
 			}
 
 			for i := 0; i < batchDeletions*2; i++ {
-				newVirtualMachine(fmt.Sprintf("testvm-migratable-1-%d", i), true, "madeup", vmiInformer.GetIndexer(), podInformer.GetStore())
+				newVirtualMachine(fmt.Sprintf("testvm-migratable-1-%d", i), true, "madeup", vmiInformer.GetIndexer(), controller.podIndexer)
 			}
 			waitForNumberOfInstancesOnVMIInformerCache(controller, batchDeletions*2)
 			kv := newKubeVirt(batchDeletions * 2)


### PR DESCRIPTION
### What this PR does
This series of commits gradually remove complexity of workload updater tests to the point where we reduce the runtime from ~100 seconds down to ~200ms.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
I recommend to review commit by commit.

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

