### PR TITLE
Remove handler cgroup pkg dep in virt-chroot

### DIFF
--- a/cmd/virt-chroot/BUILD.bazel
+++ b/cmd/virt-chroot/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/safepath:go_default_library",
-        "//pkg/virt-handler/cgroup:go_default_library",
+        "//pkg/virt-handler/cgroup/constants:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",

--- a/cmd/virt-chroot/cgroup.go
+++ b/cmd/virt-chroot/cgroup.go
@@ -12,7 +12,7 @@ import (
 	runc_fs2 "github.com/opencontainers/runc/libcontainer/cgroups/fs2"
 	runc_configs "github.com/opencontainers/runc/libcontainer/configs"
 
-	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
+	cgroupconsts "kubevirt.io/kubevirt/pkg/virt-handler/cgroup/constants"
 )
 
 func decodeResources(marshalledResourcesHash string) (*runc_configs.Resources, error) {
@@ -53,7 +53,7 @@ func decodePaths(marshalledPathsHash string) (map[string]string, error) {
 
 func setCgroupResources(paths map[string]string, resources *runc_configs.Resources, isRootless bool, isV2 bool) error {
 	config := &runc_configs.Cgroup{
-		Path:      cgroup.HostCgroupBasePath,
+		Path:      cgroupconsts.HostCgroupBasePath,
 		Resources: resources,
 		Rootless:  isRootless,
 	}
@@ -74,7 +74,7 @@ func setCgroupResources(paths map[string]string, resources *runc_configs.Resourc
 }
 
 func setCgroupResourcesV1(paths map[string]string, resources *runc_configs.Resources, config *runc_configs.Cgroup) error {
-	return RunWithChroot(cgroup.HostCgroupBasePath, func() error {
+	return RunWithChroot(cgroupconsts.HostCgroupBasePath, func() error {
 		cgroupManager, err := runc_fs.NewManager(config, paths)
 		if err != nil {
 			return fmt.Errorf("cannot create cgroups v1 manager. err: %v", err)

--- a/pkg/virt-handler/cgroup/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/safepath:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/virt-handler/cgroup/constants:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-handler/cgroup/cgroup_v1_manager.go
+++ b/pkg/virt-handler/cgroup/cgroup_v1_manager.go
@@ -19,6 +19,7 @@ import (
 	runc_configs "github.com/opencontainers/runc/libcontainer/configs"
 
 	"kubevirt.io/kubevirt/pkg/util"
+	cgroupconsts "kubevirt.io/kubevirt/pkg/virt-handler/cgroup/constants"
 )
 
 type v1Manager struct {
@@ -55,7 +56,7 @@ func (v *v1Manager) GetBasePathToHostSubsystem(subsystem string) (string, error)
 	if subsystemPath == "" {
 		return "", fmt.Errorf("controller %s does not exist", subsystem)
 	}
-	return filepath.Join(HostCgroupBasePath, subsystemPath), nil
+	return filepath.Join(cgroupconsts.HostCgroupBasePath, subsystemPath), nil
 }
 
 func (v *v1Manager) Set(r *runc_configs.Resources) error {
@@ -92,7 +93,7 @@ func getCurrentlyDefinedRules(runcManager runc_cgroups.Manager) ([]*devices.Rule
 	if !ok {
 		return nil, fmt.Errorf("devices subsystem's path is not defined for this manager")
 	}
-	devicesPath = filepath.Join(HostCgroupBasePath, devicesPath)
+	devicesPath = filepath.Join(cgroupconsts.HostCgroupBasePath, devicesPath)
 
 	currentRulesStr, err := runc_cgroups.ReadFile(devicesPath, "devices.list")
 	if err != nil {

--- a/pkg/virt-handler/cgroup/constants/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/constants/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["constants.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-handler/cgroup/constants",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/virt-handler/cgroup/constants/constants.go
+++ b/pkg/virt-handler/cgroup/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+const (
+	CgroupStr          = "cgroup"
+	ProcMountPoint     = "/proc"
+	hostRootPath       = ProcMountPoint + "/1/root"
+	CgroupBasePath     = "/sys/fs/" + CgroupStr
+	HostCgroupBasePath = hostRootPath + CgroupBasePath
+)

--- a/pkg/virt-handler/cgroup/util.go
+++ b/pkg/virt-handler/cgroup/util.go
@@ -30,16 +30,6 @@ import (
 
 type CgroupVersion string
 
-const (
-	cgroupStr = "cgroup"
-
-	procMountPoint = "/proc"
-
-	HostRootPath       = procMountPoint + "/1/root"
-	cgroupBasePath     = "/sys/fs/" + cgroupStr
-	HostCgroupBasePath = HostRootPath + cgroupBasePath
-)
-
 // Templates for logging / error messages
 const (
 	V1 CgroupVersion = "v1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
After some investigations, it seems like bringing in the handler cgroup pkg causes some
"cannot allocate memory" errors when invoking virt-chroot.
The investigation is still ongoing (one of it's deps messing with rlimits?)
but there really is no need to bloat this binary with the entire package just for a few strings.

The error can be replicated locally (huge thx @xpivarc) prior to this commit with
```bash
cd cmd/virt-chroot
go build
for i in {1..100}; do  sudo ./virt-chroot --user qemu --memory 1000000000 --cpu 10 --mount /proc/1/ns/mnt exec -- /usr/bin/echo "hi"; done
```

And the diff between the builds is quite significant
```bash
$ go version -m virt-chroot | grep dep | wc -l
83
$ go version -m virt-chroot | grep dep | wc -l
18
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
https://issues.redhat.com/browse/CNV-46286

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: "Cannot allocate memory" warnings for containerdisk VMs
```

