### PR TITLE
cleanup(virtctl,vmexport): Refactor and cleanup unit tests

### DIFF
--- a/pkg/virtctl/utils/BUILD.bazel
+++ b/pkg/virtctl/utils/BUILD.bazel
@@ -9,11 +9,9 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/utils",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/virtctl/vmexport:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/golang.org/x/term:go_default_library",

--- a/pkg/virtctl/utils/test_utils.go
+++ b/pkg/virtctl/utils/test_utils.go
@@ -1,9 +1,7 @@
 package utils
 
 import (
-	"fmt"
 	"sync"
-	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -13,14 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
+
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1beta1"
-	"kubevirt.io/client-go/kubecli"
-	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
-
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
-
-	"kubevirt.io/kubevirt/pkg/virtctl/vmexport"
+	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 )
 
 type AtomicBool struct {
@@ -220,12 +215,4 @@ func GetVMEStatus(volumes []exportv1.VirtualMachineExportVolume, secretName stri
 		},
 		TokenSecretRef: &tokenSecretRef,
 	}
-}
-
-func WaitExportCompleteDefault(kubecli.KubevirtClient, *vmexport.VMExportInfo, time.Duration, time.Duration) error {
-	return nil
-}
-
-func WaitExportCompleteError(kubecli.KubevirtClient, *vmexport.VMExportInfo, time.Duration, time.Duration) error {
-	return fmt.Errorf("processing failed: Test error")
 }

--- a/pkg/virtctl/utils/test_utils.go
+++ b/pkg/virtctl/utils/test_utils.go
@@ -185,15 +185,6 @@ func HandlePodList(k8sClient *fakek8sclient.Clientset, podName string) {
 	})
 }
 
-func HandleVMExportDelete(client *kubevirtfake.Clientset, name string) {
-	client.Fake.PrependReactor("delete", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		delete, ok := action.(testing.DeleteAction)
-		Expect(ok).To(BeTrue())
-		Expect(delete.GetName()).To(Equal(name))
-		return true, nil, nil
-	})
-}
-
 func GetExportVolumeFormat(url string, format exportv1.ExportVolumeFormat) []exportv1.VirtualMachineExportVolumeFormat {
 	return []exportv1.VirtualMachineExportVolumeFormat{
 		{

--- a/pkg/virtctl/vmexport/BUILD.bazel
+++ b/pkg/virtctl/vmexport/BUILD.bazel
@@ -37,7 +37,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
-        "//pkg/virtctl/utils:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
@@ -48,6 +48,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -581,80 +581,6 @@ var _ = Describe("vmexport", func() {
 		})
 	})
 
-	Context("getUrlFromVirtualMachineExport", func() {
-		It("Should get compressed URL even when there's multiple URLs", func() {
-			vme.Status = vmeStatusReady([]exportv1.VirtualMachineExportVolume{{
-				Name: volumeName,
-				Formats: []exportv1.VirtualMachineExportVolumeFormat{
-					{
-						Format: exportv1.KubeVirtRaw,
-						Url:    "raw",
-					},
-					{
-						Format: exportv1.KubeVirtRaw,
-						Url:    "raw",
-					},
-					{
-						Format: exportv1.KubeVirtGz,
-						Url:    "compressed",
-					},
-					{
-						Format: exportv1.KubeVirtRaw,
-						Url:    "raw",
-					},
-				}},
-			})
-			vmeInfo := &vmexport.VMExportInfo{
-				Name:       vme.Name,
-				VolumeName: volumeName,
-			}
-
-			url, err := vmexport.GetUrlFromVirtualMachineExport(vme, vmeInfo)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(url).Should(Equal("compressed"))
-		})
-
-		It("Should get raw URL when there's no other option", func() {
-			vme.Status = vmeStatusReady([]exportv1.VirtualMachineExportVolume{{
-				Name: volumeName,
-				Formats: []exportv1.VirtualMachineExportVolumeFormat{
-					{
-						Format: exportv1.KubeVirtRaw,
-						Url:    "raw",
-					},
-				}},
-			})
-			vmeInfo := &vmexport.VMExportInfo{
-				Name:       vme.Name,
-				VolumeName: volumeName,
-			}
-
-			url, err := vmexport.GetUrlFromVirtualMachineExport(vme, vmeInfo)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(url).Should(Equal("raw"))
-		})
-
-		It("Should not get any URL when there's no valid options", func() {
-			vme.Status = vmeStatusReady([]exportv1.VirtualMachineExportVolume{{
-				Name: volumeName,
-				Formats: []exportv1.VirtualMachineExportVolumeFormat{
-					{
-						Format: exportv1.Dir,
-						Url:    server.URL,
-					},
-				}},
-			})
-			vmeInfo := &vmexport.VMExportInfo{
-				Name:       vme.Name,
-				VolumeName: volumeName,
-			}
-
-			url, err := vmexport.GetUrlFromVirtualMachineExport(vme, vmeInfo)
-			Expect(err).To(HaveOccurred())
-			Expect(url).To(Equal(""))
-		})
-	})
-
 	Context("Manifest", func() {
 		const (
 			manifestUrl = "/test/all"
@@ -893,6 +819,76 @@ var _ = Describe("vmexport", func() {
 				setFlag(vmexport.OUTPUT_FLAG, outputPath),
 			)
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("getUrlFromVirtualMachineExport", func() {
+		It("Should get compressed URL even when there's multiple URLs", func() {
+			vme.Status = vmeStatusReady([]exportv1.VirtualMachineExportVolume{{
+				Name: volumeName,
+				Formats: []exportv1.VirtualMachineExportVolumeFormat{
+					{
+						Format: exportv1.KubeVirtRaw,
+						Url:    "raw",
+					},
+					{
+						Format: exportv1.KubeVirtRaw,
+						Url:    "raw",
+					},
+					{
+						Format: exportv1.KubeVirtGz,
+						Url:    "compressed",
+					},
+					{
+						Format: exportv1.KubeVirtRaw,
+						Url:    "raw",
+					},
+				}},
+			})
+			vmeInfo := &vmexport.VMExportInfo{
+				Name:       vme.Name,
+				VolumeName: volumeName,
+			}
+
+			url, err := vmexport.GetUrlFromVirtualMachineExport(vme, vmeInfo)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(url).Should(Equal("compressed"))
+		})
+
+		It("Should get raw URL when there's no other option", func() {
+			vme.Status = vmeStatusReady([]exportv1.VirtualMachineExportVolume{{
+				Name: volumeName,
+				Formats: []exportv1.VirtualMachineExportVolumeFormat{{
+					Format: exportv1.KubeVirtRaw,
+					Url:    "raw",
+				}}},
+			})
+			vmeInfo := &vmexport.VMExportInfo{
+				Name:       vme.Name,
+				VolumeName: volumeName,
+			}
+
+			url, err := vmexport.GetUrlFromVirtualMachineExport(vme, vmeInfo)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(url).Should(Equal("raw"))
+		})
+
+		It("Should not get any URL when there's no valid options", func() {
+			vme.Status = vmeStatusReady([]exportv1.VirtualMachineExportVolume{{
+				Name: volumeName,
+				Formats: []exportv1.VirtualMachineExportVolumeFormat{{
+					Format: exportv1.Dir,
+					Url:    server.URL,
+				}}},
+			})
+			vmeInfo := &vmexport.VMExportInfo{
+				Name:       vme.Name,
+				VolumeName: volumeName,
+			}
+
+			url, err := vmexport.GetUrlFromVirtualMachineExport(vme, vmeInfo)
+			Expect(err).To(MatchError(ContainSubstring("unable to get a valid URL")))
+			Expect(url).To(Equal(""))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR cleans up and enhances the vmexport unit tests by consolidating `AfterEach`/`BeforeEach` calls, simplifying test setup, reorganizing imports, and removing unnecessary cleanups. Helpers were added to reduce repeated command arguments, and global variable setters in virtctl's vmexport command were removed. The tests now properly use the fake client and a fake HTTP server where possible, with redundant dependencies eliminated. Additional assertions were added, along with missing test cases for creating and downloading VirtualMachineExport from {Snapshot, VM} sources. These changes improve test readability and maintainability.

The goal of this and further PRs is to reduce the amount of unnecessary uses of
virtctl in the e2e tests to stabilize tests, to reduce the number of flakes and to
remove redudant tests.

Before this PR:

virtctl vmexport unit tests could be refactored and cleaned up

After this PR:

virtctl vmexport unit tests are refactored and cleaned up

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

