### PR TITLE
[virt-handler]: Add options_test.go to test host capabilities parsing

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
     srcs = [
         "migration_test.go",
         "non-root_test.go",
+        "options_test.go",
         "realtime_test.go",
         "retry_manager_test.go",
         "virt_handler_suite_test.go",
@@ -105,6 +106,7 @@ go_test(
         "//pkg/virt-handler/hotplug-disk:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
+        "//pkg/virt-handler/node-labeller/api:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-handler/options.go
+++ b/pkg/virt-handler/options.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package virthandler
 
 import (

--- a/pkg/virt-handler/options_test.go
+++ b/pkg/virt-handler/options_test.go
@@ -1,0 +1,342 @@
+/*
+Copyright 2024 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virthandler
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"
+)
+
+var _ = Describe("Parsing VMI Options", func() {
+	Context("virt-handler VM processes VMI options during update", func() {
+		const memoryUnit = "KiB"
+		DescribeTable("should convert api.Capabilities to cmdv1.Topology when Capabilities is nil or empty", func(caps *api.Capabilities) {
+			actualTopology := capabilitiesToTopology(caps)
+
+			expectedTopology := &cmdv1.Topology{}
+
+			Expect(actualTopology).To(Equal(expectedTopology))
+		},
+			Entry("api.Capabilities is nil", nil),
+			Entry("api.Capabilities is empty", &api.Capabilities{}),
+		)
+		It("should convert api.Capabilities to cmdv1.Topology with single NUMA node", func() {
+			caps := &api.Capabilities{}
+			caps.Host.Topology.Cells = api.Cells{
+				Cell: []api.Cell{
+					{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 16256896},
+						Pages: []api.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 4064224},
+							{Unit: memoryUnit, Size: 2048, Count: 0},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: api.Distances{Sibling: []api.Sibling{{ID: 0, Value: 10}}},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0, 4}},
+							{ID: 1, Siblings: []uint32{1, 5}},
+							{ID: 2, Siblings: []uint32{2, 6}},
+							{ID: 3, Siblings: []uint32{3, 7}},
+							{ID: 4, Siblings: []uint32{0, 4}},
+							{ID: 5, Siblings: []uint32{1, 5}},
+							{ID: 6, Siblings: []uint32{2, 6}},
+							{ID: 7, Siblings: []uint32{3, 7}},
+						}},
+					},
+				},
+			}
+
+			actualTopology := capabilitiesToTopology(caps)
+
+			expectedTopology := &cmdv1.Topology{
+				NumaCells: []*cmdv1.Cell{
+					{
+						Memory: &cmdv1.Memory{Unit: memoryUnit, Amount: 16256896},
+						Pages: []*cmdv1.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 4064224},
+							{Unit: memoryUnit, Size: 2048, Count: 0},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: []*cmdv1.Sibling{{Id: 0, Value: 10}},
+						Cpus: []*cmdv1.CPU{
+							{Id: 0, Siblings: []uint32{0, 4}},
+							{Id: 1, Siblings: []uint32{1, 5}},
+							{Id: 2, Siblings: []uint32{2, 6}},
+							{Id: 3, Siblings: []uint32{3, 7}},
+							{Id: 4, Siblings: []uint32{0, 4}},
+							{Id: 5, Siblings: []uint32{1, 5}},
+							{Id: 6, Siblings: []uint32{2, 6}},
+							{Id: 7, Siblings: []uint32{3, 7}},
+						},
+					},
+				},
+			}
+
+			Expect(actualTopology).To(Equal(expectedTopology))
+		})
+
+		It("should convert api.Capabilities to cmdv1.Topology with multiple NUMA nodes, CPUs and pages", func() {
+			caps := &api.Capabilities{}
+			caps.Host.Topology.Cells = api.Cells{
+				Cell: []api.Cell{
+					{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 1289144},
+						Pages: []api.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 314094},
+							{Unit: memoryUnit, Size: 2048, Count: 16},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: api.Distances{Sibling: []api.Sibling{
+							{ID: 0, Value: 10},
+							{ID: 1, Value: 10},
+							{ID: 2, Value: 10},
+							{ID: 3, Value: 10},
+						}},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0}},
+							{ID: 1, Siblings: []uint32{1}},
+							{ID: 2, Siblings: []uint32{2}},
+							{ID: 3, Siblings: []uint32{3}},
+							{ID: 4, Siblings: []uint32{4}},
+							{ID: 5, Siblings: []uint32{5}},
+						}},
+					},
+					{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 1223960},
+						Pages: []api.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 297798},
+							{Unit: memoryUnit, Size: 2048, Count: 16},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: api.Distances{Sibling: []api.Sibling{
+							{ID: 0, Value: 10},
+							{ID: 1, Value: 10},
+							{ID: 2, Value: 10},
+							{ID: 3, Value: 10},
+						}},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0}},
+							{ID: 1, Siblings: []uint32{1}},
+							{ID: 2, Siblings: []uint32{2}},
+							{ID: 3, Siblings: []uint32{3}},
+							{ID: 4, Siblings: []uint32{4}},
+							{ID: 5, Siblings: []uint32{5}},
+						}},
+					},
+					{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 1251752},
+						Pages: []api.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 304746},
+							{Unit: memoryUnit, Size: 2048, Count: 16},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: api.Distances{Sibling: []api.Sibling{
+							{ID: 0, Value: 10},
+							{ID: 1, Value: 10},
+							{ID: 2, Value: 10},
+							{ID: 3, Value: 10},
+						}},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0}},
+							{ID: 1, Siblings: []uint32{1}},
+							{ID: 2, Siblings: []uint32{2}},
+							{ID: 3, Siblings: []uint32{3}},
+							{ID: 4, Siblings: []uint32{4}},
+							{ID: 5, Siblings: []uint32{5}},
+						}},
+					},
+					{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 1289404},
+						Pages: []api.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 314159},
+							{Unit: memoryUnit, Size: 2048, Count: 16},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: api.Distances{Sibling: []api.Sibling{
+							{ID: 0, Value: 10},
+							{ID: 1, Value: 10},
+							{ID: 2, Value: 10},
+							{ID: 3, Value: 10},
+						}},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0}},
+							{ID: 1, Siblings: []uint32{1}},
+							{ID: 2, Siblings: []uint32{2}},
+							{ID: 3, Siblings: []uint32{3}},
+							{ID: 4, Siblings: []uint32{4}},
+							{ID: 5, Siblings: []uint32{5}},
+						}},
+					},
+				},
+			}
+
+			actualTopology := capabilitiesToTopology(caps)
+
+			expectedTopology := &cmdv1.Topology{
+				NumaCells: []*cmdv1.Cell{
+					{
+						Memory: &cmdv1.Memory{Unit: memoryUnit, Amount: 1289144},
+						Pages: []*cmdv1.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 314094},
+							{Unit: memoryUnit, Size: 2048, Count: 16},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: []*cmdv1.Sibling{
+							{Id: 0, Value: 10},
+							{Id: 1, Value: 10},
+							{Id: 2, Value: 10},
+							{Id: 3, Value: 10},
+						},
+						Cpus: []*cmdv1.CPU{
+							{Id: 0, Siblings: []uint32{0}},
+							{Id: 1, Siblings: []uint32{1}},
+							{Id: 2, Siblings: []uint32{2}},
+							{Id: 3, Siblings: []uint32{3}},
+							{Id: 4, Siblings: []uint32{4}},
+							{Id: 5, Siblings: []uint32{5}},
+						},
+					},
+					{
+						Memory: &cmdv1.Memory{Unit: memoryUnit, Amount: 1223960},
+						Pages: []*cmdv1.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 297798},
+							{Unit: memoryUnit, Size: 2048, Count: 16},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: []*cmdv1.Sibling{
+							{Id: 0, Value: 10},
+							{Id: 1, Value: 10},
+							{Id: 2, Value: 10},
+							{Id: 3, Value: 10},
+						},
+						Cpus: []*cmdv1.CPU{
+							{Id: 0, Siblings: []uint32{0}},
+							{Id: 1, Siblings: []uint32{1}},
+							{Id: 2, Siblings: []uint32{2}},
+							{Id: 3, Siblings: []uint32{3}},
+							{Id: 4, Siblings: []uint32{4}},
+							{Id: 5, Siblings: []uint32{5}},
+						},
+					},
+					{
+						Memory: &cmdv1.Memory{Unit: memoryUnit, Amount: 1251752},
+						Pages: []*cmdv1.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 304746},
+							{Unit: memoryUnit, Size: 2048, Count: 16},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: []*cmdv1.Sibling{
+							{Id: 0, Value: 10},
+							{Id: 1, Value: 10},
+							{Id: 2, Value: 10},
+							{Id: 3, Value: 10},
+						},
+						Cpus: []*cmdv1.CPU{
+							{Id: 0, Siblings: []uint32{0}},
+							{Id: 1, Siblings: []uint32{1}},
+							{Id: 2, Siblings: []uint32{2}},
+							{Id: 3, Siblings: []uint32{3}},
+							{Id: 4, Siblings: []uint32{4}},
+							{Id: 5, Siblings: []uint32{5}},
+						},
+					},
+					{
+						Memory: &cmdv1.Memory{Unit: memoryUnit, Amount: 1289404},
+						Pages: []*cmdv1.Pages{
+							{Unit: memoryUnit, Size: 4, Count: 314159},
+							{Unit: memoryUnit, Size: 2048, Count: 16},
+							{Unit: memoryUnit, Size: 1048576, Count: 0},
+						},
+						Distances: []*cmdv1.Sibling{
+							{Id: 0, Value: 10},
+							{Id: 1, Value: 10},
+							{Id: 2, Value: 10},
+							{Id: 3, Value: 10},
+						},
+						Cpus: []*cmdv1.CPU{
+							{Id: 0, Siblings: []uint32{0}},
+							{Id: 1, Siblings: []uint32{1}},
+							{Id: 2, Siblings: []uint32{2}},
+							{Id: 3, Siblings: []uint32{3}},
+							{Id: 4, Siblings: []uint32{4}},
+							{Id: 5, Siblings: []uint32{5}},
+						},
+					},
+				},
+			}
+
+			Expect(actualTopology).To(Equal(expectedTopology))
+		})
+		It("should convert api.Capabilities to cmdv1.Topology when certain fields of Capabilities are not initialized", func() {
+			caps := &api.Capabilities{}
+			caps.Host.Topology.Cells = api.Cells{
+				Cell: []api.Cell{
+					{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 16256896},
+						Pages: []api.Pages{
+							{Size: 4, Count: 4064224},
+							{Unit: memoryUnit, Count: 0},
+							{Unit: memoryUnit, Size: 1048576},
+						},
+						Distances: api.Distances{Sibling: []api.Sibling{{ID: 0, Value: 10}}},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0},
+							{Siblings: []uint32{1, 5}},
+							{ID: 2, Siblings: []uint32{2, 6}},
+							{ID: 3, Siblings: []uint32{3, 7}},
+							{ID: 4, Siblings: []uint32{0, 4}},
+							{ID: 5, Siblings: []uint32{1, 5}},
+							{ID: 6, Siblings: []uint32{2, 6}},
+							{ID: 7, Siblings: []uint32{3, 7}},
+						}},
+					},
+				},
+			}
+
+			actualTopology := capabilitiesToTopology(caps)
+
+			expectedTopology := &cmdv1.Topology{
+				NumaCells: []*cmdv1.Cell{
+					{
+						Memory: &cmdv1.Memory{Unit: memoryUnit, Amount: 16256896},
+						Pages: []*cmdv1.Pages{
+							{Size: 4, Count: 4064224},
+							{Unit: memoryUnit, Count: 0},
+							{Unit: memoryUnit, Size: 1048576},
+						},
+						Distances: []*cmdv1.Sibling{{Id: 0, Value: 10}},
+						Cpus: []*cmdv1.CPU{
+							{Id: 0},
+							{Siblings: []uint32{1, 5}},
+							{Id: 2, Siblings: []uint32{2, 6}},
+							{Id: 3, Siblings: []uint32{3, 7}},
+							{Id: 4, Siblings: []uint32{0, 4}},
+							{Id: 5, Siblings: []uint32{1, 5}},
+							{Id: 6, Siblings: []uint32{2, 6}},
+							{Id: 7, Siblings: []uint32{3, 7}},
+						},
+					},
+				},
+			}
+
+			Expect(actualTopology).To(Equal(expectedTopology))
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

VMI options parsing wasn't covered in terms of unit testing.

**After this PR:**

VMI options parsing is now covered in terms of unit testing.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Partially addresses https://github.com/kubevirt/kubevirt/pull/12652 which introduces additional logic to `options.go` and requires that certain changes be made to it. 

### Special notes for your reviewer

Struct initialization values reference [capabilities.xml](https://github.com/kubevirt/kubevirt/blob/3766e045c0157db9bc23cbd2698fd8e2809dea4f/pkg/virt-handler/node-labeller/testdata/capabilities.xml) and [capabilities_with_numa.xml](https://github.com/kubevirt/kubevirt/blob/3766e045c0157db9bc23cbd2698fd8e2809dea4f/pkg/virt-handler/node-labeller/testdata/capabilities_with_numa.xml) respectively.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

