### PR TITLE
[virt-api, migration-create-admitter]: Use KubeVirt generated clientset

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -32,17 +32,17 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
+	kubevirt "kubevirt.io/client-go/generated/kubevirt/clientset/versioned"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )
 
 type MigrationCreateAdmitter struct {
-	virtClient kubecli.KubevirtClient
+	virtClient kubevirt.Interface
 }
 
-func NewMigrationCreateAdmitter(virtClient kubecli.KubevirtClient) *MigrationCreateAdmitter {
+func NewMigrationCreateAdmitter(virtClient kubevirt.Interface) *MigrationCreateAdmitter {
 	return &MigrationCreateAdmitter{
 		virtClient: virtClient,
 	}
@@ -58,12 +58,12 @@ func isMigratable(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-func ensureNoMigrationConflict(ctx context.Context, virtClient kubecli.KubevirtClient, vmiName string, namespace string) error {
+func ensureNoMigrationConflict(ctx context.Context, virtClient kubevirt.Interface, vmiName string, namespace string) error {
 	labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", v1.MigrationSelectorLabel, vmiName))
 	if err != nil {
 		return err
 	}
-	list, err := virtClient.VirtualMachineInstanceMigration(namespace).List(ctx, metav1.ListOptions{
+	list, err := virtClient.KubevirtV1().VirtualMachineInstanceMigrations(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	})
 	if err != nil {
@@ -96,7 +96,7 @@ func (admitter *MigrationCreateAdmitter) Admit(ctx context.Context, ar *admissio
 		return webhookutils.ToAdmissionResponse(causes)
 	}
 
-	vmi, err := admitter.virtClient.VirtualMachineInstance(migration.Namespace).Get(ctx, migration.Spec.VMIName, metav1.GetOptions{})
+	vmi, err := admitter.virtClient.KubevirtV1().VirtualMachineInstances(migration.Namespace).Get(ctx, migration.Spec.VMIName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// ensure VMI exists for the migration
 		return webhookutils.ToAdmissionResponseError(fmt.Errorf("the VMI \"%s/%s\" does not exist", migration.Namespace, migration.Spec.VMIName))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		virtClient.EXPECT().VirtualMachineInstanceMigration("default").Return(migrationInterface).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(mockVMIClient).AnyTimes()
-		migrationCreateAdmitter = &MigrationCreateAdmitter{VirtClient: virtClient}
+		migrationCreateAdmitter = NewMigrationCreateAdmitter(virtClient)
 	})
 
 	It("should reject Migration spec on create when another VMI migration is in-flight", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			},
 		}
 
-		migration := v1.VirtualMachineInstanceMigration{
+		migration := &v1.VirtualMachineInstanceMigration{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: vmi.Namespace,
 			},
@@ -58,18 +58,10 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 				VMIName: vmi.Name,
 			},
 		}
-		migrationBytes, _ := json.Marshal(&migration)
-
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: webhooks.MigrationGroupVersionResource,
-				Object: runtime.RawExtension{
-					Raw: migrationBytes,
-				},
-			},
-		}
 		virtClient := kubevirtfake.NewSimpleClientset(vmi, inFlightMigration)
 		migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+		ar, err := newAdmissionReviewForVMIMCreation(migration)
+		Expect(err).ToNot(HaveOccurred())
 
 		resp := migrationCreateAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeFalse())
@@ -77,7 +69,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 
 	Context("with no conflicting migration", func() {
 		It("should reject invalid Migration spec on create", func() {
-			migration := v1.VirtualMachineInstanceMigration{
+			migration := &v1.VirtualMachineInstanceMigration{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
@@ -85,18 +77,11 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 					VMIName: "",
 				},
 			}
-			migrationBytes, _ := json.Marshal(&migration)
 
-			ar := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					Resource: webhooks.MigrationGroupVersionResource,
-					Object: runtime.RawExtension{
-						Raw: migrationBytes,
-					},
-				},
-			}
 			virtClient := kubevirtfake.NewSimpleClientset()
 			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			ar, err := newAdmissionReviewForVMIMCreation(migration)
+			Expect(err).ToNot(HaveOccurred())
 
 			resp := migrationCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
@@ -107,7 +92,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 		It("should accept valid Migration spec on create", func() {
 			vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
 
-			migration := v1.VirtualMachineInstanceMigration{
+			migration := &v1.VirtualMachineInstanceMigration{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
 				},
@@ -115,18 +100,10 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 					VMIName: vmi.Name,
 				},
 			}
-			migrationBytes, _ := json.Marshal(&migration)
-
-			ar := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					Resource: webhooks.MigrationGroupVersionResource,
-					Object: runtime.RawExtension{
-						Raw: migrationBytes,
-					},
-				},
-			}
 			virtClient := kubevirtfake.NewSimpleClientset(vmi)
 			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			ar, err := newAdmissionReviewForVMIMCreation(migration)
+			Expect(err).ToNot(HaveOccurred())
 
 			resp := migrationCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
@@ -140,7 +117,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 				Failed:       false,
 			}
 
-			migration := v1.VirtualMachineInstanceMigration{
+			migration := &v1.VirtualMachineInstanceMigration{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
 				},
@@ -148,18 +125,11 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 					VMIName: vmi.Name,
 				},
 			}
-			migrationBytes, _ := json.Marshal(&migration)
 
-			ar := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					Resource: webhooks.MigrationGroupVersionResource,
-					Object: runtime.RawExtension{
-						Raw: migrationBytes,
-					},
-				},
-			}
 			virtClient := kubevirtfake.NewSimpleClientset(vmi)
 			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			ar, err := newAdmissionReviewForVMIMCreation(migration)
+			Expect(err).ToNot(HaveOccurred())
 
 			resp := migrationCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
@@ -169,7 +139,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
 			vmi.Status.Phase = v1.Succeeded
 
-			migration := v1.VirtualMachineInstanceMigration{
+			migration := &v1.VirtualMachineInstanceMigration{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
 				},
@@ -177,18 +147,11 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 					VMIName: vmi.Name,
 				},
 			}
-			migrationBytes, _ := json.Marshal(&migration)
 
-			ar := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					Resource: webhooks.MigrationGroupVersionResource,
-					Object: runtime.RawExtension{
-						Raw: migrationBytes,
-					},
-				},
-			}
 			virtClient := kubevirtfake.NewSimpleClientset(vmi)
 			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			ar, err := newAdmissionReviewForVMIMCreation(migration)
+			Expect(err).ToNot(HaveOccurred())
 
 			resp := migrationCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
@@ -210,7 +173,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 				},
 			}
 
-			migration := v1.VirtualMachineInstanceMigration{
+			migration := &v1.VirtualMachineInstanceMigration{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
 				},
@@ -218,18 +181,11 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 					VMIName: vmi.Name,
 				},
 			}
-			migrationBytes, _ := json.Marshal(&migration)
-
-			ar := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					Resource: webhooks.MigrationGroupVersionResource,
-					Object: runtime.RawExtension{
-						Raw: migrationBytes,
-					},
-				},
-			}
 			virtClient := kubevirtfake.NewSimpleClientset(vmi)
 			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+
+			ar, err := newAdmissionReviewForVMIMCreation(migration)
+			Expect(err).ToNot(HaveOccurred())
 
 			resp := migrationCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
@@ -267,3 +223,20 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 		)
 	})
 })
+
+func newAdmissionReviewForVMIMCreation(migration *v1.VirtualMachineInstanceMigration) (*admissionv1.AdmissionReview, error) {
+	migrationBytes, err := json.Marshal(migration)
+	if err != nil {
+		return nil, err
+	}
+
+	return &admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Resource: webhooks.MigrationGroupVersionResource,
+			Object: runtime.RawExtension{
+				Raw: migrationBytes,
+			},
+			Operation: admissionv1.Create,
+		},
+	}, nil
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package admitters
+package admitters_test
 
 import (
 	"context"
@@ -35,6 +35,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters"
 )
 
 var _ = Describe("Validating MigrationCreate Admitter", func() {
@@ -59,7 +60,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			},
 		}
 		virtClient := kubevirtfake.NewSimpleClientset(vmi, inFlightMigration)
-		migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+		migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient)
 		ar, err := newAdmissionReviewForVMIMCreation(migration)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -79,7 +80,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			}
 
 			virtClient := kubevirtfake.NewSimpleClientset()
-			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient)
 			ar, err := newAdmissionReviewForVMIMCreation(migration)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -101,7 +102,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 				},
 			}
 			virtClient := kubevirtfake.NewSimpleClientset(vmi)
-			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient)
 			ar, err := newAdmissionReviewForVMIMCreation(migration)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -127,7 +128,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			}
 
 			virtClient := kubevirtfake.NewSimpleClientset(vmi)
-			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient)
 			ar, err := newAdmissionReviewForVMIMCreation(migration)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -149,7 +150,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			}
 
 			virtClient := kubevirtfake.NewSimpleClientset(vmi)
-			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient)
 			ar, err := newAdmissionReviewForVMIMCreation(migration)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -182,7 +183,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 				},
 			}
 			virtClient := kubevirtfake.NewSimpleClientset(vmi)
-			migrationCreateAdmitter := NewMigrationCreateAdmitter(virtClient)
+			migrationCreateAdmitter := admitters.NewMigrationCreateAdmitter(virtClient)
 
 			ar, err := newAdmissionReviewForVMIMCreation(migration)
 			Expect(err).ToNot(HaveOccurred())
@@ -212,13 +213,13 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 				`{"very": "unknown", "spec": { "extremely": "unknown" }}`,
 				`.very in body is a forbidden property, spec.extremely in body is a forbidden property`,
 				webhooks.MigrationGroupVersionResource,
-				NewMigrationCreateAdmitter(kubevirtfake.NewSimpleClientset()).Admit,
+				admitters.NewMigrationCreateAdmitter(kubevirtfake.NewSimpleClientset()).Admit,
 			),
 			Entry("Migration update",
 				`{"very": "unknown", "spec": { "extremely": "unknown" }}`,
 				`.very in body is a forbidden property, spec.extremely in body is a forbidden property`,
 				webhooks.MigrationGroupVersionResource,
-				NewMigrationCreateAdmitter(kubevirtfake.NewSimpleClientset()).Admit,
+				admitters.NewMigrationCreateAdmitter(kubevirtfake.NewSimpleClientset()).Admit,
 			),
 		)
 	})

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -56,7 +56,7 @@ func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {
 }
 
 func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, admitters.NewMigrationCreateAdmitter(virtCli))
+	validating_webhooks.Serve(resp, req, admitters.NewMigrationCreateAdmitter(virtCli.GeneratedKubeVirtClient()))
 }
 
 func ServeMigrationUpdate(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -56,7 +56,7 @@ func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {
 }
 
 func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, &admitters.MigrationCreateAdmitter{VirtClient: virtCli})
+	validating_webhooks.Serve(resp, req, admitters.NewMigrationCreateAdmitter(virtCli))
 }
 
 func ServeMigrationUpdate(resp http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

MigrationCreateAdmitter:
1. Had exported fields and could be instantiated incorrectly.
2. Used the old `kubecli.KubevirtClient` clientset.
3. Used gomock for unit tests.
4. Used `v1 api` to create base VMIs for tests.

**After this PR:**
MigrationCreateAdmitter:
1. Has a constructor function and only unexported fields.
2. Uses KubeVirt's generated clientset.
3. Uses `libvmi` to create base VMIs for tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This is a follow up to https://github.com/kubevirt/kubevirt/pull/11897.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
6. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

