### PR TITLE
tests/utils: Move MountCloudInitFunc to local files

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -27,12 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/tests/testsuite"
-
-	"kubevirt.io/kubevirt/tests/libmigration"
-
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -58,13 +52,16 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	netcloudinit "kubevirt.io/kubevirt/tests/libnet/cloudinit"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
+	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 const (

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -328,18 +328,3 @@ func CheckCloudInitMetaData(vmi *v1.VirtualMachineInstance, testFile, testData s
 		Expect(res[1].Output).To(ContainSubstring(testData))
 	}
 }
-
-func MountCloudInitFunc(devName string) func(*v1.VirtualMachineInstance) {
-	return func(vmi *v1.VirtualMachineInstance) {
-		cmdCheck := fmt.Sprintf("mount $(blkid  -L %s) /mnt/\n", devName)
-		err := console.SafeExpectBatch(vmi, []expect.Batcher{
-			&expect.BSnd{S: "sudo su -\n"},
-			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: cmdCheck},
-			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: console.EchoLastReturnValue},
-			&expect.BExp{R: console.RetValue("0")},
-		}, 15)
-		Expect(err).ToNot(HaveOccurred())
-	}
-}

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -65,6 +65,9 @@ const (
 	expectedUserDataFile = "cloud-init-userdata-executed"
 	testNetworkData      = "#Test networkData"
 	testUserData         = "#cloud-config"
+
+	dataSourceNoCloudVolumeID     = "cidata"
+	dataSourceConfigDriveVolumeID = "config-2"
 )
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]CloudInit UserData", decorators.SigCompute, func() {
@@ -72,12 +75,10 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	var virtClient kubecli.KubevirtClient
 
 	var (
-		LaunchVMI                 func(*v1.VirtualMachineInstance) *v1.VirtualMachineInstance
-		VerifyUserDataVMI         func(*v1.VirtualMachineInstance, []expect.Batcher, time.Duration)
-		MountCloudInitNoCloud     func(*v1.VirtualMachineInstance)
-		MountCloudInitConfigDrive func(*v1.VirtualMachineInstance)
-		CheckCloudInitFile        func(*v1.VirtualMachineInstance, string, string)
-		CheckCloudInitIsoSize     func(vmi *v1.VirtualMachineInstance, source cloudinit.DataSourceType)
+		LaunchVMI             func(*v1.VirtualMachineInstance) *v1.VirtualMachineInstance
+		VerifyUserDataVMI     func(*v1.VirtualMachineInstance, []expect.Batcher, time.Duration)
+		CheckCloudInitFile    func(*v1.VirtualMachineInstance, string, string)
+		CheckCloudInitIsoSize func(vmi *v1.VirtualMachineInstance, source cloudinit.DataSourceType)
 	)
 
 	BeforeEach(func() {
@@ -85,8 +86,6 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		// from default virt-launcher flag: do we need to make this configurable in some cases?
 		cloudinit.SetLocalDirectoryOnly("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
-		MountCloudInitNoCloud = tests.MountCloudInitFunc("cidata")
-		MountCloudInitConfigDrive = tests.MountCloudInitFunc("config-2")
 	})
 
 	LaunchVMI = func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
@@ -347,7 +346,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
 				By("mouting cloudinit iso")
-				MountCloudInitNoCloud(vmi)
+				Expect(mountGuestDevice(vmi, dataSourceNoCloudVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "network-config", testNetworkData)
@@ -365,7 +364,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
 				By("mouting cloudinit iso")
-				MountCloudInitNoCloud(vmi)
+				Expect(mountGuestDevice(vmi, dataSourceNoCloudVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "network-config", testNetworkData)
@@ -391,7 +390,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
 				By("mouting cloudinit iso")
-				MountCloudInitNoCloud(vmi)
+				Expect(mountGuestDevice(vmi, dataSourceNoCloudVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "network-config", testNetworkData)
@@ -418,7 +417,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				By("mouting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
@@ -472,7 +471,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				buf, err := json.Marshal(metadataStruct)
 				Expect(err).ToNot(HaveOccurred())
 				By("mouting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
@@ -489,7 +488,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 				By("mouting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
@@ -520,7 +519,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				By("mouting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
@@ -574,7 +573,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				By("mounting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
@@ -614,4 +613,16 @@ func lookupCloudInitNoCloudVolume(volumes []v1.Volume) *v1.Volume {
 		}
 	}
 	return nil
+}
+
+func mountGuestDevice(vmi *v1.VirtualMachineInstance, devName string) error {
+	cmdCheck := fmt.Sprintf("mount $(blkid  -L %s) /mnt/\n", devName)
+	return console.SafeExpectBatch(vmi, []expect.Batcher{
+		&expect.BSnd{S: "sudo su -\n"},
+		&expect.BExp{R: console.PromptExpression},
+		&expect.BSnd{S: cmdCheck},
+		&expect.BExp{R: console.PromptExpression},
+		&expect.BSnd{S: console.EchoLastReturnValue},
+		&expect.BExp{R: console.RetValue("0")},
+	}, 15)
 }

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -29,36 +29,34 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/libvmi"
-	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
-	"kubevirt.io/kubevirt/pkg/pointer"
-
-	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/libvmops"
-
 	expect "github.com/google/goexpect"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	libcloudinit "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libsecret"
 	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
-
-	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
-
-	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
-	libcloudinit "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
-	"kubevirt.io/kubevirt/pkg/util/net/dns"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
-	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/console"
 )
 
 const (


### PR DESCRIPTION
### What this PR does
This PR moves MountCloudInitFunc function that is located on tests/utils to the files that use it, to be consumes locally.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

