### PR TITLE
Consider the new DV reason ImagePullFailed

### DIFF
--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -184,7 +184,7 @@ func HasDataVolumeErrors(namespace string, volumes []virtv1.Volume, dataVolumeSt
 		dvRunningCond := NewDataVolumeConditionManager().GetCondition(dv, cdiv1.DataVolumeRunning)
 		if dvRunningCond != nil &&
 			dvRunningCond.Status == v1.ConditionFalse &&
-			dvRunningCond.Reason == "Error" {
+			(dvRunningCond.Reason == "Error" || dvRunningCond.Reason == "ImagePullFailed") {
 			return fmt.Errorf("DataVolume %s importer has stopped running due to an error: %v",
 				volume.DataVolume.Name, dvRunningCond.Message)
 		}


### PR DESCRIPTION
CDI v1.60.1 introduces a new reason `ImagePullFailed` for the DataVolume `Running` condition. Take it into account to properly update the printable status of a VM and to report the error.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

The test `"[test_id:7679]should report an error status when data volume error occurs"` fails with the latest CDI v1.60.1
https://github.com/kubevirt/kubevirt/blob/a3a9e83da6fff2de37b7fd87efb43466cd6e07d4/tests/vm_test.go#L736

After this PR:

The test passes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

