### PR TITLE
vmclone: improve test time

### DIFF
--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
@@ -63,8 +64,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
-        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -62,13 +62,12 @@ const (
 
 var _ = Describe("Clone", func() {
 	var (
-		ctrl                    *gomock.Controller
-		vmInterface             *kubecli.MockVirtualMachineInterface
-		snapshotContentInformer cache.SharedIndexInformer
-		pvcInformer             cache.SharedIndexInformer
-		cloneInformer           cache.SharedIndexInformer
-		cloneSource             *framework.FakeControllerSource
-		stop                    chan struct{}
+		ctrl          *gomock.Controller
+		vmInterface   *kubecli.MockVirtualMachineInterface
+		pvcInformer   cache.SharedIndexInformer
+		cloneInformer cache.SharedIndexInformer
+		cloneSource   *framework.FakeControllerSource
+		stop          chan struct{}
 
 		controller *VMCloneController
 		recorder   *record.FakeRecorder
@@ -109,7 +108,7 @@ var _ = Describe("Clone", func() {
 	}
 
 	addSnapshotContent := func(snapshotContent *snapshotv1.VirtualMachineSnapshotContent) {
-		err := snapshotContentInformer.GetStore().Add(snapshotContent)
+		err := controller.snapshotContentStore.Add(snapshotContent)
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -232,7 +231,7 @@ var _ = Describe("Clone", func() {
 		snapshotInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
 		restoreInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineRestore{})
 		cloneInformer, cloneSource = testutils.NewFakeInformerFor(&clonev1alpha1.VirtualMachineClone{})
-		snapshotContentInformer, _ = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
+		snapshotContentInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 
 		recorder = record.NewFakeRecorder(100)

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -61,8 +61,6 @@ const (
 
 var _ = Describe("Clone", func() {
 	var (
-		vmInterface *kubecli.MockVirtualMachineInterface
-
 		controller *VMCloneController
 		recorder   *record.FakeRecorder
 		mockQueue  *testutils.MockWorkQueue
@@ -211,8 +209,6 @@ var _ = Describe("Clone", func() {
 
 	BeforeEach(func() {
 		ctrl := gomock.NewController(GinkgoT())
-
-		vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
 		vmInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachine{})
 		snapshotInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
 		restoreInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineRestore{})
@@ -239,7 +235,6 @@ var _ = Describe("Clone", func() {
 
 		client = kubevirtfake.NewSimpleClientset()
 
-		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(vmInterface).AnyTimes()
 		virtClient.EXPECT().VirtualMachineClone(metav1.NamespaceDefault).Return(client.CloneV1alpha1().VirtualMachineClones(metav1.NamespaceDefault)).AnyTimes()
 		virtClient.EXPECT().VirtualMachineSnapshot(metav1.NamespaceDefault).Return(client.SnapshotV1beta1().VirtualMachineSnapshots(metav1.NamespaceDefault)).AnyTimes()
 		virtClient.EXPECT().VirtualMachineRestore(metav1.NamespaceDefault).Return(client.SnapshotV1beta1().VirtualMachineRestores(metav1.NamespaceDefault)).AnyTimes()

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -64,7 +64,6 @@ var _ = Describe("Clone", func() {
 	var (
 		ctrl          *gomock.Controller
 		vmInterface   *kubecli.MockVirtualMachineInterface
-		pvcInformer   cache.SharedIndexInformer
 		cloneInformer cache.SharedIndexInformer
 		cloneSource   *framework.FakeControllerSource
 		stop          chan struct{}
@@ -121,7 +120,7 @@ var _ = Describe("Clone", func() {
 	}
 
 	addPVC := func(pvc *k8sv1.PersistentVolumeClaim) {
-		err := pvcInformer.GetStore().Add(pvc)
+		err := controller.pvcStore.Add(pvc)
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -232,7 +231,7 @@ var _ = Describe("Clone", func() {
 		restoreInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineRestore{})
 		cloneInformer, cloneSource = testutils.NewFakeInformerFor(&clonev1alpha1.VirtualMachineClone{})
 		snapshotContentInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
-		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This series of commits gradually remove complexity of vmclone tests to the point where we reduce the runtime from ~3 seconds down to ~250ms. On top of this we remove some unnecessary code and fix few issues.

### Special notes for your reviewer
These changes follow the logic introduced here https://github.com/kubevirt/kubevirt/pull/12468
<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

