### PR TITLE
[release-1.3] fix: correctly check dry-run requests

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/policy/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -2,11 +2,13 @@ package admitters
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	k8scorev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -32,6 +34,20 @@ func NewPodEvictionAdmitter(clusterConfig *virtconfig.ClusterConfig, kubeClient 
 		kubeClient:    kubeClient,
 		virtClient:    virtClient,
 	}
+}
+
+func isDryRun(ar *admissionv1.AdmissionReview) bool {
+	dryRun := ar.Request.DryRun != nil && *ar.Request.DryRun == true
+
+	if !dryRun {
+		evictionObject := policyv1.Eviction{}
+		if err := json.Unmarshal(ar.Request.Object.Raw, &evictionObject); err == nil {
+			if evictionObject.DeleteOptions != nil && len(evictionObject.DeleteOptions.DryRun) > 0 {
+				dryRun = evictionObject.DeleteOptions.DryRun[0] == metav1.DryRunAll
+			}
+		}
+	}
+	return dryRun
 }
 
 func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
@@ -77,8 +93,7 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 	}
 
 	if markForEviction && !vmi.IsMarkedForEviction() && vmi.Status.NodeName == pod.Spec.NodeName {
-		dryRun := ar.Request.DryRun != nil && *ar.Request.DryRun == true
-		err := admitter.markVMI(vmi.Namespace, vmi.Name, vmi.Status.NodeName, dryRun)
+		err := admitter.markVMI(vmi.Namespace, vmi.Name, vmi.Status.NodeName, isDryRun(ar))
 		if err != nil {
 			// As with the previous case, it is up to the user to issue a retry.
 			return denied(fmt.Sprintf("kubevirt failed marking the vmi for eviction: %s", err.Error()))

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -168,40 +168,36 @@ var _ = Describe("Pod eviction admitter", func() {
 	},
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is LiveMigrate and VMI is migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyLiveMigrate)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is LiveMigrateIfPossible and VMI is migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyLiveMigrateIfPossible)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrateIfPossible),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is External and VMI is not migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyExternal)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyExternal),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is External and VMI is migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyExternal)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyExternal),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is LiveMigrate, VMI eviction strategy is missing and VMI is migratable",
 			pointer.P(virtv1.EvictionStrategyLiveMigrate),
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is LiveMigrateIfPossible, VMI eviction strategy is missing and VMI is migratable",
 			pointer.P(virtv1.EvictionStrategyLiveMigrateIfPossible),
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is External, VMI eviction strategy is missing and VMI is not migratable",
 			pointer.P(virtv1.EvictionStrategyExternal),
-			withEvictionStrategy(nil),
 		),
 		Entry("When cluster-wide eviction strategy is External, VMI eviction strategy is missing and VMI is migratable",
 			pointer.P(virtv1.EvictionStrategyExternal),
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 	)
@@ -234,38 +230,33 @@ var _ = Describe("Pod eviction admitter", func() {
 	},
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is missing and VMI is not migratable",
 			nil,
-			withEvictionStrategy(nil),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is missing and VMI is migratable",
 			nil,
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is None and VMI is not migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyNone)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyNone),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is None and VMI is migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyNone)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyNone),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is LiveMigrateIfPossible and VMI is not migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyLiveMigrateIfPossible)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrateIfPossible),
 		),
 		Entry("When cluster-wide eviction strategy is None, VMI eviction strategy is missing and VMI is not migratable",
 			pointer.P(virtv1.EvictionStrategyNone),
-			withEvictionStrategy(nil),
 		),
 		Entry("When cluster-wide eviction strategy is None, VMI eviction strategy is missing and VMI is migratable",
 			pointer.P(virtv1.EvictionStrategyNone),
-			withEvictionStrategy(nil),
 			withLiveMigratableCondition(),
 		),
 		Entry("When cluster-wide eviction strategy is LiveMigrateIfPossible, VMI eviction strategy is missing and VMI is not migratable",
 			pointer.P(virtv1.EvictionStrategyLiveMigrateIfPossible),
-			withEvictionStrategy(nil),
 		),
 	)
 
@@ -301,11 +292,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	},
 		Entry("When cluster-wide eviction strategy is missing, VMI eviction strategy is LiveMigrate and VMI is not migratable",
 			nil,
-			withEvictionStrategy(pointer.P(virtv1.EvictionStrategyLiveMigrate)),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 		),
 		Entry("When cluster-wide eviction strategy is LiveMigrate, VMI eviction strategy is missing and VMI is not migratable",
 			pointer.P(virtv1.EvictionStrategyLiveMigrate),
-			withEvictionStrategy(nil),
 		),
 	)
 
@@ -346,11 +336,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should deny the request when the admitter fails to patch the VMI", func() {
-		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
 		vmiOptions := []libvmi.Option{
 			libvmi.WithNamespace(testNamespace),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 			withStatusNodeName(testNodeName),
-			withEvictionStrategy(&evictionStrategy),
 			withLiveMigratableCondition(),
 		}
 
@@ -388,11 +377,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should allow the request and not mark the VMI again when the VMI is already marked for evacuation", func() {
-		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
 		vmiOptions := []libvmi.Option{
 			libvmi.WithNamespace(testNamespace),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 			withStatusNodeName(testNodeName),
-			withEvictionStrategy(&evictionStrategy),
 			withLiveMigratableCondition(),
 			withEvacuationNodeName(testNodeName),
 		}
@@ -419,11 +407,10 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	It("should deny the request and perform a dryRun patch on the VMI when the request is a dry run", func() {
-		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
 		vmiOptions := []libvmi.Option{
 			libvmi.WithNamespace(testNamespace),
+			libvmi.WithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate),
 			withStatusNodeName(testNodeName),
-			withEvictionStrategy(&evictionStrategy),
 			withLiveMigratableCondition(),
 		}
 
@@ -586,12 +573,6 @@ func newExpectedJSONPatchToVMI(vmi *virtv1.VirtualMachineInstance, expectedJSONP
 func withStatusNodeName(nodeName string) libvmi.Option {
 	return func(vmi *virtv1.VirtualMachineInstance) {
 		vmi.Status.NodeName = nodeName
-	}
-}
-
-func withEvictionStrategy(evictionStrategy *virtv1.EvictionStrategy) libvmi.Option {
-	return func(vmi *virtv1.VirtualMachineInstance) {
-		vmi.Spec.EvictionStrategy = evictionStrategy
 	}
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters"
@@ -52,7 +53,6 @@ var _ = Describe("Pod eviction admitter", func() {
 	const (
 		testNamespace = "test-ns"
 		testNodeName  = "node01"
-		testVMIName   = "my-vmi"
 	)
 
 	const isDryRun = true
@@ -104,7 +104,12 @@ var _ = Describe("Pod eviction admitter", func() {
 	})
 
 	DescribeTable("should allow the request when it refers to a virt-launcher pod", func(podPhase k8sv1.PodPhase) {
-		vmi := newVMI(testNamespace, testVMIName, testNodeName)
+		vmiOptions = append(vmiOptions,
+			libvmi.WithNamespace(testNamespace),
+			withStatusNodeName(testNodeName),
+		)
+
+		vmi := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
 
 		pod := newVirtLauncherPodWithPhase(vmi.Namespace, vmi.Name, vmi.Status.NodeName, podPhase)
@@ -129,7 +134,12 @@ var _ = Describe("Pod eviction admitter", func() {
 	)
 
 	DescribeTable("should trigger VMI Evacuation and deny the request", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...vmiOption) {
-		vmi := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
+		vmiOptions = append(vmiOptions,
+			libvmi.WithNamespace(testNamespace),
+			withStatusNodeName(testNodeName),
+		)
+
+		vmi := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
 
 		evictedVirtLauncherPod := newVirtLauncherPod(vmi.Namespace, vmi.Name, vmi.Status.NodeName)
@@ -196,8 +206,13 @@ var _ = Describe("Pod eviction admitter", func() {
 		),
 	)
 
-	DescribeTable("should allow the request without triggering VMI evacuation", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...vmiOption) {
-		vmi := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
+	DescribeTable("should allow the request without triggering VMI evacuation", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...libvmi.Option) {
+		vmiOptions = append(vmiOptions,
+			libvmi.WithNamespace(testNamespace),
+			withStatusNodeName(testNodeName),
+		)
+
+		vmi := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
 
 		evictedVirtLauncherPod := newVirtLauncherPod(vmi.Namespace, vmi.Name, vmi.Status.NodeName)
@@ -254,8 +269,13 @@ var _ = Describe("Pod eviction admitter", func() {
 		),
 	)
 
-	DescribeTable("should deny the request without triggering VMI evacuation", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...vmiOption) {
-		vmi := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
+	DescribeTable("should deny the request without triggering VMI evacuation", func(clusterWideEvictionStrategy *virtv1.EvictionStrategy, vmiOptions ...libvmi.Option) {
+		vmiOptions = append(vmiOptions,
+			libvmi.WithNamespace(testNamespace),
+			withStatusNodeName(testNodeName),
+		)
+
+		vmi := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
 
 		evictedVirtLauncherPod := newVirtLauncherPod(vmi.Namespace, vmi.Name, vmi.Status.NodeName)
@@ -290,7 +310,12 @@ var _ = Describe("Pod eviction admitter", func() {
 	)
 
 	It("should deny the request when the admitter fails to fetch the VMI", func() {
-		vmi := newVMI(testNamespace, testVMIName, testNodeName)
+		vmiOptions := []libvmi.Option{
+			libvmi.WithNamespace(testNamespace),
+			withStatusNodeName(testNodeName),
+		}
+
+		vmi := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(vmi)
 
 		expectedError := errors.New("some error")
@@ -322,9 +347,14 @@ var _ = Describe("Pod eviction admitter", func() {
 
 	It("should deny the request when the admitter fails to patch the VMI", func() {
 		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
-		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStrategy), withLiveMigratableCondition()}
+		vmiOptions := []libvmi.Option{
+			libvmi.WithNamespace(testNamespace),
+			withStatusNodeName(testNodeName),
+			withEvictionStrategy(&evictionStrategy),
+			withLiveMigratableCondition(),
+		}
 
-		migratableVMI := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
+		migratableVMI := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)
 
 		expectedError := errors.New("some error")
@@ -359,9 +389,15 @@ var _ = Describe("Pod eviction admitter", func() {
 
 	It("should allow the request and not mark the VMI again when the VMI is already marked for evacuation", func() {
 		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
-		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStrategy), withLiveMigratableCondition(), withEvacuationNodeName(testNodeName)}
+		vmiOptions := []libvmi.Option{
+			libvmi.WithNamespace(testNamespace),
+			withStatusNodeName(testNodeName),
+			withEvictionStrategy(&evictionStrategy),
+			withLiveMigratableCondition(),
+			withEvacuationNodeName(testNodeName),
+		}
 
-		migratableVMI := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
+		migratableVMI := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)
 
 		evictedVirtLauncherPod := newVirtLauncherPod(migratableVMI.Namespace, migratableVMI.Name, migratableVMI.Status.NodeName)
@@ -384,9 +420,14 @@ var _ = Describe("Pod eviction admitter", func() {
 
 	It("should deny the request and perform a dryRun patch on the VMI when the request is a dry run", func() {
 		evictionStrategy := virtv1.EvictionStrategyLiveMigrate
-		vmiOptions := []vmiOption{withEvictionStrategy(&evictionStrategy), withLiveMigratableCondition()}
+		vmiOptions := []libvmi.Option{
+			libvmi.WithNamespace(testNamespace),
+			withStatusNodeName(testNodeName),
+			withEvictionStrategy(&evictionStrategy),
+			withLiveMigratableCondition(),
+		}
 
-		migratableVMI := newVMI(testNamespace, testVMIName, testNodeName, vmiOptions...)
+		migratableVMI := libvmi.New(vmiOptions...)
 		virtClient := kubevirtfake.NewSimpleClientset(migratableVMI)
 
 		evictedVirtLauncherPod := newVirtLauncherPod(migratableVMI.Namespace, migratableVMI.Name, migratableVMI.Status.NodeName)
@@ -542,33 +583,19 @@ func newExpectedJSONPatchToVMI(vmi *virtv1.VirtualMachineInstance, expectedJSONP
 	}
 }
 
-type vmiOption func(vmi *virtv1.VirtualMachineInstance)
-
-func newVMI(namespace, name, nodeName string, options ...vmiOption) *virtv1.VirtualMachineInstance {
-	vmi := &virtv1.VirtualMachineInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Status: virtv1.VirtualMachineInstanceStatus{
-			NodeName: nodeName,
-		},
+func withStatusNodeName(nodeName string) libvmi.Option {
+	return func(vmi *virtv1.VirtualMachineInstance) {
+		vmi.Status.NodeName = nodeName
 	}
-
-	for _, optionFunc := range options {
-		optionFunc(vmi)
-	}
-
-	return vmi
 }
 
-func withEvictionStrategy(evictionStrategy *virtv1.EvictionStrategy) vmiOption {
+func withEvictionStrategy(evictionStrategy *virtv1.EvictionStrategy) libvmi.Option {
 	return func(vmi *virtv1.VirtualMachineInstance) {
 		vmi.Spec.EvictionStrategy = evictionStrategy
 	}
 }
 
-func withLiveMigratableCondition() vmiOption {
+func withLiveMigratableCondition() libvmi.Option {
 	return func(vmi *virtv1.VirtualMachineInstance) {
 		vmi.Status.Conditions = append(vmi.Status.Conditions, virtv1.VirtualMachineInstanceCondition{
 			Type:   virtv1.VirtualMachineInstanceIsMigratable,
@@ -577,7 +604,7 @@ func withLiveMigratableCondition() vmiOption {
 	}
 }
 
-func withEvacuationNodeName(evacuationNodeName string) vmiOption {
+func withEvacuationNodeName(evacuationNodeName string) libvmi.Option {
 	return func(vmi *virtv1.VirtualMachineInstance) {
 		vmi.Status.EvacuationNodeName = evacuationNodeName
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/12353 and https://github.com/kubevirt/kubevirt/pull/12696.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

