### PR TITLE
Drain controllers: use fakeclient

### DIFF
--- a/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -5,16 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/golang/mock/gomock"
-
-	k8scorev1 "k8s.io/api/core/v1"
-
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -22,7 +19,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	v1 "kubevirt.io/api/core/v1"
-
 	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
 
@@ -66,7 +62,7 @@ var _ = Describe("Evacuation", func() {
 		)).To(BeTrue())
 	}
 
-	addNode := func(node *k8scorev1.Node) {
+	addNode := func(node *k8sv1.Node) {
 		mockQueue.ExpectAdds(1)
 		nodeSource.Add(node)
 		mockQueue.Wait()
@@ -85,8 +81,8 @@ var _ = Describe("Evacuation", func() {
 			},
 		})
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
-		nodeInformer, nodeSource = testutils.NewFakeInformerFor(&k8scorev1.Node{})
-		podInformer, podSource = testutils.NewFakeInformerFor(&k8scorev1.Pod{})
+		nodeInformer, nodeSource = testutils.NewFakeInformerFor(&k8sv1.Node{})
+		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
@@ -98,7 +94,7 @@ var _ = Describe("Evacuation", func() {
 		vmiFeeder = testutils.NewVirtualMachineFeeder(mockQueue, vmiSource)
 
 		// Set up mock client
-		virtClient.EXPECT().VirtualMachineInstanceMigration(k8scorev1.NamespaceDefault).Return(migrationInterface).AnyTimes()
+		virtClient.EXPECT().VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Return(migrationInterface).AnyTimes()
 		kubeClient = fake.NewSimpleClientset()
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().PolicyV1().Return(kubeClient.PolicyV1()).AnyTimes()
@@ -173,7 +169,7 @@ var _ = Describe("Evacuation", func() {
 
 			vmi := newVirtualMachine("testvm", node.Name)
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
-			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{{Type: v1.VirtualMachineInstanceIsMigratable, Status: k8scorev1.ConditionFalse}}
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{{Type: v1.VirtualMachineInstanceIsMigratable, Status: k8sv1.ConditionFalse}}
 			vmiFeeder.Add(vmi)
 
 			vmi1 := newVirtualMachine("testvm1", node.Name)
@@ -265,13 +261,13 @@ var _ = Describe("Evacuation", func() {
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
-					Status: k8scorev1.ConditionFalse,
+					Status: k8sv1.ConditionFalse,
 				},
 			}
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
-					Status: k8scorev1.ConditionFalse,
+					Status: k8sv1.ConditionFalse,
 				},
 			}
 			vmi.Status.EvacuationNodeName = vmi.Status.NodeName
@@ -288,7 +284,7 @@ var _ = Describe("Evacuation", func() {
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
-					Status: k8scorev1.ConditionFalse,
+					Status: k8sv1.ConditionFalse,
 				},
 			}
 			vmi.Status.EvacuationNodeName = node.Name
@@ -341,7 +337,7 @@ var _ = Describe("Evacuation", func() {
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
-					Status: k8scorev1.ConditionTrue,
+					Status: k8sv1.ConditionTrue,
 				},
 			}
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
@@ -366,10 +362,10 @@ var _ = Describe("Evacuation", func() {
 			vmi := newVirtualMachine("testvm", node.Name)
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
 
-			podSource.Add(newPod(vmi, "runningPod", k8scorev1.PodRunning, true))
-			podSource.Add(newPod(vmi, "succededPod", k8scorev1.PodSucceeded, true))
-			podSource.Add(newPod(vmi, "failedPod", k8scorev1.PodFailed, true))
-			podSource.Add(newPod(vmi, "notOwnedRunningPod", k8scorev1.PodRunning, false))
+			podSource.Add(newPod(vmi, "runningPod", k8sv1.PodRunning, true))
+			podSource.Add(newPod(vmi, "succededPod", k8sv1.PodSucceeded, true))
+			podSource.Add(newPod(vmi, "failedPod", k8sv1.PodFailed, true))
+			podSource.Add(newPod(vmi, "notOwnedRunningPod", k8sv1.PodRunning, false))
 			// pods do not cause the queue to get added to
 			// we just use them for caching purposes
 			// so wait for cache to catch up with a brief sleep
@@ -393,8 +389,8 @@ var _ = Describe("Evacuation", func() {
 			vmi := newVirtualMachine("testvm", node.Name)
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
 
-			podSource.Add(newPod(vmi, "runningPod", k8scorev1.PodRunning, true))
-			podSource.Add(newPod(vmi, "pendingPod", k8scorev1.PodPending, true))
+			podSource.Add(newPod(vmi, "runningPod", k8sv1.PodRunning, true))
+			podSource.Add(newPod(vmi, "pendingPod", k8sv1.PodPending, true))
 			// pods do not cause the queue to get added to
 			// we just use them for caching purposes
 			// so wait for cache to catch up with a brief sleep
@@ -552,12 +548,12 @@ var _ = Describe("Evacuation", func() {
 	})
 })
 
-func newNode(name string) *k8scorev1.Node {
-	return &k8scorev1.Node{
+func newNode(name string) *k8sv1.Node {
+	return &k8sv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: k8scorev1.NodeSpec{},
+		Spec: k8sv1.NodeSpec{},
 	}
 }
 
@@ -566,7 +562,7 @@ func newVirtualMachineMarkedForEviction(name string, nodeName string) *v1.Virtua
 	vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 		{
 			Type:   v1.VirtualMachineInstanceIsMigratable,
-			Status: k8scorev1.ConditionTrue,
+			Status: k8sv1.ConditionTrue,
 		},
 	}
 
@@ -579,22 +575,22 @@ func newVirtualMachine(name string, nodeName string) *v1.VirtualMachineInstance 
 	vmi := api.NewMinimalVMI("testvm")
 	vmi.Name = name
 	vmi.Status.NodeName = nodeName
-	vmi.Namespace = k8scorev1.NamespaceDefault
+	vmi.Namespace = k8sv1.NamespaceDefault
 	vmi.UID = "1234"
-	vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{{Type: v1.VirtualMachineInstanceIsMigratable, Status: k8scorev1.ConditionTrue}}
+	vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{{Type: v1.VirtualMachineInstanceIsMigratable, Status: k8sv1.ConditionTrue}}
 	return vmi
 }
 
-func newPod(vmi *v1.VirtualMachineInstance, name string, phase k8scorev1.PodPhase, ownedByVMI bool) *k8scorev1.Pod {
-	pod := &k8scorev1.Pod{
+func newPod(vmi *v1.VirtualMachineInstance, name string, phase k8sv1.PodPhase, ownedByVMI bool) *k8sv1.Pod {
+	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: vmi.Namespace,
 		},
-		Status: k8scorev1.PodStatus{
+		Status: k8sv1.PodStatus{
 			Phase: phase,
-			ContainerStatuses: []k8scorev1.ContainerStatus{
-				{Ready: false, Name: "compute", State: k8scorev1.ContainerState{Running: &k8scorev1.ContainerStateRunning{}}},
+			ContainerStatuses: []k8sv1.ContainerStatus{
+				{Ready: false, Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}}},
 			},
 		},
 	}
@@ -616,7 +612,7 @@ func newMigration(name string, vmi string, phase v1.VirtualMachineInstanceMigrat
 	migration := kubecli.NewMinimalMigration(name)
 	migration.Status.Phase = phase
 	migration.Spec.VMIName = vmi
-	migration.Namespace = k8scorev1.NamespaceDefault
+	migration.Namespace = k8sv1.NamespaceDefault
 	return migration
 }
 
@@ -630,9 +626,9 @@ func newEvictionStrategyNone() *v1.EvictionStrategy {
 	return &strategy
 }
 
-func newTaint() *k8scorev1.Taint {
-	return &k8scorev1.Taint{
-		Effect: k8scorev1.TaintEffectNoSchedule,
+func newTaint() *k8sv1.Taint {
+	return &k8sv1.Taint{
+		Effect: k8sv1.TaintEffectNoSchedule,
 		Key:    "kubevirt.io/drain",
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Switch using fakeClient since the latter better simulate real
behavior, lowering the bar for unit tests, eliminating false positives.
Also, the fake is standard for testing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

