### PR TITLE
vm state tests: get rid of custom console expecter

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -213,28 +213,6 @@ func NetBootExpecter(vmi *v1.VirtualMachineInstance) error {
 	return err
 }
 
-// LinuxExpecter should be called early in the VMI boot process.
-// It will catch the first logs printed by the Linux kernel.
-// If this function succeeds, the VMI is guaranteed to be post-firmware (BIOS/EFI).
-func LinuxExpecter(vmi *v1.VirtualMachineInstance) error {
-	virtClient := kubevirt.Client()
-	expecter, _, err := NewExpecter(virtClient, vmi, consoleConnectionTimeout)
-	if err != nil {
-		return err
-	}
-	defer expecter.Close()
-
-	_, _, res, err := expecter.ExpectSwitchCase([]expect.Caser{
-		&expect.Case{R: regexp.MustCompile(`\[ {4}0.0{6}\] Linux version`)},
-		&expect.Case{R: regexp.MustCompile(`systemd\[1\]:`)},
-	}, time.Minute)
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Failed to find Linux boot logs in: %+v", res)
-	}
-
-	return err
-}
-
 // NewExpecter will connect to an already logged in VMI console and return the generated expecter it will wait `timeout` for the connection.
 func NewExpecter(
 	virtCli kubecli.KubevirtClient,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is not really needed as we could just ensure we're past boot via the guest agent condition.
This expecter has proven to be racy as well.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
