### PR TITLE
usbredit: Don't assume order for client

### DIFF
--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -109,16 +109,17 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				time.Sleep(100 * time.Millisecond)
 			}
 
+			numOfErrors := 0
 			for i := 0; i <= v1.UsbClientPassthroughMaxNumberOf; i++ {
 				select {
 				case err := <-errors[i]:
 					Expect(err).To(MatchError(ContainSubstring("websocket: bad handshake")))
-					Expect(i).To(Equal(v1.UsbClientPassthroughMaxNumberOf))
+					numOfErrors++
 				case <-time.After(time.Second):
 					cancelFns[i]()
-					Expect(i).ToNot(Equal(v1.UsbClientPassthroughMaxNumberOf))
 				}
 			}
+			Expect(numOfErrors).To(Equal(1), "Only one connection should fail")
 		})
 
 		It("Should work in parallel", func() {


### PR DESCRIPTION
### What this PR does
As we spawn all clients in parallel we can't be
sure what goroutine will run sooner than others.
It well could be that last goroutine is running before the first.

Note: There still seem to be issue with the test as the code suggest that return value should be http status code 503 and not 500.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

<!-- optional -->

### Release note
```release-note
NONE
```

