### PR TITLE
Replace the PatchOperation with the PatchSet

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Clone mutating webhook", func() {
 			Name:     fmt.Sprintf("clone-%s-%s", expectedVirtualMachineCloneSpec.Source.Name, expectedTargetSuffix),
 		}
 
-		expectedJSONPatch, err := expectedJSONPatchForVMCloneCreation(expectedVirtualMachineCloneSpec)
+		expectedJSONPatch, err := patch.New(patch.WithReplace("/spec", expectedVirtualMachineCloneSpec)).GeneratePayload()
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(mutator.Mutate(admissionReview)).To(Equal(
@@ -172,14 +172,4 @@ func newAdmissionReviewForVMCloneCreation(vmClone *clonev1alpha1.VirtualMachineC
 	}
 
 	return ar, nil
-}
-
-func expectedJSONPatchForVMCloneCreation(vmCloneSpec *clonev1alpha1.VirtualMachineCloneSpec) ([]byte, error) {
-	return patch.GeneratePatchPayload(
-		patch.PatchOperation{
-			Op:    patch.PatchReplaceOp,
-			Path:  "/spec",
-			Value: vmCloneSpec,
-		},
-	)
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
@@ -57,14 +57,7 @@ func (mutator *MigrationCreateMutator) Mutate(ar *admissionv1.AdmissionReview) *
 	addMigrationSelectorLabel(&migration)
 	addMigrationFinalizer(&migration)
 
-	patchBytes, err := patch.GeneratePatchPayload(
-		patch.PatchOperation{
-			Op:    patch.PatchReplaceOp,
-			Path:  "/metadata",
-			Value: migration.ObjectMeta,
-		},
-	)
-
+	patchBytes, err := patch.New(patch.WithReplace("/metadata", migration.ObjectMeta)).GeneratePayload()
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -45,10 +45,8 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mutator := &mutators.MigrationCreateMutator{}
-
-		expectedJSONPatch, err := expectedJSONPatchForVMIMCreation(
-			expectedMigrationObjectMeta(migration.ObjectMeta, migration.Spec.VMIName),
-		)
+		expectedObjectMeta := expectedMigrationObjectMeta(migration.ObjectMeta, migration.Spec.VMIName)
+		expectedJSONPatch, err := patch.New(patch.WithReplace("/metadata", expectedObjectMeta)).GeneratePayload()
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(mutator.Mutate(admissionReview)).To(Equal(
@@ -99,14 +97,4 @@ func expectedMigrationObjectMeta(currentObjectMeta k8smetav1.ObjectMeta, vmiName
 	expectedObjectMeta.Finalizers = []string{v1.VirtualMachineInstanceMigrationFinalizer}
 
 	return expectedObjectMeta
-}
-
-func expectedJSONPatchForVMIMCreation(expectedObjectMeta k8smetav1.ObjectMeta) ([]byte, error) {
-	return patch.GeneratePatchPayload(
-		patch.PatchOperation{
-			Op:    patch.PatchReplaceOp,
-			Path:  "/metadata",
-			Value: expectedObjectMeta,
-		},
-	)
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -124,18 +124,10 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	mutator.setDefaultMachineType(&vm, preferenceSpec)
 	mutator.setPreferenceStorageClassName(&vm, preferenceSpec)
 
-	patchBytes, err := patch.GeneratePatchPayload(
-		patch.PatchOperation{
-			Op:    patch.PatchReplaceOp,
-			Path:  "/spec",
-			Value: vm.Spec,
-		},
-		patch.PatchOperation{
-			Op:    patch.PatchReplaceOp,
-			Path:  "/metadata",
-			Value: vm.ObjectMeta,
-		},
-	)
+	patchBytes, err := patch.New(
+		patch.WithReplace("/spec", vm.Spec),
+		patch.WithReplace("/metadata", vm.ObjectMeta),
+	).GeneratePayload()
 
 	if err != nil {
 		log.Log.Reason(err).Error("admission failed to marshall patch to JSON")

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -201,28 +201,12 @@ var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, d
 
 			By("Hotplug Memory and CPU")
 			newGuestMemory := resource.MustParse("1042Mi")
-			patchData, err := patch.GeneratePatchPayload(
-				patch.PatchOperation{
-					Op:    patch.PatchTestOp,
-					Path:  "/spec/template/spec/domain/memory/guest",
-					Value: guest.String(),
-				},
-				patch.PatchOperation{
-					Op:    patch.PatchReplaceOp,
-					Path:  "/spec/template/spec/domain/memory/guest",
-					Value: newGuestMemory.String(),
-				},
-				patch.PatchOperation{
-					Op:    patch.PatchTestOp,
-					Path:  "/spec/template/spec/domain/cpu/sockets",
-					Value: vmi.Spec.Domain.CPU.Sockets,
-				},
-				patch.PatchOperation{
-					Op:    patch.PatchReplaceOp,
-					Path:  "/spec/template/spec/domain/cpu/sockets",
-					Value: newSockets,
-				},
-			)
+			patchData, err := patch.New(
+				patch.WithTest("/spec/template/spec/domain/memory/guest", guest.String()),
+				patch.WithReplace("/spec/template/spec/domain/memory/guest", newGuestMemory.String()),
+				patch.WithTest("/spec/template/spec/domain/cpu/sockets", vmi.Spec.Domain.CPU.Sockets),
+				patch.WithReplace("/spec/template/spec/domain/cpu/sockets", newSockets),
+			).GeneratePayload()
 			Expect(err).NotTo(HaveOccurred())
 			_, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchData, k8smetav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/libnet/hotplug.go
+++ b/tests/libnet/hotplug.go
@@ -130,28 +130,12 @@ func interfaceStatusFromInterfaceNames(queueCount int32, ifaceNames ...string) [
 }
 
 func PatchVMWithNewInterface(vm *v1.VirtualMachine, newNetwork v1.Network, newIface v1.Interface) error {
-	patchData, err := patch.GeneratePatchPayload(
-		patch.PatchOperation{
-			Op:    patch.PatchTestOp,
-			Path:  "/spec/template/spec/networks",
-			Value: vm.Spec.Template.Spec.Networks,
-		},
-		patch.PatchOperation{
-			Op:    patch.PatchReplaceOp,
-			Path:  "/spec/template/spec/networks",
-			Value: append(vm.Spec.Template.Spec.Networks, newNetwork),
-		},
-		patch.PatchOperation{
-			Op:    patch.PatchTestOp,
-			Path:  "/spec/template/spec/domain/devices/interfaces",
-			Value: vm.Spec.Template.Spec.Domain.Devices.Interfaces,
-		},
-		patch.PatchOperation{
-			Op:    patch.PatchReplaceOp,
-			Path:  "/spec/template/spec/domain/devices/interfaces",
-			Value: append(vm.Spec.Template.Spec.Domain.Devices.Interfaces, newIface),
-		},
-	)
+	patchData, err := patch.New(
+		patch.WithTest("/spec/template/spec/networks", vm.Spec.Template.Spec.Networks),
+		patch.WithReplace("/spec/template/spec/networks", append(vm.Spec.Template.Spec.Networks, newNetwork)),
+		patch.WithTest("/spec/template/spec/domain/devices/interfaces", vm.Spec.Template.Spec.Domain.Devices.Interfaces),
+		patch.WithReplace("/spec/template/spec/domain/devices/interfaces", append(vm.Spec.Template.Spec.Domain.Devices.Interfaces, newIface)),
+	).GeneratePayload()
 	if err != nil {
 		return err
 	}

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -158,20 +158,7 @@ const (
 
 func patchLabelAnnotationHelper(nodeName string, newMap, oldMap map[string]string, mapType mapType) (*k8sv1.Node, error) {
 	path := "/metadata/" + string(mapType) + "s"
-	p := []patch.PatchOperation{
-		{
-			Op:    "test",
-			Path:  path,
-			Value: oldMap,
-		},
-		{
-			Op:    "replace",
-			Path:  path,
-			Value: newMap,
-		},
-	}
-
-	patchBytes, err := json.Marshal(p)
+	patchBytes, err := patch.New(patch.WithTest(path, oldMap), patch.WithReplace(path, newMap)).GeneratePayload()
 	Expect(err).ToNot(HaveOccurred())
 	client := kubevirt.Client()
 	patchedNode, err := client.CoreV1().Nodes().Patch(

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -278,13 +278,7 @@ func updateDeploymentResourcesRequest(virtClient kubecli.KubevirtClient, deploym
 }
 
 func patchDeployment(virtClient kubecli.KubevirtClient, deployment *appsv1.Deployment) {
-	patchOp := patch.PatchOperation{
-		Op:    "replace",
-		Path:  "/spec",
-		Value: deployment.Spec,
-	}
-
-	payload, err := patch.GeneratePatchPayload(patchOp)
+	payload, err := patch.New(patch.WithReplace("/spec", deployment.Spec)).GeneratePayload()
 	Expect(err).ToNot(HaveOccurred())
 
 	_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), deployment.Name, types.JSONPatchType, payload, metav1.PatchOptions{})

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -399,11 +399,9 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 		newPool, err = virtClient.VirtualMachinePool(newPool.ObjectMeta.Namespace).Get(context.Background(), newPool.ObjectMeta.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		patchData, err := patch.GeneratePatchPayload(patch.PatchOperation{
-			Op:    patch.PatchAddOp,
-			Path:  fmt.Sprintf("/spec/virtualMachineTemplate/metadata/labels/%s", newLabelKey),
-			Value: newLabelValue,
-		})
+		patchData, err := patch.New(patch.WithAdd(
+			fmt.Sprintf("/spec/virtualMachineTemplate/metadata/labels/%s", newLabelKey), newLabelValue),
+		).GeneratePayload()
 		Expect(err).ToNot(HaveOccurred())
 		newPool, err = virtClient.VirtualMachinePool(newPool.ObjectMeta.Namespace).Patch(context.Background(), newPool.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -458,11 +456,9 @@ var _ = Describe("[sig-compute]VirtualMachinePool", decorators.SigCompute, func(
 		Expect(err).ToNot(HaveOccurred())
 
 		// Make a VMI template change
-		patchData, err := patch.GeneratePatchPayload(patch.PatchOperation{
-			Op:    patch.PatchAddOp,
-			Path:  fmt.Sprintf("/spec/virtualMachineTemplate/spec/template/metadata/labels/%s", newLabelKey),
-			Value: newLabelValue,
-		})
+		patchData, err := patch.New(patch.WithAdd(
+			fmt.Sprintf("/spec/virtualMachineTemplate/spec/template/metadata/labels/%s", newLabelKey), newLabelValue),
+		).GeneratePayload()
 		Expect(err).ToNot(HaveOccurred())
 		newPool, err = virtClient.VirtualMachinePool(newPool.ObjectMeta.Namespace).Patch(context.Background(), newPool.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Directly using the [PatchOperation struct](https://github.com/kubevirt/kubevirt/blob/main/pkg/apimachinery/patch/patch.go#L28)

After this PR:
We are trying to simplify the patch operations and use everywhere in the code the [PatchSet](https://github.com/kubevirt/kubevirt/blob/main/pkg/apimachinery/patch/patch.go#L68). Eventually, we could set the PatchOperation struct as private.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
