### PR TITLE
tests: remove use of spec.Running from e2e tests

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -688,7 +688,6 @@ var _ = Describe("[Serial]VirtualMachineClone Tests", Serial, func() {
 							),
 						)
 						sourceVM = libstorage.RenderVMWithDataVolumeTemplate(dv)
-						sourceVM.Spec.Running = nil
 						sourceVM.Spec.Template.Spec.Domain.Resources = virtv1.ResourceRequirements{}
 						sourceVM.Spec.Instancetype = &virtv1.InstancetypeMatcher{
 							Name: instancetype.Name,

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -1458,7 +1458,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Instancetype: &virtv1.InstancetypeMatcher{
 							Kind: "VirtualMachineInstancetype",
 						},
@@ -1501,7 +1501,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Instancetype: &virtv1.InstancetypeMatcher{
 							Kind: "VirtualMachineInstancetype",
 						},
@@ -1535,7 +1535,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1575,7 +1575,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1612,7 +1612,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1646,7 +1646,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1686,7 +1686,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1723,7 +1723,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1786,7 +1786,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Instancetype: &virtv1.InstancetypeMatcher{
 							Kind: "VirtualMachineInstancetype",
 						},
@@ -1830,7 +1830,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Instancetype: &virtv1.InstancetypeMatcher{
 							Kind: "VirtualMachineInstancetype",
 						},
@@ -1865,7 +1865,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1906,7 +1906,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1947,7 +1947,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -1988,7 +1988,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},
@@ -2026,7 +2026,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "vm-",
 					},
 					Spec: virtv1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 						Preference: &virtv1.PreferenceMatcher{
 							Kind: "VirtualMachinePreference",
 						},

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1373,7 +1373,7 @@ spec:
 					}
 					updatedVM, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Get(context.Background(), vmYaml.vmName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return updatedVM.Spec.Running == nil && updatedVM.Spec.RunStrategy != nil && *updatedVM.Spec.RunStrategy == runStrategyHalted
+					return updatedVM.Spec.RunStrategy != nil && *updatedVM.Spec.RunStrategy == runStrategyHalted
 				}, 30*time.Second, 3*time.Second).Should(BeTrue())
 
 				By(fmt.Sprintf("Ensure vm %s can be restored from vmsnapshots", vmYaml.vmName))

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -315,7 +315,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			})
 
 			It("should successfully restore", func() {
-				vm.Spec.Running = nil
 				vm.Spec.RunStrategy = &runStrategyHalted
 				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1306,10 +1306,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 		It("vmsnapshot should update error if vmsnapshotcontent is unready to use and error", func() {
 			vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, snapshotStorageClass)
-			runStrategyAlways := v1.RunStrategyAlways
-			vm.Spec.RunStrategy = &runStrategyAlways
-			vm.Spec.Running = nil
-
+			vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -202,7 +202,6 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 			It("[test_id:3174]Should not restart when VM is not running", func() {
 				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm.Spec.RunStrategy = &manual
-				vm.Spec.Running = nil
 
 				By("Creating VM")
 				vm, err := virtCli.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
@@ -216,7 +215,6 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 			It("[test_id:3175]Should restart when VM is running", func() {
 				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm.Spec.RunStrategy = &manual
-				vm.Spec.Running = nil
 
 				By("Creating VM")
 				vm, err := virtCli.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
@@ -256,7 +254,6 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 			It("[test_id:3176]Should restart the VM", func() {
 				vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless())
 				vm.Spec.RunStrategy = &restartOnError
-				vm.Spec.Running = nil
 
 				By("Creating VM")
 				vm, err := virtCli.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -57,7 +57,6 @@ var _ = Describe("[sig-compute][virtctl]create vm", func() {
 			Expect(vm.Name).ToNot(BeEmpty())
 			Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).ToNot(BeNil())
 			Expect(*vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(int64(180)))
-			Expect(vm.Spec.Running).To(BeNil())
 			Expect(vm.Spec.RunStrategy).ToNot(BeNil())
 			Expect(*vm.Spec.RunStrategy).To(Equal(v1.RunStrategyAlways))
 			Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
@@ -182,7 +181,6 @@ var _ = Describe("[sig-compute][virtctl]create vm", func() {
 
 			Expect(vm.Name).To(Equal(vmName))
 
-			Expect(vm.Spec.Running).To(BeNil())
 			Expect(vm.Spec.RunStrategy).ToNot(BeNil())
 			Expect(*vm.Spec.RunStrategy).To(Equal(runStrategy))
 
@@ -293,7 +291,6 @@ var _ = Describe("[sig-compute][virtctl]create vm", func() {
 
 			Expect(vm.Name).To(Equal(vmName))
 
-			Expect(vm.Spec.Running).To(BeNil())
 			Expect(vm.Spec.RunStrategy).ToNot(BeNil())
 			Expect(*vm.Spec.RunStrategy).To(Equal(runStrategy))
 
@@ -430,7 +427,6 @@ var _ = Describe("[sig-compute][virtctl]create vm", func() {
 
 		Expect(vm.Name).To(Equal(vmName))
 
-		Expect(vm.Spec.Running).To(BeNil())
 		Expect(vm.Spec.RunStrategy).ToNot(BeNil())
 		Expect(*vm.Spec.RunStrategy).To(Equal(runStrategy))
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -214,7 +214,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			))
-			vm.Spec.Running = nil
 			vm.Spec.RunStrategy = &runStrategy
 
 			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
@@ -1316,7 +1315,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 					By("Creating a VM with RunStrategyManual")
 					vm := libvmi.NewVirtualMachine(vmi)
-					vm.Spec.Running = nil
 					vm.Spec.RunStrategy = &runStrategyManual
 
 					By("Annotate the VM with regard for leaving launcher pod after qemu exit")
@@ -1618,7 +1616,6 @@ status:
 				By("Checking VM Running spec does not change")
 				actualVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(actualVM.Spec.Running).To(BeEquivalentTo(originalVM.Spec.Running))
 				actualRunStrategy, err := actualVM.RunStrategy()
 				Expect(err).ToNot(HaveOccurred())
 				originalRunStrategy, err := originalVM.RunStrategy()

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -229,11 +229,10 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					fedoraPassword,
 				)
 				vmi := libvmifact.NewFedora(libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveUserData(userData)))
-				// runStrategy := v1.RunStrategyManual
 				vm := &v1.VirtualMachine{
 					ObjectMeta: vmi.ObjectMeta,
 					Spec: v1.VirtualMachineSpec{
-						Running: pointer.P(false),
+						RunStrategy: pointer.P(v1.RunStrategyManual),
 						Template: &v1.VirtualMachineInstanceTemplateSpec{
 							Spec: vmi.Spec,
 						},


### PR DESCRIPTION
### What this PR does
Deprecate the use of spec.Running and use spec.RunStrategy instead.

Before this PR: using spec.Running in e2e tests

After this PR: using spec.RunStrategy in e2e tests

Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-45444
relates to issue: #11993

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

