### PR TITLE
Rename and document Istio's annotations

### DIFF
--- a/pkg/network/istio/annotations.go
+++ b/pkg/network/istio/annotations.go
@@ -20,8 +20,12 @@
 package istio
 
 const (
-	ISTIO_INJECT_ANNOTATION = "sidecar.istio.io/inject"
+	// InjectSidecarAnnotation Specifies whether an Envoy sidecar should be automatically injected into the workload
+	// https://istio.io/latest/docs/reference/config/annotations/#SidecarInject
+	InjectSidecarAnnotation = "sidecar.istio.io/inject"
 
-	// Istio list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound traffic in envoy
-	ISTIO_KUBEVIRT_ANNOTATION = "traffic.sidecar.istio.io/kubevirtInterfaces"
+	// KubeVirtTrafficAnnotation Specifies a comma separated list of virtual interfaces
+	// whose inbound traffic (from VM) will be treated as outbound
+	// https://istio.io/latest/docs/reference/config/annotations/#SidecarTrafficKubevirtInterfaces
+	KubeVirtTrafficAnnotation = "traffic.sidecar.istio.io/kubevirtInterfaces"
 )

--- a/pkg/network/istio/proxy.go
+++ b/pkg/network/istio/proxy.go
@@ -26,7 +26,7 @@ import (
 )
 
 func ProxyInjectionEnabled(vmi *v1.VirtualMachineInstance) bool {
-	if val, ok := vmi.GetAnnotations()[ISTIO_INJECT_ANNOTATION]; ok {
+	if val, ok := vmi.GetAnnotations()[InjectSidecarAnnotation]; ok {
 		return strings.ToLower(val) == "true"
 	}
 	return false

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1353,7 +1353,7 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 	}
 
 	if HaveMasqueradeInterface(vmi.Spec.Domain.Devices.Interfaces) {
-		annotationsSet[istio.ISTIO_KUBEVIRT_ANNOTATION] = "k6t-eth0"
+		annotationsSet[istio.KubeVirtTrafficAnnotation] = "k6t-eth0"
 	}
 	annotationsSet[VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
 	annotationsSet[VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1188,7 +1188,7 @@ var _ = Describe("Template", func() {
 
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
-				value, ok := pod.Annotations[istio.ISTIO_KUBEVIRT_ANNOTATION]
+				value, ok := pod.Annotations[istio.KubeVirtTrafficAnnotation]
 				Expect(ok).To(BeTrue())
 				Expect(value).To(Equal("k6t-eth0"))
 			})
@@ -1205,7 +1205,7 @@ var _ = Describe("Template", func() {
 						Namespace: "default",
 						UID:       "1234",
 						Annotations: map[string]string{
-							istio.ISTIO_INJECT_ANNOTATION: "true",
+							istio.InjectSidecarAnnotation: "true",
 						},
 					},
 				}

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -514,7 +514,7 @@ func createMasqueradeVm(ports []v1.Port) *v1.VirtualMachineInstance {
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
-		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
+		libvmi.WithAnnotation(istio.InjectSidecarAnnotation, "true"),
 		libvmi.WithCloudInitNoCloud(
 			libvmici.WithNoCloudNetworkData(networkData),
 			libvmici.WithNoCloudEncodedUserData(enablePasswordAuth),
@@ -528,7 +528,7 @@ func createPasstVm(ports []v1.Port) *v1.VirtualMachineInstance {
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceWithPasstBindingPlugin(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
-		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
+		libvmi.WithAnnotation(istio.InjectSidecarAnnotation, "true"),
 		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudEncodedUserData(enablePasswordAuth)),
 	)
 	return vmi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
[Istio](https://istio.io/)'s annotations were written in snake case and had a redundant prefix.

After this PR:
The annotations are aligned with Go's coding conventions [1] and are better documented. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/12480#discussion_r1703831515

### Special notes for your reviewer
According to istio's documentation, the usage of the `sidecar.istio.io/inject` annotation is deprecated [2].
A follow-up PR will adjust the relevant logic.

[1] https://go.dev/doc/effective_go#mixed-caps
[2] https://istio.io/latest/docs/reference/config/annotations/#SidecarInject
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

