### PR TITLE
cleanup(tests,pausing): Use client instead of virtctl

### DIFF
--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -33,7 +33,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -41,7 +41,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -54,147 +53,99 @@ import (
 
 var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Pausing", decorators.SigCompute, func() {
 
-	var err error
 	var virtClient kubecli.KubevirtClient
-	const cirrosStartupTimeout = 90
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 	})
 
 	Context("A valid VMI", func() {
-
 		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			vmi = libvmops.RunVMIAndExpectLaunch(libvmifact.NewCirros(), cirrosStartupTimeout)
+			const timeout = 90
+			vmi = libvmops.RunVMIAndExpectLaunch(libvmifact.NewCirros(), timeout)
 		})
 
-		When("paused via API", func() {
-			It("[test_id:4597]should signal paused state with condition", func() {
+		It("[test_id:4597]should signal paused state with condition", func() {
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReady))
 
-				err = virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
+			By("Pausing VMI")
+			err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceReady))
+
+			By("Unpausing VMI")
+			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReady))
+		})
+
+		It("[test_id:3225]should signal paused state with condition when paused multiple times", func() {
+			for i := 0; i < 3; i++ {
+				By("Pausing VMI")
+				err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
+				By("Unpausing VMI")
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
-
-			})
+			}
 		})
 
-		When("paused via virtctl", func() {
-			It("[test_id:3079]should signal paused state with condition", func() {
+		It("[test_id:3224]should not be paused with a LivenessProbe configured", func() {
+			By("Launching a VMI with LivenessProbe")
+			vmi = libvmifact.NewCirros(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			// a random probe which will not fail immediately
+			vmi.Spec.LivenessProbe = &v1.Probe{
+				Handler: v1.Handler{
+					HTTPGet: &k8sv1.HTTPGetAction{
+						Path: "/something",
+						Port: intstr.FromInt(8080),
+					},
+				},
+				InitialDelaySeconds: 120,
+				TimeoutSeconds:      120,
+				PeriodSeconds:       120,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			}
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 90)
 
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
-			})
-
-			It("[test_id:3080]should signal unpaused state with removed condition", func() {
-
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
-
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
-			})
+			By("Pausing it")
+			err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
+			Expect(err).To(MatchError(ContainSubstring("Pausing VMIs with LivenessProbe is currently not supported")))
 		})
 
-		When("paused via virtctl multiple times", func() {
-			It("[test_id:3225]should signal unpaused state with removed condition at the end", func() {
-
-				for i := 0; i < 3; i++ {
-					By("Pausing VMI")
-					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-					Expect(command()).To(Succeed())
-					Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
-
-					By("Unpausing VMI")
-					command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-					Expect(command()).To(Succeed())
-					Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
-				}
-			})
-		})
-
-		Context("with a LivenessProbe configured", func() {
-			When("paused via virtctl", func() {
-				It("[test_id:3224]should not be paused", func() {
-					By("Launching a VMI with LivenessProbe")
-					vmi = libvmifact.NewCirros(
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					)
-					// a random probe which will not fail immediately
-					vmi.Spec.LivenessProbe = &v1.Probe{
-						Handler: v1.Handler{
-							HTTPGet: &k8sv1.HTTPGetAction{
-								Path: "/something",
-								Port: intstr.FromInt(8080),
-							},
-						},
-						InitialDelaySeconds: 120,
-						TimeoutSeconds:      120,
-						PeriodSeconds:       120,
-						SuccessThreshold:    1,
-						FailureThreshold:    1,
-					}
-					vmi = libvmops.RunVMIAndExpectLaunch(vmi, 90)
-
-					By("Pausing it")
-					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-					err := command()
-					Expect(err.Error()).To(ContainSubstring("Pausing VMIs with LivenessProbe is currently not supported"))
-				})
-			})
-		})
-
-		When("paused via virtctl with --dry-run flag", func() {
-			It("[test_id:7671]should not paused", func() {
-
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--dry-run", "--namespace", vmi.Namespace, vmi.Name)
-				Expect(command()).To(Succeed())
-				By("Checking that VMI remains running")
-				Consistently(matcher.ThisVMI(vmi), 5*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
-			})
-		})
-
-		When("unpaused via virtctl with --dry-run flag", func() {
-			It("[test_id:7672]should not unpaused", func() {
-
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
-
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--dry-run", "--namespace", vmi.Namespace, vmi.Name)
-				Expect(command()).To(Succeed())
-
-				By("Checking that VMI remains paused")
-				Consistently(matcher.ThisVMI(vmi), 5*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
-			})
-		})
-
-		It("should not appear as ready when paused", func() {
-			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReady))
-
-			By("Pausing the VMI and expecting to become unready")
-			err = virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
+		It("[test_id:7671]should not pause with dry run", func() {
+			err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{DryRun: []string{metav1.DryRunAll}})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceReady))
+			By("Checking that VMI remains running")
+			Consistently(matcher.ThisVMI(vmi), 5*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+		})
 
-			By("Unpausing the VMI and expecting to become ready")
-			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
+		It("[test_id:7672]should not unpause with dry run", func() {
+			err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReady))
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
+
+			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{DryRun: []string{metav1.DryRunAll}})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking that VMI remains paused")
+			Consistently(matcher.ThisVMI(vmi), 5*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 		})
 	})
 
 	Context("A valid VM", func() {
-
 		var vm *v1.VirtualMachine
 
 		BeforeEach(func() {
@@ -204,202 +155,169 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			)
 			vmi.Namespace = testsuite.NamespaceTestDefault
 			vm = libvmi.NewVirtualMachine(vmi)
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, v12.CreateOptions{})
+			vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			vm = libvmops.StartVirtualMachine(vm)
 		})
 
-		When("paused via API", func() {
-			It("[test_id:4598]should signal paused state with condition", func() {
-				err = virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+		It("[test_id:4598]should signal paused state with condition", func() {
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
-				err = virtClient.VirtualMachineInstance(vm.Namespace).Unpause(context.Background(), vm.Name, &v1.UnpauseOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
-			})
-
+			err = virtClient.VirtualMachineInstance(vm.Namespace).Unpause(context.Background(), vm.Name, &v1.UnpauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
 		})
 
-		When("paused via virtctl", func() {
+		It("[test_id:3081]should gracefully handle pausing the VM again", func() {
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
-			It("[test_id:3059]should signal paused state with condition", func() {
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-			})
-
-			It("[test_id:3081]should gracefully handle pausing the VM again", func() {
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				command = clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				err := command()
-				Expect(err.Error()).To(ContainSubstring("VMI is already paused"))
-			})
-
-			It("[test_id:3088]should gracefully handle pausing the VMI again", func() {
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				command = clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vm.Namespace, vm.Name)
-				err := command()
-				Expect(err.Error()).To(ContainSubstring("VMI is already paused"))
-			})
-
-			It("[test_id:3060]should signal unpaused state with removed condition", func() {
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
-			})
-
-			It("[test_id:3082]should gracefully handle unpausing again", func() {
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
-
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", vm.Namespace, vm.Name)
-				err := command()
-				Expect(err.Error()).To(ContainSubstring("VMI is not paused"))
-			})
-
-			It("[test_id:3085]should be stopped successfully", func() {
-				By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				By("Stopping the VM")
-				command = clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-
-				By("Checking deletion of VMI")
-				Eventually(func() error {
-					_, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, v12.GetOptions{})
-					return err
-				}, 300*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "The VMI did not disappear")
-
-				By("Checking status of VM")
-				Eventually(func() bool {
-					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, v12.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.Ready
-				}, 300*time.Second, 1*time.Second).Should(BeFalse())
-
-			})
-
-			It("[test_id:3229]should gracefully handle being started again", func() {
-				By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				By("Starting the VM")
-				command = clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", vm.Namespace, vm.Name)
-				err = command()
-				Expect(err.Error()).To(ContainSubstring("VM is already running"))
-
-			})
-
-			It("[test_id:3226]should be restarted successfully into unpaused state", func() {
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, v12.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				oldId := vmi.UID
-
-				By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				By("Restarting the VM")
-				command = clientcmd.NewRepeatableVirtctlCommand("restart", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-
-				By("Checking deletion of VMI")
-				Eventually(func() bool {
-					newVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, v12.GetOptions{})
-					if errors.IsNotFound(err) || (err == nil && newVMI.UID != oldId) {
-						return true
-					}
-					Expect(err).ToNot(HaveOccurred())
-					return false
-				}, 60*time.Second, 1*time.Second).Should(BeTrue(), "The VMI did not disappear")
-
-				By("Waiting for for new VMI to start")
-				Eventually(func() error {
-					_, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, v12.GetOptions{})
-					return err
-				}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred(), "No new VMI appeared")
-
-				newVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, v12.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitForSuccessfulVMIStart(newVMI,
-					libwait.WithTimeout(300),
-				)
-
-				By("Ensuring unpaused state")
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
-				Eventually(matcher.ThisVMI(newVMI), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
-
-			})
-
-			It("[test_id:3083]should connect to serial console", func() {
-				By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				By("Trying to console into the VM")
-				_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).SerialConsole(vm.ObjectMeta.Name, &kvcorev1.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("[test_id:3084]should connect to vnc console", func() {
-				By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				By("Trying to vnc into the VM")
-				_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).VNC(vm.ObjectMeta.Name)
-				Expect(err).ToNot(HaveOccurred())
-
-			})
+			err = virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).To(MatchError(ContainSubstring("VMI is already paused")))
 		})
 
-		When("paused via virtctl with --dry-run flag", func() {
-			It("[test_id:7673]should not paused", func() {
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--dry-run", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				By("Checking that VM remains running")
-				Consistently(matcher.ThisVM(vm), 5*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
-			})
+		It("[test_id:3060]should signal unpaused state with removed condition", func() {
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+
+			err = virtClient.VirtualMachineInstance(vm.Namespace).Unpause(context.Background(), vm.Name, &v1.UnpauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
 		})
 
-		When("unpaused via virtctl with --dry-run flag", func() {
-			It("[test_id:7674]should not unpaused", func() {
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+		It("[test_id:3082]should gracefully handle unpausing again", func() {
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--dry-run", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
+			err = virtClient.VirtualMachineInstance(vm.Namespace).Unpause(context.Background(), vm.Name, &v1.UnpauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
 
-				By("Checking that VM remains paused")
-				Consistently(matcher.ThisVM(vm), 5*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-			})
+			err = virtClient.VirtualMachineInstance(vm.Namespace).Unpause(context.Background(), vm.Name, &v1.UnpauseOptions{})
+			Expect(err).To(MatchError(ContainSubstring("VMI is not paused")))
+		})
+
+		It("[test_id:3085]should be stopped successfully", func() {
+			By("Pausing the VM")
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+
+			By("Stopping the VM")
+			err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking deletion of VMI")
+			Eventually(func() error {
+				_, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				return err
+			}, 300*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "The VMI did not disappear")
+
+			By("Checking status of VM")
+			Eventually(func() bool {
+				vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return vm.Status.Ready
+			}, 300*time.Second, 1*time.Second).Should(BeFalse())
+		})
+
+		It("[test_id:3229]should gracefully handle being started again", func() {
+			By("Pausing the VM")
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+
+			By("Starting the VM")
+			err = virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})
+			Expect(err).To(MatchError(ContainSubstring("VM is already running")))
+		})
+
+		It("[test_id:3226]should be restarted successfully into unpaused state", func() {
+			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			oldId := vmi.UID
+
+			By("Pausing the VM")
+			err = virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+
+			By("Restarting the VM")
+			err = virtClient.VirtualMachine(vm.Namespace).Restart(context.Background(), vm.Name, &v1.RestartOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking deletion of VMI")
+			Eventually(func() bool {
+				newVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				if errors.IsNotFound(err) || (err == nil && newVMI.UID != oldId) {
+					return true
+				}
+				Expect(err).ToNot(HaveOccurred())
+				return false
+			}, 60*time.Second, 1*time.Second).Should(BeTrue(), "The VMI did not disappear")
+
+			By("Waiting for for new VMI to start")
+			Eventually(func() error {
+				_, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				return err
+			}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred(), "No new VMI appeared")
+
+			newVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			libwait.WaitForSuccessfulVMIStart(newVMI,
+				libwait.WithTimeout(300),
+			)
+
+			By("Ensuring unpaused state")
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
+			Eventually(matcher.ThisVMI(newVMI), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+		})
+
+		It("[test_id:3083]should connect to serial console", func() {
+			By("Pausing the VM")
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+
+			By("Trying to console into the VM")
+			_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).SerialConsole(vm.ObjectMeta.Name, &kvcorev1.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("[test_id:3084]should connect to vnc console", func() {
+			By("Pausing the VM")
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+
+			By("Trying to vnc into the VM")
+			_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).VNC(vm.ObjectMeta.Name)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("[test_id:7673]should not pause with dry run", func() {
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{DryRun: []string{metav1.DryRunAll}})
+			Expect(err).ToNot(HaveOccurred())
+			By("Checking that VM remains running")
+			Consistently(matcher.ThisVM(vm), 5*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachinePaused))
+		})
+
+		It("[test_id:7674]should not unpause with dry run", func() {
+			err := virtClient.VirtualMachineInstance(vm.Namespace).Pause(context.Background(), vm.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
+
+			err = virtClient.VirtualMachineInstance(vm.Namespace).Unpause(context.Background(), vm.Name, &v1.UnpauseOptions{DryRun: []string{metav1.DryRunAll}})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking that VM remains paused")
+			Consistently(matcher.ThisVM(vm), 5*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 		})
 	})
 
@@ -433,7 +351,8 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		BeforeEach(func() {
 			By("Starting a Cirros VMI")
-			vmi = libvmops.RunVMIAndExpectLaunch(libvmifact.NewCirros(), cirrosStartupTimeout)
+			const timeout = 90
+			vmi = libvmops.RunVMIAndExpectLaunch(libvmifact.NewCirros(), timeout)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -444,14 +363,14 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		It("[test_id:3090]should be less than uptime difference after pause", func() {
 			By("Pausing the VMI")
-			command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-			Expect(command()).To(Succeed(), "should successfully pause the vmi")
+			err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 			time.Sleep(sleepTimeSeconds * time.Second) // sleep to increase uptime diff
 
 			By("Unpausing the VMI")
-			command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
-			Expect(command()).To(Succeed(), "should successfully unpause the vmi")
+			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 
 			By("Verifying VMI was indeed Paused")

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -84,20 +84,6 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReady))
 		})
 
-		It("[test_id:3225]should signal paused state with condition when paused multiple times", func() {
-			for i := 0; i < 3; i++ {
-				By("Pausing VMI")
-				err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(context.Background(), vmi.Name, &v1.PauseOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
-
-				By("Unpausing VMI")
-				err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
-			}
-		})
-
 		It("[test_id:3224]should not be paused with a LivenessProbe configured", func() {
 			By("Launching a VMI with LivenessProbe")
 			vmi = libvmifact.NewCirros(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Use the KubeVirt client instead of using virtctl through a NewRepeatableVirtctlCommand where applicable in
tests/migration/migration.go.

Internally virtctl uses the same client call, so using virtctl does not provide any additional value.

This also drops duplicate tests combinations which can only occur when
using virtctl (e.g. pausing VM twice and pausing VMI twice, the client can
only pause VMIs and internally virtctl only gets a VM before pausing
the corresponding VMI) and reduces the amount of tests by combining the
test for VMI Ready and Paused condition and by dropping the test pausing
and unpausing a VMI multiple times, becomes this is already covered by the
check-tests-for-flakes lane.

The correctness of API calls made by `virtctl pause` and `virtctl unpause` is already covered in unit tests specified in `pkg/virtctl/pause/pause_test.go`.

The goal of this and further PRs is to reduce the amount of unnecessary uses of
virtctl in the e2e tests to stabilize tests, to reduce the number of flakes and to
remove redudant tests.

Before this PR:

NewRepeatableVirtctlCommand is used unnecessarily.

After this PR:

The KubeVirt client is used instead.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

