### PR TITLE
volume-migration: avoid to start a vm on failed migration

### DIFF
--- a/pkg/libvmi/status/status.go
+++ b/pkg/libvmi/status/status.go
@@ -133,3 +133,35 @@ func WithInterfaceStatus(interfaceStatus v1.VirtualMachineInstanceNetworkInterfa
 		vmiStatus.Interfaces = append(vmiStatus.Interfaces, interfaceStatus)
 	}
 }
+
+type VMOption func(vmiStatus *v1.VirtualMachineStatus)
+
+// WithStatus sets the status with specified value
+func WithVMStatus(status v1.VirtualMachineStatus) libvmi.VMOption {
+	return func(vm *v1.VirtualMachine) {
+		vm.Status = status
+	}
+}
+
+// New instantiates a new VM status configuration,
+// building its properties based on the specified With* options.
+func NewVMStatus(opts ...VMOption) v1.VirtualMachineStatus {
+	vmStatus := &v1.VirtualMachineStatus{}
+	for _, f := range opts {
+		f(vmStatus)
+	}
+
+	return *vmStatus
+}
+
+func WithVMVolumeUpdateState(volumeUpdateState *v1.VolumeUpdateState) VMOption {
+	return func(vmStatus *v1.VirtualMachineStatus) {
+		vmStatus.VolumeUpdateState = volumeUpdateState
+	}
+}
+
+func WithVMCondition(cond v1.VirtualMachineCondition) VMOption {
+	return func(vmStatus *v1.VirtualMachineStatus) {
+		vmStatus.Conditions = append(vmStatus.Conditions, cond)
+	}
+}

--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -74,7 +74,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/types:go_default_library",

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -58,6 +58,8 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/status:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Possible to start a VM after a failed volume migration with an inconsistent volume set. In this case, the VM could be started from an unbootable disk

After this PR:
Avoid to start a VM if the ManualRecoveryRequiered is set.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

