### PR TITLE
[WIP] Consolidate vmi defaulting

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1308,11 +1308,6 @@ func (c *VMController) startVMI(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachi
 		return vm, err
 	}
 
-	err = vmispec.SetDefaultNetworkInterface(c.clusterConfig, &vmi.Spec)
-	if err != nil {
-		return vm, err
-	}
-
 	err = c.applyInstancetypeToVmi(vm, vmi, preferenceSpec)
 	if err != nil {
 		log.Log.Object(vm).Infof("Failed to apply instancetype to VirtualMachineInstance: %s/%s", vmi.Namespace, vmi.Name)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1855,8 +1855,6 @@ func SetupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.VirtualMachineInstance {
 		*metav1.NewControllerRef(vm, virtv1.VirtualMachineGroupVersionKind),
 	}
 
-	autoAttachInputDevice(vmi)
-
 	return vmi
 }
 
@@ -3227,22 +3225,6 @@ func (c *VMController) resolveControllerRef(namespace string, controllerRef *met
 		return nil
 	}
 	return vm.(*virtv1.VirtualMachine)
-}
-
-func autoAttachInputDevice(vmi *virtv1.VirtualMachineInstance) {
-	autoAttachInput := vmi.Spec.Domain.Devices.AutoattachInputDevice
-	// Default to False if nil and return, otherwise return if input devices are already present
-	if autoAttachInput == nil || !*autoAttachInput || len(vmi.Spec.Domain.Devices.Inputs) > 0 {
-		return
-	}
-	// Only add the device with an alias here. Preferences for the bus and type might
-	// be applied later and if not the VMI mutation webhook will apply defaults for both.
-	vmi.Spec.Domain.Devices.Inputs = append(
-		vmi.Spec.Domain.Devices.Inputs,
-		virtv1.Input{
-			Name: "default-0",
-		},
-	)
 }
 
 func (c *VMController) applyDevicePreferences(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error) {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1860,8 +1860,6 @@ func SetupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.VirtualMachineInstance {
 		*metav1.NewControllerRef(vm, virtv1.VirtualMachineGroupVersionKind),
 	}
 
-	util.SetDefaultVolumeDisk(&vmi.Spec)
-
 	autoAttachInputDevice(vmi)
 
 	return vmi

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -2561,16 +2561,16 @@ var _ = Describe("VirtualMachine", func() {
 
 		It("should have stable firmware UUIDs", func() {
 			vm1, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
-			vmi1 := controller.setupVMIFromVM(vm1)
+			vmi1 := SetupVMIFromVM(vm1)
 
 			// intentionally use the same names
 			vm2, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
-			vmi2 := controller.setupVMIFromVM(vm2)
+			vmi2 := SetupVMIFromVM(vm2)
 			Expect(vmi1.Spec.Domain.Firmware.UUID).To(Equal(vmi2.Spec.Domain.Firmware.UUID))
 
 			// now we want different names
 			vm3, _ := DefaultVirtualMachineWithNames(true, "testvm3", "testvmi3")
-			vmi3 := controller.setupVMIFromVM(vm3)
+			vmi3 := SetupVMIFromVM(vm3)
 			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi3.Spec.Domain.Firmware.UUID))
 		})
 
@@ -2579,7 +2579,7 @@ var _ = Describe("VirtualMachine", func() {
 			vm1, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
 			vm1.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{UUID: types.UID(uid)}
 
-			vmi1 := controller.setupVMIFromVM(vm1)
+			vmi1 := SetupVMIFromVM(vm1)
 			Expect(string(vmi1.Spec.Domain.Firmware.UUID)).To(Equal(uid))
 		})
 
@@ -3487,7 +3487,7 @@ var _ = Describe("VirtualMachine", func() {
 					Phase:     phase,
 				}
 
-				vmi := controller.setupVMIFromVM(vm)
+				vmi := SetupVMIFromVM(vm)
 				Expect(vmi.Spec.Volumes).To(BeEmpty())
 
 			},
@@ -5684,7 +5684,7 @@ var _ = Describe("VirtualMachine", func() {
 					vm, _ := DefaultVirtualMachine(true)
 					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{MaxSockets: maxSocketsFromSpec}
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi := SetupVMIFromVM(vm)
 					Expect(vmi.Spec.Domain.CPU.MaxSockets).To(Equal(maxSocketsFromSpec))
 				})
 
@@ -5705,7 +5705,7 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi := SetupVMIFromVM(vm)
 					Expect(vmi.Spec.Domain.CPU.MaxSockets).To(Equal(maxSocketsFromSpec))
 				})
 
@@ -5856,7 +5856,7 @@ var _ = Describe("VirtualMachine", func() {
 						MaxGuest: &maxGuestFromSpec,
 					}
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi := SetupVMIFromVM(vm)
 					Expect(*vmi.Spec.Domain.Memory.MaxGuest).To(Equal(maxGuestFromSpec))
 				})
 
@@ -5881,7 +5881,7 @@ var _ = Describe("VirtualMachine", func() {
 						},
 					})
 
-					vmi := controller.setupVMIFromVM(vm)
+					vmi := SetupVMIFromVM(vm)
 					Expect(*vmi.Spec.Domain.Memory.MaxGuest).To(Equal(maxGuestFromSpec))
 				})
 
@@ -6557,7 +6557,7 @@ var _ = Describe("VirtualMachine", func() {
 				controller.crIndexer.Add(createVMRevision(vm))
 
 				By("Creating a VMI with cluster max")
-				vmi = controller.setupVMIFromVM(vm)
+				vmi = SetupVMIFromVM(vm)
 				controller.vmiIndexer.Add(vmi)
 
 				By("Bumping the VM sockets above the cluster maximum")
@@ -6588,7 +6588,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				By("Creating a VMI with hostname 'a'")
 				vm.Spec.Template.Spec.Hostname = "a"
-				vmi = controller.setupVMIFromVM(vm)
+				vmi = SetupVMIFromVM(vm)
 				controller.vmiIndexer.Add(vmi)
 
 				By("Creating a Controller Revision with the hostname 'a'")
@@ -6616,7 +6616,7 @@ var _ = Describe("VirtualMachine", func() {
 				controller.crIndexer.Add(createVMRevision(vm))
 
 				By("Creating a VMI with cluster max")
-				vmi = controller.setupVMIFromVM(vm)
+				vmi = SetupVMIFromVM(vm)
 				controller.vmiIndexer.Add(vmi)
 
 				By("Bumping the VM sockets above the cluster maximum")
@@ -6641,7 +6641,7 @@ var _ = Describe("VirtualMachine", func() {
 				controller.crIndexer.Add(createVMRevision(vm))
 
 				By("Creating a VMI")
-				vmi = controller.setupVMIFromVM(vm)
+				vmi = SetupVMIFromVM(vm)
 				markAsReady(vmi)
 				vmi.Status.Memory = &v1.MemoryStatus{
 					GuestAtBoot:  &maxGuest,
@@ -6668,7 +6668,7 @@ var _ = Describe("VirtualMachine", func() {
 				By("Creating a VM with two sockets")
 				vm.Spec.Template.Spec.Domain.CPU.Sockets = 2
 
-				vmi = controller.setupVMIFromVM(vm)
+				vmi = SetupVMIFromVM(vm)
 				controller.vmiIndexer.Add(vmi)
 
 				By("Creating a Controller Revision with two sockets")
@@ -6707,7 +6707,7 @@ var _ = Describe("VirtualMachine", func() {
 				controller.crIndexer.Add(createVMRevision(vm))
 
 				By("Creating a VMI")
-				vmi = controller.setupVMIFromVM(vm)
+				vmi = SetupVMIFromVM(vm)
 				markAsReady(vmi)
 				vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

