### PR TITLE
virtctl, pause: Remove globals

### DIFF
--- a/pkg/virtctl/pause/pause.go
+++ b/pkg/virtctl/pause/pause.go
@@ -46,14 +46,14 @@ const (
 	ARG_VMI_LONG    = "virtualmachineinstance"
 )
 
-type VirtCommand struct {
+type virtCommand struct {
 	clientConfig clientcmd.ClientConfig
 	command      string
 	dryRun       bool
 }
 
 func NewPauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	c := VirtCommand{
+	c := virtCommand{
 		command:      COMMAND_PAUSE,
 		clientConfig: clientConfig,
 	}
@@ -77,7 +77,7 @@ Second argument is the name of the resource.`,
 }
 
 func NewUnpauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	c := VirtCommand{
+	c := virtCommand{
 		command:      COMMAND_UNPAUSE,
 		clientConfig: clientConfig,
 	}
@@ -106,7 +106,7 @@ func usage(cmd string) string {
 	return usage
 }
 
-func (vc *VirtCommand) Run(args []string) error {
+func (vc *virtCommand) Run(args []string) error {
 	resourceType := strings.ToLower(args[0])
 	resourceName := args[1]
 	namespace, _, err := vc.clientConfig.Namespace()

--- a/pkg/virtctl/pause/pause.go
+++ b/pkg/virtctl/pause/pause.go
@@ -46,11 +46,17 @@ const (
 	ARG_VMI_LONG    = "virtualmachineinstance"
 )
 
-var (
-	dryRun bool
-)
+type VirtCommand struct {
+	clientConfig clientcmd.ClientConfig
+	command      string
+	dryRun       bool
+}
 
 func NewPauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	c := VirtCommand{
+		command:      COMMAND_PAUSE,
+		clientConfig: clientConfig,
+	}
 	cmd := &cobra.Command{
 		Use:   "pause vm|vmi (VM)|(VMI)",
 		Short: "Pause a virtual machine",
@@ -60,19 +66,21 @@ Second argument is the name of the resource.`,
 		Args:    templates.ExactArgs(COMMAND_PAUSE, 2),
 		Example: usage(COMMAND_PAUSE),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := VirtCommand{
-				command:      COMMAND_PAUSE,
-				clientConfig: clientConfig,
-			}
 			return c.Run(args)
 		},
 	}
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes.")
+
+	cmd.Flags().BoolVar(&c.dryRun, "dry-run", false, "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes.")
+
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
 
 func NewUnpauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	c := VirtCommand{
+		command:      COMMAND_UNPAUSE,
+		clientConfig: clientConfig,
+	}
 	cmd := &cobra.Command{
 		Use:   "unpause vm|vmi (VM)|(VMI)",
 		Short: "Unpause a virtual machine",
@@ -82,14 +90,12 @@ Second argument is the name of the resource.`,
 		Args:    templates.ExactArgs("unpause", 2),
 		Example: usage(COMMAND_UNPAUSE),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := VirtCommand{
-				command:      COMMAND_UNPAUSE,
-				clientConfig: clientConfig,
-			}
 			return c.Run(args)
 		},
 	}
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes.")
+
+	cmd.Flags().BoolVar(&c.dryRun, "dry-run", false, "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes.")
+
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -98,11 +104,6 @@ func usage(cmd string) string {
 	usage := fmt.Sprintf("  # %s a virtualmachine called 'myvm':\n", strings.Title(cmd))
 	usage += fmt.Sprintf("  {{ProgramName}} %s vm myvm", cmd)
 	return usage
-}
-
-type VirtCommand struct {
-	clientConfig clientcmd.ClientConfig
-	command      string
 }
 
 func (vc *VirtCommand) Run(args []string) error {
@@ -119,7 +120,7 @@ func (vc *VirtCommand) Run(args []string) error {
 	}
 
 	var dryRunOption []string
-	if dryRun {
+	if vc.dryRun {
 		fmt.Println("Dry Run execution")
 		dryRunOption = []string{v1.DryRunAll}
 	}


### PR DESCRIPTION
### What this PR does
Remove globals usage.
Ran unit tests locally (which do cover dryRun).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

