### PR TITLE
[release-1.3] Admit eviction on completed virt-launcher pods

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -40,7 +40,7 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 		return validating_webhooks.NewPassingAdmissionResponse()
 	}
 
-	if !isVirtLauncher(pod) {
+	if !isVirtLauncher(pod) || isCompleted(pod) {
 		return validating_webhooks.NewPassingAdmissionResponse()
 	}
 
@@ -129,4 +129,8 @@ func denied(message string) *admissionv1.AdmissionResponse {
 
 func isVirtLauncher(pod *k8scorev1.Pod) bool {
 	return pod.Labels[virtv1.AppLabel] == "virt-launcher"
+}
+
+func isCompleted(pod *k8scorev1.Pod) bool {
+	return pod.Status.Phase == k8scorev1.PodFailed || pod.Status.Phase == k8scorev1.PodSucceeded
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -103,6 +103,31 @@ var _ = Describe("Pod eviction admitter", func() {
 		Expect(virtClient.Fake.Actions()).To(BeEmpty())
 	})
 
+	DescribeTable("should allow the request when it refers to a virt-launcher pod", func(podPhase k8sv1.PodPhase) {
+		vmi := newVMI(testNamespace, testVMIName, testNodeName)
+		virtClient := kubevirtfake.NewSimpleClientset(vmi)
+
+		pod := newVirtLauncherPodWithPhase(vmi.Namespace, vmi.Name, vmi.Status.NodeName, podPhase)
+		kubeClient := fake.NewSimpleClientset(pod)
+
+		admitter := admitters.NewPodEvictionAdmitter(
+			newClusterConfig(nil),
+			kubeClient,
+			virtClient,
+		)
+
+		actualAdmissionResponse := admitter.Admit(
+			newAdmissionReview(pod.Namespace, pod.Name, !isDryRun),
+		)
+
+		Expect(actualAdmissionResponse).To(Equal(allowedAdmissionResponse()))
+		Expect(kubeClient.Fake.Actions()).To(HaveLen(1))
+		Expect(virtClient.Fake.Actions()).To(BeEmpty())
+	},
+		Entry("in failed phase", k8sv1.PodFailed),
+		Entry("in succeeded phase", k8sv1.PodSucceeded),
+	)
+
 	DescribeTable("should trigger VMI Evacuation and deny the request", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...vmiOption) {
 		vmi := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
@@ -430,6 +455,12 @@ func newVirtLauncherPod(namespace, vmiName, nodeName string) *k8sv1.Pod {
 	}
 
 	return virtLauncher
+}
+
+func newVirtLauncherPodWithPhase(namespace, vmiName, nodeName string, phase k8sv1.PodPhase) *k8sv1.Pod {
+	pod := newVirtLauncherPod(namespace, vmiName, nodeName)
+	pod.Status.Phase = phase
+	return pod
 }
 
 func newAdmissionReview(evictedPodNamespace, evictedPodName string, isDryRun bool) *admissionv1.AdmissionReview {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/12451
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: eviction requests to completed virt-launcher pods cannot trigger a live migration
```

