### PR TITLE
virt-api: unencode authorization extra headers

### DIFF
--- a/pkg/virt-api/rest/authorizer_test.go
+++ b/pkg/virt-api/rest/authorizer_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Authorizer", func() {
 			req.Request.Header[userHeader] = []string{"user"}
 			req.Request.Header[groupHeader] = []string{"userGroup"}
 			req.Request.Header[userExtraHeaderPrefix+"test"] = []string{"userExtraValue"}
+			req.Request.Header[userExtraHeaderPrefix+"test%2fencoded"] = []string{"encodedUserExtraValue"}
 			req.Request.TLS = &tls.ConnectionState{}
 			req.Request.TLS.PeerCertificates = append(req.Request.TLS.PeerCertificates, &x509.Certificate{})
 
@@ -75,6 +76,10 @@ var _ = Describe("Authorizer", func() {
 			Context("with namespaced resource", func() {
 				allowed := func(allowed bool) func(review *authv1.SubjectAccessReview) (*authv1.SubjectAccessReview, error) {
 					return func(sar *authv1.SubjectAccessReview) (*authv1.SubjectAccessReview, error) {
+						Expect(sar.Spec.User).To(Equal("user"))
+						Expect(sar.Spec.Groups).To(Equal([]string{"userGroup"}))
+						Expect(sar.Spec.Extra).To(HaveKeyWithValue("test", authv1.ExtraValue{"userExtraValue"}))
+						Expect(sar.Spec.Extra).To(HaveKeyWithValue("test/encoded", authv1.ExtraValue{"encodedUserExtraValue"}))
 						Expect(sar.Spec.NonResourceAttributes).To(BeNil())
 						Expect(sar.Spec.ResourceAttributes).ToNot(BeNil())
 						Expect(sar.Spec.ResourceAttributes.Namespace).To(Equal("default"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

virt-api is broken on GKE because not decoding "extra" authorization header named X-Remote-Extra-Iam.gke.io%2fuser-Assertion:

After this PR:

Correctly decode header

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12459

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-api: unencode authorization extra headers
```

