### PR TITLE
[release-1.2] More control over when DataVolumeTemplates are created

### DIFF
--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -165,7 +165,7 @@ func GetDataVolumeFromCache(namespace, name string, dataVolumeInformer cache.Sha
 		return nil, fmt.Errorf("error converting object to DataVolume: object is of type %T", obj)
 	}
 
-	return dv, nil
+	return dv.DeepCopy(), nil
 }
 
 func HasDataVolumeErrors(namespace string, volumes []virtv1.Volume, dataVolumeInformer cache.SharedInformer) error {

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -168,7 +168,7 @@ func GetPersistentVolumeClaimFromCache(namespace, name string, pvcInformer cache
 		return nil, fmt.Errorf("error converting object to PersistentVolumeClaim: object is of type %T", obj)
 	}
 
-	return pvc, nil
+	return pvc.DeepCopy(), nil
 }
 
 func HasUnboundPVC(namespace string, volumes []virtv1.Volume, pvcInformer cache.SharedInformer) bool {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -374,7 +374,7 @@ func (c *VMController) execute(key string) error {
 
 	var syncErr syncError
 
-	vm, syncErr, err = c.sync(vm, vmi, key, dataVolumes)
+	vm, syncErr, err = c.sync(vm, vmi, key)
 	if err != nil {
 		return err
 	}
@@ -444,22 +444,18 @@ func (c *VMController) authorizeDataVolume(vm *virtv1.VirtualMachine, dataVolume
 	return nil
 }
 
-func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes []*cdiv1.DataVolume) (bool, error) {
+func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine) (bool, error) {
 	ready := true
 	vmKey, err := controller.KeyFunc(vm)
 	if err != nil {
 		return ready, err
 	}
 	for _, template := range vm.Spec.DataVolumeTemplates {
-		var curDataVolume *cdiv1.DataVolume
-		exists := false
-		for _, curDataVolume = range dataVolumes {
-			if curDataVolume.Name == template.Name {
-				exists = true
-				break
-			}
+		curDataVolume, err := storagetypes.GetDataVolumeFromCache(vm.Namespace, template.Name, c.dataVolumeInformer)
+		if err != nil {
+			return false, err
 		}
-		if !exists {
+		if curDataVolume == nil {
 			// Don't create DV if PVC already exists
 			pvc, err := storagetypes.GetPersistentVolumeClaimFromCache(vm.Namespace, template.Name, c.pvcInformer)
 			if err != nil {
@@ -3066,7 +3062,7 @@ func (c *VMController) addRestartRequiredIfNeeded(lastSeenVMSpec *virtv1.Virtual
 	return vm, false
 }
 
-func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, key string, dataVolumes []*cdiv1.DataVolume) (*virtv1.VirtualMachine, syncError, error) {
+func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, key string) (*virtv1.VirtualMachine, syncError, error) {
 
 	defer virtControllerVMWorkQueueTracer.StepTrace(key, "sync", trace.Field{Key: "VM Name", Value: vm.Name})
 
@@ -3126,13 +3122,13 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while storing Instancetype ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}, nil
 	}
 
-	dataVolumesReady, err := c.handleDataVolumes(vm, dataVolumes)
+	dataVolumesReady, err := c.handleDataVolumes(vm)
 	if err != nil {
 		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}, nil
 	}
 
 	if !dataVolumesReady && runStrategy != virtv1.RunStrategyHalted {
-		log.Log.Object(vm).V(3).Infof("Waiting on DataVolumes to be ready. %d datavolumes found", len(dataVolumes))
+		log.Log.Object(vm).V(3).Infof("Waiting on DataVolumes to be ready")
 		return vm, nil, nil
 	}
 

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1175,6 +1175,16 @@ func (c *VMController) cleanupRestartRequired(vm *virtv1.VirtualMachine) (*virtv
 }
 
 func (c *VMController) startVMI(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine, error) {
+	ready, err := c.handleDataVolumes(vm)
+	if err != nil {
+		return vm, err
+	}
+
+	if !ready {
+		log.Log.Object(vm).V(4).Info("Waiting for DataVolumes to be created, delaying start")
+		return vm, nil
+	}
+
 	// TODO add check for existence
 	vmKey, err := controller.KeyFunc(vm)
 	if err != nil {
@@ -3120,16 +3130,6 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		log.Log.Object(vm).Infof("Failed to store Instancetype ControllerRevisions for VirtualMachine: %s/%s", vm.Namespace, vm.Name)
 		c.recorder.Eventf(vm, k8score.EventTypeWarning, FailedCreateVirtualMachineReason, "Error encountered while storing Instancetype ControllerRevisions: %v", err)
 		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while storing Instancetype ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}, nil
-	}
-
-	dataVolumesReady, err := c.handleDataVolumes(vm)
-	if err != nil {
-		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}, nil
-	}
-
-	if !dataVolumesReady && runStrategy != virtv1.RunStrategyHalted {
-		log.Log.Object(vm).V(3).Infof("Waiting on DataVolumes to be ready")
-		return vm, nil, nil
 	}
 
 	vm, syncErr = c.syncRunStrategy(vm, vmi, runStrategy)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3132,6 +3132,20 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 		return vm, &syncErrorImpl{fmt.Errorf("Error encountered while storing Instancetype ControllerRevisions: %v", err), FailedCreateVirtualMachineReason}, nil
 	}
 
+	// eventually, would like the condition to be `== "true"`, but for now we need to support legacy behavior by default
+	if vm.Annotations[virtv1.ImmediateDataVolumeCreation] != "false" {
+		dataVolumesReady, err := c.handleDataVolumes(vm)
+		if err != nil {
+			return vm, &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}, nil
+		}
+
+		// not sure why we allow to proceed when halted but preserving legacy behavior
+		if !dataVolumesReady && runStrategy != virtv1.RunStrategyHalted {
+			log.Log.Object(vm).V(3).Info("Waiting on DataVolumes to be ready.")
+			return vm, nil, nil
+		}
+	}
+
 	vm, syncErr = c.syncRunStrategy(vm, vmi, runStrategy)
 	if syncErr != nil {
 		return vm, syncErr, nil

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -374,7 +374,7 @@ var _ = Describe("VirtualMachine", func() {
 				"Type":   Equal(v1.VirtualMachineFailure),
 				"Reason": Equal("FailedCreate"),
 				"Message": And(
-					ContainSubstring("Failure while starting VMI: failed to create DataVolume"),
+					ContainSubstring("Error encountered while creating DataVolumes: failed to create DataVolume"),
 					ContainSubstring("the server could not find the requested resource (post datavolumes.cdi.kubevirt.io)"),
 				),
 			}))
@@ -1332,8 +1332,14 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(err).To(MatchError(ContainSubstring("not found")))
 		})
 
-		DescribeTable("should create multiple DataVolumes for VirtualMachineInstance when running", func(running bool) {
+		DescribeTable("should create multiple DataVolumes for VirtualMachineInstance when running", func(running bool, anno string, shouldCreate bool) {
 			vm, _ := DefaultVirtualMachine(running)
+			if anno != "" {
+				if vm.Annotations == nil {
+					vm.Annotations = make(map[string]string)
+				}
+				vm.Annotations[v1.ImmediateDataVolumeCreation] = anno
+			}
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
 				VolumeSource: v1.VolumeSource{
@@ -1371,15 +1377,19 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": string(vm.UID)}, map[string]string{}, &createCount)
 
 			sanityExecute(vm)
-			if running {
+			if shouldCreate {
 				Expect(createCount).To(Equal(2))
 				testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 			} else {
 				Expect(createCount).To(Equal(0))
 			}
 		},
-			Entry("when VM is running", true),
-			Entry("when VM stopped", false),
+			Entry("when VM is running no annotation", true, "", true),
+			Entry("when VM stopped no annotation", false, "", true),
+			Entry("when VM is running annotation true", true, "true", true),
+			Entry("when VM stopped annotation true", false, "true", true),
+			Entry("when VM is running annotation false", true, "false", true),
+			Entry("when VM stopped annotation false", false, "false", false),
 		)
 
 		DescribeTable("should properly handle PVC existing before DV created", func(annotations map[string]string, expectedCreations int, initFunc func()) {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -374,7 +374,7 @@ var _ = Describe("VirtualMachine", func() {
 				"Type":   Equal(v1.VirtualMachineFailure),
 				"Reason": Equal("FailedCreate"),
 				"Message": And(
-					ContainSubstring("Error encountered while creating DataVolumes: failed to create DataVolume"),
+					ContainSubstring("Failure while starting VMI: failed to create DataVolume"),
 					ContainSubstring("the server could not find the requested resource (post datavolumes.cdi.kubevirt.io)"),
 				),
 			}))
@@ -1332,8 +1332,8 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(err).To(MatchError(ContainSubstring("not found")))
 		})
 
-		It("should create multiple DataVolumes for VirtualMachineInstance", func() {
-			vm, _ := DefaultVirtualMachine(true)
+		DescribeTable("should create multiple DataVolumes for VirtualMachineInstance when running", func(running bool) {
+			vm, _ := DefaultVirtualMachine(running)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
 				VolumeSource: v1.VolumeSource{
@@ -1371,12 +1371,19 @@ var _ = Describe("VirtualMachine", func() {
 			shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": string(vm.UID)}, map[string]string{}, &createCount)
 
 			sanityExecute(vm)
-			Expect(createCount).To(Equal(2))
-			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
-		})
+			if running {
+				Expect(createCount).To(Equal(2))
+				testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
+			} else {
+				Expect(createCount).To(Equal(0))
+			}
+		},
+			Entry("when VM is running", true),
+			Entry("when VM stopped", false),
+		)
 
 		DescribeTable("should properly handle PVC existing before DV created", func(annotations map[string]string, expectedCreations int, initFunc func()) {
-			vm, _ := DefaultVirtualMachine(false)
+			vm, _ := DefaultVirtualMachine(true)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",
 				VolumeSource: v1.VolumeSource{

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1051,6 +1051,10 @@ const (
 
 	// EmulatorThreadCompleteToEvenParity alpha annotation will cause Kubevirt to complete the VMI's CPU count to an even parity when IsolateEmulatorThread options are requested
 	EmulatorThreadCompleteToEvenParity string = "alpha.kubevirt.io/EmulatorThreadCompleteToEvenParity"
+
+	// ImmediateDataVolumeCreation indicates that the data volumes should be created immediately
+	// Even if the VM is halted
+	ImmediateDataVolumeCreation string = "kubevirt.io/immediate-data-volume-creation"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

Manual cherry-pick of #12194

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #11637

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VM supports kubevirt.io/immediate-data-volume-creation: "false" which delays creating DataVolumeTemplates until VM is started
```

