### PR TITLE
Report migration policies as part of the k8s reporter when tests finish

### DIFF
--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -20,5 +20,5 @@ func main() {
 	// Hardcoding maxFails to 1 since the purpouse here is just to dump the state once
 	reporter := reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"), 1)
 	reporter.Cleanup()
-	reporter.DumpAllNamespaces(duration)
+	reporter.DumpTestObjects(duration)
 }

--- a/tests/reporter/BUILD.bazel
+++ b/tests/reporter/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/virt-handler/virt-chroot:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/migrations:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//tests:go_default_library",

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -117,7 +117,7 @@ func (r *KubernetesReporter) Report(report types.Report) {
 
 	printInfo("Test suite failed, collect artifacts in %s", r.artifactsDir)
 
-	r.dumpNamespaces(report.RunTime, testsuite.TestNamespaces)
+	r.dumpTestObjects(report.RunTime, testsuite.TestNamespaces)
 }
 
 func (r *KubernetesReporter) ReportSpec(specReport types.SpecReport) {
@@ -144,14 +144,14 @@ func (r *KubernetesReporter) ReportSpec(specReport types.SpecReport) {
 }
 
 func (r *KubernetesReporter) DumpTestNamespaces(duration time.Duration) {
-	r.dumpNamespaces(duration, testsuite.TestNamespaces)
+	r.dumpTestObjects(duration, testsuite.TestNamespaces)
 }
 
 func (r *KubernetesReporter) DumpAllNamespaces(duration time.Duration) {
-	r.dumpNamespaces(duration, []string{v1.NamespaceAll})
+	r.dumpTestObjects(duration, []string{v1.NamespaceAll})
 }
 
-func (r *KubernetesReporter) dumpNamespaces(duration time.Duration, vmiNamespaces []string) {
+func (r *KubernetesReporter) dumpTestObjects(duration time.Duration, vmiNamespaces []string) {
 	cfg, err := kubecli.GetKubevirtClientConfig()
 	if err != nil {
 		printError("failed to get client config: %v", err)


### PR DESCRIPTION
### What this PR does
Before this PR:
Migration policies are not dumped as part of the `AfterSuite` after tests finish.

After this PR:
Migration policies are dumped as part of the `AfterSuite` after tests finish.
### Checklist

### Additional context
Tested locally:
```shell
> cat _out/artifacts/k8s-reporter/1_migrationpolicies.log 
{
    "metadata": {
        "resourceVersion": "247717"
    },
    "items": [
        {
            "kind": "MigrationPolicy",
            "apiVersion": "migrations.kubevirt.io/v1alpha1",
            "metadata": {
                "name": "testpolicy-vnmz7",
                "uid": "fd372a97-7974-46a5-b58f-db7039329f26",
                "resourceVersion": "247708",
                "generation": 1,
                "creationTimestamp": "2024-09-16T07:58:39Z",
                "labels": {
                    "test.kubevirt.io/kubevirt-test-default1": ""
                }
            },
            "spec": {
                "selectors": {
                    "virtualMachineInstanceSelector": {
                        "testpolicy-vnmz7-key-0": "testpolicy-vnmz7-value-0"
                    }
                }
            },
            "status": {}
        }
    ]
}
```

(file is trimmed for simplicity).

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

