### PR TITLE
Deprecate redundant Stop and Start VM functions in tests/utils.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,3 +124,15 @@ issues:
     - text: 'SA1019: libvmi.WithRunning'
       linters:
         - staticcheck
+    # We should steer users towards client.VirtualMachine(vm.Namespace).start
+    - text: 'SA1019: tests.StartVirtualMachine'
+      linters:
+        - staticcheck
+    # We should steer users towards client.VirtualMachine(vm.Namespace).Stop
+    - text: 'SA1019: tests.StopVirtualMachine'
+      linters:
+        - staticcheck
+    # We should steer users towards client.VirtualMachine(vm.Namespace).Stop
+    - text: 'SA1019: tests.StopVirtualMachineWithTimeout'
+      linters:
+        - staticcheck

--- a/tests/libvmops/lifecycle.go
+++ b/tests/libvmops/lifecycle.go
@@ -35,10 +35,16 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
+// StopVirtualMachine
+//
+// Deprecated: Use client.VirtualMachine(vm.Namespace).Stop and libwait instead
 func StopVirtualMachine(vm *v1.VirtualMachine) *v1.VirtualMachine {
 	return StopVirtualMachineWithTimeout(vm, 300*time.Second)
 }
 
+// StopVirtualMachineWithTimeout
+//
+// Deprecated:Use client.VirtualMachine(vm.Namespace).Stop and libwait instead
 func StopVirtualMachineWithTimeout(vm *v1.VirtualMachine, timeout time.Duration) *v1.VirtualMachine {
 	virtClient := kubevirt.Client()
 
@@ -59,6 +65,9 @@ func StopVirtualMachineWithTimeout(vm *v1.VirtualMachine, timeout time.Duration)
 	return updatedVM
 }
 
+// StartVirtualMachine
+//
+// Deprecated: Use client.VirtualMachine(vm.Namespace).start and libwait instead
 func StartVirtualMachine(vm *v1.VirtualMachine) *v1.VirtualMachine {
 	virtClient := kubevirt.Client()
 


### PR DESCRIPTION
Remove multiple functions for stopping and starting VMs; use the client for a more declarative approach.
Less code means less maintenance and fewer bugs.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

