### PR TITLE
Code cleanup: Remove old and left-over TODOs

### DIFF
--- a/pkg/storage/snapshot/snapshot_base.go
+++ b/pkg/storage/snapshot/snapshot_base.go
@@ -557,7 +557,6 @@ func (ctrl *VMSnapshotController) handleDV(obj interface{}) {
 	if dv, ok := obj.(*cdiv1.DataVolume); ok {
 		key, _ := cache.MetaNamespaceKeyFunc(dv)
 		log.Log.V(3).Infof("Processing DV %s", key)
-		// TODO come back when DV/PVC name may differ
 		for _, idx := range []string{"dv", "pvc"} {
 			keys, err := ctrl.VMInformer.GetIndexer().IndexKeys(idx, key)
 			if err != nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -443,7 +443,6 @@ func validateDataVolumeTemplate(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 
 			dataVolumeRefFound := false
 			for _, volume := range spec.Template.Spec.Volumes {
-				// TODO: Assuming here that PVC name == DV name which might not be the case in the future
 				if volume.VolumeSource.PersistentVolumeClaim != nil && volume.VolumeSource.PersistentVolumeClaim.ClaimName == dataVolume.Name {
 					dataVolumeRefFound = true
 					break

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -362,7 +362,6 @@ func IsDisconnected(err error) bool {
 	if grpcStatus, ok := status.FromError(err); ok {
 
 		// see https://github.com/grpc/grpc-go/blob/master/codes/codes.go
-		// TODO which other codes might be related to disconnection...?
 		switch grpcStatus.Code() {
 		case codes.Canceled:
 			// e.g. v1client connection closing

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1244,7 +1244,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			var agentVMI *v1.VirtualMachineInstance
 
 			prepareAgentVM := func() *v1.VirtualMachineInstance {
-				// TODO: actually review this once the VM image is present
 				agentVMI := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 
 				By("Starting a VirtualMachineInstance")
@@ -2504,7 +2503,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			var vmiCondition v1.VirtualMachineInstanceCondition
-			// TODO
 			Eventually(func() bool {
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1049,8 +1049,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			var hugepagesVmi *v1.VirtualMachineInstance
 
 			verifyHugepagesConsumption := func() bool {
-				// TODO: we need to check hugepages state via node allocated resources, but currently it has the issue
-				// https://github.com/kubernetes/kubernetes/issues/64691
 				pods, err := virtClient.CoreV1().Pods(hugepagesVmi.Namespace).List(context.Background(), tests.UnfinishedVMIPodSelector(hugepagesVmi))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pods.Items).To(HaveLen(1))


### PR DESCRIPTION
### What this PR does
This PR removes old left-over TODOs that are redandunt.
See the per-commit description for more info.

/sig code-quality

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [ ] ~Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

