### PR TITLE
sig-ci, quarantine: [test_id:1669]should show the requested guest memory inside the VMI

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -711,7 +711,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		)
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory", func() {
-			It("[test_id:1669]should show the requested guest memory inside the VMI", func() {
+			It("[QUARANTINE][test_id:1669]should show the requested guest memory inside the VMI", decorators.Quarantine, func() {
 				vmi := libvmifact.NewCirros()
 				guestMemory := resource.MustParse("256Mi")
 				vmi.Spec.Domain.Memory = &v1.Memory{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Test `[test_id:1669]should show the requested guest memory inside the VMI` shows a 15% impact over 14d [2]

After this PR:

Test `[test_id:1669]should show the requested guest memory inside the VMI` is put into quarantine [1]

[1]: https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md#putting-tests-in-quarantine
[2]: https://search.ci.kubevirt.io/?search=%5C%5Btest_id%3A1669%5Dshould+show+the+requested+guest+memory+inside+the+VMI&maxAge=336h&context=1&type=all&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

See https://github.com/kubevirt/kubevirt/issues/12803

### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

