### PR TITLE
Admit eviction on completed virt-launcher pods

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -40,7 +40,7 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 		return validating_webhooks.NewPassingAdmissionResponse()
 	}
 
-	if !isVirtLauncher(pod) {
+	if !isVirtLauncher(pod) || isCompleted(pod) {
 		return validating_webhooks.NewPassingAdmissionResponse()
 	}
 
@@ -129,4 +129,8 @@ func denied(message string) *admissionv1.AdmissionResponse {
 
 func isVirtLauncher(pod *k8scorev1.Pod) bool {
 	return pod.Labels[virtv1.AppLabel] == "virt-launcher"
+}
+
+func isCompleted(pod *k8scorev1.Pod) bool {
+	return pod.Status.Phase == k8scorev1.PodFailed || pod.Status.Phase == k8scorev1.PodSucceeded
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, completed virt-launcher pods can trigger a live migration if an eviction request arrives.
This is wrong since completed pods should be simply evicted.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: eviction requests to completed virt-launcher pods cannot trigger a live migration
```

