### PR TITLE
Revert "[nodelabeller, virt-handler]: Remove nodelabeller capabilities package and decouple vmcontroller from nodelabeller"

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
         "//pkg/virt-handler/node-labeller:go_default_library",
+        "//pkg/virt-handler/node-labeller/api:go_default_library",
         "//pkg/virt-handler/rest:go_default_library",
         "//pkg/virt-handler/seccomp:go_default_library",
         "//pkg/virt-handler/selinux:go_default_library",
@@ -51,7 +52,6 @@ go_library(
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/certificate:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
-        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )
 

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -49,11 +49,12 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/certificate"
 	"k8s.io/client-go/util/flowcontrol"
-	"libvirt.org/go/libvirtxml"
 
 	"kubevirt.io/kubevirt/pkg/safepath"
 
 	"kubevirt.io/kubevirt/pkg/util/ratelimiter"
+
+	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"
 
 	"kubevirt.io/kubevirt/pkg/monitoring/domainstats/downwardmetrics"
 
@@ -305,28 +306,14 @@ func (app *virtHandlerApp) Run() {
 
 	stop := make(chan struct{})
 	defer close(stop)
-	var capabilities libvirtxml.Caps
+	var capabilities *api.Capabilities
 	var hostCpuModel string
-
-	hostCapsFile, err := os.ReadFile(filepath.Join(nodelabeller.NodeLabellerVolumePath, "capabilities.xml"))
-	if err != nil {
-		panic(err)
-	}
-
-	if err := capabilities.Unmarshal(string(hostCapsFile)); err != nil {
-		panic(err)
-	}
-
 	nodeLabellerrecorder := broadcaster.NewRecorder(scheme.Scheme, k8sv1.EventSource{Component: "node-labeller", Host: app.HostOverride})
-	nodeLabellerController, err := nodelabeller.NewNodeLabeller(app.clusterConfig,
-		app.virtCli.CoreV1().Nodes(),
-		app.HostOverride,
-		nodeLabellerrecorder,
-		capabilities.Host.CPU.Counter,
-	)
+	nodeLabellerController, err := nodelabeller.NewNodeLabeller(app.clusterConfig, app.virtCli.CoreV1().Nodes(), app.HostOverride, nodeLabellerrecorder)
 	if err != nil {
 		panic(err)
 	}
+	capabilities = nodeLabellerController.HostCapabilities()
 
 	// Node labelling is only relevant on x86_64 and s390x arches.
 	if virtconfig.IsAMD64(runtime.GOARCH) || virtconfig.IsS390X(runtime.GOARCH) {
@@ -359,7 +346,7 @@ func (app *virtHandlerApp) Run() {
 		podIsolationDetector,
 		migrationProxy,
 		downwardMetricsManager,
-		&capabilities,
+		capabilities,
 		hostCpuModel,
 		netsetup.NewNetConf(),
 		netsetup.NewNetStat(),

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/virt-handler/hotplug-disk:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
+        "//pkg/virt-handler/node-labeller/api:go_default_library",
         "//pkg/virt-handler/selinux:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virtiofs:go_default_library",
@@ -67,7 +68,6 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )
 
@@ -106,6 +106,7 @@ go_test(
         "//pkg/virt-handler/hotplug-disk:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
+        "//pkg/virt-handler/node-labeller/api:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
@@ -127,7 +128,6 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-handler/node-labeller/api:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
@@ -27,35 +28,36 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = [
+        "capabilities_test.go",
         "cpu_plugin_test.go",
         "node_labeller_suite_test.go",
         "node_labeller_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
-    deps = select({
+    deps = [
+        "//pkg/virt-handler/node-labeller/api:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "//pkg/testutils:go_default_library",
             "//pkg/virt-handler/node-labeller/util:go_default_library",
             "//staging/src/kubevirt.io/api/core/v1:go_default_library",
             "//staging/src/kubevirt.io/client-go/log:go_default_library",
             "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-            "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
-            "//vendor/github.com/onsi/gomega:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
             "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
             "//vendor/k8s.io/client-go/testing:go_default_library",
             "//vendor/k8s.io/client-go/tools/record:go_default_library",
-            "//vendor/libvirt.org/go/libvirtxml:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:s390x": [
             "//pkg/testutils:go_default_library",
@@ -63,15 +65,12 @@ go_test(
             "//staging/src/kubevirt.io/api/core/v1:go_default_library",
             "//staging/src/kubevirt.io/client-go/log:go_default_library",
             "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-            "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
-            "//vendor/github.com/onsi/gomega:go_default_library",
             "//vendor/k8s.io/api/core/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
             "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
             "//vendor/k8s.io/client-go/testing:go_default_library",
             "//vendor/k8s.io/client-go/tools/record:go_default_library",
-            "//vendor/libvirt.org/go/libvirtxml:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/virt-handler/node-labeller/api/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/api/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["capabilities.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/util/hardware:go_default_library"],
+)

--- a/pkg/virt-handler/node-labeller/api/capabilities.go
+++ b/pkg/virt-handler/node-labeller/api/capabilities.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"
+)
+
+type yesnobool bool
+
+type CPUSiblings []uint32
+
+type Capabilities struct {
+	XMLName xml.Name `xml:"capabilities"`
+	Host    Host     `xml:"host"`
+}
+
+type Host struct {
+	UUID     string   `xml:"uuid"`
+	CPU      HostCPU  `xml:"cpu"`
+	Topology Topology `xml:"topology"`
+}
+
+type HostCPU struct {
+	Arch    string    `xml:"arch"`
+	Model   string    `xml:"model"`
+	Vendor  string    `xml:"vendor"`
+	Counter []Counter `xml:"counter"`
+}
+
+type Counter struct {
+	Name      string    `xml:"name,attr"`
+	Frequency int64     `xml:"frequency,attr"`
+	Scaling   yesnobool `xml:"scaling,attr"`
+}
+
+type CPU struct {
+	ID       uint32      `xml:"id,attr"`
+	SocketID uint32      `xml:"socket_id,attr"`
+	DieID    uint32      `xml:"die_id,attr"`
+	CoreID   uint32      `xml:"core_id,attr"`
+	Siblings CPUSiblings `xml:"siblings,attr"`
+}
+
+type CPUs struct {
+	Num int   `xml:"num,attr"`
+	CPU []CPU `xml:"cpu"`
+}
+
+type Distances struct {
+	Sibling []Sibling `xml:"sibling"`
+}
+
+type Sibling struct {
+	ID    uint32 `xml:"id,attr"`
+	Value uint64 `xml:"value,attr"`
+}
+
+type Pages struct {
+	Count uint64 `xml:",chardata"`
+	Unit  string `xml:"unit,attr"`
+	Size  uint32 `xml:"size,attr"`
+}
+
+type Memory struct {
+	Amount uint64 `xml:",chardata"`
+	Unit   string `xml:"unit,attr"`
+}
+
+type Cell struct {
+	ID        uint32    `xml:"id,attr"`
+	Memory    Memory    `xml:"memory"`
+	Pages     []Pages   `xml:"pages"`
+	Distances Distances `xml:"distances"`
+	Cpus      CPUs      `xml:"cpus"`
+}
+
+type Cells struct {
+	Num  uint32 `xml:"num,attr"`
+	Cell []Cell `xml:"cell"`
+}
+
+type Topology struct {
+	Cells Cells `xml:"cells"`
+}
+
+func (c *Capabilities) GetTSCCounter() (*Counter, error) {
+	for _, c := range c.Host.CPU.Counter {
+		if c.Name == "tsc" {
+			return &c, nil
+		}
+	}
+	return nil, nil
+}
+
+func (b *yesnobool) UnmarshalXMLAttr(attr xml.Attr) error {
+	if attr.Value == "yes" {
+		*b = true
+		return nil
+	} else if attr.Value == "no" {
+		*b = false
+		return nil
+	}
+	return fmt.Errorf("value %v of %v is not (yes|no)", attr.Value, attr.Name)
+}
+
+func (b *CPUSiblings) UnmarshalXMLAttr(attr xml.Attr) error {
+	if attr.Value != "" {
+		if list, err := hwutil.ParseCPUSetLine(attr.Value, 100); err == nil {
+			for _, cpu := range list {
+				*b = append(*b, uint32(cpu))
+			}
+		} else {
+			return fmt.Errorf("failed to parse %v to ints: %v", attr.Value, err)
+
+		}
+	}
+	return nil
+}

--- a/pkg/virt-handler/node-labeller/capabilities_test.go
+++ b/pkg/virt-handler/node-labeller/capabilities_test.go
@@ -1,0 +1,146 @@
+package nodelabeller
+
+import (
+	"encoding/xml"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"
+)
+
+var _ = Describe("Capabilities", func() {
+
+	It("should be able to read the TSC timer freqemency from the host", func() {
+		f, err := os.Open("testdata/capabilities.xml")
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+		capabilities := &api.Capabilities{}
+		Expect(xml.NewDecoder(f).Decode(capabilities)).To(Succeed())
+		Expect(capabilities.Host.CPU.Counter).To(HaveLen(1))
+		Expect(capabilities.Host.CPU.Counter[0].Name).To(Equal("tsc"))
+		Expect(capabilities.Host.CPU.Counter[0].Frequency).To(BeNumerically("==", 4008012000))
+		Expect(bool(capabilities.Host.CPU.Counter[0].Scaling)).To(BeFalse())
+		counter, err := capabilities.GetTSCCounter()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(counter.Frequency).To(BeNumerically("==", 4008012000))
+		Expect(bool(counter.Scaling)).To(BeFalse())
+		Expect(capabilities.Host.Topology.Cells.Cell[0].Cpus.CPU[7].Siblings).To(HaveLen(29))
+	})
+
+	It("should properly read cpu siblings", func() {
+		f, err := os.Open("testdata/capabilities.xml")
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+		capabilities := &api.Capabilities{}
+		Expect(xml.NewDecoder(f).Decode(capabilities)).To(Succeed())
+		Expect(capabilities.Host.Topology.Cells.Cell).To(HaveLen(1))
+		Expect(capabilities.Host.Topology.Cells.Cell[0].Cpus.CPU).To(HaveLen(8))
+		Expect(capabilities.Host.Topology.Cells.Cell[0].Cpus.CPU[0].Siblings).To(ConsistOf(uint32(0), uint32(4)))
+	})
+
+	It("should read the numa topology from the host", func() {
+
+		expectedCell := api.Cell{
+			ID: 0,
+			Memory: api.Memory{
+				Amount: 1289144,
+				Unit:   "KiB",
+			},
+			Pages: []api.Pages{
+				{
+					Count: 314094,
+					Unit:  "KiB",
+					Size:  4,
+				},
+				{
+					Count: 16,
+					Unit:  "KiB",
+					Size:  2048,
+				},
+				{
+					Count: 0,
+					Unit:  "KiB",
+					Size:  1048576,
+				},
+			},
+			Distances: api.Distances{
+				Sibling: []api.Sibling{
+					{
+						ID:    0,
+						Value: 10,
+					},
+					{
+						ID:    1,
+						Value: 10,
+					},
+					{
+						ID:    2,
+						Value: 10,
+					},
+					{
+						ID:    3,
+						Value: 10,
+					},
+				},
+			},
+			Cpus: api.CPUs{
+				Num: 6,
+				CPU: []api.CPU{
+					{
+						ID:       0,
+						SocketID: 0,
+						DieID:    0,
+						CoreID:   0,
+						Siblings: []uint32{0},
+					},
+					{
+						ID:       1,
+						SocketID: 1,
+						DieID:    0,
+						CoreID:   0,
+						Siblings: []uint32{1},
+					},
+					{
+						ID:       2,
+						SocketID: 2,
+						DieID:    0,
+						CoreID:   0,
+						Siblings: []uint32{2},
+					},
+					{
+						ID:       3,
+						SocketID: 3,
+						DieID:    0,
+						CoreID:   0,
+						Siblings: []uint32{3},
+					},
+					{
+						ID:       4,
+						SocketID: 4,
+						DieID:    0,
+						CoreID:   0,
+						Siblings: []uint32{4},
+					},
+					{
+						ID:       5,
+						SocketID: 5,
+						DieID:    0,
+						CoreID:   0,
+						Siblings: []uint32{5},
+					},
+				},
+			},
+		}
+
+		f, err := os.Open("testdata/capabilities_with_numa.xml")
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+		capabilities := &api.Capabilities{}
+		Expect(xml.NewDecoder(f).Decode(capabilities)).To(Succeed())
+		Expect(capabilities.Host.Topology.Cells.Num).To(BeNumerically("==", 4))
+		Expect(capabilities.Host.Topology.Cells.Cell).To(HaveLen(4))
+		Expect(capabilities.Host.Topology.Cells.Cell[0]).To(Equal(expectedCell))
+	})
+})

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -29,6 +29,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 
@@ -36,7 +37,7 @@ const (
 	isSupported            string = "yes"
 	isUnusable             string = "no"
 	isRequired             string = "require"
-	NodeLabellerVolumePath        = "/var/lib/kubevirt-node-labeller/"
+	nodeLabellerVolumePath        = "/var/lib/kubevirt-node-labeller/"
 
 	supportedFeaturesXml = "supported_features.xml"
 )
@@ -144,6 +145,16 @@ func (n *NodeLabeller) loadHostSupportedFeatures() error {
 	}
 
 	n.supportedFeatures = usableFeatures
+	return nil
+}
+
+func (n *NodeLabeller) loadHostCapabilities() error {
+	capsFile := filepath.Join(n.volumePath, "capabilities.xml")
+	n.capabilities = &api.Capabilities{}
+	err := n.getStructureFromXMLFile(capsFile, n.capabilities)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -62,24 +62,32 @@ var _ = Describe("Node-labeller config", func() {
 			logger:                  log.DefaultLogger(),
 			volumePath:              "testdata",
 			domCapabilitiesFileName: "virsh_domcapabilities.xml",
-			cpuCounter:              nil,
 			hostCPUModel:            hostCPUModel{requiredFeatures: make(map[string]bool, 0)},
 			arch:                    runtime.GOARCH,
 		}
 	})
 
-	It("should return correct cpu models", func() {
+	It("should return correct cpu models, features and tsc freqnency", func() {
 		err := nlController.loadDomCapabilities()
 		Expect(err).ToNot(HaveOccurred())
 
 		err = nlController.loadHostSupportedFeatures()
 		Expect(err).ToNot(HaveOccurred())
 
+		err = nlController.loadHostCapabilities()
+		Expect(err).ToNot(HaveOccurred())
+
 		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
 		Expect(cpuModels).To(HaveLen(4), "number of models must match")
+
 		Expect(cpuFeatures).To(HaveLen(4), "number of features must match")
+		counter, err := nlController.capabilities.GetTSCCounter()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(counter).ToNot(BeNil())
+		Expect(counter.Frequency).To(BeNumerically("==", 4008012000))
+
 	})
 
 	It("No cpu model is usable", func() {

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
-	"libvirt.org/go/libvirtxml"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -47,7 +46,6 @@ const nodeName = "testNode"
 var _ = Describe("Node-labeller ", func() {
 	var nlController *NodeLabeller
 	var kubeClient *fake.Clientset
-	var cpuCounter *libvirtxml.CapsHostCPUCounter
 
 	initNodeLabeller := func(kubevirt *v1.KubeVirt) {
 		config, _, _ := testutils.NewFakeClusterConfigUsingKV(kubevirt)
@@ -55,18 +53,13 @@ var _ = Describe("Node-labeller ", func() {
 		recorder.IncludeObject = true
 
 		var err error
-		nlController, err = newNodeLabeller(config, kubeClient.CoreV1().Nodes(), nodeName, "testdata", recorder, cpuCounter)
+		nlController, err = newNodeLabeller(config, kubeClient.CoreV1().Nodes(), nodeName, "testdata", recorder)
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	BeforeEach(func() {
-		cpuCounter = &libvirtxml.CapsHostCPUCounter{
-			Name:      "tsc",
-			Frequency: 4008012000,
-			Scaling:   "no",
-		}
-
 		node := newNode(nodeName)
+
 		kubeClient = fake.NewSimpleClientset(node)
 		initNodeLabeller(&v1.KubeVirt{
 			ObjectMeta: metav1.ObjectMeta{
@@ -166,33 +159,6 @@ var _ = Describe("Node-labeller ", func() {
 		Expect(node.Labels).To(SatisfyAll(
 			HaveKey(v1.CPUModelLabel+"Penryn"),
 			HaveKey(v1.SupportedHostModelMigrationCPU+"Penryn"),
-		))
-	})
-
-	DescribeTable("should add cpu tsc labels if tsc counter exists, its name is tsc and according to scaling value", func(scaling, result string) {
-		nlController.cpuCounter.Scaling = scaling
-		res := nlController.execute()
-		Expect(res).To(BeTrue())
-
-		node := retrieveNode(kubeClient)
-		Expect(node.Labels).To(SatisfyAll(
-			HaveKeyWithValue(v1.CPUTimerLabel+"tsc-frequency", fmt.Sprintf("%d", cpuCounter.Frequency)),
-			HaveKeyWithValue(v1.CPUTimerLabel+"tsc-scalable", result),
-		))
-	},
-		Entry("scaling is set to no", "no", "false"),
-		Entry("scaling is set to yes", "yes", "true"),
-	)
-
-	It("should not add cpu tsc labels if counter name isn't tsc", func() {
-		nlController.cpuCounter.Name = ""
-		res := nlController.execute()
-		Expect(res).To(BeTrue())
-
-		node := retrieveNode(kubeClient)
-		Expect(node.Labels).To(SatisfyAll(
-			Not(HaveKey(v1.CPUTimerLabel+"tsc-frequency")),
-			Not(HaveKey(v1.CPUTimerLabel+"tsc-scalable")),
 		))
 	})
 

--- a/pkg/virt-handler/node-labeller/testdata/capabilities.xml
+++ b/pkg/virt-handler/node-labeller/testdata/capabilities.xml
@@ -1,0 +1,363 @@
+<capabilities>
+
+    <host>
+        <uuid>aa0bd9c2-e21b-3e1f-c424-2c4d5457f2b2</uuid>
+        <cpu>
+            <arch>x86_64</arch>
+            <model>Skylake-Client-IBRS</model>
+            <vendor>Intel</vendor>
+            <microcode version='214'/>
+            <counter name='tsc' frequency='4008012000' scaling='no'/>
+            <topology sockets='1' dies='1' cores='4' threads='2'/>
+            <feature name='ds'/>
+            <feature name='acpi'/>
+            <feature name='ss'/>
+            <feature name='ht'/>
+            <feature name='tm'/>
+            <feature name='pbe'/>
+            <feature name='dtes64'/>
+            <feature name='monitor'/>
+            <feature name='ds_cpl'/>
+            <feature name='vmx'/>
+            <feature name='est'/>
+            <feature name='tm2'/>
+            <feature name='xtpr'/>
+            <feature name='pdcm'/>
+            <feature name='osxsave'/>
+            <feature name='tsc_adjust'/>
+            <feature name='clflushopt'/>
+            <feature name='intel-pt'/>
+            <feature name='md-clear'/>
+            <feature name='stibp'/>
+            <feature name='ssbd'/>
+            <feature name='xsaves'/>
+            <feature name='pdpe1gb'/>
+            <feature name='invtsc'/>
+            <pages unit='KiB' size='4'/>
+            <pages unit='KiB' size='2048'/>
+            <pages unit='KiB' size='1048576'/>
+        </cpu>
+        <power_management>
+            <suspend_mem/>
+            <suspend_disk/>
+            <suspend_hybrid/>
+        </power_management>
+        <iommu support='no'/>
+        <migration_features>
+            <live/>
+            <uri_transports>
+                <uri_transport>tcp</uri_transport>
+                <uri_transport>rdma</uri_transport>
+            </uri_transports>
+        </migration_features>
+        <topology>
+            <cells num='1'>
+                <cell id='0'>
+                    <memory unit='KiB'>16256896</memory>
+                    <pages unit='KiB' size='4'>4064224</pages>
+                    <pages unit='KiB' size='2048'>0</pages>
+                    <pages unit='KiB' size='1048576'>0</pages>
+                    <distances>
+                        <sibling id='0' value='10'/>
+                    </distances>
+                    <cpus num='8'>
+                        <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0,4'/>
+                        <cpu id='1' socket_id='0' die_id='0' core_id='1' siblings='1,5'/>
+                        <cpu id='2' socket_id='0' die_id='0' core_id='2' siblings='2,6'/>
+                        <cpu id='3' socket_id='0' die_id='0' core_id='3' siblings='3,7'/>
+                        <cpu id='4' socket_id='0' die_id='0' core_id='0' siblings='0,4'/>
+                        <cpu id='5' socket_id='0' die_id='0' core_id='1' siblings='1,5'/>
+                        <cpu id='6' socket_id='0' die_id='0' core_id='2' siblings='2,6'/>
+                        <cpu id='7' socket_id='0' die_id='0' core_id='3' siblings='3-30,35'/>
+                    </cpus>
+                </cell>
+            </cells>
+        </topology>
+        <cache>
+            <bank id='0' level='3' type='both' size='8' unit='MiB' cpus='0-7'/>
+        </cache>
+        <secmodel>
+            <model>selinux</model>
+            <doi>0</doi>
+            <baselabel type='kvm'>system_u:system_r:svirt_t:s0</baselabel>
+            <baselabel type='qemu'>system_u:system_r:svirt_tcg_t:s0</baselabel>
+        </secmodel>
+        <secmodel>
+            <model>dac</model>
+            <doi>0</doi>
+            <baselabel type='kvm'>+107:+107</baselabel>
+            <baselabel type='qemu'>+107:+107</baselabel>
+        </secmodel>
+    </host>
+
+    <guest>
+        <os_type>hvm</os_type>
+        <arch name='i686'>
+            <wordsize>32</wordsize>
+            <emulator>/usr/bin/qemu-system-i386</emulator>
+            <machine maxCpus='255'>pc-i440fx-5.2</machine>
+            <machine canonical='pc-i440fx-5.2' maxCpus='255'>pc</machine>
+            <machine maxCpus='288'>pc-q35-5.2</machine>
+            <machine canonical='pc-q35-5.2' maxCpus='288'>q35</machine>
+            <machine maxCpus='255'>pc-i440fx-2.12</machine>
+            <machine maxCpus='255'>pc-i440fx-2.0</machine>
+            <machine maxCpus='1'>xenpv</machine>
+            <machine maxCpus='288'>pc-q35-4.2</machine>
+            <machine maxCpus='255'>pc-i440fx-2.5</machine>
+            <machine maxCpus='255'>pc-i440fx-4.2</machine>
+            <machine maxCpus='255'>pc-i440fx-1.5</machine>
+            <machine maxCpus='255'>pc-q35-2.7</machine>
+            <machine maxCpus='255'>pc-i440fx-2.2</machine>
+            <machine maxCpus='255' deprecated='yes'>pc-1.1</machine>
+            <machine maxCpus='255'>pc-i440fx-2.7</machine>
+            <machine maxCpus='128'>xenfv-3.1</machine>
+            <machine canonical='xenfv-3.1' maxCpus='128'>xenfv</machine>
+            <machine maxCpus='255'>pc-q35-2.4</machine>
+            <machine maxCpus='288'>pc-q35-2.10</machine>
+            <machine maxCpus='255'>pc-i440fx-1.7</machine>
+            <machine maxCpus='288'>pc-q35-5.1</machine>
+            <machine maxCpus='288'>pc-q35-2.9</machine>
+            <machine maxCpus='255'>pc-i440fx-2.11</machine>
+            <machine maxCpus='288'>pc-q35-3.1</machine>
+            <machine maxCpus='288'>pc-q35-4.1</machine>
+            <machine maxCpus='255'>pc-i440fx-2.4</machine>
+            <machine maxCpus='255' deprecated='yes'>pc-1.3</machine>
+            <machine maxCpus='255'>pc-i440fx-4.1</machine>
+            <machine maxCpus='255'>pc-i440fx-5.1</machine>
+            <machine maxCpus='255'>pc-i440fx-2.9</machine>
+            <machine maxCpus='1'>isapc</machine>
+            <machine maxCpus='255'>pc-i440fx-1.4</machine>
+            <machine maxCpus='255'>pc-q35-2.6</machine>
+            <machine maxCpus='255'>pc-i440fx-3.1</machine>
+            <machine maxCpus='288'>pc-q35-2.12</machine>
+            <machine maxCpus='255'>pc-i440fx-2.1</machine>
+            <machine maxCpus='255' deprecated='yes'>pc-1.0</machine>
+            <machine maxCpus='255'>pc-i440fx-2.6</machine>
+            <machine maxCpus='288'>pc-q35-4.0.1</machine>
+            <machine maxCpus='255'>pc-i440fx-1.6</machine>
+            <machine maxCpus='288'>pc-q35-5.0</machine>
+            <machine maxCpus='288'>pc-q35-2.8</machine>
+            <machine maxCpus='255'>pc-i440fx-2.10</machine>
+            <machine maxCpus='288'>pc-q35-3.0</machine>
+            <machine maxCpus='288'>pc-q35-4.0</machine>
+            <machine maxCpus='128'>xenfv-4.2</machine>
+            <machine maxCpus='288'>microvm</machine>
+            <machine maxCpus='255'>pc-i440fx-2.3</machine>
+            <machine maxCpus='255' deprecated='yes'>pc-1.2</machine>
+            <machine maxCpus='255'>pc-i440fx-4.0</machine>
+            <machine maxCpus='255'>pc-i440fx-5.0</machine>
+            <machine maxCpus='255'>pc-i440fx-2.8</machine>
+            <machine maxCpus='255'>pc-q35-2.5</machine>
+            <machine maxCpus='255'>pc-i440fx-3.0</machine>
+            <machine maxCpus='288'>pc-q35-2.11</machine>
+            <domain type='qemu'/>
+            <domain type='kvm'/>
+        </arch>
+        <features>
+            <pae/>
+            <nonpae/>
+            <acpi default='on' toggle='yes'/>
+            <apic default='on' toggle='no'/>
+            <cpuselection/>
+            <deviceboot/>
+            <disksnapshot default='on' toggle='no'/>
+        </features>
+    </guest>
+
+    <guest>
+        <os_type>hvm</os_type>
+        <arch name='ppc'>
+            <wordsize>32</wordsize>
+            <emulator>/usr/bin/qemu-system-ppc</emulator>
+            <machine maxCpus='1'>g3beige</machine>
+            <machine maxCpus='1'>virtex-ml507</machine>
+            <machine maxCpus='1'>mac99</machine>
+            <machine maxCpus='1'>sam460ex</machine>
+            <machine maxCpus='32'>ppce500</machine>
+            <machine maxCpus='1'>bamboo</machine>
+            <machine maxCpus='1'>40p</machine>
+            <machine maxCpus='1'>ref405ep</machine>
+            <machine maxCpus='15'>mpc8544ds</machine>
+            <machine maxCpus='1'>taihu</machine>
+            <domain type='qemu'/>
+        </arch>
+        <features>
+            <cpuselection/>
+            <deviceboot/>
+            <disksnapshot default='on' toggle='no'/>
+        </features>
+    </guest>
+
+    <guest>
+        <os_type>hvm</os_type>
+        <arch name='ppc64'>
+            <wordsize>64</wordsize>
+            <emulator>/usr/bin/qemu-system-ppc64</emulator>
+            <machine maxCpus='1024'>pseries-5.2</machine>
+            <machine canonical='pseries-5.2' maxCpus='1024'>pseries</machine>
+            <machine maxCpus='2048'>powernv9</machine>
+            <machine canonical='powernv9' maxCpus='2048'>powernv</machine>
+            <machine maxCpus='1'>taihu</machine>
+            <machine maxCpus='1024'>pseries-4.1</machine>
+            <machine maxCpus='15'>mpc8544ds</machine>
+            <machine maxCpus='1024'>pseries-2.5</machine>
+            <machine maxCpus='2048'>powernv10</machine>
+            <machine maxCpus='1024'>pseries-4.2</machine>
+            <machine maxCpus='1024'>pseries-2.6</machine>
+            <machine maxCpus='32'>ppce500</machine>
+            <machine maxCpus='1024'>pseries-2.7</machine>
+            <machine maxCpus='1024'>pseries-3.0</machine>
+            <machine maxCpus='1024'>pseries-5.0</machine>
+            <machine maxCpus='1'>40p</machine>
+            <machine maxCpus='1024'>pseries-2.8</machine>
+            <machine maxCpus='1024'>pseries-3.1</machine>
+            <machine maxCpus='1024'>pseries-5.1</machine>
+            <machine maxCpus='1024'>pseries-2.9</machine>
+            <machine maxCpus='1'>bamboo</machine>
+            <machine maxCpus='1'>g3beige</machine>
+            <machine maxCpus='1024'>pseries-2.12-sxxm</machine>
+            <machine maxCpus='1024'>pseries-2.10</machine>
+            <machine maxCpus='1'>virtex-ml507</machine>
+            <machine maxCpus='1024'>pseries-2.11</machine>
+            <machine maxCpus='1024'>pseries-2.1</machine>
+            <machine maxCpus='1024'>pseries-2.12</machine>
+            <machine maxCpus='1024'>pseries-2.2</machine>
+            <machine maxCpus='1'>mac99</machine>
+            <machine maxCpus='1'>sam460ex</machine>
+            <machine maxCpus='1'>ref405ep</machine>
+            <machine maxCpus='1024'>pseries-2.3</machine>
+            <machine maxCpus='2048'>powernv8</machine>
+            <machine maxCpus='1024'>pseries-4.0</machine>
+            <machine maxCpus='1024'>pseries-2.4</machine>
+            <domain type='qemu'/>
+        </arch>
+        <features>
+            <cpuselection/>
+            <deviceboot/>
+            <disksnapshot default='on' toggle='no'/>
+        </features>
+    </guest>
+
+    <guest>
+        <os_type>hvm</os_type>
+        <arch name='ppc64le'>
+            <wordsize>64</wordsize>
+            <emulator>/usr/bin/qemu-system-ppc64</emulator>
+            <machine maxCpus='1024'>pseries-5.2</machine>
+            <machine canonical='pseries-5.2' maxCpus='1024'>pseries</machine>
+            <machine maxCpus='2048'>powernv9</machine>
+            <machine canonical='powernv9' maxCpus='2048'>powernv</machine>
+            <machine maxCpus='1'>taihu</machine>
+            <machine maxCpus='1024'>pseries-4.1</machine>
+            <machine maxCpus='15'>mpc8544ds</machine>
+            <machine maxCpus='1024'>pseries-2.5</machine>
+            <machine maxCpus='2048'>powernv10</machine>
+            <machine maxCpus='1024'>pseries-4.2</machine>
+            <machine maxCpus='1024'>pseries-2.6</machine>
+            <machine maxCpus='32'>ppce500</machine>
+            <machine maxCpus='1024'>pseries-2.7</machine>
+            <machine maxCpus='1024'>pseries-3.0</machine>
+            <machine maxCpus='1024'>pseries-5.0</machine>
+            <machine maxCpus='1'>40p</machine>
+            <machine maxCpus='1024'>pseries-2.8</machine>
+            <machine maxCpus='1024'>pseries-3.1</machine>
+            <machine maxCpus='1024'>pseries-5.1</machine>
+            <machine maxCpus='1024'>pseries-2.9</machine>
+            <machine maxCpus='1'>bamboo</machine>
+            <machine maxCpus='1'>g3beige</machine>
+            <machine maxCpus='1024'>pseries-2.12-sxxm</machine>
+            <machine maxCpus='1024'>pseries-2.10</machine>
+            <machine maxCpus='1'>virtex-ml507</machine>
+            <machine maxCpus='1024'>pseries-2.11</machine>
+            <machine maxCpus='1024'>pseries-2.1</machine>
+            <machine maxCpus='1024'>pseries-2.12</machine>
+            <machine maxCpus='1024'>pseries-2.2</machine>
+            <machine maxCpus='1'>mac99</machine>
+            <machine maxCpus='1'>sam460ex</machine>
+            <machine maxCpus='1'>ref405ep</machine>
+            <machine maxCpus='1024'>pseries-2.3</machine>
+            <machine maxCpus='2048'>powernv8</machine>
+            <machine maxCpus='1024'>pseries-4.0</machine>
+            <machine maxCpus='1024'>pseries-2.4</machine>
+            <domain type='qemu'/>
+        </arch>
+        <features>
+            <cpuselection/>
+            <deviceboot/>
+            <disksnapshot default='on' toggle='no'/>
+        </features>
+    </guest>
+
+    <guest>
+        <os_type>hvm</os_type>
+        <arch name='x86_64'>
+            <wordsize>64</wordsize>
+            <emulator>/usr/bin/qemu-system-x86_64</emulator>
+            <machine maxCpus='255'>pc-i440fx-5.2</machine>
+            <machine canonical='pc-i440fx-5.2' maxCpus='255'>pc</machine>
+            <machine maxCpus='288'>pc-q35-5.2</machine>
+            <machine canonical='pc-q35-5.2' maxCpus='288'>q35</machine>
+            <machine maxCpus='255'>pc-i440fx-2.12</machine>
+            <machine maxCpus='255'>pc-i440fx-2.0</machine>
+            <machine maxCpus='1'>xenpv</machine>
+            <machine maxCpus='288'>pc-q35-4.2</machine>
+            <machine maxCpus='255'>pc-i440fx-2.5</machine>
+            <machine maxCpus='255'>pc-i440fx-4.2</machine>
+            <machine maxCpus='255'>pc-i440fx-1.5</machine>
+            <machine maxCpus='255'>pc-q35-2.7</machine>
+            <machine maxCpus='255'>pc-i440fx-2.2</machine>
+            <machine maxCpus='255' deprecated='yes'>pc-1.1</machine>
+            <machine maxCpus='255'>pc-i440fx-2.7</machine>
+            <machine maxCpus='128'>xenfv-3.1</machine>
+            <machine canonical='xenfv-3.1' maxCpus='128'>xenfv</machine>
+            <machine maxCpus='255'>pc-q35-2.4</machine>
+            <machine maxCpus='288'>pc-q35-2.10</machine>
+            <machine maxCpus='255'>pc-i440fx-1.7</machine>
+            <machine maxCpus='288'>pc-q35-5.1</machine>
+            <machine maxCpus='288'>pc-q35-2.9</machine>
+            <machine maxCpus='255'>pc-i440fx-2.11</machine>
+            <machine maxCpus='288'>pc-q35-3.1</machine>
+            <machine maxCpus='288'>pc-q35-4.1</machine>
+            <machine maxCpus='255'>pc-i440fx-2.4</machine>
+            <machine maxCpus='255' deprecated='yes'>pc-1.3</machine>
+            <machine maxCpus='255'>pc-i440fx-4.1</machine>
+            <machine maxCpus='255'>pc-i440fx-5.1</machine>
+            <machine maxCpus='255'>pc-i440fx-2.9</machine>
+            <machine maxCpus='1'>isapc</machine>
+            <machine maxCpus='255'>pc-i440fx-1.4</machine>
+            <machine maxCpus='255'>pc-q35-2.6</machine>
+            <machine maxCpus='255'>pc-i440fx-3.1</machine>
+            <machine maxCpus='288'>pc-q35-2.12</machine>
+            <machine maxCpus='255'>pc-i440fx-2.1</machine>
+            <machine maxCpus='255' deprecated='yes'>pc-1.0</machine>
+            <machine maxCpus='255'>pc-i440fx-2.6</machine>
+            <machine maxCpus='288'>pc-q35-4.0.1</machine>
+            <machine maxCpus='255'>pc-i440fx-1.6</machine>
+            <machine maxCpus='288'>pc-q35-5.0</machine>
+            <machine maxCpus='288'>pc-q35-2.8</machine>
+            <machine maxCpus='255'>pc-i440fx-2.10</machine>
+            <machine maxCpus='288'>pc-q35-3.0</machine>
+            <machine maxCpus='288'>pc-q35-4.0</machine>
+            <machine maxCpus='128'>xenfv-4.2</machine>
+            <machine maxCpus='288'>microvm</machine>
+            <machine maxCpus='255'>pc-i440fx-2.3</machine>
+            <machine maxCpus='255' deprecated='yes'>pc-1.2</machine>
+            <machine maxCpus='255'>pc-i440fx-4.0</machine>
+            <machine maxCpus='255'>pc-i440fx-5.0</machine>
+            <machine maxCpus='255'>pc-i440fx-2.8</machine>
+            <machine maxCpus='255'>pc-q35-2.5</machine>
+            <machine maxCpus='255'>pc-i440fx-3.0</machine>
+            <machine maxCpus='288'>pc-q35-2.11</machine>
+            <domain type='qemu'/>
+            <domain type='kvm'/>
+        </arch>
+        <features>
+            <acpi default='on' toggle='yes'/>
+            <apic default='on' toggle='no'/>
+            <cpuselection/>
+            <deviceboot/>
+            <disksnapshot default='on' toggle='no'/>
+        </features>
+    </guest>
+
+</capabilities>

--- a/pkg/virt-handler/node-labeller/testdata/capabilities_with_numa.xml
+++ b/pkg/virt-handler/node-labeller/testdata/capabilities_with_numa.xml
@@ -1,0 +1,222 @@
+<capabilities>
+
+    <host>
+        <uuid>ace6a103-1c4d-411d-9a33-2a2e2150f29c</uuid>
+        <cpu>
+            <arch>x86_64</arch>
+            <model>Skylake-Client-IBRS</model>
+            <vendor>Intel</vendor>
+            <microcode version='1'/>
+            <counter name='tsc' frequency='4007996000' scaling='no'/>
+            <topology sockets='1' dies='1' cores='6' threads='1'/>
+            <feature name='ss'/>
+            <feature name='vmx'/>
+            <feature name='pdcm'/>
+            <feature name='osxsave'/>
+            <feature name='hypervisor'/>
+            <feature name='tsc_adjust'/>
+            <feature name='clflushopt'/>
+            <feature name='umip'/>
+            <feature name='md-clear'/>
+            <feature name='stibp'/>
+            <feature name='arch-capabilities'/>
+            <feature name='ssbd'/>
+            <feature name='xsaves'/>
+            <feature name='pdpe1gb'/>
+            <feature name='invtsc'/>
+            <feature name='ibpb'/>
+            <feature name='ibrs'/>
+            <feature name='amd-stibp'/>
+            <feature name='amd-ssbd'/>
+            <feature name='skip-l1dfl-vmentry'/>
+            <feature name='pschange-mc-no'/>
+            <pages unit='KiB' size='4'/>
+            <pages unit='KiB' size='2048'/>
+            <pages unit='KiB' size='1048576'/>
+        </cpu>
+        <power_management/>
+        <iommu support='yes'/>
+        <migration_features>
+            <live/>
+            <uri_transports>
+                <uri_transport>tcp</uri_transport>
+                <uri_transport>rdma</uri_transport>
+            </uri_transports>
+        </migration_features>
+        <topology>
+            <cells num='4'>
+                <cell id='0'>
+                    <memory unit='KiB'>1289144</memory>
+                    <pages unit='KiB' size='4'>314094</pages>
+                    <pages unit='KiB' size='2048'>16</pages>
+                    <pages unit='KiB' size='1048576'>0</pages>
+                    <distances>
+                        <sibling id='0' value='10'/>
+                        <sibling id='1' value='10'/>
+                        <sibling id='2' value='10'/>
+                        <sibling id='3' value='10'/>
+                    </distances>
+                    <cpus num='6'>
+                        <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0'/>
+                        <cpu id='1' socket_id='1' die_id='0' core_id='0' siblings='1'/>
+                        <cpu id='2' socket_id='2' die_id='0' core_id='0' siblings='2'/>
+                        <cpu id='3' socket_id='3' die_id='0' core_id='0' siblings='3'/>
+                        <cpu id='4' socket_id='4' die_id='0' core_id='0' siblings='4'/>
+                        <cpu id='5' socket_id='5' die_id='0' core_id='0' siblings='5'/>
+                    </cpus>
+                </cell>
+                <cell id='1'>
+                    <memory unit='KiB'>1223960</memory>
+                    <pages unit='KiB' size='4'>297798</pages>
+                    <pages unit='KiB' size='2048'>16</pages>
+                    <pages unit='KiB' size='1048576'>0</pages>
+                    <distances>
+                        <sibling id='0' value='10'/>
+                        <sibling id='1' value='10'/>
+                        <sibling id='2' value='10'/>
+                        <sibling id='3' value='10'/>
+                    </distances>
+                    <cpus num='6'>
+                        <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0'/>
+                        <cpu id='1' socket_id='1' die_id='0' core_id='0' siblings='1'/>
+                        <cpu id='2' socket_id='2' die_id='0' core_id='0' siblings='2'/>
+                        <cpu id='3' socket_id='3' die_id='0' core_id='0' siblings='3'/>
+                        <cpu id='4' socket_id='4' die_id='0' core_id='0' siblings='4'/>
+                        <cpu id='5' socket_id='5' die_id='0' core_id='0' siblings='5'/>
+                    </cpus>
+                </cell>
+                <cell id='2'>
+                    <memory unit='KiB'>1251752</memory>
+                    <pages unit='KiB' size='4'>304746</pages>
+                    <pages unit='KiB' size='2048'>16</pages>
+                    <pages unit='KiB' size='1048576'>0</pages>
+                    <distances>
+                        <sibling id='0' value='10'/>
+                        <sibling id='1' value='10'/>
+                        <sibling id='2' value='10'/>
+                        <sibling id='3' value='10'/>
+                    </distances>
+                    <cpus num='6'>
+                        <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0'/>
+                        <cpu id='1' socket_id='1' die_id='0' core_id='0' siblings='1'/>
+                        <cpu id='2' socket_id='2' die_id='0' core_id='0' siblings='2'/>
+                        <cpu id='3' socket_id='3' die_id='0' core_id='0' siblings='3'/>
+                        <cpu id='4' socket_id='4' die_id='0' core_id='0' siblings='4'/>
+                        <cpu id='5' socket_id='5' die_id='0' core_id='0' siblings='5'/>
+                    </cpus>
+                </cell>
+                <cell id='3'>
+                    <memory unit='KiB'>1289404</memory>
+                    <pages unit='KiB' size='4'>314159</pages>
+                    <pages unit='KiB' size='2048'>16</pages>
+                    <pages unit='KiB' size='1048576'>0</pages>
+                    <distances>
+                        <sibling id='0' value='10'/>
+                        <sibling id='1' value='10'/>
+                        <sibling id='2' value='10'/>
+                        <sibling id='3' value='10'/>
+                    </distances>
+                    <cpus num='6'>
+                        <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0'/>
+                        <cpu id='1' socket_id='1' die_id='0' core_id='0' siblings='1'/>
+                        <cpu id='2' socket_id='2' die_id='0' core_id='0' siblings='2'/>
+                        <cpu id='3' socket_id='3' die_id='0' core_id='0' siblings='3'/>
+                        <cpu id='4' socket_id='4' die_id='0' core_id='0' siblings='4'/>
+                        <cpu id='5' socket_id='5' die_id='0' core_id='0' siblings='5'/>
+                    </cpus>
+                </cell>
+            </cells>
+        </topology>
+        <cache>
+            <bank id='0' level='3' type='both' size='16' unit='MiB' cpus='0'/>
+            <bank id='1' level='3' type='both' size='16' unit='MiB' cpus='1'/>
+            <bank id='2' level='3' type='both' size='16' unit='MiB' cpus='2'/>
+            <bank id='3' level='3' type='both' size='16' unit='MiB' cpus='3'/>
+            <bank id='4' level='3' type='both' size='16' unit='MiB' cpus='4'/>
+            <bank id='5' level='3' type='both' size='16' unit='MiB' cpus='5'/>
+        </cache>
+        <secmodel>
+            <model>none</model>
+            <doi>0</doi>
+        </secmodel>
+        <secmodel>
+            <model>dac</model>
+            <doi>0</doi>
+            <baselabel type='kvm'>+107:+107</baselabel>
+            <baselabel type='qemu'>+107:+107</baselabel>
+        </secmodel>
+    </host>
+
+    <guest>
+        <os_type>hvm</os_type>
+        <arch name='i686'>
+            <wordsize>32</wordsize>
+            <emulator>/usr/libexec/qemu-kvm</emulator>
+            <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+            <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel7.5.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.3.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel7.6.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.4.0</machine>
+            <machine canonical='pc-q35-rhel8.4.0' maxCpus='710'>q35</machine>
+            <machine maxCpus='710'>pc-q35-rhel7.4.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.2.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.0.0</machine>
+            <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.1.0</machine>
+            <domain type='qemu'/>
+            <domain type='kvm'/>
+        </arch>
+        <features>
+            <pae/>
+            <nonpae/>
+            <acpi default='on' toggle='yes'/>
+            <apic default='on' toggle='no'/>
+            <cpuselection/>
+            <deviceboot/>
+            <disksnapshot default='on' toggle='no'/>
+        </features>
+    </guest>
+
+    <guest>
+        <os_type>hvm</os_type>
+        <arch name='x86_64'>
+            <wordsize>64</wordsize>
+            <emulator>/usr/libexec/qemu-kvm</emulator>
+            <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+            <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+            <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel7.5.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.3.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel7.6.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.4.0</machine>
+            <machine canonical='pc-q35-rhel8.4.0' maxCpus='710'>q35</machine>
+            <machine maxCpus='710'>pc-q35-rhel7.4.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.2.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.0.0</machine>
+            <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+            <machine maxCpus='710'>pc-q35-rhel8.1.0</machine>
+            <domain type='qemu'/>
+            <domain type='kvm'/>
+        </arch>
+        <features>
+            <acpi default='on' toggle='yes'/>
+            <apic default='on' toggle='no'/>
+            <cpuselection/>
+            <deviceboot/>
+            <disksnapshot default='on' toggle='no'/>
+        </features>
+    </guest>
+
+</capabilities>

--- a/pkg/virt-handler/options_test.go
+++ b/pkg/virt-handler/options_test.go
@@ -19,51 +19,45 @@ package virthandler
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"libvirt.org/go/libvirtxml"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"
 )
 
 var _ = Describe("Parsing VMI Options", func() {
 	Context("virt-handler VM processes VMI options during update", func() {
 		const memoryUnit = "KiB"
-		DescribeTable("should convert libvirtxml.Caps to cmdv1.Topology when Caps is nil or empty", func(caps *libvirtxml.Caps) {
+		DescribeTable("should convert api.Capabilities to cmdv1.Topology when Capabilities is nil or empty", func(caps *api.Capabilities) {
 			actualTopology := capabilitiesToTopology(caps)
 
 			expectedTopology := &cmdv1.Topology{}
 
 			Expect(actualTopology).To(Equal(expectedTopology))
 		},
-			Entry("libvirtxml.Caps is nil", nil),
-			Entry("libvirtxml.Caps is empty", &libvirtxml.Caps{
-				Host: libvirtxml.CapsHost{
-					NUMA: &libvirtxml.CapsHostNUMATopology{
-						Cells: &libvirtxml.CapsHostNUMACells{},
-					},
-				},
-			}),
+			Entry("api.Capabilities is nil", nil),
+			Entry("api.Capabilities is empty", &api.Capabilities{}),
 		)
-		It("should convert libvirtxml.Caps to cmdv1.Topology with single NUMA node", func() {
-			caps := &libvirtxml.Caps{Host: libvirtxml.CapsHost{NUMA: &libvirtxml.CapsHostNUMATopology{}}}
-			caps.Host.NUMA.Cells = &libvirtxml.CapsHostNUMACells{
-				Cells: []libvirtxml.CapsHostNUMACell{
+		It("should convert api.Capabilities to cmdv1.Topology with single NUMA node", func() {
+			caps := &api.Capabilities{}
+			caps.Host.Topology.Cells = api.Cells{
+				Cell: []api.Cell{
 					{
-						Memory: &libvirtxml.CapsHostNUMAMemory{Unit: memoryUnit, Size: 16256896},
-						PageInfo: []libvirtxml.CapsHostNUMAPageInfo{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 16256896},
+						Pages: []api.Pages{
 							{Unit: memoryUnit, Size: 4, Count: 4064224},
 							{Unit: memoryUnit, Size: 2048, Count: 0},
 							{Unit: memoryUnit, Size: 1048576, Count: 0},
 						},
-						Distances: &libvirtxml.CapsHostNUMADistances{Siblings: []libvirtxml.CapsHostNUMASibling{{ID: 0, Value: 10}}},
-						CPUS: &libvirtxml.CapsHostNUMACPUs{CPUs: []libvirtxml.CapsHostNUMACPU{
-							{ID: 0, Siblings: "0,4"},
-							{ID: 1, Siblings: "1,5"},
-							{ID: 2, Siblings: "2,6"},
-							{ID: 3, Siblings: "3,7"},
-							{ID: 4, Siblings: "0,4"},
-							{ID: 5, Siblings: "1,5"},
-							{ID: 6, Siblings: "2,6"},
-							{ID: 7, Siblings: "3,7"},
+						Distances: api.Distances{Sibling: []api.Sibling{{ID: 0, Value: 10}}},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0, 4}},
+							{ID: 1, Siblings: []uint32{1, 5}},
+							{ID: 2, Siblings: []uint32{2, 6}},
+							{ID: 3, Siblings: []uint32{3, 7}},
+							{ID: 4, Siblings: []uint32{0, 4}},
+							{ID: 5, Siblings: []uint32{1, 5}},
+							{ID: 6, Siblings: []uint32{2, 6}},
+							{ID: 7, Siblings: []uint32{3, 7}},
 						}},
 					},
 				},
@@ -98,96 +92,96 @@ var _ = Describe("Parsing VMI Options", func() {
 			Expect(actualTopology).To(Equal(expectedTopology))
 		})
 
-		It("should convert libvirtxml.Caps to cmdv1.Topology with multiple NUMA nodes, CPUs and pages", func() {
-			caps := &libvirtxml.Caps{Host: libvirtxml.CapsHost{NUMA: &libvirtxml.CapsHostNUMATopology{}}}
-			caps.Host.NUMA.Cells = &libvirtxml.CapsHostNUMACells{
-				Cells: []libvirtxml.CapsHostNUMACell{
+		It("should convert api.Capabilities to cmdv1.Topology with multiple NUMA nodes, CPUs and pages", func() {
+			caps := &api.Capabilities{}
+			caps.Host.Topology.Cells = api.Cells{
+				Cell: []api.Cell{
 					{
-						Memory: &libvirtxml.CapsHostNUMAMemory{Unit: memoryUnit, Size: 1289144},
-						PageInfo: []libvirtxml.CapsHostNUMAPageInfo{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 1289144},
+						Pages: []api.Pages{
 							{Unit: memoryUnit, Size: 4, Count: 314094},
 							{Unit: memoryUnit, Size: 2048, Count: 16},
 							{Unit: memoryUnit, Size: 1048576, Count: 0},
 						},
-						Distances: &libvirtxml.CapsHostNUMADistances{Siblings: []libvirtxml.CapsHostNUMASibling{
+						Distances: api.Distances{Sibling: []api.Sibling{
 							{ID: 0, Value: 10},
 							{ID: 1, Value: 10},
 							{ID: 2, Value: 10},
 							{ID: 3, Value: 10},
 						}},
-						CPUS: &libvirtxml.CapsHostNUMACPUs{CPUs: []libvirtxml.CapsHostNUMACPU{
-							{ID: 0, Siblings: "0"},
-							{ID: 1, Siblings: "1"},
-							{ID: 2, Siblings: "2"},
-							{ID: 3, Siblings: "3"},
-							{ID: 4, Siblings: "4"},
-							{ID: 5, Siblings: "5"},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0}},
+							{ID: 1, Siblings: []uint32{1}},
+							{ID: 2, Siblings: []uint32{2}},
+							{ID: 3, Siblings: []uint32{3}},
+							{ID: 4, Siblings: []uint32{4}},
+							{ID: 5, Siblings: []uint32{5}},
 						}},
 					},
 					{
-						Memory: &libvirtxml.CapsHostNUMAMemory{Unit: memoryUnit, Size: 1223960},
-						PageInfo: []libvirtxml.CapsHostNUMAPageInfo{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 1223960},
+						Pages: []api.Pages{
 							{Unit: memoryUnit, Size: 4, Count: 297798},
 							{Unit: memoryUnit, Size: 2048, Count: 16},
 							{Unit: memoryUnit, Size: 1048576, Count: 0},
 						},
-						Distances: &libvirtxml.CapsHostNUMADistances{Siblings: []libvirtxml.CapsHostNUMASibling{
+						Distances: api.Distances{Sibling: []api.Sibling{
 							{ID: 0, Value: 10},
 							{ID: 1, Value: 10},
 							{ID: 2, Value: 10},
 							{ID: 3, Value: 10},
 						}},
-						CPUS: &libvirtxml.CapsHostNUMACPUs{CPUs: []libvirtxml.CapsHostNUMACPU{
-							{ID: 0, Siblings: "0"},
-							{ID: 1, Siblings: "1"},
-							{ID: 2, Siblings: "2"},
-							{ID: 3, Siblings: "3"},
-							{ID: 4, Siblings: "4"},
-							{ID: 5, Siblings: "5"},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0}},
+							{ID: 1, Siblings: []uint32{1}},
+							{ID: 2, Siblings: []uint32{2}},
+							{ID: 3, Siblings: []uint32{3}},
+							{ID: 4, Siblings: []uint32{4}},
+							{ID: 5, Siblings: []uint32{5}},
 						}},
 					},
 					{
-						Memory: &libvirtxml.CapsHostNUMAMemory{Unit: memoryUnit, Size: 1251752},
-						PageInfo: []libvirtxml.CapsHostNUMAPageInfo{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 1251752},
+						Pages: []api.Pages{
 							{Unit: memoryUnit, Size: 4, Count: 304746},
 							{Unit: memoryUnit, Size: 2048, Count: 16},
 							{Unit: memoryUnit, Size: 1048576, Count: 0},
 						},
-						Distances: &libvirtxml.CapsHostNUMADistances{Siblings: []libvirtxml.CapsHostNUMASibling{
+						Distances: api.Distances{Sibling: []api.Sibling{
 							{ID: 0, Value: 10},
 							{ID: 1, Value: 10},
 							{ID: 2, Value: 10},
 							{ID: 3, Value: 10},
 						}},
-						CPUS: &libvirtxml.CapsHostNUMACPUs{CPUs: []libvirtxml.CapsHostNUMACPU{
-							{ID: 0, Siblings: "0"},
-							{ID: 1, Siblings: "1"},
-							{ID: 2, Siblings: "2"},
-							{ID: 3, Siblings: "3"},
-							{ID: 4, Siblings: "4"},
-							{ID: 5, Siblings: "5"},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0}},
+							{ID: 1, Siblings: []uint32{1}},
+							{ID: 2, Siblings: []uint32{2}},
+							{ID: 3, Siblings: []uint32{3}},
+							{ID: 4, Siblings: []uint32{4}},
+							{ID: 5, Siblings: []uint32{5}},
 						}},
 					},
 					{
-						Memory: &libvirtxml.CapsHostNUMAMemory{Unit: memoryUnit, Size: 1289404},
-						PageInfo: []libvirtxml.CapsHostNUMAPageInfo{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 1289404},
+						Pages: []api.Pages{
 							{Unit: memoryUnit, Size: 4, Count: 314159},
 							{Unit: memoryUnit, Size: 2048, Count: 16},
 							{Unit: memoryUnit, Size: 1048576, Count: 0},
 						},
-						Distances: &libvirtxml.CapsHostNUMADistances{Siblings: []libvirtxml.CapsHostNUMASibling{
+						Distances: api.Distances{Sibling: []api.Sibling{
 							{ID: 0, Value: 10},
 							{ID: 1, Value: 10},
 							{ID: 2, Value: 10},
 							{ID: 3, Value: 10},
 						}},
-						CPUS: &libvirtxml.CapsHostNUMACPUs{CPUs: []libvirtxml.CapsHostNUMACPU{
-							{ID: 0, Siblings: "0"},
-							{ID: 1, Siblings: "1"},
-							{ID: 2, Siblings: "2"},
-							{ID: 3, Siblings: "3"},
-							{ID: 4, Siblings: "4"},
-							{ID: 5, Siblings: "5"},
+						Cpus: api.CPUs{CPU: []api.CPU{
+							{ID: 0, Siblings: []uint32{0}},
+							{ID: 1, Siblings: []uint32{1}},
+							{ID: 2, Siblings: []uint32{2}},
+							{ID: 3, Siblings: []uint32{3}},
+							{ID: 4, Siblings: []uint32{4}},
+							{ID: 5, Siblings: []uint32{5}},
 						}},
 					},
 				},
@@ -290,27 +284,27 @@ var _ = Describe("Parsing VMI Options", func() {
 
 			Expect(actualTopology).To(Equal(expectedTopology))
 		})
-		It("should convert libvirtxml.Caps to cmdv1.Topology when certain fields of Caps are not initialized", func() {
-			caps := &libvirtxml.Caps{Host: libvirtxml.CapsHost{NUMA: &libvirtxml.CapsHostNUMATopology{}}}
-			caps.Host.NUMA.Cells = &libvirtxml.CapsHostNUMACells{
-				Cells: []libvirtxml.CapsHostNUMACell{
+		It("should convert api.Capabilities to cmdv1.Topology when certain fields of Capabilities are not initialized", func() {
+			caps := &api.Capabilities{}
+			caps.Host.Topology.Cells = api.Cells{
+				Cell: []api.Cell{
 					{
-						Memory: &libvirtxml.CapsHostNUMAMemory{Unit: memoryUnit, Size: 16256896},
-						PageInfo: []libvirtxml.CapsHostNUMAPageInfo{
+						Memory: api.Memory{Unit: memoryUnit, Amount: 16256896},
+						Pages: []api.Pages{
 							{Size: 4, Count: 4064224},
 							{Unit: memoryUnit, Count: 0},
 							{Unit: memoryUnit, Size: 1048576},
 						},
-						Distances: &libvirtxml.CapsHostNUMADistances{Siblings: []libvirtxml.CapsHostNUMASibling{{ID: 0, Value: 10}}},
-						CPUS: &libvirtxml.CapsHostNUMACPUs{CPUs: []libvirtxml.CapsHostNUMACPU{
+						Distances: api.Distances{Sibling: []api.Sibling{{ID: 0, Value: 10}}},
+						Cpus: api.CPUs{CPU: []api.CPU{
 							{ID: 0},
-							{Siblings: "1,5"},
-							{ID: 2, Siblings: "2,6"},
-							{ID: 3, Siblings: "3,7"},
-							{ID: 4, Siblings: "0,4"},
-							{ID: 5, Siblings: "1,5"},
-							{ID: 6, Siblings: "2,6"},
-							{ID: 7, Siblings: "3,7"},
+							{Siblings: []uint32{1, 5}},
+							{ID: 2, Siblings: []uint32{2, 6}},
+							{ID: 3, Siblings: []uint32{3, 7}},
+							{ID: 4, Siblings: []uint32{0, 4}},
+							{ID: 5, Siblings: []uint32{1, 5}},
+							{ID: 6, Siblings: []uint32{2, 6}},
+							{ID: 7, Siblings: []uint32{3, 7}},
 						}},
 					},
 				},

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -36,8 +36,6 @@ import (
 	"strings"
 	"time"
 
-	"libvirt.org/go/libvirtxml"
-
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
@@ -60,6 +58,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+
+	nodelabellerapi "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -215,7 +215,7 @@ func NewController(
 	podIsolationDetector isolation.PodIsolationDetector,
 	migrationProxy migrationproxy.ProxyManager,
 	downwardMetricsManager downwardMetricsManager,
-	capabilities *libvirtxml.Caps,
+	capabilities *nodelabellerapi.Capabilities,
 	hostCpuModel string,
 	netConf netconf,
 	netStat netstat,
@@ -355,7 +355,7 @@ type VirtualMachineController struct {
 	domainNotifyPipes           map[string]string
 	virtLauncherFSRunDirPattern string
 	heartBeat                   *heartbeat.HeartBeat
-	capabilities                *libvirtxml.Caps
+	capabilities                *nodelabellerapi.Capabilities
 	hostCpuModel                string
 	vmiExpectations             *controller.UIDTrackingControllerExpectations
 	ioErrorRetryManager         *FailRetryManager


### PR DESCRIPTION
### What this PR does
This reverts #12652. See comment here for more info: [#12652 (comment)](https://github.com/kubevirt/kubevirt/pull/12652#issuecomment-2384775892).

In short: After altering the behavior of the check of whether the CPU counter is TSC, Kubevirt stopped working for the s390x architecture.

The PR should be reverted until an appropriate fix and tests for the s390x architecture are introduced. 
 
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
NONE
```