### PR TITLE
fix: Panic when SSH key secret is empty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,8 +79,8 @@ require (
 	kubevirt.io/client-go v0.0.0-00010101000000-000000000000
 	kubevirt.io/containerized-data-importer-api v1.57.0-alpha1
 	kubevirt.io/qe-tools v0.1.8
-	libvirt.org/go/libvirt v1.10005.0
-	libvirt.org/go/libvirtxml v1.10005.0
+	libvirt.org/go/libvirt v1.10008.0
+	libvirt.org/go/libvirtxml v1.10008.0
 	mvdan.cc/sh/v3 v3.8.0
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -2730,10 +2730,10 @@ kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 kubevirt.io/qe-tools v0.1.8 h1:Ar7qicmzHdd+Ia+6rjHDg3D7GReIyq7QFXoC4F7TjhQ=
 kubevirt.io/qe-tools v0.1.8/go.mod h1:+Tr/WZGHIDQa/4pQgzM7+4J6YeVbUWAXESXtL2/zxqc=
-libvirt.org/go/libvirt v1.10005.0 h1:KQv+SZNQvHJOG7B34TI2hyKnKW6hpXTEJFHUerYuGNI=
-libvirt.org/go/libvirt v1.10005.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
-libvirt.org/go/libvirtxml v1.10005.0 h1:bKv2wYaEunDdvE4mqO+vG0bp/iIeO0mI7A+0MfilNxw=
-libvirt.org/go/libvirtxml v1.10005.0/go.mod h1:7Oq2BLDstLr/XtoQD8Fr3mfDNrzlI3utYKySXF2xkng=
+libvirt.org/go/libvirt v1.10008.0 h1:j+hybvOmBQFC2BiivOVCPE3ozpQWtxWXp9p1cGk0x1Y=
+libvirt.org/go/libvirt v1.10008.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
+libvirt.org/go/libvirtxml v1.10008.0 h1:XBRmPfZaw0VsqL5Z5w9gS3fsaYS0rHrvqaC2+9qvlFQ=
+libvirt.org/go/libvirtxml v1.10008.0/go.mod h1:7Oq2BLDstLr/XtoQD8Fr3mfDNrzlI3utYKySXF2xkng=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/cc/v3 v3.36.0/go.mod h1:NFUHyPn4ekoC/JHeZFfZurN6ixxawE1BnVonP/oahEI=

--- a/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
+        "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -32,6 +32,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+	"libvirt.org/go/libvirt"
 
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
@@ -311,6 +312,10 @@ func (l *AccessCredentialManager) agentSetAuthorizedKeys(domName string, user st
 			return err
 		}
 		defer domain.Free()
+
+		if len(authorizedKeys) == 0 {
+			return domain.AuthorizedSSHKeysSet(user, nil, libvirt.DOMAIN_AUTHORIZED_SSH_KEYS_SET_REMOVE)
+		}
 
 		// Zero flags argument means that the authorized_keys file is overwritten with the authorizedKeys
 		return domain.AuthorizedSSHKeysSet(user, authorizedKeys, 0)

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -126,6 +126,18 @@ var _ = Describe("AccessCredentials", func() {
 		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
 	})
 
+	It("should remove ssh key file when key array is empty", func() {
+		domName := "some-domain"
+		user := "someowner"
+
+		mockConn.EXPECT().LookupDomainByName(domName).Return(mockDomain, nil).Times(1)
+		mockDomain.EXPECT().AuthorizedSSHKeysSet(user, nil, libvirt.DOMAIN_AUTHORIZED_SSH_KEYS_SET_REMOVE).
+			Return(nil).Times(1)
+		mockDomain.EXPECT().Free().Times(1)
+
+		Expect(manager.agentSetAuthorizedKeys(domName, user, nil)).To(Succeed())
+	})
+
 	It("should dynamically update ssh key with old qemu agent", func() {
 		domName := "some-domain"
 		user := "someowner"

--- a/vendor/libvirt.org/go/libvirt/libvirt_generated_macros.h
+++ b/vendor/libvirt.org/go/libvirt/libvirt_generated_macros.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #if !LIBVIR_CHECK_VERSION(0, 0, 1)
-#  define LIBVIR_VERSION_NUMBER 10005000
+#  define LIBVIR_VERSION_NUMBER 10006000
 #endif
 
 #if !LIBVIR_CHECK_VERSION(5, 8, 0)
@@ -430,6 +430,10 @@
 
 #if !LIBVIR_CHECK_VERSION(1, 0, 3)
 #  define VIR_DOMAIN_JOB_TIME_REMAINING "time_remaining"
+#endif
+
+#if !LIBVIR_CHECK_VERSION(10, 6, 0)
+#  define VIR_DOMAIN_JOB_VFIO_DATA_TRANSFERRED "vfio_data_transferred"
 #endif
 
 #if !LIBVIR_CHECK_VERSION(8, 0, 0)

--- a/vendor/libvirt.org/go/libvirt/lxc.go
+++ b/vendor/libvirt.org/go/libvirt/lxc.go
@@ -68,13 +68,18 @@ func (d *Domain) LxcOpenNamespace(flags uint32) ([]os.File, error) {
 func (d *Domain) LxcEnterNamespace(fdlist []os.File, flags uint32) ([]os.File, error) {
 	var coldfdlist *C.int
 	var ncoldfdlist C.uint
-	cfdlist := make([]C.int, len(fdlist))
-	for i := 0; i < len(fdlist); i++ {
+	nfdlist := len(fdlist)
+	cfdlist := make([]C.int, nfdlist)
+	for i := 0; i < nfdlist; i++ {
 		cfdlist[i] = C.int(fdlist[i].Fd())
 	}
 
 	var err C.virError
-	ret := C.virDomainLxcEnterNamespaceWrapper(d.ptr, C.uint(len(fdlist)), &cfdlist[0], &ncoldfdlist, &coldfdlist, C.uint(flags), &err)
+	var cfdlistPtr *C.int = nil
+	if nfdlist > 0 {
+		cfdlistPtr = &cfdlist[0]
+	}
+	ret := C.virDomainLxcEnterNamespaceWrapper(d.ptr, C.uint(nfdlist), cfdlistPtr, &ncoldfdlist, &coldfdlist, C.uint(flags), &err)
 	if ret == -1 {
 		return []os.File{}, makeError(&err)
 	}

--- a/vendor/libvirt.org/go/libvirt/qemu.go
+++ b/vendor/libvirt.org/go/libvirt/qemu.go
@@ -100,9 +100,9 @@ func (d *Domain) QemuMonitorCommand(command string, flags DomainQemuMonitorComma
 
 // See also https://libvirt.org/html/libvirt-libvirt-qemu.html#virDomainQemuMonitorCommandWithFiles
 func (d *Domain) QemuMonitorCommandWithFiles(command string, infiles []os.File, flags DomainQemuMonitorCommandFlags) (string, []*os.File, error) {
-	cninfiles := C.uint(len(infiles))
-	cinfiles := make([]C.int, len(infiles))
-	for i := 0; i < len(infiles); i++ {
+	ninfiles := len(infiles)
+	cinfiles := make([]C.int, ninfiles)
+	for i := 0; i < ninfiles; i++ {
 		cinfiles[i] = C.int(infiles[i].Fd())
 	}
 	cCommand := C.CString(command)
@@ -112,8 +112,12 @@ func (d *Domain) QemuMonitorCommandWithFiles(command string, infiles []os.File, 
 	var cnoutfiles C.uint
 	var coutfiles *C.int
 	var err C.virError
+	var cinfilesPtr *C.int = nil
+	if ninfiles > 0 {
+		cinfilesPtr = &cinfiles[0]
+	}
 	result := C.virDomainQemuMonitorCommandWithFilesWrapper(d.ptr, cCommand,
-		cninfiles, &cinfiles[0], &cnoutfiles, &coutfiles,
+		C.uint(ninfiles), cinfilesPtr, &cnoutfiles, &coutfiles,
 		&cResult, C.uint(flags), &err)
 
 	if result != 0 {

--- a/vendor/libvirt.org/go/libvirt/secret.go
+++ b/vendor/libvirt.org/go/libvirt/secret.go
@@ -176,14 +176,19 @@ func (s *Secret) GetValue(flags uint32) ([]byte, error) {
 
 // See also https://libvirt.org/html/libvirt-libvirt-secret.html#virSecretSetValue
 func (s *Secret) SetValue(value []byte, flags uint32) error {
-	cvalue := make([]C.uchar, len(value))
+	nvalue := len(value)
+	cvalue := make([]C.uchar, nvalue)
 
-	for i := 0; i < len(value); i++ {
+	for i := 0; i < nvalue; i++ {
 		cvalue[i] = C.uchar(value[i])
 	}
 
 	var err C.virError
-	result := C.virSecretSetValueWrapper(s.ptr, &cvalue[0], C.size_t(len(value)), C.uint(flags), &err)
+	var cvaluePtr *C.uchar = nil
+	if nvalue > 0 {
+		cvaluePtr = &cvalue[0]
+	}
+	result := C.virSecretSetValueWrapper(s.ptr, cvaluePtr, C.size_t(nvalue), C.uint(flags), &err)
 
 	if result == -1 {
 		return makeError(&err)

--- a/vendor/libvirt.org/go/libvirt/stream.go
+++ b/vendor/libvirt.org/go/libvirt/stream.go
@@ -107,8 +107,13 @@ func (c *Stream) Ref() error {
 
 // See also https://libvirt.org/html/libvirt-libvirt-stream.html#virStreamRecv
 func (v *Stream) Recv(p []byte) (int, error) {
+	np := len(p)
 	var err C.virError
-	n := C.virStreamRecvWrapper(v.ptr, (*C.char)(unsafe.Pointer(&p[0])), C.size_t(len(p)), &err)
+	var pPtr *C.char = nil
+	if np > 0 {
+		pPtr = (*C.char)(unsafe.Pointer(&p[0]))
+	}
+	n := C.virStreamRecvWrapper(v.ptr, pPtr, C.size_t(np), &err)
 	if n < 0 {
 		return 0, makeError(&err)
 	}
@@ -121,8 +126,13 @@ func (v *Stream) Recv(p []byte) (int, error) {
 
 // See also https://libvirt.org/html/libvirt-libvirt-stream.html#virStreamRecvFlags
 func (v *Stream) RecvFlags(p []byte, flags StreamRecvFlagsValues) (int, error) {
+	np := len(p)
 	var err C.virError
-	n := C.virStreamRecvFlagsWrapper(v.ptr, (*C.char)(unsafe.Pointer(&p[0])), C.size_t(len(p)), C.uint(flags), &err)
+	var pPtr *C.char = nil
+	if np > 0 {
+		pPtr = (*C.char)(unsafe.Pointer(&p[0]))
+	}
+	n := C.virStreamRecvFlagsWrapper(v.ptr, pPtr, C.size_t(np), C.uint(flags), &err)
 	if n < 0 {
 		return 0, makeError(&err)
 	}
@@ -147,8 +157,13 @@ func (v *Stream) RecvHole(flags uint32) (int64, error) {
 
 // See also https://libvirt.org/html/libvirt-libvirt-stream.html#virStreamSend
 func (v *Stream) Send(p []byte) (int, error) {
+	np := len(p)
 	var err C.virError
-	n := C.virStreamSendWrapper(v.ptr, (*C.char)(unsafe.Pointer(&p[0])), C.size_t(len(p)), &err)
+	var pPtr *C.char = nil
+	if np > 0 {
+		pPtr = (*C.char)(unsafe.Pointer(&p[0]))
+	}
+	n := C.virStreamSendWrapper(v.ptr, pPtr, C.size_t(np), &err)
 	if n < 0 {
 		return 0, makeError(&err)
 	}

--- a/vendor/libvirt.org/go/libvirtxml/domain.go
+++ b/vendor/libvirt.org/go/libvirtxml/domain.go
@@ -516,6 +516,10 @@ type DomainFilesystemBinaryThreadPool struct {
 	Size uint `xml:"size,attr,omitempty"`
 }
 
+type DomainFilesystemBinaryOpenFiles struct {
+	Max uint `xml:"max,attr,"`
+}
+
 type DomainFilesystemBinary struct {
 	Path       string                            `xml:"path,attr,omitempty"`
 	XAttr      string                            `xml:"xattr,attr,omitempty"`
@@ -523,6 +527,7 @@ type DomainFilesystemBinary struct {
 	Sandbox    *DomainFilesystemBinarySandbox    `xml:"sandbox"`
 	Lock       *DomainFilesystemBinaryLock       `xml:"lock"`
 	ThreadPool *DomainFilesystemBinaryThreadPool `xml:"thread_pool"`
+	OpenFiles  *DomainFilesystemBinaryOpenFiles  `xml:"openfiles"`
 }
 
 type DomainFilesystemIDMapEntry struct {
@@ -666,9 +671,9 @@ type DomainInterfaceSourceNull struct {
 
 type DomainInterfaceSourceVDS struct {
 	SwitchID     string `xml:"switchid,attr"`
-	PortID       int    `xml:"portid,attr"`
-	PortGroupID  string `xml:"portgroupid,attr"`
-	ConnectionID int    `xml:"connectionid,attr"`
+	PortID       int    `xml:"portid,attr,omitempty"`
+	PortGroupID  string `xml:"portgroupid,attr,omitempty"`
+	ConnectionID int    `xml:"connectionid,attr,omitempty"`
 }
 
 type DomainInterfaceSourceLocal struct {
@@ -1984,11 +1989,12 @@ type DomainIOMMU struct {
 }
 
 type DomainIOMMUDriver struct {
-	IntRemap    string `xml:"intremap,attr,omitempty"`
-	CachingMode string `xml:"caching_mode,attr,omitempty"`
-	EIM         string `xml:"eim,attr,omitempty"`
-	IOTLB       string `xml:"iotlb,attr,omitempty"`
-	AWBits      uint   `xml:"aw_bits,attr,omitempty"`
+	IntRemap       string `xml:"intremap,attr,omitempty"`
+	CachingMode    string `xml:"caching_mode,attr,omitempty"`
+	EIM            string `xml:"eim,attr,omitempty"`
+	IOTLB          string `xml:"iotlb,attr,omitempty"`
+	AWBits         uint   `xml:"aw_bits,attr,omitempty"`
+	DMATranslation string `xml:"dma_translation,attr,omitempty"`
 }
 
 type DomainNVRAM struct {
@@ -2050,6 +2056,7 @@ type DomainTPMBackendEmulator struct {
 	Version         string                      `xml:"version,attr,omitempty"`
 	Encryption      *DomainTPMBackendEncryption `xml:"encryption"`
 	PersistentState string                      `xml:"persistent_state,attr,omitempty"`
+	Debug           uint                        `xml:"debug,attr,omitempty"`
 	ActivePCRBanks  *DomainTPMBackendPCRBanks   `xml:"active_pcr_banks"`
 }
 
@@ -2129,6 +2136,20 @@ type DomainCryptoBackendBuiltIn struct {
 type DomainCryptoBackendLKCF struct {
 }
 
+type DomainPStore struct {
+	Backend string            `xml:"backend,attr"`
+	Path    string            `xml:"path"`
+	Size    DomainPStoreSize  `xml:"size"`
+	ACPI    *DomainDeviceACPI `xml:"acpi"`
+	Alias   *DomainAlias      `xml:"alias"`
+	Address *DomainAddress    `xml:"address"`
+}
+
+type DomainPStoreSize struct {
+	Size uint64 `xml:",chardata"`
+	Unit string `xml:"unit,attr"`
+}
+
 type DomainDeviceList struct {
 	Emulator     string              `xml:"emulator,omitempty"`
 	Disks        []DomainDisk        `xml:"disk"`
@@ -2161,6 +2182,7 @@ type DomainDeviceList struct {
 	IOMMU        *DomainIOMMU        `xml:"iommu"`
 	VSock        *DomainVSock        `xml:"vsock"`
 	Crypto       []DomainCrypto      `xml:"crypto"`
+	PStore       *DomainPStore       `xml:"pstore"`
 }
 
 type DomainMemory struct {
@@ -2567,6 +2589,8 @@ type DomainFeatureHyperV struct {
 	IPI             *DomainFeatureState           `xml:"ipi"`
 	EVMCS           *DomainFeatureState           `xml:"evmcs"`
 	AVIC            *DomainFeatureState           `xml:"avic"`
+	EMSRBitmap      *DomainFeatureState           `xml:"emsr_bitmap"`
+	XMMInput        *DomainFeatureState           `xml:"xmm_input"`
 }
 
 type DomainFeatureKVMDirtyRing struct {
@@ -2758,6 +2782,7 @@ type DomainFeatureList struct {
 	TCG           *DomainFeatureTCG           `xml:"tcg"`
 	AsyncTeardown *DomainFeatureAsyncTeardown `xml:"async-teardown"`
 	RAS           *DomainFeatureState         `xml:"ras"`
+	PS2           *DomainFeatureState         `xml:"ps2"`
 }
 
 type DomainCPUTuneShares struct {

--- a/vendor/libvirt.org/go/libvirtxml/domain_capabilities.go
+++ b/vendor/libvirt.org/go/libvirtxml/domain_capabilities.go
@@ -117,6 +117,7 @@ type DomainCapsDevices struct {
 	Redirdev   *DomainCapsDevice `xml:"redirdev"`
 	Channel    *DomainCapsDevice `xml:"channel"`
 	Crypto     *DomainCapsDevice `xml:"crypto"`
+	Interface  *DomainCapsDevice `xml:"interface"`
 }
 
 type DomainCapsDevice struct {
@@ -132,6 +133,7 @@ type DomainCapsFeatures struct {
 	Backup            *DomainCapsFeatureBackup            `xml:"backup"`
 	AsyncTeardown     *DomainCapsFeatureAsyncTeardown     `xml:"async-teardown"`
 	S390PV            *DomainCapsFeatureS390PV            `xml:"s390-pv"`
+	PS2               *DomainCapsFeaturePS2               `xml:"ps2"`
 	SEV               *DomainCapsFeatureSEV               `xml:"sev"`
 	SGX               *DomainCapsFeatureSGX               `xml:"sgx"`
 	HyperV            *DomainCapsFeatureHyperV            `xml:"hyperv"`
@@ -164,6 +166,10 @@ type DomainCapsFeatureAsyncTeardown struct {
 }
 
 type DomainCapsFeatureS390PV struct {
+	Supported string `xml:"supported,attr"`
+}
+
+type DomainCapsFeaturePS2 struct {
 	Supported string `xml:"supported,attr"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1303,10 +1303,10 @@ kubevirt.io/controller-lifecycle-operator-sdk/api
 ## explicit; go 1.16
 kubevirt.io/qe-tools/pkg/ginkgo-reporters
 kubevirt.io/qe-tools/pkg/polarion-xml
-# libvirt.org/go/libvirt v1.10005.0
+# libvirt.org/go/libvirt v1.10008.0
 ## explicit; go 1.11
 libvirt.org/go/libvirt
-# libvirt.org/go/libvirtxml v1.10005.0
+# libvirt.org/go/libvirtxml v1.10008.0
 ## explicit; go 1.11
 libvirt.org/go/libvirtxml
 # mvdan.cc/editorconfig v0.2.1-0.20231228180347-1925077f8eb2


### PR DESCRIPTION


### What this PR does
This commit fixes a panic that happens when the secret that should contain SSH keys injected to VM is empty.

Related fix in libvirt-go-module:
https://gitlab.com/libvirt/libvirt-go-module/-/merge_requests/59

Fixes #12562

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

