### PR TITLE
tests/operator/operator.go: Remove CDI resource recovery in AfterEach

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	kubevirt.io/api v0.0.0-00010101000000-000000000000
 	kubevirt.io/client-go v0.0.0-00010101000000-000000000000
 	kubevirt.io/containerized-data-importer-api v1.57.0-alpha1
-	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90
 	kubevirt.io/qe-tools v0.1.8
 	libvirt.org/go/libvirt v1.10005.0
 	libvirt.org/go/libvirtxml v1.10005.0
@@ -157,6 +156,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.30.0 // indirect
+	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	mvdan.cc/editorconfig v0.2.1-0.20231228180347-1925077f8eb2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )

--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -64,7 +64,5 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
-        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
-        "//vendor/kubevirt.io/controller-lifecycle-operator-sdk/api:go_default_library",
     ],
 )


### PR DESCRIPTION
### What this PR does
This PR removes the CDI recovery code in the AfterEach block in tests/operator since there are no tests that changes the cdi resource

### Release note
```release-note
None
```

