### PR TITLE
cleanup(tests): Move VM subresource tests without run strategy and drop redundant tests

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -41,7 +41,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -755,42 +754,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 
 		Context("Using virtctl interface", func() {
-			It("[test_id:1529]should start a VirtualMachineInstance once", func() {
-				By("getting a VM")
-				vm := createVM(virtClient, libvmifact.NewCirros())
-
-				By("Invoking virtctl start")
-				startCommand := clientcmd.NewRepeatableVirtctlCommand(virtctl.COMMAND_START, "--namespace", vm.Namespace, vm.Name)
-				Expect(startCommand()).To(Succeed())
-
-				By("Getting the status of the VM")
-				Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(BeReady())
-
-				By("Getting the running VirtualMachineInstance")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 240*time.Second, 1*time.Second).Should(BeRunning())
-
-				By("Ensuring a second invocation should fail")
-				Expect(startCommand()).To(MatchError(fmt.Sprintf(`Error starting VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "%s": VM is already running`, vm.Name)))
-			})
-
-			It("[test_id:1530]should stop a VirtualMachineInstance once", func() {
-				By("getting a VM")
-				vm := libvmops.StartVirtualMachine(createVM(virtClient, libvmifact.NewCirros()))
-
-				By("Invoking virtctl stop")
-				stopCommand := clientcmd.NewRepeatableVirtctlCommand(virtctl.COMMAND_STOP, "--namespace", vm.Namespace, vm.Name)
-				Expect(stopCommand()).To(Succeed())
-
-				By("Ensuring VM is not running")
-				Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(And(Not(BeCreated()), Not(BeReady())))
-
-				By("Ensuring the VirtualMachineInstance is removed")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 240*time.Second, 1*time.Second).ShouldNot(Exist())
-
-				By("Ensuring a second invocation should fail")
-				Expect(stopCommand()).To(MatchError(fmt.Sprintf(`error stopping VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "%s": VM is not running`, vm.Name)))
-			})
-
 			It("[test_id:6310]should start a VirtualMachineInstance in paused state", func() {
 				By("getting a VM")
 				vm := createVM(virtClient, libvmifact.NewCirros())
@@ -810,85 +773,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Eventually(ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(HaveConditionTrue(v1.VirtualMachineInstancePaused))
 					return vmi.Status.Phase == v1.Running
 				}, 240*time.Second, 1*time.Second).Should(BeTrue())
-			})
-
-			It("[test_id:3007][QUARANTINE] Should force restart a VM with terminationGracePeriodSeconds>0", decorators.Quarantine, func() {
-				By("getting a VM with high TerminationGracePeriod")
-				vm := libvmops.StartVirtualMachine(createVM(virtClient, libvmifact.NewFedora(
-					libvmi.WithTerminationGracePeriod(600),
-				)))
-
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Invoking virtctl --force restart")
-				forceRestart := clientcmd.NewRepeatableVirtctlCommand(virtctl.COMMAND_RESTART, "--namespace", vm.Namespace, "--force", vm.Name, "--grace-period=0")
-				Expect(forceRestart()).To(Succeed())
-
-				zeroGracePeriod := int64(0)
-				// Checks if the old VMI Pod still exists after force-restart command
-				Eventually(func() string {
-					pod, err := libpod.GetRunningPodByLabel(string(vmi.UID), v1.CreatedByLabel, vm.Namespace, "")
-					if err != nil {
-						return err.Error()
-					}
-					if pod.GetDeletionGracePeriodSeconds() == &zeroGracePeriod && pod.GetDeletionTimestamp() != nil {
-						return "old VMI Pod still not deleted"
-					}
-					return ""
-				}, 120*time.Second, 1*time.Second).Should(ContainSubstring("failed to find pod"))
-
-				Eventually(ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(BeRestarted(vmi.UID))
-
-				By("Comparing the new UID and CreationTimeStamp with the old one")
-				newVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(newVMI.CreationTimestamp).ToNot(Equal(vmi.CreationTimestamp))
-				Expect(newVMI.UID).ToNot(Equal(vmi.UID))
-			})
-
-			It("Should force stop a VMI", func() {
-				By("getting a VM with high TerminationGracePeriod")
-				vm := libvmops.StartVirtualMachine(createVM(virtClient, libvmi.New(
-					libvmi.WithResourceMemory("128Mi"),
-					libvmi.WithTerminationGracePeriod(1600),
-				)))
-
-				By("setting up a watch for vmi")
-				lw, err := virtClient.VirtualMachineInstance(vm.Namespace).Watch(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				terminationGracePeriodUpdated := func(stopCn <-chan bool, eventsCn <-chan watch.Event, updated chan<- bool) {
-					for {
-						select {
-						case <-stopCn:
-							return
-						case e := <-eventsCn:
-							vmi, ok := e.Object.(*v1.VirtualMachineInstance)
-							Expect(ok).To(BeTrue())
-							if vmi.Name != vm.Name {
-								continue
-							}
-
-							if *vmi.Spec.TerminationGracePeriodSeconds == 0 {
-								updated <- true
-							}
-						}
-					}
-				}
-				stopCn := make(chan bool, 1)
-				updated := make(chan bool, 1)
-				go terminationGracePeriodUpdated(stopCn, lw.ResultChan(), updated)
-
-				By("Invoking virtctl --force stop")
-				forceStop := clientcmd.NewRepeatableVirtctlCommand(virtctl.COMMAND_STOP, vm.Name, "--namespace", vm.Namespace, "--force", "--grace-period=0")
-				Expect(forceStop()).To(Succeed())
-
-				By("Ensuring the VirtualMachineInstance is removed")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 240*time.Second, 1*time.Second).ShouldNot(Exist())
-
-				Expect(updated).To(Receive(), "vmi should be updated")
-				stopCn <- true
 			})
 
 			Context("Using RunStrategyAlways", func() {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -754,27 +754,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 
 		Context("Using virtctl interface", func() {
-			It("[test_id:6310]should start a VirtualMachineInstance in paused state", func() {
-				By("getting a VM")
-				vm := createVM(virtClient, libvmifact.NewCirros())
-
-				By("Invoking virtctl start")
-				startCommand := clientcmd.NewRepeatableVirtctlCommand(virtctl.COMMAND_START, "--namespace", vm.Namespace, vm.Name, "--paused")
-				Expect(startCommand()).To(Succeed())
-
-				By("Getting the status of the VM")
-				Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(BeCreated())
-
-				By("Getting running VirtualMachineInstance with paused condition")
-				Eventually(func() bool {
-					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(*vmi.Spec.StartStrategy).To(Equal(v1.StartStrategyPaused))
-					Eventually(ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(HaveConditionTrue(v1.VirtualMachineInstancePaused))
-					return vmi.Status.Phase == v1.Running
-				}, 240*time.Second, 1*time.Second).Should(BeTrue())
-			})
-
 			Context("Using RunStrategyAlways", func() {
 				It("[test_id:3163]should stop a running VM", func() {
 					By("creating a VM with RunStrategyAlways")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Move the VM subresource tests without run strategy from tests/vm_test.go
into tests/subresource_api_test.go, clean them up a little and use the
KubeVirt client instead of virtctl through a NewRepeatableVirtctlCommand
where applicable.

Drop "[test_id:6310]should start a VirtualMachineInstance in paused
state" which is already covered by "[test_id:4597]should signal paused
state with condition" in tests/pausing_test.go.

The goal of this and further PRs is to reduce the amount of unnecessary uses of
virtctl in the e2e tests to stabilize tests, to reduce the number of flakes and to
remove redudant tests.

Before this PR:

NewRepeatableVirtctlCommand is used unnecessarily.

After this PR:

The KubeVirt client is used instead.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

