### PR TITLE
Refactor net/admitter/slirp/tests to use libvmi package

### DIFF
--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",


### PR DESCRIPTION
Signed-off-by: ronger4 <rgershbu@redhat.com>

### What this PR does
Before this PR:
Unit tests directly created and modified VM and VMI resources by manipulating their fields.
After this PR:
Unit tests have been refactored to use the libvmi package for creating and modifying VM and VMI resources, promoting readability and standardization.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Partially address: https://github.com/kubevirt/kubevirt/issues/12059

### Why we need it and why it was done in this way
Using the libvmi package simplifies the unit tests and makes them more readable.
This approach ensures a standard way of creating VM and VMI resources across tests.

The following tradeoffs were made:

- Direct manipulation of resources was replaced with utility functions, which may introduce minor overhead but enhances readability and maintainability.

The following alternatives were considered:


### Special notes for your reviewer
None

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

