### PR TITLE
Migration test: Skip range cpu pin

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2879,8 +2879,12 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 			for _, line := range cpuLines {
 				lineSplits := strings.Fields(line)
+				// Range will be found when there are disabled/not plugged cpus
+				if strings.Contains(lineSplits[1], "-") {
+					continue
+				}
 				cpu, err := strconv.Atoi(lineSplits[1])
-				Expect(err).ToNot(HaveOccurred(), "cpu id is non string in vcpupin output")
+				Expect(err).ToNot(HaveOccurred(), "cpu id is non string in vcpupin output", vcpuPinOutput)
 
 				cpuSet = append(cpuSet, cpu)
 			}


### PR DESCRIPTION
### What this PR does
In case a cluster is configured to add hotpluggable cores then the `virsh vcpupin` outputs also these
cpus. Here full range is showed (as they are yet to be pinned).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

