### PR TITLE
[release-1.0] fix: correctly check dry-run requests

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/policy/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -2,12 +2,14 @@ package admitters
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/types"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -21,6 +23,20 @@ import (
 type PodEvictionAdmitter struct {
 	ClusterConfig *virtconfig.ClusterConfig
 	VirtClient    kubecli.KubevirtClient
+}
+
+func isDryRun(ar *admissionv1.AdmissionReview) bool {
+	dryRun := ar.Request.DryRun != nil && *ar.Request.DryRun == true
+
+	if !dryRun {
+		evictionObject := policyv1.Eviction{}
+		if err := json.Unmarshal(ar.Request.Object.Raw, &evictionObject); err == nil {
+			if evictionObject.DeleteOptions != nil && len(evictionObject.DeleteOptions.DryRun) > 0 {
+				dryRun = evictionObject.DeleteOptions.DryRun[0] == metav1.DryRunAll
+			}
+		}
+	}
+	return dryRun
 }
 
 func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
@@ -66,8 +82,7 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 	}
 
 	if markForEviction && !vmi.IsMarkedForEviction() && vmi.Status.NodeName == launcher.Spec.NodeName {
-		dryRun := ar.Request.DryRun != nil && *ar.Request.DryRun == true
-		err := admitter.markVMI(ar, vmi.Name, vmi.Status.NodeName, dryRun)
+		err := admitter.markVMI(ar, vmi.Name, vmi.Status.NodeName, isDryRun(ar))
 		if err != nil {
 			// As with the previous case, it is up to the user to issue a retry.
 			return denied(fmt.Sprintf("kubevirt failed marking the vmi for eviction: %s", err.Error()))


### PR DESCRIPTION
In the pod eviction admitter some dry run requests were not caught due to KubeVirt only checking the dry-run field in the admission review but not in the object contained in the admission review.

This was causing dry run requests made through kubectl drain using the '--dry-run=server' flag to be processed as non dry-run requests.

It's possible that this is Kubernetes bug but it should be anyway fixed fixed in the meantime.

Signed-off-by: Antonio Cardace <acardace@redhat.com>
(cherry picked from commit 6bdf1363534681d0d9dfaf44eb8607bbaf612869)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

