### PR TITLE
bridge, discover: Don't filter static routes in wider subnets

### DIFF
--- a/pkg/network/setup/netpod/discoverbridge.go
+++ b/pkg/network/setup/netpod/discoverbridge.go
@@ -121,6 +121,13 @@ func translateNmstateToNetlinkRoutes(otherRoutes []nmstate.Route) ([]vishnetlink
 // filterRoutesByNonLocalDestination filters out local routes (the destination is of the local link).
 // Default routes should not be filter out.
 func filterRoutesByNonLocalDestination(linkRoutes []nmstate.Route, addr *vishnetlink.Addr) ([]nmstate.Route, error) {
+	_, localNetwork, err := net.ParseCIDR(addr.String())
+	if err != nil {
+		return nil, err
+	}
+
+	localNetworkStr := localNetwork.String()
+
 	var otherRoutes []nmstate.Route
 	for _, route := range linkRoutes {
 		_, dstIPNet, perr := net.ParseCIDR(route.Destination)
@@ -128,7 +135,7 @@ func filterRoutesByNonLocalDestination(linkRoutes []nmstate.Route, addr *vishnet
 			return nil, perr
 		}
 		isDefaultRoute := route.Destination == nmstate.DefaultDestinationRoute(vishnetlink.FAMILY_V4).String()
-		localDestination := !isDefaultRoute && dstIPNet.Contains(addr.IP)
+		localDestination := !isDefaultRoute && dstIPNet.String() == localNetworkStr
 		if !localDestination {
 			otherRoutes = append(otherRoutes, route)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
PR #10396 had changed the logic deciding which routes will be passed into the VM via the DHCP server:
All non-default routes whose destination subnet contains the pod NIC's address are filtered out.

If a [CNI](https://www.cni.dev/) has defined a static route to a subnet wider than the local network of the pod's NIC - it will be filtered out.

For example, assuming the pod NIC IP address is 192.168.1.3/24, and there is the following static route:
`192.168.0.0/16 dev eth0`
it would be filtered-out.

Filter only non-default routes whose destination exactly matches the local subnet of the pod's NIC.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12413

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bridge binding: Static routes to subnets containing the pod's NIC IP address are passed to the VM.
```

