### PR TITLE
e2e,utils: Remove const that is only really used by the storage tests

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -78,6 +78,7 @@ const (
 	hostDiskName                 = "host-disk"
 	diskImgName                  = "disk.img"
 	customHostPath               = "custom-host-path"
+	diskAlpineHostPath           = "disk-alpine-host-path"
 	diskCustomHostPath           = "disk-custom-host-path"
 )
 
@@ -282,7 +283,7 @@ var _ = SIGDescribe("Storage", func() {
 						Expect(err).ToNot(HaveOccurred())
 						pvName = createNFSPvAndPvc(family, nfsPod)
 					} else {
-						pvName = tests.DiskAlpineHostPath
+						pvName = diskAlpineHostPath
 					}
 					vmi = newVMI(pvName)
 
@@ -304,7 +305,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 			DescribeTable("should be successfully started and stopped multiple times", func(newVMI VMICreationFunc) {
-				vmi = newVMI(tests.DiskAlpineHostPath)
+				vmi = newVMI(diskAlpineHostPath)
 
 				num := 3
 				By("Starting and stopping the VirtualMachineInstance number of times")
@@ -427,7 +428,7 @@ var _ = SIGDescribe("Storage", func() {
 				})
 
 				AfterEach(func() {
-					if pvName != "" && pvName != tests.DiskAlpineHostPath {
+					if pvName != "" && pvName != diskAlpineHostPath {
 						// PVs can't be reused
 						By("Deleting PV and PVC")
 						deletePvAndPvc(pvName)
@@ -444,7 +445,7 @@ var _ = SIGDescribe("Storage", func() {
 						Expect(err).ToNot(HaveOccurred())
 						pvName = createNFSPvAndPvc(family, nfsPod)
 					} else {
-						pvName = tests.DiskAlpineHostPath
+						pvName = diskAlpineHostPath
 					}
 
 					vmi = libvmi.New(
@@ -472,7 +473,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = libvmi.New(
 					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 					libvmi.WithResourceMemory("256Mi"),
-					libvmi.WithEphemeralPersistentVolumeClaim("disk0", tests.DiskAlpineHostPath),
+					libvmi.WithEphemeralPersistentVolumeClaim("disk0", diskAlpineHostPath),
 				)
 
 				By("Starting the VirtualMachineInstance")
@@ -538,7 +539,7 @@ var _ = SIGDescribe("Storage", func() {
 			// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
 			It("[test_id:3138]should start vmi multiple times", func() {
 				vmi = libvmi.New(
-					libvmi.WithPersistentVolumeClaim("disk0", tests.DiskAlpineHostPath),
+					libvmi.WithPersistentVolumeClaim("disk0", diskAlpineHostPath),
 					libvmi.WithPersistentVolumeClaim("disk1", diskCustomHostPath),
 					libvmi.WithResourceMemory("256Mi"),
 					libvmi.WithRng())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -59,10 +59,6 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-const (
-	DiskAlpineHostPath = "disk-alpine-host-path"
-)
-
 func NewRandomReplicaSetFromVMI(vmi *v1.VirtualMachineInstance, replicas int32) *v1.VirtualMachineInstanceReplicaSet {
 	name := "replicaset" + rand.String(5)
 	rs := &v1.VirtualMachineInstanceReplicaSet{

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2224,8 +2224,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 
 		It("[test_id:5360]should set appropriate IO modes", func() {
-			libstorage.CreateHostPathPv("alpine-host-path", testsuite.GetTestNamespace(nil), testsuite.HostPathAlpine)
-			libstorage.CreateHostPathPVC("alpine-host-path", testsuite.GetTestNamespace(nil), "1Gi")
+			const alpineHostPath = "alpine-host-path"
+			libstorage.CreateHostPathPv(alpineHostPath, testsuite.GetTestNamespace(nil), testsuite.HostPathAlpine)
+			libstorage.CreateHostPathPVC(alpineHostPath, testsuite.GetTestNamespace(nil), "1Gi")
 			vmi := libvmi.New(
 				libvmi.WithResourceMemory("128Mi"),
 				// disk[0]
@@ -2233,7 +2234,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				// disk[1]:  Block, no user-input, cache=none
 				libvmi.WithPersistentVolumeClaim("block-pvc", dataVolume.Name),
 				// disk[2]: File, not-sparsed, no user-input, cache=none
-				libvmi.WithPersistentVolumeClaim("hostpath-pvc", tests.DiskAlpineHostPath),
+				libvmi.WithPersistentVolumeClaim("hostpath-pvc", fmt.Sprintf("disk-%s", alpineHostPath)),
 				// disk[3]
 				libvmi.WithContainerDisk("ephemeral-disk2", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 			)


### PR DESCRIPTION
### What this PR does

This constant is used in the storage tests and the vmi configuration tests.

It is only used once in the VMI configuration tests and it can be set to any path.

Move the constant from utils to where is it used multiple times in the storage tests

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

