### PR TITLE
cluster-sync: call scripts directly instead of make targets

### DIFF
--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -27,8 +27,8 @@ function main() {
     ./hack/cluster-clean.sh >$TEMP_FILE 2>&1 &
     CLEAN_PID=$!
 
-    make cluster-build
-    make manifests
+    ./hack/cluster-build.sh
+    ./hack/manifests.sh
 
     echo "waiting for cluster-clean to finish"
     if ! wait $CLEAN_PID; then


### PR DESCRIPTION
### What this PR does

When a make target calls make and timestamping is enabled, the output gets double-timestamped.
Since the make rules for cluster-build and manifests just call the corresponding scripts, calling the scripts directly should fix double-timestamping without any side-effect.

Before this PR:
The build section of the logs for every lane is double-timestamped (like `14:55:09: 14:55:09: selecting podman as container runtime`)

After this PR:
Single timestamps

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
Set $TIMESTAMP to 0 when calling sub-targets

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

