### PR TITLE
docs: Small Spelling Fixes

### DIFF
--- a/docs/container-register-disks.md
+++ b/docs/container-register-disks.md
@@ -45,7 +45,7 @@ else a user might want to distribute with their VMIs.
 
 ### High Level Design
 
-**Standardised KubeVirt VMI disk Wrapper**
+**Standardized KubeVirt VMI disk Wrapper**
 
 KubeVirt provides a standardized base wrapper container image that serves up a
 user provided VMI disk as a local file consumable by Libvirt. This base

--- a/docs/discard-passthrough.md
+++ b/docs/discard-passthrough.md
@@ -12,7 +12,7 @@ vda         512      512B       2G         0
 └─vda1        0      512B       2G         0
 ```
 
-However, in certain cases like preallocaton or when the disk is thick provisioned, the option needs to be disabled. The disk's PVC has to be marked with an annotation that contains `/storage.preallocation` or `/storage.thick-provisioned`, and set to true. If the volume is preprovisioned using [CDI](https://github.com/kubevirt/containerized-data-importer) and the [preallocation](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/preallocation.md) is enabled, then the PVC is automatically annotated with: `cdi.kubevirt.io/storage.preallocation: true` and the discard passthrough option is disabled.
+However, in certain cases like preallocation or when the disk is thick provisioned, the option needs to be disabled. The disk's PVC has to be marked with an annotation that contains `/storage.preallocation` or `/storage.thick-provisioned`, and set to true. If the volume is preprovisioned using [CDI](https://github.com/kubevirt/containerized-data-importer) and the [preallocation](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/preallocation.md) is enabled, then the PVC is automatically annotated with: `cdi.kubevirt.io/storage.preallocation: true` and the discard passthrough option is disabled.
 
 Example of a PVC definition with the annotation to disable discard passthrough:
 ```yaml

--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -37,7 +37,7 @@ would lead to a terrible 41.81% passing rate of the whole suite (0.95 ** 17 = 0.
 
 In order to remove as much as possible the influence of changes in PRs to
 determine the stability of the suite, we will take into account only results
-from the periodics that run e2e tests from main (hese jobs can be checked
+from the periodics that run e2e tests from main (hence jobs can be checked
 [on testgrid]) and presubmits that are executed on merged code (on tide merge
 batches as reported by flakefinder).
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -229,7 +229,7 @@ cause delays.  So releases that overlap with holidays may be delayed.
 
 ### Release procedure
 
-If the release is stable, the release readiness conditions are met, and all holidas are over, then it is finally time to make a release generally available.
+If the release is stable, the release readiness conditions are met, and all holidays are over, then it is finally time to make a release generally available.
 
 The procedure for making a release generally available is described in [release-procedure.md](release-procedure.md).
 
@@ -250,7 +250,7 @@ The maintenance phase of a KubeVirt release is tied to the [support period](http
 
 ### Bug fixes
 
-During the maintenance phase contributors can backport fixes to a stable branch accoiring to the KubeVirt [backport policy](release-branch-backporting.md).
+During the maintenance phase contributors can backport fixes to a stable branch according to the KubeVirt [backport policy](release-branch-backporting.md).
 
 ### Patch releases
 


### PR DESCRIPTION
### What this PR does

Before this PR:
- a few small spelling issues within docs

After this PR:
- less spelling issues within docs

Fixes #
- N/A

### Why we need it and why it was done in this way
The following tradeoffs were made:
- N/A

The following alternatives were considered:
- leaving the spelling issues as is

Links to places where the discussion took place: N/A

### Special notes for your reviewer
- Hi there, this project is incredible :smile: !  I was just looking through the docs and caught a few spelling issues that I wanted to fix.  I'm super willing to iterate and do anything necessary to help get this PR merged in :smile:. 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

