### PR TITLE
VMRestore: fix possible miss update of dvname on vmrestore restores - fixes quarantine tests

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -442,6 +442,9 @@ func (t *vmRestoreTarget) Reconcile() (bool, error) {
 	if t.Exists() && hasLastRestoreAnnotation(t.vmRestore, t.vm) {
 		return false, nil
 	}
+	if updated, err := t.updateVMRestoreRestores(); updated || err != nil {
+		return updated, err
+	}
 
 	restoredVM, err := t.generateRestoredVMSpec()
 	if err != nil {
@@ -452,6 +455,56 @@ func (t *vmRestoreTarget) Reconcile() (bool, error) {
 	}
 
 	return t.reconcileSpec(restoredVM)
+}
+
+func (t *vmRestoreTarget) updateVMRestoreRestores() (bool, error) {
+
+	content, err := t.controller.getSnapshotContent(t.vmRestore)
+	if err != nil {
+		return false, err
+	}
+
+	snapshotVM := content.Spec.Source.VirtualMachine
+	if snapshotVM == nil {
+		return false, fmt.Errorf("unexpected snapshot source")
+	}
+	var restores = make([]snapshotv1.VolumeRestore, len(t.vmRestore.Status.Restores))
+	for i, t := range t.vmRestore.Status.Restores {
+		t.DeepCopyInto(&restores[i])
+	}
+	for k := range restores {
+		restore := &restores[k]
+		for _, volume := range snapshotVM.Spec.Template.Spec.Volumes {
+			if volume.Name != restore.VolumeName {
+				continue
+			}
+			if volume.DataVolume != nil {
+				templateIndex := findDVTemplateIndex(volume.DataVolume.Name, snapshotVM)
+				if templateIndex >= 0 {
+					dvName := restoreDVName(t.vmRestore, restore.VolumeName)
+					pvc, err := t.controller.getPVC(t.vmRestore.Namespace, restore.PersistentVolumeClaimName)
+					if err != nil {
+						return false, err
+					}
+
+					if pvc == nil {
+						return false, fmt.Errorf("pvc %s/%s does not exist and should", t.vmRestore.Namespace, restore.PersistentVolumeClaimName)
+					}
+
+					if err = t.updatePVCPopulatedForAnnotation(pvc, dvName); err != nil {
+						return false, err
+					}
+					restore.DataVolumeName = &dvName
+					break
+				}
+			}
+		}
+	}
+	if !equality.Semantic.DeepEqual(t.vmRestore.Status.Restores, restores) {
+		t.vmRestore.Status.Restores = restores
+		return true, nil
+	}
+	return false, nil
 }
 
 func (t *vmRestoreTarget) UpdateTarget(obj metav1.Object) {
@@ -481,19 +534,9 @@ func (t *vmRestoreTarget) generateRestoredVMSpec() (*kubevirtv1.VirtualMachine, 
 	for _, v := range snapshotVM.Spec.Template.Spec.Volumes {
 		nv := v.DeepCopy()
 		if nv.DataVolume != nil || nv.PersistentVolumeClaim != nil {
-			for k := range t.vmRestore.Status.Restores {
-				vr := &t.vmRestore.Status.Restores[k]
+			for _, vr := range t.vmRestore.Status.Restores {
 				if vr.VolumeName != nv.Name {
 					continue
-				}
-
-				pvc, err := t.controller.getPVC(t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
-				if err != nil {
-					return nil, err
-				}
-
-				if pvc == nil {
-					return nil, fmt.Errorf("pvc %s/%s does not exist and should", t.vmRestore.Namespace, vr.PersistentVolumeClaimName)
 				}
 
 				if nv.DataVolume == nil {
@@ -504,13 +547,7 @@ func (t *vmRestoreTarget) generateRestoredVMSpec() (*kubevirtv1.VirtualMachine, 
 				templateIndex := findDVTemplateIndex(v.DataVolume.Name, snapshotVM)
 				if templateIndex >= 0 {
 					if vr.DataVolumeName == nil {
-						dvName := restoreDVName(t.vmRestore, vr.VolumeName)
-						err = t.updatePVCPopulatedForAnnotation(pvc, dvName)
-						if err != nil {
-							return nil, err
-						}
-
-						vr.DataVolumeName = &dvName
+						return nil, fmt.Errorf("DataVolumeName for dv %s should have been updated already", v.DataVolume.Name)
 					}
 
 					dv := snapshotVM.Spec.DataVolumeTemplates[templateIndex].DeepCopy()
@@ -823,19 +860,6 @@ func (t *vmRestoreTarget) createDataVolume(restoredVM *kubevirtv1.VirtualMachine
 	if _, err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(restoredVM.Namespace).Create(context.Background(), newDataVolume, metav1.CreateOptions{}); err != nil {
 		t.controller.Recorder.Eventf(t.vm, corev1.EventTypeWarning, restoreDataVolumeCreateErrorEvent, "Error creating restore DataVolume %s: %v", newDataVolume.Name, err)
 		return false, fmt.Errorf("Failed to create restore DataVolume: %v", err)
-	}
-	// Update restore DataVolumeName
-	for _, v := range restoredVM.Spec.Template.Spec.Volumes {
-		if v.DataVolume == nil || v.DataVolume.Name != dvt.Name {
-			continue
-		}
-		for k := range t.vmRestore.Status.Restores {
-			vr := &t.vmRestore.Status.Restores[k]
-			if vr.VolumeName == v.Name {
-				vr.DataVolumeName = &dvt.Name
-				break
-			}
-		}
 	}
 
 	return true, nil

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -94,12 +94,22 @@ var _ = Describe("Restore controller", func() {
 		return r
 	}
 
+	addInitialVolumeRestores := func(r *snapshotv1.VirtualMachineRestore) {
+		r.Status.Restores = []snapshotv1.VolumeRestore{
+			{
+				VolumeName:                diskName,
+				PersistentVolumeClaimName: "restore-uid-disk1",
+				VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-disk1",
+			},
+		}
+	}
 	addVolumeRestores := func(r *snapshotv1.VirtualMachineRestore) {
 		r.Status.Restores = []snapshotv1.VolumeRestore{
 			{
 				VolumeName:                diskName,
 				PersistentVolumeClaimName: "restore-uid-disk1",
 				VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-disk1",
+				DataVolumeName:            pointer.P("restore-uid-disk1"),
 			},
 		}
 	}
@@ -457,9 +467,9 @@ var _ = Describe("Restore controller", func() {
 						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
 					},
 				}
+				addInitialVolumeRestores(rc)
 				vmSource.Add(vm)
 				expectUpdateVMRestoreInProgress(vm)
-				addVolumeRestores(rc)
 				expectVMRestoreUpdate(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
@@ -513,6 +523,81 @@ var _ = Describe("Restore controller", func() {
 				expectUpdateVMRestoreInProgress(vm)
 				expectPVCCreates(k8sClient, r, pvcSize)
 				addVirtualMachineRestore(r)
+				controller.processVMRestoreWorkItem()
+			})
+
+			It("should create pvcs for both datavolume and pvc restore volumes", func() {
+				r := createRestoreWithOwner()
+				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete: pointer.P(false),
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
+					},
+				}
+				addVolumeRestores(r)
+				r.Status.Restores = append(r.Status.Restores, snapshotv1.VolumeRestore{
+					VolumeName:                "disk2",
+					PersistentVolumeClaimName: "restore-uid-disk2",
+					VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-disk2",
+				})
+
+				vm := createModifiedVM()
+				// create extra pvc
+				pvcs := createPVCsForVM(vm)
+				pvcs = append(pvcs, corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: vm.Namespace,
+						Name:      "extra-pvc",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("2Gi"),
+							},
+						},
+						VolumeName:       "volume2",
+						StorageClassName: &storageClass.Name,
+					},
+				})
+				//add pvc volume and disk to vm
+				disk := kubevirtv1.Disk{
+					Name: "disk2",
+					DiskDevice: kubevirtv1.DiskDevice{
+						Disk: &kubevirtv1.DiskTarget{
+							Bus: kubevirtv1.DiskBusVirtio,
+						},
+					},
+				}
+				volume := kubevirtv1.Volume{
+					Name: "disk2",
+					VolumeSource: kubevirtv1.VolumeSource{
+						PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "extra-pvc"}},
+					},
+				}
+				vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, disk)
+				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, volume)
+				// delete previous vmsnapshotcontent
+				vmSnapshotContentSource.Delete(sc)
+				// create ct vmSnapshotContent with the relevant info
+				sc = createVirtualMachineSnapshotContent(s, vm, pvcs)
+				sc.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					CreationTime: timeFunc(),
+					ReadyToUse:   pointer.P(true),
+				}
+				vmSnapshotContentSource.Add(sc)
+				pvcSize := resource.MustParse("2Gi")
+				vs1 := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, pvcSize)
+				vs2 := createVolumeSnapshot(r.Status.Restores[1].VolumeSnapshotName, pvcSize)
+				fakeVolumeSnapshotProvider.Add(vs1)
+				fakeVolumeSnapshotProvider.Add(vs2)
+
+				vmSource.Add(vm)
+				addVirtualMachineRestore(r)
+
+				expectUpdateVMRestoreInProgress(vm)
+				expectPVCCreates(k8sClient, r, pvcSize)
 				controller.processVMRestoreWorkItem()
 			})
 
@@ -583,7 +668,7 @@ var _ = Describe("Restore controller", func() {
 				controller.processVMRestoreWorkItem()
 			})
 
-			It("should update restore status with datavolume", func() {
+			It("should wait for target to be ready", func() {
 				r := createRestoreWithOwner()
 				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
 					Complete: pointer.P(false),
@@ -645,6 +730,90 @@ var _ = Describe("Restore controller", func() {
 					pvc.Status.Phase = corev1.ClaimBound
 					addPVC(&pvc)
 				}
+				controller.processVMRestoreWorkItem()
+			})
+
+			It("should update correctly restore VolumeRestores with multiple volumes and update relevant PVCs", func() {
+				vm := createModifiedVM()
+				vm.Status.RestoreInProgress = &vmRestoreName
+				// create extra pvc
+				pvcs := createPVCsForVM(vm)
+				pvcs = append(pvcs, corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: vm.Namespace,
+						Name:      "extra-pvc",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName:       "volume2",
+						StorageClassName: &storageClass.Name,
+					},
+				})
+				//add pvc volume and disk to vm
+				disk := kubevirtv1.Disk{
+					Name: "disk2",
+					DiskDevice: kubevirtv1.DiskDevice{
+						Disk: &kubevirtv1.DiskTarget{
+							Bus: kubevirtv1.DiskBusVirtio,
+						},
+					},
+				}
+				volume := kubevirtv1.Volume{
+					Name: "disk2",
+					VolumeSource: kubevirtv1.VolumeSource{
+						PersistentVolumeClaim: &kubevirtv1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "extra-pvc"}},
+					},
+				}
+				vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, disk)
+				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, volume)
+				// delete previous vmsnapshotcontent
+				vmSnapshotContentSource.Delete(sc)
+				// create ct vmSnapshotContent with the relevant info
+				sc = createVirtualMachineSnapshotContent(s, vm, pvcs)
+				sc.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					CreationTime: timeFunc(),
+					ReadyToUse:   pointer.P(true),
+				}
+				vmSnapshotContentSource.Add(sc)
+
+				r := createRestoreWithOwner()
+				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete: pointer.P(false),
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
+					},
+				}
+				// note here we dont add the datavolumename
+				addInitialVolumeRestores(r)
+				r.Status.Restores = append(r.Status.Restores, snapshotv1.VolumeRestore{
+					VolumeName:                "disk2",
+					PersistentVolumeClaimName: "restore-uid-disk2",
+					VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-disk2",
+				})
+				for _, pvc := range getRestorePVCs(r) {
+					pvc.Status.Phase = corev1.ClaimBound
+					pvcSource.Add(&pvc)
+				}
+
+				rc := r.DeepCopy()
+				rc.ResourceVersion = "1"
+				rc.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionTrue, "Updating target spec"),
+					newReadyCondition(corev1.ConditionFalse, "Waiting for target update"),
+				}
+				addVolumeRestores(rc)
+				// note here we dont expect the datavolumename
+				rc.Status.Restores = append(rc.Status.Restores, snapshotv1.VolumeRestore{
+					VolumeName:                "disk2",
+					PersistentVolumeClaimName: "restore-uid-disk2",
+					VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-disk2",
+				})
+				vmSource.Add(vm)
+				addVirtualMachineRestore(r)
+
+				expectPVCUpdates(k8sClient, rc)
+				expectVMRestoreUpdate(kubevirtClient, rc)
 				controller.processVMRestoreWorkItem()
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

This miss of update was spotted in recent tests flakes, where we saw this variable missing in the test, while everything else works fine.
Looking into how this can happen I noticed the update of this variable in problematic places that with possible failure of the vmrestore status then we might not ever get to update it later.
Moving the update to before we generate the restored vm, making sure we have a dedicated function that makes sure this update is not missed. Added UT to make sure this is happening and we have the flaky tests for verification of this fix.

Those tests were quarantined in this PR: [https://github.com/kubevirt/kubevirt/pull/12824](https://github.com/kubevirt/kubevirt/pull/12824)
This changes should fix the flakes. Will remove the quarantine decorator after we will see in the periodic this tests pass for a while.

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: fix possible miss update of datavolumename on vmrestore restores
```

