### PR TITLE
Coverage for instance type resource using linter mnd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,9 +41,6 @@ linters-settings:
       - '^ExpectWithOffset$'
       - '^console\.ExpectBatch$'
       - '^console\.RunCommand$'
-    ignored-files:
-      - 'pkg/instancetype/instancetype.go$'
-      - 'tests/instancetype/instancetype.go$'
   govet:
     enable:
       - shadow

--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -40,6 +40,7 @@ const (
 	InsufficientInstanceTypeMemoryResourcesErrorFmt = "insufficient Memory resources of %s provided by instance type, preference requires %s"
 	InsufficientVMMemoryResourcesErrorFmt           = "insufficient Memory resources of %s provided by VirtualMachine, preference requires %s"
 	NoVMCPUResourcesDefinedErrorFmt                 = "no CPU resources provided by VirtualMachine, preference requires %d vCPU"
+	logVerbosityLevel                               = 3
 )
 
 type Methods interface {
@@ -801,8 +802,7 @@ func (m *InstancetypeMethods) InferDefaultInstancetype(vm *virtv1.VirtualMachine
 	if err != nil {
 		var ignoreableInferenceErr *IgnoreableInferenceError
 		if errors.As(err, &ignoreableInferenceErr) && ignoreFailure {
-			//nolint:gomnd
-			log.Log.Object(vm).V(3).Info("Ignored error during inference of instancetype, clearing matcher.")
+			log.Log.Object(vm).V(logVerbosityLevel).Info("Ignored error during inference of instancetype, clearing matcher.")
 			vm.Spec.Instancetype = nil
 			return nil
 		}
@@ -837,8 +837,7 @@ func (m *InstancetypeMethods) InferDefaultPreference(vm *virtv1.VirtualMachine) 
 			*vm.Spec.Preference.InferFromVolumeFailurePolicy == virtv1.IgnoreInferFromVolumeFailure
 
 		if errors.As(err, &ignoreableInferenceErr) && ignoreFailure {
-			//nolint:gomnd
-			log.Log.Object(vm).V(3).Info("Ignored error during inference of preference, clearing matcher.")
+			log.Log.Object(vm).V(logVerbosityLevel).Info("Ignored error during inference of preference, clearing matcher.")
 			vm.Spec.Preference = nil
 			return nil
 		}

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -47,6 +47,7 @@ import (
 
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] Instancetype and Preferences", decorators.SigCompute, func() {
 	var virtClient kubecli.KubevirtClient
+	const timeout = 300 * time.Second
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -216,7 +217,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(timeout).WithPolling(time.Second).Should(matcher.BeReady())
 
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -231,7 +232,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 	Context("Instancetype and preference application", func() {
 		var vmi *virtv1.VirtualMachineInstance
-
+		const (
+			preferredTerminationGracePeriodSeconds = 15
+			expectedCausesLength                   = 3
+		)
 		BeforeEach(func() {
 			vmi = libvmifact.NewGuestless()
 		})
@@ -259,7 +263,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(timeout).WithPolling(time.Second).Should(matcher.BeReady())
 
 			_, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vm)).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -295,7 +299,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			preference.Spec.Firmware = &instancetypev1beta1.FirmwarePreferences{
 				PreferredUseBios: pointer.P(true),
 			}
-			preference.Spec.PreferredTerminationGracePeriodSeconds = pointer.P(int64(15))
+			preference.Spec.PreferredTerminationGracePeriodSeconds = pointer.P(int64(preferredTerminationGracePeriodSeconds))
 			preference.Spec.PreferredSubdomain = pointer.P("non-existent-subdomain")
 			preference.Spec.Annotations = map[string]string{
 				"preferred-annotation-1": "1",
@@ -318,7 +322,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(timeout).WithPolling(time.Second).Should(matcher.BeReady())
 
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -373,7 +377,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(timeout).WithPolling(time.Second).Should(matcher.BeReady())
 
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -399,7 +403,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 			var apiStatus errors.APIStatus
 			Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
-			Expect(apiStatus.Status().Details.Causes).To(HaveLen(3))
+			Expect(apiStatus.Status().Details.Causes).To(HaveLen(expectedCausesLength))
 
 			cause0 := apiStatus.Status().Details.Causes[0]
 			Expect(cause0.Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
@@ -478,7 +482,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(timeout).WithPolling(time.Second).Should(matcher.BeReady())
 
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -504,7 +508,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(timeout).WithPolling(time.Second).Should(matcher.BeReady())
 
 			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -547,7 +551,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(vm.Spec.Instancetype.RevisionName).ToNot(BeEmpty())
 				g.Expect(vm.Spec.Preference.RevisionName).ToNot(BeEmpty())
-			}, 300*time.Second, 1*time.Second).Should(Succeed())
+			}, timeout, 1*time.Second).Should(Succeed())
 
 			By("Checking that ControllerRevisions have been created for the VirtualMachineInstancetype and VirtualMachinePreference")
 			instancetypeRevision, err := virtClient.AppsV1().ControllerRevisions(testsuite.GetTestNamespace(vm)).Get(context.Background(), vm.Spec.Instancetype.RevisionName, metav1.GetOptions{})
@@ -709,8 +713,9 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		)
 
 		const (
-			inferFromVolumeName    = "volume"
-			dataVolumeTemplateName = "datatemplate"
+			inferFromVolumeName     = "volume"
+			dataVolumeTemplateName  = "datatemplate"
+			dvSuccessTimeoutSeconds = 180
 		)
 
 		createAndValidateVirtualMachine := func() {
@@ -730,7 +735,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(vm.Spec.Preference.InferFromVolume).To(BeEmpty())
 			Expect(vm.Spec.Preference.InferFromVolumeFailurePolicy).To(BeNil())
 
-			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(timeout).WithPolling(time.Second).Should(matcher.BeReady())
 
 			By("Validating the VirtualMachineInstance")
 			var vmi *virtv1.VirtualMachineInstance
@@ -797,7 +802,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			}
 			sourceDV, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), sourceDV, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libstorage.EventuallyDV(sourceDV, 180, matcher.HaveSucceeded())
+			libstorage.EventuallyDV(sourceDV, dvSuccessTimeoutSeconds, matcher.HaveSucceeded())
 
 			// This is the default but it should still be cleared
 			failurePolicy := virtv1.RejectInferFromVolumeFailure
@@ -922,7 +927,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					)
 					blankDV, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), blankDV, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					libstorage.EventuallyDV(sourceDV, 180, matcher.HaveSucceeded())
+					libstorage.EventuallyDV(sourceDV, dvSuccessTimeoutSeconds, matcher.HaveSucceeded())
 
 					By("Creating a DataSource")
 					// TODO - Replace with libds?
@@ -1415,6 +1420,19 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	})
 
 	Context("VirtualMachine using preference resource requirements", func() {
+		var (
+			guestMemory2GB = resource.MustParse("2Gi")
+			guestMemory1GB = resource.MustParse("1Gi")
+		)
+		const (
+			providedvCPUs    = 2
+			requiredNumvCPUs = 2
+			requiredvCPUs    = 4
+			providedCores    = 2
+			providedSockets  = 2
+			providedThreads  = 2
+		)
+
 		DescribeTable("should be accepted when", func(instancetype *instancetypev1beta1.VirtualMachineInstancetype, preference *instancetypev1beta1.VirtualMachinePreference, vm *virtv1.VirtualMachine) {
 			var err error
 			if instancetype != nil {
@@ -1437,7 +1455,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
 						CPU: instancetypev1beta1.CPUInstancetype{
-							Guest: uint32(2),
+							Guest: uint32(providedvCPUs),
 						},
 					},
 				},
@@ -1448,7 +1466,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(2),
+								Guest: uint32(providedvCPUs),
 							},
 						},
 					},
@@ -1525,7 +1543,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(2),
+								Guest: uint32(requiredNumvCPUs),
 							},
 						},
 					},
@@ -1545,7 +1563,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 									CPU: &virtv1.CPU{
 										Cores:   uint32(1),
 										Threads: uint32(1),
-										Sockets: uint32(2),
+										Sockets: uint32(providedSockets),
 									},
 								},
 							},
@@ -1565,7 +1583,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(2),
+								Guest: uint32(providedvCPUs),
 							},
 						},
 					},
@@ -1583,7 +1601,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Spec: virtv1.VirtualMachineInstanceSpec{
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
-										Cores:   uint32(2),
+										Cores:   uint32(providedCores),
 										Threads: uint32(1),
 										Sockets: uint32(1),
 									},
@@ -1636,7 +1654,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(2),
+								Guest: uint32(providedvCPUs),
 							},
 						},
 					},
@@ -1655,7 +1673,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(1),
-										Threads: uint32(2),
+										Threads: uint32(providedThreads),
 										Sockets: uint32(1),
 									},
 								},
@@ -1676,7 +1694,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(4),
+								Guest: uint32(requiredvCPUs),
 							},
 						},
 					},
@@ -1694,9 +1712,9 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Spec: virtv1.VirtualMachineInstanceSpec{
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
-										Cores:   uint32(2),
+										Cores:   uint32(providedCores),
 										Threads: uint32(1),
-										Sockets: uint32(2),
+										Sockets: uint32(providedSockets),
 									},
 								},
 							},
@@ -1731,7 +1749,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Spec: virtv1.VirtualMachineInstanceSpec{
 								Domain: virtv1.DomainSpec{
 									Memory: &virtv1.Memory{
-										Guest: resource.NewQuantity(2*1024*1024*1024, resource.BinarySI),
+										Guest: &guestMemory2GB,
 									},
 								},
 							},
@@ -1776,7 +1794,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(2),
+								Guest: uint32(providedvCPUs),
 							},
 						},
 					},
@@ -1855,7 +1873,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(2),
+								Guest: uint32(providedvCPUs),
 							},
 						},
 					},
@@ -1896,7 +1914,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(2),
+								Guest: uint32(providedvCPUs),
 							},
 						},
 					},
@@ -1937,7 +1955,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(2),
+								Guest: uint32(providedvCPUs),
 							},
 						},
 					},
@@ -1978,7 +1996,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
-								Guest: uint32(4),
+								Guest: uint32(requiredvCPUs),
 							},
 						},
 					},
@@ -1996,7 +2014,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Spec: virtv1.VirtualMachineInstanceSpec{
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
-										Cores:   uint32(2),
+										Cores:   uint32(providedCores),
 										Threads: uint32(1),
 										Sockets: uint32(1),
 									},
@@ -2034,7 +2052,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Spec: virtv1.VirtualMachineInstanceSpec{
 								Domain: virtv1.DomainSpec{
 									Memory: &virtv1.Memory{
-										Guest: resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+										Guest: &guestMemory1GB,
 									},
 								},
 							},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
there was a need to exclude some instancetype source files for the 'mnd' linter.
After this PR:
Remove the instancetype source files from the 'mnd' ignored files by solving the errors they produce.
<!-- (optional, in `fixes #<issue number>(, fixes #12662 , ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12662 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- https://github.com/kubevirt/kubevirt/issues/12662 -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

