### PR TITLE
volume migration: fix hotplug volumes when the volume migration fg is enabled

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -931,17 +931,13 @@ func (c *VMController) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi 
 	vmCopy := vm.DeepCopy()
 	volsVMI := storagetypes.GetVolumesByName(&vmi.Spec)
 	for i, volume := range vmCopy.Spec.Template.Spec.Volumes {
-		if volume.ContainerDisk == nil {
-			continue
-		}
 		vmiVol, ok := volsVMI[volume.Name]
 		if !ok {
 			continue
 		}
-		if vmiVol.ContainerDisk == nil {
-			continue
+		if vmiVol.ContainerDisk != nil {
+			vmCopy.Spec.Template.Spec.Volumes[i].ContainerDisk.ImagePullPolicy = vmiVol.ContainerDisk.ImagePullPolicy
 		}
-		vmCopy.Spec.Template.Spec.Volumes[i].ContainerDisk.ImagePullPolicy = vmiVol.ContainerDisk.ImagePullPolicy
 	}
 	if equality.Semantic.DeepEqual(vmi.Spec.Volumes, vmCopy.Spec.Template.Spec.Volumes) {
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Hotplug is broken when the Volume migration feature gate is enabled. The volume update due to the imperative hotplug are interpreted as a replacement of the volumes.

After this PR:
Hotplug properly works with the volume migration feature gate enabled

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12670

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

