### PR TITLE
Fix ginkgo bootstrapping script

### DIFF
--- a/hack/bootstrap-ginkgo.sh
+++ b/hack/bootstrap-ginkgo.sh
@@ -4,12 +4,15 @@ set -e
 
 source $(dirname "$0")/common.sh
 
-_out/tests/ginkgo version
+FOLDERS="${KUBEVIRT_DIR}/cmd/ ${KUBEVIRT_DIR}/pkg/ ${KUBEVIRT_DIR}/staging/src/kubevirt.io/ ${KUBEVIRT_DIR}/tests/framework/"
+
+ginkgobin=$(realpath _out/tests/ginkgo)
 # Find every folder containing tests
-for dir in $(find ${KUBEVIRT_DIR}/pkg/ -type f -name '*_test.go' -printf '%h\n' | sort -u); do
+for dir in $(find ${FOLDERS} -type f -name '*_test.go' -printf '%h\n' | sort -u); do
     # If there is no file ending with _suite_test.go, bootstrap ginkgo
     SUITE_FILE=$(find $dir -maxdepth 1 -type f -name '*_suite_test.go')
     if [ -z "$SUITE_FILE" ]; then
-        (cd $dir && ginkgo bootstrap || :)
+        echo "Missing test suite entrypoint; attempt to create one automatically"
+        (cd $dir && $ginkgobin bootstrap)
     fi
 done

--- a/staging/src/kubevirt.io/api/apitesting/BUILD.bazel
+++ b/staging/src/kubevirt.io/api/apitesting/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    srcs = ["roundtrip_test.go"],
+    srcs = [
+        "apitesting_suite_test.go",
+        "roundtrip_test.go",
+    ],
     data = glob(["testdata/**"]),
     deps = [
         "//staging/src/kubevirt.io/api/apitesting/roundtrip:go_default_library",

--- a/staging/src/kubevirt.io/api/apitesting/apitesting_suite_test.go
+++ b/staging/src/kubevirt.io/api/apitesting/apitesting_suite_test.go
@@ -1,0 +1,10 @@
+package apitesting_test
+
+import (
+	"testing"
+)
+
+func TestApitesting(t *testing.T) {
+	// dummy file to bypass ginkgo check
+	// since this is a regular go test suite no ginkgo bootstrap is needed
+}

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/BUILD.bazel
@@ -40,7 +40,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["websocket_test.go"],
+    srcs = [
+        "v1_suite_test.go",
+        "websocket_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/gorilla/websocket:go_default_library",

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/v1_suite_test.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/core/v1/v1_suite_test.go
@@ -1,0 +1,13 @@
+package v1_test
+
+import (
+	"testing"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+func TestV1(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "V1 Suite")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Some logical errors were present in this script:
- Does not check all folders
- Path to ginkgo binary wrong

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12774 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

