### PR TITLE
Add RequiresRWXFilesystemStorage to backendstorage.go

### DIFF
--- a/tests/storage/backendstorage.go
+++ b/tests/storage/backendstorage.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -42,14 +43,13 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = SIGDescribe("[Serial]Backend Storage", Serial, func() {
+var _ = SIGDescribe("[Serial]Backend Storage", Serial, decorators.RequiresRWXFilesystemStorage, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 	})
 
-	// TODO: create a RequiresRWXFilesystemStorage decorator to remove the skip?
 	It("Should use RWO when RWX is not supported", func() {
 		var storageClass string
 
@@ -76,9 +76,6 @@ var _ = SIGDescribe("[Serial]Backend Storage", Serial, func() {
 				storageClass = *sp.Status.StorageClass
 				break
 			}
-		}
-		if storageClass == "" {
-			Skip("Failed to find a suitable storage class") // See TODO above
 		}
 
 		By("Setting the VM storage class to it")


### PR DESCRIPTION
### What this PR does
Before this PR:
The tests under backendstorage.go would skip if no RWX file system storage was found

After this PR:
The tests under backendstorage.go will run on clusters with RWX file system storage, and remove the TODO task

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

