### PR TITLE
Annotations generators: Add linter coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ lint:
 	  pkg/network/namescheme/... \
 	  pkg/network/domainspec/... \
 	  pkg/network/deviceinfo/... \
+	  pkg/network/pod/annotations/... \
 	  pkg/virtctl/credentials/... \
 	  tests/console/... \
 	  tests/instancetype/... \

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ lint:
 	  pkg/network/domainspec/... \
 	  pkg/network/deviceinfo/... \
 	  pkg/network/pod/annotations/... \
+	  pkg/storage/pod/annotations/... \
 	  pkg/virtctl/credentials/... \
 	  tests/console/... \
 	  tests/instancetype/... \

--- a/pkg/network/pod/annotations/generator_test.go
+++ b/pkg/network/pod/annotations/generator_test.go
@@ -249,12 +249,12 @@ func newMultusDefaultPodNetwork(name, networkAttachmentDefinitionName string) *v
 	}
 }
 
-func newStubVirtLauncherPod(vmi *v1.VirtualMachineInstance, annotations map[string]string) *k8Scorev1.Pod {
+func newStubVirtLauncherPod(vmi *v1.VirtualMachineInstance, podAnnotations map[string]string) *k8Scorev1.Pod {
 	return &k8Scorev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "virt-launcher-" + vmi.Name,
 			Namespace:   vmi.Namespace,
-			Annotations: annotations,
+			Annotations: podAnnotations,
 		},
 	}
 }

--- a/pkg/storage/pod/annotations/generator.go
+++ b/pkg/storage/pod/annotations/generator.go
@@ -30,18 +30,18 @@ import (
 type Generator struct{}
 
 func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, error) {
-	const ComputeContainerName = "compute"
+	const computeContainerName = "compute"
 
 	return map[string]string{
-		velero.PreBackupHookContainerAnnotation: ComputeContainerName,
+		velero.PreBackupHookContainerAnnotation: computeContainerName,
 		velero.PreBackupHookCommandAnnotation: fmt.Sprintf(
-			"[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"%s\", \"--namespace\", \"%s\"]",
+			"[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", %q, \"--namespace\", %q]",
 			vmi.Name,
 			vmi.Namespace,
 		),
-		velero.PostBackupHookContainerAnnotation: ComputeContainerName,
+		velero.PostBackupHookContainerAnnotation: computeContainerName,
 		velero.PostBackupHookCommandAnnotation: fmt.Sprintf(
-			"[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"%s\", \"--namespace\", \"%s\"]",
+			"[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", %q, \"--namespace\", %q]",
 			vmi.Name,
 			vmi.Namespace,
 		),

--- a/pkg/storage/pod/annotations/generator_test.go
+++ b/pkg/storage/pod/annotations/generator_test.go
@@ -38,11 +38,16 @@ var _ = Describe("Annotations Generator", func() {
 		annotations, err := generator.Generate(libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName(vmiName)))
 		Expect(err).NotTo(HaveOccurred())
 
+		const (
+			expectedPreHookBackupCommand  = `["/usr/bin/virt-freezer", "--freeze", "--name", "testvmi", "--namespace", "testns"]`
+			expectedPostHookBackupCommand = `["/usr/bin/virt-freezer", "--unfreeze", "--name", "testvmi", "--namespace", "testns"]`
+		)
+
 		expectedAnnotations := map[string]string{
 			"pre.hook.backup.velero.io/container":  "compute",
-			"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+			"pre.hook.backup.velero.io/command":    expectedPreHookBackupCommand,
 			"post.hook.backup.velero.io/container": "compute",
-			"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+			"post.hook.backup.velero.io/command":   expectedPostHookBackupCommand,
 		}
 
 		Expect(annotations).To(Equal(expectedAnnotations))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
PRs #12558 and #12710 introduced the following packages without linter covarage:
- pkg/network/pod/annotations
- pkg/storage/pod/annotations

Add linter coverage for both packages.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

