### PR TITLE
[release.1.3] Manual backport of 12395

### DIFF
--- a/pkg/libvmi/status/BUILD.bazel
+++ b/pkg/libvmi/status/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["status.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/libvmi/status",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/libvmi:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+    ],
+)

--- a/pkg/libvmi/status/status.go
+++ b/pkg/libvmi/status/status.go
@@ -1,0 +1,109 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+// Package status provides utility options to manage the vmi status.
+// This package should be used only in unit test files in which there is the need
+// to set the status of a vmi to simulate different behaviors.
+// BE AWARE: any usage of this package outside the unit test files or controllers
+// is to be considered wrong since the status should only be manipulated by the controllers.
+package status
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+)
+
+type Option func(vmiStatus *v1.VirtualMachineInstanceStatus)
+
+// WithStatus sets the status with specified value
+func WithStatus(status v1.VirtualMachineInstanceStatus) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Status = status
+	}
+}
+
+// New instantiates a new VMI status configuration,
+// building its properties based on the specified With* options.
+func New(opts ...Option) v1.VirtualMachineInstanceStatus {
+	vmiStatus := &v1.VirtualMachineInstanceStatus{}
+	for _, f := range opts {
+		f(vmiStatus)
+	}
+
+	return *vmiStatus
+}
+
+// WithPhase sets the vmi phase
+func WithPhase(phase v1.VirtualMachineInstancePhase) Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		vmiStatus.Phase = phase
+		vmiStatus.PhaseTransitionTimestamps = append(vmiStatus.PhaseTransitionTimestamps, v1.VirtualMachineInstancePhaseTransitionTimestamp{
+			Phase:                    phase,
+			PhaseTransitionTimestamp: metav1.Now(),
+		})
+	}
+}
+
+// WithPhaseTransitionTimestamps adds the vmi phase transition timestamp
+func WithPhaseTransitionTimestamps(ts v1.VirtualMachineInstancePhaseTransitionTimestamp) Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		vmiStatus.PhaseTransitionTimestamps = append(vmiStatus.PhaseTransitionTimestamps, ts)
+	}
+}
+
+// WithCondition adds the condition to the status conditions list
+func WithCondition(condition v1.VirtualMachineInstanceCondition) Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		vmiStatus.Conditions = append(vmiStatus.Conditions, condition)
+	}
+}
+
+// WithLauncherContainerImageVersion sets the status.launcherContainerImageVersion
+func WithLauncherContainerImageVersion(image string) Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		vmiStatus.LauncherContainerImageVersion = image
+	}
+}
+
+// WithActivePod adds an active pod with the given uid and nodename
+func WithActivePod(uid types.UID, nodeName string) Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		if vmiStatus.ActivePods == nil {
+			vmiStatus.ActivePods = map[types.UID]string{}
+		}
+		vmiStatus.ActivePods[uid] = nodeName
+	}
+}
+
+// WithMigratedVolume adds a migrated volume
+func WithMigratedVolume(volumeInfo v1.StorageMigratedVolumeInfo) Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		vmiStatus.MigratedVolumes = append(vmiStatus.MigratedVolumes, volumeInfo)
+	}
+}
+
+// WithVolumeStatus adds a volume status
+func WithVolumeStatus(volumeStatus v1.VolumeStatus) Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		vmiStatus.VolumeStatus = append(vmiStatus.VolumeStatus, volumeStatus)
+	}
+}

--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -263,12 +263,6 @@ func WithoutSerialConsole() Option {
 	}
 }
 
-func WithStatus(status *v1.VirtualMachineInstanceStatus) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Status = *status
-	}
-}
-
 func baseVmi(name string) *v1.VirtualMachineInstance {
 	vmi := v1.NewVMIReferenceFromNameWithNS("", name)
 	vmi.Spec = v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}

--- a/pkg/virt-controller/watch/volume-migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/volume-migration/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/status:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -408,8 +408,12 @@ func (c *WorkloadUpdateController) getUpdateData(kv *virtv1.KubeVirt) *updateDat
 		} else if exists := lookup[vmi.Namespace+"/"+vmi.Name]; exists {
 			continue
 		}
-
-		if automatedMigrationAllowed && (vmi.IsMigratable() || volumemig.CanVolumesUpdateMigration(vmi)) {
+		volMig := false
+		errValid := volumemig.ValidateVolumesUpdateMigration(vmi, nil, vmi.Status.MigratedVolumes)
+		if len(vmi.Status.MigratedVolumes) > 0 && errValid == nil {
+			volMig = true
+		}
+		if automatedMigrationAllowed && (vmi.IsMigratable() || volMig) {
 			data.migratableOutdatedVMIs = append(data.migratableOutdatedVMIs, vmi)
 		} else if automatedShutdownAllowed {
 			data.evictOutdatedVMIs = append(data.evictOutdatedVMIs, vmi)

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -563,6 +563,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Type:   v1.VirtualMachineInstanceIsMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
 			}
 
 			mockWatchdog.CreateFile(vmi)
@@ -633,6 +637,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Type:   v1.VirtualMachineInstanceIsMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
 			}
 			vmi = addActivePods(vmi, podTestUUID, host)
 
@@ -657,6 +665,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 			}
@@ -702,6 +714,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			updatedVMI.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 			}
@@ -767,6 +783,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Status: k8sv1.ConditionTrue,
 				},
 				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
 					Type:          v1.VirtualMachineInstanceAgentConnected,
 					LastProbeTime: metav1.Now(),
 					Status:        k8sv1.ConditionTrue,
@@ -803,6 +823,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 				{
@@ -862,6 +886,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Type:   v1.VirtualMachineInstanceIsMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
 			}
 			vmi = addActivePods(vmi, podTestUUID, host)
 
@@ -883,6 +911,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			updatedVMI.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 			}
@@ -929,6 +961,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Type:   v1.VirtualMachineInstanceIsMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
 			}
 
 			vmiFeeder.Add(vmi)
@@ -958,6 +994,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 				},
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 			}
@@ -999,6 +1039,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Type:   v1.VirtualMachineInstanceIsMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
 			}
 
 			mockWatchdog.CreateFile(vmi)
@@ -1014,6 +1058,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmiCopy.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 				{
@@ -1058,6 +1106,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Status: k8sv1.ConditionTrue,
 				},
 				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
 					Type:   v1.VirtualMachineInstancePaused,
 					Status: k8sv1.ConditionTrue,
 				},
@@ -1081,6 +1133,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			updatedVMI.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 			}
@@ -1179,6 +1235,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			updatedVMI.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 			}
@@ -1904,6 +1964,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Type:   v1.VirtualMachineInstanceIsMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
 			}
 			vmi = addActivePods(vmi, podTestUUID, host)
 
@@ -1947,6 +2011,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Type:   v1.VirtualMachineInstanceIsMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
 			}
 			vmi = addActivePods(vmi, podTestUUID, host)
 
@@ -1981,6 +2049,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 			}
@@ -3384,6 +3456,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+				{
+					Type:   v1.VirtualMachineInstanceIsStorageLiveMigratable,
 					Status: k8sv1.ConditionTrue,
 				},
 			}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -568,6 +568,9 @@ const (
 
 	// Summarizes that all the DataVolumes attached to the VMI are Ready or not
 	VirtualMachineInstanceDataVolumesReady VirtualMachineInstanceConditionType = "DataVolumesReady"
+
+	// Indicates whether the VMI is live migratable
+	VirtualMachineInstanceIsStorageLiveMigratable VirtualMachineInstanceConditionType = "StorageLiveMigratable"
 )
 
 // These are valid reasons for VMI conditions.
@@ -596,6 +599,9 @@ const (
 	VirtualMachineInstanceReasonNotAllDVsReady = "NotAllDVsReady"
 	// Reason means that all of the VMI's DVs are bound and not running
 	VirtualMachineInstanceReasonAllDVsReady = "AllDVsReady"
+
+	// Indicates a generic reason that the VMI isn't migratable and more details are spiecified in the condition message.
+	VirtualMachineInstanceReasonNotMigratable = "NotMigratable"
 )
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport of #12395 
The API change consists in a new condition which helps to better understand why the volume migration isn't possible.
This backport also includes the  commit from #12241 to facilitate the backport of the unit tests.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new condition for VMIStorageLiveMigratable
```

