### PR TITLE
fix(tests,virtctl): Partially revert cleanups

### DIFF
--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -146,8 +146,13 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 	)
 
 	It("local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSsh, func() {
-		cmd := clientcmd.NewRepeatableVirtctlCommand("scp", "--local1-ssh=false")
-		Expect(cmd()).To(MatchError("unknown flag: --local-ssh"))
+		// The built virtctl binary should be tested here, therefore clientcmd.CreateCommandWithNS needs to be used.
+		// Running the command through NewRepeatableVirtctlCommand would test the test binary instead.
+		_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.NamespaceTestDefault, "virtctl", "scp", "--local-ssh=false")
+		Expect(err).ToNot(HaveOccurred())
+		out, err := cmd.CombinedOutput()
+		Expect(err).To(HaveOccurred(), "out[%s]", string(out))
+		Expect(string(out)).To(Equal("unknown flag: --local-ssh\n"))
 	})
 })
 

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -101,7 +101,12 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 	)
 
 	It("local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSsh, func() {
-		cmd := clientcmd.NewRepeatableVirtctlCommand("ssh", "--local-ssh=false")
-		Expect(cmd()).To(MatchError("unknown flag: --local-ssh"))
+		// The built virtctl binary should be tested here, therefore clientcmd.CreateCommandWithNS needs to be used.
+		// Running the command through NewRepeatableVirtctlCommand would test the test binary instead.
+		_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.NamespaceTestDefault, "virtctl", "ssh", "--local-ssh=false")
+		Expect(err).ToNot(HaveOccurred())
+		out, err := cmd.CombinedOutput()
+		Expect(err).To(HaveOccurred(), "out[%s]", string(out))
+		Expect(string(out)).To(Equal("unknown flag: --local-ssh\n"))
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This partially reverts the cleanups of
be4d5584723cf9205976d37b6c9753285c02ee5c, because the now reverted
changes invalidate the results of the changed tests.

For the tests to have a meaningful result, the actual virtctl binary
needs to run (CreateCommandWithNS) instead of running the virtctl
command as part of the test binary (NewRepeatableVirtctlCommand).

Before this PR:

Tests do not have a meaningful result

After this PR:

Tests have a meaningful result

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

