### PR TITLE
export tests: patch instead of updates where it makes sense

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1139,38 +1139,9 @@ var _ = SIGDescribe("Export", func() {
 		return vm
 	}
 
-	stopVM := func(vm *v1.VirtualMachine) *v1.VirtualMachine {
-		vmName := vm.Name
-		vmNamespace := vm.Namespace
-		var err error
-		Eventually(func() error {
-			vm, err = virtClient.VirtualMachine(vmNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyHalted)
-			vm, err = virtClient.VirtualMachine(vmNamespace).Update(context.Background(), vm, metav1.UpdateOptions{})
-			return err
-		}, 15*time.Second, time.Second).Should(BeNil())
-		return vm
-	}
-
 	deleteVMI := func(vmi *v1.VirtualMachineInstance) {
 		err := virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-	}
-
-	startVM := func(vm *v1.VirtualMachine) *v1.VirtualMachine {
-		vmName := vm.Name
-		vmNamespace := vm.Namespace
-		Eventually(func() error {
-			vm, err = virtClient.VirtualMachine(vmNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
-			vm, err = virtClient.VirtualMachine(vmNamespace).Update(context.Background(), vm, metav1.UpdateOptions{})
-			return err
-		}, 15*time.Second, time.Second).Should(Succeed())
-		return vm
 	}
 
 	newSnapshot := func(vm *v1.VirtualMachine) *snapshotv1.VirtualMachineSnapshot {
@@ -1284,7 +1255,10 @@ var _ = SIGDescribe("Export", func() {
 			vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
 		}
 		vm = createVM(vm)
-		stopVM(vm)
+		if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+			err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
 		snapshot := createAndVerifyVMSnapshot(vm)
 		Expect(snapshot).ToNot(BeNil())
 		defer deleteSnapshot(snapshot)
@@ -1361,7 +1335,10 @@ var _ = SIGDescribe("Export", func() {
 			vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
 		}
 		vm = createVM(vm)
-		stopVM(vm)
+		if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+			err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
 		snapshot := createAndVerifyVMSnapshot(vm)
 		Expect(snapshot).ToNot(BeNil())
 		defer deleteSnapshot(snapshot)
@@ -1441,13 +1418,15 @@ var _ = SIGDescribe("Export", func() {
 		waitForExportCondition(export, expectedVMRunningCondition(vm.Name, vm.Namespace), "export should report VM running")
 
 		By("Stopping VM, we should get the export ready eventually")
-		vm = stopVM(vm)
+		err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+		Expect(err).ToNot(HaveOccurred())
 		export = waitForReadyExport(export)
 		checkExportSecretRef(export)
 		Expect(*export.Status.TokenSecretRef).To(Equal(token.Name))
 		verifyKubevirtInternal(export, export.Name, export.Namespace, vm.Spec.Template.Spec.Volumes[0].DataVolume.Name)
 		By("Starting VM, the export should return to pending")
-		vm = startVM(vm)
+		err = virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})
+		Expect(err).ToNot(HaveOccurred())
 		waitForExportPhase(export, exportv1.Pending)
 		waitForExportCondition(export, expectedVMRunningCondition(vm.Name, vm.Namespace), "export should report VM running")
 	})
@@ -1748,7 +1727,8 @@ var _ = SIGDescribe("Export", func() {
 		vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
 		vm = createVM(vm)
 		Expect(vm).ToNot(BeNil())
-		vm = stopVM(vm)
+		err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+		Expect(err).ToNot(HaveOccurred())
 		token := createExportTokenSecret(vm.Name, vm.Namespace)
 		export := createVMExportObject(vm.Name, vm.Namespace, token)
 		Expect(export).ToNot(BeNil())
@@ -1784,7 +1764,8 @@ var _ = SIGDescribe("Export", func() {
 		vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
 		vm = createVM(vm)
 		Expect(vm).ToNot(BeNil())
-		vm = stopVM(vm)
+		err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+		Expect(err).ToNot(HaveOccurred())
 		snapshot := createAndVerifyVMSnapshot(vm)
 		export := createRunningVMSnapshotExport(snapshot)
 		Expect(export).ToNot(BeNil())
@@ -1860,7 +1841,8 @@ var _ = SIGDescribe("Export", func() {
 		delete(vm.Spec.Template.Spec.Domain.Resources.Requests, k8sv1.ResourceMemory)
 		vm = createVM(vm)
 		Expect(vm).ToNot(BeNil())
-		vm = stopVM(vm)
+		err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+		Expect(err).ToNot(HaveOccurred())
 		token := createExportTokenSecret(vm.Name, vm.Namespace)
 		export := createVMExportObject(vm.Name, vm.Namespace, token)
 		Expect(export).ToNot(BeNil())
@@ -1991,9 +1973,11 @@ var _ = SIGDescribe("Export", func() {
 			// start the VM which triggers the populating, and then it should become ready.
 			waitForExportPhase(export, exportv1.Pending)
 			waitForExportCondition(export, expectedPVCPopulatingCondition(vm.Name, vm.Namespace), "export should report PVCs in VM populating")
-			vm = startVM(vm)
+			err = virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})
+			Expect(err).ToNot(HaveOccurred())
 			waitForDisksComplete(vm)
-			stopVM(vm)
+			err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+			Expect(err).ToNot(HaveOccurred())
 			waitForExportPhase(export, exportv1.Ready)
 		} else {
 			// With non WFFC storage we expect the disk to populate immediately and thus the export to become ready
@@ -2145,7 +2129,10 @@ var _ = SIGDescribe("Export", func() {
 				vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
 			}
 			vm = createVM(vm)
-			vm = stopVM(vm)
+			if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+				err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
 			snapshot := createAndVerifyVMSnapshot(vm)
 			Expect(snapshot).ToNot(BeNil())
 			defer deleteSnapshot(snapshot)
@@ -2173,7 +2160,8 @@ var _ = SIGDescribe("Export", func() {
 			}, 180*time.Second, time.Second).Should(Equal(v1.Running))
 
 			By("Stopping VM, we should get the export ready eventually")
-			vm = stopVM(vm)
+			err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
 			// Run vmexport
 			By("Running vmexport command")
@@ -2293,7 +2281,10 @@ var _ = SIGDescribe("Export", func() {
 					vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
 				}
 				vm = createVM(vm)
-				vm = stopVM(vm)
+				if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+					err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				}
 				snapshot := createAndVerifyVMSnapshot(vm)
 				Expect(snapshot).ToNot(BeNil())
 				defer deleteSnapshot(snapshot)
@@ -2343,7 +2334,8 @@ var _ = SIGDescribe("Export", func() {
 				}, 180*time.Second, time.Second).Should(Equal(v1.Running))
 
 				By("Stopping VM, we should get the export ready eventually")
-				vm = stopVM(vm)
+				err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				// Run vmexport
 				By("Running vmexport command")
@@ -2520,7 +2512,8 @@ var _ = SIGDescribe("Export", func() {
 				}, 180*time.Second, time.Second).Should(Equal(v1.Running))
 
 				By("Stopping VM, we should get the export ready eventually")
-				vm = stopVM(vm)
+				err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				// Run vmexport
 				By("Running vmexport create command")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- use patch to start/stop VM
there's no reason to loop over an update with eventually
when there's an API that uses patch
- use patch for kv cert config changes
Although unlikely, the kubevirt install may change and thus cause the update calls to fail.
We can instead specifically issue a patch against the fields we care
about.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

