### PR TITLE
Inline GetRunningVMIEmulator() and remove it from tests/utils.go

### DIFF
--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -88,9 +88,9 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			By("Validating VCPU scheduler placement information")
 			pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(err).ToNot(HaveOccurred())
-			emulator, err := tests.GetRunningVMIEmulator(vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			emulator = filepath.Base(emulator)
+			emulator := filepath.Base(domSpec.Devices.Emulator)
 			psOutput, err := exec.ExecuteCommandOnPod(
 				pod,
 				"compute",
@@ -131,9 +131,9 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, decorators.Si
 			pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 			By("Validating VCPU scheduler placement information")
-			emulator, err := tests.GetRunningVMIEmulator(vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			emulator = filepath.Base(emulator)
+			emulator := filepath.Base(domSpec.Devices.Emulator)
 			psOutput, err := exec.ExecuteCommandOnPod(
 				pod,
 				"compute",

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -133,9 +133,10 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 				Expect(err).ToNot(HaveOccurred())
 				libwait.WaitForSuccessfulVMIStart(vmi)
 
-				emulator, err := tests.GetRunningVMIEmulator(vmi)
+				domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				emulator = "[/]" + strings.TrimPrefix(emulator, "/")
+
+				emulator := "[/]" + strings.TrimPrefix(domSpec.Devices.Emulator, "/")
 
 				pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -208,9 +209,10 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 				libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				By("Fetching virt-launcher Pod")
-				emulator, err := tests.GetRunningVMIEmulator(vmi)
+				domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				emulator = "[/]" + strings.TrimPrefix(emulator, "/")
+
+				emulator := "[/]" + strings.TrimPrefix(domSpec.Devices.Emulator, "/")
 
 				pod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.NamespacePrivileged)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -222,14 +222,6 @@ func GetRunningVMIDomainSpec(vmi *v1.VirtualMachineInstance) (*launcherApi.Domai
 	return &runningVMISpec, err
 }
 
-func GetRunningVMIEmulator(vmi *v1.VirtualMachineInstance) (string, error) {
-	domSpec, err := GetRunningVMIDomainSpec(vmi)
-	if err != nil {
-		return "", err
-	}
-	return domSpec.Devices.Emulator, nil
-}
-
 func updateKubeVirtConfigValueAndWaitHandlerRedeploymnet(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
 	virtClient := kubevirt.Client()
 	ds, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.TODO(), "virt-handler", metav1.GetOptions{})

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1065,9 +1065,9 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Triggering a segfault in qemu")
-					emulator, err := tests.GetRunningVMIEmulator(vmi)
+					domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 					Expect(err).ToNot(HaveOccurred())
-					emulator = filepath.Base(emulator)
+					emulator := filepath.Base(domSpec.Devices.Emulator)
 					libpod.RunCommandOnVmiPod(vmi, []string{"killall", "-11", emulator})
 
 					By("Ensuring the VM stops")

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2782,10 +2782,10 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					&expect.BExp{R: "2"},
 				}, 15)).To(Succeed())
 
-				emulator, err := tests.GetRunningVMIEmulator(vmi)
+				domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				emulator = filepath.Base(emulator)
 
+				emulator := filepath.Base(domSpec.Devices.Emulator)
 				pidCmd := []string{"pidof", emulator}
 				qemuPid, err := exec.ExecuteCommandOnPod(readyPod, "compute", pidCmd)
 				// do not check for kvm-pit thread if qemu is not in use


### PR DESCRIPTION
### What this PR does
The GetRunningVMIEmulator() function is short, trivial and does not simplify the code in any way, but rather makes it more complex by creating another layer of indirection.

As a bonus, we get to shorten tests/utils.go by getting rid of it.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

