### PR TITLE
[WIP]enable initial e2e testing for s390x.

### DIFF
--- a/cluster-up/cluster/external/provider.sh
+++ b/cluster-up/cluster/external/provider.sh
@@ -20,6 +20,7 @@ docker_tag=\${DOCKER_TAG}
 docker_prefix=\${DOCKER_PREFIX}
 manifest_docker_prefix=\${DOCKER_PREFIX}
 image_pull_policy=\${IMAGE_PULL_POLICY:-Always}
+kubectl=\${KUBECTL}
 EOF
 
     if which oc; then

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -159,7 +159,7 @@ func (r rights) list() (e []rightsEntry) {
 	return
 }
 
-var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]User Access", decorators.SigCompute, func() {
+var _ = Describe("[rfe_id:500][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component][sig-compute]User Access", decorators.SigCompute, func() {
 
 	var k8sClient string
 	var authClient *authClientV1.AuthorizationV1Client

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -382,7 +382,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				}
 			})
 
-			It("[test_id:786]Should be that cfgMap and secret fs layout same for the pod and vmi", func() {
+			It("[test_id:786][s390x]Should be that cfgMap and secret fs layout same for the pod and vmi", func() {
 				expectedOutputCfgMap := "value1value2value3"
 				expectedOutputSecret := "adminredhat"
 

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -60,7 +60,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		virtClient = kubevirt.Client()
 	})
 
-	DescribeTable("should", func(image string, policy k8sv1.PullPolicy, expectedPolicy k8sv1.PullPolicy) {
+	DescribeTable("[s390x]should", func(image string, policy k8sv1.PullPolicy, expectedPolicy k8sv1.PullPolicy) {
 		vmi := libvmifact.NewGuestless(libvmi.WithContainerDisk("disk0", image))
 
 		vmi.Spec.Volumes[0].ContainerDisk.ImagePullPolicy = policy
@@ -226,7 +226,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 	})
 
-	Describe("[rfe_id:4052][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions", func() {
+	Describe("[rfe_id:4052][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions", func() {
 		Context("with ephemeral registry disk", func() {
 			It("[test_id:4299]should not have world write permissions", func() {
 				vmi := libvmifact.NewAlpine()

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1004,7 +1004,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 
-		Context("[rfe_id:2288][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component] With not existing PVC", func() {
+		Context("[rfe_id:2288][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component] With not existing PVC", func() {
 			// Not a candidate for NFS because the PVC in question doesn't actually exist
 			It("[test_id:1040] should get unschedulable condition", func() {
 				// Start the VirtualMachineInstance

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"kubevirt.io/kubevirt/tests/libstorage"
@@ -92,8 +94,27 @@ func AdjustKubeVirtResource() {
 			},
 		},
 	}
+
+	// cpu manager is currently not supported on s390x
+	buildArch := os.Getenv("BUILD_ARCH")
+	var arch string
+
+	if buildArch != "" {
+		archElements := strings.Split(buildArch, "-")
+		if len(archElements) == 2 {
+			arch = archElements[1]
+		} else {
+			arch = archElements[0]
+		}
+	}
+
+	if arch != "s390x" {
+		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
+			virtconfig.CPUManager,
+		)
+	}
+
 	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
-		virtconfig.CPUManager,
 		virtconfig.IgnitionGate,
 		virtconfig.SidecarGate,
 		virtconfig.SnapshotGate,

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -151,7 +151,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			Context("with injected ssh-key", func() {
-				It("[test_id:1616]should have ssh-key under authorized keys", func() {
+				It("[test_id:1616][s390x]should have ssh-key under authorized keys", func() {
 					userData := fmt.Sprintf(
 						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 						fedoraPassword,
@@ -190,7 +190,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			Context("with injected ssh-key", func() {
-				It("[test_id:3178]should have ssh-key under authorized keys", func() {
+				It("[test_id:3178][s390x]should have ssh-key under authorized keys", func() {
 					userData := fmt.Sprintf(
 						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 						fedoraPassword,
@@ -216,7 +216,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				})
 			})
 
-			It("cloud-init instance-id should be stable", func() {
+			It("[s390x]cloud-init instance-id should be stable", func() {
 				getInstanceId := func(vmi *v1.VirtualMachineInstance) (string, error) {
 					cmd := "cat /var/lib/cloud/data/instance-id"
 					instanceId, err := console.RunCommandAndStoreOutput(vmi, cmd, time.Second*30)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -120,17 +120,17 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 	})
 
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
-		It("[test_id:1619]should success", func() {
+		It("[s390x][test_id:1619]should success", func() {
 			vmi := libvmifact.NewAlpine()
 			_, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Create VMI successfully")
 		})
 
-		It("[test_id:1620]should start it", func() {
+		It("[s390x][test_id:1620]should start it", func() {
 			tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 		})
 
-		It("[test_id:6095]should start in paused state if start strategy set to paused", func() {
+		It("[s390x][test_id:6095]should start in paused state if start strategy set to paused", func() {
 			vmi := libvmifact.NewAlpine(libvmi.WithStartStrategy(v1.StartStrategyPaused))
 			vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
@@ -141,7 +141,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 		})
 
-		It("[test_id:1621]should attach virt-launcher to it", func() {
+		It("[s390x][test_id:1621]should attach virt-launcher to it", func() {
 			vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 			By("Getting virt-launcher logs")
@@ -152,7 +152,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				Should(ContainSubstring("Found PID for"))
 		})
 
-		It("[test_id:3195]should carry annotations to pod", func() {
+		It("[s390x][test_id:3195]should carry annotations to pod", func() {
 			vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(
 				libvmi.WithAnnotation("testannotation", "annotation from vmi")),
 				startupTimeout)
@@ -163,7 +163,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			Expect(pod.Annotations).To(HaveKeyWithValue("testannotation", "annotation from vmi"), "annotation should be carried to the pod")
 		})
 
-		It("[test_id:3196]should carry kubernetes and kubevirt annotations to pod", func() {
+		It("[s390x][test_id:3196]should carry kubernetes and kubevirt annotations to pod", func() {
 			vmi = tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(
 				libvmi.WithAnnotation("kubevirt.io/test", "test"),
 				libvmi.WithAnnotation("kubernetes.io/test", "test")),
@@ -176,7 +176,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			Expect(pod.Annotations).To(HaveKey("kubernetes.io/test"), "kubernetes annotation should not be carried to the pod")
 		})
 
-		It("Should prevent eviction when EvictionStratgy: External", func() {
+		It("[s390x]Should prevent eviction when EvictionStratgy: External", func() {
 			vmi := libvmifact.NewAlpine(libvmi.WithEvictionStrategy(v1.EvictionStrategyExternal))
 			vmi = tests.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
@@ -204,7 +204,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			}, 20*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		})
 
-		It("[test_id:1622]should log libvirtd logs", func() {
+		It("[s390x][test_id:1622]should log libvirtd logs", func() {
 			vmi := tests.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 			By("Getting virt-launcher logs")
@@ -262,7 +262,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			Entry("[test_id:8533]disabled when log verbosity, debug logs and customLogFilters are not defined", nil, nil, false),
 		)
 
-		It("[test_id:1623]should reject POST if validation webhook deems the spec invalid", func() {
+		It("[s390x][test_id:1623]should reject POST if validation webhook deems the spec invalid", func() {
 			vmi := libvmifact.NewAlpine()
 			// Add a disk that doesn't map to a volume.
 			// This should get rejected which tells us the webhook validator is working.
@@ -290,7 +290,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			Expect(reviewResponse.Details.Causes[1].Field).To(Equal("spec.domain.devices.disks[2].name"))
 		})
 
-		It("[test_id:1624]should reject PATCH if schema is invalid", func() {
+		It("[s390x][test_id:1624]should reject PATCH if schema is invalid", func() {
 			vmi := libvmifact.NewAlpine()
 			err := kubevirt.Client().RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred(), "Send POST successfully")
@@ -311,7 +311,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi = libvmifact.NewAlpine()
 				vmi.Name = "testvmi" + rand.String(63)
 			})
-			It("[test_id:1625]should start it", func() {
+			It("[s390x][test_id:1625]should start it", func() {
 				By("Creating a VirtualMachineInstance with a long name")
 				vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred(), "cannot create VirtualMachineInstance %q: %v", vmi.Name, err)
@@ -328,7 +328,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		Context("when it already exist", func() {
-			It("[test_id:1626]should be rejected", func() {
+			It("[s390x][test_id:1626]should be rejected", func() {
 				By("Creating a VirtualMachineInstance")
 				vmi := libvmifact.NewAlpine()
 				err := kubevirt.Client().RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Error()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
This is an initial draft PR raised to test the end-to-end tests against the s390x external cluster. Currently it is work in progress.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

