### PR TITLE
virt-api: skip clone auth check when DataVolume already exists

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1089,13 +1089,16 @@ func (app *virtAPIApp) Run() {
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldChangeRateLimiter)
 
 	var dataSourceInformer cache.SharedIndexInformer
+	var dataVolumeInformer cache.SharedIndexInformer
 	if app.hasCDIDataSource {
+		dataVolumeInformer = kubeInformerFactory.DataVolume()
 		dataSourceInformer = kubeInformerFactory.DataSource()
-		log.Log.Infof("CDI detected, DataSource integration enabled")
+		log.Log.Infof("CDI detected, DataVolume/DataSource integration enabled")
 	} else {
 		// Add a dummy DataSource informer in the event datasource support
 		// is disabled. This lets the controller continue to work without
 		// requiring a separate branching code path.
+		dataVolumeInformer = kubeInformerFactory.DummyDataVolume()
 		dataSourceInformer = kubeInformerFactory.DummyDataSource()
 		log.Log.Infof("CDI not detected, DataSource integration disabled")
 	}
@@ -1109,6 +1112,7 @@ func (app *virtAPIApp) Run() {
 	webhookInformers := &webhooks.Informers{
 		VMIPresetInformer:  vmiPresetInformer,
 		VMRestoreInformer:  vmRestoreInformer,
+		DataVolumeInformer: dataVolumeInformer,
 		DataSourceInformer: dataSourceInformer,
 		NamespaceInformer:  namespaceInformer,
 	}

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -76,6 +76,7 @@ var MigrationGroupVersionResource = metav1.GroupVersionResource{
 type Informers struct {
 	VMIPresetInformer  cache.SharedIndexInformer
 	VMRestoreInformer  cache.SharedIndexInformer
+	DataVolumeInformer cache.SharedIndexInformer
 	DataSourceInformer cache.SharedIndexInformer
 	NamespaceInformer  cache.SharedIndexInformer
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
+        "//pkg/storage/types:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/webhooks:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -84,7 +84,7 @@ func (p *authProxy) GetNamespace(name string) (*corev1.Namespace, error) {
 	if err != nil {
 		return nil, err
 	} else if !exists {
-		return nil, fmt.Errorf("namespace %s does not exist", name)
+		return nil, errors.NewNotFound(corev1.Resource("namespace"), name)
 	}
 
 	ns := obj.(*corev1.Namespace).DeepCopy()
@@ -97,7 +97,7 @@ func (p *authProxy) GetDataSource(namespace, name string) (*cdiv1.DataSource, er
 	if err != nil {
 		return nil, err
 	} else if !exists {
-		return nil, fmt.Errorf("dataSource %s does not exist", key)
+		return nil, errors.NewNotFound(cdiv1.Resource("datasource"), key)
 	}
 
 	ds := obj.(*cdiv1.DataSource).DeepCopy()

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -48,6 +48,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-api"
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -61,6 +62,7 @@ type VMsAdmitter struct {
 	VirtClient          kubecli.KubevirtClient
 	DataSourceInformer  cache.SharedIndexInformer
 	NamespaceInformer   cache.SharedIndexInformer
+	DataVolumeInformer  cache.SharedIndexInformer
 	InstancetypeMethods instancetype.Methods
 	ClusterConfig       *virtconfig.ClusterConfig
 	cloneAuthFunc       CloneAuthFunc
@@ -107,6 +109,7 @@ func NewVMsAdmitter(clusterConfig *virtconfig.ClusterConfig, client kubecli.Kube
 		VirtClient:          client,
 		DataSourceInformer:  informers.DataSourceInformer,
 		NamespaceInformer:   informers.NamespaceInformer,
+		DataVolumeInformer:  informers.DataVolumeInformer,
 		InstancetypeMethods: &instancetype.InstancetypeMethods{Clientset: client},
 		ClusterConfig:       clusterConfig,
 		cloneAuthFunc: func(dv *cdiv1.DataVolume, requestNamespace, requestName string, proxy cdiv1.AuthorizationHelperProxy, saNamespace, saName string) (bool, string, error) {
@@ -355,17 +358,25 @@ func (admitter *VMsAdmitter) authorizeVirtualMachineSpec(ctx context.Context, ar
 			}
 		}
 
+		dv, err := storagetypes.GetDataVolumeFromCache(targetNamespace, dataVolume.Name, admitter.DataVolumeInformer.GetStore())
+		if err != nil {
+			return nil, err
+		}
+		if dv != nil {
+			continue
+		}
+
+		dv = &cdiv1.DataVolume{
+			ObjectMeta: dataVolume.ObjectMeta,
+			Spec:       dataVolume.Spec,
+		}
+		dv.Namespace = targetNamespace
 		proxy := &authProxy{
 			ctx:                ctx,
 			client:             admitter.VirtClient,
 			dataSourceInformer: admitter.DataSourceInformer,
 			namespaceInformer:  admitter.NamespaceInformer,
 		}
-		dv := &cdiv1.DataVolume{
-			ObjectMeta: dataVolume.ObjectMeta,
-			Spec:       dataVolume.Spec,
-		}
-		dv.Namespace = targetNamespace
 		allowed, message, err := admitter.cloneAuthFunc(dv, ar.Namespace, ar.Name, proxy, targetNamespace, serviceAccountName)
 		if err != nil && err != cdiv1.ErrNoTokenOkay {
 			return nil, err

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -337,6 +337,20 @@ func (admitter *VMsAdmitter) applyInstancetypeToVm(vm *v1.VirtualMachine) (*inst
 func (admitter *VMsAdmitter) authorizeVirtualMachineSpec(ctx context.Context, ar *admissionv1.AdmissionRequest, vm *v1.VirtualMachine) ([]metav1.StatusCause, error) {
 	var causes []metav1.StatusCause
 
+	if ar.Operation == admissionv1.Update || ar.Operation == admissionv1.Delete {
+		oldVM := &v1.VirtualMachine{}
+		if err := json.Unmarshal(ar.OldObject.Raw, oldVM); err != nil {
+			return []metav1.StatusCause{{
+				Type:    metav1.CauseTypeUnexpectedServerResponse,
+				Message: "Could not fetch old VM",
+			}}, nil
+		}
+
+		if equality.Semantic.DeepEqual(oldVM.Spec.DataVolumeTemplates, vm.Spec.DataVolumeTemplates) {
+			return nil, nil
+		}
+	}
+
 	for idx, dataVolume := range vm.Spec.DataVolumeTemplates {
 		targetNamespace := vm.Namespace
 		if targetNamespace == "" {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1480,6 +1480,25 @@ var _ = Describe("Validating VM Admitter", func() {
 			Expect(causes).To(BeEmpty())
 		})
 
+		It("should not attempt to authorize if DataVolumeTemplates haven't changed", func() {
+			vm := vmDefinitionWithCloneDataVolume("ns1", "ns2")
+			oldVM := vm.DeepCopy()
+			oldVM.Annotations = map[string]string{"old": "true"}
+			oldBytes, err := json.Marshal(oldVM)
+			Expect(err).ToNot(HaveOccurred())
+
+			ar := &admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				Namespace: "ns1",
+				OldObject: runtime.RawExtension{Raw: oldBytes},
+			}
+
+			vmsAdmitter.cloneAuthFunc = makeCloneAdmitFailFunc("should not be called", fmt.Errorf("should not be called"))
+			causes, err := vmsAdmitter.authorizeVirtualMachineSpec(context.Background(), ar, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(causes).To(BeEmpty())
+		})
+
 		DescribeTable("should successfully authorize clone from sourceRef", func(
 			arNamespace,
 			vmNamespace,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Validating VM Admitter", func() {
 	config, crdInformer, kvStore := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 	var (
 		vmsAdmitter         *VMsAdmitter
+		dataVolumeInformer  cache.SharedIndexInformer
 		dataSourceInformer  cache.SharedIndexInformer
 		namespaceInformer   cache.SharedIndexInformer
 		instancetypeMethods *testutils.MockInstancetypeMethods
@@ -109,6 +110,7 @@ var _ = Describe("Validating VM Admitter", func() {
 	runStrategyHalted := v1.RunStrategyHalted
 
 	BeforeEach(func() {
+		dataVolumeInformer, _ = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		dataSourceInformer, _ = testutils.NewFakeInformerFor(&cdiv1.DataSource{})
 		namespaceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		ns1 := &k8sv1.Namespace{
@@ -137,6 +139,7 @@ var _ = Describe("Validating VM Admitter", func() {
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		vmsAdmitter = &VMsAdmitter{
 			VirtClient:          virtClient,
+			DataVolumeInformer:  dataVolumeInformer,
 			DataSourceInformer:  dataSourceInformer,
 			NamespaceInformer:   namespaceInformer,
 			ClusterConfig:       config,
@@ -1393,25 +1396,24 @@ var _ = Describe("Validating VM Admitter", func() {
 			Expect(causes[0].Field).To(Equal("fake"))
 		})
 
-		DescribeTable("should successfully authorize clone", func(arNamespace, vmNamespace, sourceNamespace,
-			serviceAccount, expectedSourceNamespace, expectedTargetNamespace, expectedServiceAccount string) {
-
-			vm := &v1.VirtualMachine{
+		vmDefinitionWithCloneDataVolume := func(vmNamespece, sourceClaimNamespace string) *v1.VirtualMachine {
+			return &v1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmNamespace,
+					Namespace: vmNamespece,
+					Name:      "vm",
 				},
 				Spec: v1.VirtualMachineSpec{
 					Template: &v1.VirtualMachineInstanceTemplateSpec{},
 					DataVolumeTemplates: []v1.DataVolumeTemplateSpec{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "whatever",
+								Name: "dv",
 							},
 							Spec: cdiv1.DataVolumeSpec{
 								Source: &cdiv1.DataVolumeSource{
 									PVC: &cdiv1.DataVolumeSourcePVC{
 										Name:      "whocares",
-										Namespace: sourceNamespace,
+										Namespace: sourceClaimNamespace,
 									},
 								},
 							},
@@ -1419,6 +1421,12 @@ var _ = Describe("Validating VM Admitter", func() {
 					},
 				},
 			}
+		}
+
+		DescribeTable("should successfully authorize clone", func(arNamespace, vmNamespace, sourceNamespace,
+			serviceAccount, expectedSourceNamespace, expectedTargetNamespace, expectedServiceAccount string) {
+
+			vm := vmDefinitionWithCloneDataVolume(vmNamespace, sourceNamespace)
 
 			if serviceAccount != "" {
 				vm.Spec.Template.Spec.Volumes = []v1.Volume{
@@ -1448,6 +1456,29 @@ var _ = Describe("Validating VM Admitter", func() {
 			Entry("when everything suppied with default service account", "ns1", "ns2", "ns3", "", "ns3", "ns2", "default"),
 			Entry("when everything suppied with 'sa' service account", "ns1", "ns2", "ns3", "sa", "ns3", "ns2", "sa"),
 		)
+
+		It("should successfully authorize clone with existing DataVolume", func() {
+
+			vm := vmDefinitionWithCloneDataVolume("ns1", "ns2")
+
+			ar := &admissionv1.AdmissionRequest{
+				Namespace: "ns1",
+			}
+
+			dv := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      vm.Spec.DataVolumeTemplates[0].Name,
+				},
+				Spec: vm.Spec.DataVolumeTemplates[0].Spec,
+			}
+			vmsAdmitter.DataVolumeInformer.GetIndexer().Add(dv)
+
+			vmsAdmitter.cloneAuthFunc = makeCloneAdmitFailFunc("should not be called", fmt.Errorf("should not be called"))
+			causes, err := vmsAdmitter.authorizeVirtualMachineSpec(context.Background(), ar, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(causes).To(BeEmpty())
+		})
 
 		DescribeTable("should successfully authorize clone from sourceRef", func(
 			arNamespace,
@@ -2373,7 +2404,7 @@ func makeCloneAdmitFunc(k8sClient *k8sfake.Clientset, expectedSourceNamespace, e
 		Expect(response.Handler.SourceName).Should(Equal(expectedPVCName))
 		Expect(saNamespace).Should(Equal(expectedTargetNamespace))
 		Expect(saName).Should(Equal(expectedServiceAccount))
-		return true, "", nil
+		return response.Allowed, "", nil
 	}
 }
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1027,6 +1027,30 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Entry("with explicit role (all namespaces) snapshot clone", explicitCloneRole, true, false, snapshotCloneMutateFunc, false),
 				Entry("with explicit role (one namespace) snapshot clone", explicitCloneRole, false, true, snapshotCloneMutateFunc, false),
 			)
+
+			It("should skip authorization when DataVolume already exists", func() {
+				cloneRole, cloneRoleBinding = addClonePermission(
+					virtClient,
+					explicitCloneRole,
+					"",
+					"",
+					testsuite.NamespaceTestAlternative,
+				)
+
+				dv := &cdiv1.DataVolume{
+					ObjectMeta: vm.Spec.DataVolumeTemplates[0].ObjectMeta,
+					Spec:       vm.Spec.DataVolumeTemplates[0].Spec,
+				}
+				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				libstorage.EventuallyDV(dv, 90, HaveSucceeded())
+
+				err := virtClient.RbacV1().RoleBindings(cloneRoleBinding.Namespace).Delete(context.Background(), cloneRoleBinding.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				cloneRoleBinding = nil
+
+				createVMSuccess()
+			})
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Would always do clone authorization check, even if the DataVolume exists.  This can be problematic with clones because the original clone source namespace may have been deleted.  Or in the case of restoring to a different cluster, never exist

After this PR:

Only do clone auth check when DataVolume does not exist.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12204

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Eventually we will probably entirely remove the auth check from virt-api. virt-controller checks auth as well

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-api: skip clone auth check when DataVolume already exists
```

