### PR TITLE
bug-fix: Ensure PDB Deletion when VMI Reaches Final State

### DIFF
--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -563,6 +563,8 @@ func shouldDeletePDB(vmiExists bool, vmi *virtv1.VirtualMachineInstance, pdb *po
 		return true, "VMI deletion"
 	case !needsEvictionProtection:
 		return true, "VMI not using evictionStrategy: LiveMigration|External"
+	case vmi.IsFinal():
+		return true, "VMI has moved to a Final state and is no longer active"
 	case isPDBFromOldVMI(vmi, pdb):
 		return true, "VMI not existing anymore"
 	case pdbs.IsPDBFromOldMigrationController(pdb):

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -317,6 +317,24 @@ var _ = Describe("Disruptionbudget", func() {
 			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
 		})
 
+		DescribeTable("should remove the pdb if the VMI reached Final state", func(vmiPhase v1.VirtualMachineInstancePhase) {
+			vmi := nonMigratableVirtualMachine()
+			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
+
+			pdb := newPodDisruptionBudget(vmi, 1)
+			pdbFeeder.Add(pdb)
+
+			vmi.Status.Phase = vmiPhase
+			vmiFeeder.Add(vmi)
+
+			shouldExpectPDBDeletion(pdb)
+			controller.Execute()
+			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+		},
+			Entry("with Succeeded vmi phase", v1.Succeeded),
+			Entry("with Failed vmi phase", v1.Failed),
+		)
+
 		DescribeTable("should add the pdb, if it does not exist", func(evictionStrategy v1.EvictionStrategy) {
 			vmi := migratableVirtualMachine()
 			vmi.Spec.EvictionStrategy = &evictionStrategy

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "kubectl_test.go",
         "mdev_configuration_allocation_test.go",
         "pausing_test.go",
+        "pdb_test.go",
         "pool_test.go",
         "portforward_test.go",
         "replicaset_test.go",

--- a/tests/pdb_test.go
+++ b/tests/pdb_test.go
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Contributors
+ *
+ */
+
+package tests_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	expect "github.com/google/goexpect"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = Describe("[sig-compute]Pod Disruption Budget (PDB)", decorators.SigCompute, func() {
+
+	It("should ensure the Pod Disruption Budget (PDB) is deleted when the VM is stopped via guest OS", func() {
+		By("Creating test VM")
+		vm := libvmi.NewVirtualMachine(
+			libvmifact.NewCirros(
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+			),
+			libvmi.WithRunStrategy(v1.RunStrategyOnce),
+		)
+		vm.Namespace = testsuite.GetTestNamespace(vm)
+
+		vm, err := kubevirt.Client().VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(ThisVMIWith(vm.Namespace, vm.Name), 10*time.Second, 1*time.Second).Should(Exist())
+
+		By("Verifying PDB existence")
+		Eventually(AllPDBs(vm.Namespace), 60*time.Second, 1*time.Second).Should(Not(BeEmpty()), "The Pod Disruption Budget should be created")
+
+		vmi, err := kubevirt.Client().VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
+		By("Issuing a poweroff command from inside VM")
+		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+			&expect.BSnd{S: "sudo poweroff\n"},
+			&expect.BExp{R: console.PromptExpression},
+		}, 10)).To(Succeed())
+
+		By("Ensuring the VirtualMachineInstance enters Succeeded phase")
+		Eventually(ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(HaveSucceeded())
+
+		By("Ensuring the PDB is deleted after the VM is powered off")
+		Eventually(AllPDBs(vm.Namespace), 60*time.Second, 1*time.Second).Should(BeEmpty(), "The Pod Disruption Budget should be deleted")
+	})
+})


### PR DESCRIPTION
### What this PR does

**Before this PR:**

When a Virtual Machine Instance (VMI) reaches its Final state (whether Succeeded or Failed, such as after a guest OS shutdown), the associated Pod Disruption Budget (PDB) is not deleted. This can lead to unnecessary PDB alerts being triggered.

**After this PR:**

The Pod Disruption Budget (PDB) associated with the VMI will be automatically removed once the VMI reaches its Final state. This prevents unnecessary PDB alerts from being triggered.

### Why we need it and why it was done this way

Without this fix, when a VMI is shut down from within the guest OS (or in similar cases), a PDB alert is triggered unnecessarily, potentially misleading users about the actual state of their VMs. This fix ensures that PDBs are properly cleaned up.

**Approach:**

The chosen solution deletes the PDB when the VMI reaches either the `Succeeded` or `Failed` phase. This allows the VMI to remain available for inspection by the user, including status, conditions, or virt-launcher pod logs.

### Special notes for your reviewer
clone of #12640

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. Consider a user-guide update if it's a user-facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note

```release-note
bug-fix: Ensure PDB associated with a VMI is deleted when it Reaches Succeeded or Failed phase
```