### PR TITLE
Re-add finalizer update RBAC for VM export

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -583,6 +583,7 @@ spec:
           resources:
           - virtualmachineexports
           - virtualmachineexports/status
+          - virtualmachineexports/finalizers
           verbs:
           - get
           - list

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -585,6 +585,7 @@ rules:
   resources:
   - virtualmachineexports
   - virtualmachineexports/status
+  - virtualmachineexports/finalizers
   verbs:
   - get
   - list

--- a/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "cluster_test.go",
+        "controller_test.go",
         "operator_test.go",
         "rbac_suite_test.go",
     ],
@@ -49,6 +50,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -327,6 +327,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"virtualmachineexports",
 					"virtualmachineexports/status",
+					"virtualmachineexports/finalizers",
 				},
 				Verbs: []string{
 					"get", "list", "watch", "create", "update", "delete", "patch",

--- a/pkg/virt-operator/resource/generate/rbac/controller_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller_test.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package rbac
+
+import (
+	"fmt"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+)
+
+var _ = Describe("RBAC", func() {
+
+	const expectedNamespace = "default"
+
+	Context("GetAllController", func() {
+		forController := GetAllController(expectedNamespace)
+
+		DescribeTable("has finalizer rbac for installs with OwnerReferencesPermissionEnforcement", func(apiGroup, resource string) {
+			clusterRole := getObject(forController, reflect.TypeOf(&rbacv1.ClusterRole{}), components.ControllerServiceAccountName).(*rbacv1.ClusterRole)
+			Expect(clusterRole).ToNot(BeNil())
+			Expect(clusterRole.Rules).To(
+				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"APIGroups": ContainElement(apiGroup),
+					"Resources": ContainElement(fmt.Sprintf("%s/finalizers", resource)),
+					"Verbs":     ContainElement("update"),
+				})), "appropriate rule for finalizers not found",
+			)
+		},
+			Entry("for vmclones", "clone.kubevirt.io", "virtualmachineclones"),
+			Entry("for vmexports", "export.kubevirt.io", "virtualmachineexports"),
+			Entry("for vmpools", "pool.kubevirt.io", "virtualmachinepools"),
+		)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Basically, OpenShift deploys enforcement that says we
`cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on` https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
We recently removed this rbac unintentionally in https://github.com/kubevirt/kubevirt/pull/12605/commits/dc6b76f494ffdb95305fed5ce038963539d469a1.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: can't create export pod on OpenShift
```

