### PR TITLE
backend-storage: add RWO FS support

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16798,6 +16798,10 @@
       "description": "The source node that the VMI originated on",
       "type": "string"
      },
+     "sourcePersistentStatePVCName": {
+      "description": "If the VMI being migrated uses persistent features (backend-storage), its source PVC name is saved here",
+      "type": "string"
+     },
      "sourcePod": {
       "type": "string"
      },
@@ -16846,6 +16850,10 @@
      },
      "targetNodeTopology": {
       "description": "If the VMI requires dedicated CPUs, this field will hold the numa topology on the target node",
+      "type": "string"
+     },
+     "targetPersistentStatePVCName": {
+      "description": "If the VMI being migrated uses persistent features (backend-storage), its target PVC name is saved here",
       "type": "string"
      },
      "targetPod": {

--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -196,7 +196,7 @@ export KUBEVIRT_DEPLOY_NET_BINDING_CNI=true
 
 export KUBEVIRT_PROVIDER="${TEST_LANE}"
 
-ginko_params="$ginko_params -no-color -succinct --label-filter=(!QUARANTINE)&&(!exclude-native-ssh) -randomize-all"
+ginko_params="$ginko_params -no-color -succinct --label-filter=(!QUARANTINE)&&(!exclude-native-ssh)&&(!no-flake-check) -randomize-all"
 for test_file in $(echo "${NEW_TESTS}" | tr '|' '\n'); do
     ginko_params+=" -focus-file=${test_file}"
 done

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/storage/backend-storage",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -14,6 +15,7 @@ go_library(
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -161,6 +161,22 @@ func MigrationHandoff(client kubecli.KubevirtClient, migration *corev1.VirtualMa
 	return nil
 }
 
+func MigrationAbort(client kubecli.KubevirtClient, migration *corev1.VirtualMachineInstanceMigration) error {
+	if migration == nil || migration.Status.MigrationState == nil ||
+		migration.Status.MigrationState.TargetPersistentStatePVCName == "" {
+		return nil
+	}
+
+	targetPVC := migration.Status.MigrationState.TargetPersistentStatePVCName
+
+	err := client.CoreV1().PersistentVolumeClaims(migration.Namespace).Delete(context.Background(), targetPVC, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete PVC: %v", err)
+	}
+
+	return nil
+}
+
 type BackendStorage struct {
 	client        kubecli.KubevirtClient
 	clusterConfig *virtconfig.ClusterConfig

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -43,7 +43,7 @@ const (
 	PVCSize   = "10Mi"
 )
 
-func BasePVC(vmi *corev1.VirtualMachineInstance) string {
+func basePVC(vmi *corev1.VirtualMachineInstance) string {
 	return PVCPrefix + "-" + vmi.Name
 }
 
@@ -57,7 +57,7 @@ func PVCForVMI(pvcIndexer cache.Store, vmi *corev1.VirtualMachineInstance) *v1.P
 		if found && vmName == vmi.Name {
 			return pvc
 		}
-		if pvc.Name == BasePVC(vmi) && pvc.Namespace == vmi.Namespace {
+		if pvc.Name == basePVC(vmi) && pvc.Namespace == vmi.Namespace {
 			legacyPVC = pvc
 		}
 	}
@@ -208,15 +208,21 @@ func (bs *BackendStorage) updateVolumeStatus(vmi *corev1.VirtualMachineInstance,
 	})
 }
 
-func (bs *BackendStorage) CreateIfNeededAndUpdateVolumeStatus(vmi *corev1.VirtualMachineInstance) (string, error) {
+func (bs *BackendStorage) CreateIfNeededAndUpdateVolumeStatus(vmi *corev1.VirtualMachineInstance, migrationTarget bool) (string, error) {
 	if !IsBackendStorageNeededForVMI(&vmi.Spec) {
 		return "", nil
 	}
 
-	pvc := PVCForVMI(bs.pvcStore, vmi)
-	if pvc != nil {
-		bs.updateVolumeStatus(vmi, pvc)
-		return pvc.Name, nil
+	if !migrationTarget {
+		// TODO: if the pvc was just created and the pvcStore doesn't yet know about it, we'll create a second PVC...
+		// We probably need an API call instead
+		// TODO 2: on migration, do we need a job with source and target PVCs as volumes to copy the certs over?
+		// Or are they not needed?
+		pvc := PVCForVMI(bs.pvcStore, vmi)
+		if pvc != nil {
+			bs.updateVolumeStatus(vmi, pvc)
+			return pvc.Name, nil
+		}
 	}
 
 	storageClass, err := bs.getStorageClass()
@@ -235,11 +241,10 @@ func (bs *BackendStorage) CreateIfNeededAndUpdateVolumeStatus(vmi *corev1.Virtua
 			*metav1.NewControllerRef(vmi, corev1.VirtualMachineInstanceGroupVersionKind),
 		}
 	}
-	pvc = &v1.PersistentVolumeClaim{
+	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName:    BasePVC(vmi) + "-",
+			GenerateName:    basePVC(vmi) + "-",
 			OwnerReferences: ownerReferences,
-			Labels:          map[string]string{PVCPrefix: vmi.Name},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{accessMode},
@@ -249,6 +254,10 @@ func (bs *BackendStorage) CreateIfNeededAndUpdateVolumeStatus(vmi *corev1.Virtua
 			StorageClassName: &storageClass,
 			VolumeMode:       &mode,
 		},
+	}
+	if !migrationTarget {
+		// If the PVC is for a migration target, we'll set the label at the end of the migration
+		pvc.Labels = map[string]string{PVCPrefix: vmi.Name}
 	}
 
 	pvc, err = bs.client.CoreV1().PersistentVolumeClaims(vmi.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -90,17 +90,16 @@ func pvcForMigrationTargetFromStore(pvcStore cache.Store, migration *corev1.Virt
 
 }
 
-func PVCForMigrationTarget(pvcStore cache.Store, migration *corev1.VirtualMachineInstanceMigration) string {
+func PVCForMigrationTarget(pvcStore cache.Store, migration *corev1.VirtualMachineInstanceMigration) *v1.PersistentVolumeClaim {
 	if migration.Status.MigrationState != nil && migration.Status.MigrationState.TargetPersistentStatePVCName != "" {
-		return migration.Status.MigrationState.TargetPersistentStatePVCName
+		obj, exists, err := pvcStore.GetByKey(migration.Namespace + "/" + migration.Status.MigrationState.TargetPersistentStatePVCName)
+		if err != nil || !exists {
+			return nil
+		}
+		return obj.(*v1.PersistentVolumeClaim)
 	}
 
-	pvc := pvcForMigrationTargetFromStore(pvcStore, migration)
-	if pvc != nil {
-		return pvc.Name
-	}
-
-	return ""
+	return pvcForMigrationTargetFromStore(pvcStore, migration)
 }
 
 func (bs *BackendStorage) labelLegacyPVC(pvc *v1.PersistentVolumeClaim, name string) {

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -22,6 +22,7 @@ package backendstorage
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -67,6 +68,16 @@ func PVCForVMI(pvcIndexer cache.Store, vmi *corev1.VirtualMachineInstance) *v1.P
 	}
 
 	return nil
+}
+
+func CurrentPVCName(vmi *corev1.VirtualMachineInstance) string {
+	for _, volume := range vmi.Status.VolumeStatus {
+		if strings.HasPrefix(volume.Name, basePVC(vmi)) {
+			return volume.Name
+		}
+	}
+
+	return ""
 }
 
 func HasPersistentTPMDevice(vmiSpec *corev1.VirtualMachineInstanceSpec) bool {

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -362,19 +362,18 @@ func PathForNVram(vmi *v1.VirtualMachineInstance) string {
 	return nvramPath
 }
 
-func withBackendStorage(vmi *v1.VirtualMachineInstance) VolumeRendererOption {
+func withBackendStorage(vmi *v1.VirtualMachineInstance, backendStoragePVCName string) VolumeRendererOption {
 	return func(renderer *VolumeRenderer) error {
 		if !backendstorage.IsBackendStorageNeededForVMI(&vmi.Spec) {
 			return nil
 		}
 
 		volumeName := "vm-state"
-		pvcName := backendstorage.PVCForVMI(vmi)
 		renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
 			Name: volumeName,
 			VolumeSource: k8sv1.VolumeSource{
 				PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-					ClaimName: pvcName,
+					ClaimName: backendStoragePVCName,
 					ReadOnly:  false,
 				},
 			},

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -277,10 +277,11 @@ func (t *templateService) RenderMigrationManifest(vmi *v1.VirtualMachineInstance
 	imageIDs := containerdisk.ExtractImageIDsFromSourcePod(vmi, sourcePod)
 	backendStoragePVCName := ""
 	if backendstorage.IsBackendStorageNeededForVMI(&vmi.Spec) {
-		backendStoragePVCName = backendstorage.PVCForMigrationTarget(t.persistentVolumeClaimStore, migration)
-		if backendStoragePVCName == "" {
+		backendStoragePVC := backendstorage.PVCForMigrationTarget(t.persistentVolumeClaimStore, migration)
+		if backendStoragePVC == nil {
 			return nil, fmt.Errorf("can't generate manifest without backend-storage PVC, waiting for the PVC to be created")
 		}
+		backendStoragePVCName = backendStoragePVC.Name
 	}
 	targetPod, err := t.renderLaunchManifest(vmi, imageIDs, backendStoragePVCName, false)
 	if err != nil {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -5094,7 +5094,7 @@ var _ = Describe("Template", func() {
 
 			sourcePod.Annotations[testKey] = initialValue
 
-			targetPod, err := svc.RenderMigrationManifest(vmi, sourcePod)
+			targetPod, err := svc.RenderMigrationManifest(vmi, nil, sourcePod)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(targetPod.Annotations).To(HaveKeyWithValue(testKey, updatedValue))
@@ -5133,7 +5133,7 @@ var _ = Describe("Template", func() {
 
 			sourcePod.Annotations[testKey] = initialValue
 
-			_, err = svc.RenderMigrationManifest(vmi, sourcePod)
+			_, err = svc.RenderMigrationManifest(vmi, nil, sourcePod)
 			Expect(err).To(MatchError(expectedErr))
 		})
 	})

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -680,6 +680,8 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.migrationInformer,
 		vca.nodeInformer,
 		vca.persistentVolumeClaimInformer,
+		vca.storageClassInformer,
+		vca.storageProfileInformer,
 		vca.pdbInformer,
 		vca.migrationPolicyInformer,
 		vca.resourceQuotaInformer,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -171,6 +171,8 @@ var _ = Describe("Application", func() {
 			migrationInformer,
 			nodeInformer,
 			pvcInformer,
+			storageClassInformer,
+			storageProfileInformer,
 			pdbInformer,
 			migrationPolicyInformer,
 			resourceQuotaInformer,

--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/migrations:go_default_library",
@@ -65,6 +66,7 @@ go_test(
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1:go_default_library",
+        "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -74,5 +76,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1069,7 +1069,7 @@ func (c *Controller) handleTargetPodCreation(key string, migration *virtv1.Virtu
 			}
 		}
 		bs := backendstorage.NewBackendStorage(c.clientset, c.clusterConfig, c.storageClassStore, c.storageProfileStore, c.pvcStore)
-		backendStoragePVCName, err := bs.CreateIfNeededAndUpdateVolumeStatus(vmi)
+		backendStoragePVCName, err := bs.CreateIfNeededAndUpdateVolumeStatus(vmi, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -599,6 +599,13 @@ func (c *Controller) processMigrationPhase(
 	case virtv1.MigrationRunning:
 		_, exists := pod.Annotations[virtv1.MigrationTargetReadyTimestamp]
 		if !exists && vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp != nil {
+			if backendstorage.IsBackendStorageNeededForVMI(&vmi.Spec) {
+				err := backendstorage.MigrationHandoff(c.clientset, migration)
+				if err != nil {
+					return err
+				}
+			}
+
 			patchBytes, err := patch.New(
 				patch.WithAdd(fmt.Sprintf("/metadata/annotations/%s", patch.EscapeJSONPointer(virtv1.MigrationTargetReadyTimestamp)), vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String()),
 			).GeneratePayload()

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,6 +35,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -244,6 +247,8 @@ var _ = Describe("Migration watcher", func() {
 		nodeInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Node{})
 
 		pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		storageClassInformer, _ := testutils.NewFakeInformerFor(&storagev1.StorageClass{})
+		storageProfileInformer, _ := testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
 		controller, _ = NewController(
@@ -253,6 +258,8 @@ var _ = Describe("Migration watcher", func() {
 			migrationInformer,
 			nodeInformer,
 			pvcInformer,
+			storageClassInformer,
+			storageProfileInformer,
 			pdbInformer,
 			migrationPolicyInformer,
 			resourceQuotaInformer,

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -53,7 +53,6 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/network/multus:go_default_library",
         "//pkg/pointer:go_default_library",
-        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -965,7 +965,7 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 		// do not return; just log the error
 	}
 
-	backendStoragePVCName, err := c.backendStorage.CreateIfNeededAndUpdateVolumeStatus(vmi)
+	backendStoragePVCName, err := c.backendStorage.CreateIfNeededAndUpdateVolumeStatus(vmi, false)
 	if err != nil {
 		return common.NewSyncError(err, controller.FailedBackendStorageCreateReason), pod
 	}

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -102,6 +102,7 @@ func NewController(templateService services.TemplateService,
 		clientset:               clientset,
 		podExpectations:         controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
 		vmiExpectations:         controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		pvcExpectations:         controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
 		dataVolumeIndexer:       dataVolumeInformer.GetIndexer(),
 		cdiStore:                cdiInformer.GetStore(),
 		cdiConfigStore:          cdiConfigInformer.GetStore(),
@@ -192,6 +193,7 @@ type Controller struct {
 	recorder                record.EventRecorder
 	podExpectations         *controller.UIDTrackingControllerExpectations
 	vmiExpectations         *controller.UIDTrackingControllerExpectations
+	pvcExpectations         *controller.UIDTrackingControllerExpectations
 	dataVolumeIndexer       cache.Indexer
 	cdiStore                cache.Store
 	cdiConfigStore          cache.Store
@@ -293,7 +295,7 @@ func (c *Controller) execute(key string) error {
 	}
 
 	// If needsSync is true (expectations fulfilled) we can make save assumptions if virt-handler or virt-controller owns the pod
-	needsSync := c.podExpectations.SatisfiedExpectations(key) && c.vmiExpectations.SatisfiedExpectations(key)
+	needsSync := c.podExpectations.SatisfiedExpectations(key) && c.vmiExpectations.SatisfiedExpectations(key) && c.pvcExpectations.SatisfiedExpectations(key)
 
 	if !needsSync {
 		return nil
@@ -965,9 +967,9 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 		// do not return; just log the error
 	}
 
-	backendStoragePVCName, err := c.backendStorage.CreateIfNeededAndUpdateVolumeStatus(vmi, false)
-	if err != nil {
-		return common.NewSyncError(err, controller.FailedBackendStorageCreateReason), pod
+	backendStoragePVCName, syncErr := c.handleBackendStorage(vmi)
+	if syncErr != nil {
+		return syncErr, pod
 	}
 
 	dataVolumesReady, isWaitForFirstConsumer, syncErr := c.handleSyncDataVolumes(vmi, dataVolumes)
@@ -992,9 +994,13 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 			return nil, pod
 		}
 
-		// Ensure the backend storage PVC is ready
+		// If a backend-storage PVC was just created but not yet seen by the informer, give it time
+		if !c.pvcExpectations.SatisfiedExpectations(key) {
+			return nil, pod
+		}
+
 		var backendStorageReady bool
-		backendStorageReady, err = c.backendStorage.IsPVCReady(vmi, backendStoragePVCName)
+		backendStorageReady, err := c.backendStorage.IsPVCReady(vmi, backendStoragePVCName)
 		if err != nil {
 			return common.NewSyncError(err, controller.FailedBackendStorageProbeReason), pod
 		}
@@ -1004,7 +1010,6 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 		}
 
 		var templatePod *k8sv1.Pod
-		var err error
 		if isWaitForFirstConsumer {
 			log.Log.V(3).Object(vmi).Infof("Scheduling temporary pod for WaitForFirstConsumer DV")
 			templatePod, err = c.templateService.RenderLaunchManifestNoVm(vmi)
@@ -1092,6 +1097,28 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 	return nil, pod
 }
 
+func (c *Controller) handleBackendStorage(vmi *virtv1.VirtualMachineInstance) (string, common.SyncError) {
+	key, err := controller.KeyFunc(vmi)
+	if err != nil {
+		return "", common.NewSyncError(err, controller.FailedBackendStorageCreateReason)
+	}
+
+	if !backendstorage.IsBackendStorageNeededForVMI(&vmi.Spec) {
+		return "", nil
+	}
+
+	pvc := backendstorage.PVCForVMI(c.pvcIndexer, vmi)
+	if pvc == nil {
+		c.pvcExpectations.ExpectCreations(key, 1)
+		if pvc, err = c.backendStorage.CreatePVCForVMI(vmi); err != nil {
+			c.pvcExpectations.CreationObserved(key)
+			return "", common.NewSyncError(err, controller.FailedBackendStorageCreateReason)
+		}
+	}
+	c.backendStorage.UpdateVolumeStatus(vmi, pvc)
+	return pvc.Name, nil
+}
+
 func (c *Controller) handleSyncDataVolumes(vmi *virtv1.VirtualMachineInstance, dataVolumes []*cdiv1.DataVolume) (bool, bool, common.SyncError) {
 
 	ready := true
@@ -1125,6 +1152,14 @@ func (c *Controller) addPVC(obj interface{}) {
 	pvc := obj.(*k8sv1.PersistentVolumeClaim)
 	if pvc.DeletionTimestamp != nil {
 		return
+	}
+
+	persistentStateFor, exists := pvc.Labels[backendstorage.PVCPrefix]
+	if exists {
+		vmiKey := pvc.Namespace + "/" + persistentStateFor
+		c.pvcExpectations.CreationObserved(vmiKey)
+		c.Queue.Add(vmiKey)
+		return // The PVC is a backend-storage PVC, won't be listed by `c.listVMIsMatchingDV()`
 	}
 
 	vmis, err := c.listVMIsMatchingDV(pvc.Namespace, pvc.Name)

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -494,6 +494,10 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 
 	c.aggregateDataVolumesConditions(vmiCopy, dataVolumes)
 
+	if pvc := backendstorage.PVCForVMI(c.pvcIndexer, vmi); pvc != nil {
+		c.backendStorage.UpdateVolumeStatus(vmiCopy, pvc)
+	}
+
 	switch {
 	case vmi.IsUnprocessed():
 		if vmiPodExists {
@@ -1115,7 +1119,6 @@ func (c *Controller) handleBackendStorage(vmi *virtv1.VirtualMachineInstance) (s
 			return "", common.NewSyncError(err, controller.FailedBackendStorageCreateReason)
 		}
 	}
-	c.backendStorage.UpdateVolumeStatus(vmi, pvc)
 	return pvc.Name, nil
 }
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -56,7 +56,6 @@ import (
 	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/network/multus"
 	"kubevirt.io/kubevirt/pkg/pointer"
-	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -543,7 +542,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				}
 				Expect(storageClassStore.Add(sc)).To(Succeed())
 
-				pvc := newPvc(vmi.Namespace, backendstorage.PVCForVMI(vmi))
+				pvc := newPvc(vmi.Namespace, "persistent-state-for-"+vmi.Name+"-12345")
+				pvc.ObjectMeta.Labels = map[string]string{"persistent-state-for": vmi.Name}
 				pvc.Status.Phase = k8sv1.ClaimPending
 				pvc.Spec.StorageClassName = pointer.P("testsc123")
 				pvc.Spec.AccessModes = []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteMany}
@@ -564,7 +564,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				}
 				Expect(storageClassStore.Add(sc)).To(Succeed())
 
-				pvc := newPvc(vmi.Namespace, backendstorage.PVCForVMI(vmi))
+				pvc := newPvc(vmi.Namespace, "persistent-state-for-"+vmi.Name+"-67890")
+				pvc.ObjectMeta.Labels = map[string]string{"persistent-state-for": vmi.Name}
 				pvc.Status.Phase = k8sv1.ClaimPending
 				pvc.Spec.StorageClassName = pointer.P("testsc456")
 				pvc.Spec.AccessModes = []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteMany}

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/safepath:go_default_library",
-        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2581,7 +2581,7 @@ func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachi
 	volumeStatusMap := make(map[string]v1.VolumeStatus)
 
 	for _, volumeStatus := range vmi.Status.VolumeStatus {
-		if volumeStatus.Name == backendstorage.PVCForVMI(vmi) && volumeStatus.PersistentVolumeClaimInfo != nil &&
+		if strings.HasPrefix(volumeStatus.Name, backendstorage.BasePVC(vmi)) && volumeStatus.PersistentVolumeClaimInfo != nil &&
 			!pvctypes.HasSharedAccessMode(volumeStatus.PersistentVolumeClaimInfo.AccessModes) {
 			return true, fmt.Errorf("cannot migrate VMI: Backend storage PVC is not RWX")
 		}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -38,8 +38,6 @@ import (
 
 	"libvirt.org/go/libvirtxml"
 
-	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
-
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	pvctypes "kubevirt.io/kubevirt/pkg/storage/types"
 
@@ -2581,10 +2579,6 @@ func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachi
 	volumeStatusMap := make(map[string]v1.VolumeStatus)
 
 	for _, volumeStatus := range vmi.Status.VolumeStatus {
-		if strings.HasPrefix(volumeStatus.Name, backendstorage.BasePVC(vmi)) && volumeStatus.PersistentVolumeClaimInfo != nil &&
-			!pvctypes.HasSharedAccessMode(volumeStatus.PersistentVolumeClaimInfo.AccessModes) {
-			return true, fmt.Errorf("cannot migrate VMI: Backend storage PVC is not RWX")
-		}
 		volumeStatusMap[volumeStatus.Name] = volumeStatus
 	}
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -13643,6 +13643,10 @@ var CRDsValidation map[string]string = map[string]string{
             sourceNode:
               description: The source node that the VMI originated on
               type: string
+            sourcePersistentStatePVCName:
+              description: If the VMI being migrated uses persistent features (backend-storage),
+                its source PVC name is saved here
+              type: string
             sourcePod:
               type: string
             startTimestamp:
@@ -13685,6 +13689,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: |-
                 If the VMI requires dedicated CPUs, this field will
                 hold the numa topology on the target node
+              type: string
+            targetPersistentStatePVCName:
+              description: If the VMI being migrated uses persistent features (backend-storage),
+                its target PVC name is saved here
               type: string
             targetPod:
               description: The target pod that the VMI is moving to
@@ -14057,6 +14065,10 @@ var CRDsValidation map[string]string = map[string]string{
             sourceNode:
               description: The source node that the VMI originated on
               type: string
+            sourcePersistentStatePVCName:
+              description: If the VMI being migrated uses persistent features (backend-storage),
+                its source PVC name is saved here
+              type: string
             sourcePod:
               type: string
             startTimestamp:
@@ -14099,6 +14111,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: |-
                 If the VMI requires dedicated CPUs, this field will
                 hold the numa topology on the target node
+              type: string
+            targetPersistentStatePVCName:
+              description: If the VMI being migrated uses persistent features (backend-storage),
+                its target PVC name is saved here
               type: string
             targetPod:
               description: The target pod that the VMI is moving to

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -951,7 +951,9 @@
       "targetCPUSet": [
         -12
       ],
-      "targetNodeTopology": "targetNodeTopologyValue"
+      "targetNodeTopology": "targetNodeTopologyValue",
+      "sourcePersistentStatePVCName": "sourcePersistentStatePVCNameValue",
+      "targetPersistentStatePVCName": "targetPersistentStatePVCNameValue"
     },
     "migrationMethod": "migrationMethodValue",
     "migrationTransport": "migrationTransportValue",

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -672,6 +672,7 @@ status:
     migrationUid: migrationUidValue
     mode: modeValue
     sourceNode: sourceNodeValue
+    sourcePersistentStatePVCName: sourcePersistentStatePVCNameValue
     sourcePod: sourcePodValue
     startTimestamp: "1986-01-01T01:01:01Z"
     targetAttachmentPodUID: targetAttachmentPodUIDValue
@@ -684,6 +685,7 @@ status:
     targetNodeDomainDetected: true
     targetNodeDomainReadyTimestamp: "1970-01-01T01:01:01Z"
     targetNodeTopology: targetNodeTopologyValue
+    targetPersistentStatePVCName: targetPersistentStatePVCNameValue
     targetPod: targetPodValue
   migrationTransport: migrationTransportValue
   nodeName: nodeNameValue

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -783,6 +783,11 @@ type VirtualMachineInstanceMigrationState struct {
 	// If the VMI requires dedicated CPUs, this field will
 	// hold the numa topology on the target node
 	TargetNodeTopology string `json:"targetNodeTopology,omitempty"`
+
+	// If the VMI being migrated uses persistent features (backend-storage), its source PVC name is saved here
+	SourcePersistentStatePVCName string `json:"sourcePersistentStatePVCName,omitempty"`
+	// If the VMI being migrated uses persistent features (backend-storage), its target PVC name is saved here
+	TargetPersistentStatePVCName string `json:"targetPersistentStatePVCName,omitempty"`
 }
 
 type MigrationAbortStatus string

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -235,6 +235,8 @@ func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 		"migrationConfiguration":         "Migration configurations to apply",
 		"targetCPUSet":                   "If the VMI requires dedicated CPUs, this field will\nhold the dedicated CPU set on the target node\n+listType=atomic",
 		"targetNodeTopology":             "If the VMI requires dedicated CPUs, this field will\nhold the numa topology on the target node",
+		"sourcePersistentStatePVCName":   "If the VMI being migrated uses persistent features (backend-storage), its source PVC name is saved here",
+		"targetPersistentStatePVCName":   "If the VMI being migrated uses persistent features (backend-storage), its target PVC name is saved here",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25311,6 +25311,20 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationState(ref comm
 							Format:      "",
 						},
 					},
+					"sourcePersistentStatePVCName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If the VMI being migrated uses persistent features (backend-storage), its source PVC name is saved here",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"targetPersistentStatePVCName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If the VMI being migrated uses persistent features (backend-storage), its target PVC name is saved here",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -134,7 +134,6 @@ go_test(
         "//pkg/libvmi/replicaset:go_default_library",
         "//pkg/network/dns:go_default_library",
         "//pkg/pointer:go_default_library",
-        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/util/hardware:go_default_library",

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -61,4 +61,8 @@ var (
 	Kubernetes130 = Label("kubernetes130")
 	// WG archs
 	WgS390x = Label("wg-s390x")
+
+	// NoFlakeChecker decorates tests that are not compatible with the check-tests-for-flakes test lane.
+	// This should only be used for legitimate purposes, like on tests that have a flake-checker-friendly clone.
+	NoFlakeCheck = Label("no-flake-check")
 )

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -47,7 +47,6 @@ var (
 	NetCustomBindingPlugins              = Label("netCustomBindingPlugins")
 	RequiresTwoSchedulableNodes          = Label("requires-two-schedulable-nodes")
 	VMLiveUpdateFeaturesGate             = Label("VMLiveUpdateFeaturesGate")
-	RequiresRWXFilesystemStorage         = Label("rwxfs")
 	USB                                  = Label("USB")
 	AutoResourceLimitsGate               = Label("AutoResourceLimitsGate")
 	RequiresTwoWorkerNodesWithCPUManager = Label("requires-two-worker-nodes-with-cpu-manager")

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
-        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/storage/velero:go_default_library",

--- a/tests/storage/backendstorage.go
+++ b/tests/storage/backendstorage.go
@@ -32,7 +32,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -41,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = SIGDescribe("[Serial]Backend Storage", Serial, decorators.RequiresRWXFilesystemStorage, func() {
+var _ = SIGDescribe("[Serial]Backend Storage", Serial, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -75,6 +74,7 @@ var _ = SIGDescribe("[Serial]Backend Storage", Serial, decorators.RequiresRWXFil
 				break
 			}
 		}
+		Expect(storageClass).NotTo(BeEmpty(), "Failed to find a storage class that only supports filesystem in RWO")
 
 		By("Setting the VM storage class to it")
 		kv := libkubevirt.GetCurrentKv(virtClient)

--- a/tests/storage/backendstorage.go
+++ b/tests/storage/backendstorage.go
@@ -31,7 +31,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -98,14 +97,5 @@ var _ = SIGDescribe("[Serial]Backend Storage", Serial, decorators.RequiresRWXFil
 		Expect(*pvc.Spec.StorageClassName).To(Equal(storageClass))
 		Expect(pvc.Status.AccessModes).To(HaveLen(1))
 		Expect(pvc.Status.AccessModes[0]).To(Equal(k8sv1.ReadWriteOnce))
-
-		By("Expecting the VMI to be non-migratable")
-		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		cond := controller.NewVirtualMachineInstanceConditionManager().GetCondition(vmi, v1.VirtualMachineInstanceIsMigratable)
-		Expect(cond).NotTo(BeNil(), "LiveMigratable condition not found")
-		Expect(cond.Status).To(Equal(k8sv1.ConditionFalse))
-		Expect(cond.Reason).To(Equal(v1.VirtualMachineInstanceReasonDisksNotMigratable))
-		Expect(cond.Message).To(ContainSubstring("Backend storage PVC is not RWX"))
 	})
 })

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	k8sv1 "k8s.io/api/core/v1"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,11 +31,20 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.RequiresRWXFilesystemStorage, func() {
-	var virtClient kubecli.KubevirtClient
-	var err error
+var _ = Describe("[sig-compute]VM state", func() {
+	const (
+		tpm = true
+		efi = true
+		rwx = true
+		rwo = false
+	)
+
+	var (
+		virtClient kubecli.KubevirtClient
+	)
 
 	BeforeEach(func() {
+		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -90,7 +101,7 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 		addDataToEFI := func(vmi *v1.VirtualMachineInstance) {
 			By("Creating an efivar")
 			cmd := `printf "\x07\x00\x00\x00\x42" > /sys/firmware/efi/efivars/kvtest-12345678-1234-1234-1234-123456789abc`
-			err = console.RunCommand(vmi, cmd, 10*time.Second)
+			err := console.RunCommand(vmi, cmd, 10*time.Second)
 			Expect(err).NotTo(HaveOccurred())
 		}
 
@@ -102,7 +113,7 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 			}, 10)).To(Succeed(), "expected efivar is missing")
 		}
 
-		DescribeTable("should persist VM state of", decorators.RequiresTwoSchedulableNodes, func(withTPM, withEFI bool, ops ...string) {
+		DescribeTable("should persist VM state of", decorators.RequiresTwoSchedulableNodes, func(withTPM, withEFI, shouldBeRWX bool, ops ...string) {
 			By("Creating a migratable Fedora VM with UEFI")
 			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -125,12 +136,12 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 				}
 			}
 			vm := libvmi.NewVirtualMachine(vmi)
-			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vm, metav1.CreateOptions{})
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			vmi.Namespace = vm.Namespace
-
 			startVM(vm)
 
+			By("Adding TPM and/or EFI data")
 			if withTPM {
 				addDataToTPM(vmi)
 			}
@@ -138,6 +149,20 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 				addDataToEFI(vmi)
 			}
 
+			By("Ensuring we're testing what we think we're testing")
+			pvcs, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: "persistent-state-for=" + vm.Name,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvcs.Items).To(HaveLen(1))
+			Expect(pvcs.Items[0].Status.AccessModes).To(HaveLen(1))
+			if shouldBeRWX {
+				Expect(pvcs.Items[0].Status.AccessModes[0]).To(Equal(k8sv1.ReadWriteMany))
+			} else {
+				Expect(pvcs.Items[0].Status.AccessModes[0]).To(Equal(k8sv1.ReadWriteOnce))
+			}
+
+			By("Running the requested operations and ensuring TPM/EFI data persist")
 			for _, op := range ops {
 				switch op {
 				case "migrate":
@@ -160,18 +185,22 @@ var _ = Describe("[sig-storage]VM state", decorators.SigStorage, decorators.Requ
 			err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(context.Background(), vm.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		},
-			Entry("[test_id:10818]TPM across migration and restart", true, false, "migrate", "restart"),
-			Entry("[test_id:10819]TPM across restart and migration", true, false, "restart", "migrate"),
-			Entry("[test_id:10820]EFI across migration and restart", false, true, "migrate", "restart"),
-			Entry("[test_id:10821]TPM+EFI across migration and restart", true, true, "migrate", "restart"),
+			Entry("[test_id:10818]TPM across migration and restart", decorators.SigComputeMigrations, tpm, !efi, rwx, "migrate", "restart"),
+			Entry("[test_id:10819]TPM across restart and migration", decorators.SigComputeMigrations, tpm, !efi, rwx, "restart", "migrate"),
+			Entry("[test_id:10820]EFI across migration and restart", decorators.SigComputeMigrations, !tpm, efi, rwx, "migrate", "restart"),
+			Entry("[test_id:10821]TPM+EFI across migration and restart", decorators.SigComputeMigrations, tpm, efi, rwx, "migrate", "restart"),
+			Entry("TPM across migration and restart", decorators.SigCompute, tpm, !efi, rwo, "migrate", "restart"),
+			Entry("TPM across restart and migration", decorators.SigCompute, tpm, !efi, rwo, "restart", "migrate"),
+			Entry("EFI across migration and restart", decorators.SigCompute, !tpm, efi, rwo, "migrate", "restart"),
+			Entry("TPM+EFI across migration and restart", decorators.SigCompute, tpm, efi, rwo, "migrate", "restart"),
 		)
-		It("should remove persistent storage PVC if VMI is not owned by a VM", func() {
+		It("should remove persistent storage PVC if VMI is not owned by a VM", decorators.SigCompute, func() {
 			By("Creating a VMI with persistent TPM enabled")
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{
 				Persistent: pointer.P(true),
 			}
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for the VMI to start")

--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -189,10 +189,12 @@ var _ = Describe("[sig-compute]VM state", func() {
 			Entry("[test_id:10819]TPM across restart and migration", decorators.SigComputeMigrations, tpm, !efi, rwx, "restart", "migrate"),
 			Entry("[test_id:10820]EFI across migration and restart", decorators.SigComputeMigrations, !tpm, efi, rwx, "migrate", "restart"),
 			Entry("[test_id:10821]TPM+EFI across migration and restart", decorators.SigComputeMigrations, tpm, efi, rwx, "migrate", "restart"),
-			Entry("TPM across migration and restart", decorators.SigCompute, tpm, !efi, rwo, "migrate", "restart"),
-			Entry("TPM across restart and migration", decorators.SigCompute, tpm, !efi, rwo, "restart", "migrate"),
-			Entry("EFI across migration and restart", decorators.SigCompute, !tpm, efi, rwo, "migrate", "restart"),
-			Entry("TPM+EFI across migration and restart", decorators.SigCompute, tpm, efi, rwo, "migrate", "restart"),
+			// The entries below are clones of the entries above, but made for cluster that *do not* support RWX FS.
+			// They can't be flake-checked since the flake-checker cluster does support RWX FS.
+			Entry("TPM across migration and restart", decorators.SigCompute, decorators.NoFlakeCheck, tpm, !efi, rwo, "migrate", "restart"),
+			Entry("TPM across restart and migration", decorators.SigCompute, decorators.NoFlakeCheck, tpm, !efi, rwo, "restart", "migrate"),
+			Entry("EFI across migration and restart", decorators.SigCompute, decorators.NoFlakeCheck, !tpm, efi, rwo, "migrate", "restart"),
+			Entry("TPM+EFI across migration and restart", decorators.SigCompute, decorators.NoFlakeCheck, tpm, efi, rwo, "migrate", "restart"),
 		)
 		It("should remove persistent storage PVC if VMI is not owned by a VM", decorators.SigCompute, func() {
 			By("Creating a VMI with persistent TPM enabled")

--- a/tests/vmi_tpm_test.go
+++ b/tests/vmi_tpm_test.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-var _ = Describe("[sig-compute]vTPM", decorators.SigCompute, decorators.RequiresRWXFilesystemStorage, func() {
+var _ = Describe("[sig-compute]vTPM", decorators.SigCompute, func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 


### PR DESCRIPTION
### What this PR does
See https://github.com/kubevirt/community/pull/314

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
backend-storage now supports RWO FS
```

