### PR TITLE
cleanup(virtctl): Use cobra.ExactArgs

### DIFF
--- a/pkg/virtctl/configuration/configuration.go
+++ b/pkg/virtctl/configuration/configuration.go
@@ -20,7 +20,7 @@ func NewListPermittedDevices(clientConfig clientcmd.ClientConfig) *cobra.Command
 		Use:     "permitted-devices",
 		Short:   "List the permitted devices for vmis.",
 		Example: usage(),
-		Args:    templates.ExactArgs("permitted-devices", 0),
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := command{clientConfig: clientConfig}
 			return c.run()

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -44,7 +44,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "console (VMI)",
 		Short:   "Connect to a console of a virtual machine instance.",
 		Example: usage(),
-		Args:    templates.ExactArgs("console", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Console{clientConfig: clientConfig}
 			return c.Run(args)

--- a/pkg/virtctl/credentials/addkey/addkey.go
+++ b/pkg/virtctl/credentials/addkey/addkey.go
@@ -24,7 +24,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add-ssh-key",
 		Short:   "Add credentials to a virtual machine.",
-		Args:    templates.ExactArgs("add-ssh-key", 1),
+		Args:    cobra.ExactArgs(1),
 		Example: exampleUsage,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAddKeyCommand(clientConfig, cmdFlags, cmd, args)

--- a/pkg/virtctl/credentials/password/password.go
+++ b/pkg/virtctl/credentials/password/password.go
@@ -20,7 +20,7 @@ func SetPasswordCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "set-password",
 		Short:   "Set password for a user",
-		Args:    templates.ExactArgs("set-password", 1),
+		Args:    cobra.ExactArgs(1),
 		Example: exampleUsage,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSetPasswordCommand(clientConfig, cmdFlags, cmd, args)

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -58,7 +58,7 @@ Possible types are (case insensitive, both single and plurant forms):
 
 virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplicaset (vmirs)`,
 		Example: usage(),
-		Args:    templates.ExactArgs("expose", 2),
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_EXPOSE, clientConfig: clientConfig}
 			return c.RunE(args)

--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -109,7 +109,7 @@ func NewMemoryDumpCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "memory-dump get/download/remove (VM)",
 		Short:   "Dump the memory of a running VM to a pvc",
 		Example: usageMemoryDump(),
-		Args:    templates.ExactArgs("memory-dump", 2),
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := command{clientConfig: clientConfig}
 			return c.run(args)

--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -209,9 +209,9 @@ var _ = Describe("MemoryDump", func() {
 		Expect(res).To(HaveOccurred())
 		Expect(res.Error()).To(ContainSubstring(errorString))
 	},
-		Entry("memorydump no args", "argument validation failed"),
-		Entry("memorydump missing action arg", "argument validation failed", "testvm"),
-		Entry("memorydump missing vm name arg", "argument validation failed", "get"),
+		Entry("memorydump no args", "accepts 2 arg(s), received 0"),
+		Entry("memorydump missing action arg", "accepts 2 arg(s), received 1", "testvm"),
+		Entry("memorydump missing vm name arg", "accepts 2 arg(s), received 1", "get"),
 		Entry("memorydump wrong action arg", "invalid action type create", "create", "testvm"),
 		Entry("memorydump name, invalid extra parameter", "unknown flag", "testvm", "--claim-name=blah", "--invalid=test"),
 		Entry("memorydump download missing outputFile", "missing outputFile", "download", "testvm", "--claim-name=pvc"),

--- a/pkg/virtctl/pause/pause.go
+++ b/pkg/virtctl/pause/pause.go
@@ -57,7 +57,7 @@ func NewPauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Long: `Pauses a virtual machine by freezing it. Machine state is kept in memory.
 First argument is the resource type, possible types are (case insensitive, both singular and plural forms) virtualmachineinstance (vmi) or virtualmachine (vm).
 Second argument is the name of the resource.`,
-		Args:    templates.ExactArgs(COMMAND_PAUSE, 2),
+		Args:    cobra.ExactArgs(2),
 		Example: usage(COMMAND_PAUSE),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VirtCommand{
@@ -79,7 +79,7 @@ func NewUnpauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Long: `Unpauses a virtual machine.
 First argument is the resource type, possible types are (case insensitive, both singular and plural forms) virtualmachineinstance (vmi) or virtualmachine (vm).
 Second argument is the name of the resource.`,
-		Args:    templates.ExactArgs("unpause", 2),
+		Args:    cobra.ExactArgs(2),
 		Example: usage(COMMAND_UNPAUSE),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VirtCommand{

--- a/pkg/virtctl/scp/scp.go
+++ b/pkg/virtctl/scp/scp.go
@@ -44,7 +44,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "scp (VM|VMI)",
 		Short:   "SCP files from/to a virtual machine instance.",
 		Example: usage(),
-		Args:    templates.ExactArgs("scp", 2),
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(cmd, args)
 		},

--- a/pkg/virtctl/softreboot/softreboot.go
+++ b/pkg/virtctl/softreboot/softreboot.go
@@ -41,7 +41,7 @@ func NewSoftRebootCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "soft-reboot (VMI)",
 		Short:   "Soft reboot a virtual machine instance",
 		Long:    `Soft reboot a virtual machine instance`,
-		Args:    templates.ExactArgs(COMMAND_SOFT_REBOOT, 1),
+		Args:    cobra.ExactArgs(1),
 		Example: usage(COMMAND_SOFT_REBOOT),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := SoftReboot{

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -55,7 +55,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "ssh (VM|VMI)",
 		Short:   "Open a SSH connection to a virtual machine instance.",
 		Example: usage(),
-		Args:    templates.ExactArgs("ssh", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.Run(cmd, args)
 		},

--- a/pkg/virtctl/templates/BUILD.bazel
+++ b/pkg/virtctl/templates/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/controller:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -2,11 +2,9 @@ package templates
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -53,18 +51,6 @@ func OptionsUsageTemplate() string {
 
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
 `
-}
-
-// ExactArgs validate the number of input parameters
-func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
-	return func(cmd *cobra.Command, args []string) error {
-		if len(args) != n {
-			fmt.Fprintf(os.Stderr, "fatal: Number of input parameters is incorrect, %s accepts %d arg(s), received %d\n\n", nameOfCommand, n, len(args))
-			cmd.Help()
-			return errors.New("argument validation failed")
-		}
-		return nil
-	}
 }
 
 // PrintWarningForPausedVMI prints warning message if VMI is paused

--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -33,7 +33,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "usbredir (vendor:product)|(bus-device) (VMI)",
 		Short:   "Redirect an USB device to a virtual machine instance.",
 		Example: usage(),
-		Args:    templates.ExactArgs("usb", 2),
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := usbredirCommand{clientConfig: clientConfig}
 			return c.Run(cmd, args)

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -27,7 +27,7 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "version",
 		Short:   "Print the client and server version information.",
 		Example: usage(),
-		Args:    templates.ExactArgs("version", 0),
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := Version{clientConfig: clientConfig}
 			return v.Run()

--- a/pkg/virtctl/vm/add_volume.go
+++ b/pkg/virtctl/vm/add_volume.go
@@ -51,7 +51,7 @@ func NewAddVolumeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "addvolume VMI",
 		Short:   "add a volume to a running VM",
 		Example: usageAddVolume(),
-		Args:    templates.ExactArgs("addvolume", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_ADDVOLUME, clientConfig: clientConfig}
 			return c.addVolumeRun(args)

--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Add volume command", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(errorString))
 	},
-		Entry("addvolume no args", "addvolume", "argument validation failed"),
+		Entry("addvolume no args", "addvolume", "accepts 1 arg(s), received 0"),
 		Entry("addvolume name, missing required volume-name", "addvolume", "required flag(s)", vmiName),
 		Entry("addvolume name, invalid extra parameter", "addvolume", "unknown flag", vmiName, "--volume-name=blah", "--invalid=test"),
 	)

--- a/pkg/virtctl/vm/fs_list.go
+++ b/pkg/virtctl/vm/fs_list.go
@@ -37,7 +37,7 @@ func NewFSListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "fslist (VMI)",
 		Short:   "Return full list of filesystems available on the guest machine.",
 		Example: usage(COMMAND_FSLIST),
-		Args:    templates.ExactArgs("fslist", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{clientConfig: clientConfig}
 			return c.fsListRun(args)

--- a/pkg/virtctl/vm/fs_list_test.go
+++ b/pkg/virtctl/vm/fs_list_test.go
@@ -50,7 +50,7 @@ var _ = Describe("FS list command", func() {
 		cmd := clientcmd.NewRepeatableVirtctlCommand("fslist")
 		err := cmd()
 		Expect(err).To(HaveOccurred())
-		Expect(err).Should(MatchError("argument validation failed"))
+		Expect(err).Should(MatchError("accepts 1 arg(s), received 0"))
 	})
 
 	It("should fail with non existing vm", func() {

--- a/pkg/virtctl/vm/guestosinfo.go
+++ b/pkg/virtctl/vm/guestosinfo.go
@@ -37,7 +37,7 @@ func NewGuestOsInfoCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "guestosinfo (VMI)",
 		Short:   "Return guest agent info about operating system.",
 		Example: usage(COMMAND_GUESTOSINFO),
-		Args:    templates.ExactArgs("guestosinfo", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{clientConfig: clientConfig}
 			return c.guestOsInfoRun(args)

--- a/pkg/virtctl/vm/guestosinfo_test.go
+++ b/pkg/virtctl/vm/guestosinfo_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Guest os info command", func() {
 		cmd := clientcmd.NewRepeatableVirtctlCommand("guestosinfo")
 		err := cmd()
 		Expect(err).To(HaveOccurred())
-		Expect(err).Should(MatchError("argument validation failed"))
+		Expect(err).Should(MatchError("accepts 1 arg(s), received 0"))
 	})
 
 	It("should fail with non existing vm", func() {

--- a/pkg/virtctl/vm/migrate.go
+++ b/pkg/virtctl/vm/migrate.go
@@ -37,7 +37,7 @@ func NewMigrateCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "migrate (VM)",
 		Short:   "Migrate a virtual machine.",
 		Example: usage(COMMAND_MIGRATE),
-		Args:    templates.ExactArgs("migrate", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_MIGRATE, clientConfig: clientConfig}
 			return c.migrateRun(args)

--- a/pkg/virtctl/vm/migrate_cancel.go
+++ b/pkg/virtctl/vm/migrate_cancel.go
@@ -38,7 +38,7 @@ func NewMigrateCancelCommand(clientConfig clientcmd.ClientConfig) *cobra.Command
 		Use:     "migrate-cancel (VM)",
 		Short:   "Cancel migration of a virtual machine.",
 		Example: usage(COMMAND_MIGRATE_CANCEL),
-		Args:    templates.ExactArgs("migrate-cancel", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_MIGRATE_CANCEL, clientConfig: clientConfig}
 			return c.migrateCancelRun(args)

--- a/pkg/virtctl/vm/migrate_cancel_test.go
+++ b/pkg/virtctl/vm/migrate_cancel_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Migrate cancel command", func() {
 		cmd := clientcmd.NewRepeatableVirtctlCommand("migrate-cancel")
 		err := cmd()
 		Expect(err).To(HaveOccurred())
-		Expect(err).Should(MatchError("argument validation failed"))
+		Expect(err).Should(MatchError("accepts 1 arg(s), received 0"))
 	})
 
 	It("should cancel the vm migration", func() {

--- a/pkg/virtctl/vm/migrate_test.go
+++ b/pkg/virtctl/vm/migrate_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Migrate command", func() {
 		cmd := clientcmd.NewRepeatableVirtctlCommand("migrate")
 		err := cmd()
 		Expect(err).To(HaveOccurred())
-		Expect(err).Should(MatchError("argument validation failed"))
+		Expect(err).Should(MatchError("accepts 1 arg(s), received 0"))
 	})
 
 	DescribeTable("should migrate a vm according to options", func(migrateOptions *v1.MigrateOptions) {

--- a/pkg/virtctl/vm/remove_volume.go
+++ b/pkg/virtctl/vm/remove_volume.go
@@ -37,7 +37,7 @@ func NewRemoveVolumeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command 
 		Use:     "removevolume VMI",
 		Short:   "remove a volume from a running VM",
 		Example: usageRemoveVolume(),
-		Args:    templates.ExactArgs("removevolume", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{clientConfig: clientConfig}
 			return c.removeVolumeRun(args)

--- a/pkg/virtctl/vm/remove_volume_test.go
+++ b/pkg/virtctl/vm/remove_volume_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Remove volume command", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(errorString))
 	},
-		Entry("removevolume no args", "argument validation failed"),
+		Entry("removevolume no args", "accepts 1 arg(s), received 0"),
 		Entry("removevolume name, missing required volume-name", "required flag(s)", "testvmi"),
 		Entry("removevolume name, invalid extra parameter", "unknown flag", "testvmi", "--volume-name=blah", "--invalid=test"),
 	)

--- a/pkg/virtctl/vm/restart.go
+++ b/pkg/virtctl/vm/restart.go
@@ -37,7 +37,7 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "restart (VM)",
 		Short:   "Restart a virtual machine.",
 		Example: usage(COMMAND_RESTART),
-		Args:    templates.ExactArgs("restart", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
 			return c.restartRun(args, cmd)

--- a/pkg/virtctl/vm/restart_test.go
+++ b/pkg/virtctl/vm/restart_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Restart command", func() {
 		cmd := clientcmd.NewRepeatableVirtctlCommand("restart")
 		err := cmd()
 		Expect(err).To(HaveOccurred())
-		Expect(err).Should(MatchError("argument validation failed"))
+		Expect(err).Should(MatchError("accepts 1 arg(s), received 0"))
 	})
 
 	DescribeTable("test", func(restartOptions v1.RestartOptions, runStrategy bool, running bool, args ...string) {

--- a/pkg/virtctl/vm/start.go
+++ b/pkg/virtctl/vm/start.go
@@ -44,7 +44,7 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "start (VM)",
 		Short:   "Start a virtual machine.",
 		Example: usage(COMMAND_START),
-		Args:    templates.ExactArgs("start", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_START, clientConfig: clientConfig}
 			return c.startRun(args)

--- a/pkg/virtctl/vm/start_test.go
+++ b/pkg/virtctl/vm/start_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Start command", func() {
 		cmd := clientcmd.NewRepeatableVirtctlCommand("start")
 		err := cmd()
 		Expect(err).To(HaveOccurred())
-		Expect(err).Should(MatchError("argument validation failed"))
+		Expect(err).Should(MatchError("accepts 1 arg(s), received 0"))
 	})
 
 	It("with dry-run parameter should not start VM", func() {

--- a/pkg/virtctl/vm/stop.go
+++ b/pkg/virtctl/vm/stop.go
@@ -37,7 +37,7 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "stop (VM)",
 		Short:   "Stop a virtual machine.",
 		Example: usage(COMMAND_STOP),
-		Args:    templates.ExactArgs("stop", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_STOP, clientConfig: clientConfig}
 			return c.stopRun(args, cmd)

--- a/pkg/virtctl/vm/stop_test.go
+++ b/pkg/virtctl/vm/stop_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Stop command", func() {
 		cmd := clientcmd.NewRepeatableVirtctlCommand("stop")
 		err := cmd()
 		Expect(err).To(HaveOccurred())
-		Expect(err).Should(MatchError("argument validation failed"))
+		Expect(err).Should(MatchError("accepts 1 arg(s), received 0"))
 	})
 
 	It("with dry-run parameter should not stop VM", func() {

--- a/pkg/virtctl/vm/user_list.go
+++ b/pkg/virtctl/vm/user_list.go
@@ -37,7 +37,7 @@ func NewUserListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "userlist (VMI)",
 		Short:   "Return full list of logged in users on the guest machine.",
 		Example: usage(COMMAND_USERLIST),
-		Args:    templates.ExactArgs("userlist", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{clientConfig: clientConfig}
 			return c.userListRun(args)

--- a/pkg/virtctl/vm/user_list_test.go
+++ b/pkg/virtctl/vm/user_list_test.go
@@ -50,7 +50,7 @@ var _ = Describe("User list command", func() {
 		cmd := clientcmd.NewRepeatableVirtctlCommand("userlist")
 		err := cmd()
 		Expect(err).To(HaveOccurred())
-		Expect(err).Should(MatchError("argument validation failed"))
+		Expect(err).Should(MatchError("accepts 1 arg(s), received 0"))
 	})
 
 	It("should fail with non existing VM", func() {

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -268,7 +268,7 @@ func NewVirtualMachineExportCommand(clientConfig clientcmd.ClientConfig) *cobra.
 		Use:     "vmexport",
 		Short:   "Export a VM volume.",
 		Example: usage(),
-		Args:    templates.ExactArgs("vmexport", 2),
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := command{clientConfig: clientConfig, cmd: cmd}
 			return v.run(args)

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -311,14 +311,14 @@ var _ = Describe("vmexport", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal(errString))
 		},
-			Entry("No arguments", "argument validation failed"),
-			Entry("Missing arg", "argument validation failed", virtctlvmexport.CREATE, setflag(virtctlvmexport.PVC_FLAG, vmexportName)),
-			Entry("More arguments than expected create", "argument validation failed", virtctlvmexport.CREATE, virtctlvmexport.DELETE, vmexportName),
+			Entry("No arguments", "accepts 2 arg(s), received 0"),
+			Entry("Missing arg", "accepts 2 arg(s), received 1", virtctlvmexport.CREATE, setflag(virtctlvmexport.PVC_FLAG, vmexportName)),
+			Entry("More arguments than expected create", "accepts 2 arg(s), received 3", virtctlvmexport.CREATE, virtctlvmexport.DELETE, vmexportName),
 			Entry("Using 'create' without export type", virtctlvmexport.ErrRequiredExportType, virtctlvmexport.CREATE, vmexportName),
 			Entry("Using 'create' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.CREATE), virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), virtctlvmexport.INSECURE_FLAG),
 			Entry("Using 'delete' with export type", virtctlvmexport.ErrIncompatibleExportType, virtctlvmexport.DELETE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test")),
 			Entry("Using 'delete' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.DELETE), virtctlvmexport.DELETE, vmexportName, virtctlvmexport.INSECURE_FLAG),
-			Entry("More arguments than expected download and 'manifest'", "argument validation failed", virtctlvmexport.DOWNLOAD, virtctlvmexport.DELETE, virtctlvmexport.MANIFEST_FLAG, vmexportName),
+			Entry("More arguments than expected download and 'manifest'", "accepts 2 arg(s), received 3", virtctlvmexport.DOWNLOAD, virtctlvmexport.DELETE, virtctlvmexport.MANIFEST_FLAG, vmexportName),
 			Entry("Using 'manifest' with pvc flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.PVC_FLAG, virtctlvmexport.MANIFEST_FLAG), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.PVC_FLAG, "test")),
 			Entry("Using 'manifest' with volume type", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.VOLUME_FLAG, virtctlvmexport.MANIFEST_FLAG), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.VM_FLAG, "test"), setflag(virtctlvmexport.VOLUME_FLAG, "volume")),
 			Entry("Using 'manifest' with invalid output_format_flag", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.OUTPUT_FORMAT_FLAG, "json/yaml"), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, "invalid")),

--- a/pkg/virtctl/vnc/screenshot/screenshot.go
+++ b/pkg/virtctl/vnc/screenshot/screenshot.go
@@ -21,7 +21,7 @@ func NewScreenshotCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "screenshot (VMI)",
 		Short:   "Create a VNC screenshot of a virtual machine instance.",
 		Example: usage(),
-		Args:    templates.ExactArgs("screenshot", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := s
 			return c.Run(cmd, args)

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -74,7 +74,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "vnc (VMI)",
 		Short:   "Open a vnc connection to a virtual machine instance.",
 		Example: usage(),
-		Args:    templates.ExactArgs("vnc", 1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VNC{clientConfig: clientConfig}
 			return c.Run(cmd, args)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Replace use of ExactArgs located in pkg/virtctl/templates with the version shipped by cobra and drop this function from the tree. This avoids duplicating functionality already provided by the cobra library.

Before this PR:

Code provided by library is duplicated

After this PR:

Code provided by library is no longer duplicated

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The error output changes from

```
fatal: Number of input parameters is incorrect, console accepts 1 arg(s), received 0

Connect to a console of a virtual machine instance.

Usage:
  virtctl console (VMI) [flags]

Examples:
  # Connect to the console on VirtualMachineInstance 'myvmi':
  virtctl console myvmi
  # Configure one minute timeout (default 5 minutes)
  virtctl console --timeout=1 myvmi

Flags:
  -h, --help          help for console
      --timeout int   The number of minutes to wait for the virtual machine instance to be ready. (default 5)

Use "virtctl options" for a list of global command-line options (applies to all commands).
```

to

```
accepts 1 arg(s), received 0
```

which is acceptable IMO.

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

