### PR TITLE
vm-controller: fix duplicate firmware UUIDs for VMIs across namespaces

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1950,7 +1950,7 @@ func setupStableFirmwareUUID(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachi
 		return
 	}
 
-	vmi.Spec.Domain.Firmware.UUID = types.UID(uuid.NewSHA1(firmwareUUIDns, []byte(vmi.ObjectMeta.Name)).String())
+	vmi.Spec.Domain.Firmware.UUID = types.UID(uuid.NewSHA1(firmwareUUIDns, []byte(vmi.Name+vmi.Namespace)).String())
 }
 
 // listControllerFromNamespace takes a namespace and returns all VirtualMachines

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -2576,6 +2576,21 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi3.Spec.Domain.Firmware.UUID))
 		})
 
+		It("should have different firmware UUIDs when having the same name but a different namespace", func() {
+			vm1, _ := watchtesting.DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
+			vmi1 := controller.setupVMIFromVM(vm1)
+
+			// intentionally use the same names
+			vm2, _ := watchtesting.DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
+			vm2.Namespace = "other-namespace"
+			vmi2 := controller.setupVMIFromVM(vm2)
+
+			Expect(vm1.Name).To(Equal(vmi2.Name))
+			Expect(vmi1.Namespace).ToNot(Equal(vmi2.Namespace))
+
+			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi2.Spec.Domain.Firmware.UUID))
+		})
+
 		It("should honour any firmware UUID present in the template", func() {
 			uid := uuid.NewString()
 			vm1, _ := watchtesting.DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")


### PR DESCRIPTION
### What this PR does
Before this PR:
- VMIs with the same name but different namespaces previously generated the same firmware UUID.

After this PR:
- Updated UUID generation to use VMI name + namespace.

Fixes #

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
None
```

