### PR TITLE
Remove openapi resource customization

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15574,7 +15574,11 @@
     "properties": {
      "limits": {
       "description": "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\" and \"cpu\".",
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+       "default": {},
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+      }
      },
      "overcommitGuestOverhead": {
       "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false.",
@@ -15582,7 +15586,11 @@
      },
      "requests": {
       "description": "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\" and \"cpu\".",
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+       "default": {},
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+      }
      }
     }
    },

--- a/pkg/util/openapi/openapi.go
+++ b/pkg/util/openapi/openapi.go
@@ -187,20 +187,6 @@ func LoadOpenAPISpec(webServices []*restful.WebService) *spec.Swagger {
 			break
 		}
 	}
-	resourceRequirements, exists := openapispec.Definitions["v1.ResourceRequirements"]
-	if exists {
-		limits, exists := resourceRequirements.Properties["limits"]
-		if exists {
-			limits.AdditionalProperties = nil
-			resourceRequirements.Properties["limits"] = limits
-		}
-		requests, exists := resourceRequirements.Properties["requests"]
-		if exists {
-			requests.AdditionalProperties = nil
-			resourceRequirements.Properties["requests"] = requests
-		}
-
-	}
 
 	objectMeta, exists := openapispec.Definitions[objectmeta]
 	if exists {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
https://github.com/kubevirt/kubevirt/pull/4844 and in particular https://github.com/kubevirt/kubevirt/pull/4844/commits/a0c3c64b4848b25fcc35f091bdcbe33c8ed87d88 introduced a fix to accept int as resource.

Since the bug was fixed at the source https://github.com/kubernetes/kube-openapi/pull/221 we can remove this customization.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

