### PR TITLE
VMI decrease test time and complexity

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -204,7 +204,6 @@ type VMIController struct {
 	vmStore           cache.Store
 	podIndexer        cache.Indexer
 	pvcIndexer        cache.Indexer
-	storageClassStore cache.Store
 	topologyHinter    topology.Hinter
 	recorder          record.EventRecorder
 	podExpectations   *controller.UIDTrackingControllerExpectations
@@ -687,7 +686,6 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		if !vmiPodExists {
 			vmiCopy.Status.Phase = virtv1.Failed
 		}
-		break
 	default:
 		return fmt.Errorf("unknown vmi phase %v", vmi.Status.Phase)
 	}
@@ -956,22 +954,6 @@ func checkForContainerImageError(pod *k8sv1.Pod) syncError {
 	}
 
 	return nil
-}
-
-func (c *VMIController) hotplugPodsReady(vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) (bool, syncError) {
-	if controller.VMIHasHotplugVolumes(vmi) {
-		hotplugAttachmentPods, err := controller.AttachmentPods(virtLauncherPod, c.podIndexer)
-		if err != nil {
-			return false, &syncErrorImpl{fmt.Errorf("failed to get attachment pods: %v", err), controller.FailedHotplugSyncReason}
-		}
-		for _, attachmentPod := range hotplugAttachmentPods {
-			if controller.IsPodReady(attachmentPod) && attachmentPod.DeletionTimestamp == nil && attachmentPod.Spec.NodeName == virtLauncherPod.Spec.NodeName {
-				return true, nil
-			}
-		}
-		return false, nil
-	}
-	return true, nil
 }
 
 func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, dataVolumes []*cdiv1.DataVolume) syncError {
@@ -1343,7 +1325,6 @@ func (c *VMIController) updatePod(old, cur interface{}) {
 	}
 	log.Log.V(4).Object(curPod).Infof("Pod updated")
 	c.enqueueVirtualMachine(vmi)
-	return
 }
 
 // When a pod is deleted, enqueue the vmi that manages the pod and update its podExpectations.

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -91,7 +91,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var storageClassInformer cache.SharedIndexInformer
 	var kvStore cache.Store
 
-	var cdiInformer cache.SharedIndexInformer
 	var cdiConfigInformer cache.SharedIndexInformer
 
 	expectMatchingPodCreation := func(vmi *virtv1.VirtualMachineInstance, matchers ...gomegaTypes.GomegaMatcher) {
@@ -258,7 +257,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		config, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		storageClassInformer, _ = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
-		cdiInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
+		cdiInformer, _ := testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		cdiConfigInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		rqInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		nsInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
@@ -2843,8 +2842,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 			}
 			// We add multiple CDI instances to trigger the error
-			Expect(cdiInformer.GetIndexer().Add(&cdi)).To(Succeed())
-			Expect(cdiInformer.GetIndexer().Add(&cdi2)).To(Succeed())
+			Expect(controller.cdiStore.Add(&cdi)).To(Succeed())
+			Expect(controller.cdiStore.Add(&cdi2)).To(Succeed())
 
 			fsOverhead, err := controller.getFilesystemOverhead(&k8sv1.PersistentVolumeClaim{})
 			Expect(err).ToNot(HaveOccurred())
@@ -2864,7 +2863,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 			}
 
-			Expect(cdiInformer.GetIndexer().Add(&cdi)).To(Succeed())
+			Expect(controller.cdiStore.Add(&cdi)).To(Succeed())
 
 			fsOverhead, err := controller.getFilesystemOverhead(nil)
 			Expect(err).To(HaveOccurred())
@@ -2904,7 +2903,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pvc.Spec.StorageClassName = &scName
 			}
 
-			Expect(cdiInformer.GetIndexer().Add(&cdi)).To(Succeed())
+			Expect(controller.cdiStore.Add(&cdi)).To(Succeed())
 			Expect(cdiConfigInformer.GetIndexer().Add(&cfg)).To(Succeed())
 
 			fsOverhead, err := controller.getFilesystemOverhead(pvc)

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -91,8 +91,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var storageClassInformer cache.SharedIndexInformer
 	var kvStore cache.Store
 
-	var cdiConfigInformer cache.SharedIndexInformer
-
 	expectMatchingPodCreation := func(vmi *virtv1.VirtualMachineInstance, matchers ...gomegaTypes.GomegaMatcher) {
 		pods, err := kubeClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", virtv1.CreatedByLabel, string(vmi.UID))})
 		Expect(err).ToNot(HaveOccurred())
@@ -258,7 +256,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		storageClassInformer, _ = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		cdiInformer, _ := testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
-		cdiConfigInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
+		cdiConfigInformer, _ := testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		rqInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		nsInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		var qemuGid int64 = 107
@@ -2904,7 +2902,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 
 			Expect(controller.cdiStore.Add(&cdi)).To(Succeed())
-			Expect(cdiConfigInformer.GetIndexer().Add(&cfg)).To(Succeed())
+			Expect(controller.cdiConfigStore.Add(&cfg)).To(Succeed())
 
 			fsOverhead, err := controller.getFilesystemOverhead(pvc)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -51,7 +51,6 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
-	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
@@ -87,7 +86,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var mockQueue *testutils.MockWorkQueue
 	var virtClientset *kubevirtfake.Clientset
 	var kubeClient *fake.Clientset
-	var networkClient *fakenetworkclient.Clientset
 	// We pass the store to backend storage and we don't have direct access
 	var storageClassStore cache.Store
 	var kvStore cache.Store
@@ -287,8 +285,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		).AnyTimes()
 		kubeClient = fake.NewSimpleClientset()
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
-		networkClient = fakenetworkclient.NewSimpleClientset()
-		virtClient.EXPECT().NetworkClient().Return(networkClient).AnyTimes()
 
 		syncCaches(stop)
 	})

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3416,8 +3416,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 
 		Context("pod status update", func() {
-			const mac1 = "abc"
-			const mac2 = "bcd"
 			BeforeEach(func() {
 				vmi = api.NewMinimalVMI(vmName)
 				pod = NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
@@ -3919,7 +3917,8 @@ func setReadyCondition(vmi *virtv1.VirtualMachineInstance, status k8sv1.Conditio
 }
 
 func setDataVolumeCondition(dv *cdiv1.DataVolume, cond cdiv1.DataVolumeCondition) {
-	for _, c := range dv.Status.Conditions {
+	for i := range dv.Status.Conditions {
+		c := &dv.Status.Conditions[i]
 		if c.Type == cond.Type {
 			c.Status = cond.Status
 			c.Message = cond.Message

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1580,10 +1580,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			if vmExists {
 				controller.vmStore.Add(vm)
-				// the controller isn't using informer callbacks for the VM informer
-				// so add a sleep here to ensure the informer has time to cache up before
-				// we call Execute()
-				time.Sleep(1 * time.Second)
 			}
 
 			addVirtualMachine(vmi)

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -91,7 +91,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var storageClassInformer cache.SharedIndexInformer
 	var kvStore cache.Store
 
-	var dataVolumeInformer cache.SharedIndexInformer
 	var cdiInformer cache.SharedIndexInformer
 	var cdiConfigInformer cache.SharedIndexInformer
 
@@ -229,12 +228,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		go vmiInformer.Run(stop)
 		go podInformer.Run(stop)
 
-		go dataVolumeInformer.Run(stop)
 		go storageClassInformer.Run(stop)
 		Expect(cache.WaitForCacheSync(stop,
 			vmiInformer.HasSynced,
 			podInformer.HasSynced,
-			dataVolumeInformer.HasSynced,
 			storageClassInformer.HasSynced)).To(BeTrue())
 	}
 
@@ -247,7 +244,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		vmInformer, _ := testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachine{}, kvcontroller.GetVirtualMachineInformerIndexers())
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
-		dataVolumeInformer, _ = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
+		dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		storageProfileInformer, _ := testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
@@ -325,7 +322,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	}
 
 	addDataVolume := func(dv *cdiv1.DataVolume) {
-		Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
+		Expect(controller.dataVolumeIndexer.Add(dv)).To(Succeed())
 	}
 
 	Context("On valid VirtualMachineInstance given with DataVolume source", func() {
@@ -1312,7 +1309,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Phase: cdiv1.Pending,
 				},
 			}
-			Expect(dataVolumeInformer.GetIndexer().Add(dv)).To(Succeed())
+			Expect(controller.dataVolumeIndexer.Add(dv)).To(Succeed())
 			Expect(controller.pvcIndexer.Add(pvc)).To(Succeed())
 			volume := virtv1.Volume{
 				Name: "test-dv",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This series of commits gradually remove complexity of VMI tests to the point where we reduce the runtime from ~20 seconds down to ~200ms. On top of this we remove some unnecessary code and fix few issues.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

