### PR TITLE
bazel: disable progress output when running e2e test lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 export GO15VENDOREXPERIMENT := 1
 
+ifeq (${CI}, true)
+  # If we're running under a test lane, enable timestamps and disable progress output
+  TIMESTAMP=1
+  ifeq (,$(wildcard ci.bazelrc))
+    $(shell echo 'build --noshow_progress' > ci.bazelrc)
+  endif
+endif
+
 ifeq (${TIMESTAMP}, 1)
-  $(info "Timestamp is enabled")
   SHELL = ./hack/timestamps.sh
 endif
 

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -267,10 +267,11 @@ if [ "$CI" != "true" ]; then
   make cluster-down
 fi
 
-# Create .bazelrc to use remote cache
+# Create .bazelrc to use 4 jobs, remote cache and disable progress output
 cat >ci.bazelrc <<EOF
 build --jobs=4
 build --remote_download_toplevel
+build --noshow_progress
 EOF
 
 # Build and test images with a custom image name prefix

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -97,7 +97,7 @@ if [ "${target}" = "install" ]; then
         if [ -z "$BIN_NAME" ] || [[ $BIN_NAME == *"container-disk"* ]]; then
             mkdir -p ${CMD_OUT_DIR}/container-disk-v2alpha
             cd cmd/container-disk-v2alpha
-            # the containerdisk bianry needs to be static, as it runs in a scratch container
+            # The containerdisk binary needs to be static, as it runs in a scratch container
             echo "building static binary container-disk"
             gcc -static -o ${CMD_OUT_DIR}/container-disk-v2alpha/container-disk main.c
         fi

--- a/hack/check-unassigned-tests.sh
+++ b/hack/check-unassigned-tests.sh
@@ -2,8 +2,8 @@
 
 main() {
     skip="SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]|\\[sig-performance\\]|\\[sig-compute-realtime\\]|\\[sig-monitoring\\]"
-    result=$(FUNC_TEST_ARGS="--dry-run -skip=${skip}" make functest)
-    total_tests=$(echo "${result}" | grep "Ran[[:space:]].*of" | awk '{print $2}')
+    result=$(FUNC_TEST_ARGS="--dry-run --no-color -skip=${skip}" make functest)
+    total_tests=$(echo "${result}" | sed -n "s/.*Ran \([0-9]\+\) of .* Specs in .* seconds.*/\1/p")
     if [ "${total_tests}" != "0" ]; then
         echo "Found ${total_tests} tests not assigned to any SIG, please check: ${result}"
         exit 1


### PR DESCRIPTION
### What this PR does
Before this PR:
When building KubeVirt, lane logs have a lot of:
```
18:45:31: 18:45:31: [0 / 4] [Prepa] BazelWorkspaceStatusAction stable-status.txt
1774
18:45:33: 18:45:33: [14 / 21] ImageLayer cmd/pr-helper/version-container-layer.tar; 1s remote-cache, linux-sandbox
1775
18:45:35: 18:45:35: [14 / 21] ImageLayer cmd/pr-helper/version-container-layer.tar; 3s remote-cache, linux-sandbox
1776
18:45:36: 18:45:36: [16 / 21] GZIP cmd/pr-helper/version-container-layer.tar.gz; 0s remote-cache, linux-sandbox ... (3 actions, 2 running)
1777
18:45:38: 18:45:38: [18 / 21] GZIP cmd/pr-helper/version-container-layer.tar.gz; 2s remote-cache, linux-sandbox
1778
18:45:42: 18:45:42: [18 / 21] GZIP cmd/pr-helper/version-container-layer.tar.gz; 6s remote-cache, linux-sandbox
```

After this PR:
Progress should not be shown anymore, reducing garbage logs (double-timestamps addressed in separate PR)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

