### PR TITLE
Rest package: reduce test runtime

### DIFF
--- a/pkg/virt-api/rest/streamer_test.go
+++ b/pkg/virt-api/rest/streamer_test.go
@@ -54,7 +54,9 @@ var _ = Describe("Streamer", func() {
 		streamToClientCalled = make(chan struct{}, 1)
 		streamToServerCalled = make(chan struct{}, 1)
 		serverConn, serverPipe = net.Pipe()
+
 		directDialer = NewDirectDialer(
+			// fake fetch vmi function
 			func(_, _ string) (*v1.VirtualMachineInstance, *errors.StatusError) {
 				fetchVMICalled = true
 				return testVMI, nil
@@ -104,6 +106,13 @@ var _ = Describe("Streamer", func() {
 		params := req.PathParameters()
 		params[definitions.NamespaceParamName] = testNamespace
 		params[definitions.NameParamName] = testName
+
+		streamer.dialer.fetchVMI = func(namespace, name string) (*v1.VirtualMachineInstance, *errors.StatusError) {
+			Expect(namespace).To(Equal(testNamespace))
+			Expect(name).To(Equal(testName))
+			fetchVMICalled = true
+			return nil, nil
+		}
 
 		streamer.Handle(req, resp)
 		Expect(fetchVMICalled).To(BeTrue())

--- a/pkg/virt-api/rest/streamer_test.go
+++ b/pkg/virt-api/rest/streamer_test.go
@@ -315,12 +315,12 @@ var _ = Describe("Streamer", func() {
 	It("closes clientSocket when keepAliveClient cancels context", func() {
 		streamer.streamToClient = func(clientSocket *websocket.Conn, serverConn net.Conn, result chan<- streamFuncResult) {
 			streamToClientCalled <- struct{}{}
-			time.Sleep(defaultTestTimeout * 2)
+			_, _ = io.Copy(io.Discard, serverConn)
 			result <- nil
 		}
 		streamer.streamToServer = func(clientSocket *websocket.Conn, serverConn net.Conn, result chan<- streamFuncResult) {
 			streamToServerCalled <- struct{}{}
-			time.Sleep(defaultTestTimeout * 2)
+			_, _ = io.Copy(io.Discard, clientSocket.UnderlyingConn())
 			result <- nil
 		}
 		streamer.keepAliveClient = func(ctx context.Context, conn *websocket.Conn, cancel func()) {
@@ -400,7 +400,7 @@ var _ = Describe("Streamer", func() {
 		}
 		streamer.streamToServer = func(clientSocket *websocket.Conn, serverConn net.Conn, result chan<- streamFuncResult) {
 			streamToServerCalled <- struct{}{}
-			time.Sleep(defaultTestTimeout * 2)
+			_, _ = io.Copy(io.Discard, clientSocket.UnderlyingConn())
 			result <- nil
 		}
 		var wg sync.WaitGroup
@@ -421,7 +421,7 @@ var _ = Describe("Streamer", func() {
 		testErrStreamEnded := goerrors.New("stream ended")
 		streamer.streamToClient = func(clientSocket *websocket.Conn, serverConn net.Conn, result chan<- streamFuncResult) {
 			streamToClientCalled <- struct{}{}
-			time.Sleep(defaultTestTimeout * 2)
+			_, _ = io.Copy(io.Discard, serverConn)
 			result <- nil
 		}
 		streamer.streamToServer = func(clientSocket *websocket.Conn, serverConn net.Conn, result chan<- streamFuncResult) {

--- a/pkg/virt-api/rest/streamer_test.go
+++ b/pkg/virt-api/rest/streamer_test.go
@@ -228,13 +228,11 @@ var _ = Describe("Streamer", func() {
 		Eventually(call, defaultTestTimeout).Should(Receive())
 		wg.Wait()
 	})
-	It("does not call keepAliveClient if the client connection upgrade failed", func() {
-		call := make(chan struct{})
-		streamer.keepAliveClient = func(ctx context.Context, conn *websocket.Conn, _ func()) {
-			call <- struct{}{}
-		}
+	It("returns if the client connection upgrade failed", func() {
 		Expect(streamer.Handle(req, resp)).To(HaveOccurred())
-		Consistently(call, defaultTestTimeout).ShouldNot(Receive())
+		response, err := io.ReadAll(respRecorder.Body)
+		Expect(err).To(Not(HaveOccurred()))
+		Expect(string(response)).To(ContainSubstring("the client is not using the websocket protocol"))
 	})
 	It("does start streamToClient with connections", func() {
 		streamer.streamToClient = func(clientSocket *websocket.Conn, serverConn net.Conn, result chan<- streamFuncResult) {


### PR DESCRIPTION
### What this PR does
Removes unnecessary `time.Sleep`. This reduce the runtime from ~40 seconds down to ~2 seconds

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

