### PR TITLE
virtctl/imageupload progress bar: write to stdout

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -461,6 +461,7 @@ func uploadData(uploadProxyURL, token string, file *os.File, insecure bool) erro
 	}
 
 	bar := pb.Full.Start64(fi.Size())
+	bar.SetWriter(os.Stdout)
 	bar.Set(pb.Bytes, true)
 	reader := bar.NewProxyReader(file)
 

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -110,7 +110,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 			}
 
 			By("Upload image")
-			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
+			stdout, stderr, err := clientcmd.RunCommand(testsuite.GetTestNamespace(nil), "virtctl", imageUploadCmd,
 				resource, targetName,
 				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--image-path", imagePath,
@@ -118,14 +118,16 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 				"--storage-class", sc,
 				"--force-bind",
 				"--volume-mode", "block",
-				insecureArg)
-			err := virtctlCmd()
+				insecureArg,
+			)
 			if err != nil {
 				fmt.Printf("UploadImage Error: %+v\n", err)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
 			validateFunc(targetName, sc)
+			Expect(stdout).To(MatchRegexp(`\d{1,3}\.?\d{1,2}%`), "progress missing from stdout")
+			Expect(stderr).To(BeEmpty())
 
 			if startVM {
 				By("Start VM")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
We've been using an older progress bar library for ages now that defaulted to stdout:
https://github.com/kubevirt/kubevirt/pull/12184
Let's keep it that way

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

