### PR TITLE
pool controller: Use fakeclient

### DIFF
--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	v1 "kubevirt.io/api/core/v1"
-	virtv1 "kubevirt.io/api/core/v1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/api"
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
@@ -56,7 +55,7 @@ var _ = Describe("Pool", func() {
 
 		namespace := "test"
 		baseName := "my-pool"
-		vmInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachine{})
+		vmInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachine{})
 
 		for _, name := range existing {
 			vm, _ := DefaultVirtualMachine(true)
@@ -123,13 +122,13 @@ var _ = Describe("Pool", func() {
 			mockQueue.Wait()
 		}
 
-		addVM := func(vm *virtv1.VirtualMachine) {
+		addVM := func(vm *v1.VirtualMachine) {
 			mockQueue.ExpectAdds(1)
 			vmSource.Add(vm)
 			mockQueue.Wait()
 		}
 
-		addVMI := func(vm *virtv1.VirtualMachineInstance, expectQueue bool) {
+		addVMI := func(vm *v1.VirtualMachineInstance, expectQueue bool) {
 			if expectQueue {
 				mockQueue.ExpectAdds(1)
 			}
@@ -283,8 +282,8 @@ var _ = Describe("Pool", func() {
 			vmi.Namespace = vm.Namespace
 			vmi.Labels = vm.Spec.Template.ObjectMeta.Labels
 			vmi.OwnerReferences = []metav1.OwnerReference{{
-				APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-				Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
+				APIVersion:         v1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+				Kind:               v1.VirtualMachineGroupVersionKind.Kind,
 				Name:               vm.ObjectMeta.Name,
 				UID:                vm.ObjectMeta.UID,
 				Controller:         &t,
@@ -304,7 +303,7 @@ var _ = Describe("Pool", func() {
 			vmiInterface.EXPECT().Delete(context.Background(), gomock.Any(), gomock.Any()).Times(0)
 			vmInterface.EXPECT().Update(context.Background(), gomock.Any(), metav1.UpdateOptions{}).MaxTimes(1).Do(func(ctx context.Context, arg interface{}, options metav1.UpdateOptions) {
 				newVM := arg.(*v1.VirtualMachine)
-				revisionName := newVM.Labels[virtv1.VirtualMachinePoolRevisionName]
+				revisionName := newVM.Labels[v1.VirtualMachinePoolRevisionName]
 				Expect(revisionName).To(Equal(newPoolRevision.Name))
 			}).Return(vm, nil)
 
@@ -348,15 +347,15 @@ var _ = Describe("Pool", func() {
 			vmi.Namespace = vm.Namespace
 			vmi.Labels = maps.Clone(vm.Spec.Template.ObjectMeta.Labels)
 			vmi.OwnerReferences = []metav1.OwnerReference{{
-				APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-				Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
+				APIVersion:         v1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+				Kind:               v1.VirtualMachineGroupVersionKind.Kind,
 				Name:               vm.ObjectMeta.Name,
 				UID:                vm.ObjectMeta.UID,
 				Controller:         &t,
 				BlockOwnerDeletion: &t,
 			}}
 
-			vmi.Labels[virtv1.VirtualMachinePoolRevisionName] = oldPoolRevision.Name
+			vmi.Labels[v1.VirtualMachinePoolRevisionName] = oldPoolRevision.Name
 
 			addPool(pool)
 			addVM(vm)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Switch using fakeClient since the latter better simulate real
behavior, lowering the bar for unit tests, eliminating false positives.
Also, the fake is standard for testing.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

