### PR TITLE
sig-storage: update unit tests to use runStrategy instead of spec.Running

### DIFF
--- a/pkg/storage/snapshot/BUILD.bazel
+++ b/pkg/storage/snapshot/BUILD.bazel
@@ -87,7 +87,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/storage/snapshot/BUILD.bazel
+++ b/pkg/storage/snapshot/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/status:go_default_library",

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
@@ -34,6 +33,7 @@ import (
 
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/instancetype"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/util/status"
 )
@@ -84,12 +84,12 @@ var _ = Describe("Restore controller", func() {
 				Kind:               "VirtualMachine",
 				Name:               vmName,
 				UID:                vmUID,
-				Controller:         &t,
-				BlockOwnerDeletion: &t,
+				Controller:         pointer.P(true),
+				BlockOwnerDeletion: pointer.P(true),
 			},
 		}
 		r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-			Complete: &f,
+			Complete: pointer.P(false),
 		}
 		return r
 	}
@@ -126,7 +126,7 @@ var _ = Describe("Restore controller", func() {
 		s := createVirtualMachineSnapshot(testNamespace, vmSnapshotName, vmName)
 		s.Finalizers = []string{"snapshot.kubevirt.io/vmsnapshot-protection"}
 		s.Status = &snapshotv1.VirtualMachineSnapshotStatus{
-			ReadyToUse:   &t,
+			ReadyToUse:   pointer.P(true),
 			CreationTime: timeFunc(),
 			SourceUID:    &vmUID,
 		}
@@ -396,7 +396,7 @@ var _ = Describe("Restore controller", func() {
 				s.Status.VirtualMachineSnapshotContentName = &sc.Name
 				sc.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
 					CreationTime: timeFunc(),
-					ReadyToUse:   &t,
+					ReadyToUse:   pointer.P(true),
 				}
 				vmSnapshotSource.Add(s)
 				vmSnapshotContentSource.Add(sc)
@@ -409,7 +409,7 @@ var _ = Describe("Restore controller", func() {
 				rc := r.DeepCopy()
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionFalse, "VMSnapshot default/snapshot does not exist"),
 						newReadyCondition(corev1.ConditionFalse, "VMSnapshot default/snapshot does not exist"),
@@ -433,7 +433,7 @@ var _ = Describe("Restore controller", func() {
 				rc.OwnerReferences = refs
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Initializing VirtualMachineRestore"),
 						newReadyCondition(corev1.ConditionFalse, "Initializing VirtualMachineRestore"),
@@ -452,7 +452,7 @@ var _ = Describe("Restore controller", func() {
 				rc := r.DeepCopy()
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
@@ -469,7 +469,7 @@ var _ = Describe("Restore controller", func() {
 			It("should return error if volumesnapshot doesnt exist", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
@@ -480,7 +480,7 @@ var _ = Describe("Restore controller", func() {
 				rc := r.DeepCopy()
 				rc.ResourceVersion = "1"
 				rc.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionFalse, "missing volumeSnapshot vmsnapshot-snapshot-uid-volume-disk1"),
 						newReadyCondition(corev1.ConditionFalse, "missing volumeSnapshot vmsnapshot-snapshot-uid-volume-disk1"),
@@ -500,7 +500,7 @@ var _ = Describe("Restore controller", func() {
 				r := createRestoreWithOwner()
 				vm := createModifiedVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
@@ -521,7 +521,7 @@ var _ = Describe("Restore controller", func() {
 				r := createRestoreWithOwner()
 				vm := createModifiedVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
@@ -542,7 +542,7 @@ var _ = Describe("Restore controller", func() {
 				r := createRestoreWithOwner()
 				vm := createModifiedVM()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
@@ -563,7 +563,7 @@ var _ = Describe("Restore controller", func() {
 			It("should wait for bound", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
@@ -587,7 +587,7 @@ var _ = Describe("Restore controller", func() {
 			It("should update restore status with datavolume", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
@@ -618,7 +618,7 @@ var _ = Describe("Restore controller", func() {
 			It("should update PVCs and restores to have datavolumename", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete: &f,
+					Complete: pointer.P(false),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
 						newReadyCondition(corev1.ConditionFalse, "Waiting for target to be ready"),
@@ -652,7 +652,7 @@ var _ = Describe("Restore controller", func() {
 			It("should update VM spec", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete:           &f,
+					Complete:           pointer.P(false),
 					DeletedDataVolumes: getDeletedDataVolumes(createModifiedVM()),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Updating target spec"),
@@ -685,7 +685,7 @@ var _ = Describe("Restore controller", func() {
 			It("should cleanup and unlock vm", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete:           &f,
+					Complete:           pointer.P(false),
 					DeletedDataVolumes: getDeletedDataVolumes(createModifiedVM()),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Updating target spec"),
@@ -716,7 +716,7 @@ var _ = Describe("Restore controller", func() {
 
 				ur := r.DeepCopy()
 				ur.ResourceVersion = "1"
-				ur.Status.Complete = &f
+				ur.Status.Complete = pointer.P(false)
 				ur.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionTrue, "Updating target status"),
 					newReadyCondition(corev1.ConditionFalse, "Waiting for target update"),
@@ -752,7 +752,7 @@ var _ = Describe("Restore controller", func() {
 			It("should complete restore", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete:           &f,
+					Complete:           pointer.P(false),
 					DeletedDataVolumes: getDeletedDataVolumes(createModifiedVM()),
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Updating target status"),
@@ -777,7 +777,7 @@ var _ = Describe("Restore controller", func() {
 
 				ur := r.DeepCopy()
 				ur.ResourceVersion = "1"
-				ur.Status.Complete = &t
+				ur.Status.Complete = pointer.P(true)
 				ur.Status.RestoreTime = timeFunc()
 				ur.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
@@ -863,7 +863,7 @@ var _ = Describe("Restore controller", func() {
 					}
 
 					Expect(vmRestore.Status.Restores).To(HaveLen(1))
-					vmRestore.Status.Restores[0].DataVolumeName = pointer.String(restoreDVName(vmRestore, vmRestore.Status.Restores[0].VolumeName))
+					vmRestore.Status.Restores[0].DataVolumeName = pointer.P(restoreDVName(vmRestore, vmRestore.Status.Restores[0].VolumeName))
 					expectPVCUpdates(k8sClient, vmRestore)
 
 					By("Making sure right VM update occurs")
@@ -915,8 +915,8 @@ var _ = Describe("Restore controller", func() {
 							Kind:               "VirtualMachine",
 							Name:               newVM.Name,
 							UID:                newVM.UID,
-							Controller:         pointer.BoolPtr(true),
-							BlockOwnerDeletion: pointer.BoolPtr(true),
+							Controller:         pointer.P(true),
+							BlockOwnerDeletion: pointer.P(true),
 						},
 					}
 
@@ -944,7 +944,7 @@ var _ = Describe("Restore controller", func() {
 						r = createRestore()
 						r.Spec.Target.Name = newVmName
 						r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-							Complete: &f,
+							Complete: pointer.P(false),
 						}
 
 						changeNamePatch = fmt.Sprintf(`{"op": "replace", "path": "/metadata/name", "value": "%s"}`, newVmName)
@@ -1007,7 +1007,7 @@ var _ = Describe("Restore controller", func() {
 			s.Status.VirtualMachineSnapshotContentName = &sc.Name
 			sc.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
 				CreationTime: timeFunc(),
-				ReadyToUse:   &t,
+				ReadyToUse:   pointer.P(true),
 			}
 			vmSnapshotSource.Add(s)
 			vmSnapshotContentSource.Add(sc)
@@ -1017,7 +1017,7 @@ var _ = Describe("Restore controller", func() {
 			r := createRestoreWithOwner()
 			vm = createModifiedVM()
 			r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-				Complete: &f,
+				Complete: pointer.P(false),
 				Conditions: []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
 					newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
@@ -1120,7 +1120,7 @@ var _ = Describe("Restore controller", func() {
 				vmSnapshotContent = createVirtualMachineSnapshotContent(vmSnapshot, originalVM, nil)
 				vmSnapshotContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
 					CreationTime: timeFunc(),
-					ReadyToUse:   &t,
+					ReadyToUse:   pointer.P(true),
 				}
 
 				vmSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -56,8 +56,6 @@ var (
 	vmUID             types.UID        = "vm-uid"
 	vmAPIGroup                         = "kubevirt.io"
 	storageClassName                   = "rook-ceph-block"
-	t                                  = true
-	f                                  = false
 	noFailureDeadline *metav1.Duration = &metav1.Duration{Duration: 0}
 	instancetypeUID   types.UID        = "instancetype-uid"
 	preferenceUID     types.UID        = "preference-uid"
@@ -85,7 +83,7 @@ var _ = Describe("Snapshot controlleer", func() {
 		vms := createVMSnapshot()
 		vms.Finalizers = []string{"snapshot.kubevirt.io/vmsnapshot-protection"}
 		vms.Status = &snapshotv1.VirtualMachineSnapshotStatus{
-			ReadyToUse:   &t,
+			ReadyToUse:   pointer.P(true),
 			SourceUID:    &vmUID,
 			CreationTime: timeFunc(),
 			Conditions: []snapshotv1.Condition{
@@ -102,7 +100,7 @@ var _ = Describe("Snapshot controlleer", func() {
 		vms := createVMSnapshot()
 		vms.Finalizers = []string{"snapshot.kubevirt.io/vmsnapshot-protection"}
 		vms.Status = &snapshotv1.VirtualMachineSnapshotStatus{
-			ReadyToUse: &f,
+			ReadyToUse: pointer.P(false),
 			SourceUID:  &vmUID,
 			Phase:      snapshotv1.InProgress,
 		}
@@ -165,7 +163,7 @@ var _ = Describe("Snapshot controlleer", func() {
 	createErrorVMSnapshotContent := func() *snapshotv1.VirtualMachineSnapshotContent {
 		content := createVMSnapshotContent()
 		content.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-			ReadyToUse: &f,
+			ReadyToUse: pointer.P(false),
 		}
 		errorMessage := "VolumeSnapshot vol1 error: error"
 		content.Status.Error = &snapshotv1.Error{
@@ -178,7 +176,7 @@ var _ = Describe("Snapshot controlleer", func() {
 	createReadyVMSnapshotContent := func() *snapshotv1.VirtualMachineSnapshotContent {
 		content := createVMSnapshotContent()
 		content.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-			ReadyToUse:   &t,
+			ReadyToUse:   pointer.P(true),
 			CreationTime: timeFunc(),
 		}
 		return content
@@ -188,7 +186,7 @@ var _ = Describe("Snapshot controlleer", func() {
 		vms := createVMSnapshotInProgress()
 		content := createErrorVMSnapshotContent()
 		vms.Status.VirtualMachineSnapshotContentName = &content.Name
-		vms.Status.ReadyToUse = &f
+		vms.Status.ReadyToUse = pointer.P(false)
 		vms.Status.Indications = nil
 		vms.Status.Conditions = []snapshotv1.Condition{
 			newProgressingCondition(corev1.ConditionFalse, "In error state"),
@@ -224,7 +222,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					},
 				},
 				Status: &vsv1.VolumeSnapshotStatus{
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 				},
 			}
 			volumeSnapshots = append(volumeSnapshots, vs)
@@ -478,7 +476,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Finalizers = []string{"snapshot.kubevirt.io/vmsnapshot-protection"}
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					SourceUID:  &vmUID,
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
@@ -497,7 +495,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Finalizers = []string{"snapshot.kubevirt.io/vmsnapshot-protection"}
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionFalse, "Source does not exist"),
@@ -517,7 +515,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Finalizers = []string{"snapshot.kubevirt.io/vmsnapshot-protection"}
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					SourceUID:  &vmUID,
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
@@ -953,7 +951,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					SourceUID:  &vmUID,
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
@@ -1011,7 +1009,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					SourceUID:  &vmUID,
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
@@ -1052,7 +1050,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					SourceUID:  &vmUID,
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
@@ -1074,7 +1072,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.SourceUID = &vmUID
 				updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
 				updatedSnapshot.Status.CreationTime = timeFunc()
-				updatedSnapshot.Status.ReadyToUse = &t
+				updatedSnapshot.Status.ReadyToUse = pointer.P(true)
 				updatedSnapshot.Status.Phase = snapshotv1.Succeeded
 				updatedSnapshot.Status.Indications = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
@@ -1115,7 +1113,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.SourceUID = &vmUID
 				updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
 				updatedSnapshot.Status.CreationTime = timeFunc()
-				updatedSnapshot.Status.ReadyToUse = &t
+				updatedSnapshot.Status.ReadyToUse = pointer.P(true)
 				updatedSnapshot.Status.Phase = snapshotv1.Succeeded
 				updatedSnapshot.Status.Indications = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
@@ -1145,7 +1143,7 @@ var _ = Describe("Snapshot controlleer", func() {
 
 				updatedSnapshot := vmSnapshot.DeepCopy()
 				updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
-				updatedSnapshot.Status.ReadyToUse = &f
+				updatedSnapshot.Status.ReadyToUse = pointer.P(false)
 				updatedSnapshot.Status.Indications = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "In error state"),
@@ -1251,7 +1249,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 				}
 
 				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
@@ -1289,7 +1287,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 				}
 
 				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
@@ -1334,7 +1332,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 				}
 
 				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
@@ -1388,7 +1386,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 				}
 
 				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
@@ -1459,7 +1457,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse:   &t,
+					ReadyToUse:   pointer.P(true),
 					CreationTime: timeFunc(),
 				}
 
@@ -1522,7 +1520,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmSnapshotContent := createReadyVMSnapshotContent()
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
-				updatedContent.Status.ReadyToUse = &f
+				updatedContent.Status.ReadyToUse = pointer.P(false)
 				updatedContent.Status.CreationTime = nil
 
 				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
@@ -1532,7 +1530,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				}
 				errorMessage := fmt.Sprintf("VolumeSnapshots (%s) missing", strings.Join(volumeSnapshotNames, ","))
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse:   &f,
+					ReadyToUse:   pointer.P(false),
 					CreationTime: timeFunc(),
 					Error: &snapshotv1.Error{
 						Message: &errorMessage,
@@ -1571,7 +1569,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmSnapshotContent := createVMSnapshotContent()
 				vmSnapshotContent.UID = contentUID
 				vmSnapshotContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 				}
 				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
 				for i := range volumeSnapshots {
@@ -1640,7 +1638,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmSnapshotContent := createVMSnapshotContent()
 				vmSnapshotContent.UID = contentUID
 				vmSnapshotContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse: &f,
+					ReadyToUse: pointer.P(false),
 				}
 
 				vmSnapshotContentSource.Add(vmSnapshotContent)
@@ -2174,7 +2172,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					expectedSnapshotUpdate.ResourceVersion = "1"
 					expectedSnapshotUpdate.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 						SourceUID:  &vmUID,
-						ReadyToUse: &f,
+						ReadyToUse: pointer.P(false),
 						Phase:      snapshotv1.InProgress,
 						Conditions: []snapshotv1.Condition{
 							newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -56,10 +57,6 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 	var vmUID types.UID = "vm-uid"
 	apiGroup := "kubevirt.io"
 
-	t := true
-	f := false
-	runStrategyManual := v1.RunStrategyManual
-
 	snapshot := &snapshotv1.VirtualMachineSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      vmSnapshotName,
@@ -67,7 +64,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 		},
 		Status: &snapshotv1.VirtualMachineSnapshotStatus{
 			SourceUID:  &vmUID,
-			ReadyToUse: &t,
+			ReadyToUse: pointer.P(true),
 		},
 	}
 
@@ -280,7 +277,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				vm.Spec.Running = &t
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
@@ -305,7 +302,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				vm.Spec.RunStrategy = &runStrategyManual
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyManual)
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
@@ -331,7 +328,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				vm.Spec.Running = &f
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm).Admit(context.Background(), ar)
@@ -356,7 +353,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				vm.Spec.Running = &f
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
 				s := snapshot.DeepCopy()
 				s.Status.Phase = snapshotv1.Failed
 
@@ -383,9 +380,9 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				vm.Spec.Running = &f
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
 				s := snapshot.DeepCopy()
-				s.Status.ReadyToUse = &f
+				s.Status.ReadyToUse = pointer.P(false)
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, s).Admit(context.Background(), ar)
@@ -410,7 +407,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				vm.Spec.Running = &t
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
@@ -436,7 +433,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				vm.Spec.Running = &t
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
@@ -461,8 +458,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				f := false
-				vm.Spec.Running = &f
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
 
 				restoreInProcess := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
@@ -498,8 +494,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				f := false
-				vm.Spec.Running = &f
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
@@ -23,8 +23,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"k8s.io/utils/pointer"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,6 +38,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -217,8 +216,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 					},
 				}
 
-				t := true
-				vm.Spec.Running = &t
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
 
 				ar := createSnapshotAdmissionReview(snapshot)
 				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)
@@ -236,8 +234,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 					},
 				}
 
-				t := true
-				vm.Spec.Running = &t
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
 
 				ar := createSnapshotAdmissionReview(snapshot)
 				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)
@@ -258,8 +255,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 					},
 				}
 
-				t := true
-				vm.Spec.Running = &t
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
 
 				ar := createSnapshotAdmissionReview(snapshot)
 				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)
@@ -274,7 +270,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 						Domain: v1.DomainSpec{
 							Devices: v1.Devices{
 								TPM: &v1.TPMDevice{
-									Persistent: pointer.BoolPtr(true),
+									Persistent: pointer.P(true),
 								},
 							},
 						},
@@ -309,8 +305,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 					},
 				}
 
-				f := false
-				vm.Spec.Running = &f
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
 
 				ar := createSnapshotAdmissionReview(snapshot)
 				resp := createTestVMSnapshotAdmitter(config, vm).Admit(context.Background(), ar)

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -185,9 +185,6 @@ var _ = Describe("Clone", func() {
 		)
 		sourceVMI.Namespace = metav1.NamespaceDefault
 		sourceVM = libvmi.NewVirtualMachine(sourceVMI)
-		sourceVM.Spec.Running = nil
-		runStrategy := virtv1.RunStrategyHalted
-		sourceVM.Spec.RunStrategy = &runStrategy
 
 		vmClone = kubecli.NewMinimalCloneWithNS("testclone", metav1.NamespaceDefault)
 		cloneSourceRef := &k8sv1.TypedLocalObjectReference{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
We want to deprecate the use of spec.Running and use spec.RunStrategy instead.
Before this PR: using spec.Running in storage UT

After this PR: using spec.RunStrategy in storage UT

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-45439
relates to issue: #11993 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

