### PR TITLE
Tests cleanup: Use /bin/bash directly

### DIFF
--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -226,7 +226,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			stdout, err := exec.ExecuteCommandOnPod(
 				helperPod,
 				helperPod.Spec.Containers[0].Name,
-				[]string{tests.BinBash, "-c", command})
+				[]string{"/bin/bash", "-c", command})
 			return strings.TrimSpace(stdout), err
 		}
 

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -95,7 +95,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			psOutput, err := exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
-				[]string{tests.BinBash, "-c", "ps -LC " + emulator + " -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
+				[]string{"/bin/bash", "-c", "ps -LC " + emulator + " -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			slice := strings.Split(strings.TrimSpace(psOutput), "\n")
@@ -107,7 +107,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			psOutput, err = exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
-				[]string{tests.BinBash, "-c", "grep 'locked memory' /proc/$(ps -C " + emulator + " -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
+				[]string{"/bin/bash", "-c", "grep 'locked memory' /proc/$(ps -C " + emulator + " -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			limits := strings.Split(strings.TrimSpace(psOutput), " ")
@@ -138,7 +138,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			psOutput, err := exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
-				[]string{tests.BinBash, "-c", "ps -LC " + emulator + " -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
+				[]string{"/bin/bash", "-c", "ps -LC " + emulator + " -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			slice := strings.Split(strings.TrimSpace(psOutput), "\n")
@@ -149,7 +149,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			psOutput, err = exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
-				[]string{tests.BinBash, "-c", "ps -TcC " + emulator + " |grep CPU |awk '{print $3\" \" $8}'"},
+				[]string{"/bin/bash", "-c", "ps -TcC " + emulator + " |grep CPU |awk '{print $3\" \" $8}'"},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			slice = strings.Split(strings.TrimSpace(psOutput), "\n")

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -839,12 +839,12 @@ var _ = SIGDescribe("Storage", func() {
 					diskPath = filepath.Join(mountDir, diskImgName)
 					srcDir := filepath.Join(tmpDir, "src")
 					cmd := "mkdir -p " + mountDir + " && mkdir -p " + srcDir + " && chcon -t container_file_t " + srcDir + " && mount --bind " + srcDir + " " + mountDir + " && while true; do sleep 1; done"
-					pod = libpod.RenderHostPathPod("host-path-preparator", tmpDir, k8sv1.HostPathDirectoryOrCreate, k8sv1.MountPropagationBidirectional, []string{tests.BinBash, "-c"}, []string{cmd})
+					pod = libpod.RenderHostPathPod("host-path-preparator", tmpDir, k8sv1.HostPathDirectoryOrCreate, k8sv1.MountPropagationBidirectional, []string{"/bin/bash", "-c"}, []string{cmd})
 					pod.Spec.Containers[0].Lifecycle = &k8sv1.Lifecycle{
 						PreStop: &k8sv1.LifecycleHandler{
 							Exec: &k8sv1.ExecAction{
 								Command: []string{
-									tests.BinBash, "-c",
+									"/bin/bash", "-c",
 									fmt.Sprintf("rm -f %s && umount %s", diskPath, mountDir),
 								},
 							},
@@ -860,7 +860,7 @@ var _ = SIGDescribe("Storage", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Determining the size of the mounted directory")
-					diskSizeStr, _, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, []string{tests.BinBash, "-c", fmt.Sprintf("df %s | tail -n 1 | awk '{print $4}'", mountDir)})
+					diskSizeStr, _, err := exec.ExecuteCommandOnPodWithResults(pod, pod.Spec.Containers[0].Name, []string{"/bin/bash", "-c", fmt.Sprintf("df %s | tail -n 1 | awk '{print $4}'", mountDir)})
 					Expect(err).ToNot(HaveOccurred())
 					diskSize, err = strconv.Atoi(strings.TrimSpace(diskSizeStr))
 					diskSize = diskSize * 1000 // byte to kilobyte

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -60,8 +60,6 @@ import (
 )
 
 const (
-	BinBash = "/bin/bash"
-
 	CustomHostPath     = "custom-host-path"
 	DiskAlpineHostPath = "disk-alpine-host-path"
 	DiskWindowsSysprep = "disk-windows-sysprep"

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -131,7 +131,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			podVirtioFsFileExist, err := exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
-				[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
+				[]string{"/bin/bash", "-c", virtioFsFileTestCmd},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
@@ -143,7 +143,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			podVirtioFsFileExist, err = exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
-				[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
+				[]string{"/bin/bash", "-c", virtioFsFileTestCmd},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
@@ -243,7 +243,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			podVirtioFsFileExist, err := exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
-				[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
+				[]string{"/bin/bash", "-c", virtioFsFileTestCmd},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
@@ -347,7 +347,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			podVirtioFsFileExist, err := exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
-				[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
+				[]string{"/bin/bash", "-c", virtioFsFileTestCmd},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -3434,7 +3434,7 @@ func getKvmPitMask(qemupid, nodeName string) (output string, err error) {
 
 	kvmpitpid := strings.TrimSpace(output)
 	tasksetcmd := "taskset -c -p " + kvmpitpid + " | cut -f2 -d:"
-	args = []string{tests.BinBash, "-c", tasksetcmd}
+	args = []string{"/bin/bash", "-c", tasksetcmd}
 	output, err = tests.ExecuteCommandInVirtHandlerPod(nodeName, args)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Follow up for https://github.com/kubevirt/kubevirt/pull/12612.

This Pull Request eliminates the `BinBash` const from test/utils so tests from other packages don't depend on it.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

