### PR TITLE
[node-labeller] fix hasTSCCounter nil pointer dereference 

### DIFF
--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -335,5 +335,5 @@ func (n *NodeLabeller) alertIfHostModelIsObsolete(originalNode *v1.Node, hostMod
 }
 
 func (n *NodeLabeller) hasTSCCounter() bool {
-	return n.cpuCounter.Name == "tsc"
+	return n.cpuCounter != nil && n.cpuCounter.Name == "tsc"
 }

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -184,8 +184,8 @@ var _ = Describe("Node-labeller ", func() {
 		Entry("scaling is set to yes", "yes", "true"),
 	)
 
-	It("should not add cpu tsc labels if counter name isn't tsc", func() {
-		nlController.cpuCounter.Name = ""
+	DescribeTable("should not add cpu tsc labels", func(counter *libvirtxml.CapsHostCPUCounter) {
+		nlController.cpuCounter = counter
 		res := nlController.execute()
 		Expect(res).To(BeTrue())
 
@@ -194,7 +194,10 @@ var _ = Describe("Node-labeller ", func() {
 			Not(HaveKey(v1.CPUTimerLabel+"tsc-frequency")),
 			Not(HaveKey(v1.CPUTimerLabel+"tsc-scalable")),
 		))
-	})
+	},
+		Entry("cpuCounter name is not tsc", &libvirtxml.CapsHostCPUCounter{}),
+		Entry("cpuCounter is nil", nil),
+	)
 
 	It("should remove not found cpu model and migration model", func() {
 		node := retrieveNode(kubeClient)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

#12652 introduced an issue where calling the `hasTSCCounter` method of node-labeller with a nil cpu counter would result in a nil pointer dereference.

This is a common occurence in some architectures such as s390x.

After this PR:

This PR relies on Go's short-circuit behavior to assert whether `cpuCounter` is nil as the first condition.
It also introduces a test to `node_labeller_test.go` that tests execution behavior when `cpuCounter` is nil.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes bug introduced in #12652 

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

