### PR TITLE
tests: warn against reading into libvirt domxml during e2e tests

### DIFF
--- a/tests/libdomain/domain.go
+++ b/tests/libdomain/domain.go
@@ -37,6 +37,9 @@ import (
 	"kubevirt.io/kubevirt/tests/libpod"
 )
 
+// GetRunningVirtualMachineInstanceDomainXML should typically not be used by
+// end-to-end tests. Attempt to log into the guest to ensure that the requested
+// functionality is available there.
 func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (string, error) {
 	// get current vmi
 	freshVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
@@ -66,6 +69,7 @@ func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient
 	return stdout, err
 }
 
+// GetRunningVMIDomainSpec should typically not be used by end-to-end tests
 func GetRunningVMIDomainSpec(vmi *v1.VirtualMachineInstance) (*api.DomainSpec, error) {
 	runningVMISpec := api.DomainSpec{}
 	cli := kubevirt.Client()


### PR DESCRIPTION
End-to-end tests should be testing the KubeVirt API and behaviour. They should typically start a VM with specific options and then verify that the guest behaves as expected. E2e tests should *not* look into KubeVirt or Kubernetes implementation details. This is important in order to keep e2e short, few and limited to their level. Libvirt and qemu are very important to KubeVirt, but they sit below the KubeVirt API. Good e2e test should not look at them.

For example, tests verifying that the libvirt domxml was build as expected should be converted to unit test of domxml rendering function. A test that checks that a memory hotplug modified the domxml should be changed to a test that ensures that the additional memory is available inside the guest.

This PR deprecates two helper functions that break test levels so that we remember to avoid them.

```release-note
NONE
```

