### PR TITLE
bazel-images: Split image targets per architecture

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -200,6 +200,8 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)example-cloudinit-hook-sidecar:$(container_tag)": "//cmd/sidecars/cloudinit:example-cloudinit-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)network-slirp-binding:$(container_tag)": "//cmd/sidecars/network-slirp-binding:network-slirp-binding-image",
         "$(container_prefix)/$(image_prefix)network-passt-binding:$(container_tag)": "//cmd/sidecars/network-passt-binding:network-passt-binding-image",
+        "$(container_prefix)/$(image_prefix)libguestfs-tools:$(container_tag)": "//cmd/libguestfs:libguestfs-tools-image",
+        "$(container_prefix)/$(image_prefix)pr-helper:$(container_tag)": "//cmd/pr-helper:pr-helper",
         # container-disk images
         "$(container_prefix)/$(image_prefix)alpine-container-disk-demo:$(container_tag)": "//containerimages:alpine-container-disk-image",
         "$(container_prefix)/$(image_prefix)cirros-container-disk-demo:$(container_tag)": "//containerimages:cirros-container-disk-image",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -190,11 +190,25 @@ config_setting(
     values = {"define": "release=true"},
 )
 
-container_bundle(
-    name = "build-other-images",
-    images = {
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+
+build_other_images_default = {
+    # cmd images
+    "$(container_prefix)/$(image_prefix)sidecar-shim:$(container_tag)": "//cmd/sidecars:sidecar-shim-image",
+    # container-disk images
+    "$(container_prefix)/$(image_prefix)alpine-container-disk-demo:$(container_tag)": "//containerimages:alpine-container-disk-image",
+    # Kernel boot container
+    # -
+    # Customized container-disk images
+    "$(container_prefix)/$(image_prefix)fedora-with-test-tooling-container-disk:$(container_tag)": "//containerimages:fedora-with-test-tooling",
+    # testing images
+    "$(container_prefix)/$(image_prefix)vm-killer:$(container_tag)": "//images/vm-killer:vm-killer-image",
+}
+
+build_other_images_aarch64_x86_64 = dicts.add(
+    build_other_images_default,
+    {
         # cmd images
-        "$(container_prefix)/$(image_prefix)sidecar-shim:$(container_tag)": "//cmd/sidecars:sidecar-shim-image",
         "$(container_prefix)/$(image_prefix)example-hook-sidecar:$(container_tag)": "//cmd/sidecars/smbios:example-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)example-disk-mutation-hook-sidecar:$(container_tag)": "//cmd/sidecars/disk-mutation:example-disk-mutation-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)example-cloudinit-hook-sidecar:$(container_tag)": "//cmd/sidecars/cloudinit:example-cloudinit-hook-sidecar-image",
@@ -203,22 +217,34 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)libguestfs-tools:$(container_tag)": "//cmd/libguestfs:libguestfs-tools-image",
         "$(container_prefix)/$(image_prefix)pr-helper:$(container_tag)": "//cmd/pr-helper:pr-helper",
         # container-disk images
-        "$(container_prefix)/$(image_prefix)alpine-container-disk-demo:$(container_tag)": "//containerimages:alpine-container-disk-image",
         "$(container_prefix)/$(image_prefix)cirros-container-disk-demo:$(container_tag)": "//containerimages:cirros-container-disk-image",
         "$(container_prefix)/$(image_prefix)cirros-custom-container-disk-demo:$(container_tag)": "//containerimages:cirros-custom-container-disk-image",
         "$(container_prefix)/$(image_prefix)virtio-container-disk:$(container_tag)": "//containerimages:virtio-container-disk-image",
         # Kernel boot container
         "$(container_prefix)/$(image_prefix)alpine-ext-kernel-boot-demo:$(container_tag)": "//containerimages:alpine-ext-kernel-boot-demo-container",
         # Customized container-disk images
-        "$(container_prefix)/$(image_prefix)fedora-with-test-tooling-container-disk:$(container_tag)": "//containerimages:fedora-with-test-tooling",
         "$(container_prefix)/$(image_prefix)alpine-with-test-tooling-container-disk:$(container_tag)": "//containerimages:alpine-with-test-tooling",
         "$(container_prefix)/$(image_prefix)fedora-realtime-container-disk:$(container_tag)": "//containerimages:fedora-realtime",
         # testing images
         "$(container_prefix)/$(image_prefix)disks-images-provider:$(container_tag)": "//images/disks-images-provider:disks-images-provider-image",
         "$(container_prefix)/$(image_prefix)nfs-server:$(container_tag)": "//images/nfs-server:nfs-server-image",
-        "$(container_prefix)/$(image_prefix)vm-killer:$(container_tag)": "//images/vm-killer:vm-killer-image",
         "$(container_prefix)/$(image_prefix)winrmcli:$(container_tag)": "//images/winrmcli:winrmcli-image",
     },
+)
+
+container_bundle(
+    name = "build-other-images_s390x",
+    images = build_other_images_default,
+)
+
+container_bundle(
+    name = "build-other-images_aarch64",
+    images = build_other_images_aarch64_x86_64,
+)
+
+container_bundle(
+    name = "build-other-images_x86_64",
+    images = build_other_images_aarch64_x86_64,
 )
 
 # This is for generating a bundle of the core components for external processing

--- a/cmd/sidecars/BUILD.bazel
+++ b/cmd/sidecars/BUILD.bazel
@@ -43,6 +43,9 @@ container_image(
     entrypoint = ["/sidecar-shim"],
     files = [":sidecar-shim"],
     tars = select({
+        "@io_bazel_rules_go//go/platform:linux_s390x": [
+            "//rpm:sidecar-shim_s390x",
+        ],
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             "//rpm:sidecar-shim_aarch64",
         ],

--- a/containerimages/container-disk-images.md
+++ b/containerimages/container-disk-images.md
@@ -99,10 +99,10 @@ container_image(
 )
 ```
 
-Then add new line for the container_bundle rule at the pojects`BUILD.bazel` file
+Then add new line for the container_bundle rules for each architecture at the pojects`BUILD.bazel` file
 ```bash
 container_bundle(
-    name = "build-other-images",
+    name = "build-other-images_<arch>",
     images = {
         ...
         "$(container_prefix)/$(image_prefix)fedora-sriov-lane-container-disk:$(container_tag)": "//containerimages:fedora-extended-container-disk-image",

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -31,7 +31,7 @@ bazel build \
     --define image_prefix= \
     --define container_tag= \
     //:build-other-images //cmd/virt-operator:virt-operator-image //cmd/virt-api:virt-api-image \
-    //cmd/virt-controller:virt-controller-image //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image //cmd/libguestfs:libguestfs-tools-image //cmd/pr-helper:pr-helper //tests:conformance_image
+    //cmd/virt-controller:virt-controller-image //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image //tests:conformance_image
 
 rm -rf ${DIGESTS_DIR}/${ARCHITECTURE}
 mkdir -p ${DIGESTS_DIR}/${ARCHITECTURE}

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -25,13 +25,33 @@ source hack/config.sh
 
 # vars are uninteresting for the build step, they are interesting for the push step only
 
+case ${ARCHITECTURE} in
+"s390x" | "crossbuild-s390x")
+    other_images="
+        //:build-other-images_s390x
+    "
+    ;;
+"aarch64" | "crossbuild-aarch64")
+    other_images="
+        //:build-other-images_aarch64
+        //tests:conformance_image
+    "
+    ;;
+*)
+    other_images="
+        //:build-other-images_x86_64
+        //tests:conformance_image
+    "
+    ;;
+esac
+
 bazel build \
     --config=${ARCHITECTURE} \
     --define container_prefix= \
     --define image_prefix= \
     --define container_tag= \
-    //:build-other-images //cmd/virt-operator:virt-operator-image //cmd/virt-api:virt-api-image \
-    //cmd/virt-controller:virt-controller-image //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image //tests:conformance_image
+    //cmd/virt-operator:virt-operator-image //cmd/virt-api:virt-api-image //cmd/virt-controller:virt-controller-image \
+    //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image ${other_images[@]}
 
 rm -rf ${DIGESTS_DIR}/${ARCHITECTURE}
 mkdir -p ${DIGESTS_DIR}/${ARCHITECTURE}

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -29,30 +29,38 @@ default_targets="
     virt-controller
     virt-handler
     virt-launcher
-    virt-exportserver
-    virt-exportproxy
-    conformance
-    libguestfs-tools
-    pr-helper
-    example-hook-sidecar
-    example-disk-mutation-hook-sidecar
-    example-cloudinit-hook-sidecar
     alpine-container-disk-demo
-    cirros-container-disk-demo
-    cirros-custom-container-disk-demo
-    virtio-container-disk
-    alpine-ext-kernel-boot-demo
     fedora-with-test-tooling-container-disk
-    alpine-with-test-tooling-container-disk
-    fedora-realtime-container-disk
-    disks-images-provider
-    nfs-server
     vm-killer
-    winrmcli
     sidecar-shim
-    network-slirp-binding
-    network-passt-binding
 "
+
+case ${ARCHITECTURE} in
+"s390x" | "crossbuild-s390x") ;;
+*)
+    default_targets+="
+        virt-exportserver
+        virt-exportproxy
+        conformance
+        libguestfs-tools
+        pr-helper
+        example-hook-sidecar
+        example-disk-mutation-hook-sidecar
+        example-cloudinit-hook-sidecar
+        cirros-container-disk-demo
+        cirros-custom-container-disk-demo
+        virtio-container-disk
+        alpine-ext-kernel-boot-demo
+        alpine-with-test-tooling-container-disk
+        fedora-realtime-container-disk
+        disks-images-provider
+        nfs-server
+        winrmcli
+        network-slirp-binding
+        network-passt-binding
+    "
+    ;;
+esac
 
 PUSH_TARGETS=(${PUSH_TARGETS:-${default_targets}})
 

--- a/hack/push-container-manifest.sh
+++ b/hack/push-container-manifest.sh
@@ -34,6 +34,9 @@ function podman_push_manifest() {
     ${KUBEVIRT_CRI} manifest create ${DOCKER_PREFIX}/${image}:${DOCKER_TAG}
     for ARCH in ${BUILD_ARCH//,/ }; do
         FORMATED_ARCH=$(format_archname ${ARCH})
+        if [ ! -f ${DIGESTS_DIR}/${FORMATED_ARCH}/bazel-bin/push-$image.digest ]; then
+            continue
+        fi
         digest=$(cat ${DIGESTS_DIR}/${FORMATED_ARCH}/bazel-bin/push-$image.digest)
         ${KUBEVIRT_CRI} manifest add ${DOCKER_PREFIX}/${image}:${DOCKER_TAG} ${DOCKER_PREFIX}/${image}@${digest}
     done
@@ -45,6 +48,9 @@ function docker_push_manifest() {
     MANIFEST_IMAGES=""
     for ARCH in ${BUILD_ARCH//,/ }; do
         FORMATED_ARCH=$(format_archname ${ARCH})
+        if [ ! -f ${DIGESTS_DIR}/${FORMATED_ARCH}/bazel-bin/push-$image.digest ]; then
+            continue
+        fi
         digest=$(cat ${DIGESTS_DIR}/${FORMATED_ARCH}/bazel-bin/push-$image.digest)
         MANIFEST_IMAGES="${MANIFEST_IMAGES} --amend ${DOCKER_PREFIX}/${image}@${digest}"
     done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Images not implemented by an architecture would result in broken "amd64" images, where the binary is the target arch, but the base image is amd64, even though the image should not have been built for the target-arch in the first place.
After this PR:
We only build image for an architecture if it is enabled.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12843

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Testing the PR requires to delete the kubevirt volume containing the bazel cache, as otherwise old images might be pulled into the manifest instead. Please run:
```
podman volume rm kubevirt
```
before testing.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed additional broken amd64 image in some image manifests
```

