### PR TITLE
refactor(virtctl/imageupload): remove global variables usages

### DIFF
--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
-        "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/cheggaaa/pb/v3:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
-	cdiClientset "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	uploadcdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
@@ -94,31 +93,6 @@ const (
 	OptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
 )
 
-var (
-	insecure                bool
-	uploadProxyURL          string
-	name                    string
-	size                    string
-	pvcSize                 string
-	storageClass            string
-	imagePath               string
-	volumeMode              string
-	archivePath             string
-	accessMode              string
-	defaultInstancetype     string
-	defaultInstancetypeKind string
-	defaultPreference       string
-	defaultPreferenceKind   string
-
-	uploadPodWaitSecs uint
-	blockVolume       bool
-	noCreate          bool
-	createPVC         bool
-	forceBind         bool
-	dataSource        bool
-	archiveUpload     bool
-)
-
 // HTTPClientCreator is a function that creates http clients
 type HTTPClientCreator func(bool) *http.Client
 
@@ -146,35 +120,47 @@ func init() {
 
 // NewImageUploadCommand returns a cobra.Command for handling the uploading of VM images
 func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	c := command{}
 	cmd := &cobra.Command{
 		Use:     "image-upload",
 		Short:   "Upload a VM image to a DataVolume/PersistentVolumeClaim.",
 		Example: usage(),
 		Args:    cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			v := command{clientConfig: clientConfig}
-			return v.run(args)
+			namespace, _, err := clientConfig.Namespace()
+			if err != nil {
+				return err
+			}
+
+			client, err := kubecli.GetKubevirtClientFromClientConfig(clientConfig)
+			if err != nil {
+				return fmt.Errorf("cannot obtain KubeVirt client: %v", err)
+			}
+
+			c.namespace = namespace
+			c.client = client
+			return c.run(args)
 		},
 	}
-	cmd.Flags().BoolVar(&insecure, "insecure", false, "Allow insecure server connections when using HTTPS.")
-	cmd.Flags().StringVar(&uploadProxyURL, "uploadproxy-url", "", "The URL of the cdi-upload proxy service.")
-	cmd.Flags().StringVar(&name, "pvc-name", "", "The destination DataVolume/PVC name.")
-	cmd.Flags().StringVar(&pvcSize, "pvc-size", "", "The size of the PVC to create (ex. 10Gi, 500Mi).")
-	cmd.Flags().StringVar(&size, "size", "", "The size of the DataVolume to create (ex. 10Gi, 500Mi).")
-	cmd.Flags().StringVar(&storageClass, "storage-class", "", "The storage class for the PVC.")
-	cmd.Flags().StringVar(&accessMode, "access-mode", "", "The access mode for the PVC.")
-	cmd.Flags().BoolVar(&blockVolume, "block-volume", false, "Create a PVC with VolumeMode=Block (default is the storageProfile default. for archive upload default is filesystem).")
-	cmd.Flags().StringVar(&volumeMode, "volume-mode", "", "Specify the VolumeMode (block/filesystem) used to create the PVC. Default is the storageProfile default. For archive upload default is filesystem.")
-	cmd.Flags().StringVar(&imagePath, "image-path", "", "Path to the local VM image.")
-	cmd.Flags().StringVar(&archivePath, "archive-path", "", "Path to the local archive.")
-	cmd.Flags().BoolVar(&noCreate, "no-create", false, "Don't attempt to create a new DataVolume/PVC.")
-	cmd.Flags().UintVar(&uploadPodWaitSecs, "wait-secs", 300, "Seconds to wait for upload pod to start.")
-	cmd.Flags().BoolVar(&forceBind, "force-bind", false, "Force bind the PVC, ignoring the WaitForFirstConsumer logic.")
-	cmd.Flags().BoolVar(&dataSource, "datasource", false, "Create a DataSource pointing to the created DataVolume/PVC.")
-	cmd.Flags().StringVar(&defaultInstancetype, "default-instancetype", "", "The default instance type to associate with the image.")
-	cmd.Flags().StringVar(&defaultInstancetypeKind, "default-instancetype-kind", "", "The default instance type kind to associate with the image.")
-	cmd.Flags().StringVar(&defaultPreference, "default-preference", "", "The default preference to associate with the image.")
-	cmd.Flags().StringVar(&defaultPreferenceKind, "default-preference-kind", "", "The default preference kind to associate with the image.")
+	cmd.Flags().BoolVar(&c.insecure, "insecure", false, "Allow insecure server connections when using HTTPS.")
+	cmd.Flags().StringVar(&c.uploadProxyURL, "uploadproxy-url", "", "The URL of the cdi-upload proxy service.")
+	cmd.Flags().StringVar(&c.name, "pvc-name", "", "The destination DataVolume/PVC name.")
+	cmd.Flags().StringVar(&c.pvcSize, "pvc-size", "", "The size of the PVC to create (ex. 10Gi, 500Mi).")
+	cmd.Flags().StringVar(&c.size, "size", "", "The size of the DataVolume to create (ex. 10Gi, 500Mi).")
+	cmd.Flags().StringVar(&c.storageClass, "storage-class", "", "The storage class for the PVC.")
+	cmd.Flags().StringVar(&c.accessMode, "access-mode", "", "The access mode for the PVC.")
+	cmd.Flags().BoolVar(&c.blockVolume, "block-volume", false, "Create a PVC with VolumeMode=Block (default is the storageProfile default. for archive upload default is filesystem).")
+	cmd.Flags().StringVar(&c.volumeMode, "volume-mode", "", "Specify the VolumeMode (block/filesystem) used to create the PVC. Default is the storageProfile default. For archive upload default is filesystem.")
+	cmd.Flags().StringVar(&c.imagePath, "image-path", "", "Path to the local VM image.")
+	cmd.Flags().StringVar(&c.archivePath, "archive-path", "", "Path to the local archive.")
+	cmd.Flags().BoolVar(&c.noCreate, "no-create", false, "Don't attempt to create a new DataVolume/PVC.")
+	cmd.Flags().UintVar(&c.uploadPodWaitSecs, "wait-secs", 300, "Seconds to wait for upload pod to start.")
+	cmd.Flags().BoolVar(&c.forceBind, "force-bind", false, "Force bind the PVC, ignoring the WaitForFirstConsumer logic.")
+	cmd.Flags().BoolVar(&c.dataSource, "datasource", false, "Create a DataSource pointing to the created DataVolume/PVC.")
+	cmd.Flags().StringVar(&c.defaultInstancetype, "default-instancetype", "", "The default instance type to associate with the image.")
+	cmd.Flags().StringVar(&c.defaultInstancetypeKind, "default-instancetype-kind", "", "The default instance type kind to associate with the image.")
+	cmd.Flags().StringVar(&c.defaultPreference, "default-preference", "", "The default preference to associate with the image.")
+	cmd.Flags().StringVar(&c.defaultPreferenceKind, "default-preference-kind", "", "The default preference kind to associate with the image.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	cmd.Flags().MarkDeprecated("pvc-name", "specify the name as the second argument instead.")
 	cmd.Flags().MarkDeprecated("pvc-size", "use --size instead.")
@@ -207,50 +193,72 @@ func usage() string {
 }
 
 type command struct {
-	clientConfig clientcmd.ClientConfig
+	client                  kubecli.KubevirtClient
+	insecure                bool
+	uploadProxyURL          string
+	name                    string
+	namespace               string
+	size                    string
+	pvcSize                 string
+	storageClass            string
+	imagePath               string
+	volumeMode              string
+	archivePath             string
+	accessMode              string
+	defaultInstancetype     string
+	defaultInstancetypeKind string
+	defaultPreference       string
+	defaultPreferenceKind   string
+	uploadPodWaitSecs       uint
+	blockVolume             bool
+	noCreate                bool
+	createPVC               bool
+	forceBind               bool
+	dataSource              bool
+	archiveUpload           bool
 }
 
-func parseArgs(args []string) error {
-	if len(size) > 0 && len(pvcSize) > 0 && size != pvcSize {
+func (c *command) parseArgs(args []string) error {
+	if len(c.size) > 0 && len(c.pvcSize) > 0 && c.size != c.pvcSize {
 		return fmt.Errorf("--pvc-size and --size can not be specified at the same time")
 	}
 
-	if len(pvcSize) > 0 {
-		size = pvcSize
+	if len(c.pvcSize) > 0 {
+		c.size = c.pvcSize
 	}
 
 	// check deprecated invocation
-	if name != "" {
+	if c.name != "" {
 		if len(args) != 0 {
 			return fmt.Errorf("cannot use --pvc-name and args")
 		}
 
-		createPVC = true
+		c.createPVC = true
 
 		return nil
 	}
 
 	// check deprecated blockVolume flag
-	if blockVolume {
-		if volumeMode == "" {
-			volumeMode = "block"
-		} else if volumeMode != "block" {
-			return fmt.Errorf("incompatible --volume-mode '%s' and --block-volume", volumeMode)
+	if c.blockVolume {
+		if c.volumeMode == "" {
+			c.volumeMode = "block"
+		} else if c.volumeMode != "block" {
+			return fmt.Errorf("incompatible --volume-mode '%s' and --block-volume", c.volumeMode)
 		}
 	}
-	if volumeMode != "block" && volumeMode != "filesystem" && volumeMode != "" {
-		return fmt.Errorf("Invalid volume mode '%s'. Valid values are 'block' and 'filesystem'.", volumeMode)
+	if c.volumeMode != "block" && c.volumeMode != "filesystem" && c.volumeMode != "" {
+		return fmt.Errorf("Invalid volume mode '%s'. Valid values are 'block' and 'filesystem'.", c.volumeMode)
 	}
 
-	archiveUpload = false
-	if imagePath == "" && archivePath == "" {
+	c.archiveUpload = false
+	if c.imagePath == "" && c.archivePath == "" {
 		return fmt.Errorf("either image-path or archive-path must be provided")
-	} else if imagePath != "" && archivePath != "" {
+	} else if c.imagePath != "" && c.archivePath != "" {
 		return fmt.Errorf("cannot handle both image-path and archive-path, provide only one")
-	} else if archivePath != "" {
-		archiveUpload = true
-		imagePath = archivePath
-		if volumeMode == "block" {
+	} else if c.archivePath != "" {
+		c.archiveUpload = true
+		c.imagePath = c.archivePath
+		if c.volumeMode == "block" {
 			return fmt.Errorf("In archive upload the volume mode should always be filesystem")
 		}
 	}
@@ -261,77 +269,67 @@ func parseArgs(args []string) error {
 
 	switch strings.ToLower(args[0]) {
 	case "dv":
-		createPVC = false
+		c.createPVC = false
 	case "pvc":
-		createPVC = true
+		c.createPVC = true
 	default:
 		return fmt.Errorf("invalid resource type %s", args[0])
 	}
 
-	name = args[1]
+	c.name = args[1]
 
 	return nil
 }
 
-func validateDefaultInstancetypeArgs() error {
-	if defaultInstancetype == "" && defaultInstancetypeKind != "" {
+func (c *command) validateDefaultInstancetypeArgs() error {
+	if c.defaultInstancetype == "" && c.defaultInstancetypeKind != "" {
 		return fmt.Errorf("--default-instancetype must be provided with --default-instancetype-kind")
 	}
-	if defaultPreference == "" && defaultPreferenceKind != "" {
+	if c.defaultPreference == "" && c.defaultPreferenceKind != "" {
 		return fmt.Errorf("--default-preference must be provided with --default-preference-kind")
 	}
-	if (defaultInstancetype != "" || defaultPreference != "") && noCreate {
+	if (c.defaultInstancetype != "" || c.defaultPreference != "") && c.noCreate {
 		return fmt.Errorf("--default-instancetype and --default-preference cannot be used with --no-create")
 	}
 	return nil
 }
 
 func (c *command) run(args []string) error {
-	if err := parseArgs(args); err != nil {
+	if err := c.parseArgs(args); err != nil {
 		return err
 	}
 
-	if err := validateDefaultInstancetypeArgs(); err != nil {
+	if err := c.validateDefaultInstancetypeArgs(); err != nil {
 		return err
 	}
 
 	// #nosec G304 No risk for path injection as this function executes with
 	// the same privileges as those of virtctl user who supplies imagePath
-	file, err := os.Open(imagePath)
+	file, err := os.Open(c.imagePath)
 	if err != nil {
 		return err
 	}
 	defer util.CloseIOAndCheckErr(file, nil)
 
-	namespace, _, err := c.clientConfig.Namespace()
+	pvc, err := c.getAndValidateUploadPVC()
 	if err != nil {
-		return err
-	}
-
-	virtClient, err := kubecli.GetKubevirtClientFromClientConfig(c.clientConfig)
-	if err != nil {
-		return fmt.Errorf("cannot obtain KubeVirt client: %v", err)
-	}
-
-	pvc, err := getAndValidateUploadPVC(virtClient, namespace, name, noCreate, archiveUpload)
-	if err != nil {
-		if !(k8serrors.IsNotFound(err) && !noCreate) {
+		if !(k8serrors.IsNotFound(err) && !c.noCreate) {
 			return err
 		}
 
-		if !noCreate && len(size) == 0 {
+		if !c.noCreate && len(c.size) == 0 {
 			return fmt.Errorf("when creating a resource, the size must be specified")
 		}
 
 		var obj metav1.Object
 
-		if createPVC {
-			obj, err = createUploadPVC(virtClient, namespace, name, size, storageClass, accessMode, volumeMode, archiveUpload)
+		if c.createPVC {
+			obj, err = c.createUploadPVC()
 			if err != nil {
 				return err
 			}
 		} else {
-			obj, err = createUploadDataVolume(virtClient, namespace, name, size, storageClass, accessMode, volumeMode, archiveUpload)
+			obj, err = c.createUploadDataVolume()
 			if err != nil {
 				return err
 			}
@@ -339,68 +337,65 @@ func (c *command) run(args []string) error {
 
 		fmt.Printf("%s %s/%s created\n", reflect.TypeOf(obj).Elem().Name(), obj.GetNamespace(), obj.GetName())
 	} else {
-		pvc, err = ensurePVCSupportsUpload(virtClient, pvc)
+		pvc, err = c.ensurePVCSupportsUpload(pvc)
 		if err != nil {
 			return err
 		}
 
-		fmt.Printf("Using existing PVC %s/%s\n", namespace, pvc.Name)
+		fmt.Printf("Using existing PVC %s/%s\n", c.namespace, pvc.Name)
 	}
 
-	if createPVC {
-		err = waitUploadServerReady(virtClient, namespace, name, uploadReadyWaitInterval, time.Duration(uploadPodWaitSecs)*time.Second)
-		if err != nil {
+	if c.createPVC {
+		if err := c.waitUploadServerReady(); err != nil {
 			return err
 		}
 	} else {
-		err = waitDvUploadScheduled(virtClient, namespace, name, uploadReadyWaitInterval, time.Duration(uploadPodWaitSecs)*time.Second)
-		if err != nil {
+		if err := c.waitDvUploadScheduled(); err != nil {
 			return err
 		}
 	}
-	if uploadProxyURL == "" {
-		uploadProxyURL, err = getUploadProxyURL(virtClient.CdiClient())
+	if c.uploadProxyURL == "" {
+		c.uploadProxyURL, err = c.getUploadProxyURL()
 		if err != nil {
 			return err
 		}
-		if uploadProxyURL == "" {
+		if c.uploadProxyURL == "" {
 			return fmt.Errorf("uploadproxy URL not found")
 		}
 	}
 
-	u, err := url.Parse(uploadProxyURL)
+	u, err := url.Parse(c.uploadProxyURL)
 	if err != nil {
 		return err
 	}
 
 	if u.Scheme == "" {
-		uploadProxyURL = fmt.Sprintf("https://%s", uploadProxyURL)
+		c.uploadProxyURL = fmt.Sprintf("https://%s", c.uploadProxyURL)
 	}
 
-	fmt.Printf("Uploading data to %s\n", uploadProxyURL)
+	fmt.Printf("Uploading data to %s\n", c.uploadProxyURL)
 
-	token, err := getUploadToken(virtClient.CdiClient(), namespace, name)
+	token, err := c.getUploadToken()
 	if err != nil {
 		return err
 	}
 
-	err = uploadData(uploadProxyURL, token, file, insecure)
-	if err != nil {
+	if err := c.uploadData(token, file); err != nil {
 		return err
 	}
 
-	if dataSource {
-		if err := handleDataSource(virtClient, name, namespace); err != nil {
+	if c.dataSource {
+		if err := c.handleDataSource(); err != nil {
 			return err
 		}
 	}
 
 	fmt.Println("Uploading data completed successfully, waiting for processing to complete, you can hit ctrl-c without interrupting the progress")
-	err = UploadProcessingCompleteFunc(virtClient, namespace, name, processingWaitInterval, processingWaitTotal)
+	err = UploadProcessingCompleteFunc(c.client, c.namespace, c.name, processingWaitInterval, processingWaitTotal)
 	if err != nil {
 		fmt.Printf("Timed out waiting for post upload processing to complete, please check upload pod status for progress\n")
 	} else {
-		fmt.Printf("Uploading %s completed successfully\n", imagePath)
+		fmt.Printf("Uploading %s completed successfully\n", c.imagePath)
 	}
 
 	return err
@@ -458,8 +453,8 @@ func ConstructUploadProxyPathAsync(uploadProxyURL, token string, insecure bool) 
 	return u.String(), nil
 }
 
-func uploadData(uploadProxyURL, token string, file *os.File, insecure bool) error {
-	url, err := ConstructUploadProxyPathAsync(uploadProxyURL, token, insecure)
+func (c *command) uploadData(token string, file *os.File) error {
+	url, err := ConstructUploadProxyPathAsync(c.uploadProxyURL, token, c.insecure)
 	if err != nil {
 		return err
 	}
@@ -474,7 +469,7 @@ func uploadData(uploadProxyURL, token string, file *os.File, insecure bool) erro
 	bar.Set(pb.Bytes, true)
 	reader := bar.NewProxyReader(file)
 
-	client := httpClientCreatorFunc(insecure)
+	client := httpClientCreatorFunc(c.insecure)
 	req, _ := http.NewRequest("POST", url, io.NopCloser(reader))
 
 	req.Header.Add("Authorization", "Bearer "+token)
@@ -504,17 +499,17 @@ func uploadData(uploadProxyURL, token string, file *os.File, insecure bool) erro
 	return nil
 }
 
-func getUploadToken(client cdiClientset.Interface, namespace, name string) (string, error) {
+func (c *command) getUploadToken() (string, error) {
 	request := &uploadcdiv1.UploadTokenRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "token-for-virtctl",
 		},
 		Spec: uploadcdiv1.UploadTokenRequestSpec{
-			PvcName: name,
+			PvcName: c.name,
 		},
 	}
 
-	response, err := client.UploadV1beta1().UploadTokenRequests(namespace).Create(context.Background(), request, metav1.CreateOptions{})
+	response, err := c.client.CdiClient().UploadV1beta1().UploadTokenRequests(c.namespace).Create(context.Background(), request, metav1.CreateOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -522,34 +517,34 @@ func getUploadToken(client cdiClientset.Interface, namespace, name string) (stri
 	return response.Status.Token, nil
 }
 
-func waitDvUploadScheduled(client kubecli.KubevirtClient, namespace, name string, interval, timeout time.Duration) error {
+func (c *command) waitDvUploadScheduled() error {
 	loggedStatus := false
 	//
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		dv, err := client.CdiClient().CdiV1beta1().DataVolumes(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	err := wait.PollImmediate(uploadReadyWaitInterval, time.Duration(c.uploadPodWaitSecs)*time.Second, func() (bool, error) {
+		dv, err := c.client.CdiClient().CdiV1beta1().DataVolumes(c.namespace).Get(context.Background(), c.name, metav1.GetOptions{})
 
 		if err != nil {
 			// DataVolume controller may not have created the DV yet ? TODO:
 			if k8serrors.IsNotFound(err) {
-				fmt.Printf("DV %s not found... \n", name)
+				fmt.Printf("DV %s not found... \n", c.name)
 				return false, nil
 			}
 
 			return false, err
 		}
 
-		if (dv.Status.Phase == cdiv1.WaitForFirstConsumer || dv.Status.Phase == cdiv1.PendingPopulation) && !forceBind {
+		if (dv.Status.Phase == cdiv1.WaitForFirstConsumer || dv.Status.Phase == cdiv1.PendingPopulation) && !c.forceBind {
 			return false, fmt.Errorf("cannot upload to DataVolume in %s phase, make sure the PVC is Bound, or use force-bind flag", string(dv.Status.Phase))
 		}
 
 		done := dv.Status.Phase == cdiv1.UploadReady
 		if !done {
 			// We check events to provide user with pertinent error messages
-			if err := handleEventErrors(client, dv.Status.ClaimName, name, namespace); err != nil {
+			if err := c.handleEventErrors(dv.Status.ClaimName, c.name); err != nil {
 				return false, err
 			}
 			if !loggedStatus {
-				fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", name)
+				fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", c.name)
 				loggedStatus = true
 			}
 		}
@@ -564,11 +559,11 @@ func waitDvUploadScheduled(client kubecli.KubevirtClient, namespace, name string
 	return err
 }
 
-func waitUploadServerReady(client kubecli.KubevirtClient, namespace, name string, interval, timeout time.Duration) error {
+func (c *command) waitUploadServerReady() error {
 	loggedStatus := false
 
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	err := wait.PollImmediate(uploadReadyWaitInterval, time.Duration(c.uploadPodWaitSecs)*time.Second, func() (bool, error) {
+		pvc, err := c.client.CoreV1().PersistentVolumeClaims(c.namespace).Get(context.Background(), c.name, metav1.GetOptions{})
 		if err != nil {
 			// DataVolume controller may not have created the PVC yet
 			if k8serrors.IsNotFound(err) {
@@ -583,11 +578,11 @@ func waitUploadServerReady(client kubecli.KubevirtClient, namespace, name string
 
 		if !done {
 			// We check events to provide user with pertinent error messages
-			if err := handleEventErrors(client, name, name, namespace); err != nil {
+			if err := c.handleEventErrors(c.name, c.name); err != nil {
 				return false, err
 			}
 			if !loggedStatus {
-				fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", name)
+				fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", c.name)
 				loggedStatus = true
 			}
 		}
@@ -622,53 +617,53 @@ func waitUploadProcessingComplete(client kubernetes.Interface, namespace, name s
 	return err
 }
 
-func setDefaultInstancetypeLabels(target metav1.Object) {
+func (c *command) setDefaultInstancetypeLabels(target metav1.Object) {
 	if target.GetLabels() == nil {
 		target.SetLabels(make(map[string]string))
 	}
 
-	if defaultInstancetype != "" {
-		target.GetLabels()[instancetypeapi.DefaultInstancetypeLabel] = defaultInstancetype
+	if c.defaultInstancetype != "" {
+		target.GetLabels()[instancetypeapi.DefaultInstancetypeLabel] = c.defaultInstancetype
 	}
-	if defaultInstancetypeKind != "" {
-		target.GetLabels()[instancetypeapi.DefaultInstancetypeKindLabel] = defaultInstancetypeKind
+	if c.defaultInstancetypeKind != "" {
+		target.GetLabels()[instancetypeapi.DefaultInstancetypeKindLabel] = c.defaultInstancetypeKind
 	}
-	if defaultPreference != "" {
-		target.GetLabels()[instancetypeapi.DefaultPreferenceLabel] = defaultPreference
+	if c.defaultPreference != "" {
+		target.GetLabels()[instancetypeapi.DefaultPreferenceLabel] = c.defaultPreference
 	}
-	if defaultPreferenceKind != "" {
-		target.GetLabels()[instancetypeapi.DefaultPreferenceKindLabel] = defaultPreferenceKind
+	if c.defaultPreferenceKind != "" {
+		target.GetLabels()[instancetypeapi.DefaultPreferenceKindLabel] = c.defaultPreferenceKind
 	}
 }
 
-func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size, storageClass, accessMode, volumeMode string, archiveUpload bool) (*cdiv1.DataVolume, error) {
-	pvcSpec, err := createStorageSpec(client, size, storageClass, accessMode, volumeMode)
+func (c *command) createUploadDataVolume() (*cdiv1.DataVolume, error) {
+	pvcSpec, err := c.createStorageSpec()
 	if err != nil {
 		return nil, err
 	}
 
 	// We check if the user-defined storageClass exists before attempting to create the dataVolume
-	if storageClass != "" {
-		_, err = client.StorageV1().StorageClasses().Get(context.Background(), storageClass, metav1.GetOptions{})
+	if c.storageClass != "" {
+		_, err = c.client.StorageV1().StorageClasses().Get(context.Background(), c.storageClass, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	annotations := map[string]string{}
-	if forceBind {
+	if c.forceBind {
 		annotations[forceImmediateBindingAnnotation] = ""
 	}
 
 	contentType := cdiv1.DataVolumeKubeVirt
-	if archiveUpload {
+	if c.archiveUpload {
 		contentType = cdiv1.DataVolumeArchive
 	}
 
 	dv := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
+			Name:        c.name,
+			Namespace:   c.namespace,
 			Annotations: annotations,
 		},
 		Spec: cdiv1.DataVolumeSpec{
@@ -679,9 +674,9 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 			Storage:     pvcSpec,
 		},
 	}
-	setDefaultInstancetypeLabels(&dv.ObjectMeta)
+	c.setDefaultInstancetypeLabels(&dv.ObjectMeta)
 
-	dv, err = client.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+	dv, err = c.client.CdiClient().CdiV1beta1().DataVolumes(c.namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -689,10 +684,10 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 	return dv, nil
 }
 
-func createStorageSpec(client kubecli.KubevirtClient, size, storageClass, accessMode, volumeMode string) (*cdiv1.StorageSpec, error) {
-	quantity, err := resource.ParseQuantity(size)
+func (c *command) createStorageSpec() (*cdiv1.StorageSpec, error) {
+	quantity, err := resource.ParseQuantity(c.size)
 	if err != nil {
-		return nil, fmt.Errorf("validation failed for size=%s: %s", size, err)
+		return nil, fmt.Errorf("validation failed for size=%s: %s", c.size, err)
 	}
 
 	spec := &cdiv1.StorageSpec{
@@ -703,18 +698,18 @@ func createStorageSpec(client kubecli.KubevirtClient, size, storageClass, access
 		},
 	}
 
-	if storageClass != "" {
-		spec.StorageClassName = &storageClass
+	if c.storageClass != "" {
+		spec.StorageClassName = &c.storageClass
 	}
 
-	if accessMode != "" {
-		if accessMode == string(v1.ReadOnlyMany) {
+	if c.accessMode != "" {
+		if c.accessMode == string(v1.ReadOnlyMany) {
 			return nil, fmt.Errorf("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported")
 		}
-		spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(accessMode)}
+		spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(c.accessMode)}
 	}
 
-	switch volumeMode {
+	switch c.volumeMode {
 	case "block":
 		volMode := v1.PersistentVolumeBlock
 		spec.VolumeMode = &volMode
@@ -726,31 +721,31 @@ func createStorageSpec(client kubecli.KubevirtClient, size, storageClass, access
 	return spec, nil
 }
 
-func createUploadPVC(client kubecli.KubevirtClient, namespace, name, size, storageClass, accessMode, volumeMode string, archiveUpload bool) (*v1.PersistentVolumeClaim, error) {
-	if accessMode == string(v1.ReadOnlyMany) {
+func (c *command) createUploadPVC() (*v1.PersistentVolumeClaim, error) {
+	if c.accessMode == string(v1.ReadOnlyMany) {
 		return nil, fmt.Errorf("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported")
 	}
 
 	// We check if the user-defined storageClass exists before attempting to create the PVC
-	if storageClass != "" {
-		_, err := client.StorageV1().StorageClasses().Get(context.Background(), storageClass, metav1.GetOptions{})
+	if c.storageClass != "" {
+		_, err := c.client.StorageV1().StorageClasses().Get(context.Background(), c.storageClass, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	quantity, err := resource.ParseQuantity(size)
+	quantity, err := resource.ParseQuantity(c.size)
 	if err != nil {
-		return nil, fmt.Errorf("validation failed for size=%s: %s", size, err)
+		return nil, fmt.Errorf("validation failed for size=%s: %s", c.size, err)
 	}
-	pvc := storagetypes.RenderPVC(&quantity, name, namespace, storageClass, accessMode, volumeMode == "block")
-	if volumeMode == "filesystem" {
+	pvc := storagetypes.RenderPVC(&quantity, c.name, c.namespace, c.storageClass, c.accessMode, c.volumeMode == "block")
+	if c.volumeMode == "filesystem" {
 		volMode := v1.PersistentVolumeFilesystem
 		pvc.Spec.VolumeMode = &volMode
 	}
 
 	contentType := string(cdiv1.DataVolumeKubeVirt)
-	if archiveUpload {
+	if c.archiveUpload {
 		contentType = string(cdiv1.DataVolumeArchive)
 	}
 
@@ -759,14 +754,14 @@ func createUploadPVC(client kubecli.KubevirtClient, namespace, name, size, stora
 		contentTypeAnnotation:   contentType,
 	}
 
-	if forceBind {
+	if c.forceBind {
 		annotations[forceImmediateBindingAnnotation] = ""
 	}
 
 	pvc.ObjectMeta.Annotations = annotations
-	setDefaultInstancetypeLabels(&pvc.ObjectMeta)
+	c.setDefaultInstancetypeLabels(&pvc.ObjectMeta)
 
-	pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
+	pvc, err = c.client.CoreV1().PersistentVolumeClaims(c.namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -774,7 +769,7 @@ func createUploadPVC(client kubecli.KubevirtClient, namespace, name, size, stora
 	return pvc, nil
 }
 
-func ensurePVCSupportsUpload(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+func (c *command) ensurePVCSupportsUpload(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
 	var err error
 	_, hasAnnotation := pvc.Annotations[uploadRequestAnnotation]
 
@@ -783,7 +778,7 @@ func ensurePVCSupportsUpload(client kubernetes.Interface, pvc *v1.PersistentVolu
 			pvc.SetAnnotations(make(map[string]string, 0))
 		}
 		pvc.Annotations[uploadRequestAnnotation] = ""
-		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
+		pvc, err = c.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -792,15 +787,15 @@ func ensurePVCSupportsUpload(client kubernetes.Interface, pvc *v1.PersistentVolu
 	return pvc, nil
 }
 
-func getAndValidateUploadPVC(client kubecli.KubevirtClient, namespace, name string, shouldExist, archiveUpload bool) (*v1.PersistentVolumeClaim, error) {
-	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func (c *command) getAndValidateUploadPVC() (*v1.PersistentVolumeClaim, error) {
+	pvc, err := c.client.CoreV1().PersistentVolumeClaims(c.namespace).Get(context.Background(), c.name, metav1.GetOptions{})
 	if err != nil {
-		fmt.Printf("PVC %s/%s not found \n", namespace, name)
+		fmt.Printf("PVC %s/%s not found \n", c.namespace, c.name)
 		return nil, err
 	}
 
-	if !createPVC {
-		pvc, err = validateUploadDataVolume(client, pvc)
+	if !c.createPVC {
+		pvc, err = c.validateUploadDataVolume(pvc)
 		if err != nil {
 			return nil, err
 		}
@@ -815,37 +810,37 @@ func getAndValidateUploadPVC(client kubecli.KubevirtClient, namespace, name stri
 	podPhase := pvc.Annotations[PodPhaseAnnotation]
 
 	if podPhase == string(v1.PodSucceeded) {
-		return nil, fmt.Errorf("PVC %s already successfully imported/cloned/updated", name)
+		return nil, fmt.Errorf("PVC %s already successfully imported/cloned/updated", c.name)
 	}
 
-	if !shouldExist && !isUploadPVC {
-		return nil, fmt.Errorf("PVC %s not available for upload", name)
+	if !c.noCreate && !isUploadPVC {
+		return nil, fmt.Errorf("PVC %s not available for upload", c.name)
 	}
 
 	// for PVCs that exist and the user wants to upload archive
 	// the pvc has to have the contentType archive annotation
-	if archiveUpload {
+	if c.archiveUpload {
 		contentType, found := pvc.Annotations[contentTypeAnnotation]
 		if !found || contentType != string(cdiv1.DataVolumeArchive) {
-			return nil, fmt.Errorf("PVC %s doesn't have archive contentType annotation", name)
+			return nil, fmt.Errorf("PVC %s doesn't have archive contentType annotation", c.name)
 		}
 	}
 
 	return pvc, nil
 }
 
-func validateUploadDataVolume(client kubecli.KubevirtClient, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
-	dv, err := client.CdiClient().CdiV1beta1().DataVolumes(pvc.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+func (c *command) validateUploadDataVolume(pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+	dv, err := c.client.CdiClient().CdiV1beta1().DataVolumes(pvc.Namespace).Get(context.Background(), c.name, metav1.GetOptions{})
 	if err != nil {
 		// When the PVC exists but the DV doesn't, there are two possible outcomes:
 		if k8serrors.IsNotFound(err) {
 			// 1. The DV was already garbage-collected. The PVC was created and populated by CDI as expected.
 			if dvGarbageCollected := pvc.Annotations[deleteAfterCompletionAnnotation] == "true" &&
 				pvc.Annotations[PodPhaseAnnotation] == string(v1.PodSucceeded); dvGarbageCollected {
-				return nil, fmt.Errorf("DataVolume already garbage-collected: Assuming PVC %s/%s is successfully populated", pvc.Namespace, name)
+				return nil, fmt.Errorf("DataVolume already garbage-collected: Assuming PVC %s/%s is successfully populated", pvc.Namespace, c.name)
 			}
 			// 2. The PVC was created independently of a DV.
-			return nil, fmt.Errorf("No DataVolume is associated with the existing PVC %s/%s", pvc.Namespace, name)
+			return nil, fmt.Errorf("No DataVolume is associated with the existing PVC %s/%s", pvc.Namespace, c.name)
 		}
 		return nil, err
 	}
@@ -854,24 +849,24 @@ func validateUploadDataVolume(client kubecli.KubevirtClient, pvc *v1.PersistentV
 	if dv.Annotations[UsePopulatorAnnotation] == "true" {
 		// We can assume the PVC is populated once it's bound
 		if pvc.Status.Phase == v1.ClaimBound {
-			return nil, fmt.Errorf("PVC %s already successfully populated", name)
+			return nil, fmt.Errorf("PVC %s already successfully populated", c.name)
 		}
 		// Get the PVC Prime since the upload is happening there
 		pvcPrimeName, ok := pvc.Annotations[PVCPrimeNameAnnotation]
 		if !ok {
-			return nil, fmt.Errorf("Unable to get PVC Prime name from PVC %s/%s", pvc.Namespace, name)
+			return nil, fmt.Errorf("Unable to get PVC Prime name from PVC %s/%s", pvc.Namespace, c.name)
 		}
-		pvc, err = client.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), pvcPrimeName, metav1.GetOptions{})
+		pvc, err = c.client.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), pvcPrimeName, metav1.GetOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("Unable to get PVC Prime %s/%s", dv.Namespace, name)
+			return nil, fmt.Errorf("Unable to get PVC Prime %s/%s", dv.Namespace, c.name)
 		}
 	}
 
 	return pvc, nil
 }
 
-func getUploadProxyURL(client cdiClientset.Interface) (string, error) {
-	cdiConfig, err := client.CdiV1beta1().CDIConfigs().Get(context.Background(), configName, metav1.GetOptions{})
+func (c *command) getUploadProxyURL() (string, error) {
+	cdiConfig, err := c.client.CdiClient().CdiV1beta1().CDIConfigs().Get(context.Background(), configName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -885,17 +880,17 @@ func getUploadProxyURL(client cdiClientset.Interface) (string, error) {
 }
 
 // handleEventErrors checks PVC and DV-related events and, when encountered, returns appropriate errors
-func handleEventErrors(client kubecli.KubevirtClient, pvcName, dvName, namespace string) error {
+func (c *command) handleEventErrors(pvcName, dvName string) error {
 	var pvcUID types.UID
 	var dvUID types.UID
 
-	eventList, err := client.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
+	eventList, err := c.client.CoreV1().Events(c.namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
 	if pvcName != "" {
-		pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(context.Background(), pvcName, metav1.GetOptions{})
+		pvc, err := c.client.CoreV1().PersistentVolumeClaims(c.namespace).Get(context.Background(), pvcName, metav1.GetOptions{})
 		if !k8serrors.IsNotFound(err) {
 			if err != nil {
 				return err
@@ -905,7 +900,7 @@ func handleEventErrors(client kubecli.KubevirtClient, pvcName, dvName, namespace
 	}
 
 	if dvName != "" {
-		dv, err := client.CdiClient().CdiV1beta1().DataVolumes(namespace).Get(context.Background(), dvName, metav1.GetOptions{})
+		dv, err := c.client.CdiClient().CdiV1beta1().DataVolumes(c.namespace).Get(context.Background(), dvName, metav1.GetOptions{})
 		if !k8serrors.IsNotFound(err) {
 			if err != nil {
 				return err
@@ -934,47 +929,47 @@ func handleEventErrors(client kubecli.KubevirtClient, pvcName, dvName, namespace
 	return nil
 }
 
-func handleDataSource(client kubecli.KubevirtClient, name string, namespace string) error {
-	ds, err := client.CdiClient().CdiV1beta1().DataSources(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func (c *command) handleDataSource() error {
+	ds, err := c.client.CdiClient().CdiV1beta1().DataSources(c.namespace).Get(context.Background(), c.name, metav1.GetOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
 
 	if ds != nil {
-		err = updateExistingDataSource(client, name, namespace, ds)
+		err = c.updateExistingDataSource(ds)
 	} else {
-		err = createNewDataSource(client, name, namespace)
+		err = c.createNewDataSource()
 	}
 	return err
 }
 
-func createNewDataSource(client kubecli.KubevirtClient, name, namespace string) error {
+func (c *command) createNewDataSource() error {
 	ds := &cdiv1.DataSource{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:      c.name,
+			Namespace: c.namespace,
 			Labels:    map[string]string{},
 		},
 		Spec: cdiv1.DataSourceSpec{
 			Source: cdiv1.DataSourceSource{
 				PVC: &cdiv1.DataVolumeSourcePVC{
-					Name:      name,
-					Namespace: namespace,
+					Name:      c.name,
+					Namespace: c.namespace,
 				},
 			},
 		},
 	}
-	setDefaultInstancetypeLabels(&ds.ObjectMeta)
+	c.setDefaultInstancetypeLabels(&ds.ObjectMeta)
 
-	_, err := client.CdiClient().CdiV1beta1().DataSources(namespace).Create(context.Background(), ds, metav1.CreateOptions{})
+	_, err := c.client.CdiClient().CdiV1beta1().DataSources(c.namespace).Create(context.Background(), ds, metav1.CreateOptions{})
 	if err == nil {
-		fmt.Printf("Created a new DataSource %s/%s\n", namespace, name)
+		fmt.Printf("Created a new DataSource %s/%s\n", c.namespace, c.name)
 	}
 	return err
 }
 
-func updateExistingDataSource(client kubecli.KubevirtClient, pvcName, pvcNamespace string, ds *cdiv1.DataSource) error {
-	setDefaultInstancetypeLabels(&ds.ObjectMeta)
+func (c *command) updateExistingDataSource(ds *cdiv1.DataSource) error {
+	c.setDefaultInstancetypeLabels(&ds.ObjectMeta)
 
 	patchBytes, err := patch.GeneratePatchPayload(
 		patch.PatchOperation{
@@ -986,8 +981,8 @@ func updateExistingDataSource(client kubecli.KubevirtClient, pvcName, pvcNamespa
 			Op:   patch.PatchReplaceOp,
 			Path: "/spec/source/pvc",
 			Value: map[string]string{
-				"name":      pvcName,
-				"namespace": pvcNamespace,
+				"name":      c.name,
+				"namespace": c.namespace,
 			},
 		},
 	)
@@ -995,7 +990,7 @@ func updateExistingDataSource(client kubecli.KubevirtClient, pvcName, pvcNamespa
 		return err
 	}
 
-	if _, err = client.CdiClient().CdiV1beta1().DataSources(ds.Namespace).Patch(context.Background(), ds.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}); err == nil {
+	if _, err = c.client.CdiClient().CdiV1beta1().DataSources(ds.Namespace).Patch(context.Background(), ds.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}); err == nil {
 		fmt.Printf("Updated an existing DataSource %s/%s\n", ds.Namespace, ds.Name)
 	}
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Remove global variables that shared across
multiple functions in this command.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```