### PR TITLE
vmpool: improve test time

### DIFF
--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -95,7 +95,6 @@ var _ = Describe("Pool", func() {
 
 		var vmiSource *framework.FakeControllerSource
 		var vmiInformer cache.SharedIndexInformer
-		var vmInformer cache.SharedIndexInformer
 		var stop chan struct{}
 		var controller *PoolController
 		var recorder *record.FakeRecorder
@@ -105,9 +104,8 @@ var _ = Describe("Pool", func() {
 
 		syncCaches := func(stop chan struct{}) {
 			go vmiInformer.Run(stop)
-			go vmInformer.Run(stop)
 			go crInformer.Run(stop)
-			Expect(cache.WaitForCacheSync(stop, vmiInformer.HasSynced, vmInformer.HasSynced, crInformer.HasSynced)).To(BeTrue())
+			Expect(cache.WaitForCacheSync(stop, vmiInformer.HasSynced, crInformer.HasSynced)).To(BeTrue())
 		}
 
 		addCR := func(cr *appsv1.ControllerRevision) {
@@ -141,7 +139,7 @@ var _ = Describe("Pool", func() {
 			virtClient := kubecli.NewMockKubevirtClient(ctrl)
 
 			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
-			vmInformer, _ = testutils.NewFakeInformerFor(&v1.VirtualMachine{})
+			vmInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachine{})
 			poolInformer, _ := testutils.NewFakeInformerFor(&poolv1.VirtualMachinePool{})
 			recorder = record.NewFakeRecorder(100)
 			recorder.IncludeObject = true

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -86,8 +86,6 @@ var _ = Describe("Pool", func() {
 			testNamespace = "default"
 		)
 
-		var ctrl *gomock.Controller
-
 		var controller *PoolController
 		var recorder *record.FakeRecorder
 		var mockQueue *testutils.MockWorkQueue
@@ -116,8 +114,7 @@ var _ = Describe("Pool", func() {
 		}
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			virtClient := kubecli.NewMockKubevirtClient(ctrl)
+			virtClient := kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
 
 			vmiInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			vmInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachine{})

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -95,7 +95,6 @@ var _ = Describe("Pool", func() {
 
 		var vmiSource *framework.FakeControllerSource
 		var vmSource *framework.FakeControllerSource
-		var poolSource *framework.FakeControllerSource
 		var vmiInformer cache.SharedIndexInformer
 		var vmInformer cache.SharedIndexInformer
 		var poolInformer cache.SharedIndexInformer
@@ -145,7 +144,7 @@ var _ = Describe("Pool", func() {
 
 			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			vmInformer, vmSource = testutils.NewFakeInformerFor(&v1.VirtualMachine{})
-			poolInformer, poolSource = testutils.NewFakeInformerFor(&poolv1.VirtualMachinePool{})
+			poolInformer, _ = testutils.NewFakeInformerFor(&poolv1.VirtualMachinePool{})
 			recorder = record.NewFakeRecorder(100)
 			recorder.IncludeObject = true
 
@@ -196,9 +195,10 @@ var _ = Describe("Pool", func() {
 		})
 
 		addPool := func(pool *poolv1.VirtualMachinePool) {
-			mockQueue.ExpectAdds(1)
-			poolSource.Add(pool)
-			mockQueue.Wait()
+			controller.poolIndexer.Add(pool)
+			key, err := virtcontroller.KeyFunc(pool)
+			Expect(err).To(Not(HaveOccurred()))
+			mockQueue.Add(key)
 		}
 
 		createPoolRevision := func(pool *poolv1.VirtualMachinePool) *appsv1.ControllerRevision {

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -92,7 +92,6 @@ var _ = Describe("Pool", func() {
 		var crInformer cache.SharedIndexInformer
 		var crSource *framework.FakeControllerSource
 
-		var vmiInformer cache.SharedIndexInformer
 		var stop chan struct{}
 		var controller *PoolController
 		var recorder *record.FakeRecorder
@@ -101,9 +100,8 @@ var _ = Describe("Pool", func() {
 		var k8sClient *k8sfake.Clientset
 
 		syncCaches := func(stop chan struct{}) {
-			go vmiInformer.Run(stop)
 			go crInformer.Run(stop)
-			Expect(cache.WaitForCacheSync(stop, vmiInformer.HasSynced, crInformer.HasSynced)).To(BeTrue())
+			Expect(cache.WaitForCacheSync(stop, crInformer.HasSynced)).To(BeTrue())
 		}
 
 		addCR := func(cr *appsv1.ControllerRevision) {
@@ -131,7 +129,7 @@ var _ = Describe("Pool", func() {
 			ctrl = gomock.NewController(GinkgoT())
 			virtClient := kubecli.NewMockKubevirtClient(ctrl)
 
-			vmiInformer, _ = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
+			vmiInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			vmInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachine{})
 			poolInformer, _ := testutils.NewFakeInformerFor(&poolv1.VirtualMachinePool{})
 			recorder = record.NewFakeRecorder(100)

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -97,7 +97,6 @@ var _ = Describe("Pool", func() {
 		var vmSource *framework.FakeControllerSource
 		var vmiInformer cache.SharedIndexInformer
 		var vmInformer cache.SharedIndexInformer
-		var poolInformer cache.SharedIndexInformer
 		var stop chan struct{}
 		var controller *PoolController
 		var recorder *record.FakeRecorder
@@ -108,9 +107,8 @@ var _ = Describe("Pool", func() {
 		syncCaches := func(stop chan struct{}) {
 			go vmiInformer.Run(stop)
 			go vmInformer.Run(stop)
-			go poolInformer.Run(stop)
 			go crInformer.Run(stop)
-			Expect(cache.WaitForCacheSync(stop, vmiInformer.HasSynced, vmInformer.HasSynced, poolInformer.HasSynced, crInformer.HasSynced)).To(BeTrue())
+			Expect(cache.WaitForCacheSync(stop, vmiInformer.HasSynced, vmInformer.HasSynced, crInformer.HasSynced)).To(BeTrue())
 		}
 
 		addCR := func(cr *appsv1.ControllerRevision) {
@@ -144,7 +142,7 @@ var _ = Describe("Pool", func() {
 
 			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			vmInformer, vmSource = testutils.NewFakeInformerFor(&v1.VirtualMachine{})
-			poolInformer, _ = testutils.NewFakeInformerFor(&poolv1.VirtualMachinePool{})
+			poolInformer, _ := testutils.NewFakeInformerFor(&poolv1.VirtualMachinePool{})
 			recorder = record.NewFakeRecorder(100)
 			recorder.IncludeObject = true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This series of commits gradually remove complexity of pool tests to the point where we reduce the runtime from ~19 seconds down to ~250ms. On top of this we remove some unnecessary code and fix few issues.

### Special notes for your reviewer
These changes follow the logic introduced here https://github.com/kubevirt/kubevirt/pull/12468
<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

