### PR TITLE
[WIP] e2e, SR-IOV: PoC: Ignore warnings for defined amount of occurances

### DIFF
--- a/tests/libwait/wait.go
+++ b/tests/libwait/wait.go
@@ -121,6 +121,26 @@ func WithWarningsIgnoreList(warningIgnoreList []string) Option {
 	}
 }
 
+// WithWarningsTolerationPolicy sets warning events max occurrences policy.
+// Expects a map where keys are the warning events message and values are the event max occurrences.
+//
+// Given warning events will be ignored during the waiting-for-phase, when the event exceed the max occurrences
+// an error is raised.
+//
+// Given warning events should not overlap with the ignore-events-list configured by WithWarningsIgnoreList.
+//
+// This option will be ignored if a warning policy has been set before and the failOnWarnings is false
+// If no warning policy has been set before, a new one will be set implicitly with fail on warnings enabled and the ignore list added
+func WithWarningsTolerationPolicy(warningsMaxToleration map[string]int) Option {
+	return func(waiting *Waiting) {
+		if waiting.wp == nil {
+			waiting.wp = &watcher.WarningsPolicy{FailOnWarnings: true}
+		}
+
+		waiting.wp.WarningsMaxToleration = warningsMaxToleration
+	}
+}
+
 // WithWaitForFail adds the specific waitForFail to the waiting struct
 func WithWaitForFail(waitForFail bool) Option {
 	return func(waiting *Waiting) {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -686,7 +686,16 @@ func waitVMI(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 	// Kubevirt re-enqueue the request once it happens, so its safe to ignore this warning.
 	// see https://github.com/kubevirt/kubevirt/issues/5027
 	warningsIgnoreList := []string{"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
-	libwait.WaitUntilVMIReady(vmi, console.LoginToFedora, libwait.WithWarningsIgnoreList(warningsIgnoreList))
+
+	const timeoutWaitingForConditionMaxOccurrences = 2
+	warningMaxOccurrences := map[string]int{
+		"timed out waiting for condition": timeoutWaitingForConditionMaxOccurrences,
+	}
+
+	libwait.WaitUntilVMIReady(vmi, console.LoginToFedora,
+		libwait.WithWarningsIgnoreList(warningsIgnoreList),
+		libwait.WithWarningsTolerationPolicy(warningMaxOccurrences),
+	)
 
 	virtClient := kubevirt.Client()
 

--- a/tests/watcher/tracker.go
+++ b/tests/watcher/tracker.go
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package watcher
+
+import k8sv1 "k8s.io/api/core/v1"
+
+type EventsTracker struct {
+	eventOccurrences map[string]int
+}
+
+func NewEventsTracker(trackEvents []string) *EventsTracker {
+	eventOccurrences := make(map[string]int, len(trackEvents))
+	for _, event := range trackEvents {
+		eventOccurrences[event] = 0
+	}
+	return &EventsTracker{
+		eventOccurrences: eventOccurrences,
+	}
+}
+
+func (t EventsTracker) Record(event *k8sv1.Event) {
+	if event == nil {
+		return
+	}
+	t.eventOccurrences[event.Message]++
+}
+
+func (t EventsTracker) GetEventOccurrences(eventMessage string) int {
+	return t.eventOccurrences[eventMessage]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**WORK IN PROGRESS** 

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

https://github.com/kubevirt/kubevirt/issues/12691

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

