### PR TITLE
virt-controller, template: Move Velero annotations to a dedicated package

### DIFF
--- a/pkg/storage/velero/BUILD.bazel
+++ b/pkg/storage/velero/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["annotations.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/storage/velero",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/storage/velero/annotations.go
+++ b/pkg/storage/velero/annotations.go
@@ -19,9 +19,17 @@
 
 package velero
 
+// For additional information please see https://velero.io/docs/v1.14/backup-hooks/#specifying-hooks-as-pod-annotations
 const (
-	VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION  = "pre.hook.backup.velero.io/container"
-	VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION    = "pre.hook.backup.velero.io/command"
-	VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION = "post.hook.backup.velero.io/container"
-	VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION   = "post.hook.backup.velero.io/command"
+	// PreBackupHookContainerAnnotation specifies the container where the command should be executed.
+	PreBackupHookContainerAnnotation = "pre.hook.backup.velero.io/container"
+
+	// PreBackupHookCommandAnnotation specifies the command to execute.
+	PreBackupHookCommandAnnotation = "pre.hook.backup.velero.io/command"
+
+	// PostBackupHookContainerAnnotation specifies the container where the command should be executed.
+	PostBackupHookContainerAnnotation = "post.hook.backup.velero.io/container"
+
+	// PostBackupHookCommandAnnotation specifies the command to execute.
+	PostBackupHookCommandAnnotation = "post.hook.backup.velero.io/command"
 )

--- a/pkg/storage/velero/annotations.go
+++ b/pkg/storage/velero/annotations.go
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package velero
+
+const (
+	VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION  = "pre.hook.backup.velero.io/container"
+	VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION    = "pre.hook.backup.velero.io/command"
+	VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION = "post.hook.backup.velero.io/container"
+	VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION   = "post.hook.backup.velero.io/command"
+)

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
+        "//pkg/storage/velero:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -53,6 +53,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
 	"kubevirt.io/kubevirt/pkg/storage/types"
+	"kubevirt.io/kubevirt/pkg/storage/velero"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -96,11 +97,6 @@ const (
 const LibvirtStartupDelay = 10
 
 const IntelVendorName = "Intel"
-
-const VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION = "pre.hook.backup.velero.io/container"
-const VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION = "pre.hook.backup.velero.io/command"
-const VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION = "post.hook.backup.velero.io/container"
-const VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION = "post.hook.backup.velero.io/command"
 
 const ENV_VAR_LIBVIRT_DEBUG_LOGS = "LIBVIRT_DEBUG_LOGS"
 const ENV_VAR_VIRTIOFSD_DEBUG_LOGS = "VIRTIOFSD_DEBUG_LOGS"
@@ -1355,13 +1351,13 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 	if HaveMasqueradeInterface(vmi.Spec.Domain.Devices.Interfaces) {
 		annotationsSet[istio.KubeVirtTrafficAnnotation] = "k6t-eth0"
 	}
-	annotationsSet[VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
-	annotationsSet[VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(
+	annotationsSet[velero.VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
+	annotationsSet[velero.VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(
 		"[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"%s\", \"--namespace\", \"%s\"]",
 		vmi.GetObjectMeta().GetName(),
 		vmi.GetObjectMeta().GetNamespace())
-	annotationsSet[VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
-	annotationsSet[VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(
+	annotationsSet[velero.VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
+	annotationsSet[velero.VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(
 		"[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"%s\", \"--namespace\", \"%s\"]",
 		vmi.GetObjectMeta().GetName(),
 		vmi.GetObjectMeta().GetNamespace())

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1351,13 +1351,13 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance, config *virtconfig.C
 	if HaveMasqueradeInterface(vmi.Spec.Domain.Devices.Interfaces) {
 		annotationsSet[istio.KubeVirtTrafficAnnotation] = "k6t-eth0"
 	}
-	annotationsSet[velero.VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
-	annotationsSet[velero.VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(
+	annotationsSet[velero.PreBackupHookContainerAnnotation] = "compute"
+	annotationsSet[velero.PreBackupHookCommandAnnotation] = fmt.Sprintf(
 		"[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"%s\", \"--namespace\", \"%s\"]",
 		vmi.GetObjectMeta().GetName(),
 		vmi.GetObjectMeta().GetNamespace())
-	annotationsSet[velero.VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
-	annotationsSet[velero.VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(
+	annotationsSet[velero.PostBackupHookContainerAnnotation] = "compute"
+	annotationsSet[velero.PostBackupHookCommandAnnotation] = fmt.Sprintf(
 		"[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"%s\", \"--namespace\", \"%s\"]",
 		vmi.GetObjectMeta().GetName(),
 		vmi.GetObjectMeta().GetNamespace())

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
+        "//pkg/storage/velero:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -28,6 +28,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/storage/velero"
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -336,11 +337,6 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		})
 
 		Context("With online vm snapshot", func() {
-			const VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION = "pre.hook.backup.velero.io/container"
-			const VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION = "pre.hook.backup.velero.io/command"
-			const VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION = "post.hook.backup.velero.io/container"
-			const VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION = "post.hook.backup.velero.io/command"
-
 			createAndStartVM := func(vm *v1.VirtualMachine) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
 				var vmi *v1.VirtualMachineInstance
 				vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
@@ -822,7 +818,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Calling Velero pre-backup hook")
-				_, _, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)
+				_, _, err := callVeleroHook(vmi, velero.PreBackupHookContainerAnnotation, velero.PreBackupHookCommandAnnotation)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Veryfing the VM was frozen")
@@ -841,7 +837,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				}, 180*time.Second, time.Second).Should(Equal("frozen"))
 
 				By("Calling Velero post-backup hook")
-				_, _, err = callVeleroHook(vmi, VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION)
+				_, _, err = callVeleroHook(vmi, velero.PostBackupHookContainerAnnotation, velero.PostBackupHookCommandAnnotation)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Veryfing the VM was thawed")
@@ -872,12 +868,12 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				)
 
 				By("Calling Velero pre-backup hook")
-				_, stderr, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)
+				_, stderr, err := callVeleroHook(vmi, velero.PreBackupHookContainerAnnotation, velero.PreBackupHookCommandAnnotation)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stderr).Should(ContainSubstring(noGuestAgentString))
 
 				By("Calling Velero post-backup hook")
-				_, stderr, err = callVeleroHook(vmi, VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION)
+				_, stderr, err = callVeleroHook(vmi, velero.PostBackupHookContainerAnnotation, velero.PostBackupHookCommandAnnotation)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stderr).Should(ContainSubstring(noGuestAgentString))
 			})
@@ -903,7 +899,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 				By("Calling Velero pre-backup hook")
-				_, stderr, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)
+				_, stderr, err := callVeleroHook(vmi, velero.PreBackupHookContainerAnnotation, velero.PreBackupHookCommandAnnotation)
 				Expect(err).To(HaveOccurred())
 				Expect(stderr).Should(ContainSubstring("Paused VM"))
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Move Velero [1] annotations constants to a dedicated package under `pkg/storage`.
This is done in order for them to be under sig-storage's ownership.

Rename the annotations constants to use camel case in order to align them with Go's coding conventions [2].
Drop the `VELERO` prefix, as it repeats the package name.

Use the annotations constants from the `velero` package in the snapshot e2e test in order to re-use code.

[1] https://velero.io/
[2] https://go.dev/wiki/CodeReviewComments#mixed-caps

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

