### PR TITLE
libvmi: random name for cloudinit volume

### DIFF
--- a/pkg/libvmi/cloudinit.go
+++ b/pkg/libvmi/cloudinit.go
@@ -25,14 +25,14 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-const cloudInitDiskName = "disk1"
+const CloudInitDiskName = "cloudinitdisk"
 
 // WithCloudInitNoCloud adds cloud-init no-cloud sources.
 func WithCloudInitNoCloud(opts ...cloudinit.NoCloudOption) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+		addDiskVolumeWithCloudInitNoCloud(vmi, CloudInitDiskName, v1.DiskBusVirtio)
 
-		volume := getVolume(vmi, cloudInitDiskName)
+		volume := getVolume(vmi, CloudInitDiskName)
 
 		for _, f := range opts {
 			f(volume.CloudInitNoCloud)
@@ -43,9 +43,9 @@ func WithCloudInitNoCloud(opts ...cloudinit.NoCloudOption) Option {
 // WithCloudInitConfigDrive adds cloud-init config-drive sources.
 func WithCloudInitConfigDrive(opts ...cloudinit.ConfigDriveOption) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
+		addDiskVolumeWithCloudInitConfigDrive(vmi, CloudInitDiskName, v1.DiskBusVirtio)
 
-		volume := getVolume(vmi, cloudInitDiskName)
+		volume := getVolume(vmi, CloudInitDiskName)
 
 		for _, f := range opts {
 			f(volume.CloudInitConfigDrive)
@@ -72,5 +72,5 @@ func setCloudInitNoCloud(volume *v1.Volume, source *v1.CloudInitNoCloudSource) {
 }
 
 func GetCloudInitVolume(vmi *v1.VirtualMachineInstance) *v1.Volume {
-	return getVolume(vmi, cloudInitDiskName)
+	return getVolume(vmi, CloudInitDiskName)
 }

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -313,7 +313,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 						"Name": Equal("disk0")}),
 					gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Name": Equal("disk1")}),
+						"Name": Equal(libvmi.CloudInitDiskName)}),
 				),
 			}))
 		})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2213,7 +2213,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(disks[3].Driver.Cache).To(Equal(cacheNone))
 
 			By("checking if default cache 'none' has been set to cloud-init disk")
-			Expect(disks[4].Alias.GetName()).To(Equal("disk1"))
+			Expect(disks[4].Alias.GetName()).To(Equal(libvmi.CloudInitDiskName))
 			Expect(disks[4].Driver.Cache).To(Equal(cacheNone))
 
 			By("checking if default cache 'writethrough' has been set to fs which does not support direct I/O")


### PR DESCRIPTION
If there is another volume using the name `disk1`, then it will conflict with the cloudinit constant name. Therefore, this change adds the random generation of the cloudinit name of the volume for libvmi.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Constant name `disk1` for the cloudinit volume for libvmi

After this PR:
Random suffix for the cloudinit volume

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12535

### Why we need it and why it was done in this way
The following tradeoffs were made:


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

