### PR TITLE
enable initial e2e tests for s390x.

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -97,6 +97,8 @@ elif [[ $TARGET =~ sig-operator ]]; then
 elif [[ $TARGET =~ sig-monitoring ]]; then
     export KUBEVIRT_PROVIDER=${TARGET/-sig-monitoring/}
     export KUBEVIRT_DEPLOY_PROMETHEUS=true
+elif [[ $TARGET =~ wg-s390x ]]; then
+    export KUBEVIRT_PROVIDER=${TARGET/-wg-s390x}
 else
   export KUBEVIRT_PROVIDER=${TARGET}
 fi
@@ -421,6 +423,8 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     fi
   elif [[ $TARGET =~ sig-storage ]]; then
     label_filter='(sig-storage)'
+  elif [[ $TARGET =~ wg-s390x ]]; then
+    label_filter='(wg-s390x)'
   elif [[ $TARGET =~ vgpu.* ]]; then
     label_filter='(VGPU)'
   elif [[ $TARGET =~ sig-compute-realtime ]]; then

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -293,3 +293,24 @@ func GenerateKubeVirtGroupVersionKind(obj runtime.Object) (runtime.Object, error
 
 	return objCopy, nil
 }
+
+/*
+TranslateBuildArch translates the build_arch to arch
+
+	case1:
+	  build_arch is crossbuild-s390x, which will be translated to s390x arch
+	case2:
+	  build_arch is s390x, which will be translated to s390x arch
+*/
+func TranslateBuildArch() string {
+	buildArch := os.Getenv("BUILD_ARCH")
+
+	if buildArch == "" {
+		return ""
+	}
+	archElements := strings.Split(buildArch, "-")
+	if len(archElements) == 2 {
+		return archElements[1]
+	}
+	return archElements[0]
+}

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -159,7 +159,7 @@ func (r rights) list() (e []rightsEntry) {
 	return
 }
 
-var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]User Access", decorators.SigCompute, func() {
+var _ = Describe("[rfe_id:500][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component][sig-compute]User Access", decorators.SigCompute, func() {
 
 	var k8sClient string
 	var authClient *authClientV1.AuthorizationV1Client

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -159,7 +159,7 @@ func (r rights) list() (e []rightsEntry) {
 	return
 }
 
-var _ = Describe("[rfe_id:500][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component][sig-compute]User Access", decorators.SigCompute, func() {
+var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]User Access", decorators.SigCompute, decorators.WgS390x, func() {
 
 	var k8sClient string
 	var authClient *authClientV1.AuthorizationV1Client

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -226,7 +226,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 	})
 
-	Describe("[rfe_id:4052][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions", func() {
+	Describe("[rfe_id:4052][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions", func() {
 		Context("with ephemeral registry disk", func() {
 			It("[test_id:4299]should not have world write permissions", func() {
 				vmi := libvmifact.NewAlpine()

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -226,7 +226,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 	})
 
-	Describe("[rfe_id:4052][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions", func() {
+	Describe("[rfe_id:4052][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions", decorators.WgS390x, func() {
 		Context("with ephemeral registry disk", func() {
 			It("[test_id:4299]should not have world write permissions", func() {
 				vmi := libvmifact.NewAlpine()

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -60,4 +60,7 @@ var (
 
 	// Kubernetes versions
 	Kubernetes130 = []interface{}{Label("kubernetes130")}
+
+	// WG archs
+	WgS390x = []interface{}{Label("wg-s390x")}
 )

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1009,7 +1009,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 
-		Context("[rfe_id:2288][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component] With not existing PVC", func() {
+		Context("[rfe_id:2288][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component] With not existing PVC", decorators.WgS390x, func() {
 			// Not a candidate for NFS because the PVC in question doesn't actually exist
 			It("[test_id:1040] should get unschedulable condition", func() {
 				// Start the VirtualMachineInstance

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1009,7 +1009,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 
-		Context("[rfe_id:2288][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component] With not existing PVC", func() {
+		Context("[rfe_id:2288][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component] With not existing PVC", func() {
 			// Not a candidate for NFS because the PVC in question doesn't actually exist
 			It("[test_id:1040] should get unschedulable condition", func() {
 				// Start the VirtualMachineInstance

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -37,6 +37,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	putil "kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -91,8 +92,13 @@ func AdjustKubeVirtResource() {
 			},
 		},
 	}
+	// Disable CPUManager Featuregate for s390x as it is not supported.
+	if putil.TranslateBuildArch() != "s390x" {
+		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
+			virtconfig.CPUManager,
+		)
+	}
 	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
-		virtconfig.CPUManager,
 		virtconfig.IgnitionGate,
 		virtconfig.SidecarGate,
 		virtconfig.SnapshotGate,

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2521,7 +2521,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(vmiCondition.Reason).To(Equal("Synchronizing with the Domain failed."))
 		})
 	})
-	Describe("[rfe_id:897][crit:medium][arm64][s390x][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", func() {
+	Describe("[rfe_id:897][crit:medium][arm64][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", decorators.WgS390x, func() {
 		var nodes *k8sv1.NodeList
 
 		isNodeHasCPUManagerLabel := func(nodeName string) bool {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2521,7 +2521,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(vmiCondition.Reason).To(Equal("Synchronizing with the Domain failed."))
 		})
 	})
-	Describe("[rfe_id:897][crit:medium][arm64][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", func() {
+	Describe("[rfe_id:897][crit:medium][arm64][s390x][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", func() {
 		var nodes *k8sv1.NodeList
 
 		isNodeHasCPUManagerLabel := func(nodeName string) bool {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -74,7 +74,7 @@ import (
 	"kubevirt.io/kubevirt/tests/watcher"
 )
 
-var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIlifecycle", decorators.SigCompute, decorators.VMIlifecycle, func() {
+var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIlifecycle", decorators.SigCompute, decorators.VMIlifecycle, func() {
 
 	var err error
 
@@ -347,6 +347,8 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 		Context("with boot order", func() {
 			DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should be able to boot from selected disk", func(alpineBootOrder uint, cirrosBootOrder uint, consoleText string, wait int) {
+				arch := testsuite.TranslateBuildArch()
+				checks.SkipIfS390X(arch, "skipping for s390x as this test requires both cirros and alpine.")
 				By("defining a VirtualMachineInstance with an Alpine disk")
 				vmi = libvmifact.NewAlpine(libvmi.WithContainerDisk("disk2", cd.ContainerDiskFor(cd.ContainerDiskCirros)))
 
@@ -567,7 +569,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		Context("[Serial]when virt-handler is responsive", Serial, func() {
-			It("[test_id:1633]should indicate that a node is ready for vmis", func() {
+			It("[test_id:1633]should indicate that a node is ready for vmis", decorators.WgS390x, func() {
 
 				By("adding a heartbeat annotation and a schedulable label to the node")
 				nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
@@ -661,6 +663,8 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			var virtHandlerAvailablePods int32
 
 			BeforeEach(func() {
+				arch := testsuite.TranslateBuildArch()
+				checks.SkipIfS390X(arch, "failing for s390x.")
 				// Schedule a vmi and make sure that virt-handler gets evicted from the node where the vmi was started
 				// Note: we want VMI without any container
 				vmi = libvmifact.NewGuestless(libvmi.WithLogSerialConsole(false))
@@ -884,6 +888,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			BeforeEach(func() {
 				// arm64 does not support cpu model
 				checks.SkipIfARM64(testsuite.Arch, "arm64 does not support cpu model")
+				checks.SkipIfS390X(testsuite.Arch, "the kubevirt support of s390x cpu model is not yet added.")
 				nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				supportedCpuModels = libnode.GetSupportedCPUModels(*nodes)
@@ -993,6 +998,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			BeforeEach(func() {
 				// arm64 does not support cpu model
 				checks.SkipIfARM64(testsuite.Arch, "arm64 does not support cpu model")
+				checks.SkipIfS390X(testsuite.Arch, "the kubevirt support of s390x cpu model is not yet added.")
 				nodes = libnode.GetAllSchedulableNodes(kubevirt.Client())
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
@@ -1573,6 +1579,9 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 		Context("with grace period greater than 0", func() {
 			It("[test_id:1655]should run graceful shutdown", func() {
+				arch := testsuite.TranslateBuildArch()
+				checks.SkipIfS390X(arch, "failing for s390x.")
+
 				nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				node := nodes.Items[0].Name

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -74,7 +74,7 @@ import (
 	"kubevirt.io/kubevirt/tests/watcher"
 )
 
-var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIlifecycle", decorators.SigCompute, decorators.VMIlifecycle, func() {
+var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIlifecycle", decorators.SigCompute, decorators.VMIlifecycle, func() {
 
 	var err error
 
@@ -91,7 +91,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 		testsuite.EnsureKVMPresent()
 	})
 
-	Context("when virt-handler is deleted", Serial, func() {
+	Context("when virt-handler is deleted", Serial, decorators.WgS390x, func() {
 		It("[Serial][test_id:4716]should label the node with kubevirt.io/schedulable=false", func() {
 			pods, err := kubevirt.Client().CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"),
@@ -121,17 +121,17 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 	})
 
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
-		It("[test_id:1619]should success", func() {
+		It("[test_id:1619]should success", decorators.WgS390x, func() {
 			vmi := libvmifact.NewAlpine()
 			_, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Create VMI successfully")
 		})
 
-		It("[test_id:1620]should start it", func() {
+		It("[test_id:1620]should start it", decorators.WgS390x, func() {
 			libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 		})
 
-		It("[test_id:6095]should start in paused state if start strategy set to paused", func() {
+		It("[test_id:6095]should start in paused state if start strategy set to paused", decorators.WgS390x, func() {
 			vmi := libvmifact.NewAlpine(libvmi.WithStartStrategy(v1.StartStrategyPaused))
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
@@ -142,7 +142,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 		})
 
-		It("[test_id:1621]should attach virt-launcher to it", func() {
+		It("[test_id:1621]should attach virt-launcher to it", decorators.WgS390x, func() {
 			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 			By("Getting virt-launcher logs")
@@ -153,7 +153,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 				Should(ContainSubstring("Found PID for"))
 		})
 
-		It("[test_id:3195]should carry annotations to pod", func() {
+		It("[test_id:3195]should carry annotations to pod", decorators.WgS390x, func() {
 			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(
 				libvmi.WithAnnotation("testannotation", "annotation from vmi")),
 				startupTimeout)
@@ -164,7 +164,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			Expect(pod.Annotations).To(HaveKeyWithValue("testannotation", "annotation from vmi"), "annotation should be carried to the pod")
 		})
 
-		It("[test_id:3196]should carry kubernetes and kubevirt annotations to pod", func() {
+		It("[test_id:3196]should carry kubernetes and kubevirt annotations to pod", decorators.WgS390x, func() {
 			vmi = libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(
 				libvmi.WithAnnotation("kubevirt.io/test", "test"),
 				libvmi.WithAnnotation("kubernetes.io/test", "test")),
@@ -177,7 +177,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			Expect(pod.Annotations).To(HaveKey("kubernetes.io/test"), "kubernetes annotation should not be carried to the pod")
 		})
 
-		It("Should prevent eviction when EvictionStratgy: External", func() {
+		It("Should prevent eviction when EvictionStratgy: External", decorators.WgS390x, func() {
 			vmi := libvmifact.NewAlpine(libvmi.WithEvictionStrategy(v1.EvictionStrategyExternal))
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
 
@@ -205,7 +205,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			}, 20*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		})
 
-		It("[test_id:1622]should log libvirtd logs", func() {
+		It("[test_id:1622]should log libvirtd logs", decorators.WgS390x, func() {
 			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
 
 			By("Getting virt-launcher logs")
@@ -263,7 +263,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			Entry("[test_id:8533]disabled when log verbosity, debug logs and customLogFilters are not defined", nil, nil, false),
 		)
 
-		It("[test_id:1623]should reject POST if validation webhook deems the spec invalid", func() {
+		It("[test_id:1623]should reject POST if validation webhook deems the spec invalid", decorators.WgS390x, func() {
 			vmi := libvmifact.NewAlpine()
 			// Add a disk that doesn't map to a volume.
 			// This should get rejected which tells us the webhook validator is working.
@@ -291,7 +291,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			Expect(reviewResponse.Details.Causes[1].Field).To(Equal("spec.domain.devices.disks[2].name"))
 		})
 
-		It("[test_id:1624]should reject PATCH if schema is invalid", func() {
+		It("[test_id:1624]should reject PATCH if schema is invalid", decorators.WgS390x, func() {
 			vmi := libvmifact.NewAlpine()
 			err := kubevirt.Client().RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred(), "Send POST successfully")
@@ -307,7 +307,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity), "The entity should be unprocessable")
 		})
 
-		Context("when name is longer than 63 characters", func() {
+		Context("when name is longer than 63 characters", decorators.WgS390x, func() {
 			BeforeEach(func() {
 				vmi = libvmifact.NewAlpine()
 				vmi.Name = "testvmi" + rand.String(63)
@@ -328,7 +328,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			})
 		})
 
-		Context("when it already exist", func() {
+		Context("when it already exist", decorators.WgS390x, func() {
 			It("[test_id:1626]should be rejected", func() {
 				By("Creating a VirtualMachineInstance")
 				vmi := libvmifact.NewAlpine()
@@ -347,8 +347,6 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 
 		Context("with boot order", func() {
 			DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should be able to boot from selected disk", func(alpineBootOrder uint, cirrosBootOrder uint, consoleText string, wait int) {
-				arch := testsuite.TranslateBuildArch()
-				checks.SkipIfS390X(arch, "skipping for s390x as this test requires both cirros and alpine.")
 				By("defining a VirtualMachineInstance with an Alpine disk")
 				vmi = libvmifact.NewAlpine(libvmi.WithContainerDisk("disk2", cd.ContainerDiskFor(cd.ContainerDiskCirros)))
 
@@ -493,7 +491,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			})
 		})
 
-		Context("when virt-launcher crashes", func() {
+		Context("when virt-launcher crashes", decorators.WgS390x, func() {
 			It("[Serial][test_id:1631]should be stopped and have Failed phase", Serial, func() {
 				vmi := libvmifact.NewAlpine()
 				vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
@@ -663,8 +661,6 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			var virtHandlerAvailablePods int32
 
 			BeforeEach(func() {
-				arch := testsuite.TranslateBuildArch()
-				checks.SkipIfS390X(arch, "failing for s390x.")
 				// Schedule a vmi and make sure that virt-handler gets evicted from the node where the vmi was started
 				// Note: we want VMI without any container
 				vmi = libvmifact.NewGuestless(libvmi.WithLogSerialConsole(false))
@@ -888,7 +884,6 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			BeforeEach(func() {
 				// arm64 does not support cpu model
 				checks.SkipIfARM64(testsuite.Arch, "arm64 does not support cpu model")
-				checks.SkipIfS390X(testsuite.Arch, "the kubevirt support of s390x cpu model is not yet added.")
 				nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				supportedCpuModels = libnode.GetSupportedCPUModels(*nodes)
@@ -998,7 +993,6 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			BeforeEach(func() {
 				// arm64 does not support cpu model
 				checks.SkipIfARM64(testsuite.Arch, "arm64 does not support cpu model")
-				checks.SkipIfS390X(testsuite.Arch, "the kubevirt support of s390x cpu model is not yet added.")
 				nodes = libnode.GetAllSchedulableNodes(kubevirt.Client())
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
@@ -1294,7 +1288,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			)
 		})
 
-		Context("VirtualMachineInstance Emulation Mode", func() {
+		Context("VirtualMachineInstance Emulation Mode", decorators.WgS390x, func() {
 			BeforeEach(func() {
 				// allowEmulation won't change in a test suite run, so cache it
 				if allowEmulation == nil {
@@ -1403,7 +1397,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 			})
 		})
 
-		Context("VM Accelerated Mode", func() {
+		Context("VM Accelerated Mode", decorators.WgS390x, func() {
 			BeforeEach(func() {
 				// allowEmulation won't change in a test suite run, so cache it
 				if allowEmulation == nil {
@@ -1476,7 +1470,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 		})
 	})
 
-	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Get a VirtualMachineInstance", func() {
+	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Get a VirtualMachineInstance", decorators.WgS390x, func() {
 		Context("when that not exist", func() {
 			It("[test_id:1649]should return 404", func() {
 				vmi := libvmifact.NewAlpine()
@@ -1490,7 +1484,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 		})
 	})
 
-	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance's Pod", func() {
+	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance's Pod", decorators.WgS390x, func() {
 		It("[test_id:1650]should result in the VirtualMachineInstance moving to a finalized state", func() {
 			By("Creating the VirtualMachineInstance")
 			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), startupTimeout)
@@ -1521,7 +1515,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 		})
 	})
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance", func() {
-		Context("with an active pod.", func() {
+		Context("with an active pod.", decorators.WgS390x, func() {
 			It("[test_id:1651]should result in pod being terminated", func() {
 
 				By("Creating the VirtualMachineInstance")
@@ -1579,9 +1573,6 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 		})
 		Context("with grace period greater than 0", func() {
 			It("[test_id:1655]should run graceful shutdown", func() {
-				arch := testsuite.TranslateBuildArch()
-				checks.SkipIfS390X(arch, "failing for s390x.")
-
 				nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				node := nodes.Items[0].Name
@@ -1633,7 +1624,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 		})
 	})
 
-	Describe("[Serial][rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", Serial, func() {
+	Describe("[Serial][rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", Serial, decorators.WgS390x, func() {
 		It("[test_id:1656]should be in Failed phase", func() {
 			By("Starting a VirtualMachineInstance")
 			vmi := libvmifact.NewAlpine()
@@ -1689,7 +1680,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][s390x][vendor:cnv-qe@redhat.com
 		})
 	})
 
-	Context("replicaset with topology spread constraints", func() {
+	Context("replicaset with topology spread constraints", decorators.WgS390x, func() {
 		It("Replicas should be spread across nodes", func() {
 			nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
 			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some schedulable nodes")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
There are no e2e tests enabled for s390x.

After this PR:
A subset of the existing e2e tests is enabled for s390x and tested against external CI cluster. All these tests which are tagged with [s390x] are tested against s390x cluster are passing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
    enable initial e2e tests for s390x.

```

