### PR TITLE
s390x: Enable exportproxy and exportserver image

### DIFF
--- a/cmd/virt-exportproxy/BUILD.bazel
+++ b/cmd/virt-exportproxy/BUILD.bazel
@@ -47,6 +47,7 @@ container_image(
     name = "virt-exportproxy-image",
     architecture = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "@io_bazel_rules_go//go/platform:linux_s390x": "s390x",
         "//conditions:default": "amd64",
     }),
     base = ":version-container",

--- a/cmd/virt-exportserver/BUILD.bazel
+++ b/cmd/virt-exportserver/BUILD.bazel
@@ -65,6 +65,10 @@ container_image(
             ":passwd-tar",
             "//rpm:exportserverbase_aarch64",
         ],
+        "@io_bazel_rules_go//go/platform:linux_s390x": [
+            ":passwd-tar",
+            "//rpm:exportserverbase_s390x",
+        ],
         "//conditions:default": [
             ":passwd-tar",
             "//rpm:exportserverbase_x86_64",
@@ -76,6 +80,7 @@ container_image(
     name = "virt-exportserver-image",
     architecture = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "@io_bazel_rules_go//go/platform:linux_s390x": "s390x",
         "//conditions:default": "amd64",
     }),
     base = ":version-container",

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -51,7 +51,8 @@ bazel build \
     --define image_prefix= \
     --define container_tag= \
     //cmd/virt-operator:virt-operator-image //cmd/virt-api:virt-api-image //cmd/virt-controller:virt-controller-image \
-    //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image ${other_images[@]}
+    //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image //cmd/virt-exportproxy:virt-exportproxy-image \
+    //cmd/virt-exportserver:virt-exportserver-image ${other_images[@]}
 
 rm -rf ${DIGESTS_DIR}/${ARCHITECTURE}
 mkdir -p ${DIGESTS_DIR}/${ARCHITECTURE}

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -29,6 +29,8 @@ default_targets="
     virt-controller
     virt-handler
     virt-launcher
+    virt-exportserver
+    virt-exportproxy
     alpine-container-disk-demo
     fedora-with-test-tooling-container-disk
     vm-killer
@@ -39,8 +41,6 @@ case ${ARCHITECTURE} in
 "s390x" | "crossbuild-s390x") ;;
 *)
     default_targets+="
-        virt-exportserver
-        virt-exportproxy
         conformance
         libguestfs-tools
         pr-helper


### PR DESCRIPTION
Both x86_64 image versions during the 1.4.0-alpha release contained s390x binaries. Enable to build actual images for the architecture to ensure this does not happen again.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable virt-exportproxy and virt-exportserver image for s390x
```

