### PR TITLE
cleanup(tests,vmi_vsock): Replace virtctl with netcat

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -202,7 +202,6 @@ go_test(
         "//tests/libregistry:go_default_library",
         "//tests/libreplicaset:go_default_library",
         "//tests/libsecret:go_default_library",
-        "//tests/libssh:go_default_library",
         "//tests/libstorage:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/libvmops:go_default_library",

--- a/tests/libssh/BUILD.bazel
+++ b/tests/libssh/BUILD.bazel
@@ -6,8 +6,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libssh",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//tests/clientcmd:go_default_library",
         "//tests/errorhandling:go_default_library",
         "//vendor/golang.org/x/crypto/ssh:go_default_library",
     ],

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -22,6 +22,7 @@ package tests_test
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -39,10 +40,7 @@ import (
 	"k8s.io/utils/pointer"
 	v1 "kubevirt.io/api/core/v1"
 
-	"kubevirt.io/kubevirt/tests/libssh"
-
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
@@ -177,13 +175,10 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		if flags.KubeVirtExampleGuestAgentPath == "" {
 			Skip("example guest agent path is not specified")
 		}
-		privateKeyPath, publicKey, err := libssh.GenerateKeyPair(GinkgoT().TempDir())
-		Expect(err).ToNot(HaveOccurred())
-		userData := libssh.RenderUserDataWithKey(publicKey)
+
 		vmi := libvmifact.NewFedora(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(userData)),
 		)
 		vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 		vmi = libvmops.RunVMIAndExpectLaunch(vmi, 60)
@@ -193,14 +188,11 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("copying the guest agent binary")
-		Expect(os.Setenv("SSH_AUTH_SOCK", "/dev/null")).To(Succeed())
-		Expect(libssh.SCPToVMI(vmi, privateKeyPath, flags.KubeVirtExampleGuestAgentPath, "/usr/bin/")).To(Succeed())
+		copyExampleGuestAgent(vmi)
 
 		By("starting the guest agent binary")
 		Expect(startExampleGuestAgent(vmi, useTLS, 1234)).To(Succeed())
 		time.Sleep(2 * time.Second)
-
-		virtClient := kubevirt.Client()
 
 		By("Connect to the guest via API")
 		cliConn, svrConn := net.Pipe()
@@ -211,7 +203,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 		stopChan := make(chan error)
 		go func() {
 			defer GinkgoRecover()
-			vsock, err := virtClient.VirtualMachineInstance(vmi.Namespace).VSOCK(vmi.Name, &v1.VSOCKOptions{TargetPort: uint32(1234), UseTLS: pointer.Bool(useTLS)})
+			vsock, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).VSOCK(vmi.Name, &v1.VSOCKOptions{TargetPort: uint32(1234), UseTLS: pointer.Bool(useTLS)})
 			if err != nil {
 				stopChan <- err
 				return
@@ -281,8 +273,34 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 	})
 })
 
-func startExampleGuestAgent(vmi *v1.VirtualMachineInstance, useTLS bool, port uint32) error {
+func copyExampleGuestAgent(vmi *v1.VirtualMachineInstance) {
+	const port = 4444
 
+	err := console.RunCommand(vmi, fmt.Sprintf("netcat-openbsd -vl %d > /usr/bin/example-guest-agent &", port), 60*time.Second)
+	Expect(err).ToNot(HaveOccurred())
+
+	file, err := os.Open(flags.KubeVirtExampleGuestAgentPath)
+	Expect(err).ToNot(HaveOccurred())
+	defer file.Close()
+
+	var stream kvcorev1.StreamInterface
+	Eventually(func() error {
+		stream, err = kubevirt.Client().VirtualMachineInstance(vmi.Namespace).PortForward(vmi.Name, port, "tcp")
+		return err
+	}, 60*time.Second, 1*time.Second).Should(Succeed())
+
+	conn := stream.AsConn()
+	_, err = io.Copy(conn, file)
+	Expect(err).ToNot(HaveOccurred())
+	err = conn.Close()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Wait for netcat to exit
+	err = console.RunCommand(vmi, "while sleep 3; lsof /usr/bin/example-guest-agent > /dev/null 2>&1; do true; done", 60*time.Second)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func startExampleGuestAgent(vmi *v1.VirtualMachineInstance, useTLS bool, port uint32) error {
 	serverArgs := fmt.Sprintf("--port %v", port)
 	if useTLS {
 		serverArgs = strings.Join([]string{serverArgs, "--use-tls"}, " ")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Replace virtctl with netcat in tests where the example-guest-agent
needs to be copied into the VMI used to test the VSOCK functionality.

While functionally equivalent, this allows to decouple the VSOCK tests from virtctl.

The goal of this and further PRs is to reduce the amount of unnecessary uses of
virtctl in the e2e tests to stabilize tests, to reduce the number of flakes and to
remove redudant tests.

Before this PR:

NewRepeatableVirtctlCommand is used.

After this PR:

netcat is used instead.

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

