### PR TITLE
Use client instead of virtctl in RunStrategy related VM tests and cleanup subresource_api_test.go further

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -154,7 +154,6 @@ go_test(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
-        "//pkg/virtctl/vm:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Use the KubeVirt client instead of using virtctl through a
NewRepeatableVirtlCommand where applicable in tests/vm_test.go.

This restructures the RunStrategy related VM tests to work without
virtctl and also consolidates the tests where possible to avoid
duplication of test code.

The newVirtualMachineWithRunStrategy helper is dropped and instead the
tests create VMs with the help of libvmi now. This change allows to use
a guestless VM in most of the tests.

Drop duplicate tests in tests/subresource_api_test.go that are already
covered by tests in tests/vm_test.go and consolidate tests that assert
the behavior when trying to restart a stopped VM.

"[test_id:1304] should restart a VM" is already covered by
"[test_id:3164]with RunStrategyAlways".

"[test_id:3175]Should restart when VM is running" is already covered by
"[test_id:2035]with RunStrategyManual".

"[test_id:3176]Should restart the VM" is already covered by
"[test_id:2187]with RunStrategyRerunOnFailure".

"[test_id:1305]" is changed to assert behavior when using
RunStrategyHalted explicitly. This was already done implicitly before.

The goal of this and further PRs is to reduce the amount of unnecessary uses of
virtctl in the e2e tests to stabilize tests, to reduce the number of flakes and to
remove redudant tests.

Before this PR:

NewRepeatableVirtctlCommand is used unnecessarily and tests are duplicated.

After this PR:

The KubeVirt client is used instead and duplicate tests are dropped.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Merge after https://github.com/kubevirt/kubevirt/pull/12717

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

