### PR TITLE
GA BochsDisplayForEFIGuests

### DIFF
--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -59,6 +59,9 @@ const (
 	// GA:    v1.4.0
 	HotplugNetworkIfacesGate = "HotplugNICs"
 
+	// When BochsDisplayForEFIGuests is enabled, EFI guests will be started with Bochs display instead of VGA
+	BochsDisplayForEFIGuests = "BochsDisplayForEFIGuests" // GA
+
 	PasstGate   = "Passt"   // Deprecated
 	MacvtapGate = "Macvtap" // Deprecated
 	// DockerSELinuxMCSWorkaround sets the SELinux level of all the non-compute virt-launcher containers to "s0".
@@ -84,6 +87,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: CommonInstancetypesDeploymentGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: GPUGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: HotplugNetworkIfacesGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: BochsDisplayForEFIGuests, State: GA})
 
 	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Discontinued, Message: PasstDiscontinueMessage, VmiSpecUsed: passtApiUsed})
 	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -58,8 +58,6 @@ const (
 	MultiArchitecture = "MultiArchitecture"
 	// VMLiveUpdateFeaturesGate allows updating certain VM fields, such as CPU sockets to enable hot-plug functionality.
 	VMLiveUpdateFeaturesGate = "VMLiveUpdateFeatures"
-	// When BochsDisplayForEFIGuests is enabled, EFI guests will be started with Bochs display instead of VGA
-	BochsDisplayForEFIGuests = "BochsDisplayForEFIGuests"
 	// NetworkBindingPlugingsGate enables using a plugin to bind the pod and the VM network
 	// Alpha: v1.1.0
 	// Beta:  v1.4.0
@@ -225,10 +223,6 @@ func (config *ClusterConfig) MultiArchitectureEnabled() bool {
 
 func (config *ClusterConfig) VMLiveUpdateFeaturesEnabled() bool {
 	return config.isFeatureGateEnabled(VMLiveUpdateFeaturesGate)
-}
-
-func (config *ClusterConfig) BochsDisplayForEFIGuestsEnabled() bool {
-	return config.isFeatureGateEnabled(BochsDisplayForEFIGuests)
 }
 
 func (config *ClusterConfig) NetworkBindingPlugingsEnabled() bool {

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -468,3 +468,12 @@ func (c *ClusterConfig) GetNetworkBindings() map[string]v1.InterfaceBindingPlugi
 	}
 	return nil
 }
+
+func (config *ClusterConfig) VGADisplayForEFIGuestsEnabled() bool {
+	VGADisplayForEFIGuestsAnnotationExists := false
+	kv := config.GetConfigFromKubeVirtCR()
+	if kv != nil {
+		_, VGADisplayForEFIGuestsAnnotationExists = kv.Annotations[v1.VGADisplayForEFIGuestsX86Annotation]
+	}
+	return VGADisplayForEFIGuestsAnnotationExists
+}

--- a/pkg/virt-handler/options.go
+++ b/pkg/virt-handler/options.go
@@ -54,11 +54,15 @@ func virtualMachineOptions(
 	}
 
 	if clusterConfig != nil {
+		bochsDisplay := true
+		if clusterConfig.VGADisplayForEFIGuestsEnabled() {
+			bochsDisplay = false
+		}
 		options.ExpandDisksEnabled = clusterConfig.ExpandDisksEnabled()
 		options.ClusterConfig = &cmdv1.ClusterConfig{
 			ExpandDisksEnabled:        clusterConfig.ExpandDisksEnabled(),
 			FreePageReportingDisabled: clusterConfig.IsFreePageReportingDisabled(),
-			BochsDisplayForEFIGuests:  clusterConfig.BochsDisplayForEFIGuestsEnabled(),
+			BochsDisplayForEFIGuests:  bochsDisplay,
 			SerialConsoleLogDisabled:  clusterConfig.IsSerialConsoleLogDisabled(),
 		}
 	}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -847,6 +847,11 @@ const (
 	Unknown VirtualMachineInstancePhase = "Unknown"
 )
 
+// Annotations in the KubeVirt custom resource are used to modify KubeVirt's behavior, often serving as workarounds for bugs in other layers.
+const (
+	// VGADisplayForEFIGuestsX86Annotation when set, x86 EFI guests will be started with VGA display instead of Bochs
+	VGADisplayForEFIGuestsX86Annotation string = "kubevirt.io/vga-display-efi-x86"
+)
 const (
 	// AppLabel and AppName labels marks resources that belong to KubeVirt. An optional value
 	// may indicate which specific KubeVirt component a resource belongs to.


### PR DESCRIPTION
### What this PR does
Promote Boshs display as default for EFI x86 guests.
For retaining the compatibility (in case some guest
need direct access) we provide kubevirt.io/vga-display-efi-x86
annotation on the Kubevirt CR that needs to be set
before cluster upgrade.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BochsDisplayForEFIGuests is GAed, use  "kubevirt.io/vga-display-efi-x86" annotation on Kubevirt CR before upgrading in case you need retain compatibility.
```

