### PR TITLE
Use usable size instead of requested capacity in disk expansion logic

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -100,6 +101,44 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		}
 	})
 
+	getImageSize := func(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume) int64 {
+		var imageSize int64
+		var unused string
+		pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		lsOutput, err := exec.ExecuteCommandOnPod(
+			pod,
+			"compute",
+			[]string{"ls", "-s", "/var/run/kubevirt-private/vmi-disks/disk0/disk.img"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		if _, err := fmt.Sscanf(lsOutput, "%d %s", &imageSize, &unused); err != nil {
+			return 0
+		}
+		return imageSize
+	}
+
+	getVirtualSize := func(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume) int64 {
+		pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		output, err := exec.ExecuteCommandOnPod(
+			pod,
+			"compute",
+			[]string{"qemu-img", "info", "--output", "json", "/var/run/kubevirt-private/vmi-disks/disk0/disk.img"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		var info struct {
+			VirtualSize int64 `json:"virtual-size"`
+		}
+		err = json.Unmarshal([]byte(output), &info)
+		Expect(err).ToNot(HaveOccurred())
+
+		return info.VirtualSize
+	}
+
 	createAndWaitForVMIReady := func(vmi *v1.VirtualMachineInstance, dataVolume *cdiv1.DataVolume) *v1.VirtualMachineInstance {
 		vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -107,6 +146,14 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		libstorage.EventuallyDV(dataVolume, 500, HaveSucceeded())
 		By("Waiting until the VirtualMachineInstance starts")
 		return libwait.WaitForVMIPhase(vmi, []v1.VirtualMachineInstancePhase{v1.Running}, libwait.WithTimeout(500))
+	}
+
+	alignImageSizeTo1MiB := func(size int64) int64 {
+		remainder := size % (1024 * 1024)
+		if remainder == 0 {
+			return size
+		}
+		return size - remainder
 	}
 
 	Context("[storage-req]PVC expansion", decorators.StorageReq, func() {
@@ -189,6 +236,59 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			Entry("with Block PVC", k8sv1.PersistentVolumeBlock),
 			Entry("with Filesystem PVC", k8sv1.PersistentVolumeFilesystem),
 		)
+
+		It("Check disk expansion accounts for actual usable size", func() {
+			checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
+
+			sc, exists := libstorage.GetRWOFileSystemStorageClass()
+			if !exists {
+				Skip("Skip test when Filesystem storage is not present")
+			}
+
+			volumeExpansionAllowed := volumeExpansionAllowed(sc)
+			if !volumeExpansionAllowed {
+				Skip("Skip when volume expansion storage class not available")
+			}
+
+			imageUrl := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)
+			dataVolume := libdv.NewDataVolume(
+				libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullNode),
+				libdv.WithPVC(
+					libdv.PVCWithStorageClass(sc),
+					libdv.PVCWithVolumeSize("512Mi"),
+					libdv.PVCWithAccessMode(k8sv1.ReadWriteOnce),
+					libdv.PVCWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
+				),
+			)
+			dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, dataVolume.Namespace, libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()))
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 500)
+
+			By("Expecting the VirtualMachineInstance console")
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+			pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Get(context.Background(), dataVolume.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			pv, err := virtClient.CoreV1().PersistentVolumes().Get(context.Background(), pvc.Spec.VolumeName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			pvcRequestSize := pvc.Spec.Resources.Requests[k8sv1.ResourceStorage]
+			pvCapacitySize := pv.Spec.Capacity[k8sv1.ResourceStorage]
+
+			By("Checking if PV capacity is larger than PVC request")
+			if pvCapacitySize.Cmp(pvcRequestSize) > 0 {
+				Expect(getVirtualSize(vmi, dataVolume)).To(Equal((pvcRequestSize.Value())))
+			} else {
+				overheadPercentage, err := strconv.ParseFloat(string(*vmi.Status.VolumeStatus[1].PersistentVolumeClaimInfo.FilesystemOverhead), 64)
+				Expect(err).ToNot(HaveOccurred())
+				overheadSize := float64(pvcRequestSize.Value()) * (1.0 - overheadPercentage)
+				expectedSize := alignImageSizeTo1MiB(int64(overheadSize))
+				Expect(getVirtualSize(vmi, dataVolume)).To(Equal(expectedSize))
+			}
+		})
 	})
 
 	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source", func() {
@@ -1121,23 +1221,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			} else {
 				return true
 			}
-		}
-		getImageSize := func(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume) int64 {
-			var imageSize int64
-			var unused string
-			pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(err).ToNot(HaveOccurred())
-
-			lsOutput, err := exec.ExecuteCommandOnPod(
-				pod,
-				"compute",
-				[]string{"ls", "-s", "/var/run/kubevirt-private/vmi-disks/disk0/disk.img"},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			if _, err := fmt.Sscanf(lsOutput, "%d %s", &imageSize, &unused); err != nil {
-				return 0
-			}
-			return imageSize
 		}
 
 		noop := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This Pull Request aims to fix disk expansion logic in Kubevirt so, instead of taking into account the requested disk capacity, we calculate the usable size instead.

The usable size provided by the storage provider can differ from the one requested in the PVC capacity. This can lead to unwanted behavior when expanding the disk to the requested size, as seen in [these](https://search.ci.kubevirt.io/?search=http+endpoint+when+exporting+snapshot&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) test flakes.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-47542

### Special notes for your reviewer

Work in progress.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix disk expansion logic by checking usable size instead of requested capacity
```

