### PR TITLE
net: Decouple DHCP server from converter pkg

### DIFF
--- a/pkg/network/dns/BUILD.bazel
+++ b/pkg/network/dns/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["resolveconf.go"],
     importpath = "kubevirt.io/kubevirt/pkg/network/dns",
     visibility = ["//visibility:public"],
+    deps = ["//staging/src/kubevirt.io/client-go/log:go_default_library"],
 )
 
 go_test(

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/network/dhcp/server:go_default_library",
         "//pkg/network/dhcp/serverv6:go_default_library",
         "//pkg/network/dns:go_default_library",
-        "//pkg/virt-launcher/virtwrap/converter:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
-
 	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -162,7 +160,7 @@ func (h *NetworkUtilsHandler) ReadIPAddressesFromLink(interfaceName string) (str
 
 func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
 	log.Log.V(4).Infof("StartDHCP network Nic: %+v", nic)
-	nameservers, searchDomains, err := converter.GetResolvConfDetailsFromPod()
+	nameservers, searchDomains, err := dns.GetResolvConfDetailsFromPod()
 	if err != nil {
 		return fmt.Errorf("Failed to get DNS servers from resolv.conf: %v", err)
 	}

--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/ignition:go_default_library",
-        "//pkg/network/dns:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/reservation:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -72,10 +72,7 @@ import (
 const deviceTypeNotCompatibleFmt = "device %s is of type lun. Not compatible with a file based disk"
 
 // The location of uefi boot loader on ARM64 is different from that on x86
-const (
-	defaultIOThread = uint(1)
-	resolvConf      = "/etc/resolv.conf"
-)
+const defaultIOThread = uint(1)
 
 const (
 	multiQueueMaxQueues  = uint32(256)

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -20,17 +20,13 @@
 package converter
 
 import (
-	"bytes"
 	"fmt"
-	"os"
-	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
 
-	"kubevirt.io/kubevirt/pkg/network/dns"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
@@ -149,30 +145,6 @@ func NetworkQueuesCapacity(vmi *v1.VirtualMachineInstance) uint32 {
 
 func isTrue(networkInterfaceMultiQueue *bool) bool {
 	return (networkInterfaceMultiQueue != nil) && (*networkInterfaceMultiQueue)
-}
-
-// returns nameservers [][]byte, searchdomains []string, error
-func GetResolvConfDetailsFromPod() ([][]byte, []string, error) {
-	// #nosec No risk for path injection. resolvConf is static "/etc/resolve.conf"
-	b, err := os.ReadFile(resolvConf)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	nameservers, err := dns.ParseNameservers(string(b))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	searchDomains, err := dns.ParseSearchDomains(string(b))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	log.Log.Reason(err).Infof("Found nameservers in %s: %s", resolvConf, bytes.Join(nameservers, []byte{' '}))
-	log.Log.Reason(err).Infof("Found search domains in %s: %s", resolvConf, strings.Join(searchDomains, " "))
-
-	return nameservers, searchDomains, err
 }
 
 func translateModel(useVirtioTransitional *bool, bus string, archString string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The GetResolvConfDetailsFromPod function reads and parses `/etc/resolv.conf` - the DNS resolver's configuration file.

Move it from `pkg/virt-launcher/virtwrap/converter` to the `pkg/network/dns` package - under SIG network's ownership.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

