### PR TITLE
Fix wrong label order in kubevirt_vm_info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/krolaw/dhcp4 v0.0.0-20180925202202-7cead472c414
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a
-	github.com/machadovilaca/operator-observability v0.0.21
+	github.com/machadovilaca/operator-observability v0.0.22
 	github.com/mdlayher/vsock v1.2.1
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed

--- a/go.sum
+++ b/go.sum
@@ -1389,8 +1389,8 @@ github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuz
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
-github.com/machadovilaca/operator-observability v0.0.21 h1:H0nH+45wtqsxCrJOm8wmcrJLuRZ5QY6iTlHKMlMEZss=
-github.com/machadovilaca/operator-observability v0.0.21/go.mod h1:trC+BjI6zhvZMBcX0q7vHrKKRX3lWZdwJxgVUmRJCfw=
+github.com/machadovilaca/operator-observability v0.0.22 h1:6+SdraJf91TmoPkZXJbjhxp99wMdYfBgk0WsV4fnfPo=
+github.com/machadovilaca/operator-observability v0.0.22/go.mod h1:trC+BjI6zhvZMBcX0q7vHrKKRX3lWZdwJxgVUmRJCfw=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -40,7 +40,7 @@ var (
 		},
 		[]string{
 			// Basic info
-			"namespace", "name",
+			"name", "namespace",
 
 			// VM annotations
 			"os", "workload", "flavor",

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -149,13 +149,16 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr.Value).To(BeEquivalentTo(1))
 				Expect(cr.Labels).To(HaveLen(9))
 
-				os, workload, flavor := getSystemInfoFromAnnotations(vms[i].Spec.Template.ObjectMeta.Annotations)
-				Expect(cr.Labels[2]).To(Equal(os))
-				Expect(cr.Labels[3]).To(Equal(workload))
-				Expect(cr.Labels[4]).To(Equal(flavor))
+				Expect(cr.GetLabelValue("name")).To(Equal(vms[i].ObjectMeta.Name))
+				Expect(cr.GetLabelValue("namespace")).To(Equal(vms[i].ObjectMeta.Namespace))
 
-				Expect(cr.Labels[7]).To(Equal("CrashLoopBackOff"))
-				Expect(cr.Labels[8]).To(Equal("error"))
+				os, workload, flavor := getSystemInfoFromAnnotations(vms[i].Spec.Template.ObjectMeta.Annotations)
+				Expect(cr.GetLabelValue("os")).To(Equal(os))
+				Expect(cr.GetLabelValue("workload")).To(Equal(workload))
+				Expect(cr.GetLabelValue("flavor")).To(Equal(flavor))
+
+				Expect(cr.GetLabelValue("status")).To(Equal("CrashLoopBackOff"))
+				Expect(cr.GetLabelValue("status_group")).To(Equal("error"))
 			}
 		})
 
@@ -177,7 +180,7 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
 			Expect(cr.Labels).To(HaveLen(9))
-			Expect(cr.Labels[5]).To(Equal(expected))
+			Expect(cr.GetLabelValue("instance_type")).To(Equal(expected))
 		},
 			Entry("with no instance type expect <none>", "VirtualMachineInstancetype", "", "<none>"),
 			Entry("with managed instance type expect its name", "VirtualMachineInstancetype", "i-managed", "i-managed"),
@@ -205,7 +208,7 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
 			Expect(cr.Labels).To(HaveLen(9))
-			Expect(cr.Labels[6]).To(Equal(expected))
+			Expect(cr.GetLabelValue("preference")).To(Equal(expected))
 		},
 			Entry("with no preference expect <none>", "VirtualMachinePreference", "", "<none>"),
 			Entry("with managed preference expect its name", "VirtualMachinePreference", "p-managed", "p-managed"),

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/BUILD.bazel
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "collector.go",
+        "collector_result.go",
         "counter.go",
         "counter_vec.go",
         "gauge.go",

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector.go
@@ -3,7 +3,6 @@ package operatormetrics
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -20,14 +19,6 @@ type Collector struct {
 	CollectCallback func() []CollectorResult
 }
 
-type CollectorResult struct {
-	Metric      Metric
-	Labels      []string
-	ConstLabels map[string]string
-	Value       float64
-	Timestamp   time.Time
-}
-
 func (c Collector) hash() string {
 	var sb strings.Builder
 
@@ -40,7 +31,7 @@ func (c Collector) hash() string {
 
 func (c Collector) Describe(ch chan<- *prometheus.Desc) {
 	for _, cm := range c.Metrics {
-		cm.getCollector().Describe(ch)
+		cm.GetCollector().Describe(ch)
 	}
 }
 

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector_result.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/collector_result.go
@@ -1,0 +1,24 @@
+package operatormetrics
+
+import (
+	"errors"
+	"time"
+)
+
+type CollectorResult struct {
+	Metric      Metric
+	Labels      []string
+	ConstLabels map[string]string
+	Value       float64
+	Timestamp   time.Time
+}
+
+func (cr CollectorResult) GetLabelValue(key string) (string, error) {
+	for i, label := range cr.Metric.GetOpts().labels {
+		if label == key {
+			return cr.Labels[i], nil
+		}
+	}
+
+	return "", errors.New("label not found")
+}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter.go
@@ -31,6 +31,6 @@ func (c *Counter) GetBaseType() MetricType {
 	return CounterType
 }
 
-func (c *Counter) getCollector() prometheus.Collector {
+func (c *Counter) GetCollector() prometheus.Collector {
 	return c.Counter
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/counter_vec.go
@@ -33,6 +33,6 @@ func (c *CounterVec) GetBaseType() MetricType {
 	return CounterType
 }
 
-func (c *CounterVec) getCollector() prometheus.Collector {
+func (c *CounterVec) GetCollector() prometheus.Collector {
 	return c.CounterVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge.go
@@ -31,6 +31,6 @@ func (c *Gauge) GetBaseType() MetricType {
 	return GaugeType
 }
 
-func (c *Gauge) getCollector() prometheus.Collector {
+func (c *Gauge) GetCollector() prometheus.Collector {
 	return c.Gauge
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/gauge_vec.go
@@ -33,6 +33,6 @@ func (c *GaugeVec) GetBaseType() MetricType {
 	return GaugeType
 }
 
-func (c *GaugeVec) getCollector() prometheus.Collector {
+func (c *GaugeVec) GetCollector() prometheus.Collector {
 	return c.GaugeVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram.go
@@ -46,6 +46,6 @@ func (c *Histogram) GetBaseType() MetricType {
 	return HistogramType
 }
 
-func (c *Histogram) getCollector() prometheus.Collector {
+func (c *Histogram) GetCollector() prometheus.Collector {
 	return c.Histogram
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/histogram_vec.go
@@ -37,6 +37,6 @@ func (c *HistogramVec) GetBaseType() MetricType {
 	return HistogramType
 }
 
-func (c *HistogramVec) getCollector() prometheus.Collector {
+func (c *HistogramVec) GetCollector() prometheus.Collector {
 	return c.HistogramVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/metric.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/metric.go
@@ -15,8 +15,7 @@ type Metric interface {
 	GetOpts() MetricOpts
 	GetType() MetricType
 	GetBaseType() MetricType
-
-	getCollector() prometheus.Collector
+	GetCollector() prometheus.Collector
 }
 
 type MetricType string

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary.go
@@ -46,6 +46,6 @@ func (c *Summary) GetBaseType() MetricType {
 	return SummaryType
 }
 
-func (c *Summary) getCollector() prometheus.Collector {
+func (c *Summary) GetCollector() prometheus.Collector {
 	return c.Summary
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary_vec.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/summary_vec.go
@@ -37,6 +37,6 @@ func (c *SummaryVec) GetBaseType() MetricType {
 	return SummaryType
 }
 
-func (c *SummaryVec) getCollector() prometheus.Collector {
+func (c *SummaryVec) GetCollector() prometheus.Collector {
 	return c.SummaryVec
 }

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/wrapper_registry.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatormetrics/wrapper_registry.go
@@ -122,7 +122,7 @@ func metricExists(metric Metric) bool {
 }
 
 func unregisterMetric(metric Metric) error {
-	if succeeded := Unregister(metric.getCollector()); succeeded {
+	if succeeded := Unregister(metric.GetCollector()); succeeded {
 		delete(operatorRegistry.registeredMetrics, metric.GetOpts().Name)
 		return nil
 	}
@@ -131,7 +131,7 @@ func unregisterMetric(metric Metric) error {
 }
 
 func registerMetric(metric Metric) error {
-	err := Register(metric.getCollector())
+	err := Register(metric.GetCollector())
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/BUILD.bazel
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "compatibility.go",
         "prometheusrules.go",
         "rbac.go",
         "recordingrule.go",

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/compatibility.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/compatibility.go
@@ -1,0 +1,37 @@
+package operatorrules
+
+import promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+// Deprecated: operatorRegistry is deprecated.
+var operatorRegistry = NewRegistry()
+
+// Deprecated: RegisterRecordingRules is deprecated.
+func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
+	return operatorRegistry.RegisterRecordingRules(recordingRules...)
+}
+
+// Deprecated: RegisterAlerts is deprecated.
+func RegisterAlerts(alerts ...[]promv1.Rule) error {
+	return operatorRegistry.RegisterAlerts(alerts...)
+}
+
+// Deprecated: ListRecordingRules is deprecated.
+func ListRecordingRules() []RecordingRule {
+	return operatorRegistry.ListRecordingRules()
+}
+
+// Deprecated: ListAlerts is deprecated.
+func ListAlerts() []promv1.Rule {
+	return operatorRegistry.ListAlerts()
+}
+
+// Deprecated: CleanRegistry is deprecated.
+func CleanRegistry() error {
+	operatorRegistry = NewRegistry()
+	return nil
+}
+
+// Deprecated: BuildPrometheusRule is deprecated.
+func BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
+	return operatorRegistry.BuildPrometheusRule(name, namespace, labels)
+}

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/prometheusrules.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/prometheusrules.go
@@ -11,8 +11,8 @@ import (
 )
 
 // BuildPrometheusRule builds a PrometheusRule object from the registered recording rules and alerts.
-func BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
-	spec, err := buildPrometheusRuleSpec()
+func (r *Registry) BuildPrometheusRule(name, namespace string, labels map[string]string) (*promv1.PrometheusRule, error) {
+	spec, err := r.buildPrometheusRuleSpec()
 	if err != nil {
 		return nil, err
 	}
@@ -31,20 +31,20 @@ func BuildPrometheusRule(name, namespace string, labels map[string]string) (*pro
 	}, nil
 }
 
-func buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
+func (r *Registry) buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
 	var groups []promv1.RuleGroup
 
-	if len(operatorRegistry.registeredRecordingRules) != 0 {
+	if len(r.registeredRecordingRules) != 0 {
 		groups = append(groups, promv1.RuleGroup{
 			Name:  "recordingRules.rules",
-			Rules: buildRecordingRulesRules(),
+			Rules: r.buildRecordingRulesRules(),
 		})
 	}
 
-	if len(operatorRegistry.registeredAlerts) != 0 {
+	if len(r.registeredAlerts) != 0 {
 		groups = append(groups, promv1.RuleGroup{
 			Name:  "alerts.rules",
-			Rules: ListAlerts(),
+			Rules: r.ListAlerts(),
 		})
 	}
 
@@ -55,10 +55,10 @@ func buildPrometheusRuleSpec() (*promv1.PrometheusRuleSpec, error) {
 	return &promv1.PrometheusRuleSpec{Groups: groups}, nil
 }
 
-func buildRecordingRulesRules() []promv1.Rule {
+func (r *Registry) buildRecordingRulesRules() []promv1.Rule {
 	var rules []promv1.Rule
 
-	for _, recordingRule := range operatorRegistry.registeredRecordingRules {
+	for _, recordingRule := range r.registeredRecordingRules {
 		rules = append(rules, promv1.Rule{
 			Record: recordingRule.MetricsOpts.Name,
 			Expr:   recordingRule.Expr,

--- a/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
+++ b/vendor/github.com/machadovilaca/operator-observability/pkg/operatorrules/registry.go
@@ -7,26 +7,24 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
-var operatorRegistry = newRegistry()
-
-type operatorRegisterer struct {
+type Registry struct {
 	registeredRecordingRules map[string]RecordingRule
 	registeredAlerts         map[string]promv1.Rule
 }
 
-func newRegistry() operatorRegisterer {
-	return operatorRegisterer{
+func NewRegistry() *Registry {
+	return &Registry{
 		registeredRecordingRules: map[string]RecordingRule{},
 		registeredAlerts:         map[string]promv1.Rule{},
 	}
 }
 
 // RegisterRecordingRules registers the given recording rules.
-func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
+func (r *Registry) RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 	for _, recordingRuleList := range recordingRules {
 		for _, recordingRule := range recordingRuleList {
 			key := recordingRule.MetricsOpts.Name + ":" + recordingRule.Expr.String()
-			operatorRegistry.registeredRecordingRules[key] = recordingRule
+			r.registeredRecordingRules[key] = recordingRule
 		}
 	}
 
@@ -34,10 +32,10 @@ func RegisterRecordingRules(recordingRules ...[]RecordingRule) error {
 }
 
 // RegisterAlerts registers the given alerts.
-func RegisterAlerts(alerts ...[]promv1.Rule) error {
+func (r *Registry) RegisterAlerts(alerts ...[]promv1.Rule) error {
 	for _, alertList := range alerts {
 		for _, alert := range alertList {
-			operatorRegistry.registeredAlerts[alert.Alert] = alert
+			r.registeredAlerts[alert.Alert] = alert
 		}
 	}
 
@@ -45,9 +43,9 @@ func RegisterAlerts(alerts ...[]promv1.Rule) error {
 }
 
 // ListRecordingRules returns the registered recording rules.
-func ListRecordingRules() []RecordingRule {
+func (r *Registry) ListRecordingRules() []RecordingRule {
 	var rules []RecordingRule
-	for _, rule := range operatorRegistry.registeredRecordingRules {
+	for _, rule := range r.registeredRecordingRules {
 		rules = append(rules, rule)
 	}
 
@@ -62,9 +60,9 @@ func ListRecordingRules() []RecordingRule {
 }
 
 // ListAlerts returns the registered alerts.
-func ListAlerts() []promv1.Rule {
+func (r *Registry) ListAlerts() []promv1.Rule {
 	var alerts []promv1.Rule
-	for _, alert := range operatorRegistry.registeredAlerts {
+	for _, alert := range r.registeredAlerts {
 		alerts = append(alerts, alert)
 	}
 
@@ -73,10 +71,4 @@ func ListAlerts() []promv1.Rule {
 	})
 
 	return alerts
-}
-
-// CleanRegistry removes all registered rules and alerts.
-func CleanRegistry() error {
-	operatorRegistry = newRegistry()
-	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -240,7 +240,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/kubevirt/monitoring/pkg/metrics/parser v0.0.0-20230627123556-81a891d4462a
 ## explicit; go 1.20
 github.com/kubevirt/monitoring/pkg/metrics/parser
-# github.com/machadovilaca/operator-observability v0.0.21
+# github.com/machadovilaca/operator-observability v0.0.22
 ## explicit; go 1.21
 github.com/machadovilaca/operator-observability/pkg/docs
 github.com/machadovilaca/operator-observability/pkg/operatormetrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

kubevirt_vm_info add VM name and namespace order switched

After this PR:

order is corrected and unit tests are added to more accurately validate
labels values against keys and not use relative position

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

