### PR TITLE
net, e2e: Remove VMI with custom MAC address in non-conventional format

### DIFF
--- a/pkg/network/admitter/netiface_test.go
+++ b/pkg/network/admitter/netiface_test.go
@@ -195,8 +195,10 @@ var _ = Describe("Validating VMI network spec", func() {
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(BeEmpty())
 	},
-		Entry("valid address", "de:ad:00:00:be:af"),
-		Entry("valid address with '-'", "de-ad-00-00-be-af"),
+		Entry("valid address in lowercase and colon separated", "de:ad:00:00:be:af"),
+		Entry("valid address in uppercase and colon separated", "DE:AD:00:00:BE:AF"),
+		Entry("valid address in lowercase and dash separated", "de-ad-00-00-be-af"),
+		Entry("valid address in uppercase and dash separated", "DE-AD-00-00-BE-AF"),
 	)
 
 	DescribeTable("should reject invalid PCI addresses", func(pciAddress string) {

--- a/pkg/network/link/address_test.go
+++ b/pkg/network/link/address_test.go
@@ -95,16 +95,21 @@ var _ = Describe("Common Methods", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(mac).To(BeNil())
 		})
-		It("Should return the spec parsed MAC address", func() {
-			macString := "de-ad-00-00-be-af"
+
+		DescribeTable("Should return the spec parsed MAC address", func(rawMACAddress string) {
 			iface := &v1.Interface{
-				MacAddress: macString,
+				MacAddress: rawMACAddress,
 			}
 			mac, err := RetrieveMacAddressFromVMISpecIface(iface)
 			Expect(err).ToNot(HaveOccurred())
-			expectedMac, _ := net.ParseMAC(macString)
+			expectedMac, _ := net.ParseMAC(rawMACAddress)
 			Expect(mac).To(Equal(&expectedMac))
-		})
+		},
+			Entry("lowercase and colon separated", "de:ad:00:00:be:af"),
+			Entry("uppercase and colon separated", "DE:AD:00:00:BE:AF"),
+			Entry("lowercase and dash separated", "de-ad-00-00-be-af"),
+			Entry("uppercase and dash separated", "DE-AD-00-00-BE-AF"),
+		)
 	})
 	Context("GetFakeBridgeIP function", func() {
 		It("Should return empty string when interface name is not in the interface list", func() {

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -323,24 +323,6 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 	})
 
-	Context("VirtualMachineInstance with custom MAC address in non-conventional format", func() {
-		It("[test_id:1772]should configure custom MAC address", func() {
-			libnet.SkipWhenClusterNotSupportIpv4()
-			By(checkingEth0MACAddr)
-			masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
-			masqIface.MacAddress = "BE-AF-00-00-DE-AD"
-			beafdeadVMI := libvmifact.NewCirros(
-				libvmi.WithInterface(masqIface),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			beafdeadVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), beafdeadVMI, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			libwait.WaitUntilVMIReady(beafdeadVMI, console.LoginToCirros)
-			checkMacAddress(beafdeadVMI, "be:af:00:00:de:ad")
-		})
-	})
-
 	Context("VirtualMachineInstance with disabled automatic attachment of interfaces", func() {
 		It("[test_id:1774]should not configure any external interfaces", func() {
 			By("checking loopback is the only guest interface")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Remove "VirtualMachineInstance with custom MAC address in non-conventional format".
Enhance unit tests to make sure this scenario is covered.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

