### PR TITLE
Code Quality: test utils cleanup

### DIFF
--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -2,7 +2,6 @@ package tests_test
 
 import (
 	"context"
-	"encoding/xml"
 	"fmt"
 	"strings"
 	"time"
@@ -287,11 +286,8 @@ var _ = Describe("[sig-compute] Hyper-V enlightenments", decorators.SigCompute, 
 			vmi := libvmifact.NewCirros(withHypervPassthrough())
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 60)
 
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domXml), domSpec)).To(Succeed())
 			Expect(domSpec.Features.Hyperv.Mode).To(Equal(api.HypervModePassthrough))
 
 			Eventually(matcher.ThisVMI(vmi), 60*time.Second, 1*time.Second).Should(matcher.HaveConditionFalse(v1.VirtualMachineInstanceIsMigratable))

--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -1,39 +1,25 @@
 package tests_test
 
 import (
-	"encoding/xml"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/libvmops"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/client-go/kubecli"
-
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
-
 	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 )
 
 var _ = Describe("[sig-compute]Controller devices", decorators.SigCompute, func() {
-	var virtClient kubecli.KubevirtClient
-
-	BeforeEach(func() {
-		virtClient = kubevirt.Client()
-	})
 
 	Context("with ephemeral disk", func() {
 		DescribeTable("a scsi controller", func(enabled bool) {
 			vmi := libvmifact.NewCirros()
 			vmi.Spec.Domain.Devices.DisableHotplug = !enabled
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 30)
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 			found := false
 			for _, controller := range domSpec.Devices.Controllers {
 				if controller.Type == "scsi" {

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -21,7 +21,6 @@ package tests_test
 
 import (
 	"context"
-	"encoding/xml"
 	"fmt"
 	"strconv"
 
@@ -75,10 +74,8 @@ var _ = Describe("[sig-compute]IOThreads", decorators.SigCompute, func() {
 			newVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, getOptions)
 			Expect(err).ToNot(HaveOccurred())
 
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 
 			expectedIOThreads := 1
 			Expect(int(domSpec.IOThreads.IOThreads)).To(Equal(expectedIOThreads))
@@ -109,10 +106,8 @@ var _ = Describe("[sig-compute]IOThreads", decorators.SigCompute, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Fetching the domain XML from the running pod")
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 
 			By("Verifying the total number of ioThreads")
 			expectedIOThreads := 2
@@ -167,10 +162,8 @@ var _ = Describe("[sig-compute]IOThreads", decorators.SigCompute, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Fetching the domain XML from the running pod")
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, newVMI)
+			domSpec, err := tests.GetRunningVMIDomainSpec(newVMI)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 
 			By("Verifying the total number of ioThreads")
 			Expect(int(domSpec.IOThreads.IOThreads)).To(Equal(expectedIOThreads))
@@ -249,10 +242,8 @@ var _ = Describe("[sig-compute]IOThreads", decorators.SigCompute, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Fetching the domain XML from the running pod")
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 
 			By("Verifying the total number of ioThreads")
 			// This will create 1 thread for all disks w/o dedicated iothread and 1 for a disk with a dedicated iothread

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -21,7 +21,6 @@ package tests_test
 
 import (
 	"context"
-	"encoding/xml"
 	"fmt"
 	"strconv"
 
@@ -41,7 +40,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -123,10 +121,8 @@ var _ = Describe("[sig-compute]MultiQueue", decorators.SigCompute, func() {
 			Expect(*newVMI.Spec.Domain.Devices.BlockMultiQueue).To(BeTrue())
 
 			By("Fetching Domain XML from running pod")
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 
 			By("Ensuring each disk has three queues assigned")
 			for _, disk := range domSpec.Devices.Disks {
@@ -146,10 +142,8 @@ var _ = Describe("[sig-compute]MultiQueue", decorators.SigCompute, func() {
 			libwait.WaitForSuccessfulVMIStart(vmi)
 
 			By("Fetching Domain XML from running pod")
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 
 			for i, iface := range domSpec.Devices.Interfaces {
 				expectedIfaceName := fmt.Sprintf("tap%d", i)

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -21,7 +21,6 @@ package tests_test
 
 import (
 	"context"
-	"encoding/xml"
 	"fmt"
 
 	expect "github.com/google/goexpect"
@@ -102,10 +101,8 @@ func createSoundVMI(virtClient kubecli.KubevirtClient, soundDevice string) (*v1.
 }
 
 func checkXMLSoundCard(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, model string) {
-	domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+	domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 	Expect(err).ToNot(HaveOccurred())
-	domSpec := &api.DomainSpec{}
-	Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 	Expect(domSpec.Devices.SoundCards).To(HaveLen(1))
 	Expect(domSpec.Devices.SoundCards).To(ContainElement(api.SoundCard{
 		Alias: api.NewUserDefinedAlias("test-audio-device"),

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"encoding/xml"
 	"fmt"
 	"io"
 	"net"
@@ -42,8 +41,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
-
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -78,10 +75,8 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 
 			By("creating valid libvirt domain")
 
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 			Expect(domSpec.Devices.VSOCK.CID.Auto).To(Equal("no"))
 			Expect(domSpec.Devices.VSOCK.CID.Address).To(Equal(*vmi.Status.VSOCKCID))
 
@@ -134,10 +129,8 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			Expect(vmi.Status.VSOCKCID).NotTo(BeNil())
 
 			By("creating valid libvirt domain")
-			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 			Expect(domSpec.Devices.VSOCK.CID.Auto).To(Equal("no"))
 			Expect(domSpec.Devices.VSOCK.CID.Address).To(Equal(*vmi.Status.VSOCKCID))
 
@@ -150,10 +143,9 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			Expect(vmi2.Status.VSOCKCID).NotTo(BeNil())
 
 			By("creating valid libvirt domain")
-			domain2, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi2)
+			domSpec2, err := tests.GetRunningVMIDomainSpec(vmi2)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec2 := &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain2), domSpec2)).To(Succeed())
+
 			Expect(domSpec2.Devices.VSOCK.CID.Auto).To(Equal("no"))
 			Expect(domSpec2.Devices.VSOCK.CID.Address).To(Equal(*vmi2.Status.VSOCKCID))
 
@@ -162,10 +154,9 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 			migration := libmigration.New(vmi2.Name, vmi2.Namespace)
 			libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 
-			domain2, err = tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi2)
+			domSpec2, err = tests.GetRunningVMIDomainSpec(vmi2)
 			Expect(err).ToNot(HaveOccurred())
-			domSpec2 = &api.DomainSpec{}
-			Expect(xml.Unmarshal([]byte(domain2), domSpec2)).To(Succeed())
+
 			Expect(domSpec2.Devices.VSOCK.CID.Auto).To(Equal("no"))
 			Expect(domSpec2.Devices.VSOCK.CID.Address).To(Equal(*vmi2.Status.VSOCKCID))
 		})


### PR DESCRIPTION
Replace the use of GetRunningVirtualMachineInstanceDomainXML with the shorter and simpler to use GetRunningVMIDomainSpec wherever replacement is trivial. Some other tests perform a string analysis on the raw XML, those are not handled within the scope of this commit.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Test code was needlessly longer and more cumbersome that it could have been 

After this PR:
Some test code is a bit more concise, and in some cases imports fewer packages

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

More instances can be removed with not too much of an effort

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

