### PR TITLE
[tests] introduce a decorator for Periodic tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -459,6 +459,12 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
   if [[ ! $TARGET =~ k8s-1\.3[0-9].* ]]; then
     add_to_label_filter "(!kubernetes130)" "&&"
   fi
+
+  # execute tests labelled as PERIODIC only on periodic test lanes (according to lane name)
+  if [[ ! $TARGET =~ .*periodic.* ]]; then
+    add_to_label_filter "(!PERIODIC)" "&&"
+  fi
+
 fi
 
 # No lane currently supports loading a custom policy

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -5,6 +5,7 @@ import . "github.com/onsi/ginkgo/v2"
 var (
 	//
 	Quarantine = []interface{}{Label("QUARANTINE")}
+	Periodic   = []interface{}{Label("PERIODIC")}
 
 	// SIGs
 	SigCompute           = []interface{}{Label("sig-compute")}

--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -172,7 +172,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				Expect(logs).To(ContainSubstring("\n" + testString + "\n"))
 			})
 
-			It("it should rotate the internal log files", func() {
+			It("it should rotate the internal log files", decorators.Periodic, func() {
 				vmi = libvmops.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")
@@ -192,7 +192,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				Expect(strings.Count(outputString, "virt-serial0-log")).To(Equal(4 + 1))
 			})
 
-			It("it should not skip any log line even trying to flood the serial console for QOSGuaranteed VMs", func() {
+			It("it should not skip any log line even trying to flood the serial console for QOSGuaranteed VMs", decorators.Periodic, func() {
 				cirrosVmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
 						k8sv1.ResourceCPU:    resource.MustParse("1000m"),


### PR DESCRIPTION
Introduce a decorator to label tests for being
executed only on periodic lanes.
Tests labelled as `PERIODIC` will only be executed
on test lanes containing periodic in their name so that
they are going to be skipped on pre-submit lanes.
This is especially useful for long running an not critical tests
and it will help containing CI execution time on open PRs.

### What this PR does
Before this PR:
We lack a mechanism to label long running non critical tests for being executed only on periodic lanes but not on pre-submit ones.

After this PR:
We lack a mechanism to label long running non critical tests for being executed only on periodic lanes but not on pre-submit ones.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-46060

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Periodic test lanes are identified according to their name
- We lack a more fine grained mechanism to discriminate daily vs weekly...

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[tests] introduce a decorator for Periodic_only tests
```

