### PR TITLE
net, vmispec, hotplug, tests: Use libvmi for resource creation

### DIFF
--- a/pkg/libvmi/status/status.go
+++ b/pkg/libvmi/status/status.go
@@ -126,3 +126,10 @@ func WithMigrationState(migrationState v1.VirtualMachineInstanceMigrationState) 
 		vmiStatus.MigrationState = &migrationState
 	}
 }
+
+// WithInterfaceStatus adds an interface status
+func WithInterfaceStatus(interfaceStatus v1.VirtualMachineInstanceNetworkInterface) Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		vmiStatus.Interfaces = append(vmiStatus.Interfaces, interfaceStatus)
+	}
+}

--- a/pkg/network/vmispec/BUILD.bazel
+++ b/pkg/network/vmispec/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/status:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",


### PR DESCRIPTION
Signed-off-by: ronger4 <rgershbu@redhat.com>

### What this PR does
Before this PR:
Unit tests directly created and modified VM and VMI resources by manipulating their fields.
After this PR:
Unit tests have been refactored to use the libvmi package for creating and modifying VM and VMI resources, promoting readability and standardization.
Unused funcs and vars are removed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially address: https://github.com/kubevirt/kubevirt/issues/12059

### Why we need it and why it was done in this way
Using the libvmi package simplifies the unit tests and makes them more readable.
This approach ensures a standard way of creating VM and VMI resources across tests.
In addition, I removed unused vars and funcs.

The following tradeoffs were made:

- Direct manipulation of resources was replaced with utility functions, which may introduce minor overhead but enhances readability and maintainability.
- Had to add another DescribeTable as I couldn't find the implementation in libvmi for vmi.Status.Interfaces.

The following alternatives were considered:
Creating new func per Entry and creating all the resources from scratch per Entry, might be more readable but less effective and would create code dupclications.
Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/12059

### Special notes for your reviewer
I created this as draft for now to re-check that I didn't miss an option to implement 
`vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
		{Name: networkName, InterfaceName: guestIfaceName, InfoSource: vmispec.InfoSourceMultusStatus}`
Using libvmi. I didn't find such method in the libvmi package. Hence, I had to split the test to 2.  If there is an option that I missed I can align the last 2 entries as-well.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

