### PR TITLE
volume-migration: remove restriction for the hotplug volumes

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -944,7 +944,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 		Expect(resp.Allowed).To(BeFalse())
 	})
 
-	It("should allow change for a persistent volume if it is a migrated volume", func() {
+	DescribeTable("should allow change for a persistent volume if it is a migrated volume", func(hotpluggable bool) {
 		disks := []v1.Disk{
 			{
 				Name:       "vol0",
@@ -961,6 +961,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 				VolumeSource: v1.VolumeSource{
 					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc0"},
+						Hotpluggable:                      hotpluggable,
 					},
 				},
 			},
@@ -969,6 +970,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 				VolumeSource: v1.VolumeSource{
 					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+						Hotpluggable:                      hotpluggable,
 					},
 				},
 			},
@@ -979,6 +981,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 				VolumeSource: v1.VolumeSource{
 					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc0"},
+						Hotpluggable:                      hotpluggable,
 					},
 				},
 			},
@@ -987,6 +990,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 				VolumeSource: v1.VolumeSource{
 					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc2"},
+						Hotpluggable:                      hotpluggable,
 					},
 				},
 			},
@@ -1004,5 +1008,8 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			},
 		}
 		Expect(admitStorageUpdate(newVols, oldVols, disks, disks, volumeStatuses, vmi, vmiUpdateAdmitter.clusterConfig)).To(BeNil())
-	})
+	},
+		Entry("and not hotpluggable", false),
+		Entry("and hotpluggable", true),
+	)
 })

--- a/pkg/virt-controller/watch/volume-migration/volume-migration.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration.go
@@ -115,12 +115,6 @@ func ValidateVolumes(vmi *virtv1.VirtualMachineInstance, vm *virtv1.VirtualMachi
 			continue
 		}
 
-		// Hotplugged volumes
-		if storagetypes.IsHotplugVolume(&v) {
-			invalidVols.hotplugged = append(invalidVols.hotplugged, v.Name)
-			valid = false
-			continue
-		}
 		// Filesystems
 		if _, ok := filesystems[v.Name]; ok {
 			invalidVols.fs = append(invalidVols.fs, v.Name)

--- a/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
@@ -81,11 +81,11 @@ var _ = Describe("Volume Migration", func() {
 			), libvmi.NewVirtualMachine(libvmi.New(
 				libvmi.WithPersistentVolumeClaim("disk0", "vol2"), withFilesystemVolume("disk1", "vol4"),
 			)), fmt.Errorf("invalid volumes to update with migration: filesystems: [disk1]")),
-			Entry("with an invalid hotplugged volume", libvmi.New(
-				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), withFilesystemVolume("disk1", "vol1"),
+			Entry("with valid hotplugged volume", libvmi.New(
+				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), withHotpluggedVolume("disk1", "vol1"),
 			), libvmi.NewVirtualMachine(libvmi.New(
 				libvmi.WithPersistentVolumeClaim("disk0", "vol2"), withHotpluggedVolume("disk1", "vol4"),
-			)), fmt.Errorf("invalid volumes to update with migration: hotplugged: [disk1]")),
+			)), nil),
 		)
 	})
 

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -96,23 +97,6 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			size     = "1Gi"
 		)
 
-		waitMigrationToExist := func(vmiName, ns string) {
-			Eventually(func() bool {
-				ls := labels.Set{
-					virtv1.VolumesUpdateMigration: vmiName,
-				}
-				migList, err := virtClient.VirtualMachineInstanceMigration(ns).List(context.Background(),
-					metav1.ListOptions{
-						LabelSelector: ls.String(),
-					})
-				Expect(err).ToNot(HaveOccurred())
-				if len(migList.Items) < 0 {
-					return false
-				}
-				return true
-
-			}, 120*time.Second, time.Second).Should(BeTrue())
-		}
 		waitMigrationToNotExist := func(vmiName, ns string) {
 			Eventually(func() bool {
 				ls := labels.Set{
@@ -140,23 +124,6 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			}, 120*time.Second, time.Second).Should(BeTrue())
 		}
 
-		waitForMigrationToSucceed := func(vmiName, ns string) {
-			waitMigrationToExist(vmiName, ns)
-			Eventually(func() bool {
-				vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vmiName,
-					metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				if vmi.Status.MigrationState == nil {
-					return false
-				}
-				if !vmi.Status.MigrationState.Completed {
-					return false
-				}
-				Expect(vmi.Status.MigrationState.Failed).To(BeFalse())
-
-				return true
-			}, 120*time.Second, time.Second).Should(BeTrue())
-		}
 		createDV := func() *cdiv1.DataVolume {
 			sc, exist := libstorage.GetRWOFileSystemStorageClass()
 			Expect(exist).To(BeTrue())
@@ -302,7 +269,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 				claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
 				return claim == destPVC
 			}, 120*time.Second, time.Second).Should(BeTrue())
-			waitForMigrationToSucceed(vm.Name, ns)
+			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		},
 			Entry("to a filesystem volume", fsPVC),
 			Entry("to a block volume", decorators.RequiresBlockStorage, blockPVC),
@@ -321,7 +288,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 				claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
 				return claim == destDV.Name
 			}, 120*time.Second, time.Second).Should(BeTrue())
-			waitForMigrationToSucceed(vm.Name, ns)
+			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		})
 
 		It("should migrate the source volume from a source and destination block RWX DVs", decorators.RequiresRWXBlock, func() {
@@ -358,7 +325,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 				claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
 				return claim == destDV.Name
 			}, 120*time.Second, time.Second).Should(BeTrue())
-			waitForMigrationToSucceed(vm.Name, ns)
+			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		})
 
 		It("should migrate the source volume from a block source and filesystem destination DVs", decorators.RequiresBlockStorage, func() {
@@ -398,7 +365,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 				claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
 				return claim == destDV.Name
 			}, 120*time.Second, time.Second).Should(BeTrue())
-			waitForMigrationToSucceed(vm.Name, ns)
+			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		})
 
 		It("should migrate a PVC with a VM using a containerdisk", func() {
@@ -436,7 +403,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 				}
 				return false
 			}, 120*time.Second, time.Second).Should(BeTrue())
-			waitForMigrationToSucceed(vm.Name, ns)
+			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		})
 
 		It("should cancel the migration by the reverting to the source volume", func() {
@@ -447,7 +414,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			createUnschedulablePVC(destPVC, ns, size)
 			By("Update volumes")
 			updateVMWithPVC(vm, volName, destPVC)
-			waitMigrationToExist(vm.Name, ns)
+			waitMigrationToExist(virtClient, vm.Name, ns)
 			waitVMIToHaveVolumeChangeCond(vm.Name, ns)
 			By("Cancel the volume migration")
 			updateVMWithPVC(vm, volName, dv.Name)
@@ -535,7 +502,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			createUnschedulablePVC(destPVC, ns, size)
 			By("Update volumes")
 			updateVMWithPVC(vm, volName, destPVC)
-			waitMigrationToExist(vm.Name, ns)
+			waitMigrationToExist(virtClient, vm.Name, ns)
 			waitVMIToHaveVolumeChangeCond(vm.Name, ns)
 
 			By("Restarting the VM during the volume migration")
@@ -585,7 +552,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			createUnschedulablePVC(destPVC, ns, size)
 			By("Update volumes")
 			updateVMWithPVC(vm, volName, destPVC)
-			waitMigrationToExist(vm.Name, ns)
+			waitMigrationToExist(virtClient, vm.Name, ns)
 			waitVMIToHaveVolumeChangeCond(vm.Name, ns)
 			Eventually(func() []virtv1.StorageMigratedVolumeInfo {
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
@@ -622,6 +589,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 
 	Describe("Hotplug volumes", func() {
 		var fgDisabled bool
+		const size = "1Gi"
 		BeforeEach(func() {
 			var err error
 			virtClient, err = kubecli.GetKubevirtClient()
@@ -637,6 +605,19 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 				config.DisableFeatureGate(virtconfig.HotplugVolumesGate)
 			}
 		})
+
+		waitForHotplugVol := func(vmName, ns, volName string) {
+			Eventually(func() string {
+				updatedVMI, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vmName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, volumeStatus := range updatedVMI.Status.VolumeStatus {
+					if volumeStatus.Name == volName && volumeStatus.HotplugVolume != nil {
+						return volumeStatus.Target
+					}
+				}
+				return ""
+			}).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(Equal(""))
+		}
 
 		DescribeTable("should be able to add and remove a volume with the volume migration feature gate enabled", func(persist bool) {
 			const volName = "vol0"
@@ -711,7 +692,69 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			Entry("with a persistent volume", true),
 			Entry("with an ephemeral volume", false),
 		)
+
+		It("should be able to migrate an hotplugged volume", func() {
+			const volName = "vol0"
+			ns := testsuite.GetTestNamespace(nil)
+			dv := createBlankDV(virtClient, ns, "2G")
+			vmi := libvmifact.NewCirros(
+				libvmi.WithNamespace(ns),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+			)
+			vm := libvmi.NewVirtualMachine(vmi,
+				libvmi.WithRunStrategy(virtv1.RunStrategyAlways),
+			)
+			vm, err := virtClient.VirtualMachine(ns).Create(context.Background(), vm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
+			libwait.WaitForSuccessfulVMIStart(vmi)
+
+			volumeSource := &v1.HotplugVolumeSource{
+				DataVolume: &v1.DataVolumeSource{
+					Name: dv.Name,
+				},
+			}
+
+			// Add the volume
+			addOpts := &v1.AddVolumeOptions{
+				Name: volName,
+				Disk: &v1.Disk{
+					DiskDevice: v1.DiskDevice{
+						Disk: &v1.DiskTarget{Bus: v1.DiskBusSCSI},
+					},
+					//					Serial: volName,
+				},
+				VolumeSource: volumeSource,
+			}
+			Expect(virtClient.VirtualMachine(ns).AddVolume(context.Background(), vm.Name, addOpts)).ToNot(HaveOccurred())
+			waitForHotplugVol(vm.Name, vm.Namespace, volName)
+
+			dvDst := createBlankDV(virtClient, vm.Namespace, "2Gi")
+			By("Update volumes")
+			var index int
+			Eventually(func() int {
+				vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for i, v := range vm.Spec.Template.Spec.Volumes {
+					if v.Name == volName {
+						index = i
+						return i
+					}
+				}
+				return -1
+			}).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).Should(BeNumerically(">", -1))
+			p, err := patch.New(
+				patch.WithReplace(fmt.Sprintf("/spec/template/spec/volumes/%d/dataVolume/name", index), dvDst.Name),
+				patch.WithReplace("/spec/updateVolumesStrategy", virtv1.UpdateVolumesStrategyMigration),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, p, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			waitForMigrationToSucceed(virtClient, vm.Name, vm.Namespace)
+		})
 	})
+
 })
 
 func createUnschedulablePVC(name, namespace, size string) *k8sv1.PersistentVolumeClaim {
@@ -817,4 +860,39 @@ func createBlankDV(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.Da
 		dv, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	return dv
+}
+
+func waitMigrationToExist(virtClient kubecli.KubevirtClient, vmiName, ns string) {
+	Eventually(func() bool {
+		ls := labels.Set{
+			virtv1.VolumesUpdateMigration: vmiName,
+		}
+		migList, err := virtClient.VirtualMachineInstanceMigration(ns).List(context.Background(),
+			metav1.ListOptions{
+				LabelSelector: ls.String(),
+			})
+		Expect(err).ToNot(HaveOccurred())
+		if len(migList.Items) < 0 {
+			return false
+		}
+		return true
+
+	}, 120*time.Second, time.Second).Should(BeTrue())
+}
+
+func waitForMigrationToSucceed(virtClient kubecli.KubevirtClient, vmiName, ns string) {
+	waitMigrationToExist(virtClient, vmiName, ns)
+	Eventually(func() bool {
+		vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vmiName,
+			metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		if vmi.Status.MigrationState == nil {
+			return false
+		}
+		if !vmi.Status.MigrationState.Completed {
+			return false
+		}
+
+		return true
+	}, 120*time.Second, time.Second).Should(BeTrue())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Volume migration wasn't allowed for hotplugged volumes

After this PR:
Enable volume migration for volume hotplug

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable volume migration for hotplugged volumes
```

