### PR TITLE
usbdir test: Add missing defer GinkgoRecover

### DIFF
--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -188,6 +188,7 @@ func usbredirConnect(
 	Expect(err).ToNot(HaveOccurred())
 
 	usbredirClient.ClientConnect = func(inCtx context.Context, device, address string) error {
+		defer GinkgoRecover()
 		conn, err := net.Dial("tcp", address)
 		Expect(err).ToNot(HaveOccurred())
 		defer conn.Close()


### PR DESCRIPTION
### What this PR does
ClientConnect is running in goroutine as well.
Therefore we need another defer here.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->


### Release note
```release-note
NONE
```

