### PR TITLE
check-tests-for-flakes: don't run native ssh tests

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -196,7 +196,7 @@ export KUBEVIRT_DEPLOY_NET_BINDING_CNI=true
 
 export KUBEVIRT_PROVIDER="${TEST_LANE}"
 
-ginko_params="$ginko_params -no-color -succinct --label-filter=!QUARANTINE -randomize-all"
+ginko_params="$ginko_params -no-color -succinct --label-filter=(!QUARANTINE)&&(!exclude-native-ssh) -randomize-all"
 for test_file in $(echo "${NEW_TESTS}" | tr '|' '\n'); do
     ginko_params+=" -focus-file=${test_file}"
 done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
As noted here [1] `repeated_tests.sh` can only run either native or non native ssh tests, since what works depends on how the virtctl binary is built.

After this PR:
Since test.sh always excludes the native ssh tests [2] we add the filter to do the same for `repeated_test.sh`

[1]: https://github.com/kubevirt/kubevirt/pull/12804#issuecomment-2346046040
[2]: https://github.com/kubevirt/kubevirt/blob/6fb17773c7dddb9c9a526959605eb5acf07619cc/automation/test.sh#L479


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12814

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

#12804

### Special notes for your reviewer

/cc @0xFelix 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

