### PR TITLE
volume-migration: append disk image for block replacement

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -908,7 +908,7 @@ func configureLocalDiskToMigrate(dom *libvirtxml.Domain, vmi *v1.VirtualMachineI
 		if _, ok := blockSrcFsDstVols[name]; ok {
 			log.Log.V(2).Infof("Replace block source with destination for volume %s", name)
 			dom.Devices.Disks[i].Source.File = &libvirtxml.DomainDiskSourceFile{
-				File: hostdisk.GetMountedHostDiskDir(name),
+				File: filepath.Join(hostdisk.GetMountedHostDiskDir(name), "disk.img"),
 			}
 			dom.Devices.Disks[i].Source.Block = nil
 		}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2931,7 +2931,7 @@ var _ = Describe("Manager helper functions", func() {
 		}
 
 		getFsImagePath := func(name string) string {
-			return hostdisk.GetMountedHostDiskDir(name)
+			return filepath.Join(hostdisk.GetMountedHostDiskDir(name), "disk.img")
 		}
 
 		getBlockPath := func(name string) string {

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -333,6 +333,46 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			waitForMigrationToSucceed(vm.Name, ns)
 		})
 
+		It("should migrate the source volume from a block source and filesystem destination DVs", func() {
+			volName := "disk0"
+			sc, exist := libstorage.GetRWOBlockStorageClass()
+			Expect(exist).To(BeTrue())
+			srcDV := libdv.NewDataVolume(
+				libdv.WithBlankImageSource(),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc),
+					libdv.PVCWithVolumeSize(size),
+					libdv.PVCWithVolumeMode(k8sv1.PersistentVolumeBlock),
+				),
+			)
+			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+				srcDV, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			sc, exist = libstorage.GetRWOFileSystemStorageClass()
+			Expect(exist).To(BeTrue())
+			destDV := libdv.NewDataVolume(
+				libdv.WithBlankImageSource(),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc),
+					libdv.PVCWithVolumeSize(size),
+					libdv.PVCWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
+				),
+			)
+			_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+				destDV, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			vm := createVMWithDV(srcDV, volName)
+			By("Update volumes")
+			updateVMWithDV(vm, volName, destDV.Name)
+			Eventually(func() bool {
+				vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
+					metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
+				return claim == destDV.Name
+			}, 120*time.Second, time.Second).Should(BeTrue())
+			waitForMigrationToSucceed(vm.Name, ns)
+		})
+
 		It("should migrate a PVC with a VM using a containerdisk", func() {
 			volName := "volume"
 			srcPVC := "src-" + rand.String(5)


### PR DESCRIPTION
During volume migration, when the volumes are migrated from a block PVC to a filesystem one, the replacement needs to take into account that for filesystem PVC, the path of the PVC is the directory plus the image name.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
During the replacement of block by filesystem, the path for the raw image was truncated

After this PR:
Fixes the image path by adding the `disk.img`

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/12823


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

