### PR TITLE
[cherry-pick-1.3]  workload-updater: avoid cancelling the migration when the migration has finished

### DIFF
--- a/pkg/virt-controller/watch/workload-updater/BUILD.bazel
+++ b/pkg/virt-controller/watch/workload-updater/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -352,6 +352,9 @@ func (c *WorkloadUpdateController) shouldAbortMigration(vmi *virtv1.VirtualMachi
 	if isVolumesUpdateInProgress(vmi) {
 		return false
 	}
+	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
+		return false
+	}
 	return numMig > 0
 }
 

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -18,6 +18,8 @@ import (
 
 	"kubevirt.io/client-go/api"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -549,6 +551,28 @@ var _ = Describe("Workload Updater", func() {
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, FailedChangeAbortionReason)
+		})
+
+		It("shouldn't cancel the migration if the migration object is still in running phase but the domain is ready on the target", func() {
+			vmi := api.NewMinimalVMI("testvm")
+			vmi.Namespace = k8sv1.NamespaceDefault
+			vmi.Status.Phase = v1.Running
+			vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
+				Type: v1.VirtualMachineInstanceIsMigratable, Status: k8sv1.ConditionTrue})
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				StartTimestamp:                 pointer.P(metav1.Now()),
+				Completed:                      false,
+				Failed:                         false,
+				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+			}
+			// Ensure that the deletion operation isn't called. The test reproduces the race when the migration operation
+			// was completed, but the migration object was still in running phase and it was accidentally deleted.
+			migrationInterface.EXPECT().Delete(gomock.Any(), gomock.Any(), metav1.DeleteOptions{}).Return(nil).Times(0)
+			vmiSource.Add(vmi)
+			createMig(vmi.Name, v1.MigrationRunning)
+			controller.Execute()
+			Expect(recorder.Events).To(BeEmpty())
+
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/12324


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

