### PR TITLE
tests: remove and set annotations on VM creation

### DIFF
--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -3121,6 +3121,21 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(vmi.Annotations).To(Equal(annotations))
 		})
 
+		It("should not copy annotations from vm to vmi", func() {
+			vm, _ := DefaultVirtualMachine(true)
+			vm.Annotations["kubevirt.io/test"] = "test"
+
+			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+			addVirtualMachine(vm)
+
+			sanityExecute(vm)
+
+			vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmi.Annotations).ToNot(HaveKey("kubevirt.io/test"))
+		})
+
 		It("should copy kubevirt ignitiondata annotation from spec.template to vmi", func() {
 			vm, _ := DefaultVirtualMachine(true)
 			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{"kubevirt.io/ignitiondata": "test"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Currently, our tests create a VM and then use
"tests.RetryWithMetadataIfModified()" to update
the VM with annotations.

This process involves creating the VM object in
a non-running state, patching it with annotations,
and then starting it.

Instead, setting annotations during VM creation
simplifies the process and improves efficiency.

Additionally, remove irrelevant functional test
that was testing carrying annotations from VM
to VMI and ignoring "kubevirt.io" and
"kubernetes.io" labels. This filtering and
functionality was removed in PR kubevirt#3110.

Instead, add a new unit test that tests the
scenario where VM's annotations can not be
carried to VMI annotations.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```