### PR TITLE
volume-migration: fix migration from source RWX volumes

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2588,6 +2588,10 @@ func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachi
 		volumeStatusMap[volumeStatus.Name] = volumeStatus
 	}
 
+	if len(vmi.Status.MigratedVolumes) > 0 {
+		blockMigrate = true
+	}
+
 	// Check if all VMI volumes can be shared between the source and the destination
 	// of a live migration. blockMigrate will be returned as false, only if all volumes
 	// are shared and the VMI has no local disks
@@ -2667,8 +2671,7 @@ func (d *VirtualMachineController) handleTargetMigrationProxy(vmi *v1.VirtualMac
 	baseDir := fmt.Sprintf(filepath.Join(d.virtLauncherFSRunDirPattern, "kubevirt"), res.Pid())
 	migrationTargetSockets = append(migrationTargetSockets, socketFile)
 
-	isBlockMigration := vmi.Status.MigrationMethod == v1.BlockMigration
-	migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration)
+	migrationPortsRange := migrationproxy.GetMigrationPortsList(vmi.IsBlockMigration())
 	for _, port := range migrationPortsRange {
 		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
 		// a proxy between the target direct qemu channel and the connector in the destination pod

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -721,10 +721,6 @@ func (l *LibvirtDomainManager) asyncMigrationAbort(vmi *v1.VirtualMachineInstanc
 	}(l, vmi)
 }
 
-func isBlockMigration(vmi *v1.VirtualMachineInstance) bool {
-	return vmi.Status.MigrationMethod == v1.BlockMigration
-}
-
 func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions, virtShareDir string, domSpec *api.DomainSpec) (*libvirt.DomainMigrateParameters, error) {
 	bandwidth, err := vcpu.QuantityToMebiByte(options.Bandwidth)
 	if err != nil {
@@ -937,7 +933,7 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 	if err != nil {
 		return fmt.Errorf("failed to retrive domain state")
 	}
-	migrateFlags := generateMigrationFlags(isBlockMigration(vmi), migratePaused, options)
+	migrateFlags := generateMigrationFlags(vmi.IsBlockMigration(), migratePaused, options)
 
 	// anything that modifies the domain needs to be performed with the domainModifyLock held
 	// The domain params and unHotplug need to be performed in a critical section together.

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -201,7 +201,7 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 		logger.V(3).Info("Setting up TCP proxies to support incoming legacy VMI migration")
 		loopbackAddress := ip.GetLoopbackAddress()
 
-		migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration(vmi))
+		migrationPortsRange := migrationproxy.GetMigrationPortsList(vmi.IsBlockMigration())
 		for _, port := range migrationPortsRange {
 			// Prepare the direct migration proxy
 			key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -468,6 +468,11 @@ func (v *VirtualMachineInstance) IsMigratable() bool {
 	return false
 }
 
+func (v *VirtualMachineInstance) IsBlockMigration() bool {
+	return v.Status.MigrationMethod == BlockMigration ||
+		len(v.Status.MigratedVolumes) > 0
+}
+
 func (v *VirtualMachineInstance) IsFinal() bool {
 	return v.Status.Phase == Failed || v.Status.Phase == Succeeded
 }

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -296,6 +296,43 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			waitForMigrationToSucceed(vm.Name, ns)
 		})
 
+		It("should migrate the source volume from a source and destination block RWX DVs", func() {
+			volName := "disk0"
+			sc, exist := libstorage.GetRWXBlockStorageClass()
+			Expect(exist).To(BeTrue())
+			srcDV := libdv.NewDataVolume(
+				libdv.WithBlankImageSource(),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc),
+					libdv.PVCWithVolumeSize(size),
+					libdv.PVCWithVolumeMode(k8sv1.PersistentVolumeBlock),
+				),
+			)
+			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+				srcDV, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			destDV := libdv.NewDataVolume(
+				libdv.WithBlankImageSource(),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc),
+					libdv.PVCWithVolumeSize(size),
+					libdv.PVCWithVolumeMode(k8sv1.PersistentVolumeBlock),
+				),
+			)
+			_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+				destDV, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			vm := createVMWithDV(srcDV, volName)
+			By("Update volumes")
+			updateVMWithDV(vm, volName, destDV.Name)
+			Eventually(func() bool {
+				vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
+					metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
+				return claim == destDV.Name
+			}, 120*time.Second, time.Second).Should(BeTrue())
+			waitForMigrationToSucceed(vm.Name, ns)
+		})
+
 		It("should migrate a PVC with a VM using a containerdisk", func() {
 			volName := "volume"
 			srcPVC := "src-" + rand.String(5)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The libvirt option MIGRATE_NON_SHARED_INC wasn't set for volume migration

After this PR:
Consider block migration when there is a volume update change with shareable storage.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12811


<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```