### PR TITLE
instancetype: Remove use of `k8s.io/utils/ptr`

### DIFF
--- a/pkg/instancetype/BUILD.bazel
+++ b/pkg/instancetype/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
@@ -31,7 +32,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/json:go_default_library",
     ],
@@ -76,6 +76,5 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/utils/ptr:go_default_library",
     ],
 )

--- a/pkg/instancetype/compatibility_test.go
+++ b/pkg/instancetype/compatibility_test.go
@@ -10,12 +10,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 
 	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
 	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	snapshotv1beta1 "kubevirt.io/api/snapshot/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 var _ = Describe("compatibility", func() {
@@ -46,9 +47,9 @@ var _ = Describe("compatibility", func() {
 				CPU: instancetypev1beta1.CPUInstancetype{
 					Guest: 4,
 					// Set the following values to be compatible with objects converted from prior API versions
-					Model:                 ptr.To(""),
-					DedicatedCPUPlacement: ptr.To(false),
-					IsolateEmulatorThread: ptr.To(false),
+					Model:                 pointer.P(""),
+					DedicatedCPUPlacement: pointer.P(false),
+					IsolateEmulatorThread: pointer.P(false),
 				},
 				Memory: instancetypev1beta1.MemoryInstancetype{
 					Guest: resource.MustParse("128Mi"),

--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/ptr"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	apiinstancetype "kubevirt.io/api/instancetype"
@@ -30,6 +29,7 @@ import (
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	utils "kubevirt.io/kubevirt/pkg/util"
 )
 
@@ -1300,35 +1300,35 @@ func ApplyDevicePreferences(preferenceSpec *instancetypev1beta1.VirtualMachinePr
 	// 2. The user hasn't defined the corresponding attribute already within the VMI
 	//
 	if preferenceSpec.Devices.PreferredAutoattachGraphicsDevice != nil && vmiSpec.Domain.Devices.AutoattachGraphicsDevice == nil {
-		vmiSpec.Domain.Devices.AutoattachGraphicsDevice = ptr.To(*preferenceSpec.Devices.PreferredAutoattachGraphicsDevice)
+		vmiSpec.Domain.Devices.AutoattachGraphicsDevice = pointer.P(*preferenceSpec.Devices.PreferredAutoattachGraphicsDevice)
 	}
 
 	if preferenceSpec.Devices.PreferredAutoattachMemBalloon != nil && vmiSpec.Domain.Devices.AutoattachMemBalloon == nil {
-		vmiSpec.Domain.Devices.AutoattachMemBalloon = ptr.To(*preferenceSpec.Devices.PreferredAutoattachMemBalloon)
+		vmiSpec.Domain.Devices.AutoattachMemBalloon = pointer.P(*preferenceSpec.Devices.PreferredAutoattachMemBalloon)
 	}
 
 	if preferenceSpec.Devices.PreferredAutoattachPodInterface != nil && vmiSpec.Domain.Devices.AutoattachPodInterface == nil {
-		vmiSpec.Domain.Devices.AutoattachPodInterface = ptr.To(*preferenceSpec.Devices.PreferredAutoattachPodInterface)
+		vmiSpec.Domain.Devices.AutoattachPodInterface = pointer.P(*preferenceSpec.Devices.PreferredAutoattachPodInterface)
 	}
 
 	if preferenceSpec.Devices.PreferredAutoattachSerialConsole != nil && vmiSpec.Domain.Devices.AutoattachSerialConsole == nil {
-		vmiSpec.Domain.Devices.AutoattachSerialConsole = ptr.To(*preferenceSpec.Devices.PreferredAutoattachSerialConsole)
+		vmiSpec.Domain.Devices.AutoattachSerialConsole = pointer.P(*preferenceSpec.Devices.PreferredAutoattachSerialConsole)
 	}
 
 	if preferenceSpec.Devices.PreferredUseVirtioTransitional != nil && vmiSpec.Domain.Devices.UseVirtioTransitional == nil {
-		vmiSpec.Domain.Devices.UseVirtioTransitional = ptr.To(*preferenceSpec.Devices.PreferredUseVirtioTransitional)
+		vmiSpec.Domain.Devices.UseVirtioTransitional = pointer.P(*preferenceSpec.Devices.PreferredUseVirtioTransitional)
 	}
 
 	if preferenceSpec.Devices.PreferredBlockMultiQueue != nil && vmiSpec.Domain.Devices.BlockMultiQueue == nil {
-		vmiSpec.Domain.Devices.BlockMultiQueue = ptr.To(*preferenceSpec.Devices.PreferredBlockMultiQueue)
+		vmiSpec.Domain.Devices.BlockMultiQueue = pointer.P(*preferenceSpec.Devices.PreferredBlockMultiQueue)
 	}
 
 	if preferenceSpec.Devices.PreferredNetworkInterfaceMultiQueue != nil && vmiSpec.Domain.Devices.NetworkInterfaceMultiQueue == nil {
-		vmiSpec.Domain.Devices.NetworkInterfaceMultiQueue = ptr.To(*preferenceSpec.Devices.PreferredNetworkInterfaceMultiQueue)
+		vmiSpec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.P(*preferenceSpec.Devices.PreferredNetworkInterfaceMultiQueue)
 	}
 
 	if preferenceSpec.Devices.PreferredAutoattachInputDevice != nil && vmiSpec.Domain.Devices.AutoattachInputDevice == nil {
-		vmiSpec.Domain.Devices.AutoattachInputDevice = ptr.To(*preferenceSpec.Devices.PreferredAutoattachInputDevice)
+		vmiSpec.Domain.Devices.AutoattachInputDevice = pointer.P(*preferenceSpec.Devices.PreferredAutoattachInputDevice)
 	}
 
 	// FIXME DisableHotplug isn't a pointer bool so we don't have a way to tell if a user has actually set it, for now override.
@@ -1379,7 +1379,7 @@ func applyDiskPreferences(preferenceSpec *instancetypev1beta1.VirtualMachinePref
 			}
 
 			if preferenceSpec.Devices.PreferredDiskDedicatedIoThread != nil && vmiDisk.DedicatedIOThread == nil && vmiDisk.DiskDevice.Disk.Bus == virtv1.DiskBusVirtio {
-				vmiDisk.DedicatedIOThread = ptr.To(*preferenceSpec.Devices.PreferredDiskDedicatedIoThread)
+				vmiDisk.DedicatedIOThread = pointer.P(*preferenceSpec.Devices.PreferredDiskDedicatedIoThread)
 			}
 		} else if vmiDisk.DiskDevice.CDRom != nil {
 			if preferenceSpec.Devices.PreferredCdromBus != "" && vmiDisk.DiskDevice.CDRom.Bus == "" {
@@ -1547,7 +1547,7 @@ func applyFirmwarePreferences(preferenceSpec *instancetypev1beta1.VirtualMachine
 	}
 
 	if preferenceSpec.Firmware.PreferredUseBiosSerial != nil && vmiSpec.Domain.Firmware.Bootloader.BIOS != nil && vmiSpec.Domain.Firmware.Bootloader.BIOS.UseSerial == nil {
-		vmiSpec.Domain.Firmware.Bootloader.BIOS.UseSerial = ptr.To(*preferenceSpec.Firmware.PreferredUseBiosSerial)
+		vmiSpec.Domain.Firmware.Bootloader.BIOS.UseSerial = pointer.P(*preferenceSpec.Firmware.PreferredUseBiosSerial)
 	}
 
 	if preferenceSpec.Firmware.PreferredUseEfi != nil && *preferenceSpec.Firmware.PreferredUseEfi && vmiSpec.Domain.Firmware.Bootloader.EFI == nil && vmiSpec.Domain.Firmware.Bootloader.BIOS == nil {
@@ -1555,7 +1555,7 @@ func applyFirmwarePreferences(preferenceSpec *instancetypev1beta1.VirtualMachine
 	}
 
 	if preferenceSpec.Firmware.PreferredUseSecureBoot != nil && vmiSpec.Domain.Firmware.Bootloader.EFI != nil && vmiSpec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil {
-		vmiSpec.Domain.Firmware.Bootloader.EFI.SecureBoot = ptr.To(*preferenceSpec.Firmware.PreferredUseSecureBoot)
+		vmiSpec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.P(*preferenceSpec.Firmware.PreferredUseSecureBoot)
 	}
 }
 
@@ -1600,6 +1600,6 @@ func applySubdomain(preferenceSpec *instancetypev1beta1.VirtualMachinePreference
 
 func applyTerminationGracePeriodSeconds(preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
 	if preferenceSpec.PreferredTerminationGracePeriodSeconds != nil && vmiSpec.TerminationGracePeriodSeconds == nil {
-		vmiSpec.TerminationGracePeriodSeconds = ptr.To(*preferenceSpec.PreferredTerminationGracePeriodSeconds)
+		vmiSpec.TerminationGracePeriodSeconds = pointer.P(*preferenceSpec.PreferredTerminationGracePeriodSeconds)
 	}
 }

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/ptr"
 
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -309,9 +308,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 				clusterInstancetype.Spec.CPU = instancetypev1beta1.CPUInstancetype{
 					Guest: uint32(2),
 					// Set the following values to be compatible with objects converted from v1alpha1
-					Model:                 ptr.To(""),
-					DedicatedCPUPlacement: ptr.To(false),
-					IsolateEmulatorThread: ptr.To(false),
+					Model:                 pointer.P(""),
+					DedicatedCPUPlacement: pointer.P(false),
+					IsolateEmulatorThread: pointer.P(false),
 				}
 
 				specData, err := json.Marshal(clusterInstancetype.Spec)
@@ -498,9 +497,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 				fakeInstancetype.Spec.CPU = instancetypev1beta1.CPUInstancetype{
 					Guest: uint32(2),
 					// Set the following values to be compatible with objects converted from v1alpha1
-					Model:                 ptr.To(""),
-					DedicatedCPUPlacement: ptr.To(false),
-					IsolateEmulatorThread: ptr.To(false),
+					Model:                 pointer.P(""),
+					DedicatedCPUPlacement: pointer.P(false),
+					IsolateEmulatorThread: pointer.P(false),
 				}
 
 				specData, err := json.Marshal(fakeInstancetype.Spec)
@@ -1008,9 +1007,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 				instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					CPU: instancetypev1beta1.CPUInstancetype{
 						Guest:                 uint32(2),
-						Model:                 ptr.To("host-passthrough"),
-						DedicatedCPUPlacement: ptr.To(true),
-						IsolateEmulatorThread: ptr.To(true),
+						Model:                 pointer.P("host-passthrough"),
+						DedicatedCPUPlacement: pointer.P(true),
+						IsolateEmulatorThread: pointer.P(true),
 						NUMA: &v1.NUMA{
 							GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{},
 						},
@@ -1803,8 +1802,8 @@ var _ = Describe("Instancetype and Preferences", func() {
 						Physical: 512,
 					},
 				}
-				vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = ptr.To(false)
-				vmi.Spec.Domain.Devices.AutoattachMemBalloon = ptr.To(false)
+				vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = pointer.P(false)
+				vmi.Spec.Domain.Devices.AutoattachMemBalloon = pointer.P(false)
 				vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 					{
 						Cache:     v1.CacheWriteBack,
@@ -1866,16 +1865,16 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Devices: &instancetypev1beta1.DevicePreferences{
-						PreferredAutoattachGraphicsDevice:   ptr.To(true),
-						PreferredAutoattachMemBalloon:       ptr.To(true),
-						PreferredAutoattachPodInterface:     ptr.To(true),
-						PreferredAutoattachSerialConsole:    ptr.To(true),
-						PreferredAutoattachInputDevice:      ptr.To(true),
-						PreferredDiskDedicatedIoThread:      ptr.To(true),
-						PreferredDisableHotplug:             ptr.To(true),
-						PreferredUseVirtioTransitional:      ptr.To(true),
-						PreferredNetworkInterfaceMultiQueue: ptr.To(true),
-						PreferredBlockMultiQueue:            ptr.To(true),
+						PreferredAutoattachGraphicsDevice:   pointer.P(true),
+						PreferredAutoattachMemBalloon:       pointer.P(true),
+						PreferredAutoattachPodInterface:     pointer.P(true),
+						PreferredAutoattachSerialConsole:    pointer.P(true),
+						PreferredAutoattachInputDevice:      pointer.P(true),
+						PreferredDiskDedicatedIoThread:      pointer.P(true),
+						PreferredDisableHotplug:             pointer.P(true),
+						PreferredUseVirtioTransitional:      pointer.P(true),
+						PreferredNetworkInterfaceMultiQueue: pointer.P(true),
+						PreferredBlockMultiQueue:            pointer.P(true),
 						PreferredDiskBlockSize: &v1.BlockSize{
 							Custom: &v1.CustomBlockSize{
 								Logical:  4096,
@@ -2027,26 +2026,26 @@ var _ = Describe("Instancetype and Preferences", func() {
 					Features: &instancetypev1beta1.FeaturePreferences{
 						PreferredAcpi: &v1.FeatureState{},
 						PreferredApic: &v1.FeatureAPIC{
-							Enabled:        ptr.To(true),
+							Enabled:        pointer.P(true),
 							EndOfInterrupt: false,
 						},
 						PreferredHyperv: &v1.FeatureHyperv{
 							Relaxed: &v1.FeatureState{},
 							VAPIC:   &v1.FeatureState{},
 							Spinlocks: &v1.FeatureSpinlocks{
-								Enabled: ptr.To(true),
+								Enabled: pointer.P(true),
 								Retries: &spinLockRetries,
 							},
 							VPIndex: &v1.FeatureState{},
 							Runtime: &v1.FeatureState{},
 							SyNIC:   &v1.FeatureState{},
 							SyNICTimer: &v1.SyNICTimer{
-								Enabled: ptr.To(true),
+								Enabled: pointer.P(true),
 								Direct:  &v1.FeatureState{},
 							},
 							Reset: &v1.FeatureState{},
 							VendorID: &v1.FeatureVendorID{
-								Enabled:  ptr.To(true),
+								Enabled:  pointer.P(true),
 								VendorID: "1234",
 							},
 							Frequencies:     &v1.FeatureState{},
@@ -2080,7 +2079,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				vmi.Spec.Domain.Features = &v1.Features{
 					Hyperv: &v1.FeatureHyperv{
 						EVMCS: &v1.FeatureState{
-							Enabled: ptr.To(false),
+							Enabled: pointer.P(false),
 						},
 					},
 				}
@@ -2096,10 +2095,10 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should apply BIOS preferences full to VMI", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Firmware: &instancetypev1beta1.FirmwarePreferences{
-						PreferredUseBios:       ptr.To(true),
-						PreferredUseBiosSerial: ptr.To(true),
-						PreferredUseEfi:        ptr.To(false),
-						PreferredUseSecureBoot: ptr.To(false),
+						PreferredUseBios:       pointer.P(true),
+						PreferredUseBiosSerial: pointer.P(true),
+						PreferredUseEfi:        pointer.P(false),
+						PreferredUseSecureBoot: pointer.P(false),
 					},
 				}
 
@@ -2112,10 +2111,10 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should apply SecureBoot preferences full to VMI", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Firmware: &instancetypev1beta1.FirmwarePreferences{
-						PreferredUseBios:       ptr.To(false),
-						PreferredUseBiosSerial: ptr.To(false),
-						PreferredUseEfi:        ptr.To(true),
-						PreferredUseSecureBoot: ptr.To(true),
+						PreferredUseBios:       pointer.P(false),
+						PreferredUseBiosSerial: pointer.P(false),
+						PreferredUseEfi:        pointer.P(true),
+						PreferredUseSecureBoot: pointer.P(true),
 					},
 				}
 
@@ -2128,14 +2127,14 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should not overwrite user defined Bootloader.BIOS with PreferredUseEfi - bug #10313", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Firmware: &instancetypev1beta1.FirmwarePreferences{
-						PreferredUseEfi:        ptr.To(true),
-						PreferredUseSecureBoot: ptr.To(true),
+						PreferredUseEfi:        pointer.P(true),
+						PreferredUseSecureBoot: pointer.P(true),
 					},
 				}
 				vmi.Spec.Domain.Firmware = &v1.Firmware{
 					Bootloader: &v1.Bootloader{
 						BIOS: &v1.BIOS{
-							UseSerial: ptr.To(false),
+							UseSerial: pointer.P(false),
 						},
 					},
 				}
@@ -2147,14 +2146,14 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should not overwrite user defined value with PreferredUseBiosSerial - bug #10313", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Firmware: &instancetypev1beta1.FirmwarePreferences{
-						PreferredUseBios:       ptr.To(true),
-						PreferredUseBiosSerial: ptr.To(true),
+						PreferredUseBios:       pointer.P(true),
+						PreferredUseBiosSerial: pointer.P(true),
 					},
 				}
 				vmi.Spec.Domain.Firmware = &v1.Firmware{
 					Bootloader: &v1.Bootloader{
 						BIOS: &v1.BIOS{
-							UseSerial: ptr.To(false),
+							UseSerial: pointer.P(false),
 						},
 					},
 				}
@@ -2165,14 +2164,14 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should not overwrite user defined Bootloader.EFI with PreferredUseBios - bug #10313", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Firmware: &instancetypev1beta1.FirmwarePreferences{
-						PreferredUseBios:       ptr.To(true),
-						PreferredUseBiosSerial: ptr.To(true),
+						PreferredUseBios:       pointer.P(true),
+						PreferredUseBiosSerial: pointer.P(true),
 					},
 				}
 				vmi.Spec.Domain.Firmware = &v1.Firmware{
 					Bootloader: &v1.Bootloader{
 						EFI: &v1.EFI{
-							SecureBoot: ptr.To(false),
+							SecureBoot: pointer.P(false),
 						},
 					},
 				}
@@ -2184,14 +2183,14 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should not overwrite user defined value with PreferredUseSecureBoot - bug #10313", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Firmware: &instancetypev1beta1.FirmwarePreferences{
-						PreferredUseEfi:        ptr.To(true),
-						PreferredUseSecureBoot: ptr.To(true),
+						PreferredUseEfi:        pointer.P(true),
+						PreferredUseSecureBoot: pointer.P(true),
 					},
 				}
 				vmi.Spec.Domain.Firmware = &v1.Firmware{
 					Bootloader: &v1.Bootloader{
 						EFI: &v1.EFI{
-							SecureBoot: ptr.To(false),
+							SecureBoot: pointer.P(false),
 						},
 					},
 				}
@@ -2220,7 +2219,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 					Clock: &instancetypev1beta1.ClockPreferences{
 						PreferredClockOffset: &v1.ClockOffset{
 							UTC: &v1.ClockOffsetUTC{
-								OffsetSeconds: ptr.To(30),
+								OffsetSeconds: pointer.P(30),
 							},
 						},
 						PreferredTimer: &v1.Timer{
@@ -2240,7 +2239,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 		Context("Preference.PreferredSubdomain", func() {
 			It("should apply to VMI", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferredSubdomain: ptr.To("kubevirt.io"),
+					PreferredSubdomain: pointer.P("kubevirt.io"),
 				}
 				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(vmi.Spec.Subdomain).To(Equal(*preferenceSpec.PreferredSubdomain))
@@ -2250,7 +2249,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				const userDefinedValue = "foo.com"
 				vmi.Spec.Subdomain = userDefinedValue
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferredSubdomain: ptr.To("kubevirt.io"),
+					PreferredSubdomain: pointer.P("kubevirt.io"),
 				}
 				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(vmi.Spec.Subdomain).To(Equal(userDefinedValue))
@@ -2260,7 +2259,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 		Context("Preference.PreferredTerminationGracePeriodSeconds", func() {
 			It("should apply to VMI", func() {
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferredTerminationGracePeriodSeconds: ptr.To(int64(180)),
+					PreferredTerminationGracePeriodSeconds: pointer.P(int64(180)),
 				}
 				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(*vmi.Spec.TerminationGracePeriodSeconds).To(Equal(*preferenceSpec.PreferredTerminationGracePeriodSeconds))
@@ -2268,9 +2267,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 			It("should not overwrite user defined value", func() {
 				const userDefinedValue = int64(100)
-				vmi.Spec.TerminationGracePeriodSeconds = ptr.To(userDefinedValue)
+				vmi.Spec.TerminationGracePeriodSeconds = pointer.P(userDefinedValue)
 				preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
-					PreferredTerminationGracePeriodSeconds: ptr.To(int64(180)),
+					PreferredTerminationGracePeriodSeconds: pointer.P(int64(180)),
 				}
 				Expect(instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(BeEmpty())
 				Expect(*vmi.Spec.TerminationGracePeriodSeconds).To(Equal(userDefinedValue))

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -243,9 +243,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(err).ToNot(HaveOccurred())
 
 			clusterPreference := builder.NewClusterPreference()
-			preferredCPUTopology := instancetypev1beta1.Sockets
 			clusterPreference.Spec.CPU = &instancetypev1beta1.CPUPreferences{
-				PreferredCPUTopology: &preferredCPUTopology,
+				PreferredCPUTopology: pointer.P(instancetypev1beta1.Sockets),
 			}
 
 			clusterPreference, err = virtClient.VirtualMachineClusterPreference().
@@ -277,9 +276,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(err).ToNot(HaveOccurred())
 
 			preference := builder.NewPreference()
-			preferredCPUTopology := instancetypev1beta1.Sockets
 			preference.Spec.CPU = &instancetypev1beta1.CPUPreferences{
-				PreferredCPUTopology: &preferredCPUTopology,
+				PreferredCPUTopology: pointer.P(instancetypev1beta1.Sockets),
 			}
 			preference.Spec.Devices = &instancetypev1beta1.DevicePreferences{
 				PreferredDiskBus: virtv1.DiskBusSATA,
@@ -526,10 +524,9 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 			By("Creating a VirtualMachinePreference")
 			preference := builder.NewPreference()
-			preferredCPUTopology := instancetypev1beta1.Sockets
 			preference.Spec = instancetypev1beta1.VirtualMachinePreferenceSpec{
 				CPU: &instancetypev1beta1.CPUPreferences{
-					PreferredCPUTopology: &preferredCPUTopology,
+					PreferredCPUTopology: pointer.P(instancetypev1beta1.Sockets),
 				},
 			}
 			preference, err = virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(preference)).
@@ -777,10 +774,9 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 			By("Creating a VirtualMachinePreference")
 			preference = builder.NewPreference()
-			preferredCPUTopology := instancetypev1beta1.Cores
 			preference.Spec = instancetypev1beta1.VirtualMachinePreferenceSpec{
 				CPU: &instancetypev1beta1.CPUPreferences{
-					PreferredCPUTopology: &preferredCPUTopology,
+					PreferredCPUTopology: pointer.P(instancetypev1beta1.Cores),
 				},
 			}
 			preference, err = virtClient.VirtualMachinePreference(namespace).Create(context.Background(), preference, metav1.CreateOptions{})
@@ -1328,7 +1324,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				fetchVirtualMachinePreferencev1beta1,
 			),
 			Entry("VirtualMachinePreference v1beta1 and fetch using v1alpha1, v1alpha2 and v1beta1", func() string {
-				preferredCPUTopology := instancetypev1beta1.Cores
 				createdObj, err := virtClient.VirtualMachinePreference(testsuite.NamespaceTestDefault).Create(context.Background(), &instancetypev1beta1.VirtualMachinePreference{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: instancetypev1beta1.SchemeGroupVersion.String(),
@@ -1339,7 +1334,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						CPU: &instancetypev1beta1.CPUPreferences{
-							PreferredCPUTopology: &preferredCPUTopology,
+							PreferredCPUTopology: pointer.P(instancetypev1beta1.Cores),
 						},
 					},
 				}, metav1.CreateOptions{})
@@ -1395,7 +1390,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				fetchVirtualMachineClusterPreferencev1beta1,
 			),
 			Entry("VirtualMachineClusterPreference v1beta1 and fetch using v1alpha1, v1alpha2 and v1beta1", func() string {
-				preferredCPUTopology := instancetypev1beta1.Cores
 				createdObj, err := virtClient.VirtualMachineClusterPreference().Create(context.Background(), &instancetypev1beta1.VirtualMachineClusterPreference{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: instancetypev1beta1.SchemeGroupVersion.String(),
@@ -1406,7 +1400,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						CPU: &instancetypev1beta1.CPUPreferences{
-							PreferredCPUTopology: &preferredCPUTopology,
+							PreferredCPUTopology: pointer.P(instancetypev1beta1.Cores),
 						},
 					},
 				}, metav1.CreateOptions{})
@@ -1421,12 +1415,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	})
 
 	Context("VirtualMachine using preference resource requirements", func() {
-		var (
-			preferCores   = instancetypev1beta1.Cores
-			preferThreads = instancetypev1beta1.Threads
-			preferAny     = instancetypev1beta1.Any
-		)
-
 		DescribeTable("should be accepted when", func(instancetype *instancetypev1beta1.VirtualMachineInstancetype, preference *instancetypev1beta1.VirtualMachinePreference, vm *virtv1.VirtualMachine) {
 			var err error
 			if instancetype != nil {
@@ -1573,7 +1561,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						CPU: &instancetypev1beta1.CPUPreferences{
-							PreferredCPUTopology: &preferCores,
+							PreferredCPUTopology: pointer.P(instancetypev1beta1.Cores),
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
@@ -1644,7 +1632,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						CPU: &instancetypev1beta1.CPUPreferences{
-							PreferredCPUTopology: &preferThreads,
+							PreferredCPUTopology: pointer.P(instancetypev1beta1.Threads),
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
@@ -1684,7 +1672,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						CPU: &instancetypev1beta1.CPUPreferences{
-							PreferredCPUTopology: &preferAny,
+							PreferredCPUTopology: pointer.P(instancetypev1beta1.Any),
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
@@ -1904,7 +1892,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						CPU: &instancetypev1beta1.CPUPreferences{
-							PreferredCPUTopology: &preferCores,
+							PreferredCPUTopology: pointer.P(instancetypev1beta1.Cores),
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
@@ -1945,7 +1933,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						CPU: &instancetypev1beta1.CPUPreferences{
-							PreferredCPUTopology: &preferThreads,
+							PreferredCPUTopology: pointer.P(instancetypev1beta1.Threads),
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{
@@ -1986,7 +1974,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 					Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 						CPU: &instancetypev1beta1.CPUPreferences{
-							PreferredCPUTopology: &preferAny,
+							PreferredCPUTopology: pointer.P(instancetypev1beta1.Any),
 						},
 						Requirements: &instancetypev1beta1.PreferenceRequirements{
 							CPU: &instancetypev1beta1.CPUPreferenceRequirement{


### PR DESCRIPTION
/cc @0xFelix 

### What this PR does
Before this PR:

$subject, this removes the final use of this package and replaces it `kubevirt.io/kubevirt/pkg/pointer`.

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

