### PR TITLE
vmexport: enable status subresource for VirtualMachineExport

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -581,9 +581,16 @@ spec:
         - apiGroups:
           - export.kubevirt.io
           resources:
-          - '*'
+          - virtualmachineexports
+          - virtualmachineexports/status
           verbs:
-          - '*'
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+          - patch
         - apiGroups:
           - pool.kubevirt.io
           resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -583,9 +583,16 @@ rules:
 - apiGroups:
   - export.kubevirt.io
   resources:
-  - '*'
+  - virtualmachineexports
+  - virtualmachineexports/status
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - pool.kubevirt.io
   resources:

--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/status:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch/util:go_default_library",

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -1202,7 +1202,7 @@ func (ctrl *VMExportController) updateCommonVMExportStatusFields(vmExport, vmExp
 
 func (ctrl *VMExportController) updateVMExportStatus(vmExport, vmExportCopy *exportv1.VirtualMachineExport) error {
 	if !equality.Semantic.DeepEqual(vmExport.Status, vmExportCopy.Status) {
-		if _, err := ctrl.Client.VirtualMachineExport(vmExportCopy.Namespace).Update(context.Background(), vmExportCopy, metav1.UpdateOptions{}); err != nil {
+		if _, err := ctrl.Client.VirtualMachineExport(vmExportCopy.Namespace).UpdateStatus(context.Background(), vmExportCopy, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
 	}

--- a/pkg/util/status/BUILD.bazel
+++ b/pkg/util/status/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/export/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+	exportv1 "kubevirt.io/api/export/v1beta1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 )
@@ -203,6 +204,13 @@ func (u *updater) updateUnstructured(obj runtime.Object) (oldStatus interface{},
 			return nil, nil, err
 		}
 		return oldObj.Status, newObj.Status, nil
+	case *exportv1.VirtualMachineExport:
+		oldObj := obj.(*exportv1.VirtualMachineExport)
+		newObj, err := u.cli.VirtualMachineExport(a.GetNamespace()).Update(context.Background(), oldObj, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, nil, err
+		}
+		return oldObj.Status, newObj.Status, nil
 	default:
 		panic(unknownObj)
 	}
@@ -232,6 +240,9 @@ func (u *updater) updateStatusUnstructured(obj runtime.Object) (err error) {
 	case *poolv1.VirtualMachinePool:
 		oldObj := obj.(*poolv1.VirtualMachinePool)
 		_, err = u.cli.VirtualMachinePool(oldObj.Namespace).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
+	case *exportv1.VirtualMachineExport:
+		oldObj := obj.(*exportv1.VirtualMachineExport)
+		_, err = u.cli.VirtualMachineExport(oldObj.Namespace).UpdateStatus(context.Background(), oldObj, metav1.UpdateOptions{})
 	default:
 		panic(unknownObj)
 	}
@@ -363,6 +374,24 @@ func (v *VMPStatusUpdater) PatchStatus(vp *poolv1.VirtualMachinePool, pt types.P
 
 func NewVMPStatusUpdater(cli kubecli.KubevirtClient) *VMPStatusUpdater {
 	return &VMPStatusUpdater{
+		updater: updater{
+			lock:        sync.Mutex{},
+			subresource: true,
+			cli:         cli,
+		},
+	}
+}
+
+type VMExportStatusUpdater struct {
+	updater
+}
+
+func (v *VMExportStatusUpdater) UpdateStatus(vmExport *exportv1.VirtualMachineExport) error {
+	return v.update(vmExport)
+}
+
+func NewVMExportStatusUpdater(cli kubecli.KubevirtClient) *VMExportStatusUpdater {
+	return &VMExportStatusUpdater{
 		updater: updater{
 			lock:        sync.Mutex{},
 			subresource: true,

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -604,11 +604,17 @@ func NewVirtualMachineExportCrd() (*extv1.CustomResourceDefinition, error) {
 				Name:    exportv1alpha1.SchemeGroupVersion.Version,
 				Served:  true,
 				Storage: false,
+				Subresources: &extv1.CustomResourceSubresources{
+					Status: &extv1.CustomResourceSubresourceStatus{},
+				},
 			},
 			{
 				Name:    exportv1beta1.SchemeGroupVersion.Version,
 				Served:  true,
 				Storage: true,
+				Subresources: &extv1.CustomResourceSubresources{
+					Status: &extv1.CustomResourceSubresourceStatus{},
+				},
 			},
 		},
 		Scope: "Namespaced",

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -325,10 +325,11 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"export.kubevirt.io",
 				},
 				Resources: []string{
-					"*",
+					"virtualmachineexports",
+					"virtualmachineexports/status",
 				},
 				Verbs: []string{
-					"*",
+					"get", "list", "watch", "create", "update", "delete", "patch",
 				},
 			},
 			{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

status subresource enabled and consumed by virt-controller

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vmexport: enable status subresource for VirtualMachineExport
```

