### PR TITLE
migration test: improve test time

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -63,7 +63,6 @@ var _ = Describe("Migration watcher", func() {
 
 	var ctrl *gomock.Controller
 	var podInformer cache.SharedIndexInformer
-	var migrationInformer cache.SharedIndexInformer
 	var nodeInformer cache.SharedIndexInformer
 	var pdbInformer cache.SharedIndexInformer
 	var migrationPolicyInformer cache.SharedIndexInformer
@@ -235,7 +234,6 @@ var _ = Describe("Migration watcher", func() {
 
 	syncCaches := func(stop chan struct{}) {
 		go podInformer.Run(stop)
-		go migrationInformer.Run(stop)
 		go nodeInformer.Run(stop)
 		go pdbInformer.Run(stop)
 		go migrationPolicyInformer.Run(stop)
@@ -244,7 +242,6 @@ var _ = Describe("Migration watcher", func() {
 
 		Expect(cache.WaitForCacheSync(stop,
 			podInformer.HasSynced,
-			migrationInformer.HasSynced,
 			nodeInformer.HasSynced,
 			pdbInformer.HasSynced,
 			resourceQuotaInformer.HasSynced,
@@ -264,7 +261,7 @@ var _ = Describe("Migration watcher", func() {
 		virtClientset = kubevirtfake.NewSimpleClientset()
 
 		vmiInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
-		migrationInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
+		migrationInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
 		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		pdbInformer, _ = testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
 		resourceQuotaInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
@@ -1017,7 +1014,7 @@ var _ = Describe("Migration watcher", func() {
 
 					mCopy.CreationTimestamp = metav1.Unix(int64(rand.Intn(100)), int64(0))
 
-					Expect(migrationInformer.GetStore().Add(mCopy)).To(Succeed())
+					Expect(controller.migrationIndexer.Add(mCopy)).To(Succeed())
 					_, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(mCopy.Namespace).Create(context.Background(), mCopy, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}
@@ -1029,7 +1026,7 @@ var _ = Describe("Migration watcher", func() {
 					mCopy.Labels = map[string]string{"should-delete": "yes"}
 					mCopy.CreationTimestamp = metav1.Unix(int64(rand.Intn(100)), int64(0))
 
-					Expect(migrationInformer.GetStore().Add(mCopy)).To(Succeed())
+					Expect(controller.migrationIndexer.Add(mCopy)).To(Succeed())
 					_, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(mCopy.Namespace).Create(context.Background(), mCopy, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -64,7 +64,6 @@ var _ = Describe("Migration watcher", func() {
 
 	var ctrl *gomock.Controller
 	var migrationSource *framework.FakeControllerSource
-	var vmiInformer cache.SharedIndexInformer
 	var podInformer cache.SharedIndexInformer
 	var migrationInformer cache.SharedIndexInformer
 	var nodeInformer cache.SharedIndexInformer
@@ -237,7 +236,6 @@ var _ = Describe("Migration watcher", func() {
 	}
 
 	syncCaches := func(stop chan struct{}) {
-		go vmiInformer.Run(stop)
 		go podInformer.Run(stop)
 		go migrationInformer.Run(stop)
 		go nodeInformer.Run(stop)
@@ -247,7 +245,6 @@ var _ = Describe("Migration watcher", func() {
 		go namespaceInformer.Run(stop)
 
 		Expect(cache.WaitForCacheSync(stop,
-			vmiInformer.HasSynced,
 			podInformer.HasSynced,
 			migrationInformer.HasSynced,
 			nodeInformer.HasSynced,
@@ -268,7 +265,7 @@ var _ = Describe("Migration watcher", func() {
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		virtClientset = kubevirtfake.NewSimpleClientset()
 
-		vmiInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
+		vmiInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
 		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		pdbInformer, _ = testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
@@ -1049,7 +1046,7 @@ var _ = Describe("Migration watcher", func() {
 
 			sourcePod := newSourcePodForVirtualMachine(vmi)
 			Expect(podInformer.GetStore().Add(sourcePod)).To(Succeed())
-			Expect(vmiInformer.GetStore().Add(vmi)).To(Succeed())
+			Expect(controller.vmiStore.Add(vmi)).To(Succeed())
 
 			controller.Execute()
 

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -60,16 +60,16 @@ import (
 
 var _ = Describe("Migration watcher", func() {
 
-	var ctrl *gomock.Controller
-	var controller *MigrationController
-	var recorder *record.FakeRecorder
-	var mockQueue *testutils.MockWorkQueue
-	var virtClient *kubecli.MockKubevirtClient
-	var virtClientset *kubevirtfake.Clientset
-	var kubeClient *fake.Clientset
-	var networkClient *fakenetworkclient.Clientset
-	var qemuGid int64 = 107
-	var namespace k8sv1.Namespace
+	var (
+		controller    *MigrationController
+		recorder      *record.FakeRecorder
+		mockQueue     *testutils.MockWorkQueue
+		virtClientset *kubevirtfake.Clientset
+		kubeClient    *fake.Clientset
+		networkClient *fakenetworkclient.Clientset
+		namespace     k8sv1.Namespace
+	)
+	const qemuGid int64 = 107
 
 	expectMigrationFinalizerRemoved := func(namespace, name string) {
 		updatedVMIM, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(namespace).Get(context.Background(), name, metav1.GetOptions{})
@@ -229,8 +229,7 @@ var _ = Describe("Migration watcher", func() {
 	}
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		virtClient = kubecli.NewMockKubevirtClient(ctrl)
+		virtClient := kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
 		virtClientset = kubevirtfake.NewSimpleClientset()
 
 		vmiInformer, _ := testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This series of commits gradually remove complexity of pool tests to the point where we reduce the runtime from ~12 seconds down to ~150ms. On top of this we remove some unnecessary code and fix few issues.

### Special notes for your reviewer
These changes follow the logic introduced here https://github.com/kubevirt/kubevirt/pull/12468
<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

