### PR TITLE
[virt-tail] Replace watchFS polling with PollUntilContextTimeout

### DIFF
--- a/cmd/virt-tail/BUILD.bazel
+++ b/cmd/virt-tail/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//vendor/github.com/nxadm/tail:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/golang.org/x/sync/errgroup:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
 )
 

--- a/cmd/virt-tail/main.go
+++ b/cmd/virt-tail/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nxadm/tail"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"kubevirt.io/client-go/log"
 )
@@ -113,24 +114,24 @@ func (v *VirtTail) watchFS() error {
 
 	// Add a path.
 	dirPath := filepath.Dir(v.logFile)
-	found := false
-	i := 0
-	for i < 30 && !found {
-		i = i + 1
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (bool, error) {
 		if _, derr := os.Stat(dirPath); derr == nil {
-			found = true
 			if err = watcher.Add(dirPath); err != nil {
 				log.Log.V(3).Infof("watcher error: %v - %s", err, dirPath)
-				return err
+				return false, err
 			}
-		} else {
-			time.Sleep(100 * time.Millisecond)
+			return true, nil
 		}
-	}
-	if !found {
-		rerr := errors.New("expected directory is still not ready")
-		log.Log.V(3).Infof("watchFS error: %v", rerr)
-		return rerr
+		return false, nil
+	})
+
+	if err != nil {
+		if wait.Interrupted(err) {
+			rerr := errors.New("expected directory is still not ready")
+			log.Log.V(3).Infof("watchFS error: %v", rerr)
+			return rerr
+		}
+		return err
 	}
 
 	// initial timeout for serial console socket creation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

When virt-tail was first introduced, the logic for polling the directory's existence during watchFS() setup was using a for loop with sleep.

**After this PR:**

It was suggested then to use apimachinery's `PollUntilContextTimeout` instead to simplify the logic[1] but the implementation was postponed as the apimachinery version of KubeVirt at the time didn't have PollUntilContextTimeout.

[1] https://github.com/kubevirt/kubevirt/pull/10110/files#r1341050446

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

