### PR TITLE
refactor(virtctl/imageupload): remove init function

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -122,7 +122,9 @@ var (
 // HTTPClientCreator is a function that creates http clients
 type HTTPClientCreator func(bool) *http.Client
 
-var httpClientCreatorFunc HTTPClientCreator
+var defaultHTTPClientCreator = getHTTPClient
+
+var httpClientCreatorFunc HTTPClientCreator = defaultHTTPClientCreator
 
 type processingCompleteFunc func(kubernetes.Interface, string, string, time.Duration, time.Duration) error
 
@@ -137,11 +139,7 @@ func SetHTTPClientCreator(f HTTPClientCreator) {
 
 // SetDefaultHTTPClientCreator sets the http client creator back to default
 func SetDefaultHTTPClientCreator() {
-	httpClientCreatorFunc = getHTTPClient
-}
-
-func init() {
-	SetDefaultHTTPClientCreator()
+	httpClientCreatorFunc = defaultHTTPClientCreator
 }
 
 // NewImageUploadCommand returns a cobra.Command for handling the uploading of VM images


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Init function is redundant and replaced by variable.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```