### PR TITLE
Update kubevirt_rest_client_request_latency_seconds to count list cal…

### DIFF
--- a/pkg/monitoring/metrics/common/client/client_test.go
+++ b/pkg/monitoring/metrics/common/client/client_test.go
@@ -35,12 +35,13 @@ var _ = BeforeSuite(func() {
 
 var _ = Describe("URL Parsing", func() {
 	Context("with resource and operation", func() {
-		DescribeTable("accurately parse resource and operation", func(urlStr, method, expectedResource, expectedOperation string) {
+		DescribeTable("accurately parse resource and operation", func(urlStr, queryStr, method, expectedResource, expectedOperation string) {
 
 			request := &http.Request{
 				Method: method,
 				URL: &url.URL{
-					Path: urlStr,
+					Path:     urlStr,
+					RawQuery: queryStr,
 				},
 			}
 
@@ -49,24 +50,26 @@ var _ = Describe("URL Parsing", func() {
 			Expect(operation).To(Equal(expectedOperation))
 
 		},
-			Entry("should handle an empty URL and method", "", "", "", ""),
-			Entry("should handle an empty URL", "", "GET", "", ""),
-			Entry("should handle an empty Method", "/api/v1/watch/namespaces/kubevirt/pods", "", "", ""),
-			Entry("should handle watching namespaced resource", "/api/v1/watch/namespaces/kubevirt/pods", "GET", "pods", "WATCH"),
-			Entry("should handle watching globally scoped resource", "/api/v1/watch/pods", "GET", "pods", "WATCH"),
-			Entry("should handle list of namespaced resources", "/api/v1/namespaces/kubevirt/pods", "GET", "pods", "LIST"),
-			Entry("should handle get of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "GET", "pods", "GET"),
-			Entry("should handle list of custom namespaced resources", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances", "GET", "virtualmachineinstances", "LIST"),
-			Entry("should handle get of custom namespaced resources", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi", "GET", "virtualmachineinstances", "GET"),
-			Entry("should handle list of custom globally scoped resources", "/apis/kubevirt.io/v1/kubevirts", "GET", "kubevirts", "LIST"),
-			Entry("should handle get of custom globally scoped resources", "/apis/kubevirt.io/v1/kubevirts/my-kv", "GET", "kubevirts", "GET"),
-			Entry("should handle UPDATE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "PUT", "pods", "UPDATE"),
-			Entry("should handle PATCH of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "PATCH", "pods", "PATCH"),
-			Entry("should handle CREATE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "POST", "pods", "CREATE"),
-			Entry("should handle DELETE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "DELETE", "pods", "DELETE"),
-			Entry("should handle UPDATE to status subresource", "/api/v1/namespaces/kubevirt/pods/my-pod/status", "PUT", "pods", "UPDATE"),
-			Entry("should handle UPDATE to custom subresource", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi/some-subresource", "PUT", "virtualmachineinstances", "UPDATE"),
+			Entry("should handle an empty URL and method", "", "", " ", "none", "none"),
+			Entry("should handle an empty URL", "", "", "GET", "none", "none"),
+			Entry("should handle an empty Method", "/api/v1/watch/namespaces/kubevirt/pods", "", "", "none", "none"),
+			Entry("should handle watching namespaced resource", "/api/v1/watch/namespaces/kubevirt/pods", "", "GET", "pods", "WATCH"),
+			Entry("should handle watching globally scoped resource", "/api/v1/watch/pods", "", "GET", "pods", "WATCH"),
+			Entry("should handle list of namespaced resources", "/api/v1/namespaces/kubevirt/pods", "", "GET", "pods", "LIST"),
+			Entry("should handle list of namespaced resources with a fieldSelector as a query", "/api/v1/namespaces/kubevirt/pods", "fieldSelector=value", "GET", "pods", "LIST"),
+			Entry("should handle list of namespaced resources with watch query", "/api/v1/namespaces/kubevirt/pods", "fieldSelector=value&watch=true", "GET", "pods", "WATCH"),
+			Entry("should handle get of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "GET", "pods", "GET"),
+			Entry("should handle get of namespaced resources with a query", "/api/v1/namespaces/kubevirt/pods/my-pod", "label=value", "GET", "pods", "GET"),
+			Entry("should handle list of custom namespaced resources", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances", "", "GET", "virtualmachineinstances", "LIST"),
+			Entry("should handle get of custom namespaced resources", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi", "", "GET", "virtualmachineinstances", "GET"),
+			Entry("should handle list of custom globally scoped resources", "/apis/kubevirt.io/v1/kubevirts", "", "GET", "kubevirts", "LIST"),
+			Entry("should handle get of custom globally scoped resources", "/apis/kubevirt.io/v1/kubevirts/my-kv", "", "GET", "kubevirts", "GET"),
+			Entry("should handle UPDATE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "PUT", "pods", "UPDATE"),
+			Entry("should handle PATCH of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "PATCH", "pods", "PATCH"),
+			Entry("should handle CREATE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "POST", "pods", "CREATE"),
+			Entry("should handle DELETE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "", "DELETE", "pods", "DELETE"),
+			Entry("should handle UPDATE to status subresource", "/api/v1/namespaces/kubevirt/pods/my-pod/status", "", "PUT", "pods", "UPDATE"),
+			Entry("should handle UPDATE to custom subresource", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi/some-subresource", "", "PUT", "virtualmachineinstances", "UPDATE"),
 		)
 	})
-
 })

--- a/pkg/monitoring/metrics/common/client/latency_adapter.go
+++ b/pkg/monitoring/metrics/common/client/latency_adapter.go
@@ -31,5 +31,5 @@ type latencyAdapter struct {
 }
 
 func (l *latencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
-	l.m.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
+	l.m.WithLabelValues(getVerbFromHTTPVerb(u, verb), u.String()).Observe(latency.Seconds())
 }


### PR DESCRIPTION
### What this PR does
Currently, when a list call is made using field-selector or label-selector those calls are inaccurately counted as get calls. This MR will solve this issue.


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Update kubevirt_rest_client_request_latency_seconds to count list calls if made using query params
```

