### PR TITLE
Monitor tests reduce runtime

### DIFF
--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -133,7 +133,6 @@ var _ = Describe("VirtLauncher", func() {
 			It("verify pid detection works", func() {
 				StartProcess()
 				VerifyProcessStarted()
-				go func() { CleanupProcess() }()
 				StopProcess()
 				VerifyProcessStopped()
 			})
@@ -184,7 +183,6 @@ var _ = Describe("VirtLauncher", func() {
 
 				StartProcess()
 				VerifyProcessStarted()
-				go func() { CleanupProcess() }()
 
 				go func() {
 					defer GinkgoRecover()
@@ -203,7 +201,6 @@ var _ = Describe("VirtLauncher", func() {
 
 				StartProcess()
 				VerifyProcessStarted()
-				go func() { CleanupProcess() }()
 				go func() {
 					defer GinkgoRecover()
 					mon.gracePeriod = 1


### PR DESCRIPTION
### What this PR does
Reduce runtime of these test from ~38s down to ~6s. Major setbacks where locks that were held by goroutines and were only released when fake process times out.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
```release-note
NONE
```

