### PR TITLE
cleanup(tests,migration): Inline helpers and use client instead of virtctl 

### DIFF
--- a/tests/libmigration/BUILD.bazel
+++ b/tests/libmigration/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
-        "//tests/clientcmd:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -426,38 +426,6 @@ func CancelMigration(migration *v1.VirtualMachineInstanceMigration, vminame stri
 	}
 }
 
-func RunAndCancelMigration(migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, with_virtctl bool, timeout int) *v1.VirtualMachineInstanceMigration {
-	var err error
-	virtClient := kubevirt.Client()
-	By("Starting a Migration")
-	Eventually(func() error {
-		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
-		return err
-	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
-
-	By("Waiting until the Migration is Running")
-
-	Eventually(func() bool {
-		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(migration.Status.Phase).ToNot(Equal(v1.MigrationFailed))
-		if migration.Status.Phase == v1.MigrationRunning {
-			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			if vmi.Status.MigrationState.Completed != true {
-				return true
-			}
-		}
-		return false
-
-	}, timeout, 1*time.Second).Should(BeTrue())
-
-	CancelMigration(migration, vmi.Name, with_virtctl)
-
-	return migration
-}
-
 func RunAndImmediatelyCancelMigration(migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, with_virtctl bool, timeout int) *v1.VirtualMachineInstanceMigration {
 	var err error
 	virtClient := kubevirt.Client()

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -426,27 +426,6 @@ func CancelMigration(migration *v1.VirtualMachineInstanceMigration, vminame stri
 	}
 }
 
-func RunAndImmediatelyCancelMigration(migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, with_virtctl bool, timeout int) *v1.VirtualMachineInstanceMigration {
-	var err error
-	virtClient := kubevirt.Client()
-	By("Starting a Migration")
-	Eventually(func() error {
-		migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
-		return err
-	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
-
-	By("Waiting until the Migration is Running")
-	Eventually(func() bool {
-		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		return migration.Status.Phase == v1.MigrationRunning
-	}, timeout, 1*time.Second).Should(BeTrue())
-
-	CancelMigration(migration, vmi.Name, with_virtctl)
-
-	return migration
-}
-
 func RunMigrationAndExpectFailure(migration *v1.VirtualMachineInstanceMigration, timeout int) string {
 	var err error
 	virtClient := kubevirt.Client()

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -20,7 +20,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -412,18 +411,6 @@ func ConfirmVMIPostMigrationAborted(vmi *v1.VirtualMachineInstance, migrationUID
 	By("Verifying the VMI's is in the running state")
 	ExpectWithOffset(1, vmi).To(matcher.BeInPhase(v1.Running))
 	return vmi
-}
-
-func CancelMigration(migration *v1.VirtualMachineInstanceMigration, vminame string, with_virtctl bool) {
-	virtClient := kubevirt.Client()
-	if !with_virtctl {
-		By("Cancelling a Migration")
-		Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(context.Background(), migration.Name, metav1.DeleteOptions{})).To(Succeed(), "Migration should be deleted successfully")
-	} else {
-		By("Cancelling a Migration with virtctl")
-		command := clientcmd.NewRepeatableVirtctlCommand("migrate-cancel", "--namespace", migration.Namespace, vminame)
-		Expect(command()).To(Succeed(), "should successfully migrate-cancel a migration")
-	}
 }
 
 func RunMigrationAndExpectFailure(migration *v1.VirtualMachineInstanceMigration, timeout int) string {

--- a/tests/migration/BUILD.bazel
+++ b/tests/migration/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//tests:go_default_library",
-        "//tests/clientcmd:go_default_library",
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2010,7 +2010,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				return vmi
 			}
 
-			DescribeTable("should be able to cancel a migration", decorators.SigStorage, func(createVMI vmiBuilder, with_virtctl bool) {
+			DescribeTable("should be able to cancel a migration", decorators.SigStorage, func(createVMI vmiBuilder) {
 				vmi := createVMI()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -2023,7 +2023,32 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Starting the Migration")
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
 
-				migration = libmigration.RunAndCancelMigration(migration, vmi, with_virtctl, 180)
+				By("Starting a Migration")
+				const timeout = 180
+				Eventually(func() error {
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(context.Background(), migration, metav1.CreateOptions{})
+					return err
+				}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
+
+				By("Waiting until the Migration is Running")
+				Eventually(func() bool {
+					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(migration.Status.Phase).ToNot(Equal(v1.MigrationFailed))
+					if migration.Status.Phase == v1.MigrationRunning {
+						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						if vmi.Status.MigrationState.Completed != true {
+							return true
+						}
+					}
+					return false
+
+				}, timeout, 1*time.Second).Should(BeTrue())
+
+				By("Cancelling a Migration")
+				Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(context.Background(), migration.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				// check VMI, confirm migration state
 				libmigration.ConfirmVMIPostMigrationAborted(vmi, string(migration.UID), 180)
@@ -2031,10 +2056,9 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Waiting for the migration object to disappear")
 				libwait.WaitForMigrationToDisappearWithTimeout(migration, 240)
 			},
-				Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk, false),
-				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", decorators.StorageReq, newVirtualMachineInstanceWithFedoraRWXBlockDisk, false),
-				Entry("[sig-storage][test_id:2228] with ContainerDisk and virtctl", newVirtualMachineInstanceWithFedoraContainerDisk, true),
-				Entry("[sig-storage][storage-req][test_id:2732] with RWX block disk and virtctl", decorators.StorageReq, newVirtualMachineInstanceWithFedoraRWXBlockDisk, true))
+				Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
+				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", decorators.StorageReq, newVirtualMachineInstanceWithFedoraRWXBlockDisk),
+			)
 
 			DescribeTable("Immediate migration cancellation after migration starts running", func(with_virtctl bool) {
 				vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -64,7 +64,6 @@ import (
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -725,8 +724,8 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				Expect(isPaused).To(BeTrue(), "The VMI should be paused after migration, but it is not.")
 
 				By("verify that VMI can be unpaused after migration")
-				command := clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-				Expect(command()).To(Succeed(), "should successfully unpause tthe vmi")
+				err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
+				Expect(err).ToNot(HaveOccurred(), "should successfully unpause the vmi")
 				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 
 				By("verifying that the vmi is running")

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2131,7 +2131,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				libwait.WaitForMigrationToDisappearWithTimeout(migration, 20)
 			})
 
-			DescribeTable("Immediate migration cancellation before migration starts running", func(with_virtctl bool) {
+			It("[sig-compute][test_id:8584]Immediate migration cancellation before migration starts running cancel a migration by deleting vmim object", func() {
 				vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -2160,8 +2160,8 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					return migration.UID != ""
 				}, timeout, 1*time.Second).Should(BeTrue())
 
-				By("Cancelling migration")
-				libmigration.CancelMigration(migration, vmi.Name, with_virtctl)
+				By("Cancelling a Migration")
+				Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(context.Background(), migration.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				By("Waiting for the migration object to disappear")
 				libwait.WaitForMigrationToDisappearWithTimeout(migration, 240)
@@ -2176,10 +2176,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Verifying the VMI's is in the running state and on original node")
 				Expect(vmi.Status.Phase).To(Equal(v1.Running))
 				Expect(vmi.Status.NodeName).To(Equal(vmiOriginalNode), "expecting VMI to not migrate")
-			},
-				Entry("[sig-compute][test_id:8584]cancel a migration by deleting vmim object", false),
-				Entry("[sig-compute][test_id:8585]cancel a migration with virtctl", true),
-			)
+			})
 
 			Context("[Serial]when target pod cannot be scheduled and is suck in Pending phase", Serial, func() {
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Inline several helpers since they are used only in a single place.
Additionally remove the virtctl case from the tests that used
these helpers because it does not provide any additional value.

Use the KubeVirt client instead of using virtctl through a
NewRepeatableVirtctlCommand where applicable in
tests/migration/migration.go.

Internally virtctl uses the same client call, so using virtctl does not
provide any additional value.

The goal of this and further PRs is to reduce the amount of unnecessary uses of
virtctl in the e2e tests to stabilize tests, to reduce the number of flakes and to
remove redudant tests.

Before this PR:

NewRepeatableVirtctlCommand is used unnecessarily.

After this PR:

The KubeVirt client is used istead.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

