### PR TITLE
[release 1.3] bugfix: In case of err in vmrestore, leave VM without RestoreInProgress annotation allowing it to be started

### DIFF
--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -46,6 +46,13 @@ function remove_finalizers() {
         patch_remove_finalizers -n $ns vmsnapshots $name
     done
 
+    _kubectl get vmrestores --all-namespaces -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,FINALIZERS:.metadata.finalizers --no-headers | grep vmrestore-protection | while read p; do
+        local arr=($p)
+        local name="${arr[0]}"
+        local ns="${arr[1]}"
+        patch_remove_finalizers -n $ns vmrestores $name
+    done
+
     _kubectl get vmsnapshotcontents --all-namespaces -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,FINALIZERS:.metadata.finalizers --no-headers | grep vmsnapshotcontent-protection | while read p; do
         local arr=($p)
         local name="${arr[0]}"

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -49,6 +49,8 @@ import (
 const (
 	RestoreNameAnnotation = "restore.kubevirt.io/name"
 
+	vmRestoreFinalizer = "snapshot.kubevirt.io/vmrestore-protection"
+
 	populatedForPVCAnnotation = "cdi.kubevirt.io/storage.populatedFor"
 
 	lastRestoreAnnotation = "restore.kubevirt.io/lastRestoreUID"
@@ -71,6 +73,7 @@ type restoreTarget interface {
 	UpdateDoneRestore() (bool, error)
 	UpdateRestoreInProgress() error
 	UpdateTarget(obj metav1.Object)
+	DoesTargetVMExist() bool
 }
 
 type vmRestoreTarget struct {
@@ -100,13 +103,13 @@ func VmRestoreProgressing(vmRestore *snapshotv1.VirtualMachineRestore) bool {
 	return vmRestore.Status == nil || vmRestore.Status.Complete == nil || !*vmRestore.Status.Complete
 }
 
+func vmRestoreDeleting(vmRestore *snapshotv1.VirtualMachineRestore) bool {
+	return vmRestore != nil && vmRestore.DeletionTimestamp != nil
+}
+
 func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.VirtualMachineRestore) (time.Duration, error) {
 	logger := log.Log.Object(vmRestoreIn)
 	logger.V(1).Infof("Updating VirtualMachineRestore")
-
-	if !VmRestoreProgressing(vmRestoreIn) {
-		return 0, nil
-	}
 
 	vmRestoreOut := vmRestoreIn.DeepCopy()
 	if vmRestoreOut.Status == nil {
@@ -122,11 +125,19 @@ func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.Virtual
 		return 0, ctrl.doUpdateError(vmRestoreOut, err)
 	}
 
+	if vmRestoreDeleting(vmRestoreOut) {
+		return 0, ctrl.handleVMRestoreDeletion(vmRestoreOut, target)
+	}
+	if !VmRestoreProgressing(vmRestoreOut) {
+		return 0, nil
+	}
+
 	if len(vmRestoreOut.OwnerReferences) == 0 {
 		target.Own(vmRestoreOut)
 		updateRestoreCondition(vmRestoreOut, newProgressingCondition(corev1.ConditionTrue, "Initializing VirtualMachineRestore"))
 		updateRestoreCondition(vmRestoreOut, newReadyCondition(corev1.ConditionFalse, "Initializing VirtualMachineRestore"))
 	}
+	controller.AddFinalizer(vmRestoreOut, vmRestoreFinalizer)
 
 	err = target.UpdateRestoreInProgress()
 	if err != nil {
@@ -236,6 +247,33 @@ func (ctrl *VMRestoreController) doUpdate(original, updated *snapshotv1.VirtualM
 	return nil
 }
 
+func (ctrl *VMRestoreController) handleVMRestoreDeletion(vmRestore *snapshotv1.VirtualMachineRestore, target restoreTarget) error {
+	logger := log.Log.Object(vmRestore)
+	logger.V(3).Infof("Deleting VirtualMachineRestore")
+
+	if !controller.HasFinalizer(vmRestore, vmRestoreFinalizer) {
+		return nil
+	}
+
+	vmRestoreCpy := vmRestore.DeepCopy()
+	updateRestoreCondition(vmRestoreCpy, newProgressingCondition(corev1.ConditionFalse, "VM restore is deleting"))
+	updateRestoreCondition(vmRestoreCpy, newReadyCondition(corev1.ConditionFalse, "VM restore is deleting"))
+
+	if target.DoesTargetVMExist() {
+		updated, err := target.UpdateDoneRestore()
+		if err != nil {
+			logger.Reason(err).Error("Error updating done restore")
+			return ctrl.doUpdateError(vmRestoreCpy, err)
+		}
+		if updated {
+			return ctrl.doUpdate(vmRestore, vmRestoreCpy)
+		}
+	}
+
+	controller.RemoveFinalizer(vmRestoreCpy, vmRestoreFinalizer)
+	return ctrl.doUpdate(vmRestore, vmRestoreCpy)
+}
+
 func (ctrl *VMRestoreController) reconcileVolumeRestores(vmRestore *snapshotv1.VirtualMachineRestore, target restoreTarget) (bool, error) {
 	content, err := ctrl.getSnapshotContent(vmRestore)
 	if err != nil {
@@ -335,6 +373,10 @@ func (ctrl *VMRestoreController) getBindingMode(pvc *corev1.PersistentVolumeClai
 }
 
 func (t *vmRestoreTarget) UpdateDoneRestore() (bool, error) {
+	if !t.DoesTargetVMExist() {
+		return false, fmt.Errorf("At this point target should exist")
+	}
+
 	if t.vm.Status.RestoreInProgress == nil || *t.vm.Status.RestoreInProgress != t.vmRestore.Name {
 		return false, nil
 	}
@@ -348,7 +390,7 @@ func (t *vmRestoreTarget) UpdateDoneRestore() (bool, error) {
 }
 
 func (t *vmRestoreTarget) UpdateRestoreInProgress() error {
-	if !t.doesTargetVMExist() || hasLastRestoreAnnotation(t.vmRestore, t.vm) {
+	if !t.DoesTargetVMExist() || hasLastRestoreAnnotation(t.vmRestore, t.vm) {
 		return nil
 	}
 
@@ -370,7 +412,7 @@ func (t *vmRestoreTarget) UpdateRestoreInProgress() error {
 }
 
 func (t *vmRestoreTarget) Ready() (bool, error) {
-	if !t.doesTargetVMExist() {
+	if !t.DoesTargetVMExist() {
 		return true, nil
 	}
 
@@ -399,7 +441,7 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 }
 
 func (t *vmRestoreTarget) Reconcile() (bool, error) {
-	if t.doesTargetVMExist() && hasLastRestoreAnnotation(t.vmRestore, t.vm) {
+	if t.DoesTargetVMExist() && hasLastRestoreAnnotation(t.vmRestore, t.vm) {
 		return false, nil
 	}
 
@@ -500,7 +542,7 @@ func (t *vmRestoreTarget) generateRestoredVMSpec() (*kubevirtv1.VirtualMachine, 
 	}
 
 	var newVM *kubevirtv1.VirtualMachine
-	if !t.doesTargetVMExist() {
+	if !t.DoesTargetVMExist() {
 		newVM = &kubevirtv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        t.vmRestore.Spec.Target.Name,
@@ -540,7 +582,7 @@ func (t *vmRestoreTarget) reconcileSpec(restoredVM *kubevirtv1.VirtualMachine) (
 		return false, err
 	}
 
-	if !t.doesTargetVMExist() {
+	if !t.DoesTargetVMExist() {
 		restoredVM, err = patchVM(restoredVM, t.vmRestore.Spec.Patches)
 		if err != nil {
 			return false, fmt.Errorf("error patching VM %s: %v", restoredVM.Name, err)
@@ -552,6 +594,7 @@ func (t *vmRestoreTarget) reconcileSpec(restoredVM *kubevirtv1.VirtualMachine) (
 	if err != nil {
 		return false, err
 	}
+
 	t.UpdateTarget(restoredVM)
 
 	if err = t.claimInstancetypeControllerRevisionsOwnership(t.vm); err != nil {
@@ -630,7 +673,7 @@ func (t *vmRestoreTarget) reconcileDataVolumes(restoredVM *kubevirtv1.VirtualMac
 		createdDV = createdDV || created
 	}
 
-	if t.doesTargetVMExist() {
+	if t.DoesTargetVMExist() {
 		deletedDataVolumes := findDatavolumesForDeletion(t.vm.Spec.DataVolumeTemplates, restoredVM.Spec.DataVolumeTemplates)
 		if !equality.Semantic.DeepEqual(t.vmRestore.Status.DeletedDataVolumes, deletedDataVolumes) {
 			t.vmRestore.Status.DeletedDataVolumes = deletedDataVolumes
@@ -670,7 +713,7 @@ func (t *vmRestoreTarget) restoreInstancetypeControllerRevision(vmSnapshotRevisi
 	// If the target VirtualMachine already exists it's likely that the original ControllerRevision is already present.
 	// Check that here by attempting to lookup the CR using the generated restoredCRName.
 	// Ignore any NotFound errors raised allowing the CR to be restored below.
-	if t.doesTargetVMExist() {
+	if t.DoesTargetVMExist() {
 		existingCR, err := t.getControllerRevision(vm.Namespace, restoredCRName)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, err
@@ -801,7 +844,7 @@ func (t *vmRestoreTarget) createDataVolume(restoredVM *kubevirtv1.VirtualMachine
 }
 
 func (t *vmRestoreTarget) Own(obj metav1.Object) {
-	if !t.doesTargetVMExist() {
+	if !t.DoesTargetVMExist() {
 		return
 	}
 
@@ -838,7 +881,7 @@ func (ctrl *VMRestoreController) deleteObsoleteDataVolumes(vmRestore *snapshotv1
 	return nil
 }
 
-func (t *vmRestoreTarget) doesTargetVMExist() bool {
+func (t *vmRestoreTarget) DoesTargetVMExist() bool {
 	return t.vm != nil
 }
 

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -67,7 +67,6 @@ const (
 type restoreTarget interface {
 	Ready() (bool, error)
 	Reconcile() (bool, error)
-	Cleanup() error
 	Own(obj metav1.Object)
 	UpdateDoneRestore() (bool, error)
 	UpdateRestoreInProgress() error
@@ -174,7 +173,7 @@ func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.Virtual
 		return 0, ctrl.doUpdate(vmRestoreIn, vmRestoreOut)
 	}
 
-	if err = target.Cleanup(); err != nil {
+	if err = ctrl.deleteObsoleteDataVolumes(vmRestoreOut); err != nil {
 		logger.Reason(err).Error("Error cleaning up")
 		return 0, ctrl.doUpdateError(vmRestoreIn, err)
 	}
@@ -819,16 +818,16 @@ func (t *vmRestoreTarget) Own(obj metav1.Object) {
 	})
 }
 
-func (t *vmRestoreTarget) Cleanup() error {
-	for _, dvName := range t.vmRestore.Status.DeletedDataVolumes {
-		objKey := cacheKeyFunc(t.vmRestore.Namespace, dvName)
-		_, exists, err := t.controller.DataVolumeInformer.GetStore().GetByKey(objKey)
+func (ctrl *VMRestoreController) deleteObsoleteDataVolumes(vmRestore *snapshotv1.VirtualMachineRestore) error {
+	for _, dvName := range vmRestore.Status.DeletedDataVolumes {
+		objKey := cacheKeyFunc(vmRestore.Namespace, dvName)
+		_, exists, err := ctrl.DataVolumeInformer.GetStore().GetByKey(objKey)
 		if err != nil {
 			return err
 		}
 
 		if exists {
-			err = t.controller.Client.CdiClient().CdiV1beta1().DataVolumes(t.vmRestore.Namespace).
+			err = ctrl.Client.CdiClient().CdiV1beta1().DataVolumes(vmRestore.Namespace).
 				Delete(context.Background(), dvName, metav1.DeleteOptions{})
 			if err != nil {
 				return err

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -139,14 +139,14 @@ func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.Virtual
 	}
 	controller.AddFinalizer(vmRestoreOut, vmRestoreFinalizer)
 
-	err = target.UpdateRestoreInProgress()
-	if err != nil {
-		return 0, err
-	}
-
 	// let's make sure everything is initialized properly before continuing
 	if !equality.Semantic.DeepEqual(vmRestoreIn, vmRestoreOut) {
 		return 0, ctrl.doUpdate(vmRestoreIn, vmRestoreOut)
+	}
+
+	err = target.UpdateRestoreInProgress()
+	if err != nil {
+		return 0, err
 	}
 
 	updated, err := ctrl.reconcileVolumeRestores(vmRestoreOut, target)

--- a/pkg/storage/snapshot/restore_base.go
+++ b/pkg/storage/snapshot/restore_base.go
@@ -72,6 +72,7 @@ func (ctrl *VMRestoreController) Init() error {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    ctrl.handleVMRestore,
 			UpdateFunc: func(oldObj, newObj interface{}) { ctrl.handleVMRestore(newObj) },
+			DeleteFunc: ctrl.handleVMRestore,
 		},
 	)
 

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -765,6 +765,101 @@ var _ = Describe("Restore controller", func() {
 				testutils.ExpectEvent(recorder, "VirtualMachineRestoreComplete")
 			})
 
+			It("should remove finalizer if restore deleted after completion", func() {
+				r := createRestoreWithOwner()
+				r.DeletionTimestamp = timeFunc()
+				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete:           pointer.P(true),
+					DeletedDataVolumes: getDeletedDataVolumes(createModifiedVM()),
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
+						newReadyCondition(corev1.ConditionTrue, "Operation complete"),
+					},
+					RestoreTime: timeFunc(),
+				}
+
+				vm := createModifiedVM()
+				vm.Annotations = map[string]string{"restore.kubevirt.io/lastRestoreUID": "restore-uid"}
+
+				vmRestoreSource.Add(r)
+				addVM(vm)
+
+				updatedVMRestore := r.DeepCopy()
+				updatedVMRestore.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionFalse, "VM restore is deleting"),
+					newReadyCondition(corev1.ConditionFalse, "VM restore is deleting"),
+				}
+				updatedVMRestore.ResourceVersion = "1"
+				updatedVMRestore.Finalizers = []string{}
+
+				expectVMRestoreUpdate(kubevirtClient, updatedVMRestore)
+				controller.processVMRestoreWorkItem()
+			})
+
+			It("should clean existing vm before removing restore finalizer if restore deleted before completeion", func() {
+				r := createRestoreWithOwner()
+				r.DeletionTimestamp = timeFunc()
+				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete: pointer.P(false),
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Updating target status"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for target update"),
+					},
+				}
+
+				vm := createModifiedVM()
+				vm.Status.RestoreInProgress = &vmRestoreName
+
+				vmRestoreSource.Add(r)
+				addVM(vm)
+
+				vmUpdated := vm.DeepCopy()
+				vmUpdated.Status.RestoreInProgress = nil
+				vmInterface.EXPECT().UpdateStatus(context.Background(), vmUpdated, metav1.UpdateOptions{}).Return(vmUpdated, nil)
+
+				updatedVMRestore := r.DeepCopy()
+				updatedVMRestore.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionFalse, "VM restore is deleting"),
+					newReadyCondition(corev1.ConditionFalse, "VM restore is deleting"),
+				}
+				updatedVMRestore.ResourceVersion = "1"
+				//note that we didnt remove the finalizer here
+
+				expectVMRestoreUpdate(kubevirtClient, updatedVMRestore)
+
+				controller.processVMRestoreWorkItem()
+			})
+
+			It("should remove restore finalizer if deleted only if cleaned vm", func() {
+				r := createRestoreWithOwner()
+				r.DeletionTimestamp = timeFunc()
+				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete:           pointer.P(false),
+					DeletedDataVolumes: getDeletedDataVolumes(createModifiedVM()),
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Updating target status"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for target update"),
+					},
+				}
+
+				vm := createModifiedVM()
+				// note vm doesnt have restoreInProgress annotation
+
+				vmRestoreSource.Add(r)
+				addVM(vm)
+
+				updatedVMRestore := r.DeepCopy()
+				updatedVMRestore.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionFalse, "VM restore is deleting"),
+					newReadyCondition(corev1.ConditionFalse, "VM restore is deleting"),
+				}
+				updatedVMRestore.ResourceVersion = "1"
+				updatedVMRestore.Finalizers = []string{}
+
+				expectVMRestoreUpdate(kubevirtClient, updatedVMRestore)
+				controller.processVMRestoreWorkItem()
+			})
+
 			Context("target Reconcile", func() {
 				var (
 					r        *snapshotv1.VirtualMachineRestore
@@ -1002,6 +1097,30 @@ var _ = Describe("Restore controller", func() {
 
 				})
 
+				It("should remove restore finalizer if deleted and failed to restore", func() {
+					// This VM will never be created
+					newVM := createVirtualMachine(testNamespace, "new-test-vm")
+					newVM.UID = ""
+
+					By("Creating VM restore")
+					vmRestore := createRestoreWithOwner()
+					vmRestore.Spec.Target.Name = newVM.Name
+					vmRestore.DeletionTimestamp = timeFunc()
+					addVolumeRestores(vmRestore)
+
+					addVirtualMachineRestore(vmRestore)
+
+					updatedVMRestore := vmRestore.DeepCopy()
+					updatedVMRestore.Status.Conditions = []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionFalse, "VM restore is deleting"),
+						newReadyCondition(corev1.ConditionFalse, "VM restore is deleting"),
+					}
+					updatedVMRestore.ResourceVersion = "1"
+					updatedVMRestore.Finalizers = []string{}
+
+					expectVMRestoreUpdate(kubevirtClient, updatedVMRestore)
+					controller.processVMRestoreWorkItem()
+				})
 			})
 		})
 

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -441,7 +441,6 @@ var _ = Describe("Restore controller", func() {
 					},
 				}
 				vmSource.Add(vm)
-				expectUpdateVMRestoreInProgress(vm)
 				expectVMRestoreUpdate(kubevirtClient, rc)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -78,6 +78,7 @@ var _ = Describe("Restore controller", func() {
 
 	createRestoreWithOwner := func() *snapshotv1.VirtualMachineRestore {
 		r := createRestore()
+		r.Finalizers = []string{"snapshot.kubevirt.io/vmrestore-protection"}
 		r.OwnerReferences = []metav1.OwnerReference{
 			{
 				APIVersion:         kubevirtv1.GroupVersion.String(),
@@ -892,6 +893,7 @@ var _ = Describe("Restore controller", func() {
 
 					By("Creating VM restore")
 					vmRestore := createRestore()
+					vmRestore.Finalizers = []string{"snapshot.kubevirt.io/vmrestore-protection"}
 					vmRestore.Spec.Target.Name = newVM.Name
 					addVolumeRestores(vmRestore)
 					addVirtualMachineRestore(vmRestore)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -206,6 +206,10 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			err = nil
 		}
 		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() error {
+			_, err = virtClient.VirtualMachineRestore(r.Namespace).Get(context.Background(), r.Name, metav1.GetOptions{})
+			return err
+		}, 30*time.Second, 2*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
 	}
 
 	deleteWebhook := func(wh *admissionregistrationv1.ValidatingWebhookConfiguration) {
@@ -1302,7 +1306,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Entry("to a new VM", true),
 			)
 
-			It("should reject vm start if restore in progress", func() {
+			DescribeTable("should reject vm start if restore in progress", func(deleteFunc string) {
 				vm, vmi = createAndStartVM(newVMWithDataVolumeForRestore(snapshotStorageClass))
 
 				By(stoppingVM)
@@ -1386,10 +1390,17 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Cannot start VM until restore %q completes", restore.Name)))
 
-				deleteWebhook(webhook)
-				webhook = nil
+				switch deleteFunc {
+				case "deleteWebhook":
+					deleteWebhook(webhook)
+					webhook = nil
 
-				restore = waitRestoreComplete(restore, vm.Name, &vm.UID)
+					restore = waitRestoreComplete(restore, vm.Name, &vm.UID)
+				case "deleteRestore":
+					deleteRestore(restore)
+				default:
+					Fail("Delete function not valid")
+				}
 
 				Eventually(func() bool {
 					updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
@@ -1399,7 +1410,10 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 				vm = tests.StartVirtualMachine(vm)
 				deleteRestore(restore)
-			})
+			},
+				Entry("and allow it to start after completion", "deleteWebhook"),
+				Entry("and allow it to start after vmrestore deletion", "deleteRestore"),
+			)
 
 			DescribeTable("should restore a vm from an online snapshot", func(restoreToNewVM bool) {
 				vm = newVMWithDataVolumeForRestore(snapshotStorageClass)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

This is a manual backport of PR https://github.com/kubevirt/kubevirt/pull/12835
(removed the last commit which is only relevant to main since in this release we still use statusUpdater)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticker: https://issues.redhat.com/browse/CNV-48787

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: In case of err in vmrestore, leave VM without RestoreInProgress annotation allowing it to be started
```

