### PR TITLE
[release 1.1] VMRestore: create DVs before creation/update of restored VM

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -25,7 +25,7 @@ import (
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	utils "kubevirt.io/kubevirt/pkg/util"
@@ -868,7 +868,7 @@ func (m *InstancetypeMethods) inferDefaultsFromDataVolume(vm *virtv1.VirtualMach
 	return m.inferDefaultsFromDataVolumeSpec(&dv.Spec, defaultNameLabel, defaultKindLabel, vm.Namespace)
 }
 
-func (m *InstancetypeMethods) inferDefaultsFromDataVolumeSpec(dataVolumeSpec *v1beta1.DataVolumeSpec, defaultNameLabel, defaultKindLabel, vmNameSpace string) (defaultName, defaultKind string, err error) {
+func (m *InstancetypeMethods) inferDefaultsFromDataVolumeSpec(dataVolumeSpec *cdiv1.DataVolumeSpec, defaultNameLabel, defaultKindLabel, vmNameSpace string) (defaultName, defaultKind string, err error) {
 	if dataVolumeSpec != nil && dataVolumeSpec.Source != nil && dataVolumeSpec.Source.PVC != nil {
 		return m.inferDefaultsFromPVC(dataVolumeSpec.Source.PVC.Name, dataVolumeSpec.Source.PVC.Namespace, defaultNameLabel, defaultKindLabel)
 	}
@@ -894,7 +894,7 @@ func (m *InstancetypeMethods) inferDefaultsFromDataSource(dataSourceName, dataSo
 	return "", "", NewIgnoreableInferenceError(fmt.Errorf("unable to infer defaults from DataSource that doesn't provide DataVolumeSourcePVC"))
 }
 
-func (m *InstancetypeMethods) inferDefaultsFromDataVolumeSourceRef(sourceRef *v1beta1.DataVolumeSourceRef, defaultNameLabel, defaultKindLabel, vmNameSpace string) (defaultName, defaultKind string, err error) {
+func (m *InstancetypeMethods) inferDefaultsFromDataVolumeSourceRef(sourceRef *cdiv1.DataVolumeSourceRef, defaultNameLabel, defaultKindLabel, vmNameSpace string) (defaultName, defaultKind string, err error) {
 	if sourceRef.Kind == "DataSource" {
 		// The namespace can be left blank here with the assumption that the DataSource is in the same namespace as the VM
 		namespace := vmNameSpace

--- a/pkg/storage/snapshot/BUILD.bazel
+++ b/pkg/storage/snapshot/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/status:go_default_library",
@@ -86,7 +87,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -44,7 +44,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/instancetype"
-	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
+	typesutil "kubevirt.io/kubevirt/pkg/storage/types"
 )
 
 const (
@@ -401,36 +401,40 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 }
 
 func (t *vmRestoreTarget) Reconcile() (bool, error) {
-	if updated, err := t.reconcileSpec(); updated || err != nil {
+	if t.doesTargetVMExist() && hasLastRestoreAnnotation(t.vmRestore, t.vm) {
+		return false, nil
+	}
+
+	restoredVM, err := t.generateRestoredVMSpec()
+	if err != nil {
+		return false, err
+	}
+	if updated, err := t.reconcileDataVolumes(restoredVM); updated || err != nil {
 		return updated, err
 	}
-	return t.reconcileDataVolumes()
+
+	return t.reconcileSpec(restoredVM)
 }
 
 func (t *vmRestoreTarget) UpdateTarget(obj metav1.Object) {
 	t.vm = obj.(*kubevirtv1.VirtualMachine)
 }
 
-func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
-	log.Log.Object(t.vmRestore).V(3).Info("Reconciling VM")
-
-	if t.doesTargetVMExist() && hasLastRestoreAnnotation(t.vmRestore, t.vm) {
-		return false, nil
-	}
+func (t *vmRestoreTarget) generateRestoredVMSpec() (*kubevirtv1.VirtualMachine, error) {
+	log.Log.Object(t.vmRestore).V(3).Info("generating restored VM spec")
 
 	content, err := t.controller.getSnapshotContent(t.vmRestore)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	snapshotVM := content.Spec.Source.VirtualMachine
 	if snapshotVM == nil {
-		return false, fmt.Errorf("unexpected snapshot source")
+		return nil, fmt.Errorf("unexpected snapshot source")
 	}
 
 	var newTemplates = make([]kubevirtv1.DataVolumeTemplateSpec, len(snapshotVM.Spec.DataVolumeTemplates))
 	var newVolumes []kubevirtv1.Volume
-	updatedStatus := false
 
 	for i, t := range snapshotVM.Spec.DataVolumeTemplates {
 		t.DeepCopyInto(&newTemplates[i])
@@ -447,11 +451,11 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 
 				pvc, err := t.controller.getPVC(t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
 				if err != nil {
-					return false, err
+					return nil, err
 				}
 
 				if pvc == nil {
-					return false, fmt.Errorf("pvc %s/%s does not exist and should", t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
+					return nil, fmt.Errorf("pvc %s/%s does not exist and should", t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
 				}
 
 				if nv.DataVolume == nil {
@@ -465,11 +469,10 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 						dvName := restoreDVName(t.vmRestore, vr.VolumeName)
 						err = t.updatePVCPopulatedForAnnotation(pvc, dvName)
 						if err != nil {
-							return false, err
+							return nil, err
 						}
 
 						vr.DataVolumeName = &dvName
-						updatedStatus = true
 					}
 
 					dv := snapshotVM.Spec.DataVolumeTemplates[templateIndex].DeepCopy()
@@ -496,12 +499,6 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 			continue
 		}
 		newVolumes = append(newVolumes, *nv)
-	}
-
-	if t.doesTargetVMExist() && updatedStatus {
-		t.vmRestore.Status.DeletedDataVolumes = findDatavolumesForDeletion(t.vm.Spec.DataVolumeTemplates, newTemplates)
-
-		return true, nil
 	}
 
 	var newVM *kubevirtv1.VirtualMachine
@@ -534,23 +531,30 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 	newVM.Spec.Template.Spec.Volumes = newVolumes
 	setLastRestoreAnnotation(t.vmRestore, newVM)
 
-	if err = t.restoreInstancetypeControllerRevisions(newVM); err != nil {
+	return newVM, nil
+}
+
+func (t *vmRestoreTarget) reconcileSpec(restoredVM *kubevirtv1.VirtualMachine) (bool, error) {
+	log.Log.Object(t.vmRestore).V(3).Info("Reconcile new VM spec")
+
+	var err error
+	if err = t.restoreInstancetypeControllerRevisions(restoredVM); err != nil {
 		return false, err
 	}
 
 	if !t.doesTargetVMExist() {
-		newVM, err = patchVM(newVM, t.vmRestore.Spec.Patches)
+		restoredVM, err = patchVM(restoredVM, t.vmRestore.Spec.Patches)
 		if err != nil {
-			return false, fmt.Errorf("error patching VM %s: %v", newVM.Name, err)
+			return false, fmt.Errorf("error patching VM %s: %v", restoredVM.Name, err)
 		}
-		newVM, err = t.controller.Client.VirtualMachine(t.vmRestore.Namespace).Create(context.Background(), newVM)
+		restoredVM, err = t.controller.Client.VirtualMachine(t.vmRestore.Namespace).Create(context.Background(), restoredVM)
 	} else {
-		newVM, err = t.controller.Client.VirtualMachine(newVM.Namespace).Update(context.Background(), newVM)
+		restoredVM, err = t.controller.Client.VirtualMachine(restoredVM.Namespace).Update(context.Background(), restoredVM)
 	}
 	if err != nil {
 		return false, err
 	}
-	t.UpdateTarget(newVM)
+	t.UpdateTarget(restoredVM)
 
 	if err = t.claimInstancetypeControllerRevisionsOwnership(t.vm); err != nil {
 		return false, err
@@ -606,11 +610,11 @@ func findDatavolumesForDeletion(oldDVTemplates, newDVTemplates []kubevirtv1.Data
 	return deletedDataVolumes
 }
 
-func (t *vmRestoreTarget) reconcileDataVolumes() (bool, error) {
+func (t *vmRestoreTarget) reconcileDataVolumes(restoredVM *kubevirtv1.VirtualMachine) (bool, error) {
 	createdDV := false
 	waitingDV := false
-	for _, dvt := range t.vm.Spec.DataVolumeTemplates {
-		dv, err := t.controller.getDV(t.vm.Namespace, dvt.Name)
+	for _, dvt := range restoredVM.Spec.DataVolumeTemplates {
+		dv, err := t.controller.getDV(restoredVM.Namespace, dvt.Name)
 		if err != nil {
 			return false, err
 		}
@@ -621,12 +625,22 @@ func (t *vmRestoreTarget) reconcileDataVolumes() (bool, error) {
 					dv.Status.Phase != v1beta1.PendingPopulation)
 			continue
 		}
-		created, err := t.createDataVolume(dvt)
+		created, err := t.createDataVolume(restoredVM, dvt)
 		if err != nil {
 			return false, err
 		}
 		createdDV = createdDV || created
 	}
+
+	if t.doesTargetVMExist() {
+		deletedDataVolumes := findDatavolumesForDeletion(t.vm.Spec.DataVolumeTemplates, restoredVM.Spec.DataVolumeTemplates)
+		if !equality.Semantic.DeepEqual(t.vmRestore.Status.DeletedDataVolumes, deletedDataVolumes) {
+			t.vmRestore.Status.DeletedDataVolumes = deletedDataVolumes
+
+			return true, nil
+		}
+	}
+
 	return createdDV || waitingDV, nil
 }
 
@@ -743,16 +757,20 @@ func (t *vmRestoreTarget) claimInstancetypeControllerRevisionsOwnership(vm *kube
 	return nil
 }
 
-func (t *vmRestoreTarget) createDataVolume(dvt kubevirtv1.DataVolumeTemplateSpec) (bool, error) {
-	pvc, err := t.controller.getPVC(t.vm.Namespace, dvt.Name)
+func (t *vmRestoreTarget) createDataVolume(restoredVM *kubevirtv1.VirtualMachine, dvt kubevirtv1.DataVolumeTemplateSpec) (bool, error) {
+	pvc, err := t.controller.getPVC(restoredVM.Namespace, dvt.Name)
 	if err != nil {
 		return false, err
+	}
+	if pvc == nil {
+		return false, fmt.Errorf("when creating restore dv pvc %s/%s does not exist and should",
+			t.vmRestore.Namespace, dvt.Name)
 	}
 	if pvc.Annotations[populatedForPVCAnnotation] != dvt.Name || len(pvc.OwnerReferences) > 0 {
 		return false, nil
 	}
 
-	newDataVolume, err := watchutil.CreateDataVolumeManifest(t.controller.Client, dvt, t.vm)
+	newDataVolume, err := typesutil.GenerateDataVolumeFromTemplate(t.controller.Client, dvt, restoredVM.Namespace, restoredVM.Spec.Template.Spec.PriorityClassName)
 	if err != nil {
 		return false, fmt.Errorf("Unable to create restore DataVolume manifest: %v", err)
 	}
@@ -761,13 +779,14 @@ func (t *vmRestoreTarget) createDataVolume(dvt kubevirtv1.DataVolumeTemplateSpec
 		newDataVolume.Annotations = make(map[string]string)
 	}
 	newDataVolume.Annotations[RestoreNameAnnotation] = t.vmRestore.Name
+	newDataVolume.Annotations[v1beta1.AnnPrePopulated] = "true"
 
-	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(t.vm.Namespace).Create(context.Background(), newDataVolume, v1.CreateOptions{}); err != nil {
+	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(restoredVM.Namespace).Create(context.Background(), newDataVolume, v1.CreateOptions{}); err != nil {
 		t.controller.Recorder.Eventf(t.vm, corev1.EventTypeWarning, restoreDataVolumeCreateErrorEvent, "Error creating restore DataVolume %s: %v", newDataVolume.Name, err)
 		return false, fmt.Errorf("Failed to create restore DataVolume: %v", err)
 	}
 	// Update restore DataVolumeName
-	for _, v := range t.vm.Spec.Template.Spec.Volumes {
+	for _, v := range restoredVM.Spec.Template.Spec.Volumes {
 		if v.DataVolume == nil || v.DataVolume.Name != dvt.Name {
 			continue
 		}

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -430,7 +430,6 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 
 	var newTemplates = make([]kubevirtv1.DataVolumeTemplateSpec, len(snapshotVM.Spec.DataVolumeTemplates))
 	var newVolumes []kubevirtv1.Volume
-	var deletedDataVolumes []string
 	updatedStatus := false
 
 	for i, t := range snapshotVM.Spec.DataVolumeTemplates {
@@ -455,57 +454,41 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 					return false, fmt.Errorf("pvc %s/%s does not exist and should", t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
 				}
 
-				if nv.DataVolume != nil {
-					templateIndex := -1
-					for i, dvt := range snapshotVM.Spec.DataVolumeTemplates {
-						if v.DataVolume.Name == dvt.Name {
-							templateIndex = i
-							break
+				if nv.DataVolume == nil {
+					nv.PersistentVolumeClaim.ClaimName = vr.PersistentVolumeClaimName
+					continue
+				}
+
+				templateIndex := findDVTemplateIndex(v.DataVolume.Name, snapshotVM)
+				if templateIndex >= 0 {
+					if vr.DataVolumeName == nil {
+						dvName := restoreDVName(t.vmRestore, vr.VolumeName)
+						err = t.updatePVCPopulatedForAnnotation(pvc, dvName)
+						if err != nil {
+							return false, err
 						}
+
+						vr.DataVolumeName = &dvName
+						updatedStatus = true
 					}
 
-					if templateIndex >= 0 {
-						if vr.DataVolumeName == nil {
-							updatePVC := pvc.DeepCopy()
-							dvName := restoreDVName(t.vmRestore, vr.VolumeName)
+					dv := snapshotVM.Spec.DataVolumeTemplates[templateIndex].DeepCopy()
+					dv.Name = *vr.DataVolumeName
+					newTemplates[templateIndex] = *dv
 
-							if updatePVC.Annotations[populatedForPVCAnnotation] != dvName {
-								if updatePVC.Annotations == nil {
-									updatePVC.Annotations = make(map[string]string)
-								}
-								updatePVC.Annotations[populatedForPVCAnnotation] = dvName
-								// datavolume will take ownership
-								updatePVC.OwnerReferences = nil
-								_, err = t.controller.Client.CoreV1().PersistentVolumeClaims(updatePVC.Namespace).Update(context.Background(), updatePVC, metav1.UpdateOptions{})
-								if err != nil {
-									return false, err
-								}
-							}
-
-							vr.DataVolumeName = &dvName
-							updatedStatus = true
-						}
-
-						dv := snapshotVM.Spec.DataVolumeTemplates[templateIndex].DeepCopy()
-						dv.Name = *vr.DataVolumeName
-						newTemplates[templateIndex] = *dv
-
-						nv.DataVolume.Name = *vr.DataVolumeName
-					} else {
-						// convert to PersistentVolumeClaim volume
-						nv = &kubevirtv1.Volume{
-							Name: nv.Name,
-							VolumeSource: kubevirtv1.VolumeSource{
-								PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
-									PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
-										ClaimName: vr.PersistentVolumeClaimName,
-									},
+					nv.DataVolume.Name = *vr.DataVolumeName
+				} else {
+					// convert to PersistentVolumeClaim volume
+					nv = &kubevirtv1.Volume{
+						Name: nv.Name,
+						VolumeSource: kubevirtv1.VolumeSource{
+							PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: vr.PersistentVolumeClaimName,
 								},
 							},
-						}
+						},
 					}
-				} else {
-					nv.PersistentVolumeClaim.ClaimName = vr.PersistentVolumeClaimName
 				}
 			}
 		} else if nv.MemoryDump != nil {
@@ -516,20 +499,7 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 	}
 
 	if t.doesTargetVMExist() && updatedStatus {
-		// find DataVolumes that will no longer exist
-		for _, cdv := range t.vm.Spec.DataVolumeTemplates {
-			found := false
-			for _, ndv := range newTemplates {
-				if cdv.Name == ndv.Name {
-					found = true
-					break
-				}
-			}
-			if !found {
-				deletedDataVolumes = append(deletedDataVolumes, cdv.Name)
-			}
-		}
-		t.vmRestore.Status.DeletedDataVolumes = deletedDataVolumes
+		t.vmRestore.Status.DeletedDataVolumes = findDatavolumesForDeletion(t.vm.Spec.DataVolumeTemplates, newTemplates)
 
 		return true, nil
 	}
@@ -587,6 +557,53 @@ func (t *vmRestoreTarget) reconcileSpec() (bool, error) {
 	}
 
 	return true, nil
+}
+
+func findDVTemplateIndex(dvName string, vm *snapshotv1.VirtualMachine) int {
+	templateIndex := -1
+	for i, dvt := range vm.Spec.DataVolumeTemplates {
+		if dvName == dvt.Name {
+			templateIndex = i
+			break
+		}
+	}
+	return templateIndex
+}
+
+func (t *vmRestoreTarget) updatePVCPopulatedForAnnotation(pvc *corev1.PersistentVolumeClaim, dvName string) error {
+	updatePVC := pvc.DeepCopy()
+	if updatePVC.Annotations[populatedForPVCAnnotation] != dvName {
+		if updatePVC.Annotations == nil {
+			updatePVC.Annotations = make(map[string]string)
+		}
+		updatePVC.Annotations[populatedForPVCAnnotation] = dvName
+		// datavolume will take ownership
+		updatePVC.OwnerReferences = nil
+		_, err := t.controller.Client.CoreV1().PersistentVolumeClaims(updatePVC.Namespace).Update(context.Background(), updatePVC, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// findDatavolumesForDeletion find DataVolumes that will no longer
+// exist after the vmrestore is completed
+func findDatavolumesForDeletion(oldDVTemplates, newDVTemplates []kubevirtv1.DataVolumeTemplateSpec) []string {
+	var deletedDataVolumes []string
+	for _, cdv := range oldDVTemplates {
+		found := false
+		for _, ndv := range newDVTemplates {
+			if cdv.Name == ndv.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			deletedDataVolumes = append(deletedDataVolumes, cdv.Name)
+		}
+	}
+	return deletedDataVolumes
 }
 
 func (t *vmRestoreTarget) reconcileDataVolumes() (bool, error) {

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -40,7 +40,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/log"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/instancetype"
@@ -620,9 +620,9 @@ func (t *vmRestoreTarget) reconcileDataVolumes(restoredVM *kubevirtv1.VirtualMac
 		}
 		if dv != nil {
 			waitingDV = waitingDV ||
-				(dv.Status.Phase != v1beta1.Succeeded &&
-					dv.Status.Phase != v1beta1.WaitForFirstConsumer &&
-					dv.Status.Phase != v1beta1.PendingPopulation)
+				(dv.Status.Phase != cdiv1.Succeeded &&
+					dv.Status.Phase != cdiv1.WaitForFirstConsumer &&
+					dv.Status.Phase != cdiv1.PendingPopulation)
 			continue
 		}
 		created, err := t.createDataVolume(restoredVM, dvt)
@@ -779,7 +779,7 @@ func (t *vmRestoreTarget) createDataVolume(restoredVM *kubevirtv1.VirtualMachine
 		newDataVolume.Annotations = make(map[string]string)
 	}
 	newDataVolume.Annotations[RestoreNameAnnotation] = t.vmRestore.Name
-	newDataVolume.Annotations[v1beta1.AnnPrePopulated] = "true"
+	newDataVolume.Annotations[cdiv1.AnnPrePopulated] = "true"
 
 	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(restoredVM.Namespace).Create(context.Background(), newDataVolume, v1.CreateOptions{}); err != nil {
 		t.controller.Recorder.Eventf(t.vm, corev1.EventTypeWarning, restoreDataVolumeCreateErrorEvent, "Error creating restore DataVolume %s: %v", newDataVolume.Name, err)
@@ -927,7 +927,7 @@ func patchVM(vm *kubevirtv1.VirtualMachine, patches []string) (*kubevirtv1.Virtu
 	return vm, nil
 }
 
-func (ctrl *VMRestoreController) getDV(namespace, name string) (*v1beta1.DataVolume, error) {
+func (ctrl *VMRestoreController) getDV(namespace, name string) (*cdiv1.DataVolume, error) {
 	objKey := cacheKeyFunc(namespace, name)
 	obj, exists, err := ctrl.DataVolumeInformer.GetStore().GetByKey(objKey)
 	if err != nil {
@@ -938,7 +938,7 @@ func (ctrl *VMRestoreController) getDV(namespace, name string) (*v1beta1.DataVol
 		return nil, nil
 	}
 
-	return obj.(*v1beta1.DataVolume).DeepCopy(), nil
+	return obj.(*cdiv1.DataVolume).DeepCopy(), nil
 }
 
 func (ctrl *VMRestoreController) getPVC(namespace, name string) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/storage/snapshot/restore_base.go
+++ b/pkg/storage/snapshot/restore_base.go
@@ -35,7 +35,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/util/status"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
@@ -188,7 +188,7 @@ func (ctrl *VMRestoreController) handleDataVolume(obj interface{}) {
 		obj = unknown.Obj
 	}
 
-	if dv, ok := obj.(*v1beta1.DataVolume); ok {
+	if dv, ok := obj.(*cdiv1.DataVolume); ok {
 		restoreName, ok := dv.Annotations[RestoreNameAnnotation]
 		if !ok {
 			return

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/onsi/gomega/ghttp"
 
 	"kubevirt.io/client-go/api"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/util/status"
 
@@ -60,6 +59,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	cdifake "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 
@@ -1210,16 +1210,16 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			return pvc
 		}
 
-		cdiConfigInit := func() (cdiConfig *v1beta1.CDIConfig) {
-			cdiConfig = &v1beta1.CDIConfig{
+		cdiConfigInit := func() (cdiConfig *cdiv1.CDIConfig) {
+			cdiConfig = &cdiv1.CDIConfig{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: storagetypes.ConfigName,
 				},
-				Spec: v1beta1.CDIConfigSpec{
+				Spec: cdiv1.CDIConfigSpec{
 					UploadProxyURLOverride: nil,
 				},
-				Status: v1beta1.CDIConfigStatus{
-					FilesystemOverhead: &v1beta1.FilesystemOverhead{
+				Status: cdiv1.CDIConfigStatus{
+					FilesystemOverhead: &cdiv1.FilesystemOverhead{
 						Global: storagetypes.DefaultFSOverhead,
 					},
 				},

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -41,7 +41,7 @@ import (
 	apiinstancetype "kubevirt.io/api/instancetype"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/instancetype"
 
@@ -398,7 +398,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			}
 
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
-				Spec: v1beta1.DataVolumeSpec{},
+				Spec: cdiv1.DataVolumeSpec{},
 			}}
 		})
 
@@ -419,14 +419,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		})
 
 		It("should apply PreferredStorageClassName to Storage", func() {
-			vm.Spec.DataVolumeTemplates[0].Spec.Storage = &v1beta1.StorageSpec{}
+			vm.Spec.DataVolumeTemplates[0].Spec.Storage = &cdiv1.StorageSpec{}
 			vmSpec, _ := getVMSpecMetaFromResponse(rt.GOARCH)
 			assertStorageStorageClassName(vmSpec.DataVolumeTemplates, preference.Spec.Volumes.PreferredStorageClassName)
 		})
 
 		It("should not fail if DataVolumeSpec PersistentVolumeClaimSpec is nil - bug #9868", func() {
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
-				Spec: v1beta1.DataVolumeSpec{},
+				Spec: cdiv1.DataVolumeSpec{},
 			}}
 			resp := admitVM(rt.GOARCH)
 			Expect(resp.Allowed).To(BeTrue())
@@ -435,7 +435,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		It("should not overwrite storageclass already defined in PVC of DataVolumeTemplate", func() {
 			storageClass := "local"
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
-				Spec: v1beta1.DataVolumeSpec{
+				Spec: cdiv1.DataVolumeSpec{
 					PVC: &k8sv1.PersistentVolumeClaimSpec{
 						StorageClassName: &storageClass,
 					},
@@ -448,8 +448,8 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		It("should not overwrite storageclass already defined in Storage of DataVolumeTemplate", func() {
 			storageClass := "local"
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
-				Spec: v1beta1.DataVolumeSpec{
-					Storage: &v1beta1.StorageSpec{
+				Spec: cdiv1.DataVolumeSpec{
+					Storage: &cdiv1.StorageSpec{
 						StorageClassName: &storageClass,
 					},
 				},
@@ -682,10 +682,10 @@ var _ = Describe("VirtualMachine Mutator", func() {
 
 		var (
 			pvc               *k8sv1.PersistentVolumeClaim
-			dvWithSourcePVC   *v1beta1.DataVolume
-			dvWithAnnotations *v1beta1.DataVolume
-			dsWithSourcePVC   *v1beta1.DataSource
-			dsWithAnnotations *v1beta1.DataSource
+			dvWithSourcePVC   *cdiv1.DataVolume
+			dvWithAnnotations *cdiv1.DataVolume
+			dsWithSourcePVC   *cdiv1.DataSource
+			dsWithAnnotations *cdiv1.DataSource
 		)
 
 		const (
@@ -720,14 +720,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Create(context.Background(), pvc, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			dvWithSourcePVC = &v1beta1.DataVolume{
+			dvWithSourcePVC = &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      dvWithSourcePVCName,
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					Source: &v1beta1.DataVolumeSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -737,14 +737,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			dvWithSourcePVC, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Create(context.Background(), dvWithSourcePVC, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			dsWithSourcePVC = &v1beta1.DataSource{
+			dsWithSourcePVC = &cdiv1.DataSource{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      dsWithSourcePVCName,
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataSourceSpec{
-					Source: v1beta1.DataSourceSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -754,7 +754,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			dsWithSourcePVC, err = virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.Background(), dsWithSourcePVC, k8smetav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			dsWithAnnotations = &v1beta1.DataSource{
+			dsWithAnnotations = &cdiv1.DataSource{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      dsWithAnnotationsName,
 					Namespace: vm.Namespace,
@@ -765,9 +765,9 @@ var _ = Describe("VirtualMachine Mutator", func() {
 						apiinstancetype.DefaultPreferenceKindLabel:   defaultInferedKindFromDS,
 					},
 				},
-				Spec: v1beta1.DataSourceSpec{
-					Source: v1beta1.DataSourceSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -868,9 +868,9 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "dataVolume",
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					Source: &v1beta1.DataVolumeSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -905,7 +905,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should infer defaults from DataVolume with labels", func(instancetypeMatcher, expectedInstancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher, expectedPreferenceMatcher *v1.PreferenceMatcher) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
-			dvWithAnnotations = &v1beta1.DataVolume{
+			dvWithAnnotations = &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithAnnotations",
 					Namespace: vm.Namespace,
@@ -916,9 +916,9 @@ var _ = Describe("VirtualMachine Mutator", func() {
 						apiinstancetype.DefaultPreferenceKindLabel:   defaultInferedKindFromDV,
 					},
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					Source: &v1beta1.DataVolumeSource{
-						PVC: &v1beta1.DataVolumeSourcePVC{
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						PVC: &cdiv1.DataVolumeSourcePVC{
 							Name:      pvc.Name,
 							Namespace: pvc.Namespace,
 						},
@@ -969,13 +969,13 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			if sourceRefNamespace != "" {
 				sourceRefNamespacePointer = &sourceRefNamespace
 			}
-			dvWithSourceRef := &v1beta1.DataVolume{
+			dvWithSourceRef := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithSourceRef",
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					SourceRef: &v1beta1.DataVolumeSourceRef{
+				Spec: cdiv1.DataVolumeSpec{
+					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Name:      sourceRefName,
 						Kind:      sourceRefKind,
 						Namespace: sourceRefNamespacePointer,
@@ -1091,8 +1091,8 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "dataVolume",
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					SourceRef: &v1beta1.DataVolumeSourceRef{
+				Spec: cdiv1.DataVolumeSpec{
+					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Name:      sourceRefName,
 						Kind:      "DataSource",
 						Namespace: &sourceRefNamespace,
@@ -1440,14 +1440,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should fail to infer defaults from DataVolume with an unsupported DataVolumeSource", func(instancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher *v1.PreferenceMatcher, allowed bool) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
-			dvWithUnsupportedSource := &v1beta1.DataVolume{
+			dvWithUnsupportedSource := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithSourceRef",
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					Source: &v1beta1.DataVolumeSource{
-						VDDK: &v1beta1.DataVolumeSourceVDDK{},
+				Spec: cdiv1.DataVolumeSpec{
+					Source: &cdiv1.DataVolumeSource{
+						VDDK: &cdiv1.DataVolumeSourceVDDK{},
 					},
 				},
 			}
@@ -1515,13 +1515,13 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should fail to infer defaults from DataVolume with an unknown DataVolumeSourceRef Kind", func(instancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher *v1.PreferenceMatcher, allowed bool) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
-			dvWithUnknownSourceRefKind := &v1beta1.DataVolume{
+			dvWithUnknownSourceRefKind := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithSourceRef",
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					SourceRef: &v1beta1.DataVolumeSourceRef{
+				Spec: cdiv1.DataVolumeSpec{
+					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Kind: "foo",
 					},
 				},
@@ -1590,13 +1590,13 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should fail to infer defaults from DataSource missing DataVolumeSourcePVC", func(instancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher *v1.PreferenceMatcher, allowed bool) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
-			dsWithoutSourcePVC := &v1beta1.DataSource{
+			dsWithoutSourcePVC := &cdiv1.DataSource{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dsWithoutSourcePVC",
 					Namespace: vm.Namespace,
 				},
-				Spec: v1beta1.DataSourceSpec{
-					Source: v1beta1.DataSourceSource{},
+				Spec: cdiv1.DataSourceSpec{
+					Source: cdiv1.DataSourceSource{},
 				},
 			}
 			_, err := virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.Background(), dsWithoutSourcePVC, k8smetav1.CreateOptions{})
@@ -1606,8 +1606,8 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name: "dataVolume",
 				},
-				Spec: v1beta1.DataVolumeSpec{
-					SourceRef: &v1beta1.DataVolumeSourceRef{
+				Spec: cdiv1.DataVolumeSpec{
+					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Kind:      "DataSource",
 						Name:      dsWithoutSourcePVC.Name,
 						Namespace: &dsWithoutSourcePVC.Namespace,

--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -28,7 +28,7 @@ import (
 	cdifake "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/memorydump"
 	"kubevirt.io/kubevirt/pkg/virtctl/utils"
@@ -77,8 +77,8 @@ var _ = Describe("MemoryDump", func() {
 	updateCDIConfig := func() {
 		config, err := cdiClient.CdiV1beta1().CDIConfigs().Get(context.Background(), configName, k8smetav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		config.Status.FilesystemOverhead.StorageClass = make(map[string]v1beta1.Percent)
-		config.Status.FilesystemOverhead.StorageClass["fakeSC"] = v1beta1.Percent("0.1")
+		config.Status.FilesystemOverhead.StorageClass = make(map[string]cdiv1.Percent)
+		config.Status.FilesystemOverhead.StorageClass["fakeSC"] = cdiv1.Percent("0.1")
 		_, err = cdiClient.CdiV1beta1().CDIConfigs().Update(context.Background(), config, k8smetav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	}
@@ -493,17 +493,17 @@ var _ = Describe("MemoryDump", func() {
 	})
 })
 
-func cdiConfigInit() (cdiConfig *v1beta1.CDIConfig) {
-	cdiConfig = &v1beta1.CDIConfig{
+func cdiConfigInit() (cdiConfig *cdiv1.CDIConfig) {
+	cdiConfig = &cdiv1.CDIConfig{
 		ObjectMeta: k8smetav1.ObjectMeta{
 			Name: configName,
 		},
-		Spec: v1beta1.CDIConfigSpec{
+		Spec: cdiv1.CDIConfigSpec{
 			UploadProxyURLOverride: nil,
 		},
-		Status: v1beta1.CDIConfigStatus{
-			FilesystemOverhead: &v1beta1.FilesystemOverhead{
-				Global: v1beta1.Percent(defaultFSOverhead),
+		Status: cdiv1.CDIConfigStatus{
+			FilesystemOverhead: &cdiv1.FilesystemOverhead{
+				Global: cdiv1.Percent(defaultFSOverhead),
 			},
 		},
 	}

--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -34,7 +34,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	cdifake "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
 )
@@ -57,8 +57,8 @@ var _ = Describe("Add volume command", func() {
 		coreClient = fake.NewSimpleClientset()
 	})
 
-	createTestDataVolume := func() *v1beta1.DataVolume {
-		return &v1beta1.DataVolume{
+	createTestDataVolume := func() *cdiv1.DataVolume {
+		return &cdiv1.DataVolume{
 			ObjectMeta: k8smetav1.ObjectMeta{
 				Name: "testvolume",
 			},

--- a/tests/framework/matcher/getter.go
+++ b/tests/framework/matcher/getter.go
@@ -13,7 +13,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 // ThisPod fetches the latest state of the pod. If the object does not exist, nil is returned.
@@ -87,13 +87,13 @@ func AllPDBs(namespace string) func() ([]policyv1.PodDisruptionBudget, error) {
 }
 
 // ThisDV fetches the latest state of the DataVolume. If the object does not exist, nil is returned.
-func ThisDV(dv *v1beta1.DataVolume) func() (*v1beta1.DataVolume, error) {
+func ThisDV(dv *cdiv1.DataVolume) func() (*cdiv1.DataVolume, error) {
 	return ThisDVWith(dv.Namespace, dv.Name)
 }
 
 // ThisDVWith fetches the latest state of the DataVolume based on namespace and name. If the object does not exist, nil is returned.
-func ThisDVWith(namespace string, name string) func() (*v1beta1.DataVolume, error) {
-	return func() (p *v1beta1.DataVolume, err error) {
+func ThisDVWith(namespace string, name string) func() (*cdiv1.DataVolume, error) {
+	return func() (p *cdiv1.DataVolume, err error) {
 		virtClient := kubevirt.Client()
 		p, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 		if errors.IsNotFound(err) {

--- a/tests/framework/matcher/phase_test.go
+++ b/tests/framework/matcher/phase_test.go
@@ -9,7 +9,7 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v13 "kubevirt.io/api/core/v1"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/tests/framework/matcher/helper"
 )
@@ -40,7 +40,7 @@ var _ = Describe("Matcher", func() {
 		},
 	}
 
-	var nameAndKindDV = &v1beta1.DataVolume{
+	var nameAndKindDV = &cdiv1.DataVolume{
 		ObjectMeta: v12.ObjectMeta{
 			Name: "testdv",
 		},
@@ -64,7 +64,7 @@ var _ = Describe("Matcher", func() {
 		},
 	}
 
-	var onlyKindDV = &v1beta1.DataVolume{
+	var onlyKindDV = &cdiv1.DataVolume{
 		TypeMeta: v12.TypeMeta{
 			Kind: "DataVolume",
 		},
@@ -82,7 +82,7 @@ var _ = Describe("Matcher", func() {
 		},
 	}
 
-	var onlyNameDV = &v1beta1.DataVolume{
+	var onlyNameDV = &cdiv1.DataVolume{
 		ObjectMeta: v12.ObjectMeta{
 			Name: "testdv",
 		},
@@ -162,7 +162,7 @@ var _ = Describe("Matcher", func() {
 		Entry("with a DataVolume having only name", onlyNameDV, onlyNameDV.Kind, onlyNameDV.Name),
 		Entry("with a VirtualMachineInstance having only name", onlyNameVMI, onlyNameVMI.Kind, onlyNameVMI.Name),
 		Entry("with a Pod having no kind and name", &v1.Pod{}, "", ""),
-		Entry("with a DataVolume having no kind and name", &v1beta1.DataVolume{}, "", ""),
+		Entry("with a DataVolume having no kind and name", &cdiv1.DataVolume{}, "", ""),
 		Entry("with a VirtualMachineInstance having no kind and name", &v13.VirtualMachineInstance{}, "", ""),
 	)
 })

--- a/tests/libdv/dv.go
+++ b/tests/libdv/dv.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
@@ -34,12 +34,12 @@ const (
 )
 
 // dvOption is an option type for the NewDataVolume function
-type dvOption func(*v1beta1.DataVolume)
+type dvOption func(*cdiv1.DataVolume)
 
 // NewDataVolume Set up a new DataVolume with a random name, a namespace and an optional list of options
-func NewDataVolume(options ...dvOption) *v1beta1.DataVolume {
+func NewDataVolume(options ...dvOption) *cdiv1.DataVolume {
 	name := randName()
-	dv := &v1beta1.DataVolume{
+	dv := &cdiv1.DataVolume{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cdi.kubevirt.io/v1beta1",
 			Kind:       "DataVolume",
@@ -57,7 +57,7 @@ func NewDataVolume(options ...dvOption) *v1beta1.DataVolume {
 }
 
 func WithNamespace(namespace string) dvOption {
-	return func(dv *v1beta1.DataVolume) {
+	return func(dv *cdiv1.DataVolume) {
 		dv.Namespace = namespace
 	}
 }
@@ -86,31 +86,31 @@ func WithPVC(options ...pvcOption) dvOption {
 		opt(pvc)
 	}
 
-	return func(dv *v1beta1.DataVolume) {
+	return func(dv *cdiv1.DataVolume) {
 		dv.Spec.PVC = pvc
 	}
 }
 
 // withSource is a dvOption to add a DataVolumeSource to the DataVolume
-func withSource(s v1beta1.DataVolumeSource) dvOption {
-	return func(dv *v1beta1.DataVolume) {
+func withSource(s cdiv1.DataVolumeSource) dvOption {
+	return func(dv *cdiv1.DataVolume) {
 		dv.Spec.Source = &s
 	}
 }
 
 // WithRegistryURLSource is a dvOption to add a DataVolumeSource to the DataVolume, with a registry and a URL
 func WithRegistryURLSource(imageURL string) dvOption {
-	return withSource(v1beta1.DataVolumeSource{
-		Registry: &v1beta1.DataVolumeSourceRegistry{
+	return withSource(cdiv1.DataVolumeSource{
+		Registry: &cdiv1.DataVolumeSourceRegistry{
 			URL: &imageURL,
 		},
 	})
 }
 
 // WithRegistryURLSourceAndPullMethod is a dvOption to add a DataVolumeSource to the DataVolume, with a registry and URL + pull method
-func WithRegistryURLSourceAndPullMethod(imageURL string, pullMethod v1beta1.RegistryPullMethod) dvOption {
-	return withSource(v1beta1.DataVolumeSource{
-		Registry: &v1beta1.DataVolumeSourceRegistry{
+func WithRegistryURLSourceAndPullMethod(imageURL string, pullMethod cdiv1.RegistryPullMethod) dvOption {
+	return withSource(cdiv1.DataVolumeSource{
+		Registry: &cdiv1.DataVolumeSourceRegistry{
 			URL:        &imageURL,
 			PullMethod: &pullMethod,
 		},
@@ -119,15 +119,15 @@ func WithRegistryURLSourceAndPullMethod(imageURL string, pullMethod v1beta1.Regi
 
 // WithBlankImageSource is a dvOption to add a blank DataVolumeSource to the DataVolume
 func WithBlankImageSource() dvOption {
-	return withSource(v1beta1.DataVolumeSource{
-		Blank: &v1beta1.DataVolumeBlankImage{},
+	return withSource(cdiv1.DataVolumeSource{
+		Blank: &cdiv1.DataVolumeBlankImage{},
 	})
 }
 
 // WithPVCSource is a dvOption to add a DataVolumeSource to the DataVolume, with a PVC source
 func WithPVCSource(namespace, name string) dvOption {
-	return withSource(v1beta1.DataVolumeSource{
-		PVC: &v1beta1.DataVolumeSourcePVC{
+	return withSource(cdiv1.DataVolumeSource{
+		PVC: &cdiv1.DataVolumeSourcePVC{
 			Namespace: namespace,
 			Name:      name,
 		},
@@ -137,7 +137,7 @@ func WithPVCSource(namespace, name string) dvOption {
 // WithForceBindAnnotation adds the "cdi.kubevirt.io/storage.bind.immediate.requested" annotation to the DV,
 // with the value of "true"
 func WithForceBindAnnotation() dvOption {
-	return func(dv *v1beta1.DataVolume) {
+	return func(dv *cdiv1.DataVolume) {
 		if dv.Annotations == nil {
 			dv.Annotations = make(map[string]string)
 		}

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -37,7 +37,7 @@ import (
 
 	v13 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
@@ -64,7 +64,7 @@ func AddDataVolumeDisk(vmi *v13.VirtualMachineInstance, diskName, dataVolumeName
 	return vmi
 }
 
-func AddDataVolumeTemplate(vm *v13.VirtualMachine, dataVolume *v1beta1.DataVolume) {
+func AddDataVolumeTemplate(vm *v13.VirtualMachine, dataVolume *cdiv1.DataVolume) {
 	dvt := &v13.DataVolumeTemplateSpec{}
 
 	dvt.Spec = *dataVolume.Spec.DeepCopy()
@@ -73,7 +73,7 @@ func AddDataVolumeTemplate(vm *v13.VirtualMachine, dataVolume *v1beta1.DataVolum
 	vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
 }
 
-func AddDataVolume(vm *v13.VirtualMachine, diskName string, dataVolume *v1beta1.DataVolume) {
+func AddDataVolume(vm *v13.VirtualMachine, diskName string, dataVolume *cdiv1.DataVolume) {
 	vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v13.Disk{
 		Name: diskName,
 		DiskDevice: v13.DiskDevice{
@@ -92,7 +92,7 @@ func AddDataVolume(vm *v13.VirtualMachine, diskName string, dataVolume *v1beta1.
 	})
 }
 
-func EventuallyDV(dv *v1beta1.DataVolume, timeoutSec int, matcher gomegatypes.GomegaMatcher) {
+func EventuallyDV(dv *cdiv1.DataVolume, timeoutSec int, matcher gomegatypes.GomegaMatcher) {
 	Expect(dv).ToNot(BeNil())
 	EventuallyDVWith(dv.Namespace, dv.Name, timeoutSec, matcher)
 }
@@ -106,8 +106,8 @@ func EventuallyDVWith(namespace, name string, timeoutSec int, matcher gomegatype
 	}
 
 	ginkgo.By("Verifying DataVolume garbage collection")
-	var dv *v1beta1.DataVolume
-	Eventually(func() *v1beta1.DataVolume {
+	var dv *cdiv1.DataVolume
+	Eventually(func() *cdiv1.DataVolume {
 		var err error
 		dv, err = ThisDVWith(namespace, name)()
 		Expect(err).ToNot(HaveOccurred())
@@ -115,7 +115,7 @@ func EventuallyDVWith(namespace, name string, timeoutSec int, matcher gomegatype
 	}, timeoutSec, time.Second).Should(Or(BeNil(), matcher))
 
 	if dv != nil {
-		if dv.Status.Phase != v1beta1.Succeeded {
+		if dv.Status.Phase != cdiv1.Succeeded {
 			return
 		}
 		if dv.Annotations["cdi.kubevirt.io/storage.deleteAfterCompletion"] == "true" {
@@ -130,7 +130,7 @@ func EventuallyDVWith(namespace, name string, timeoutSec int, matcher gomegatype
 	}, timeoutSec, time.Second).Should(BeTrue())
 }
 
-func DeleteDataVolume(dv **v1beta1.DataVolume) {
+func DeleteDataVolume(dv **cdiv1.DataVolume) {
 	Expect(dv).ToNot(BeNil())
 	if *dv == nil {
 		return
@@ -175,7 +175,7 @@ func IsDataVolumeGC(virtCli kubecli.KubevirtClient) bool {
 	return config.Spec.DataVolumeTTLSeconds != nil && *config.Spec.DataVolumeTTLSeconds >= 0
 }
 
-func GetCDI(virtCli kubecli.KubevirtClient) *v1beta1.CDI {
+func GetCDI(virtCli kubecli.KubevirtClient) *cdiv1.CDI {
 	cdiList, err := virtCli.CdiClient().CdiV1beta1().CDIs().List(context.Background(), v12.ListOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cdiList.Items).To(HaveLen(1))

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1763,7 +1763,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 						libdv.WithPVC(libdv.PVCWithStorageClass(sourceSC)),
 						libdv.WithForceBindAnnotation(),
 					)
-
 					source, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.NamespaceTestAlternative).Create(context.Background(), source, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					sourceDV = source
@@ -1779,6 +1778,12 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				})
 
 				AfterEach(func() {
+					// Make sure we recreate the alternative namespace when completing the tests
+					_, err := virtClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testsuite.NamespaceTestAlternative}}, metav1.CreateOptions{})
+					if err != nil && !errors.IsAlreadyExists(err) {
+						Expect(err).ToNot(HaveOccurred())
+					}
+
 					if sourceDV != nil {
 						libstorage.DeleteDataVolume(&sourceDV)
 					}
@@ -1828,21 +1833,32 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					return vm
 				}
 
-				DescribeTable("should restore a vm that boots from a network cloned datavolumetemplate", func(restoreToNewVM, deleteSourcePVC bool) {
+				DescribeTable("should restore a vm that boots from a network cloned datavolumetemplate", func(restoreToNewVM, deleteSourcePVC, deleteSourceNamespace bool) {
 					vm, vmi = createAndStartVM(createNetworkCloneVMFromSource())
 
 					checkCloneAnnotations(vm, true)
-					if deleteSourcePVC {
+					if deleteSourceNamespace {
+						err = virtClient.CoreV1().Namespaces().Delete(context.Background(), testsuite.NamespaceTestAlternative, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Eventually(func() error {
+							return virtClient.CoreV1().Namespaces().Delete(context.Background(), testsuite.NamespaceTestAlternative, metav1.DeleteOptions{})
+						}, 120*time.Second, 2*time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), fmt.Sprintf("should successfully delete namespace '%s'", testsuite.NamespaceTestAlternative))
+						sourceDV = nil
+						cloneRole = nil
+						cloneRoleBinding = nil
+					} else if deleteSourcePVC {
 						libstorage.DeleteDataVolume(&sourceDV)
 					}
 
 					doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
 					checkCloneAnnotations(getTargetVM(restoreToNewVM), false)
 				},
-					Entry("to the same VM", false, false),
-					Entry("to a new VM", true, false),
-					Entry("to the same VM, no source pvc", false, true),
-					Entry("to a new VM, no source pvc", true, true),
+					Entry("to the same VM", false, false, false),
+					Entry("to a new VM", true, false, false),
+					Entry("to the same VM, no source pvc", false, true, false),
+					Entry("to a new VM, no source pvc", true, true, false),
+					Entry("to the same VM, no source namespace", false, false, true),
+					Entry("to a new VM, no source namespace", true, false, true),
 				)
 
 				DescribeTable("should restore a vm that boots from a network cloned datavolume (not template)", func(restoreToNewVM, deleteSourcePVC bool) {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1142,7 +1142,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Entry("to a new VM", true),
 			)
 
-			DescribeTable("should restore a vm that boots from a datavolumetemplate", func(restoreToNewVM bool) {
+			DescribeTable("[QUARANTINE] should restore a vm that boots from a datavolumetemplate", decorators.Quarantine, func(restoreToNewVM bool) {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					testsuite.GetTestNamespace(nil),
@@ -1522,7 +1522,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Entry("to a new VM", true),
 			)
 
-			DescribeTable("should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", func(restoreToNewVM bool) {
+			DescribeTable("[QUARANTINE] should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", decorators.Quarantine, func(restoreToNewVM bool) {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
 					testsuite.GetTestNamespace(nil),

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -16,7 +16,7 @@ import (
 	apiinstancetype "kubevirt.io/api/instancetype"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/yaml"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
@@ -528,8 +528,8 @@ func createPreference(virtClient kubecli.KubevirtClient) *instancetypev1beta1.Vi
 	return preference
 }
 
-func createAnnotatedDataSource(virtClient kubecli.KubevirtClient, instancetypeName, preferenceName string) *v1beta1.DataSource {
-	dataSource := &v1beta1.DataSource{
+func createAnnotatedDataSource(virtClient kubecli.KubevirtClient, instancetypeName, preferenceName string) *cdiv1.DataSource {
+	dataSource := &cdiv1.DataSource{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vm-datasource-",
 			Labels: map[string]string{
@@ -539,8 +539,8 @@ func createAnnotatedDataSource(virtClient kubecli.KubevirtClient, instancetypeNa
 				apiinstancetype.DefaultPreferenceKindLabel:   apiinstancetype.SingularPreferenceResourceName,
 			},
 		},
-		Spec: v1beta1.DataSourceSpec{
-			Source: v1beta1.DataSourceSource{},
+		Spec: cdiv1.DataSourceSpec{
+			Source: cdiv1.DataSourceSource{},
 		},
 	}
 	dataSource, err := virtClient.CdiClient().CdiV1beta1().DataSources(util.NamespaceTestDefault).Create(context.Background(), dataSource, metav1.CreateOptions{})


### PR DESCRIPTION
This is a manual backport of PR https://github.com/kubevirt/kubevirt/pull/12764
NOTE On top of the backport Im adding another commit that was not introduced in the original PR since after the original PR merged a flake started to happen more frequently. I cherry-picked a commit that puts those tests in Quarantine as explained in PR: https://github.com/kubevirt/kubevirt/pull/12824

Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-47105

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: vmrestore create DVs before creation/update of restored VM
```

