### PR TITLE
documentation error: reference to a file that does not exist

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -253,8 +253,12 @@ If you would like to run specific functional tests only, you can leverage `ginkg
 command line options as follows (run a specified suite):
 
 ```
-    FUNC_TEST_ARGS='-focus-file=vmi_networking_test' make functest
+    FUNC_TEST_ARGS='--focus-file=vmi_networking' make functest
 ```
+
+> [!NOTE]
+> Ginkgo's [Location-Based Filtering](https://onsi.github.io/ginkgo/#location-based-filtering) and [Description-Based Filtering](https://onsi.github.io/ginkgo/#description-based-filtering) documentation 
+> describe additional helpful options for focused execution that do not require recompilation.
 
 In addition, if you want to run a specific test or tests you can prepend any `Describe`,
 `Context` and `It` statements of your test with an `F` and Ginkgo will only run items


### PR DESCRIPTION
The Getting Started Guide for developers explains that in order to run e2e tests while focusing on only a single test file, the user can set the FUNC_TEST_ARGS variable and indicate a test file to focus on. The file that it references does not exist, but the execution does not indicate that and basically performs a no-op.
Fix the file reference to a file with a similar name that does exist

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
There was an error in the documentation referencing a file that did not exist, thus confusing the user.
If the user would run run the e2e tests as indicated ` FUNC_TEST_ARGS='-focus-file=vmi_networking_test' make functest` the process would execute and actually succeed, but when looking at the stats, one can notice that no tests were executed 

After this PR:
If the user executes the command as indicated, vmi tests are executed. 28 specs as of today.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
Finding a file with fewer tests

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

