### PR TITLE
cleanup(virtctl): Minor cleanups in virtctl ssh and scp functests

### DIFF
--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -8,15 +8,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"golang.org/x/crypto/ssh"
 
+	"golang.org/x/crypto/ssh"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
-
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -36,7 +35,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 		args := []string{
 			"scp",
 			"--local-ssh=false",
-			"--namespace", testsuite.NamespaceTestDefault,
+			"--namespace", testsuite.GetTestNamespace(nil),
 			"--username", "root",
 			"--identity-file", keyFile,
 			"--known-hosts=",
@@ -45,7 +44,6 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 			args = append(args, "--recursive")
 		}
 		args = append(args, src, dst)
-
 		Expect(clientcmd.NewRepeatableVirtctlCommand(args...)()).To(Succeed())
 	}
 
@@ -53,7 +51,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 		return func(src, dst string, recursive bool) {
 			args := []string{
 				"scp",
-				"--namespace", testsuite.NamespaceTestDefault,
+				"--namespace", testsuite.GetTestNamespace(nil),
 				"--username", "root",
 				"--identity-file", keyFile,
 				"-t", "-o StrictHostKeyChecking=no",
@@ -67,11 +65,12 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 			}
 			args = append(args, src, dst)
 
-			_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.NamespaceTestDefault, "virtctl", args...)
+			// The virtctl binary needs to run here because of the way local SCP client wrapping works.
+			// Running the command through NewRepeatableVirtctlCommand does not suffice.
+			_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.GetTestNamespace(nil), "virtctl", args...)
 			Expect(err).ToNot(HaveOccurred())
-
 			out, err := cmd.CombinedOutput()
-			Expect(err).ToNot(HaveOccurred(), "out[%s]", string(out))
+			Expect(err).ToNot(HaveOccurred())
 			Expect(out).ToNot(BeEmpty())
 		}
 	}
@@ -91,8 +90,9 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 	DescribeTable("should copy a local file back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))))
-		vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))),
+		)
+		vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
@@ -115,8 +115,9 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 	DescribeTable("should copy a local directory back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))))
-		vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))),
+		)
+		vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
@@ -144,12 +145,9 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 		Entry("using the local scp method without --local-ssh flag", decorators.ExcludeNativeSsh, copyLocal(false)),
 	)
 
-	It("local-ssh flag should be unavailable in virtctl binary", decorators.ExcludeNativeSsh, func() {
-		_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.NamespaceTestDefault, "virtctl", "scp", "--local-ssh=false")
-		Expect(err).ToNot(HaveOccurred())
-		out, err := cmd.CombinedOutput()
-		Expect(err).To(HaveOccurred(), "out[%s]", string(out))
-		Expect(string(out)).To(Equal("unknown flag: --local-ssh\n"))
+	It("local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSsh, func() {
+		cmd := clientcmd.NewRepeatableVirtctlCommand("scp", "--local1-ssh=false")
+		Expect(cmd()).To(MatchError("unknown flag: --local-ssh"))
 	})
 })
 

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -8,15 +8,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"golang.org/x/crypto/ssh"
 
+	"golang.org/x/crypto/ssh"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
-
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -36,19 +35,20 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 		Expect(clientcmd.NewRepeatableVirtctlCommand(
 			"ssh",
 			"--local-ssh=false",
-			"--namespace", testsuite.NamespaceTestDefault,
+			"--namespace", testsuite.GetTestNamespace(nil),
 			"--username", "root",
 			"--identity-file", keyFile,
 			"--known-hosts=",
-			`--command='true'`,
-			vmiName)()).To(Succeed())
+			"--command", "true",
+			vmiName,
+		)()).To(Succeed())
 	}
 
 	cmdLocal := func(appendLocalSSH bool) func(vmiName string) {
 		return func(vmiName string) {
 			args := []string{
 				"ssh",
-				"--namespace", testsuite.NamespaceTestDefault,
+				"--namespace", testsuite.GetTestNamespace(nil),
 				"--username", "root",
 				"--identity-file", keyFile,
 				"-t", "-o StrictHostKeyChecking=no",
@@ -60,21 +60,22 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 			}
 			args = append(args, vmiName)
 
-			_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.NamespaceTestDefault, "virtctl", args...)
+			// The virtctl binary needs to run here because of the way local SSH client wrapping works.
+			// Running the command through NewRepeatableVirtctlCommand does not suffice.
+			_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.GetTestNamespace(nil), "virtctl", args...)
 			Expect(err).ToNot(HaveOccurred())
-
 			out, err := cmd.CombinedOutput()
-			Expect(err).ToNot(HaveOccurred(), "out[%s]", string(out))
+			Expect(err).ToNot(HaveOccurred())
 			Expect(out).ToNot(BeEmpty())
 		}
 	}
 
 	BeforeEach(func() {
-		var err error
 		virtClient = kubevirt.Client()
 		// Disable SSH_AGENT to not influence test results
 		Expect(os.Setenv("SSH_AUTH_SOCK", "/dev/null")).To(Succeed())
 		keyFile = filepath.Join(GinkgoT().TempDir(), "id_rsa")
+		var err error
 		var priv *ecdsa.PrivateKey
 		priv, pub, err = libssh.NewKeyPair()
 		Expect(err).ToNot(HaveOccurred())
@@ -84,8 +85,9 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 	DescribeTable("should succeed to execute a command on the VM", func(cmdFn func(string)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
-			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))))
-		vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))),
+		)
+		vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
@@ -98,11 +100,8 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 		Entry("using the local ssh method without --local-ssh flag", decorators.ExcludeNativeSsh, cmdLocal(false)),
 	)
 
-	It("local-ssh flag should be unavailable in virtctl binary", decorators.ExcludeNativeSsh, func() {
-		_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.NamespaceTestDefault, "virtctl", "ssh", "--local-ssh=false")
-		Expect(err).ToNot(HaveOccurred())
-		out, err := cmd.CombinedOutput()
-		Expect(err).To(HaveOccurred(), "out[%s]", string(out))
-		Expect(string(out)).To(Equal("unknown flag: --local-ssh\n"))
+	It("local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSsh, func() {
+		cmd := clientcmd.NewRepeatableVirtctlCommand("ssh", "--local-ssh=false")
+		Expect(cmd()).To(MatchError("unknown flag: --local-ssh"))
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Apply minor cleanups to the virtctl ssh and scp functests:

- Import order
- Format of passed arguments
- Use testsuite.GetTestNamespace(nil) where applicable
- Use NewRepeatableVirtctlCommand instead of manually constructing cmd with CreateCommandWithNS

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

