### PR TITLE
Remove usage of "filters" in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,38 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-filters:
-  ".*":
-    reviewers:
-      - code-reviewers
-    approvers:
-      - approvers
-    emeritus_approvers:
-      - emeritus_approvers
-
-  "cluster-up/.*|WORKSPACE|.bazel.*|.fossa.yml|cluster-up-sha.txt":
-    reviewers:
-      - sig-buildsystem-reviewers
-    approvers:
-      - sig-buildsystem-approvers
-    labels:
-      - sig/buildsystem
-  ".*_test.go":
-    reviewers:
-      - sig-test-reviewers
-    approvers:
-       - sig-test-approvers
-    labels:
-      - sig/test
-  ".golangci.yml":
-    approvers:
-      - sig-test-approvers
-      - sig-compute-approvers
-      - sig-network-approvers
-
-  "docs/metrics.md":
-    reviewers:
-      - sig-observability-reviewers
-    approvers:
-      - sig-observability-approvers
-    labels:
-      - sig/observability
+reviewers:
+  - code-reviewers
+approvers:
+  - approvers
+emeritus_approvers:
+  - emeritus_approvers
+  

--- a/cluster-up/OWNERS
+++ b/cluster-up/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - sig-buildsystem-reviewers
+approvers:
+  - sig-buildsystem-approvers
+labels:
+  - sig/buildsystem
+   

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-filters:
-  # examples:
-  #   virt-api/BUILD.bazel
-  "virt.*/BUILD\\.bazel$":
-    labels:
-      - kind/build-change

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,17 +1,6 @@
-filters:
-
-  ".*":
-    reviewers:
-    - sig-buildsystem-reviewers
-    approvers:
-    - sig-buildsystem-approvers
-    labels:
-    - sig/buildsystem
-
-  ".*perf.*":
-    reviewers:
-      - sig-scale-reviewers
-    approvers:
-      - sig-scale-approvers
-    labels:
-      - sig/scale
+reviewers:
+- sig-buildsystem-reviewers
+approvers:
+- sig-buildsystem-approvers
+labels:
+- sig/buildsystem

--- a/staging/src/kubevirt.io/api/OWNERS
+++ b/staging/src/kubevirt.io/api/OWNERS
@@ -1,9 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-filters:
-  # examples:
-  #   pkg/api/types.go
-  #   pkg/api/*/register.go
-  "\\.go$":
-    labels:
-      - kind/api-change
+labels:
+  - kind/api-change


### PR DESCRIPTION
### What this PR does
The documentation states:
"WARNING: The approve plugin does not currently respect filters. Until that is fixed, filters should only be used for the labels key (as shown in the above example)"

From now on we can only use OWNERS files per directory.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
```release-note
NONE
```

