### PR TITLE
adding virtctl config cmd

### DIFF
--- a/pkg/virtctl/config/config.go
+++ b/pkg/virtctl/config/config.go
@@ -21,15 +21,12 @@ func NewConfigCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 Supported actions are:
 - set <key> <value>: Set a configuration option
 - get <key>: Retrieve the value of a configuration option
-- reset: Reset all configuration options to default
 
 Usage Examples:
 # Set the path to the ssh binary
 kube config set ssh /usr/bin/ssh
 # Get the configured ssh path
 kube config get ssh
-# Reset all configurations
-kube config reset
 		`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -55,14 +52,8 @@ kube config reset
 				fmt.Printf("Configuration %s: %s\n", key, value)
 				return nil
 
-			case "reset":
-				if len(args) != 1 {
-					return fmt.Errorf("reset does not accept any arguments. Usage: config reset")
-				}
-				return resetConfig()
-
 			default:
-				return fmt.Errorf("invalid action: %s. Supported actions: set, get, reset", action)
+				return fmt.Errorf("invalid action: %s. Supported actions: set, get", action)
 			}
 		},
 	}
@@ -89,16 +80,6 @@ func getConfigOption(key string) (string, error) {
 		return value, nil
 	}
 	return "", fmt.Errorf("configuration for %s not found", key)
-}
-
-func resetConfig() error {
-	configFilePath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	err := os.Remove(configFilePath)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	fmt.Println("Configuration reset to defaults")
-	return nil
 }
 
 func loadConfig(filePath string) map[string]string {

--- a/pkg/virtctl/config/config.go
+++ b/pkg/virtctl/config/config.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+	"kubevirt.io/client-go/log"
+)
+
+func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+    log.InitializeLogging("config")
+
+    cmd := &cobra.Command{
+        Use:   "config SUBCOMMAND",
+        Short: "Manage kubevirt configuration",
+        Long: `The 'config' command allows you to manage configuration options for kubevirt, such as specifying paths for SSH binaries or VNC clients. 
+This command supports setting, retrieving, and resetting configurations, which will be stored in a local configuration file.
+    Usage Examples:
+    # Set the path to the ssh binary
+    virtctl config set ssh /usr/bin/ssh
+    # Get the configured ssh path
+    virtctl config get ssh
+    # Reset all configurations
+    virtctl config reset
+        `,
+    }
+
+    // Add subcommands here
+    cmd.AddCommand(newSetCommand())
+    cmd.AddCommand(newGetCommand())
+    cmd.AddCommand(newResetCommand())
+
+    return cmd
+}
+
+
+func newSetCommand() *cobra.Command {
+    var key, value string
+    cmd := &cobra.Command{
+        Use:   "set <key> <value>",
+        Short: "Set a configuration option",
+        Args:  cobra.ExactArgs(2),
+        RunE: func(cmd *cobra.Command, args []string) error {
+            key = args[0]
+            value = args[1]
+            err := setConfigOption(key, value)
+            if err != nil {
+                return err
+            }
+            fmt.Printf("Configuration %s set to %s\n", key, value)
+            return nil
+        },
+    }
+    return cmd
+}
+
+func newGetCommand() *cobra.Command {
+    var key string
+    cmd := &cobra.Command{
+        Use:   "get <key>",
+        Short: "Get a configuration option",
+        Args:  cobra.ExactArgs(1),
+        RunE: func(cmd *cobra.Command, args []string) error {
+            key = args[0]
+            value, err := getConfigOption(key)
+            if err != nil {
+                return err
+            }
+            fmt.Printf("Configuration %s: %s\n", key, value)
+            return nil
+        },
+    }
+    return cmd
+}
+
+func newResetCommand() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "reset",
+        Short: "Reset all configuration options to default",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            err := resetConfig()
+            if err != nil {
+                return err
+            }
+            fmt.Println("Configuration reset to defaults")
+            return nil
+        },
+    }
+    return cmd
+}
+
+func setConfigOption(key, value string) error {
+    configFilePath := filepath.Join(os.Getenv("HOME"), ".virtctl", "config")
+    config := loadConfig(configFilePath)
+    config[key] = value
+    return saveConfig(configFilePath, config)
+}
+
+func getConfigOption(key string) (string, error) {
+    configFilePath := filepath.Join(os.Getenv("HOME"), ".virtctl", "config")
+    config := loadConfig(configFilePath)
+    if value, exists := config[key]; exists {
+        return value, nil
+    }
+    return "", fmt.Errorf("configuration for %s not found", key)
+}
+
+func resetConfig() error {
+    configFilePath := filepath.Join(os.Getenv("HOME"), ".virtctl", "config")
+    return os.Remove(configFilePath)
+}
+
+func loadConfig(filePath string) map[string]string {
+    config := make(map[string]string)
+    file, err := os.Open(filePath)
+    if err != nil {
+        return config
+    }
+    defer file.Close()
+    // Load config (assuming JSON format for simplicity)
+    json.NewDecoder(file).Decode(&config)
+    return config
+}
+
+func saveConfig(filePath string, config map[string]string) error {
+    os.MkdirAll(filepath.Dir(filePath), 0755)
+    file, err := os.Create(filePath)
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+    return json.NewEncoder(file).Encode(config)
+}

--- a/pkg/virtctl/config/config.go
+++ b/pkg/virtctl/config/config.go
@@ -11,7 +11,7 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+func NewConfigCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	log.InitializeLogging("config")
 
 	cmd := &cobra.Command{
@@ -25,11 +25,11 @@ Supported actions are:
 
 Usage Examples:
 # Set the path to the ssh binary
-virtctl config set ssh /usr/bin/ssh
+kube config set ssh /usr/bin/ssh
 # Get the configured ssh path
-virtctl config get ssh
+kube config get ssh
 # Reset all configurations
-virtctl config reset
+kube config reset
 		`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,7 +71,7 @@ virtctl config reset
 }
 
 func setConfigOption(key, value string) error {
-	configFilePath := filepath.Join(os.Getenv("HOME"), ".virtctl", "config")
+	configFilePath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	config := loadConfig(configFilePath)
 	config[key] = value
 	err := saveConfig(configFilePath, config)
@@ -83,7 +83,7 @@ func setConfigOption(key, value string) error {
 }
 
 func getConfigOption(key string) (string, error) {
-	configFilePath := filepath.Join(os.Getenv("HOME"), ".virtctl", "config")
+	configFilePath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	config := loadConfig(configFilePath)
 	if value, exists := config[key]; exists {
 		return value, nil
@@ -92,7 +92,7 @@ func getConfigOption(key string) (string, error) {
 }
 
 func resetConfig() error {
-	configFilePath := filepath.Join(os.Getenv("HOME"), ".virtctl", "config")
+	configFilePath := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	err := os.Remove(configFilePath)
 	if err != nil && !os.IsNotExist(err) {
 		return err

--- a/pkg/virtctl/config/config.go
+++ b/pkg/virtctl/config/config.go
@@ -24,9 +24,9 @@ Supported actions are:
 
 Usage Examples:
 # Set the path to the ssh binary
-kube config set ssh /usr/bin/ssh
+virtctl config set ssh /usr/bin/ssh
 # Get the configured ssh path
-kube config get ssh
+virtctl config get ssh
 		`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -13,6 +13,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/virtctl/config"
 	"kubevirt.io/kubevirt/pkg/virtctl/adm"
 	"kubevirt.io/kubevirt/pkg/virtctl/configuration"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
@@ -80,6 +81,7 @@ func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 	rootCmd.SetUsageTemplate(templates.MainUsageTemplate())
 	rootCmd.SetOut(os.Stdout)
 	rootCmd.AddCommand(
+		config.NewConfigCommand(clientConfig),
 		configuration.NewListPermittedDevices(clientConfig),
 		console.NewCommand(clientConfig),
 		usbredir.NewCommand(clientConfig),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR: The 'config' command allows you to manage configuration options for kubevirt, such as specifying paths for SSH binaries or VNC clients. 
This command supports setting, retrieving, and resetting configurations, which will be stored in a local configuration file.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #6617

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

