### PR TITLE
Retry up to 15 times when hotpluggin a volume with virtctl

### DIFF
--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -21,6 +21,7 @@ package vm_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	k8sv1 "k8s.io/api/core/v1"
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -45,6 +45,10 @@ import (
 )
 
 type verifyFn func(*v1.AddVolumeOptions)
+
+const (
+	concurrentErrorAdd = "the server rejected our request due to an error in our request"
+)
 
 var _ = Describe("Add volume command", func() {
 	const (
@@ -130,12 +134,12 @@ var _ = Describe("Add volume command", func() {
 			})
 		}
 
-		expectVMEndpointAddVolume := func(verifyFns ...verifyFn) {
+		expectVMEndpointAddVolumeErrorFunc := func(errFunc func() error, verifyFns ...verifyFn) {
 			kubecli.MockKubevirtClientInstance.
 				EXPECT().
 				VirtualMachine(metav1.NamespaceDefault).
 				Return(virtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault)).
-				Times(1)
+				AnyTimes()
 			virtClient.PrependReactor("put", "virtualmachines/addvolume", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
 				switch action := action.(type) {
 				case kvtesting.PutAction[*v1.AddVolumeOptions]:
@@ -146,7 +150,10 @@ var _ = Describe("Add volume command", func() {
 					for _, verifyFn := range verifyFns {
 						verifyFn(volumeOptions)
 					}
-					return true, nil, nil
+					if errFunc == nil {
+						return true, nil, nil
+					}
+					return true, nil, errFunc()
 				default:
 					Fail("unexpected action type on addvolume")
 					return false, nil, nil
@@ -154,54 +161,8 @@ var _ = Describe("Add volume command", func() {
 			})
 		}
 
-		expectVMEndpointAddVolumeRepeatedError := func(repeatCount int, verifyFns ...verifyFn) {
-			kubecli.MockKubevirtClientInstance.
-				EXPECT().
-				VirtualMachine(k8smetav1.NamespaceDefault).
-				Return(virtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault)).
-				Times(repeatCount)
-			for i := 0; i < repeatCount; i++ {
-				virtClient.PrependReactor("put", "virtualmachines/addvolume", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
-					switch action := action.(type) {
-					case kvtesting.PutAction[*v1.AddVolumeOptions]:
-						volumeOptions := action.GetOptions()
-						Expect(volumeOptions).ToNot(BeNil())
-						Expect(volumeOptions.Name).To(Equal(volumeName))
-						Expect(volumeOptions.VolumeSource).ToNot(BeNil())
-						for _, verifyFn := range verifyFns {
-							verifyFn(volumeOptions)
-						}
-						return true, nil, fmt.Errorf(concurrentError)
-					default:
-						Fail("unexpected action type on addvolume")
-						return false, nil, nil
-					}
-				})
-			}
-		}
-
-		expectVMEndpointAddVolumeFatalError := func(verifyFns ...verifyFn) {
-			kubecli.MockKubevirtClientInstance.
-				EXPECT().
-				VirtualMachine(k8smetav1.NamespaceDefault).
-				Return(virtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault)).
-				Times(1)
-			virtClient.PrependReactor("put", "virtualmachines/addvolume", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
-				switch action := action.(type) {
-				case kvtesting.PutAction[*v1.AddVolumeOptions]:
-					volumeOptions := action.GetOptions()
-					Expect(volumeOptions).ToNot(BeNil())
-					Expect(volumeOptions.Name).To(Equal(volumeName))
-					Expect(volumeOptions.VolumeSource).ToNot(BeNil())
-					for _, verifyFn := range verifyFns {
-						verifyFn(volumeOptions)
-					}
-					return true, nil, fmt.Errorf("fatal error")
-				default:
-					Fail("unexpected action type on addvolume")
-					return false, nil, nil
-				}
-			})
+		expectVMEndpointAddVolume := func(verifyFns ...verifyFn) {
+			expectVMEndpointAddVolumeErrorFunc(nil, verifyFns...)
 		}
 
 		runCmd := func(persist bool, extraArg string) error {
@@ -263,73 +224,80 @@ var _ = Describe("Add volume command", func() {
 			)
 
 			It("should fail immediately on non concurrent error", func() {
-				expectVMEndpointAddVolumeFatalError(verifyDVVolumeSource)
-				Expect(runCmd(true, "")).To(HaveOccurred())
-				Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachines", "addvolume")).To(BeEmpty())
-			})
-
-			It("should retry on error", func() {
-				expectVMEndpointAddVolumeRepeatedError(1, verifyDVVolumeSource)
-				expectVMEndpointAddVolume(verifyDVVolumeSource)
-				Expect(runCmd(true, "")).To(Succeed())
+				expectVMEndpointAddVolumeErrorFunc(func() error { return fmt.Errorf("fatal error") }, verifyDVVolumeSource)
+				Expect(runCmd(true, "")).To(MatchError(ContainSubstring("fatal error")))
 				Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachines", "addvolume")).To(HaveLen(1))
 			})
 
+			It("should retry on error", func() {
+				count := 0
+				expectVMEndpointAddVolumeErrorFunc(func() error {
+					if count == 0 {
+						count++
+						return errors.New(concurrentErrorAdd)
+					} else {
+						return nil
+					}
+				}, verifyDVVolumeSource)
+				Expect(runCmd(true, "")).To(Succeed())
+				Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachines", "addvolume")).To(HaveLen(2))
+			})
+
 			It("should fail after 15 retries", func() {
-				expectVMEndpointAddVolumeRepeatedError(15, verifyDVVolumeSource)
-				err := runCmd(true, "")
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("error adding volume after 15 retries"))
-				Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachines", "addvolume")).To(BeEmpty())
+				expectVMEndpointAddVolumeErrorFunc(func() error {
+					return errors.New(concurrentErrorAdd)
+				}, verifyDVVolumeSource)
+				Expect(runCmd(true, "")).To(MatchError(ContainSubstring(("error adding volume after 15 retries"))))
+				Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachines", "addvolume")).To(HaveLen(15))
 			})
+		})
 
-			Context("with PVC", func() {
-				BeforeEach(func() {
-					kubecli.MockKubevirtClientInstance.EXPECT().CdiClient().Return(cdiClient)
-					kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(coreClient.CoreV1())
-					_, err := coreClient.CoreV1().PersistentVolumeClaims(metav1.NamespaceDefault).Create(
-						context.Background(),
-						&k8sv1.PersistentVolumeClaim{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: volumeName,
-							},
+		Context("with PVC", func() {
+			BeforeEach(func() {
+				kubecli.MockKubevirtClientInstance.EXPECT().CdiClient().Return(cdiClient)
+				kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(coreClient.CoreV1())
+				_, err := coreClient.CoreV1().PersistentVolumeClaims(metav1.NamespaceDefault).Create(
+					context.Background(),
+					&k8sv1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: volumeName,
 						},
-						metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				DescribeTable("should call VMI endpoint without persist and with", func(arg string, verifyFns ...verifyFn) {
-					verifyFns = append(verifyFns, verifyPVCVolumeSource)
-					expectVMIEndpointAddVolume(verifyFns...)
-					runCmd(false, arg)
-					Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachineinstances", "addvolume")).To(HaveLen(1))
-				},
-					Entry("no args", "", verifyDiskSerial(volumeName)),
-					Entry("dry-run", "--dry-run", verifyDiskSerial(volumeName), verifyDryRun),
-					Entry("disk-type disk", "--disk-type=disk", verifyDiskSerial(volumeName), verifyDiskTypeDisk),
-					Entry("disk-type lun", "--disk-type=lun", verifyDiskSerial(volumeName), verifyDiskTypeLun),
-					Entry("serial", "--serial=test", verifyDiskSerial("test")),
-					Entry("cache none", "--cache=none", verifyDiskSerial(volumeName), verifyCache(v1.CacheNone)),
-					Entry("cache writethrough", "--cache=writethrough", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteThrough)),
-					Entry("cache writeback", "--cache=writeback", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteBack)),
-				)
-
-				DescribeTable("should call VM endpoint with persist and", func(arg string, verifyFns ...verifyFn) {
-					verifyFns = append(verifyFns, verifyPVCVolumeSource)
-					expectVMEndpointAddVolume(verifyFns...)
-					runCmd(true, arg)
-					Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachines", "addvolume")).To(HaveLen(1))
-				},
-					Entry("no args", "", verifyDiskSerial(volumeName)),
-					Entry("dry-run", "--dry-run", verifyDiskSerial(volumeName), verifyDryRun),
-					Entry("disk-type disk", "--disk-type=disk", verifyDiskSerial(volumeName), verifyDiskTypeDisk),
-					Entry("disk-type lun", "--disk-type=lun", verifyDiskSerial(volumeName), verifyDiskTypeLun),
-					Entry("serial", "--serial=test", verifyDiskSerial("test")),
-					Entry("cache none", "--cache=none", verifyDiskSerial(volumeName), verifyCache(v1.CacheNone)),
-					Entry("cache writethrough", "--cache=writethrough", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteThrough)),
-					Entry("cache writeback", "--cache=writeback", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteBack)),
-				)
+					},
+					metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 			})
+
+			DescribeTable("should call VMI endpoint without persist and with", func(arg string, verifyFns ...verifyFn) {
+				verifyFns = append(verifyFns, verifyPVCVolumeSource)
+				expectVMIEndpointAddVolume(verifyFns...)
+				Expect(runCmd(false, arg)).To(Succeed())
+				Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachineinstances", "addvolume")).To(HaveLen(1))
+			},
+				Entry("no args", "", verifyDiskSerial(volumeName)),
+				Entry("dry-run", "--dry-run", verifyDiskSerial(volumeName), verifyDryRun),
+				Entry("disk-type disk", "--disk-type=disk", verifyDiskSerial(volumeName), verifyDiskTypeDisk),
+				Entry("disk-type lun", "--disk-type=lun", verifyDiskSerial(volumeName), verifyDiskTypeLun),
+				Entry("serial", "--serial=test", verifyDiskSerial("test")),
+				Entry("cache none", "--cache=none", verifyDiskSerial(volumeName), verifyCache(v1.CacheNone)),
+				Entry("cache writethrough", "--cache=writethrough", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteThrough)),
+				Entry("cache writeback", "--cache=writeback", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteBack)),
+			)
+
+			DescribeTable("should call VM endpoint with persist and", func(arg string, verifyFns ...verifyFn) {
+				verifyFns = append(verifyFns, verifyPVCVolumeSource)
+				expectVMEndpointAddVolume(verifyFns...)
+				Expect(runCmd(true, arg)).To(Succeed())
+				Expect(kvtesting.FilterActions(&virtClient.Fake, "put", "virtualmachines", "addvolume")).To(HaveLen(1))
+			},
+				Entry("no args", "", verifyDiskSerial(volumeName)),
+				Entry("dry-run", "--dry-run", verifyDiskSerial(volumeName), verifyDryRun),
+				Entry("disk-type disk", "--disk-type=disk", verifyDiskSerial(volumeName), verifyDiskTypeDisk),
+				Entry("disk-type lun", "--disk-type=lun", verifyDiskSerial(volumeName), verifyDiskTypeLun),
+				Entry("serial", "--serial=test", verifyDiskSerial("test")),
+				Entry("cache none", "--cache=none", verifyDiskSerial(volumeName), verifyCache(v1.CacheNone)),
+				Entry("cache writethrough", "--cache=writethrough", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteThrough)),
+				Entry("cache writeback", "--cache=writeback", verifyDiskSerial(volumeName), verifyCache(v1.CacheWriteBack)),
+			)
 		})
 	})
 })

--- a/pkg/virtctl/vm/remove_volume_test.go
+++ b/pkg/virtctl/vm/remove_volume_test.go
@@ -21,11 +21,13 @@ package vm_test
 
 import (
 	"errors"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/testing"
@@ -36,6 +38,10 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
+)
+
+const (
+	concurrentError = "the server rejected our request due to an error in our request"
 )
 
 var _ = Describe("Remove volume command", func() {
@@ -127,6 +133,55 @@ var _ = Describe("Remove volume command", func() {
 		}
 	}
 
+	expectVMIEndpointRemoveVolumeRepeatedError := func(dryRun bool, repeatCount int) {
+		kubecli.MockKubevirtClientInstance.
+			EXPECT().
+			VirtualMachineInstance(k8smetav1.NamespaceDefault).
+			Return(virtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault)).
+			Times(repeatCount)
+		for i := 0; i < repeatCount; i++ {
+			virtClient.PrependReactor("put", "virtualmachines/removevolume", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+				switch action := action.(type) {
+				case kvtesting.PutAction[*v1.RemoveVolumeOptions]:
+					volumeOptions := action.GetOptions()
+					Expect(volumeOptions.Name).To(Equal(volumeName))
+					if dryRun {
+						Expect(volumeOptions.DryRun).To(Equal([]string{metav1.DryRunAll}))
+					} else {
+						Expect(volumeOptions.DryRun).To(BeEmpty())
+					}
+					return true, nil, fmt.Errorf(concurrentError)
+				default:
+					Fail("unexpected action type on removevolume")
+					return false, nil, nil
+				}
+			})
+		}
+	}
+	expectVMIEndpointRemoveVolumeFatalError := func(dryRun bool) {
+		kubecli.MockKubevirtClientInstance.
+			EXPECT().
+			VirtualMachineInstance(k8smetav1.NamespaceDefault).
+			Return(virtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault)).
+			Times(1)
+		virtClient.PrependReactor("put", "virtualmachines/removevolume", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+			switch action := action.(type) {
+			case kvtesting.PutAction[*v1.RemoveVolumeOptions]:
+				volumeOptions := action.GetOptions()
+				Expect(volumeOptions.Name).To(Equal(volumeName))
+				if dryRun {
+					Expect(volumeOptions.DryRun).To(Equal([]string{metav1.DryRunAll}))
+				} else {
+					Expect(volumeOptions.DryRun).To(BeEmpty())
+				}
+				return true, nil, fmt.Errorf("fatal error")
+			default:
+				Fail("unexpected action type on removevolume")
+				return false, nil, nil
+			}
+		})
+	}
+
 	DescribeTable("should fail with missing required or invalid parameters", func(expected string, extraArgs ...string) {
 		args := append([]string{"removevolume"}, extraArgs...)
 		cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
@@ -162,4 +217,30 @@ var _ = Describe("Remove volume command", func() {
 		Entry("no persist with dry-run should call VMI endpoint", expectVMIEndpointRemoveVolume(true), "virtualmachineinstances", "--dry-run"),
 		Entry("with persist with dry-run should call VM endpoint", expectVMEndpointRemoveVolume(true), "virtualmachines", "--persist", "--dry-run"),
 	)
+
+	It("should fail immediately on non concurrent error", func() {
+		expectVMIEndpointRemoveVolumeFatalError(false)
+		commandAndArgs := []string{"removevolume", "testvmi", "--volume-name=testvolume"}
+		cmdAdd := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
+		err := cmdAdd()
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should retry on error", func() {
+		expectVMIEndpointRemoveVolumeRepeatedError(false, 1)
+		expectVMIEndpointRemoveVolume("testvmi", "testvolume", false)
+		commandAndArgs := []string{"removevolume", "testvmi", "--volume-name=testvolume"}
+		cmdAdd := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
+		err := cmdAdd()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should fail after 15 retries", func() {
+		expectVMIEndpointRemoveVolumeRepeatedError(false, 15)
+		commandAndArgs := []string{"removevolume", "testvmi", "--volume-name=testvolume"}
+		cmdAdd := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
+		err := cmdAdd()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("error removing volume after 15 retries"))
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
When adding many volumes concurrently using virtctl one can get failures due to concurrent modifications of the VM resource.
After this PR:
When adding many volumes concurrently using virtctl, all the volumes are added successfully.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-31844

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Concurrent addvolume/removevolume using virtctl no longer fail if concurrent modifications happen
```

