### PR TITLE
Revert: "vm-controller: fix duplicate firmware UUIDs for VMIs across n…

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1986,7 +1986,7 @@ func setupStableFirmwareUUID(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachi
 		return
 	}
 
-	vmi.Spec.Domain.Firmware.UUID = types.UID(uuid.NewSHA1(firmwareUUIDns, []byte(vmi.Name+vmi.Namespace)).String())
+	vmi.Spec.Domain.Firmware.UUID = types.UID(uuid.NewSHA1(firmwareUUIDns, []byte(vmi.ObjectMeta.Name)).String())
 }
 
 // listControllerFromNamespace takes a namespace and returns all VirtualMachines

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -2576,21 +2576,6 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi3.Spec.Domain.Firmware.UUID))
 		})
 
-		It("should have different firmware UUIDs when having the same name but a different namespace", func() {
-			vm1, _ := watchtesting.DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
-			vmi1 := controller.setupVMIFromVM(vm1)
-
-			// intentionally use the same names
-			vm2, _ := watchtesting.DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
-			vm2.Namespace = "other-namespace"
-			vmi2 := controller.setupVMIFromVM(vm2)
-
-			Expect(vm1.Name).To(Equal(vmi2.Name))
-			Expect(vmi1.Namespace).ToNot(Equal(vmi2.Namespace))
-
-			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi2.Spec.Domain.Firmware.UUID))
-		})
-
 		It("should honour any firmware UUID present in the template", func() {
 			uid := uuid.NewString()
 			vm1, _ := watchtesting.DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")


### PR DESCRIPTION
### What this PR does
This reverts commit d9f2eb056855723a6acf07ccf01fa426fc5dae21.
See discussion here for more info: https://github.com/kubevirt/kubevirt/pull/12885#issuecomment-2369245917.

In short: it will affect existing VMs after upgrades since the firmware UUID will change.

This fix already took place and was reverted [1]. We need to come up with a proper fix.

[1] https://github.com/kubevirt/kubevirt/pull/11250

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

