### PR TITLE
Fix behaivor of MaxCpuSockets

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14781,7 +14781,7 @@
     "type": "object",
     "properties": {
      "maxCpuSockets": {
-      "description": "MaxCpuSockets holds the maximum amount of sockets that can be hotplugged",
+      "description": "MaxCpuSockets provides a MaxSockets value for VMs that do not provide their own. For VMs with more sockets than maximum the MaxSockets will be set to equal number of sockets.",
       "type": "integer",
       "format": "int64"
      },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -471,8 +471,9 @@ spec:
                       features
                     properties:
                       maxCpuSockets:
-                        description: MaxCpuSockets holds the maximum amount of sockets
-                          that can be hotplugged
+                        description: |-
+                          MaxCpuSockets provides a MaxSockets value for VMs that do not provide their own.
+                          For VMs with more sockets than maximum the MaxSockets will be set to equal number of sockets.
                         format: int32
                         type: integer
                       maxGuest:
@@ -3756,8 +3757,9 @@ spec:
                       features
                     properties:
                       maxCpuSockets:
-                        description: MaxCpuSockets holds the maximum amount of sockets
-                          that can be hotplugged
+                        description: |-
+                          MaxCpuSockets provides a MaxSockets value for VMs that do not provide their own.
+                          For VMs with more sockets than maximum the MaxSockets will be set to equal number of sockets.
                         format: int32
                         type: integer
                       maxGuest:

--- a/pkg/virt-api/webhooks/defaults.go
+++ b/pkg/virt-api/webhooks/defaults.go
@@ -69,7 +69,11 @@ func setupHotplug(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachin
 
 func setupCPUHotplug(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance) {
 	if vmi.Spec.Domain.CPU.MaxSockets == 0 {
-		vmi.Spec.Domain.CPU.MaxSockets = clusterConfig.GetMaximumCpuSockets()
+		maxSockets := clusterConfig.GetMaximumCpuSockets()
+		if vmi.Spec.Domain.CPU.Sockets > maxSockets && maxSockets != 0 {
+			maxSockets = vmi.Spec.Domain.CPU.Sockets
+		}
+		vmi.Spec.Domain.CPU.MaxSockets = maxSockets
 	}
 
 	if vmi.Spec.Domain.CPU.MaxSockets == 0 {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -1405,6 +1405,21 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
 				Expect(spec.Domain.CPU.MaxSockets).To(Equal(uint32(4)))
 			})
+
+			It("to set MaxSockets to number of sockets when MaxCpuSockets is lower", func() {
+				kvCR := testutils.GetFakeKubeVirtClusterConfig(kvStore)
+				kvCR.Spec.Configuration.LiveUpdateConfiguration = &v1.LiveUpdateConfiguration{
+					MaxCpuSockets: pointer.Uint32(2),
+				}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvCR)
+
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Sockets: 3,
+				}
+
+				_, spec, _ := getMetaSpecStatusFromAdmit(rt.GOARCH)
+				Expect(spec.Domain.CPU.MaxSockets).To(Equal(uint32(3)))
+			})
 		})
 		Context("configure Memory hotplug", func() {
 			It("to keep VMI values of max guest when provided", func() {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1092,8 +1092,9 @@ var CRDsValidation map[string]string = map[string]string{
                 features
               properties:
                 maxCpuSockets:
-                  description: MaxCpuSockets holds the maximum amount of sockets that
-                    can be hotplugged
+                  description: |-
+                    MaxCpuSockets provides a MaxSockets value for VMs that do not provide their own.
+                    For VMs with more sockets than maximum the MaxSockets will be set to equal number of sockets.
                   format: int32
                   type: integer
                 maxGuest:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -3015,7 +3015,8 @@ type LiveUpdateConfiguration struct {
 	// defined and MaxHotplugRatio is 2 then MaxGuest = 1Gi
 	// defaults to 4
 	MaxHotplugRatio uint32 `json:"maxHotplugRatio,omitempty"`
-	// MaxCpuSockets holds the maximum amount of sockets that can be hotplugged
+	// MaxCpuSockets provides a MaxSockets value for VMs that do not provide their own.
+	// For VMs with more sockets than maximum the MaxSockets will be set to equal number of sockets.
 	MaxCpuSockets *uint32 `json:"maxCpuSockets,omitempty"`
 	// MaxGuest defines the maximum amount memory that can be allocated
 	// to the guest using hotplug.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -991,7 +991,7 @@ func (PreferenceMatcher) SwaggerDoc() map[string]string {
 func (LiveUpdateConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"maxHotplugRatio": "MaxHotplugRatio is the ratio used to define the max amount\nof a hotplug resource that can be made available to a VM\nwhen the specific Max* setting is not defined (MaxCpuSockets, MaxGuest)\nExample: VM is configured with 512Mi of guest memory, if MaxGuest is not\ndefined and MaxHotplugRatio is 2 then MaxGuest = 1Gi\ndefaults to 4",
-		"maxCpuSockets":   "MaxCpuSockets holds the maximum amount of sockets that can be hotplugged",
+		"maxCpuSockets":   "MaxCpuSockets provides a MaxSockets value for VMs that do not provide their own.\nFor VMs with more sockets than maximum the MaxSockets will be set to equal number of sockets.",
 		"maxGuest":        "MaxGuest defines the maximum amount memory that can be allocated\nto the guest using hotplug.",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21133,7 +21133,7 @@ func schema_kubevirtio_api_core_v1_LiveUpdateConfiguration(ref common.ReferenceC
 					},
 					"maxCpuSockets": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxCpuSockets holds the maximum amount of sockets that can be hotplugged",
+							Description: "MaxCpuSockets provides a MaxSockets value for VMs that do not provide their own. For VMs with more sockets than maximum the MaxSockets will be set to equal number of sockets.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -76,6 +76,29 @@ var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, deco
 		})
 	})
 
+	Context("with Kubevirt CR declaring MaxCpuSockets", func() {
+
+		It("should be able to start", func() {
+			By("Kubevirt CR with MaxCpuSockets set to 2")
+			kubevirt := libkubevirt.GetCurrentKv(virtClient)
+			if kubevirt.Spec.Configuration.LiveUpdateConfiguration == nil {
+				kubevirt.Spec.Configuration.LiveUpdateConfiguration = &v1.LiveUpdateConfiguration{}
+			}
+			kubevirt.Spec.Configuration.LiveUpdateConfiguration.MaxCpuSockets = pointer.P(uint32(2))
+			tests.UpdateKubeVirtConfigValueAndWait(kubevirt.Spec.Configuration)
+
+			By("Run VM with 3 sockets")
+			vmi := libvmifact.NewAlpine(libvmi.WithCPUCount(1, 1, 3))
+			vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+
+			By("Expecting to see VMI that is starting")
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vm, k8smetav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 10*time.Second, 1*time.Second).Should(Exist())
+		})
+
+	})
+
 	Context("A VM with cpu.maxSockets set higher than cpu.sockets", func() {
 		type cpuCount struct {
 			enabled  int


### PR DESCRIPTION
### What this PR does
See issue for background. Now `MaxCpuSockets` will no be used if a VM defines more sockets but rather the #of sockets will be used for `MaxSockets`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12394

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
MaxCpuSockets won't block creation of VMs with more Sockets than MaxCpuSockets declare
```
