### PR TITLE
instancetype: Harden CR upgrade func test

### DIFF
--- a/tests/instancetype/upgrade.go
+++ b/tests/instancetype/upgrade.go
@@ -172,11 +172,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(decodedObj.GetObjectKind().GroupVersionKind().Version).To(Equal(instancetypeapi.LatestVersion))
 		}, 30*time.Second, time.Second).Should(Succeed())
 
-		// If a new CR has been created assert that the old CR has been deleted
+		// If a new CR has been created assert that the old CR is eventually deleted
 		if originalTestRevisionName != revisionName {
-			_, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), originalTestRevisionName, metav1.GetOptions{})
-			Expect(err).Should(HaveOccurred())
-			Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonNotFound))
+			Eventually(func() error {
+				_, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(context.Background(), originalTestRevisionName, metav1.GetOptions{})
+				return err
+			}, 30*time.Second, time.Second).Should(MatchError(errors.IsNotFound, "errors.IsNotFound"), "ControllerRevision %s has not been deleted", originalTestRevisionName)
 		}
 	},
 		Entry("VirtualMachineInstancetype from v1beta1 without labels to latest",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
When replacing the original CR the test asserts that it is removed from the cluster. This can take the controller some time to complete in a busy env so move this check into an Eventually call.

Reported downstream within RH under https://issues.redhat.com/browse/CNV-48098 with the following trace:

```
tests/instancetype/upgrade.go:340
Expected an error to have occurred.  Got:
    <nil>: nil
tests/instancetype/upgrade.go:178
```

AFAICT this hasn't failed recently upstream searching on [`search.ci.kubevirt.io`](https://search.ci.kubevirt.io/?search=%22ControllerRevision+Upgrades+should+upgrade%22&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

