### PR TITLE
OWNERS_ALIAS: Remove Alona Kaplan from the reviewer list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -30,7 +30,6 @@ aliases:
     - vladikr
     - enp0s3
     - jean-edouard
-    - AlonaKaplan
     - mhenriks
     - EdDev
     - acardace
@@ -63,7 +62,6 @@ aliases:
   # Owns anything related to networking.
   #
   sig-network-reviewers:
-    - AlonaKaplan
     - EdDev
     - RamLavi
     - ormergi


### PR DESCRIPTION
### What this PR does

Alona is no longer actively reviewing PRs in the project. Therefore, help Prow bot to avoid automatically assigning PRs for review on her name.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
This change is made with consent from @AlonaKaplan .

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

