### PR TITLE
Add kubevirt_vm_info metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -87,6 +87,9 @@ The total number of VMs created by namespace, since install. Type: Counter.
 ### kubevirt_vm_error_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to error status. Type: Counter.
 
+### kubevirt_vm_info
+Information about Virtual Machines. Type: Gauge.
+
 ### kubevirt_vm_migrating_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to migrating status. Type: Counter.
 

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	k8sv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/log"
 
 	k6tv1 "kubevirt.io/api/core/v1"
-	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
@@ -103,7 +104,7 @@ func collectVMIInfo(vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.Coll
 	var cr []operatormetrics.CollectorResult
 
 	for _, vmi := range vmis {
-		os, workload, flavor := getVMISystemInfo(vmi)
+		os, workload, flavor := getSystemInfoFromAnnotations(vmi.Annotations)
 		instanceType := getVMIInstancetype(vmi)
 		preference := getVMIPreference(vmi)
 		kernelRelease, machine, name, versionID := getGuestOSInfo(vmi)
@@ -126,20 +127,20 @@ func getVMIPhase(vmi *k6tv1.VirtualMachineInstance) string {
 	return strings.ToLower(string(vmi.Status.Phase))
 }
 
-func getVMISystemInfo(vmi *k6tv1.VirtualMachineInstance) (os, workload, flavor string) {
+func getSystemInfoFromAnnotations(annotations map[string]string) (os, workload, flavor string) {
 	os = none
 	workload = none
 	flavor = none
 
-	if val, ok := vmi.Annotations[annotationPrefix+"os"]; ok {
+	if val, ok := annotations[annotationPrefix+"os"]; ok {
 		os = val
 	}
 
-	if val, ok := vmi.Annotations[annotationPrefix+"workload"]; ok {
+	if val, ok := annotations[annotationPrefix+"workload"]; ok {
 		workload = val
 	}
 
-	if val, ok := vmi.Annotations[annotationPrefix+"flavor"]; ok {
+	if val, ok := annotations[annotationPrefix+"flavor"]; ok {
 		flavor = val
 	}
 
@@ -172,71 +173,46 @@ func getGuestOSInfo(vmi *k6tv1.VirtualMachineInstance) (kernelRelease, machine, 
 }
 
 func getVMIInstancetype(vmi *k6tv1.VirtualMachineInstance) string {
-	instanceType := none
-
 	if instancetypeName, ok := vmi.Annotations[k6tv1.InstancetypeAnnotation]; ok {
-		instanceType = other
-
-		obj, ok, err := instanceTypeInformer.GetIndexer().GetByKey(instancetypeName)
-		if err != nil || !ok {
-			return instanceType
-		}
-
-		vendorName := obj.(*instancetypev1beta1.VirtualMachineInstancetype).Labels[instancetypeVendorLabel]
-		if _, isWhitelisted := whitelistedInstanceTypeVendors[vendorName]; isWhitelisted {
-			instanceType = instancetypeName
-		}
+		return fetchResourceName(instancetypeName, instanceTypeInformer.GetIndexer())
 	}
 
 	if instancetypeName, ok := vmi.Annotations[k6tv1.ClusterInstancetypeAnnotation]; ok {
-		instanceType = other
-
-		obj, ok, err := clusterInstanceTypeInformer.GetIndexer().GetByKey(instancetypeName)
-		if err != nil || !ok {
-			return instanceType
-		}
-
-		vendorName := obj.(*instancetypev1beta1.VirtualMachineClusterInstancetype).Labels[instancetypeVendorLabel]
-		if _, isWhitelisted := whitelistedInstanceTypeVendors[vendorName]; isWhitelisted {
-			instanceType = instancetypeName
-		}
+		return fetchResourceName(instancetypeName, clusterInstanceTypeInformer.GetIndexer())
 	}
 
-	return instanceType
+	return none
 }
 
 func getVMIPreference(vmi *k6tv1.VirtualMachineInstance) string {
-	preference := none
-
 	if instancetypeName, ok := vmi.Annotations[k6tv1.PreferenceAnnotation]; ok {
-		preference = other
-
-		obj, ok, err := preferenceInformer.GetIndexer().GetByKey(instancetypeName)
-		if err != nil || !ok {
-			return preference
-		}
-
-		vendorName := obj.(*instancetypev1beta1.VirtualMachinePreference).Labels[instancetypeVendorLabel]
-		if _, isWhitelisted := whitelistedInstanceTypeVendors[vendorName]; isWhitelisted {
-			preference = instancetypeName
-		}
+		return fetchResourceName(instancetypeName, preferenceInformer.GetIndexer())
 	}
 
 	if instancetypeName, ok := vmi.Annotations[k6tv1.ClusterPreferenceAnnotation]; ok {
-		preference = other
-
-		obj, ok, err := clusterPreferenceInformer.GetIndexer().GetByKey(instancetypeName)
-		if err != nil || !ok {
-			return preference
-		}
-
-		vendorName := obj.(*instancetypev1beta1.VirtualMachineClusterPreference).Labels[instancetypeVendorLabel]
-		if _, isWhitelisted := whitelistedInstanceTypeVendors[vendorName]; isWhitelisted {
-			preference = instancetypeName
-		}
+		return fetchResourceName(instancetypeName, clusterPreferenceInformer.GetIndexer())
 	}
 
-	return preference
+	return none
+}
+
+func fetchResourceName(name string, indexer cache.Indexer) string {
+	obj, ok, err := indexer.GetByKey(name)
+	if err != nil || !ok {
+		return other
+	}
+
+	apiObj, ok := obj.(v1.Object)
+	if !ok {
+		return other
+	}
+
+	vendorName := apiObj.GetLabels()[instancetypeVendorLabel]
+	if _, isWhitelisted := whitelistedInstanceTypeVendors[vendorName]; isWhitelisted {
+		return name
+	}
+
+	return other
 }
 
 func getEvictionBlocker(vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -38,7 +38,7 @@ var _ = BeforeSuite(func() {
 
 var _ = Describe("VMI Stats Collector", func() {
 	Context("VMI info", func() {
-		setupTestVMICollector()
+		setupTestCollector()
 
 		It("should handle no VMIs", func() {
 			cr := collectVMIInfo([]*k6tv1.VirtualMachineInstance{})
@@ -132,7 +132,7 @@ var _ = Describe("VMI Stats Collector", func() {
 				Expect(cr.Labels).To(HaveLen(13))
 
 				Expect(cr.Labels[3]).To(Equal(getVMIPhase(vmis[i])))
-				os, workload, flavor := getVMISystemInfo(vmis[i])
+				os, workload, flavor := getSystemInfoFromAnnotations(vmis[i].Annotations)
 				Expect(cr.Labels[4]).To(Equal(os))
 				Expect(cr.Labels[5]).To(Equal(workload))
 				Expect(cr.Labels[6]).To(Equal(flavor))
@@ -264,7 +264,7 @@ func createVMISForEviction(evictionStrategy *k6tv1.EvictionStrategy, migratableC
 	return vmis
 }
 
-func setupTestVMICollector() {
+func setupTestCollector() {
 	instanceTypeInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineInstancetype{})
 	clusterInstanceTypeInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterInstancetype{})
 	preferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -30,9 +30,26 @@ import (
 
 var (
 	vmStatsCollector = operatormetrics.Collector{
-		Metrics:         append(timestampMetrics, vmResourceRequests),
+		Metrics:         append(timestampMetrics, vmResourceRequests, vmInfo),
 		CollectCallback: vmStatsCollectorCallback,
 	}
+
+	vmInfo = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vm_info",
+			Help: "Information about Virtual Machines.",
+		},
+		[]string{
+			// Basic info
+			"namespace", "name",
+
+			// VM annotations
+			"os", "workload", "flavor",
+
+			// Instance type
+			"instance_type", "preference",
+		},
+	)
 
 	vmResourceRequests = operatormetrics.NewGaugeVec(
 		operatormetrics.MetricOpts{
@@ -138,9 +155,72 @@ func vmStatsCollectorCallback() []operatormetrics.CollectorResult {
 	}
 
 	var results []operatormetrics.CollectorResult
+	results = append(results, CollectVMsInfo(vms)...)
 	results = append(results, CollectResourceRequests(vms)...)
 	results = append(results, reportVmsStats(vms)...)
 	return results
+}
+
+func CollectVMsInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResult {
+	var results []operatormetrics.CollectorResult
+
+	for _, vm := range vms {
+		os, workload, flavor := none, none, none
+		if vm.Spec.Template != nil {
+			os, workload, flavor = getSystemInfoFromAnnotations(vm.Spec.Template.ObjectMeta.Annotations)
+		}
+
+		instanceType := getVMInstancetype(vm)
+		preference := getVMPreference(vm)
+
+		results = append(results, operatormetrics.CollectorResult{
+			Metric: vmInfo,
+			Labels: []string{
+				vm.Name, vm.Namespace,
+				os, workload, flavor,
+				instanceType, preference,
+			},
+			Value: 1.0,
+		})
+	}
+
+	return results
+}
+
+func getVMInstancetype(vm *k6tv1.VirtualMachine) string {
+	instancetype := vm.Spec.Instancetype
+
+	if instancetype == nil {
+		return none
+	}
+
+	if instancetype.Kind == "VirtualMachineInstancetype" {
+		return fetchResourceName(instancetype.Name, instanceTypeInformer.GetIndexer())
+	}
+
+	if instancetype.Kind == "VirtualMachineClusterInstancetype" {
+		return fetchResourceName(instancetype.Name, clusterInstanceTypeInformer.GetIndexer())
+	}
+
+	return none
+}
+
+func getVMPreference(vm *k6tv1.VirtualMachine) string {
+	preference := vm.Spec.Preference
+
+	if preference == nil {
+		return none
+	}
+
+	if preference.Kind == "VirtualMachinePreference" {
+		return fetchResourceName(preference.Name, preferenceInformer.GetIndexer())
+	}
+
+	if preference.Kind == "VirtualMachineClusterPreference" {
+		return fetchResourceName(preference.Name, clusterPreferenceInformer.GetIndexer())
+	}
+
+	return none
 }
 
 func CollectResourceRequests(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResult {

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -50,7 +50,7 @@ var (
 			"instance_type", "preference",
 
 			// Status
-			"status",
+			"status", "status_group",
 		},
 	)
 
@@ -182,7 +182,7 @@ func CollectVMsInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResu
 				vm.Name, vm.Namespace,
 				os, workload, flavor,
 				instanceType, preference,
-				string(vm.Status.PrintableStatus),
+				string(vm.Status.PrintableStatus), getVMStatusGroup(vm.Status.PrintableStatus),
 			},
 			Value: 1.0,
 		})
@@ -225,6 +225,23 @@ func getVMPreference(vm *k6tv1.VirtualMachine) string {
 	}
 
 	return none
+}
+
+func getVMStatusGroup(status k6tv1.VirtualMachinePrintableStatus) string {
+	switch {
+	case containsStatus(status, startingStatuses):
+		return "starting"
+	case containsStatus(status, runningStatuses):
+		return "running"
+	case containsStatus(status, migratingStatuses):
+		return "migrating"
+	case containsStatus(status, nonRunningStatuses):
+		return "non_running"
+	case containsStatus(status, errorStatuses):
+		return "error"
+	}
+
+	return "<unknown>"
 }
 
 func CollectResourceRequests(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResult {

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -48,6 +48,9 @@ var (
 
 			// Instance type
 			"instance_type", "preference",
+
+			// Status
+			"status",
 		},
 	)
 
@@ -179,6 +182,7 @@ func CollectVMsInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResu
 				vm.Name, vm.Namespace,
 				os, workload, flavor,
 				instanceType, preference,
+				string(vm.Status.PrintableStatus),
 			},
 			Value: 1.0,
 		})

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -117,6 +117,9 @@ var _ = Describe("VM Stats Collector", func() {
 							},
 						},
 					},
+					Status: k6tv1.VirtualMachineStatus{
+						PrintableStatus: k6tv1.VirtualMachineStatusCrashLoopBackOff,
+					},
 				},
 				{
 					Spec: k6tv1.VirtualMachineSpec{
@@ -131,6 +134,9 @@ var _ = Describe("VM Stats Collector", func() {
 							},
 						},
 					},
+					Status: k6tv1.VirtualMachineStatus{
+						PrintableStatus: k6tv1.VirtualMachineStatusCrashLoopBackOff,
+					},
 				},
 			}
 
@@ -141,12 +147,14 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr).ToNot(BeNil())
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(7))
+				Expect(cr.Labels).To(HaveLen(8))
 
 				os, workload, flavor := getSystemInfoFromAnnotations(vms[i].Spec.Template.ObjectMeta.Annotations)
 				Expect(cr.Labels[2]).To(Equal(os))
 				Expect(cr.Labels[3]).To(Equal(workload))
 				Expect(cr.Labels[4]).To(Equal(flavor))
+
+				Expect(cr.Labels[7]).To(Equal("CrashLoopBackOff"))
 			}
 		})
 
@@ -167,7 +175,7 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(cr).ToNot(BeNil())
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(7))
+			Expect(cr.Labels).To(HaveLen(8))
 			Expect(cr.Labels[5]).To(Equal(expected))
 		},
 			Entry("with no instance type expect <none>", "VirtualMachineInstancetype", "", "<none>"),
@@ -195,7 +203,7 @@ var _ = Describe("VM Stats Collector", func() {
 
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(7))
+			Expect(cr.Labels).To(HaveLen(8))
 			Expect(cr.Labels[6]).To(Equal(expected))
 		},
 			Entry("with no preference expect <none>", "VirtualMachinePreference", "", "<none>"),

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -147,7 +147,7 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr).ToNot(BeNil())
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(8))
+				Expect(cr.Labels).To(HaveLen(9))
 
 				os, workload, flavor := getSystemInfoFromAnnotations(vms[i].Spec.Template.ObjectMeta.Annotations)
 				Expect(cr.Labels[2]).To(Equal(os))
@@ -155,6 +155,7 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr.Labels[4]).To(Equal(flavor))
 
 				Expect(cr.Labels[7]).To(Equal("CrashLoopBackOff"))
+				Expect(cr.Labels[8]).To(Equal("error"))
 			}
 		})
 
@@ -175,7 +176,7 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(cr).ToNot(BeNil())
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(8))
+			Expect(cr.Labels).To(HaveLen(9))
 			Expect(cr.Labels[5]).To(Equal(expected))
 		},
 			Entry("with no instance type expect <none>", "VirtualMachineInstancetype", "", "<none>"),
@@ -203,7 +204,7 @@ var _ = Describe("VM Stats Collector", func() {
 
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(8))
+			Expect(cr.Labels).To(HaveLen(9))
 			Expect(cr.Labels[6]).To(Equal(expected))
 		},
 			Entry("with no preference expect <none>", "VirtualMachinePreference", "", "<none>"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

The only info available was about VMIs. Since Virtual Machines may not have been started yet, we would have no metrics about them. Users may be interested in this information to predict cluster state and capacities.

After this PR:

kubevirt_vm_info adds information about VMs not started yet

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-46768

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vm_info metric
```

