### PR TITLE
Migration update admitter: Refactor tests

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
@@ -29,6 +29,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
+	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )
 
 type MigrationUpdateAdmitter struct {
@@ -89,7 +90,5 @@ func (admitter *MigrationUpdateAdmitter) Admit(_ context.Context, ar *admissionv
 		return webhookutils.ToAdmissionResponse(causes)
 	}
 
-	reviewResponse := admissionv1.AdmissionResponse{}
-	reviewResponse.Allowed = true
-	return &reviewResponse
+	return validating_webhooks.NewPassingAdmissionResponse()
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
@@ -40,8 +40,6 @@ import (
 )
 
 var _ = Describe("Validating MigrationUpdate Admitter", func() {
-	migrationUpdateAdmitter := &admitters.MigrationUpdateAdmitter{}
-
 	It("should reject Migration on update if spec changes", func() {
 		migration := v1.VirtualMachineInstanceMigration{
 			ObjectMeta: metav1.ObjectMeta{
@@ -72,7 +70,8 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
+		admitter := &admitters.MigrationUpdateAdmitter{}
+		resp := admitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 	})
 
@@ -103,7 +102,8 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
+		admitter := &admitters.MigrationUpdateAdmitter{}
+		resp := admitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 
@@ -144,7 +144,8 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
+		admitter := &admitters.MigrationUpdateAdmitter{}
+		resp := admitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 	})
 
@@ -185,7 +186,8 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
+		admitter := &admitters.MigrationUpdateAdmitter{}
+		resp := admitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
 	})
 
@@ -226,7 +228,8 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 			},
 		}
 
-		resp := migrationUpdateAdmitter.Admit(context.Background(), ar)
+		admitter := &admitters.MigrationUpdateAdmitter{}
+		resp := admitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
 	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package admitters
+package admitters_test
 
 import (
 	"context"
@@ -25,19 +25,22 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	admissionv1 "k8s.io/api/admission/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"kubevirt.io/client-go/api"
-
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/client-go/api"
+
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters"
 )
 
 var _ = Describe("Validating MigrationUpdate Admitter", func() {
-	migrationUpdateAdmitter := &MigrationUpdateAdmitter{}
+	migrationUpdateAdmitter := &admitters.MigrationUpdateAdmitter{}
 
 	It("should reject Migration on update if spec changes", func() {
 		migration := v1.VirtualMachineInstanceMigration{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
@@ -22,6 +22,7 @@ package admitters_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -60,7 +61,25 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 
 		admitter := &admitters.MigrationUpdateAdmitter{}
 		resp := admitter.Admit(context.Background(), ar)
-		Expect(resp.Allowed).To(BeFalse())
+
+		expectedResponse := &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Code:    http.StatusUnprocessableEntity,
+				Message: "update of Migration object's spec is restricted",
+				Reason:  metav1.StatusReasonInvalid,
+				Details: &metav1.StatusDetails{
+					Causes: []metav1.StatusCause{
+						{
+							Type:    metav1.CauseTypeFieldValueNotSupported,
+							Message: "update of Migration object's spec is restricted",
+						},
+					},
+				},
+			},
+		}
+
+		Expect(resp).To(Equal(expectedResponse))
 	})
 
 	It("should accept Migration on update if spec doesn't change", func() {
@@ -82,7 +101,7 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 
 		admitter := &admitters.MigrationUpdateAdmitter{}
 		resp := admitter.Admit(context.Background(), ar)
-		Expect(resp.Allowed).To(BeTrue())
+		Expect(resp).To(Equal(allowedAdmissionResponse()))
 	})
 
 	It("should reject Migration on update if labels include our selector and are removed", func() {
@@ -111,7 +130,25 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 
 		admitter := &admitters.MigrationUpdateAdmitter{}
 		resp := admitter.Admit(context.Background(), ar)
-		Expect(resp.Allowed).To(BeFalse())
+
+		expectedResponse := &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Code:    http.StatusUnprocessableEntity,
+				Message: "selector label can't be removed from an in-flight migration",
+				Reason:  metav1.StatusReasonInvalid,
+				Details: &metav1.StatusDetails{
+					Causes: []metav1.StatusCause{
+						{
+							Type:    metav1.CauseTypeFieldValueNotSupported,
+							Message: "selector label can't be removed from an in-flight migration",
+						},
+					},
+				},
+			},
+		}
+
+		Expect(resp).To(Equal(expectedResponse))
 	})
 
 	It("should reject Migration on update if our selector label is removed", func() {
@@ -140,7 +177,25 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 
 		admitter := &admitters.MigrationUpdateAdmitter{}
 		resp := admitter.Admit(context.Background(), ar)
-		Expect(resp.Allowed).To(BeFalse())
+
+		expectedResponse := &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Code:    http.StatusUnprocessableEntity,
+				Message: "selector label can't be modified on an in-flight migration",
+				Reason:  metav1.StatusReasonInvalid,
+				Details: &metav1.StatusDetails{
+					Causes: []metav1.StatusCause{
+						{
+							Type:    metav1.CauseTypeFieldValueNotSupported,
+							Message: "selector label can't be modified on an in-flight migration",
+						},
+					},
+				},
+			},
+		}
+
+		Expect(resp).To(Equal(expectedResponse))
 	})
 
 	It("should accept Migration on update if non-selector label is removed", func() {
@@ -169,7 +224,8 @@ var _ = Describe("Validating MigrationUpdate Admitter", func() {
 
 		admitter := &admitters.MigrationUpdateAdmitter{}
 		resp := admitter.Admit(context.Background(), ar)
-		Expect(resp.Allowed).To(BeTrue())
+
+		Expect(resp).To(Equal(allowedAdmissionResponse()))
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- Move the unit tests to the `admitters_test` package in order to explicitly test public API.
- Use fresh admitter instance per test.
- Extract the instantiation of the AdmissionRequest to a single function.
- Expect the full admission response.

Also, simplify the allowed response in the production code.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

