### PR TITLE
ci: add ionice idle level to cluster-sync

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -297,7 +297,7 @@ set -e
 echo "Nodes are ready:"
 kubectl get nodes
 
-make cluster-sync
+ionice --class idle make cluster-sync
 
 # OpenShift is running important containers under default namespace
 namespaces=(kubevirt default)


### PR DESCRIPTION
### What this PR does

`make cluster-sync` causes a large amount of IO operations as it is
building the required images and pushing them to the local registry.

This pushing of the images is reading and writing these images to the
same underlying disk.

This high level of IO can impact other CI jobs that are running on the
same worker node which can lead to some issues such as etcd timeouts that are
seen intermittently

Setting an ionice idle level for cluster-sync should reduce this impact
and give priority to the processes running the tests.

Before this PR:

High levels of IO at the start of  presubmit prowjobs while cluster-sync is running
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/12095/pull-kubevirt-e2e-k8s-1.30-sig-storage/1820723312959950848

![Screenshot from 2024-08-06 11-09-15](https://github.com/user-attachments/assets/0bc1938f-5a81-4c15-978a-be44100fe277)

After this PR:

Much lower levels of IO from the same test lane but with these changes applied
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/12511/pull-kubevirt-e2e-k8s-1.30-sig-storage/1820724177204678656

![Screenshot from 2024-08-06 11-08-48](https://github.com/user-attachments/assets/68f29ff1-9181-47d0-b493-b97fcd24771d)


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

