### PR TITLE
tests: Allow more matches when watching Linux console

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -224,10 +224,10 @@ func LinuxExpecter(vmi *v1.VirtualMachineInstance) error {
 	}
 	defer expecter.Close()
 
-	b := []expect.Batcher{
-		&expect.BExp{R: `\[    0.000000\] Linux version`},
-	}
-	res, err := expecter.ExpectBatch(b, time.Minute)
+	_, _, res, err := expecter.ExpectSwitchCase([]expect.Caser{
+		&expect.Case{R: regexp.MustCompile(`\[ {4}0.0{6}\] Linux version`)},
+		&expect.Case{R: regexp.MustCompile(`systemd\[1\]:`)},
+	}, time.Minute)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Failed to find Linux boot logs in: %+v", res)
 	}


### PR DESCRIPTION
The LinuxExpecter function watches the console for the beginning of the Linux boot (in order to ensure that keystrokes will not be sent to the firmware.  This is inherently racy because it's easy to miss the initial "Linux version" string if the expecter is not connected to the console quickly enough.  We can make it less racy by allowing other strings to match.  Switch to ExpectSwitchCase and add a regex for systemd messages which occur more frequently and throughout the boot process.

This does not completely eliminate the race but should help immensely.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: [sig-storage]VM state tests are flaky

After this PR: [sig-storage]VM state tests are less flaky


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

