### PR TITLE
e2e, storage-migration: Replace client Update operations with patch

### DIFF
--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -235,10 +235,8 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 		}
 		// TODO: right now, for simplicity, this function assumes the DV in the first position in the datavolumes templata list. Otherwise, we need
 		// to pass the old name of the DV to be replaces.
-		updateVMWithDV := func(vmName, volName, name string) {
+		updateVMWithDV := func(vm *virtv1.VirtualMachine, volName, name string) {
 			var replacedIndex int
-			vm, err := virtClient.VirtualMachine(ns).Get(context.Background(), vmName, metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
 			for i, v := range vm.Spec.Template.Spec.Volumes {
 				if v.Name == volName {
 					replacedIndex = i
@@ -302,7 +300,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			vm := createVMWithDV(createDV(), volName)
 			destDV := createBlankDV()
 			By("Update volumes")
-			updateVMWithDV(vm.Name, volName, destDV.Name)
+			updateVMWithDV(vm, volName, destDV.Name)
 			Eventually(func() bool {
 				vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
 					metav1.GetOptions{})
@@ -425,7 +423,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
 			libwait.WaitForSuccessfulVMIStart(vmi)
 			By("Update volumes")
-			updateVMWithDV(vm.Name, volName, destDV.Name)
+			updateVMWithDV(vm, volName, destDV.Name)
 			Eventually(func() []virtv1.VirtualMachineCondition {
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -236,13 +236,11 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 		// TODO: right now, for simplicity, this function assumes the DV in the first position in the datavolumes templata list. Otherwise, we need
 		// to pass the old name of the DV to be replaces.
 		updateVMWithDV := func(vm *virtv1.VirtualMachine, volName, name string) {
-			var replacedIndex int
-			for i, v := range vm.Spec.Template.Spec.Volumes {
-				if v.Name == volName {
-					replacedIndex = i
-					break
-				}
-			}
+			i := slices.IndexFunc(vm.Spec.Template.Spec.Volumes, func(volume virtv1.Volume) bool {
+				return volume.Name == volName
+			})
+			Expect(i).To(BeNumerically(">", -1))
+			By(fmt.Sprintf("Replacing volume %s with DV %s", volName, name))
 
 			updatedVolume := virtv1.Volume{
 				Name: volName,
@@ -252,14 +250,14 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 
 			p, err := patch.New(
 				patch.WithReplace("/spec/dataVolumeTemplates/0/metadata/name", name),
-				patch.WithReplace(fmt.Sprintf("/spec/template/spec/volumes/%d", replacedIndex), updatedVolume),
+				patch.WithReplace(fmt.Sprintf("/spec/template/spec/volumes/%d", i), updatedVolume),
 				patch.WithReplace("/spec/updateVolumesStrategy", virtv1.UpdateVolumesStrategyMigration),
 			).GeneratePayload()
 			Expect(err).ToNot(HaveOccurred())
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, p, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(vm.Spec.Template.Spec.Volumes[replacedIndex].VolumeSource.DataVolume.Name).To(Equal(name))
+			Expect(vm.Spec.Template.Spec.Volumes[i].VolumeSource.DataVolume.Name).To(Equal(name))
 		}
 
 		BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
 E2e storage migration helpers `UpdateVMWithPVC` and `UpdateVMWithDV` use client Update operation   to mutate the test VM object.

After this PR:
 E2e storage migration helpers `UpdateVMWithPVC` and `UpdateVMWithDV` use client Patch to mutate the test VM object.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The code that finds the index of the subject volume name is simplified by using builtin `slices`.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

