### PR TITLE
feat: create datasource after image uploaded

### DIFF
--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/imageupload",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virtctl/templates:go_default_library",

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -49,6 +49,7 @@ const (
 	targetNamespace         = "default"
 	targetName              = "test-volume"
 	pvcSize                 = "500Mi"
+	dvSize                  = "500Mi"
 	configName              = "config"
 	defaultInstancetypeName = "instancetype"
 	defaultInstancetypeKind = "VirtualMachineInstancetype"
@@ -700,6 +701,73 @@ var _ = Describe("ImageUpload", func() {
 			validatePVCDefaultInstancetypeLabels()
 		})
 
+		It("Should create DataSource pointing to the PVC", func() {
+			testInit(http.StatusOK)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(
+				commandName, "dv", targetName,
+				"--size", dvSize,
+				"--uploadproxy-url", server.URL,
+				"--insecure",
+				"--force-bind",
+				"--datasource",
+				"--image-path", imagePath,
+				"--default-instancetype", "fake.large",
+				"--default-instancetype-kind", "fake.large",
+				"--default-preference", "fake.centos",
+				"--default-preference-kind", "fake.centos",
+			)
+			Expect(cmd()).To(Succeed())
+			Expect(pvcCreateCalled.IsTrue()).To(BeTrue())
+
+			ds, err := cdiClient.CdiV1beta1().DataSources(targetNamespace).Get(context.Background(), targetName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			assertDataSource(ds, targetName, targetNamespace)
+		})
+
+		It("Should patch DataSource pointing to the PVC", func() {
+			testInit(http.StatusOK)
+
+			ds := &cdiv1.DataSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      targetName,
+					Namespace: targetNamespace,
+					Labels:    map[string]string{},
+				},
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
+							Name:      "",
+							Namespace: "",
+						},
+					},
+				},
+			}
+			_, err := cdiClient.CdiV1beta1().DataSources(targetNamespace).Create(context.Background(), ds, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			cmd := clientcmd.NewRepeatableVirtctlCommand(
+				commandName, "dv", targetName,
+				"--size", dvSize,
+				"--uploadproxy-url", server.URL,
+				"--insecure",
+				"--force-bind",
+				"--datasource",
+				"--image-path", imagePath,
+				"--default-instancetype", "fake.large",
+				"--default-instancetype-kind", "fake.large",
+				"--default-preference", "fake.centos",
+				"--default-preference-kind", "fake.centos",
+			)
+			Expect(cmd()).To(Succeed())
+			Expect(pvcCreateCalled.IsTrue()).To(BeTrue())
+
+			ds, err = cdiClient.CdiV1beta1().DataSources(targetNamespace).Get(context.Background(), targetName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			assertDataSource(ds, targetName, targetNamespace)
+		})
+
 		AfterEach(func() {
 			testDone()
 		})
@@ -935,4 +1003,14 @@ func getVolumeMode(dvSpec cdiv1.DataVolumeSpec) *v1.PersistentVolumeMode {
 		return dvSpec.PVC.VolumeMode
 	}
 	return dvSpec.Storage.VolumeMode
+}
+
+func assertDataSource(ds *cdiv1.DataSource, targetName, targetNamespace string) {
+	Expect(ds.Labels).To(HaveKeyWithValue(instancetypeapi.DefaultInstancetypeLabel, "fake.large"))
+	Expect(ds.Labels).To(HaveKeyWithValue(instancetypeapi.DefaultInstancetypeKindLabel, "fake.large"))
+	Expect(ds.Labels).To(HaveKeyWithValue(instancetypeapi.DefaultPreferenceLabel, "fake.centos"))
+	Expect(ds.Labels).To(HaveKeyWithValue(instancetypeapi.DefaultPreferenceKindLabel, "fake.centos"))
+	Expect(ds.Spec.Source.PVC).ToNot(BeNil())
+	Expect(ds.Spec.Source.PVC.Name).To(Equal(targetName))
+	Expect(ds.Spec.Source.PVC.Namespace).To(Equal(targetNamespace))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

The golden image workflow in the UI needs a DataSource with a default-preference label, so extend the image-upload virtctl command to optionally create this DataSource and label it after image was uploaded.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Optionally create data source using virtctl image upload.
```
