### PR TITLE
Replace update with patch in snapshot test

### DIFF
--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1053,8 +1053,9 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				origStatus := ss.Status
 				// zero out the times to be able to compare after
 				clearConditionsTimestamps(origStatus.Conditions)
-				ss.Status = nil
-				ss, err = virtClient.VirtualMachineSnapshot(ss.Namespace).Update(context.Background(), ss, metav1.UpdateOptions{})
+				patchPayload, err := patch.New(patch.WithRemove("/status")).GeneratePayload()
+				Expect(err).NotTo(HaveOccurred())
+				ss, err = virtClient.VirtualMachineSnapshot(ss.Namespace).Patch(context.Background(), ss.Name, types.JSONPatchType, patchPayload, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ss.Status).To(BeNil())
 


### PR DESCRIPTION
### What this PR does
Before this PR:
snapshot.go test would use update

After this PR:
snapshot.go test will use patch

Fixes #
https://issues.redhat.com/browse/CNV-44586

This change helps to avoid conflicts on objects and reduce flakiness in snapshot.go test

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

