### PR TITLE
libvmi: Introduce replicaset subpackage builder

### DIFF
--- a/pkg/libvmi/replicaset/BUILD.bazel
+++ b/pkg/libvmi/replicaset/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["replicaset.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/libvmi/replicaset",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+    ],
+)

--- a/pkg/libvmi/replicaset/replicaset.go
+++ b/pkg/libvmi/replicaset/replicaset.go
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Authors.
+ *
+ */
+
+package replicaset
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func New(vmi *v1.VirtualMachineInstance, replicas int) *v1.VirtualMachineInstanceReplicaSet {
+	const taillength = 5
+	replicas32 := int32(replicas)
+	name := "replicaset" + rand.String(taillength)
+	return &v1.VirtualMachineInstanceReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(taillength)},
+		Spec: v1.VirtualMachineInstanceReplicaSetSpec{
+			Replicas: &replicas32,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": name},
+			},
+			Template: &v1.VirtualMachineInstanceTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"name": name},
+					Name:   vmi.ObjectMeta.Name,
+				},
+				Spec: vmi.Spec,
+			},
+		},
+	}
+}

--- a/pkg/libvmi/replicaset/replicaset.go
+++ b/pkg/libvmi/replicaset/replicaset.go
@@ -29,17 +29,17 @@ import (
 func New(vmi *v1.VirtualMachineInstance, replicas int) *v1.VirtualMachineInstanceReplicaSet {
 	const taillength = 5
 	replicas32 := int32(replicas)
-	name := "replicaset" + rand.String(taillength)
+	rsselector := "rsselector" + rand.String(taillength)
 	return &v1.VirtualMachineInstanceReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(taillength)},
 		Spec: v1.VirtualMachineInstanceReplicaSetSpec{
 			Replicas: &replicas32,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"name": name},
+				MatchLabels: map[string]string{"rsslector": rsselector},
 			},
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"name": name},
+					Labels: map[string]string{"rsslector": rsselector},
 					Name:   vmi.ObjectMeta.Name,
 				},
 				Spec: vmi.Spec,

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -137,6 +137,7 @@ go_test(
         "//pkg/hooks/v1alpha3:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
+        "//pkg/libvmi/replicaset:go_default_library",
         "//pkg/network/dns:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",

--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/replicaset:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/tests/infrastructure/k8s-client-changes.go
+++ b/tests/infrastructure/k8s-client-changes.go
@@ -32,6 +32,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/libvmi/replicaset"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -69,7 +70,7 @@ var _ = DescribeInfra("changes to the kubernetes client", func() {
 
 	It("on the controller rate limiter should lead to delayed VMI starts", func() {
 		By("first getting the basetime for a replicaset")
-		replicaset := tests.NewRandomReplicaSetFromVMI(libvmifact.NewCirros(libvmi.WithResourceMemory("1Mi")), int32(0))
+		replicaset := replicaset.New(libvmifact.NewCirros(libvmi.WithResourceMemory("1Mi")), 0)
 		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(context.Background(), replicaset, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		start := time.Now()
@@ -105,7 +106,7 @@ var _ = DescribeInfra("changes to the kubernetes client", func() {
 			libvmi.WithNodeSelectorFor(targetNode.Name),
 		)
 
-		replicaset := tests.NewRandomReplicaSetFromVMI(vmi, 0)
+		replicaset := replicaset.New(vmi, 0)
 		replicaset, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(nil)).Create(context.Background(), replicaset, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 10)

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/cloud-init:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
+        "//pkg/libvmi/replicaset:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -33,8 +33,8 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/libvmi/replicaset"
 
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libpod"
@@ -487,7 +487,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		var vmrs *v1.VirtualMachineInstanceReplicaSet
 		BeforeEach(func() {
 			By("Creating a VMRS object with 2 replicas")
-			vmrs = tests.NewRandomReplicaSetFromVMI(newLabeledVMI("vmirs"), int32(numberOfVMs))
+			vmrs = replicaset.New(newLabeledVMI("vmirs"), numberOfVMs)
 			vmrs.Labels = map[string]string{"expose": "vmirs"}
 
 			By("Start the replica set")

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/libvmi/replicaset"
 	"kubevirt.io/kubevirt/pkg/pointer"
 
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -120,7 +121,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	}
 
 	newReplicaSetWithTemplate := func(template *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceReplicaSet {
-		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(0))
+		newRS := replicaset.New(template, 0)
 		newRS, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(template)).Create(context.Background(), newRS, v12.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return newRS
@@ -161,7 +162,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
-		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(1))
+		newRS := replicaset.New(template, 1)
 		newRS, err = virtClient.ReplicaSet(testsuite.GetTestNamespace(newRS)).Create(context.Background(), newRS, v12.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		doScaleWithHPA(newRS.ObjectMeta.Name, int32(startScale), int32(startScale), int32(startScale))

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -59,27 +59,6 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-func NewRandomReplicaSetFromVMI(vmi *v1.VirtualMachineInstance, replicas int32) *v1.VirtualMachineInstanceReplicaSet {
-	name := "replicaset" + rand.String(5)
-	rs := &v1.VirtualMachineInstanceReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(5)},
-		Spec: v1.VirtualMachineInstanceReplicaSetSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"name": name},
-			},
-			Template: &v1.VirtualMachineInstanceTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"name": name},
-					Name:   vmi.ObjectMeta.Name,
-				},
-				Spec: vmi.Spec,
-			},
-		},
-	}
-	return rs
-}
-
 func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (string, error) {
 	// get current vmi
 	freshVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})


### PR DESCRIPTION
### What this PR does

Move tests.NewRandomReplicaSetFromVMI from test/utils to a properly-named new package & file under libvmi.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This PR supersedes #12405 , rebasing and relocating the suggested builder under a libvmi sub-package.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

