### PR TITLE
pkg/network: Break cyclic dependency

### DIFF
--- a/pkg/network/multus/BUILD.bazel
+++ b/pkg/network/multus/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "annotation_test.go",
         "multus_suite_test.go",
         "nad_test.go",
+        "status_test.go",
     ],
     deps = [
         ":go_default_library",
@@ -35,8 +36,10 @@ go_test(
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/network/multus/BUILD.bazel
+++ b/pkg/network/multus/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "annotation.go",
         "nad.go",
+        "status.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/network/multus",
     visibility = ["//visibility:public"],
@@ -14,8 +15,10 @@ go_library(
         "//pkg/network/vmispec:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )
 

--- a/pkg/network/multus/status.go
+++ b/pkg/network/multus/status.go
@@ -29,7 +29,7 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-func NonDefaultMultusNetworksIndexedByIfaceName(pod *k8Scorev1.Pod) map[string]networkv1.NetworkStatus {
+func NonDefaultNetworkStatusIndexedByIfaceName(pod *k8Scorev1.Pod) map[string]networkv1.NetworkStatus {
 	indexedNetworkStatus := map[string]networkv1.NetworkStatus{}
 	podNetworkStatus, found := pod.Annotations[networkv1.NetworkStatusAnnot]
 

--- a/pkg/network/multus/status.go
+++ b/pkg/network/multus/status.go
@@ -17,19 +17,19 @@
  *
  */
 
-package network
+package multus
 
 import (
 	"encoding/json"
 
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	k8Scorev1 "k8s.io/api/core/v1"
 
-	k8sv1 "k8s.io/api/core/v1"
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	"kubevirt.io/client-go/log"
 )
 
-func NonDefaultMultusNetworksIndexedByIfaceName(pod *k8sv1.Pod) map[string]networkv1.NetworkStatus {
+func NonDefaultMultusNetworksIndexedByIfaceName(pod *k8Scorev1.Pod) map[string]networkv1.NetworkStatus {
 	indexedNetworkStatus := map[string]networkv1.NetworkStatus{}
 	podNetworkStatus, found := pod.Annotations[networkv1.NetworkStatusAnnot]
 

--- a/pkg/network/multus/status_test.go
+++ b/pkg/network/multus/status_test.go
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 The KubeVirt Authors.
+ *
+ */
+
+package multus_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8scorev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/multus"
+)
+
+var _ = Describe("Network Status", func() {
+	const multusNetworkStatusWithPrimaryNet = `[{"name":"k8s-pod-network","ips":["10.244.196.146","fd10:244::c491"],"default":true,"dns":{}}]`
+
+	DescribeTable("It should return empty", func(annotations map[string]string) {
+		result := multus.NonDefaultMultusNetworksIndexedByIfaceName(newStubPod(annotations))
+		Expect(result).To(BeEmpty())
+	},
+		Entry("when network-status is missing", map[string]string{}),
+		Entry("when network-status contains only pod network",
+			map[string]string{networkv1.NetworkStatusAnnot: multusNetworkStatusWithPrimaryNet},
+		),
+	)
+
+	It("Should return a map of pod interface name to network status when interface name is hashed", func() {
+		const (
+			multusNetworksAnnotation                       = `[{"name":"meganet","namespace":"default","interface":"pod7e0055a6880"}]`
+			multusNetworkStatusWithPrimaryAndSecondaryNets = `[` +
+				`{"name":"k8s-pod-network","ips":["10.244.196.146","fd10:244::c491"],"default":true,"dns":{}},` +
+				`{"name":"meganet","interface":"pod7e0055a6880","mac":"8a:37:d9:e7:0f:18","dns":{}}` +
+				`]`
+		)
+
+		annotations := map[string]string{
+			networkv1.NetworkAttachmentAnnot: multusNetworksAnnotation,
+			networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndSecondaryNets,
+		}
+
+		result := multus.NonDefaultMultusNetworksIndexedByIfaceName(newStubPod(annotations))
+
+		expectedResult := map[string]networkv1.NetworkStatus{
+			"pod7e0055a6880": {
+				Name:      "meganet",
+				Interface: "pod7e0055a6880",
+				Mac:       "8a:37:d9:e7:0f:18",
+				Default:   false,
+			},
+		}
+
+		Expect(result).To(Equal(expectedResult))
+	})
+
+	It("Should return a map of pod interface name to network status when interface name is ordinal", func() {
+		const (
+			multusOrdinalNetworksAnnotation                       = `[{"name":"meganet","namespace":"default","interface":"net1"}]`
+			multusNetworkStatusWithPrimaryAndOrdinalSecondaryNets = `[` +
+				`{"name":"k8s-pod-network","ips":["10.244.196.146","fd10:244::c491"],"default":true,"dns":{}},` +
+				`{"name":"meganet","interface":"net1","mac":"8a:37:d9:e7:0f:18","dns":{}}` +
+				`]`
+		)
+
+		annotations := map[string]string{
+			networkv1.NetworkAttachmentAnnot: multusOrdinalNetworksAnnotation,
+			networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndOrdinalSecondaryNets,
+		}
+
+		result := multus.NonDefaultMultusNetworksIndexedByIfaceName(newStubPod(annotations))
+
+		expectedResult := map[string]networkv1.NetworkStatus{
+			"net1": {
+				Name:      "meganet",
+				Interface: "net1",
+				Mac:       "8a:37:d9:e7:0f:18",
+				Default:   false,
+			},
+		}
+
+		Expect(result).To(Equal(expectedResult))
+	})
+})
+
+func newStubPod(annotations map[string]string) *k8scorev1.Pod {
+	return &k8scorev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+		},
+	}
+}

--- a/pkg/network/multus/status_test.go
+++ b/pkg/network/multus/status_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Network Status", func() {
 	const multusNetworkStatusWithPrimaryNet = `[{"name":"k8s-pod-network","ips":["10.244.196.146","fd10:244::c491"],"default":true,"dns":{}}]`
 
 	DescribeTable("It should return empty", func(annotations map[string]string) {
-		result := multus.NonDefaultMultusNetworksIndexedByIfaceName(newStubPod(annotations))
+		result := multus.NonDefaultNetworkStatusIndexedByIfaceName(newStubPod(annotations))
 		Expect(result).To(BeEmpty())
 	},
 		Entry("when network-status is missing", map[string]string{}),
@@ -59,7 +59,7 @@ var _ = Describe("Network Status", func() {
 			networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndSecondaryNets,
 		}
 
-		result := multus.NonDefaultMultusNetworksIndexedByIfaceName(newStubPod(annotations))
+		result := multus.NonDefaultNetworkStatusIndexedByIfaceName(newStubPod(annotations))
 
 		expectedResult := map[string]networkv1.NetworkStatus{
 			"pod7e0055a6880": {
@@ -87,7 +87,7 @@ var _ = Describe("Network Status", func() {
 			networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndOrdinalSecondaryNets,
 		}
 
-		result := multus.NonDefaultMultusNetworksIndexedByIfaceName(newStubPod(annotations))
+		result := multus.NonDefaultNetworkStatusIndexedByIfaceName(newStubPod(annotations))
 
 		expectedResult := map[string]networkv1.NetworkStatus{
 			"net1": {

--- a/pkg/network/pod/annotations/BUILD.bazel
+++ b/pkg/network/pod/annotations/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/virt-config:go_default_library",
-        "//pkg/virt-controller/network:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -35,7 +35,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-controller/network"
 )
 
 type Generator struct {
@@ -85,7 +84,7 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 func (g Generator) GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8Scorev1.Pod) (map[string]string, error) {
 	annotations := map[string]string{}
 
-	if namescheme.PodHasOrdinalInterfaceName(network.NonDefaultMultusNetworksIndexedByIfaceName(sourcePod)) {
+	if namescheme.PodHasOrdinalInterfaceName(multus.NonDefaultMultusNetworksIndexedByIfaceName(sourcePod)) {
 		ordinalNameScheme := namescheme.CreateOrdinalNetworkNameScheme(vmi.Spec.Networks)
 		multusNetworksAnnotation, err := multus.GenerateCNIAnnotationFromNameScheme(
 			vmi.Namespace,

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -84,7 +84,7 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 func (g Generator) GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8Scorev1.Pod) (map[string]string, error) {
 	annotations := map[string]string{}
 
-	if namescheme.PodHasOrdinalInterfaceName(multus.NonDefaultMultusNetworksIndexedByIfaceName(sourcePod)) {
+	if namescheme.PodHasOrdinalInterfaceName(multus.NonDefaultNetworkStatusIndexedByIfaceName(sourcePod)) {
 		ordinalNameScheme := namescheme.CreateOrdinalNetworkNameScheme(vmi.Spec.Networks)
 		multusNetworksAnnotation, err := multus.GenerateCNIAnnotationFromNameScheme(
 			vmi.Namespace,

--- a/pkg/network/vmicontroller/BUILD.bazel
+++ b/pkg/network/vmicontroller/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/network/vmicontroller",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/multus:go_default_library",
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/vmispec:go_default_library",
-        "//pkg/virt-controller/network:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/pkg/network/vmicontroller/status.go
+++ b/pkg/network/vmicontroller/status.go
@@ -26,13 +26,13 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/network/multus"
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
-	"kubevirt.io/kubevirt/pkg/virt-controller/network"
 )
 
 func UpdateStatus(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) error {
-	indexedMultusStatusIfaces := network.NonDefaultMultusNetworksIndexedByIfaceName(pod)
+	indexedMultusStatusIfaces := multus.NonDefaultMultusNetworksIndexedByIfaceName(pod)
 	ifaceNamingScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(vmi.Spec.Networks, indexedMultusStatusIfaces)
 	for _, network := range vmi.Spec.Networks {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)

--- a/pkg/network/vmicontroller/status.go
+++ b/pkg/network/vmicontroller/status.go
@@ -32,7 +32,7 @@ import (
 )
 
 func UpdateStatus(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) error {
-	indexedMultusStatusIfaces := multus.NonDefaultMultusNetworksIndexedByIfaceName(pod)
+	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByIfaceName(pod)
 	ifaceNamingScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(vmi.Spec.Networks, indexedMultusStatusIfaces)
 	for _, network := range vmi.Spec.Networks {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)

--- a/pkg/virt-controller/network/BUILD.bazel
+++ b/pkg/virt-controller/network/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "hotplug.go",
-        "multus_annotations.go",
         "render.go",
         "vmcontroller.go",
     ],

--- a/pkg/virt-controller/network/vmcontroller.go
+++ b/pkg/virt-controller/network/vmcontroller.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/network/multus"
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
@@ -138,7 +139,7 @@ func (v *VMNetController) hasOrdinalNetworkInterfaces(vmi *v1.VirtualMachineInst
 		// This is an old virt-launcher that uses ordinal network interface names.
 		return true, nil
 	}
-	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName(NonDefaultMultusNetworksIndexedByIfaceName(pod))
+	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName(multus.NonDefaultMultusNetworksIndexedByIfaceName(pod))
 	return hasOrdinalIfaces, nil
 }
 

--- a/pkg/virt-controller/network/vmcontroller.go
+++ b/pkg/virt-controller/network/vmcontroller.go
@@ -139,7 +139,7 @@ func (v *VMNetController) hasOrdinalNetworkInterfaces(vmi *v1.VirtualMachineInst
 		// This is an old virt-launcher that uses ordinal network interface names.
 		return true, nil
 	}
-	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName(multus.NonDefaultMultusNetworksIndexedByIfaceName(pod))
+	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName(multus.NonDefaultNetworkStatusIndexedByIfaceName(pod))
 	return hasOrdinalIfaces, nil
 }
 

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -2137,7 +2137,7 @@ func (c *Controller) getVolumePhaseMessageReason(volume *virtv1.Volume, namespac
 func (c *Controller) updateMultusAnnotation(namespace string, interfaces []virtv1.Interface, networks []virtv1.Network, pod *k8sv1.Pod) error {
 	podAnnotations := pod.GetAnnotations()
 
-	indexedMultusStatusIfaces := network.NonDefaultMultusNetworksIndexedByIfaceName(pod)
+	indexedMultusStatusIfaces := multus.NonDefaultMultusNetworksIndexedByIfaceName(pod)
 	networkToPodIfaceMap := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, indexedMultusStatusIfaces)
 	multusAnnotations, err := multus.GenerateCNIAnnotationFromNameScheme(namespace, interfaces, networks, networkToPodIfaceMap, c.clusterConfig)
 	if err != nil {

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -2137,7 +2137,7 @@ func (c *Controller) getVolumePhaseMessageReason(volume *virtv1.Volume, namespac
 func (c *Controller) updateMultusAnnotation(namespace string, interfaces []virtv1.Interface, networks []virtv1.Network, pod *k8sv1.Pod) error {
 	podAnnotations := pod.GetAnnotations()
 
-	indexedMultusStatusIfaces := multus.NonDefaultMultusNetworksIndexedByIfaceName(pod)
+	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByIfaceName(pod)
 	networkToPodIfaceMap := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, indexedMultusStatusIfaces)
 	multusAnnotations, err := multus.GenerateCNIAnnotationFromNameScheme(namespace, interfaces, networks, networkToPodIfaceMap, c.clusterConfig)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
PRs https://github.com/kubevirt/kubevirt/pull/12558 and https://github.com/kubevirt/kubevirt/pull/12833 have made the `pkg/network` package dependent on `pkg/virt-controller/network`.

Following this move, the cyclic dependency is broken.
Add unit tests to the moved function.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/12833#discussion_r1760051643
https://github.com/kubevirt/kubevirt/pull/12833#discussion_r1762945994

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

