### PR TITLE
[release-1.2] fix: do not clear out spec.Domain.Memory

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -3457,16 +3457,16 @@ func setGuestMemory(spec *virtv1.VirtualMachineInstanceSpec) {
 		return
 	}
 
+	if spec.Domain.Memory == nil {
+		spec.Domain.Memory = &virtv1.Memory{}
+	}
+
 	switch {
 	case !spec.Domain.Resources.Requests.Memory().IsZero():
-		spec.Domain.Memory = &virtv1.Memory{
-			Guest: spec.Domain.Resources.Requests.Memory(),
-		}
+		spec.Domain.Memory.Guest = spec.Domain.Resources.Requests.Memory()
 	case !spec.Domain.Resources.Limits.Memory().IsZero():
-		spec.Domain.Memory = &virtv1.Memory{
-			Guest: spec.Domain.Resources.Limits.Memory(),
-		}
-	case spec.Domain.Memory != nil && spec.Domain.Memory.Hugepages != nil:
+		spec.Domain.Memory.Guest = spec.Domain.Resources.Limits.Memory()
+	case spec.Domain.Memory.Hugepages != nil:
 		if hugepagesSize, err := resource.ParseQuantity(spec.Domain.Memory.Hugepages.PageSize); err == nil {
 			spec.Domain.Memory.Guest = &hugepagesSize
 		}


### PR DESCRIPTION
Do not clear out `Memory` in `setGuestMemory` but rather overwrite the `Guest` field, otherwise if hugepages are configured for the VM the setting would get lost.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Creating a VM configured with hugepages does not actually use hugepages if memory is set through `memory.requests`

After this PR:
Creating a VM configured with hugepages does use hugepages if memory is set through `memory.requests`

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

