### PR TITLE
tests/libkubevirt/kvconfig: refactor UpdateKubeVirtConfigValueAndWait

### DIFF
--- a/tests/libkubevirt/config/featuregate.go
+++ b/tests/libkubevirt/config/featuregate.go
@@ -97,7 +97,7 @@ func updateKubeVirtConfigValueAndWaitHandlerRedeploymnet(kvConfig v1.KubeVirtCon
 	ds, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.TODO(), "virt-handler", metav1.GetOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	currentGen := ds.Status.ObservedGeneration
-	kv := testsuite.UpdateKubeVirtConfigValue(kvConfig)
+	kv, _ := testsuite.UpdateKubeVirtConfigValue(kvConfig)
 	EventuallyWithOffset(1, func() bool {
 		ds, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.TODO(), "virt-handler", metav1.GetOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -274,7 +274,7 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 				kv.Spec.Configuration.MigrationConfiguration = &v1.MigrationConfiguration{
 					BandwidthPerMigration: &migrationBandwidth,
 				}
-				kv = testsuite.UpdateKubeVirtConfigValue(kv.Spec.Configuration)
+				kv, _ = testsuite.UpdateKubeVirtConfigValue(kv.Spec.Configuration)
 				config.WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", kv.ResourceVersion, config.ExpectResourceVersionToBeLessEqualThanConfigVersion, 60*time.Second)
 			})
 		})


### PR DESCRIPTION
This PR Refactors the function `UpdateKubeVirtConfigValueAndWait` to wait only when the kubevirt resource configuration actually changed, what wait logic is  based on the kubevirt resource status field `observedGeneration`

### Release note
```release-note
None
```

