### PR TITLE
tools/vms-generator: use runStrategy for example VMs instead of running

### DIFF
--- a/examples/vm-alpine-datavolume.yaml
+++ b/examples/vm-alpine-datavolume.yaml
@@ -21,7 +21,7 @@ spec:
       source:
         registry:
           url: docker://registry:5000/kubevirt/alpine-container-disk-demo:devel
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-alpine-multipvc.yaml
+++ b/examples/vm-alpine-multipvc.yaml
@@ -6,7 +6,7 @@ metadata:
     kubevirt.io/vm: vm-alpine-multipvc
   name: vm-alpine-multipvc
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-cirros-clarge-virtio.yaml
+++ b/examples/vm-cirros-clarge-virtio.yaml
@@ -12,7 +12,7 @@ spec:
   preference:
     kind: VirtualMachinePreference
     name: virtio
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-cirros-clarge-windows.yaml
+++ b/examples/vm-cirros-clarge-windows.yaml
@@ -12,7 +12,7 @@ spec:
   preference:
     kind: VirtualMachinePreference
     name: windows
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-cirros-clarge.yaml
+++ b/examples/vm-cirros-clarge.yaml
@@ -9,7 +9,7 @@ spec:
   instancetype:
     kind: VirtualMachineInstancetype
     name: clarge
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-cirros-cluster-csmall.yaml
+++ b/examples/vm-cirros-cluster-csmall.yaml
@@ -9,7 +9,7 @@ spec:
   instancetype:
     kind: VirtualMachineClusterInstancetype
     name: cluster-csmall
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-cirros-csmall.yaml
+++ b/examples/vm-cirros-csmall.yaml
@@ -9,7 +9,7 @@ spec:
   instancetype:
     kind: VirtualMachineInstancetype
     name: csmall
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-cirros-sata.yaml
+++ b/examples/vm-cirros-sata.yaml
@@ -6,7 +6,7 @@ metadata:
     kubevirt.io/vm: vm-cirros-sata
   name: vm-cirros-sata
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-cirros-with-sidecar-hook-configmap.yaml
+++ b/examples/vm-cirros-with-sidecar-hook-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     kubevirt.io/vm: vm-cirros-with-sidecar-hook-configmap
   name: vm-cirros-with-sidecar-hook-configmap
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       annotations:

--- a/examples/vm-cirros.yaml
+++ b/examples/vm-cirros.yaml
@@ -6,7 +6,7 @@ metadata:
     kubevirt.io/vm: vm-cirros
   name: vm-cirros
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -6,7 +6,7 @@ metadata:
     kubevirt.io/vm: vm-cirros
   name: vm-non-preemtible
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/examples/vm-windows-clarge-windows.yaml
+++ b/examples/vm-windows-clarge-windows.yaml
@@ -12,7 +12,7 @@ spec:
   preference:
     kind: VirtualMachinePreference
     name: windows
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -630,7 +630,6 @@ func AddKernelBootToVMI(vmi *v1.VirtualMachineInstance) {
 
 func getBaseVM(name string, labels map[string]string) *v1.VirtualMachine {
 	baseVMISpec := getBaseVMISpec()
-	running := false
 
 	return &v1.VirtualMachine{
 		TypeMeta: metav1.TypeMeta{
@@ -642,7 +641,7 @@ func getBaseVM(name string, labels map[string]string) *v1.VirtualMachine {
 			Labels: labels,
 		},
 		Spec: v1.VirtualMachineSpec{
-			Running: &running,
+			RunStrategy: k6tpointer.P(v1.RunStrategyHalted),
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,


### PR DESCRIPTION
### What this PR does
Before this PR:
example vms are being generated with running field

After this PR:
examples vms will be generated with runStrategy instead of running

relates to issue: #11993
Partially addresses issue #12285 by replacing `spec.running` with `spec.runStrategy`

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place:

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

