### PR TITLE
Parallelize migration bandwidth tests by relying on migration policies instead of KubevirtCR

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"kubevirt.io/api/migrations/v1alpha1"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -269,12 +270,26 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 		})
 		Context("[Serial] with bandwidth limitations", Serial, func() {
 
-			var repeatedlyMigrateWithBandwidthLimitation = func(vmi *v1.VirtualMachineInstance, bandwidth string, repeat int) time.Duration {
+			updateMigrationPolicyBandwidth := func(migrationPolicy *v1alpha1.MigrationPolicy, bandwidth resource.Quantity) {
+				migrationPolicy, err = virtClient.MigrationPolicy().Get(context.Background(), migrationPolicy.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				if policyBandwidth := migrationPolicy.Spec.BandwidthPerMigration; policyBandwidth != nil && policyBandwidth.Equal(bandwidth) {
+					return
+				}
+
+				patchPayload, err := patch.New(
+					patch.WithAdd("/spec/bandwidthPerMigration", pointer.P(bandwidth)),
+				).GeneratePayload()
+				Expect(err).ToNot(HaveOccurred())
+
+				migrationPolicy, err = virtClient.MigrationPolicy().Patch(context.Background(), migrationPolicy.Name, types.JSONPatchType, patchPayload, metav1.PatchOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			repeatedlyMigrateWithBandwidthLimitation := func(vmi *v1.VirtualMachineInstance, migrationPolicy *v1alpha1.MigrationPolicy, bandwidth string, repeat int) time.Duration {
 				var migrationDurationTotal time.Duration
-				config := getCurrentKvConfig(virtClient)
-				limit := resource.MustParse(bandwidth)
-				config.MigrationConfiguration.BandwidthPerMigration = &limit
-				tests.UpdateKubeVirtConfigValueAndWait(config)
+				updateMigrationPolicyBandwidth(migrationPolicy, resource.MustParse(bandwidth))
 
 				for x := 0; x < repeat; x++ {
 					By("Checking that the VirtualMachineInstance console has expected output")
@@ -298,11 +313,13 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 
 			It("[test_id:6968]should apply them and result in different migration durations", func() {
 				vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
+				migrationPolicy := CreateMigrationPolicy(virtClient, GeneratePolicyAndAlignVMI(vmi))
+
 				By("Starting the VirtualMachineInstance")
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
 
-				durationLowBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "10Mi", 3)
-				durationHighBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "128Mi", 3)
+				durationLowBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, migrationPolicy, "10Mi", 3)
+				durationHighBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, migrationPolicy, "128Mi", 3)
 				Expect(durationHighBandwidth.Seconds() * 2).To(BeNumerically("<", durationLowBandwidth.Seconds()))
 			})
 		})

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -268,7 +268,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				Expect(err.Error()).To(ContainSubstring("InterfaceNotLiveMigratable"))
 			})
 		})
-		Context("[Serial] with bandwidth limitations", Serial, func() {
+		Context("with bandwidth limitations", func() {
 
 			updateMigrationPolicyBandwidth := func(migrationPolicy *v1alpha1.MigrationPolicy, bandwidth resource.Quantity) {
 				migrationPolicy, err = virtClient.MigrationPolicy().Get(context.Background(), migrationPolicy.Name, metav1.GetOptions{})


### PR DESCRIPTION
### What this PR does
Before this PR:
Migration bandwidth tests **are serial** and rely on changing **Kubevirt CR's cluster-wide configurations** to reduce migration bandwidth.

After this PR:
Migration bandwidth tests are **not serial** and rely on **migration policies** reduce migration bandwidth only for the specific VMI that's being tested.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

