### PR TITLE
Remove assafad as a sig-observability reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -131,7 +131,6 @@ aliases:
   sig-observability-reviewers:
     - machadovilaca
     - avlitman
-    - assafad
 
   #
   # SIG Release


### PR DESCRIPTION
### What this PR does
Remove @assafad from being a sig-observability reviewer, since he is no longer active on this repository.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

