### PR TITLE
[release 1.3] volume migration: fix hotplug volumes when the volume migration fg is enabled

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -934,6 +934,20 @@ func (c *VMController) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi 
 			vmCopy.Spec.Template.Spec.Volumes[i].ContainerDisk.ImagePullPolicy = vmiVol.ContainerDisk.ImagePullPolicy
 		}
 	}
+	hotplugOp := false
+	volsVM := storagetypes.GetVolumesByName(&vmCopy.Spec.Template.Spec)
+	for _, volume := range vmi.Spec.Volumes {
+		hotpluggableVol := (volume.VolumeSource.PersistentVolumeClaim != nil &&
+			volume.VolumeSource.PersistentVolumeClaim.Hotpluggable) ||
+			(volume.VolumeSource.DataVolume != nil && volume.VolumeSource.DataVolume.Hotpluggable)
+		_, ok := volsVM[volume.Name]
+		if !ok && hotpluggableVol {
+			hotplugOp = true
+		}
+	}
+	if hotplugOp {
+		return nil
+	}
 	if equality.Semantic.DeepEqual(vmi.Spec.Volumes, vmCopy.Spec.Template.Spec.Volumes) {
 		return nil
 	}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -926,17 +926,13 @@ func (c *VMController) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi 
 	vmCopy := vm.DeepCopy()
 	volsVMI := storagetypes.GetVolumesByName(&vmi.Spec)
 	for i, volume := range vmCopy.Spec.Template.Spec.Volumes {
-		if volume.ContainerDisk == nil {
-			continue
-		}
 		vmiVol, ok := volsVMI[volume.Name]
 		if !ok {
 			continue
 		}
-		if vmiVol.ContainerDisk == nil {
-			continue
+		if vmiVol.ContainerDisk != nil {
+			vmCopy.Spec.Template.Spec.Volumes[i].ContainerDisk.ImagePullPolicy = vmiVol.ContainerDisk.ImagePullPolicy
 		}
-		vmCopy.Spec.Template.Spec.Volumes[i].ContainerDisk.ImagePullPolicy = vmiVol.ContainerDisk.ImagePullPolicy
 	}
 	if equality.Semantic.DeepEqual(vmi.Spec.Volumes, vmCopy.Spec.Template.Spec.Volumes) {
 		return nil

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
+
+	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -167,20 +169,6 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 			return dv
 		}
-		createBlankDV := func() *cdiv1.DataVolume {
-			sc, exist := libstorage.GetRWOFileSystemStorageClass()
-			Expect(exist).To(BeTrue())
-			dv := libdv.NewDataVolume(
-				libdv.WithBlankImageSource(),
-				libdv.WithPVC(libdv.PVCWithStorageClass(sc),
-					libdv.PVCWithVolumeSize(size),
-				),
-			)
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
-				dv, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return dv
-		}
 		createVMWithDV := func(dv *cdiv1.DataVolume, volName string) *virtv1.VirtualMachine {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(ns),
@@ -287,7 +275,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 		It("should migrate the source volume from a source DV to a destination DV", func() {
 			volName := "disk0"
 			vm := createVMWithDV(createDV(), volName)
-			destDV := createBlankDV()
+			destDV := createBlankDV(virtClient, ns, size)
 			By("Update volumes")
 			updateVMWithDV(vm.Name, volName, destDV.Name)
 			Eventually(func() bool {
@@ -392,8 +380,8 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 		It("should set the restart condition since the second volume is RWO and not part of the migration", func() {
 			const volName = "vol0"
 			dv1 := createDV()
-			dv2 := createBlankDV()
-			destDV := createBlankDV()
+			dv2 := createBlankDV(virtClient, ns, size)
+			destDV := createBlankDV(virtClient, ns, size)
 			vmi := libvmi.New(
 				libvmi.WithNamespace(ns),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -425,6 +413,99 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 				})), "The RestartRequired condition should be false",
 			)
 		})
+	})
+
+	Describe("Hotplug volumes", func() {
+		var fgDisabled bool
+		BeforeEach(func() {
+			var err error
+			virtClient, err = kubecli.GetKubevirtClient()
+			Expect(err).ToNot(HaveOccurred())
+			fgDisabled = !checks.HasFeature(virtconfig.HotplugVolumesGate)
+			if fgDisabled {
+				tests.EnableFeatureGate(virtconfig.HotplugVolumesGate)
+			}
+
+		})
+		AfterEach(func() {
+			if fgDisabled {
+				tests.DisableFeatureGate(virtconfig.HotplugVolumesGate)
+			}
+		})
+
+		DescribeTable("should be able to add and remove a volume with the volume migration feature gate enabled", func(persist bool) {
+			const volName = "vol0"
+			ns := testsuite.GetTestNamespace(nil)
+			dv := createBlankDV(virtClient, ns, "1Gi")
+			vmi := libvmifact.NewCirros(
+				libvmi.WithNamespace(ns),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+			)
+			vm := libvmi.NewVirtualMachine(vmi,
+				libvmi.WithRunning(),
+			)
+			vm, err := virtClient.VirtualMachine(ns).Create(context.Background(), vm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
+			libwait.WaitForSuccessfulVMIStart(vmi)
+
+			volumeSource := &v1.HotplugVolumeSource{
+				DataVolume: &v1.DataVolumeSource{
+					Name: dv.Name,
+				},
+			}
+
+			// Add the volume
+			addOpts := &v1.AddVolumeOptions{
+				Name: volName,
+				Disk: &v1.Disk{
+					DiskDevice: v1.DiskDevice{
+						Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
+					},
+					Serial: volName,
+				},
+				VolumeSource: volumeSource,
+			}
+			if persist {
+				Expect(virtClient.VirtualMachine(ns).AddVolume(context.Background(), vm.Name, addOpts)).ToNot(HaveOccurred())
+			} else {
+				Expect(virtClient.VirtualMachineInstance(ns).AddVolume(context.Background(), vm.Name, addOpts)).ToNot(HaveOccurred())
+			}
+			Eventually(func() string {
+				updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, volumeStatus := range updatedVMI.Status.VolumeStatus {
+					if volumeStatus.Name == volName && volumeStatus.HotplugVolume != nil {
+						return volumeStatus.Target
+					}
+				}
+				return ""
+			}).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(Equal(""))
+
+			// Remove the volume
+			removeOpts := &v1.RemoveVolumeOptions{
+				Name: volName,
+			}
+			if persist {
+				Expect(virtClient.VirtualMachine(ns).RemoveVolume(context.Background(), vm.Name, removeOpts)).ToNot(HaveOccurred())
+			} else {
+				Expect(virtClient.VirtualMachineInstance(ns).RemoveVolume(context.Background(), vm.Name, removeOpts)).ToNot(HaveOccurred())
+			}
+			Eventually(func() bool {
+				updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, volumeStatus := range updatedVMI.Status.VolumeStatus {
+					if volumeStatus.Name == volName {
+						return true
+					}
+				}
+				return false
+			}).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).Should(BeTrue())
+		},
+			Entry("with a persistent volume", true),
+			Entry("with an ephemeral volume", false),
+		)
 	})
 })
 
@@ -516,4 +597,19 @@ func createSmallImageForDestinationMigration(vm *virtv1.VirtualMachine, name, si
 	p, err := virtCli.CoreV1().Pods(vmi.Namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(matcher.ThisPod(p)).WithTimeout(120 * time.Second).WithPolling(time.Second).Should(matcher.HaveSucceeded())
+}
+
+func createBlankDV(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.DataVolume {
+	sc, exist := libstorage.GetRWOFileSystemStorageClass()
+	Expect(exist).To(BeTrue())
+	dv := libdv.NewDataVolume(
+		libdv.WithBlankImageSource(),
+		libdv.WithPVC(libdv.PVCWithStorageClass(sc),
+			libdv.PVCWithVolumeSize(size),
+		),
+	)
+	_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+		dv, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	return dv
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/12686

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

