### PR TITLE
cleanup(operator.go): Use client instead of virtctl

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1224,12 +1224,9 @@ spec:
 					Expect(err).ToNot(HaveOccurred(), stderr)
 				}
 
-				// Use Current virtctl to start VM
-				// NOTE: we are using virtctl explicitly here because we want to start the VM
-				// using the subresource endpoint in the same way virtctl performs this.
-				By("Starting VM with virtctl")
-				startCommand := clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", testsuite.GetTestNamespace(nil), vmYaml.vmName)
-				Expect(startCommand()).To(Succeed())
+				By("Starting VM")
+				err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Start(context.Background(), vmYaml.vmName, &v1.StartOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				By(fmt.Sprintf("Waiting for VM with %s api to become ready", vmYaml.apiVersion))
 
@@ -1325,11 +1322,9 @@ spec:
 					return nil
 				}, 60*time.Second, 1*time.Second).Should(BeNil())
 
-				By("Stopping VM with virtctl")
-				stopFn := clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", testsuite.GetTestNamespace(nil), vmYaml.vmName)
-				Eventually(func() error {
-					return stopFn()
-				}, 30*time.Second, 1*time.Second).Should(BeNil())
+				By("Stopping VM")
+				err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Stop(context.Background(), vmYaml.vmName, &v1.StopOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VMI to stop")
 				Eventually(func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Use the KubeVirt client instead of using virtctl through a 
NewRepeatableVirtctlCommand where applicable in tests/operator/operator.go.

The tests state that virtctl is used so that the subresources
for starting/stopping a VM are used. The KubeVirt client uses these
subresources too and if you look at the code of virtctl you see that it
does nothing different than calling the client like the tests do now.

The goal of this and further PRs is to reduce the amount of unnecessary uses of
virtctl in the e2e tests to stabilize tests, to reduce the number of flakes and to
remove redudant tests.

Before this PR:

NewRepeatableVirtctlCommand is used unnecessarily.

After this PR:

The KubeVirt client is used istead.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

