### PR TITLE
virtctl vmexport: Improve garbage collection of vmexport resources

### DIFF
--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -510,7 +510,10 @@ func DownloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExpo
 func downloadVirtualMachineExport(client kubecli.KubevirtClient, vmeInfo *VMExportInfo) (bool, error) {
 	if vmeInfo.ShouldCreate {
 		if err := CreateVirtualMachineExport(client, vmeInfo); err != nil {
-			if !errExportAlreadyExists(err) {
+			if errExportAlreadyExists(err) {
+				// Don't delete VMExports that already exist unless specified explicitely
+				vmeInfo.KeepVme = true
+			} else {
 				return false, err
 			}
 		}

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2324,9 +2324,6 @@ var _ = SIGDescribe("Export", func() {
 				Expect(err).ToNot(HaveOccurred())
 				_, err = os.Stat(outputFile)
 				Expect(err).ToNot(HaveOccurred())
-
-				// Check VMExport has been deleted
-				checkForDeletedExport(vmeName)
 			})
 
 			It("Download succeeds creating and downloading a vmexport using VM source", func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This Pull Request improves the garbage collection of `virtualmachineexport` resources in virtctl so, by default, we only delete resources created during the command's lifecycle.

Previously, the decision to delete a `virtualmachineexport` was based on the provided flags without adequately accounting for pre-existing resources. This could lead to inconsistencies between the flags and the actual state of resources.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

