### PR TITLE
virt-api: make VM defaulting and mutations public

### DIFF
--- a/pkg/virt-api/rest/expand.go
+++ b/pkg/virt-api/rest/expand.go
@@ -116,8 +116,8 @@ func (app *SubresourceAPIApp) expandSpecResponse(vm *v1.VirtualMachine, errorFun
 		return
 	}
 
-	// Apply defaults to VM after applying instance types to ensure we don't conflict
-	if err := webhooks.SetDefaultVirtualMachine(app.clusterConfig, vm); err != nil {
+	// Apply defaults to VM.Spec.Template.Spec after applying instance types to ensure we don't conflict
+	if err = webhooks.SetDefaultVirtualMachineInstanceSpec(app.clusterConfig, &vm.Spec.Template.Spec); err != nil {
 		writeError(errorFunc(err), response)
 		return
 	}

--- a/pkg/virt-api/rest/expand_test.go
+++ b/pkg/virt-api/rest/expand_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Instancetype expansion subresources", func() {
 
 			expectedVm := vm.DeepCopy()
 
-			Expect(webhooks.SetDefaultVirtualMachine(app.clusterConfig, expectedVm)).To(Succeed())
+			Expect(webhooks.SetDefaultVirtualMachineInstanceSpec(app.clusterConfig, &expectedVm.Spec.Template.Spec)).To(Succeed())
 
 			util.SetDefaultVolumeDisk(&expectedVm.Spec.Template.Spec)
 			Expect(expectedVm.Spec.Template.Spec.Domain.Devices.Disks).To(HaveLen(1))
@@ -207,7 +207,7 @@ var _ = Describe("Instancetype expansion subresources", func() {
 
 			expectedVm := vm.DeepCopy()
 
-			Expect(webhooks.SetDefaultVirtualMachine(app.clusterConfig, expectedVm)).To(Succeed())
+			Expect(webhooks.SetDefaultVirtualMachineInstanceSpec(app.clusterConfig, &expectedVm.Spec.Template.Spec)).To(Succeed())
 
 			util.SetDefaultVolumeDisk(&expectedVm.Spec.Template.Spec)
 			Expect(expectedVm.Spec.Template.Spec.Domain.Devices.Disks).To(HaveLen(1))

--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-api/webhooks",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/instancetype:go_default_library",
         "//pkg/liveupdate/memory:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",
@@ -22,6 +23,8 @@ go_library(
         "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/util:go_default_library",

--- a/pkg/virt-api/webhooks/defaults.go
+++ b/pkg/virt-api/webhooks/defaults.go
@@ -38,17 +38,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-func SetDefaultVirtualMachine(clusterConfig *virtconfig.ClusterConfig, vm *v1.VirtualMachine) error {
-	if err := setDefaultVirtualMachineInstanceSpec(clusterConfig, &vm.Spec.Template.Spec); err != nil {
-		return err
-	}
-	setDefaultFeatures(&vm.Spec.Template.Spec)
-	v1.SetObjectDefaults_VirtualMachine(vm)
-	setDefaultHypervFeatureDependencies(&vm.Spec.Template.Spec)
-	setDefaultCPUArch(clusterConfig, &vm.Spec.Template.Spec)
-	return nil
-}
-
 func SetVirtualMachineDefaults(vm *v1.VirtualMachine, clusterConfig *virtconfig.ClusterConfig, instancetypeMethods instancetype.Methods) {
 	setDefaultInstancetypeKind(vm)
 	setDefaultPreferenceKind(vm)
@@ -130,7 +119,7 @@ func setDefaultPreferenceKind(vm *v1.VirtualMachine) {
 }
 
 func SetDefaultVirtualMachineInstance(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance) error {
-	if err := setDefaultVirtualMachineInstanceSpec(clusterConfig, &vmi.Spec); err != nil {
+	if err := SetDefaultVirtualMachineInstanceSpec(clusterConfig, &vmi.Spec); err != nil {
 		return err
 	}
 	setDefaultFeatures(&vmi.Spec)
@@ -243,7 +232,7 @@ func setDefaultHypervFeatureDependencies(spec *v1.VirtualMachineInstanceSpec) {
 	}
 }
 
-func setDefaultVirtualMachineInstanceSpec(clusterConfig *virtconfig.ClusterConfig, spec *v1.VirtualMachineInstanceSpec) error {
+func SetDefaultVirtualMachineInstanceSpec(clusterConfig *virtconfig.ClusterConfig, spec *v1.VirtualMachineInstanceSpec) error {
 	setDefaultArchitecture(clusterConfig, spec)
 	setDefaultMachineType(clusterConfig, spec)
 	setDefaultResourceRequests(clusterConfig, spec)

--- a/pkg/virt-api/webhooks/defaults.go
+++ b/pkg/virt-api/webhooks/defaults.go
@@ -28,6 +28,10 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
+	apiinstancetype "kubevirt.io/api/instancetype"
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -43,6 +47,86 @@ func SetDefaultVirtualMachine(clusterConfig *virtconfig.ClusterConfig, vm *v1.Vi
 	setDefaultHypervFeatureDependencies(&vm.Spec.Template.Spec)
 	setDefaultCPUArch(clusterConfig, &vm.Spec.Template.Spec)
 	return nil
+}
+
+func SetVirtualMachineDefaults(vm *v1.VirtualMachine, clusterConfig *virtconfig.ClusterConfig, instancetypeMethods instancetype.Methods) {
+	setDefaultInstancetypeKind(vm)
+	setDefaultPreferenceKind(vm)
+	setDefaultArchitecture(clusterConfig, &vm.Spec.Template.Spec)
+	preferenceSpec := getPreferenceSpec(vm, instancetypeMethods)
+	setVMDefaultMachineType(vm, preferenceSpec, clusterConfig)
+	setPreferenceStorageClassName(vm, preferenceSpec)
+}
+
+func getPreferenceSpec(vm *v1.VirtualMachine, instancetypeMethods instancetype.Methods) *instancetypev1beta1.VirtualMachinePreferenceSpec {
+	if vm.Spec.Preference == nil {
+		return nil
+	}
+
+	preferenceSpec, _ := instancetypeMethods.FindPreferenceSpec(vm)
+	return preferenceSpec
+}
+
+func setVMDefaultMachineType(vm *v1.VirtualMachine, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, clusterConfig *virtconfig.ClusterConfig) {
+	// Nothing to do, let's the validating webhook fail later
+	if vm.Spec.Template == nil {
+		return
+	}
+
+	if machine := vm.Spec.Template.Spec.Domain.Machine; machine != nil && machine.Type != "" {
+		return
+	}
+
+	if vm.Spec.Template.Spec.Domain.Machine == nil {
+		vm.Spec.Template.Spec.Domain.Machine = &v1.Machine{}
+	}
+
+	if preferenceSpec != nil && preferenceSpec.Machine != nil {
+		vm.Spec.Template.Spec.Domain.Machine.Type = preferenceSpec.Machine.PreferredMachineType
+	}
+
+	// Only use the cluster default if the user hasn't provided a machine type or referenced a preference with PreferredMachineType
+	if vm.Spec.Template.Spec.Domain.Machine.Type == "" {
+		vm.Spec.Template.Spec.Domain.Machine.Type = clusterConfig.GetMachineType(vm.Spec.Template.Spec.Architecture)
+	}
+}
+
+func setPreferenceStorageClassName(vm *v1.VirtualMachine, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec) {
+	// Nothing to do, let's the validating webhook fail later
+	if vm.Spec.Template == nil {
+		return
+	}
+
+	if preferenceSpec != nil && preferenceSpec.Volumes != nil && preferenceSpec.Volumes.PreferredStorageClassName != "" {
+		for _, dv := range vm.Spec.DataVolumeTemplates {
+			if dv.Spec.PVC != nil && dv.Spec.PVC.StorageClassName == nil {
+				dv.Spec.PVC.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
+			}
+			if dv.Spec.Storage != nil && dv.Spec.Storage.StorageClassName == nil {
+				dv.Spec.Storage.StorageClassName = &preferenceSpec.Volumes.PreferredStorageClassName
+			}
+		}
+	}
+}
+
+func setDefaultInstancetypeKind(vm *v1.VirtualMachine) {
+	if vm.Spec.Instancetype == nil {
+		return
+	}
+
+	if vm.Spec.Instancetype.Kind == "" {
+		vm.Spec.Instancetype.Kind = apiinstancetype.ClusterSingularResourceName
+	}
+}
+
+func setDefaultPreferenceKind(vm *v1.VirtualMachine) {
+	if vm.Spec.Preference == nil {
+		return
+	}
+
+	if vm.Spec.Preference.Kind == "" {
+		vm.Spec.Preference.Kind = apiinstancetype.ClusterSingularPreferenceResourceName
+	}
 }
 
 func SetDefaultVirtualMachineInstance(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance) error {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -23,8 +23,6 @@ go_library(
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
-        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -155,7 +155,7 @@ func (admitter *VMsAdmitter) Admit(ctx context.Context, ar *admissionv1.Admissio
 	}
 
 	// Set VirtualMachine defaults on the copy before validating
-	if err = webhooks.SetDefaultVirtualMachine(admitter.ClusterConfig, vmCopy); err != nil {
+	if err = webhooks.SetDefaultVirtualMachineInstanceSpec(admitter.ClusterConfig, &vmCopy.Spec.Template.Spec); err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -467,7 +467,6 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 					Sockets: 2,
 					Cores:   1,
 					Threads: 1,
-					Model:   "host-model",
 				}
 			})
 


### PR DESCRIPTION
### What this PR does

This PR separates the VM defaulting and mutations into a public function so external components can use it.

It also removed the `SetDefaultVirtualMachine` function that was not used anywhere in the VM creation flow.
This function didn't reflect reality in terms of changes that are applied to the VM object.



### Release note
```release-note
None
```

