### PR TITLE
virt-api, VMI update admitter: Remove file-system reads

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -872,7 +872,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMICreate(w, r, app.clusterConfig)
 	})
 	http.HandleFunc(components.VMIUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig)
+		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig, app.kubeVirtServiceAccounts)
 	})
 	http.HandleFunc(components.VMValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers)

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -80,7 +80,7 @@ type Informers struct {
 	NamespaceInformer  cache.SharedIndexInformer
 }
 
-func IsComponentServiceAccount(serviceAccount, namespace, component string) bool {
+func isComponentServiceAccount(serviceAccount, namespace, component string) bool {
 	return serviceAccount == fmt.Sprintf("system:serviceaccount:%s:%s", namespace, component)
 }
 
@@ -98,9 +98,9 @@ func GetNamespace() string {
 func IsKubeVirtServiceAccount(serviceAccount string) bool {
 	ns := GetNamespace()
 
-	return IsComponentServiceAccount(serviceAccount, ns, components.ApiServiceAccountName) ||
-		IsComponentServiceAccount(serviceAccount, ns, components.HandlerServiceAccountName) ||
-		IsComponentServiceAccount(serviceAccount, ns, components.ControllerServiceAccountName)
+	return isComponentServiceAccount(serviceAccount, ns, components.ApiServiceAccountName) ||
+		isComponentServiceAccount(serviceAccount, ns, components.HandlerServiceAccountName) ||
+		isComponentServiceAccount(serviceAccount, ns, components.ControllerServiceAccountName)
 }
 
 func IsARM64(vmiSpec *v1.VirtualMachineInstanceSpec) bool {

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -95,6 +95,10 @@ func GetNamespace() string {
 	return ns
 }
 
+// IsKubeVirtServiceAccount returns true in case `serviceAccount` belongs to one of
+// KubeVirt's main components
+//
+// Deprecated: because it directly reads the namespace from the file-system
 func IsKubeVirtServiceAccount(serviceAccount string) bool {
 	ns := GetNamespace()
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -95,7 +95,7 @@ func (admitter *VMIUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *admis
 	// Reject VMI update if VMI spec changed
 	if !equality.Semantic.DeepEqual(newVMI.Spec, oldVMI.Spec) {
 		// Only allow the KubeVirt SA to modify the VMI spec, since that means it went through the sub resource.
-		if webhooks.IsKubeVirtServiceAccount(ar.Request.UserInfo.Username) {
+		if _, isKubeVirtServiceAccount := admitter.KubeVirtServiceAccounts[ar.Request.UserInfo.Username]; isKubeVirtServiceAccount {
 			hotplugResponse := admitHotplug(oldVMI, newVMI, admitter.ClusterConfig)
 			if hotplugResponse != nil {
 				return hotplugResponse

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -48,6 +48,8 @@ import (
 )
 
 var _ = Describe("Validating VMIUpdate Admitter", func() {
+	const kubeVirtNamespace = "kubevirt"
+
 	kv := &v1.KubeVirt{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt",
@@ -63,7 +65,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 		},
 	}
 	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
-	vmiUpdateAdmitter := &VMIUpdateAdmitter{config}
+	vmiUpdateAdmitter := &VMIUpdateAdmitter{ClusterConfig: config, KubeVirtServiceAccounts: webhooks.KubeVirtServiceAccounts(kubeVirtNamespace)}
 
 	enableFeatureGate := func(featureGate string) {
 		kvConfig := kv.DeepCopy()

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -34,8 +34,8 @@ func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *
 	validating_webhooks.Serve(resp, req, &admitters.VMICreateAdmitter{ClusterConfig: clusterConfig})
 }
 
-func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMIUpdateAdmitter{ClusterConfig: clusterConfig})
+func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, kubeVirtServiceAccounts map[string]struct{}) {
+	validating_webhooks.Serve(resp, req, &admitters.VMIUpdateAdmitter{ClusterConfig: clusterConfig, KubeVirtServiceAccounts: kubeVirtServiceAccounts})
 }
 
 func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
PR #12009 introduced a check to see whether the VMI update had originated from the virt-handler.

Remove the file-system read made by `webhooks.GetNamespace()`.
Additionally, remove a call to `IsKubeVirtServiceAccount` that internally performs a file-system read.

Base the logic on the KubeVirtServiceAccount set introduced by PR #11931.

Deprecate `IsKubeVirtServiceAccount`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Partially addresses #11177.
After this PR, a single call to `IsKubeVirtServiceAccount` is still left.
Removing it requires additional refactoring.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

