### PR TITLE
tests, utils: use VM Start/Stop and Patch instead of Update

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/pointer:go_default_library",
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -37,6 +37,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",


### PR DESCRIPTION
### What this PR does
Before this PR: VM is updated
After this PR: VM is started/stopped and patched

jira-ticket: https://issues.redhat.com/browse/CNV-44587

### Why we need it and why it was done in this way
Use VM Start/Stop and Patch instead of Update whenever possible for shortening the tests and reducing potential conflicts.

### Release note
```release-note
NONE
```