### PR TITLE
doc: Extend quarantine doc to cover flaky required lanes

### DIFF
--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -110,13 +110,15 @@ number of tests failing each time. This can cause major delays to merging import
 requests and overload CI. Individual test case quarantining does not make sense in this case.
 
 A required test lane should be made optional if the following criteria are met:
-* The required test lane has a failure rate higher than 25% in the last 24 hours
+* The required test lane has a failure rate higher than 25% in the last 7 days
 * More than ten individual test cases are causing the required test lane to fail
 * The SIG responsible for the required test lane is unable to deliver a fix for the
-flake within 24 hours
+flake within 7 days
 
 The percentage impact of a flaky test lane can be measured by searching for a relevant
 error on the [CI search page](https://search.ci.kubevirt.io/).
+The failure rate of a test lane can be checked by going to the 
+[top failed lane list](https://github.com/kubevirt/ci-health?tab=readme-ov-file#failures-per-sig-against-last-code-push-for-merged-prs) in the ci-health repository.
 
 Following a required test lane being made optional a number of actions must happen:
 * Create github issue with a comment `/release-blocker main` to ensure that
@@ -124,8 +126,8 @@ the issue is addressed before a new release is cut.
 * Ensure that the github issue is assigned to a member of the responsible SIG who
 will own bringing the blocker to completion within a quick time frame.
 * The SIG should stop all feature and refactoring work until a fix for the flake
-has been identified and a pull request has been created. If the flaky test lane is 
-not receiving the required attention from the responsible SIG, SIG CI will hold 
-merge queue PRs from the responsible SIG that are not related to a fix.
+has been identified and a pull request has been created. If the quarantined test lane is 
+not receiving the required attention from the responsible SIG, SIG CI can take a 
+decision to hold merge queue PRs from the responsible SIG that are not related to a fix.
 * Once the fix is merged and the test lane returns to an acceptable failure
 rate, the test lane should be set back to required as soon as possible

--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -115,6 +115,9 @@ A required test lane should be made optional if the following criteria are met:
 * The SIG responsible for the required test lane is unable to deliver a fix for the
 flake within 24 hours
 
+The percentage impact of a flaky test lane can be measured by searching for a relevant
+error on the [CI search page](https://search.ci.kubevirt.io/).
+
 Following a required test lane being made optional a number of actions must happen:
 * Create github issue with a comment `/release-blocker main` to ensure that
 the issue is addressed before a new release is cut.

--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -102,3 +102,27 @@ After merging this PR the test will be out of quarantine.
 [2]: https://www.thoughtworks.com/en-us/insights/blog/no-more-flaky-tests-go-team
 [3]: https://docs.gitlab.com/ee/development/testing_guide/flaky_tests.html#quarantined-tests
 [on testgrid]: https://testgrid.k8s.io/kubevirt-periodics
+
+# Test Lane Quarantine
+
+There can be cases where required test lanes are flaking in a clustered manner with a large
+number of tests failing each time. This can cause major delays to merging important pull
+requests and overload CI. Individual test case quarantining does not make sense in this case.
+
+A required test lane should be made optional if the following criteria are met:
+* The required test lane has a failure rate higher than 25% in the last 24 hours
+* More than ten individual test cases are causing the required test lane to fail
+* The SIG responsible for the required test lane is unable to deliver a fix for the
+flake within 24 hours
+
+Following a required test lane being made optional a number of actions must happen:
+* Create github issue with a comment `/release-blocker main` to ensure that
+the issue is addressed before a new release is cut.
+* Ensure that the github issue is assigned to a member of the responsible SIG who
+will own bringing the blocker to completion within a quick time frame.
+* The SIG should stop all feature and refactoring work until a fix for the flake
+has been identified and a pull request has been created. If the flaky test lane is 
+not receiving the required attention from the responsible SIG, SIG CI will hold 
+merge queue PRs from the responsible SIG that are not related to a fix.
+* Once the fix is merged and the test lane returns to an acceptable failure
+rate, the test lane should be set back to required as soon as possible


### PR DESCRIPTION
### What this PR does

This document update covers what actions should be taken when test lanes are flaking with multiple test failures where quaranting the individual tests might not make sense.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
/cc @dhiller @EdDev 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

