### PR TITLE
[release-1.0] Allow lun disks to be mapped to DataVolume sources

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1017,10 +1017,10 @@ func validateBootOrder(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec
 		}
 
 		// Verify Lun disks are only mapped to network/block devices.
-		if disk.LUN != nil && volumeExists && matchingVolume.PersistentVolumeClaim == nil {
+		if disk.LUN != nil && volumeExists && matchingVolume.PersistentVolumeClaim == nil && matchingVolume.DataVolume == nil {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s can only be mapped to a PersistentVolumeClaim volume.", field.Child("domain", "devices", "disks").Index(idx).Child("lun").String()),
+				Message: fmt.Sprintf("%s can only be mapped to a DataVolume or PersistentVolumeClaim volume.", field.Child("domain", "devices", "disks").Index(idx).Child("lun").String()),
 				Field:   field.Child("domain", "devices", "disks").Index(idx).Child("lun").String(),
 			})
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1033,6 +1033,15 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
 					},
 				}, 0),
+			Entry("and accept DataVolume sources",
+				&v1.Volume{
+					Name: "testdisk",
+					VolumeSource: v1.VolumeSource{
+						DataVolume: &v1.DataVolumeSource{
+							Name: "testDV",
+						},
+					},
+				}, 0),
 		)
 		It("should accept a single interface and network", func() {
 			vm := api.NewMinimalVMI("testvm")

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1466,13 +1466,30 @@ var _ = SIGDescribe("Storage", func() {
 				})
 
 			}
+			addDataVolumeLunDisk := func(vmi *virtv1.VirtualMachineInstance, deviceName, claimName string) {
+				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
+					Name: deviceName,
+					DiskDevice: virtv1.DiskDevice{
+						LUN: &virtv1.LunTarget{
+							Bus:      v1.DiskBusSCSI,
+							ReadOnly: false,
+						},
+					},
+				})
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+					Name: deviceName,
+					VolumeSource: virtv1.VolumeSource{
+						DataVolume: &virtv1.DataVolumeSource{
+							Name: claimName,
+						},
+					},
+				})
+
+			}
 
 			BeforeEach(func() {
 				nodeName = tests.NodeNameWithHandler()
 				address, device = tests.CreateSCSIDisk(nodeName, []string{})
-				var err error
-				pv, pvc, err = tests.CreatePVandPVCwithSCSIDisk(nodeName, device, testsuite.GetTestNamespace(nil), "scsi-disks", "scsipv", "scsipvc")
-				Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for scsi disk")
 			})
 
 			AfterEach(func() {
@@ -1480,11 +1497,14 @@ var _ = SIGDescribe("Storage", func() {
 				Expect(virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
 			})
 
-			It("should run the VMI", func() {
+			DescribeTable("should run the VMI using", func(addLunDisk func(*virtv1.VirtualMachineInstance, string, string)) {
+				pv, pvc, err = tests.CreatePVandPVCwithSCSIDisk(nodeName, device, testsuite.GetTestNamespace(nil), "scsi-disks", "scsipv", "scsipvc")
+				Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for scsi disk")
+
 				By("Creating VMI with LUN disk")
 				vmi := libvmi.NewAlpine()
-				addPVCLunDisk(vmi, "lun0", pvc.ObjectMeta.Name)
-				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+				addLunDisk(vmi, "lun0", pvc.ObjectMeta.Name)
+				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)
 
 				libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 180)
@@ -1493,8 +1513,56 @@ var _ = SIGDescribe("Storage", func() {
 				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
 				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
-			})
+			},
+				Entry("PVC source", addPVCLunDisk),
+				Entry("DataVolume source", addDataVolumeLunDisk),
+			)
 
+			It("should run the VMI created with a DataVolume source and use the LUN disk", func() {
+				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
+				if !foundSC {
+					Skip("Unable to find valid storage class")
+				}
+				pv, err = tests.CreatePVwithSCSIDisk(sc, "scsipv", nodeName, device)
+				Expect(err).ToNot(HaveOccurred())
+				dv := libdv.NewDataVolume(
+					libdv.WithBlankImageSource(),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc),
+						libdv.PVCWithBlockVolumeMode(),
+						libdv.PVCWithAccessMode(k8sv1.ReadWriteOnce),
+						libdv.PVCWithVolumeSize("8Mi"),
+					),
+				)
+				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dv, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating VMI with LUN disk")
+				vmi := libvmi.NewCirros(libvmi.WithResourceMemory("512M"))
+				addDataVolumeLunDisk(vmi, "lun0", dv.Name)
+				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
+				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)
+
+				libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 240)
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+				By(fmt.Sprintf("Checking that %s has a capacity of 8Mi", device))
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("sudo blockdev --getsize64 %s\n", device)},
+					&expect.BExp{R: "8388608"}, // 8Mi in bytes
+				}, 30)).To(Succeed())
+
+				By(fmt.Sprintf("Checking if we can write to %s", device))
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 -F %s\n", device)},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: tests.EchoLastReturnValue},
+					&expect.BExp{R: console.RetValue("0")},
+				}, 30)).To(Succeed())
+
+				err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
+				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
+			})
 		})
 	})
 })

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1519,15 +1519,11 @@ var _ = SIGDescribe("Storage", func() {
 			)
 
 			It("should run the VMI created with a DataVolume source and use the LUN disk", func() {
-				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
-				if !foundSC {
-					Skip("Unable to find valid storage class")
-				}
-				pv, err = tests.CreatePVwithSCSIDisk(sc, "scsipv", nodeName, device)
+				pv, err = tests.CreatePVwithSCSIDisk("scsi-disks", "scsipv", nodeName, device)
 				Expect(err).ToNot(HaveOccurred())
 				dv := libdv.NewDataVolume(
 					libdv.WithBlankImageSource(),
-					libdv.WithPVC(libdv.PVCWithStorageClass(sc),
+					libdv.WithPVC(libdv.PVCWithStorageClass(pv.Spec.StorageClassName),
 						libdv.PVCWithBlockVolumeMode(),
 						libdv.PVCWithAccessMode(k8sv1.ReadWriteOnce),
 						libdv.PVCWithVolumeSize("8Mi"),
@@ -1545,15 +1541,28 @@ var _ = SIGDescribe("Storage", func() {
 				libwait.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 240)
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
-				By(fmt.Sprintf("Checking that %s has a capacity of 8Mi", device))
+				lunDisk := "/dev/"
+				Eventually(func() bool {
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for _, volStatus := range vmi.Status.VolumeStatus {
+						if volStatus.Name == "lun0" {
+							lunDisk += volStatus.Target
+							return true
+						}
+					}
+					return false
+				}, 30*time.Second, time.Second).Should(BeTrue())
+
+				By(fmt.Sprintf("Checking that %s has a capacity of 8Mi", lunDisk))
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("sudo blockdev --getsize64 %s\n", device)},
+					&expect.BSnd{S: fmt.Sprintf("sudo blockdev --getsize64 %s\n", lunDisk)},
 					&expect.BExp{R: "8388608"}, // 8Mi in bytes
 				}, 30)).To(Succeed())
 
-				By(fmt.Sprintf("Checking if we can write to %s", device))
+				By(fmt.Sprintf("Checking if we can write to %s", lunDisk))
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 -F %s\n", device)},
+					&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 -F %s\n", lunDisk)},
 					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: tests.EchoLastReturnValue},
 					&expect.BExp{R: console.RetValue("0")},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This is a cherry-pick of https://github.com/kubevirt/kubevirt/pull/9872.

This is a manual backport so it also includes a fix that was introduced later to address a test flake https://github.com/kubevirt/kubevirt/pull/10451.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Allow lun disks to be mapped to DataVolume sources
```

