### PR TITLE
add allocated disk size metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -84,6 +84,9 @@ The total number of VMs created by namespace and virt-api pod, since install. Ty
 ### kubevirt_vm_created_total
 The total number of VMs created by namespace, since install. Type: Counter.
 
+### kubevirt_vm_disk_allocated_size_bytes
+Allocated disk size of a Virtual Machine in bytes, based on its PersistentVolumeClaim. Includes persistentvolumeclaim (PVC name), volume_mode (disk presentation mode: Filesystem or Block), and device (disk name). Type: Gauge.
+
 ### kubevirt_vm_error_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to error status. Type: Counter.
 

--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -41,19 +41,21 @@ var (
 		vmSnapshotMetrics,
 	}
 
-	vmInformer                  cache.SharedIndexInformer
-	vmiInformer                 cache.SharedIndexInformer
-	clusterInstanceTypeInformer cache.SharedIndexInformer
-	instanceTypeInformer        cache.SharedIndexInformer
-	clusterPreferenceInformer   cache.SharedIndexInformer
-	preferenceInformer          cache.SharedIndexInformer
-	vmiMigrationInformer        cache.SharedIndexInformer
-	clusterConfig               *virtconfig.ClusterConfig
+	vmInformer                    cache.SharedIndexInformer
+	vmiInformer                   cache.SharedIndexInformer
+	persistentVolumeClaimInformer cache.SharedIndexInformer
+	clusterInstanceTypeInformer   cache.SharedIndexInformer
+	instanceTypeInformer          cache.SharedIndexInformer
+	clusterPreferenceInformer     cache.SharedIndexInformer
+	preferenceInformer            cache.SharedIndexInformer
+	vmiMigrationInformer          cache.SharedIndexInformer
+	clusterConfig                 *virtconfig.ClusterConfig
 )
 
 func SetupMetrics(
 	vm cache.SharedIndexInformer,
 	vmi cache.SharedIndexInformer,
+	pvc cache.SharedIndexInformer,
 	clusterInstanceType cache.SharedIndexInformer,
 	instanceType cache.SharedIndexInformer,
 	clusterPreference cache.SharedIndexInformer,
@@ -63,6 +65,7 @@ func SetupMetrics(
 ) error {
 	vmInformer = vm
 	vmiInformer = vmi
+	persistentVolumeClaimInformer = pvc
 	clusterInstanceTypeInformer = clusterInstanceType
 	instanceTypeInformer = instanceType
 	clusterPreferenceInformer = clusterPreference

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -435,6 +435,7 @@ func Execute() {
 	if err := metrics.SetupMetrics(
 		app.vmInformer,
 		app.vmiInformer,
+		app.persistentVolumeClaimInformer,
 		app.clusterInstancetypeInformer,
 		app.instancetypeInformer,
 		app.clusterPreferenceInformer,

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -29,6 +29,7 @@ import (
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -43,6 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libmonitoring"
+	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -95,7 +97,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			err = virtapi.SetupMetrics()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil)
+			err = virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = virtcontroller.RegisterLeaderMetrics()
@@ -136,6 +138,17 @@ func basicVMLifecycle(virtClient kubecli.KubevirtClient) {
 	By("Waiting for the VM domainstats metrics to be reported")
 	libmonitoring.WaitForMetricValueWithLabelsToBe(virtClient, "kubevirt_vmi_filesystem_capacity_bytes", map[string]string{"namespace": vm.Namespace, "name": vm.Name}, 0, ">", 0)
 
+	By("Verifying kubevirt_vm_disk_allocated_size_bytes metric")
+	libmonitoring.WaitForMetricValueWithLabelsToBe(virtClient, "kubevirt_vm_disk_allocated_size_bytes",
+		map[string]string{
+			"namespace":             vm.Namespace,
+			"name":                  vm.Name,
+			"persistentvolumeclaim": "test-vm-pvc",
+			"volume_mode":           "Filesystem",
+			"device":                "testdisk",
+		},
+		0, ">", 0)
+
 	By("Deleting the VirtualMachine")
 	err := virtClient.VirtualMachine(vm.Namespace).Delete(context.Background(), vm.Name, metav1.DeleteOptions{})
 	Expect(err).ToNot(HaveOccurred())
@@ -145,10 +158,15 @@ func basicVMLifecycle(virtClient kubecli.KubevirtClient) {
 }
 
 func createAndRunVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
+	vmDiskPVC := "test-vm-pvc"
+	pvc := libstorage.CreateFSPVC(vmDiskPVC, testsuite.GetTestNamespace(nil), "512Mi", nil)
+
 	vmi := libvmifact.NewFedora(
 		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 		libvmi.WithLimitMemory("512Mi"),
+		libvmi.WithPersistentVolumeClaim("testdisk", pvc.Name),
 	)
+
 	vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 	vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -41,7 +41,7 @@ this document.
 `
 
 func main() {
-	if err := virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
+	if err := virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
add allocated disk size metric in order to monitor vms sizes.

Before this PR:
kubevirt_vm_disk_allocated_size_bytes does not exists
After this PR:
kubevirt_vm_disk_allocated_size_bytes exists
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # 
jira-ticket: https://issues.redhat.com/browse/CNV-49002

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Metric output:

![Screenshot from 2024-11-04 14-15-08](https://github.com/user-attachments/assets/43860146-30b4-4645-b34b-f8bb0a23fec6)

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubevirt_vm_disk_allocated_size_bytes metric added in order to monitor vm sizes
```

