### PR TITLE
VMRestore: create DVs before creation/update of restored VM

### DIFF
--- a/pkg/libvmi/vm.go
+++ b/pkg/libvmi/vm.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
@@ -78,7 +78,7 @@ func WithRunStrategy(strategy v1.VirtualMachineRunStrategy) VMOption {
 	}
 }
 
-func WithDataVolumeTemplate(datavolume *v1beta1.DataVolume) VMOption {
+func WithDataVolumeTemplate(datavolume *cdiv1.DataVolume) VMOption {
 	return func(vm *v1.VirtualMachine) {
 		vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates,
 			v1.DataVolumeTemplateSpec{

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 
 	"kubevirt.io/client-go/log"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"k8s.io/client-go/tools/cache"
 
@@ -126,7 +126,7 @@ func (bs *BackendStorage) getAccessMode(storageClass string, mode v1.PersistentV
 		log.Log.Infof("no storage profile found for %s, defaulting to %s", storageClass, accessMode)
 		return accessMode
 	}
-	storageProfile := obj.(*v1beta1.StorageProfile)
+	storageProfile := obj.(*cdiv1.StorageProfile)
 
 	if storageProfile.Status.ClaimPropertySets == nil || len(storageProfile.Status.ClaimPropertySets) == 0 {
 		log.Log.Infof("no ClaimPropertySets in storage profile %s, defaulting to %s", storageProfile.Name, accessMode)

--- a/pkg/storage/backend-storage/backend-storage_test.go
+++ b/pkg/storage/backend-storage/backend-storage_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -51,7 +51,7 @@ var _ = Describe("Backend Storage", func() {
 		kubevirtFakeConfig := &virtv1.KubeVirtConfiguration{}
 		config, _, kvStore = testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		storageClassInformer, _ = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
-		storageProfileInformer, _ = testutils.NewFakeInformerFor(&v1beta1.StorageProfile{})
+		storageProfileInformer, _ = testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 		pvcInformer, _ := testutils.NewFakeInformerFor(&v1.PersistentVolumeClaim{})
 
 		backendStorage = NewBackendStorage(virtClient, config, storageClassInformer.GetStore(), storageProfileInformer.GetStore(), pvcInformer.GetIndexer())
@@ -103,13 +103,13 @@ var _ = Describe("Backend Storage", func() {
 	Context("Access mode", func() {
 		BeforeEach(func() {
 			By("Creating a storage profile with no access/volume mode")
-			sp := &v1beta1.StorageProfile{
+			sp := &cdiv1.StorageProfile{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "nomode",
 				},
-				Spec: v1beta1.StorageProfileSpec{},
-				Status: v1beta1.StorageProfileStatus{
-					ClaimPropertySets: []v1beta1.ClaimPropertySet{},
+				Spec: cdiv1.StorageProfileSpec{},
+				Status: cdiv1.StorageProfileStatus{
+					ClaimPropertySets: []cdiv1.ClaimPropertySet{},
 				},
 			}
 			err := storageProfileInformer.GetStore().Add(sp)
@@ -118,7 +118,7 @@ var _ = Describe("Backend Storage", func() {
 			By("Creating a storage profile with RWO FS as its only mode")
 			sp = sp.DeepCopy()
 			sp.Name = "onlyrwo"
-			sp.Status.ClaimPropertySets = []v1beta1.ClaimPropertySet{{
+			sp.Status.ClaimPropertySets = []cdiv1.ClaimPropertySet{{
 				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				VolumeMode:  pointer.P(v1.PersistentVolumeFilesystem),
 			}}
@@ -128,7 +128,7 @@ var _ = Describe("Backend Storage", func() {
 			By("Creating a storage profile that supports FS in both RWO and RWX")
 			sp = sp.DeepCopy()
 			sp.Name = "both"
-			sp.Status.ClaimPropertySets = []v1beta1.ClaimPropertySet{{
+			sp.Status.ClaimPropertySets = []cdiv1.ClaimPropertySet{{
 				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany, v1.ReadWriteOnce},
 				VolumeMode:  pointer.P(v1.PersistentVolumeFilesystem),
 			}}

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -430,7 +430,6 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 
 	var newTemplates = make([]kubevirtv1.DataVolumeTemplateSpec, len(snapshotVM.Spec.DataVolumeTemplates))
 	var newVolumes []kubevirtv1.Volume
-	var deletedDataVolumes []string
 	updatedStatus := false
 
 	for i, t := range snapshotVM.Spec.DataVolumeTemplates {
@@ -455,57 +454,41 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 					return false, fmt.Errorf("pvc %s/%s does not exist and should", t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
 				}
 
-				if nv.DataVolume != nil {
-					templateIndex := -1
-					for i, dvt := range snapshotVM.Spec.DataVolumeTemplates {
-						if v.DataVolume.Name == dvt.Name {
-							templateIndex = i
-							break
+				if nv.DataVolume == nil {
+					nv.PersistentVolumeClaim.ClaimName = vr.PersistentVolumeClaimName
+					continue
+				}
+
+				templateIndex := findDVTemplateIndex(v.DataVolume.Name, snapshotVM)
+				if templateIndex >= 0 {
+					if vr.DataVolumeName == nil {
+						dvName := restoreDVName(t.vmRestore, vr.VolumeName)
+						err = t.updatePVCPopulatedForAnnotation(pvc, dvName)
+						if err != nil {
+							return false, err
 						}
+
+						vr.DataVolumeName = &dvName
+						updatedStatus = true
 					}
 
-					if templateIndex >= 0 {
-						if vr.DataVolumeName == nil {
-							updatePVC := pvc.DeepCopy()
-							dvName := restoreDVName(t.vmRestore, vr.VolumeName)
+					dv := snapshotVM.Spec.DataVolumeTemplates[templateIndex].DeepCopy()
+					dv.Name = *vr.DataVolumeName
+					newTemplates[templateIndex] = *dv
 
-							if updatePVC.Annotations[populatedForPVCAnnotation] != dvName {
-								if updatePVC.Annotations == nil {
-									updatePVC.Annotations = make(map[string]string)
-								}
-								updatePVC.Annotations[populatedForPVCAnnotation] = dvName
-								// datavolume will take ownership
-								updatePVC.OwnerReferences = nil
-								_, err = t.controller.Client.CoreV1().PersistentVolumeClaims(updatePVC.Namespace).Update(context.Background(), updatePVC, metav1.UpdateOptions{})
-								if err != nil {
-									return false, err
-								}
-							}
-
-							vr.DataVolumeName = &dvName
-							updatedStatus = true
-						}
-
-						dv := snapshotVM.Spec.DataVolumeTemplates[templateIndex].DeepCopy()
-						dv.Name = *vr.DataVolumeName
-						newTemplates[templateIndex] = *dv
-
-						nv.DataVolume.Name = *vr.DataVolumeName
-					} else {
-						// convert to PersistentVolumeClaim volume
-						nv = &kubevirtv1.Volume{
-							Name: nv.Name,
-							VolumeSource: kubevirtv1.VolumeSource{
-								PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
-									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-										ClaimName: vr.PersistentVolumeClaimName,
-									},
+					nv.DataVolume.Name = *vr.DataVolumeName
+				} else {
+					// convert to PersistentVolumeClaim volume
+					nv = &kubevirtv1.Volume{
+						Name: nv.Name,
+						VolumeSource: kubevirtv1.VolumeSource{
+							PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: vr.PersistentVolumeClaimName,
 								},
 							},
-						}
+						},
 					}
-				} else {
-					nv.PersistentVolumeClaim.ClaimName = vr.PersistentVolumeClaimName
 				}
 			}
 		} else if nv.MemoryDump != nil {
@@ -516,20 +499,7 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 	}
 
 	if t.doesTargetVMExist() && updatedStatus {
-		// find DataVolumes that will no longer exist
-		for _, cdv := range t.vm.Spec.DataVolumeTemplates {
-			found := false
-			for _, ndv := range newTemplates {
-				if cdv.Name == ndv.Name {
-					found = true
-					break
-				}
-			}
-			if !found {
-				deletedDataVolumes = append(deletedDataVolumes, cdv.Name)
-			}
-		}
-		t.vmRestore.Status.DeletedDataVolumes = deletedDataVolumes
+		t.vmRestore.Status.DeletedDataVolumes = findDatavolumesForDeletion(t.vm.Spec.DataVolumeTemplates, newTemplates)
 
 		return true, nil
 	}
@@ -587,6 +557,53 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 	}
 
 	return true, nil
+}
+
+func findDVTemplateIndex(dvName string, vm *snapshotv1.VirtualMachine) int {
+	templateIndex := -1
+	for i, dvt := range vm.Spec.DataVolumeTemplates {
+		if dvName == dvt.Name {
+			templateIndex = i
+			break
+		}
+	}
+	return templateIndex
+}
+
+func (t *vmRestoreTarget) updatePVCPopulatedForAnnotation(pvc *corev1.PersistentVolumeClaim, dvName string) error {
+	updatePVC := pvc.DeepCopy()
+	if updatePVC.Annotations[populatedForPVCAnnotation] != dvName {
+		if updatePVC.Annotations == nil {
+			updatePVC.Annotations = make(map[string]string)
+		}
+		updatePVC.Annotations[populatedForPVCAnnotation] = dvName
+		// datavolume will take ownership
+		updatePVC.OwnerReferences = nil
+		_, err := t.controller.Client.CoreV1().PersistentVolumeClaims(updatePVC.Namespace).Update(context.Background(), updatePVC, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// findDatavolumesForDeletion find DataVolumes that will no longer
+// exist after the vmrestore is completed
+func findDatavolumesForDeletion(oldDVTemplates, newDVTemplates []kubevirtv1.DataVolumeTemplateSpec) []string {
+	var deletedDataVolumes []string
+	for _, cdv := range oldDVTemplates {
+		found := false
+		for _, ndv := range newDVTemplates {
+			if cdv.Name == ndv.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			deletedDataVolumes = append(deletedDataVolumes, cdv.Name)
+		}
+	}
+	return deletedDataVolumes
 }
 
 func (t *vmRestoreTarget) reconcileDataVolumes() (bool, error) {

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -39,7 +39,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/log"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/instancetype"
@@ -620,9 +620,9 @@ func (t *vmRestoreTarget) reconcileDataVolumes(restoredVM *kubevirtv1.VirtualMac
 		}
 		if dv != nil {
 			waitingDV = waitingDV ||
-				(dv.Status.Phase != v1beta1.Succeeded &&
-					dv.Status.Phase != v1beta1.WaitForFirstConsumer &&
-					dv.Status.Phase != v1beta1.PendingPopulation)
+				(dv.Status.Phase != cdiv1.Succeeded &&
+					dv.Status.Phase != cdiv1.WaitForFirstConsumer &&
+					dv.Status.Phase != cdiv1.PendingPopulation)
 			continue
 		}
 		created, err := t.createDataVolume(restoredVM, dvt)
@@ -779,7 +779,7 @@ func (t *vmRestoreTarget) createDataVolume(restoredVM *kubevirtv1.VirtualMachine
 		newDataVolume.Annotations = make(map[string]string)
 	}
 	newDataVolume.Annotations[RestoreNameAnnotation] = t.vmRestore.Name
-	newDataVolume.Annotations[v1beta1.AnnPrePopulated] = "true"
+	newDataVolume.Annotations[cdiv1.AnnPrePopulated] = "true"
 
 	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(restoredVM.Namespace).Create(context.Background(), newDataVolume, metav1.CreateOptions{}); err != nil {
 		t.controller.Recorder.Eventf(t.vm, corev1.EventTypeWarning, restoreDataVolumeCreateErrorEvent, "Error creating restore DataVolume %s: %v", newDataVolume.Name, err)
@@ -927,7 +927,7 @@ func patchVM(vm *kubevirtv1.VirtualMachine, patches []string) (*kubevirtv1.Virtu
 	return vm, nil
 }
 
-func (ctrl *VMRestoreController) getDV(namespace, name string) (*v1beta1.DataVolume, error) {
+func (ctrl *VMRestoreController) getDV(namespace, name string) (*cdiv1.DataVolume, error) {
 	objKey := cacheKeyFunc(namespace, name)
 	obj, exists, err := ctrl.DataVolumeInformer.GetStore().GetByKey(objKey)
 	if err != nil {
@@ -938,7 +938,7 @@ func (ctrl *VMRestoreController) getDV(namespace, name string) (*v1beta1.DataVol
 		return nil, nil
 	}
 
-	return obj.(*v1beta1.DataVolume).DeepCopy(), nil
+	return obj.(*cdiv1.DataVolume).DeepCopy(), nil
 }
 
 func (ctrl *VMRestoreController) getPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -43,7 +43,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/instancetype"
-	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
+	typesutil "kubevirt.io/kubevirt/pkg/storage/types"
 )
 
 const (
@@ -401,36 +401,40 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 }
 
 func (t *vmRestoreTarget) Reconcile() (bool, error) {
-	if updated, err := t.reconcileSpec(); updated || err != nil {
+	if t.doesTargetVMExist() && hasLastRestoreAnnotation(t.vmRestore, t.vm) {
+		return false, nil
+	}
+
+	restoredVM, err := t.generateRestoredVMSpec()
+	if err != nil {
+		return false, err
+	}
+	if updated, err := t.reconcileDataVolumes(restoredVM); updated || err != nil {
 		return updated, err
 	}
-	return t.reconcileDataVolumes()
+
+	return t.reconcileSpec(restoredVM)
 }
 
 func (t *vmRestoreTarget) UpdateTarget(obj metav1.Object) {
 	t.vm = obj.(*kubevirtv1.VirtualMachine)
 }
 
-func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
-	log.Log.Object(t.vmRestore).V(3).Info("Reconciling VM")
-
-	if t.doesTargetVMExist() && hasLastRestoreAnnotation(t.vmRestore, t.vm) {
-		return false, nil
-	}
+func (t *vmRestoreTarget) generateRestoredVMSpec() (*kubevirtv1.VirtualMachine, error) {
+	log.Log.Object(t.vmRestore).V(3).Info("generating restored VM spec")
 
 	content, err := t.controller.getSnapshotContent(t.vmRestore)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	snapshotVM := content.Spec.Source.VirtualMachine
 	if snapshotVM == nil {
-		return false, fmt.Errorf("unexpected snapshot source")
+		return nil, fmt.Errorf("unexpected snapshot source")
 	}
 
 	var newTemplates = make([]kubevirtv1.DataVolumeTemplateSpec, len(snapshotVM.Spec.DataVolumeTemplates))
 	var newVolumes []kubevirtv1.Volume
-	updatedStatus := false
 
 	for i, t := range snapshotVM.Spec.DataVolumeTemplates {
 		t.DeepCopyInto(&newTemplates[i])
@@ -447,11 +451,11 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 
 				pvc, err := t.controller.getPVC(t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
 				if err != nil {
-					return false, err
+					return nil, err
 				}
 
 				if pvc == nil {
-					return false, fmt.Errorf("pvc %s/%s does not exist and should", t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
+					return nil, fmt.Errorf("pvc %s/%s does not exist and should", t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
 				}
 
 				if nv.DataVolume == nil {
@@ -465,11 +469,10 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 						dvName := restoreDVName(t.vmRestore, vr.VolumeName)
 						err = t.updatePVCPopulatedForAnnotation(pvc, dvName)
 						if err != nil {
-							return false, err
+							return nil, err
 						}
 
 						vr.DataVolumeName = &dvName
-						updatedStatus = true
 					}
 
 					dv := snapshotVM.Spec.DataVolumeTemplates[templateIndex].DeepCopy()
@@ -496,12 +499,6 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 			continue
 		}
 		newVolumes = append(newVolumes, *nv)
-	}
-
-	if t.doesTargetVMExist() && updatedStatus {
-		t.vmRestore.Status.DeletedDataVolumes = findDatavolumesForDeletion(t.vm.Spec.DataVolumeTemplates, newTemplates)
-
-		return true, nil
 	}
 
 	var newVM *kubevirtv1.VirtualMachine
@@ -534,23 +531,30 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 	newVM.Spec.Template.Spec.Volumes = newVolumes
 	setLastRestoreAnnotation(t.vmRestore, newVM)
 
-	if err = t.restoreInstancetypeControllerRevisions(newVM); err != nil {
+	return newVM, nil
+}
+
+func (t *vmRestoreTarget) reconcileSpec(restoredVM *kubevirtv1.VirtualMachine) (bool, error) {
+	log.Log.Object(t.vmRestore).V(3).Info("Reconcile new VM spec")
+
+	var err error
+	if err = t.restoreInstancetypeControllerRevisions(restoredVM); err != nil {
 		return false, err
 	}
 
 	if !t.doesTargetVMExist() {
-		newVM, err = patchVM(newVM, t.vmRestore.Spec.Patches)
+		restoredVM, err = patchVM(restoredVM, t.vmRestore.Spec.Patches)
 		if err != nil {
-			return false, fmt.Errorf("error patching VM %s: %v", newVM.Name, err)
+			return false, fmt.Errorf("error patching VM %s: %v", restoredVM.Name, err)
 		}
-		newVM, err = t.controller.Client.VirtualMachine(t.vmRestore.Namespace).Create(context.Background(), newVM, metav1.CreateOptions{})
+		restoredVM, err = t.controller.Client.VirtualMachine(t.vmRestore.Namespace).Create(context.Background(), restoredVM, metav1.CreateOptions{})
 	} else {
-		newVM, err = t.controller.Client.VirtualMachine(newVM.Namespace).Update(context.Background(), newVM, metav1.UpdateOptions{})
+		restoredVM, err = t.controller.Client.VirtualMachine(restoredVM.Namespace).Update(context.Background(), restoredVM, metav1.UpdateOptions{})
 	}
 	if err != nil {
 		return false, err
 	}
-	t.UpdateTarget(newVM)
+	t.UpdateTarget(restoredVM)
 
 	if err = t.claimInstancetypeControllerRevisionsOwnership(t.vm); err != nil {
 		return false, err
@@ -606,11 +610,11 @@ func findDatavolumesForDeletion(oldDVTemplates, newDVTemplates []kubevirtv1.Data
 	return deletedDataVolumes
 }
 
-func (t *vmRestoreTarget) reconcileDataVolumes() (bool, error) {
+func (t *vmRestoreTarget) reconcileDataVolumes(restoredVM *kubevirtv1.VirtualMachine) (bool, error) {
 	createdDV := false
 	waitingDV := false
-	for _, dvt := range t.vm.Spec.DataVolumeTemplates {
-		dv, err := t.controller.getDV(t.vm.Namespace, dvt.Name)
+	for _, dvt := range restoredVM.Spec.DataVolumeTemplates {
+		dv, err := t.controller.getDV(restoredVM.Namespace, dvt.Name)
 		if err != nil {
 			return false, err
 		}
@@ -621,12 +625,22 @@ func (t *vmRestoreTarget) reconcileDataVolumes() (bool, error) {
 					dv.Status.Phase != v1beta1.PendingPopulation)
 			continue
 		}
-		created, err := t.createDataVolume(dvt)
+		created, err := t.createDataVolume(restoredVM, dvt)
 		if err != nil {
 			return false, err
 		}
 		createdDV = createdDV || created
 	}
+
+	if t.doesTargetVMExist() {
+		deletedDataVolumes := findDatavolumesForDeletion(t.vm.Spec.DataVolumeTemplates, restoredVM.Spec.DataVolumeTemplates)
+		if !equality.Semantic.DeepEqual(t.vmRestore.Status.DeletedDataVolumes, deletedDataVolumes) {
+			t.vmRestore.Status.DeletedDataVolumes = deletedDataVolumes
+
+			return true, nil
+		}
+	}
+
 	return createdDV || waitingDV, nil
 }
 
@@ -743,16 +757,20 @@ func (t *vmRestoreTarget) claimInstancetypeControllerRevisionsOwnership(vm *kube
 	return nil
 }
 
-func (t *vmRestoreTarget) createDataVolume(dvt kubevirtv1.DataVolumeTemplateSpec) (bool, error) {
-	pvc, err := t.controller.getPVC(t.vm.Namespace, dvt.Name)
+func (t *vmRestoreTarget) createDataVolume(restoredVM *kubevirtv1.VirtualMachine, dvt kubevirtv1.DataVolumeTemplateSpec) (bool, error) {
+	pvc, err := t.controller.getPVC(restoredVM.Namespace, dvt.Name)
 	if err != nil {
 		return false, err
+	}
+	if pvc == nil {
+		return false, fmt.Errorf("when creating restore dv pvc %s/%s does not exist and should",
+			t.vmRestore.Namespace, dvt.Name)
 	}
 	if pvc.Annotations[populatedForPVCAnnotation] != dvt.Name || len(pvc.OwnerReferences) > 0 {
 		return false, nil
 	}
 
-	newDataVolume, err := watchutil.CreateDataVolumeManifest(t.controller.Client, dvt, t.vm)
+	newDataVolume, err := typesutil.GenerateDataVolumeFromTemplate(t.controller.Client, dvt, restoredVM.Namespace, restoredVM.Spec.Template.Spec.PriorityClassName)
 	if err != nil {
 		return false, fmt.Errorf("Unable to create restore DataVolume manifest: %v", err)
 	}
@@ -761,13 +779,14 @@ func (t *vmRestoreTarget) createDataVolume(dvt kubevirtv1.DataVolumeTemplateSpec
 		newDataVolume.Annotations = make(map[string]string)
 	}
 	newDataVolume.Annotations[RestoreNameAnnotation] = t.vmRestore.Name
+	newDataVolume.Annotations[v1beta1.AnnPrePopulated] = "true"
 
-	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(t.vm.Namespace).Create(context.Background(), newDataVolume, metav1.CreateOptions{}); err != nil {
+	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(restoredVM.Namespace).Create(context.Background(), newDataVolume, metav1.CreateOptions{}); err != nil {
 		t.controller.Recorder.Eventf(t.vm, corev1.EventTypeWarning, restoreDataVolumeCreateErrorEvent, "Error creating restore DataVolume %s: %v", newDataVolume.Name, err)
 		return false, fmt.Errorf("Failed to create restore DataVolume: %v", err)
 	}
 	// Update restore DataVolumeName
-	for _, v := range t.vm.Spec.Template.Spec.Volumes {
+	for _, v := range restoredVM.Spec.Template.Spec.Volumes {
 		if v.DataVolume == nil || v.DataVolume.Name != dvt.Name {
 			continue
 		}

--- a/pkg/storage/snapshot/restore_base.go
+++ b/pkg/storage/snapshot/restore_base.go
@@ -35,7 +35,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
 )
@@ -183,7 +183,7 @@ func (ctrl *VMRestoreController) handleDataVolume(obj interface{}) {
 		obj = unknown.Obj
 	}
 
-	if dv, ok := obj.(*v1beta1.DataVolume); ok {
+	if dv, ok := obj.(*cdiv1.DataVolume); ok {
 		restoreName, ok := dv.Annotations[RestoreNameAnnotation]
 		if !ok {
 			return

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -647,39 +647,6 @@ var _ = Describe("Restore controller", func() {
 				controller.processVMRestoreWorkItem()
 			})
 
-			It("should update VM spec", func() {
-				r := createRestoreWithOwner()
-				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-					Complete:           pointer.P(false),
-					DeletedDataVolumes: getDeletedDataVolumes(createModifiedVM()),
-					Conditions: []snapshotv1.Condition{
-						newProgressingCondition(corev1.ConditionTrue, "Updating target spec"),
-						newReadyCondition(corev1.ConditionFalse, "Waiting for target update"),
-					},
-				}
-				addVolumeRestores(r)
-				vm := createModifiedVM()
-				vm.Status.RestoreInProgress = &vmRestoreName
-				updatedVM := createSnapshotVM()
-				updatedVM.Status.RestoreInProgress = &vmRestoreName
-				updatedVM.ResourceVersion = "1"
-				updatedVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
-				updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
-				updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
-				for i := range r.Status.Restores {
-					r.Status.Restores[i].DataVolumeName = &r.Status.Restores[i].PersistentVolumeClaimName
-				}
-				vmSource.Add(vm)
-				vmInterface.EXPECT().Update(context.Background(), updatedVM, metav1.UpdateOptions{}).Return(updatedVM, nil)
-				for _, pvc := range getRestorePVCs(r) {
-					pvc.Annotations["cdi.kubevirt.io/storage.populatedFor"] = pvc.Name
-					pvc.Status.Phase = corev1.ClaimBound
-					pvcSource.Add(&pvc)
-				}
-				addVirtualMachineRestore(r)
-				controller.processVMRestoreWorkItem()
-			})
-
 			It("should cleanup and unlock vm", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
@@ -795,58 +762,87 @@ var _ = Describe("Restore controller", func() {
 				testutils.ExpectEvent(recorder, "VirtualMachineRestoreComplete")
 			})
 
-			DescribeTable("reconcileDataVolumes should", func(dvExists bool, phase cdiv1.DataVolumePhase, expectedRes bool) {
-				r := createRestoreWithOwner()
-				vm := createModifiedVM()
-				setLastRestoreAnnotation(r, vm)
-				pvc := corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:   testNamespace,
-						Name:        vm.Spec.DataVolumeTemplates[0].Name,
-						Annotations: map[string]string{populatedForPVCAnnotation: vm.Spec.DataVolumeTemplates[0].Name},
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &storageClassName,
-					},
-				}
-				if dvExists {
-					dv := &cdiv1.DataVolume{
+			Context("target Reconcile", func() {
+				var (
+					r        *snapshotv1.VirtualMachineRestore
+					targetVM restoreTarget
+				)
+				BeforeEach(func() {
+					r = createRestoreWithOwner()
+					addVolumeRestores(r)
+					vm = createModifiedVM()
+					vm.Status.RestoreInProgress = &vmRestoreName
+					targetVM, _ = controller.getTarget(r)
+					targetVM.UpdateTarget(vm)
+				})
+
+				addRestoreVolumes := func(dvExists bool, phase cdiv1.DataVolumePhase) {
+					pvc := corev1.PersistentVolumeClaim{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      vm.Spec.DataVolumeTemplates[0].Name,
-							Namespace: testNamespace,
+							Namespace:   testNamespace,
+							Name:        "restore-uid-disk1",
+							Annotations: map[string]string{populatedForPVCAnnotation: "restore-uid-disk1"},
 						},
-						Status: cdiv1.DataVolumeStatus{
-							Phase: phase,
+						Spec: corev1.PersistentVolumeClaimSpec{
+							StorageClassName: &storageClassName,
+						},
+						Status: corev1.PersistentVolumeClaimStatus{
+							Phase: corev1.ClaimBound,
 						},
 					}
-					dataVolumeSource.Add(dv)
-					pvc.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(dv, schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: "v1beta1", Kind: "DataVolume"})}
+					if dvExists {
+						dv := &cdiv1.DataVolume{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "restore-uid-disk1",
+								Namespace: testNamespace,
+							},
+							Status: cdiv1.DataVolumeStatus{
+								Phase: phase,
+							},
+						}
+						dataVolumeSource.Add(dv)
+						pvc.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(dv, schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: "v1beta1", Kind: "DataVolume"})}
+						r.Status.DeletedDataVolumes = getDeletedDataVolumes(vm)
+					} else {
+						expectDataVolumeCreate(cdiClient, "restore-uid-disk1")
+					}
+					pvcSource.Add(&pvc)
 				}
-				pvcSource.Add(&pvc)
+				expectUpdateRestoredVM := func() {
+					updatedVM := createSnapshotVM()
+					updatedVM.Status.RestoreInProgress = &vmRestoreName
+					updatedVM.ResourceVersion = "1"
+					updatedVM.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+					updatedVM.Spec.DataVolumeTemplates[0].Name = "restore-uid-disk1"
+					updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = "restore-uid-disk1"
+					vmInterface.EXPECT().Update(context.Background(), updatedVM, metav1.UpdateOptions{}).Return(updatedVM, nil)
+				}
 
-				vmRestoreSource.Add(r)
-				addVM(vm)
-				targetVM, err := controller.getTarget(r)
-				Expect(err).ShouldNot(HaveOccurred())
-				targetVM.UpdateTarget(vm)
-				res, err := targetVM.Reconcile()
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(res).To(Equal(expectedRes))
-			},
-				Entry("return false when dv phase succeeded", true, cdiv1.Succeeded, false),
-				Entry("return false when dv phase WFFC", true, cdiv1.WaitForFirstConsumer, false),
-				Entry("return true when dv phase pending", true, cdiv1.Pending, true),
-				Entry("return true when dv doesnt exists", false, cdiv1.PhaseUnset, true),
-			)
+				DescribeTable("should", func(dvExists bool, phase cdiv1.DataVolumePhase, expecteUpdateVM bool) {
+					addRestoreVolumes(dvExists, phase)
+
+					vmRestoreSource.Add(r)
+					addVM(vm)
+					if expecteUpdateVM == false {
+						expectUpdateRestoredVM()
+					}
+					res, err := targetVM.Reconcile()
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(res).To(BeTrue())
+				},
+					Entry("update VM spec when dv phase succeeded", true, cdiv1.Succeeded, false),
+					Entry("update VM spec when dv phase WFFC", true, cdiv1.WaitForFirstConsumer, false),
+					Entry("wait for dvs when dv phase pending", true, cdiv1.Pending, true),
+					Entry("create dvs when dv doesnt exists", false, cdiv1.PhaseUnset, true),
+				)
+			})
 
 			Context("target VM is different than source VM", func() {
 
 				It("should be able to restore to a new VM", func() {
 					By("Creating new VM")
 					newVM := createVirtualMachine(testNamespace, "new-test-vm")
-					newVM.Status.RestoreInProgress = &vmRestoreName
-					newVM.UID = "new-vm-uid"
-					vmSource.Add(newVM)
+					newVM.UID = ""
 
 					By("Creating VM restore")
 					vmRestore := createRestoreWithOwner()
@@ -865,13 +861,11 @@ var _ = Describe("Restore controller", func() {
 					expectPVCUpdates(k8sClient, vmRestore)
 
 					By("Making sure right VM update occurs")
-					updatedVM := newVM.DeepCopy()
-					updatedVM.Spec.DataVolumeTemplates[0].Name = *vmRestore.Status.Restores[0].DataVolumeName
-					updatedVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = *vmRestore.Status.Restores[0].DataVolumeName
-					updatedVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
-					updatedVM.ResourceVersion = "1"
+					newVM.Spec.DataVolumeTemplates[0].Name = *vmRestore.Status.Restores[0].DataVolumeName
+					newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = *vmRestore.Status.Restores[0].DataVolumeName
+					newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
 
-					vmInterface.EXPECT().Update(context.Background(), updatedVM, metav1.UpdateOptions{}).Return(updatedVM, nil)
+					vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil)
 
 					By("Making sure right VMRestore update occurs")
 					updatedVMRestore := vmRestore.DeepCopy()
@@ -887,11 +881,11 @@ var _ = Describe("Restore controller", func() {
 					controller.processVMRestoreWorkItem()
 				})
 
-				It("should define owner reference properly", func() {
+				It("should own the vmrestore after creation", func() {
 					By("Creating new VM")
 					newVM := createVirtualMachine(testNamespace, "new-test-vm")
 					newVM.Status.RestoreInProgress = &vmRestoreName
-					newVM.UID = "new-vm-uid"
+					newVM.UID = ""
 					vmSource.Add(newVM)
 
 					By("Creating VM restore")
@@ -940,28 +934,41 @@ var _ = Describe("Restore controller", func() {
 
 					BeforeEach(func() {
 						r = createRestore()
-						r.Spec.Target.Name = newVmName
-						r.Status = &snapshotv1.VirtualMachineRestoreStatus{
-							Complete: pointer.P(false),
+						r.Spec.Target.Name = "new-vm-name"
+						r.Status.Complete = pointer.P(false)
+						addVolumeRestores(r)
+
+						for _, pvc := range getRestorePVCs(r) {
+							dv := &cdiv1.DataVolume{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      pvc.Name,
+									Namespace: pvc.Namespace,
+								},
+								Status: cdiv1.DataVolumeStatus{
+									Phase: cdiv1.Succeeded,
+								},
+							}
+							dataVolumeSource.Add(dv)
+							pvc.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(dv, schema.GroupVersionKind{Group: "cdi.kubevirt.io", Version: "v1beta1", Kind: "DataVolume"})}
+							pvc.Annotations["cdi.kubevirt.io/storage.populatedFor"] = pvc.Name
+							pvc.Status.Phase = corev1.ClaimBound
+							addPVC(&pvc)
 						}
 
 						changeNamePatch = fmt.Sprintf(`{"op": "replace", "path": "/metadata/name", "value": "%s"}`, newVmName)
 						changeMacAddressPatch = fmt.Sprintf(`{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "%s"}`, newMacAddress)
-
-						err := vmSnapshotInformer.GetStore().Add(s)
-						Expect(err).ShouldNot(HaveOccurred())
-
-						err = vmSnapshotContentInformer.GetStore().Add(sc)
-						Expect(err).ShouldNot(HaveOccurred())
 					})
 
 					It("with changed name", func() {
 						r.Spec.Patches = []string{changeNamePatch}
 
-						vmInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).DoAndReturn(func(ctx context.Context, newVM *kubevirtv1.VirtualMachine, options metav1.CreateOptions) (*kubevirtv1.VirtualMachine, error) {
-							Expect(newVM.Name).To(Equal(newVmName), "the created VM should be the new VM")
-							return newVM, nil
-						}).Times(1)
+						newVM := createVirtualMachine(testNamespace, newVmName)
+						newVM.UID = ""
+						newVM.Spec.DataVolumeTemplates[0].Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
+						newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
+						newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
+
+						vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil)
 
 						targetVM, err := controller.getTarget(r)
 						Expect(err).ShouldNot(HaveOccurred())
@@ -973,15 +980,14 @@ var _ = Describe("Restore controller", func() {
 					It("with changed name and MAC address", func() {
 						r.Spec.Patches = []string{changeNamePatch, changeMacAddressPatch}
 
-						vmInterface.EXPECT().Create(context.Background(), gomock.Any(), metav1.CreateOptions{}).DoAndReturn(func(ctx context.Context, newVM *kubevirtv1.VirtualMachine, options metav1.CreateOptions) (*kubevirtv1.VirtualMachine, error) {
-							Expect(newVM.Name).To(Equal(newVmName), "the created VM should be the new VM")
+						newVM := createVirtualMachine(testNamespace, newVmName)
+						newVM.UID = ""
+						newVM.Spec.DataVolumeTemplates[0].Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
+						newVM.Spec.Template.Spec.Volumes[0].DataVolume.Name = restoreDVName(r, r.Status.Restores[0].VolumeName)
+						newVM.Annotations = map[string]string{lastRestoreAnnotation: "restore-uid"}
+						newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress = newMacAddress
 
-							interfaces := newVM.Spec.Template.Spec.Domain.Devices.Interfaces
-							Expect(interfaces).ToNot(BeEmpty())
-							Expect(interfaces[0].MacAddress).To(Equal(newMacAddress))
-
-							return newVM, nil
-						}).Times(1)
+						vmInterface.EXPECT().Create(context.Background(), newVM, metav1.CreateOptions{}).Return(newVM, nil)
 
 						targetVM, err := controller.getTarget(r)
 						Expect(err).ShouldNot(HaveOccurred())
@@ -1112,6 +1118,7 @@ var _ = Describe("Restore controller", func() {
 				virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
 
 				originalVM = createSnapshotVM()
+				originalVM.Spec.DataVolumeTemplates = []kubevirtv1.DataVolumeTemplateSpec{}
 				restore = createRestoreWithOwner()
 
 				vmSnapshot = createSnapshot()
@@ -1475,6 +1482,21 @@ func expectVMRestoreUpdate(client *kubevirtfake.Clientset, vmRestore *snapshotv1
 
 		return true, update.GetObject(), nil
 	})
+}
+
+func expectDataVolumeCreate(client *cdifake.Clientset, name string) {
+	client.Fake.PrependReactor("create", "datavolumes", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		a, ok := action.(testing.CreateAction)
+		Expect(ok).To(BeTrue())
+
+		dv, ok := a.GetObject().(*cdiv1.DataVolume)
+		Expect(ok).To(BeTrue())
+		Expect(dv.Name).To(Equal(name))
+		Expect(dv.Annotations[cdiv1.AnnPrePopulated]).To(Equal("true"))
+
+		return true, nil, nil
+	})
+
 }
 
 func expectDataVolumeDeletes(client *cdifake.Clientset, names []string) {

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -55,7 +55,6 @@ import (
 	"kubevirt.io/client-go/api"
 	cdifake "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
@@ -1278,16 +1277,16 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			return pvc
 		}
 
-		cdiConfigInit := func() (cdiConfig *v1beta1.CDIConfig) {
-			cdiConfig = &v1beta1.CDIConfig{
+		cdiConfigInit := func() (cdiConfig *cdiv1.CDIConfig) {
+			cdiConfig = &cdiv1.CDIConfig{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: storagetypes.ConfigName,
 				},
-				Spec: v1beta1.CDIConfigSpec{
+				Spec: cdiv1.CDIConfigSpec{
 					UploadProxyURLOverride: nil,
 				},
-				Status: v1beta1.CDIConfigStatus{
-					FilesystemOverhead: &v1beta1.FilesystemOverhead{
+				Status: cdiv1.CDIConfigStatus{
+					FilesystemOverhead: &cdiv1.FilesystemOverhead{
 						Global: cdiv1.Percent(storagetypes.DefaultFSOverhead),
 					},
 				},

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -41,7 +41,7 @@ import (
 	apiinstancetype "kubevirt.io/api/instancetype"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/instancetype"
 
@@ -407,7 +407,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			}
 
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
-				Spec: v1beta1.DataVolumeSpec{},
+				Spec: cdiv1.DataVolumeSpec{},
 			}}
 		})
 
@@ -428,14 +428,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		})
 
 		It("should apply PreferredStorageClassName to Storage", func() {
-			vm.Spec.DataVolumeTemplates[0].Spec.Storage = &v1beta1.StorageSpec{}
+			vm.Spec.DataVolumeTemplates[0].Spec.Storage = &cdiv1.StorageSpec{}
 			vmSpec, _ := getVMSpecMetaFromResponse(rt.GOARCH)
 			assertStorageStorageClassName(vmSpec.DataVolumeTemplates, preference.Spec.Volumes.PreferredStorageClassName)
 		})
 
 		It("should not fail if DataVolumeSpec PersistentVolumeClaimSpec is nil - bug #9868", func() {
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
-				Spec: v1beta1.DataVolumeSpec{},
+				Spec: cdiv1.DataVolumeSpec{},
 			}}
 			resp := admitVM(rt.GOARCH)
 			Expect(resp.Allowed).To(BeTrue())
@@ -444,7 +444,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		It("should not overwrite storageclass already defined in PVC of DataVolumeTemplate", func() {
 			storageClass := "local"
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
-				Spec: v1beta1.DataVolumeSpec{
+				Spec: cdiv1.DataVolumeSpec{
 					PVC: &k8sv1.PersistentVolumeClaimSpec{
 						StorageClassName: &storageClass,
 					},
@@ -457,8 +457,8 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		It("should not overwrite storageclass already defined in Storage of DataVolumeTemplate", func() {
 			storageClass := "local"
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
-				Spec: v1beta1.DataVolumeSpec{
-					Storage: &v1beta1.StorageSpec{
+				Spec: cdiv1.DataVolumeSpec{
+					Storage: &cdiv1.StorageSpec{
 						StorageClassName: &storageClass,
 					},
 				},
@@ -691,10 +691,10 @@ var _ = Describe("VirtualMachine Mutator", func() {
 
 		var (
 			pvc               *k8sv1.PersistentVolumeClaim
-			dvWithSourcePVC   *v1beta1.DataVolume
-			dvWithAnnotations *v1beta1.DataVolume
-			dsWithSourcePVC   *v1beta1.DataSource
-			dsWithAnnotations *v1beta1.DataSource
+			dvWithSourcePVC   *cdiv1.DataVolume
+			dvWithAnnotations *cdiv1.DataVolume
+			dsWithSourcePVC   *cdiv1.DataSource
+			dsWithAnnotations *cdiv1.DataSource
 		)
 
 		const (
@@ -729,14 +729,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Create(context.Background(), pvc, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			dvWithSourcePVC = &v1beta1.DataVolume{
+			dvWithSourcePVC = &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      dvWithSourcePVCName,
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					Source: &v1beta1.DataVolumeSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -746,14 +746,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			dvWithSourcePVC, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Create(context.Background(), dvWithSourcePVC, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			dsWithSourcePVC = &v1beta1.DataSource{
+			dsWithSourcePVC = &cdiv1.DataSource{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      dsWithSourcePVCName,
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataSourceSpec{
-					Source: v1beta1.DataSourceSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -763,7 +763,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			dsWithSourcePVC, err = virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.Background(), dsWithSourcePVC, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			dsWithAnnotations = &v1beta1.DataSource{
+			dsWithAnnotations = &cdiv1.DataSource{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      dsWithAnnotationsName,
 					Namespace: vm.Namespace,
@@ -774,9 +774,9 @@ var _ = Describe("VirtualMachine Mutator", func() {
 						apiinstancetype.DefaultPreferenceKindLabel:   defaultInferedKindFromDS,
 					},
 				},
-				Spec: v1beta1.DataSourceSpec{
-					Source: v1beta1.DataSourceSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -877,9 +877,9 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "dataVolume",
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					Source: &v1beta1.DataVolumeSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -914,7 +914,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should infer defaults from DataVolume with labels", func(instancetypeMatcher, expectedInstancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher, expectedPreferenceMatcher *v1.PreferenceMatcher) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
-			dvWithAnnotations = &v1beta1.DataVolume{
+			dvWithAnnotations = &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithAnnotations",
 					Namespace: vm.Namespace,
@@ -925,9 +925,9 @@ var _ = Describe("VirtualMachine Mutator", func() {
 						apiinstancetype.DefaultPreferenceKindLabel:   defaultInferedKindFromDV,
 					},
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					Source: &v1beta1.DataVolumeSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -978,13 +978,13 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			if sourceRefNamespace != "" {
 				sourceRefNamespacePointer = &sourceRefNamespace
 			}
-			dvWithSourceRef := &v1beta1.DataVolume{
+			dvWithSourceRef := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithSourceRef",
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					SourceRef: &v1beta1.DataVolumeSourceRef{
+				Spec: cdiv1.DataVolumeSpec{
+					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Name:      sourceRefName,
 						Kind:      sourceRefKind,
 						Namespace: sourceRefNamespacePointer,
@@ -1100,8 +1100,8 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "dataVolume",
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					SourceRef: &v1beta1.DataVolumeSourceRef{
+				Spec: cdiv1.DataVolumeSpec{
+					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Name:      sourceRefName,
 						Kind:      "DataSource",
 						Namespace: &sourceRefNamespace,
@@ -1449,14 +1449,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should fail to infer defaults from DataVolume with an unsupported DataVolumeSource", func(instancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher *v1.PreferenceMatcher, allowed bool) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
-			dvWithUnsupportedSource := &v1beta1.DataVolume{
+			dvWithUnsupportedSource := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithSourceRef",
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					Source: &v1beta1.DataVolumeSource{
-						VDDK: &v1beta1.DataVolumeSourceVDDK{},
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						VDDK: &cdiv1.DataVolumeSourceVDDK{},
 					},
 				},
 			}
@@ -1524,13 +1524,13 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should fail to infer defaults from DataVolume with an unknown DataVolumeSourceRef Kind", func(instancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher *v1.PreferenceMatcher, allowed bool) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
-			dvWithUnknownSourceRefKind := &v1beta1.DataVolume{
+			dvWithUnknownSourceRefKind := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithSourceRef",
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					SourceRef: &v1beta1.DataVolumeSourceRef{
+				Spec: cdiv1.DataVolumeSpec{
+					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Kind: "foo",
 					},
 				},
@@ -1599,13 +1599,13 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should fail to infer defaults from DataSource missing DataVolumeSourcePVC", func(instancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher *v1.PreferenceMatcher, allowed bool) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
-			dsWithoutSourcePVC := &v1beta1.DataSource{
+			dsWithoutSourcePVC := &cdiv1.DataSource{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dsWithoutSourcePVC",
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataSourceSpec{
-					Source: v1beta1.DataSourceSource{},
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{},
 				},
 			}
 			_, err := virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.Background(), dsWithoutSourcePVC, k8smetav1.CreateOptions{})
@@ -1615,8 +1615,8 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "dataVolume",
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					SourceRef: &v1beta1.DataVolumeSourceRef{
+				Spec: cdiv1.DataVolumeSpec{
+					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Kind:      "DataSource",
 						Name:      dsWithoutSourcePVC.Name,
 						Namespace: &dsWithoutSourcePVC.Namespace,

--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -28,7 +28,7 @@ import (
 	cdifake "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/memorydump"
 	"kubevirt.io/kubevirt/pkg/virtctl/utils"
@@ -77,8 +77,8 @@ var _ = Describe("MemoryDump", func() {
 	updateCDIConfig := func() {
 		config, err := cdiClient.CdiV1beta1().CDIConfigs().Get(context.Background(), configName, k8smetav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		config.Status.FilesystemOverhead.StorageClass = make(map[string]v1beta1.Percent)
-		config.Status.FilesystemOverhead.StorageClass["fakeSC"] = v1beta1.Percent("0.1")
+		config.Status.FilesystemOverhead.StorageClass = make(map[string]cdiv1.Percent)
+		config.Status.FilesystemOverhead.StorageClass["fakeSC"] = cdiv1.Percent("0.1")
 		_, err = cdiClient.CdiV1beta1().CDIConfigs().Update(context.Background(), config, k8smetav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -493,17 +493,17 @@ var _ = Describe("MemoryDump", func() {
 	})
 })
 
-func cdiConfigInit() (cdiConfig *v1beta1.CDIConfig) {
-	cdiConfig = &v1beta1.CDIConfig{
+func cdiConfigInit() (cdiConfig *cdiv1.CDIConfig) {
+	cdiConfig = &cdiv1.CDIConfig{
 		ObjectMeta: k8smetav1.ObjectMeta{
 			Name: configName,
 		},
-		Spec: v1beta1.CDIConfigSpec{
+		Spec: cdiv1.CDIConfigSpec{
 			UploadProxyURLOverride: nil,
 		},
-		Status: v1beta1.CDIConfigStatus{
-			FilesystemOverhead: &v1beta1.FilesystemOverhead{
-				Global: v1beta1.Percent(defaultFSOverhead),
+		Status: cdiv1.CDIConfigStatus{
+			FilesystemOverhead: &cdiv1.FilesystemOverhead{
+				Global: cdiv1.Percent(defaultFSOverhead),
 			},
 		},
 	}

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1693,7 +1693,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 						libdv.WithPVC(libdv.PVCWithStorageClass(sourceSC)),
 						libdv.WithForceBindAnnotation(),
 					)
-
 					source, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.NamespaceTestAlternative).Create(context.Background(), source, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					sourceDV = source
@@ -1709,6 +1708,12 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				})
 
 				AfterEach(func() {
+					// Make sure we recreate the alternative namespace when completing the tests
+					_, err := virtClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testsuite.NamespaceTestAlternative}}, metav1.CreateOptions{})
+					if err != nil && !errors.IsAlreadyExists(err) {
+						Expect(err).ToNot(HaveOccurred())
+					}
+
 					if sourceDV != nil {
 						libstorage.DeleteDataVolume(&sourceDV)
 					}
@@ -1752,26 +1757,38 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					)
 
 					return libvmi.NewVirtualMachine(
-						libstorage.RenderVMIWithDataVolume(dataVolume.Name, sourceDV.Namespace, libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot())),
+						libstorage.RenderVMIWithDataVolume(dataVolume.Name, testsuite.GetTestNamespace(nil), libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot())),
 						libvmi.WithDataVolumeTemplate(dataVolume),
 					)
 				}
 
-				DescribeTable("should restore a vm that boots from a network cloned datavolumetemplate", func(restoreToNewVM, deleteSourcePVC bool) {
+				DescribeTable("should restore a vm that boots from a network cloned datavolumetemplate", func(restoreToNewVM, deleteSourcePVC, deleteSourceNamespace bool) {
 					vm, vmi = createAndStartVM(createNetworkCloneVMFromSource())
 
 					checkCloneAnnotations(vm, true)
-					if deleteSourcePVC {
+					if deleteSourceNamespace {
+						err = virtClient.CoreV1().Namespaces().Delete(context.Background(), testsuite.NamespaceTestAlternative, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Eventually(func() error {
+							_, err := virtClient.CoreV1().Namespaces().Get(context.Background(), testsuite.NamespaceTestAlternative, metav1.GetOptions{})
+							return err
+						}, 60*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
+						sourceDV = nil
+						cloneRole = nil
+						cloneRoleBinding = nil
+					} else if deleteSourcePVC {
 						libstorage.DeleteDataVolume(&sourceDV)
 					}
 
 					doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
 					checkCloneAnnotations(getTargetVM(restoreToNewVM), false)
 				},
-					Entry("to the same VM", false, false),
-					Entry("to a new VM", true, false),
-					Entry("to the same VM, no source pvc", false, true),
-					Entry("to a new VM, no source pvc", true, true),
+					Entry("to the same VM", false, false, false),
+					Entry("to a new VM", true, false, false),
+					Entry("to the same VM, no source pvc", false, true, false),
+					Entry("to a new VM, no source pvc", true, true, false),
+					Entry("to the same VM, no source namespace", false, false, true),
+					Entry("to a new VM, no source namespace", true, false, true),
 				)
 
 				DescribeTable("should restore a vm that boots from a network cloned datavolume (not template)", func(restoreToNewVM, deleteSourcePVC bool) {

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -16,7 +16,7 @@ import (
 	apiinstancetype "kubevirt.io/api/instancetype"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/yaml"
 
 	. "kubevirt.io/kubevirt/pkg/virtctl/create/vm"
@@ -526,8 +526,8 @@ func createPreference(virtClient kubecli.KubevirtClient) *instancetypev1beta1.Vi
 	return preference
 }
 
-func createAnnotatedDataSource(virtClient kubecli.KubevirtClient, instancetypeName, preferenceName string) *v1beta1.DataSource {
-	dataSource := &v1beta1.DataSource{
+func createAnnotatedDataSource(virtClient kubecli.KubevirtClient, instancetypeName, preferenceName string) *cdiv1.DataSource {
+	dataSource := &cdiv1.DataSource{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vm-datasource-",
 			Labels: map[string]string{
@@ -537,8 +537,8 @@ func createAnnotatedDataSource(virtClient kubecli.KubevirtClient, instancetypeNa
 				apiinstancetype.DefaultPreferenceKindLabel:   apiinstancetype.SingularPreferenceResourceName,
 			},
 		},
-		Spec: v1beta1.DataSourceSpec{
-			Source: v1beta1.DataSourceSource{},
+		Spec: cdiv1.DataSourceSpec{
+			Source: cdiv1.DataSourceSource{},
 		},
 	}
 	dataSource, err := virtClient.CdiClient().CdiV1beta1().DataSources(testsuite.NamespaceTestDefault).Create(context.Background(), dataSource, metav1.CreateOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
In VM restore we updated/created the vm before the creation of the restored datavolumes

After this PR:
Instead of creating/updating the vm before the creation of the dv we create the dvs (as we do for the pvcs) before the
creation/update of the restored VM.
This is needed in order to prevent a race between the creation of the dvs by the restore controller and the vm contoller.
Also this makes the update of the VM spec to be after making sure all the new volumes of the restored vm exist without any errors so it prevents a case of having the vm spec updated with volumes that doesnt exist and cannot exist due to some error.
Add the prePouplated annotation to the DataVolumes to show CDI that no action is required on the dv other then owning and adopting the PVC. (For example skip authentication of dv source)


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-47105
This is also a first step for addressing bug: 
Jira-ticket: https://issues.redhat.com/browse/CNV-47106

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: vmrestore create DVs before creation/update of restored VM
```

