### PR TITLE
Add a 'outdated' label to kubevirt_vmi_info metric

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -63,7 +63,18 @@ var (
 			Name: "kubevirt_vmi_info",
 			Help: "Information about VirtualMachineInstances.",
 		},
-		[]string{"node", "namespace", "name", "phase", "os", "workload", "flavor", "instance_type", "preference", "guest_os_kernel_release", "guest_os_machine", "guest_os_name", "guest_os_version_id", "evictable"},
+		[]string{
+			// Basic info
+			"node", "namespace", "name",
+			// Domain info
+			"phase", "os", "workload", "flavor",
+			// Instance type
+			"instance_type", "preference",
+			// Guest OS info
+			"guest_os_kernel_release", "guest_os_machine", "guest_os_name", "guest_os_version_id",
+			// State info
+			"evictable", "outdated",
+		},
 	)
 
 	vmiEvictionBlocker = operatormetrics.NewGaugeVec(
@@ -117,6 +128,7 @@ func collectVMIInfo(vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.Coll
 				getVMIPhase(vmi), os, workload, flavor, instanceType, preference,
 				kernelRelease, machine, name, versionID,
 				strconv.FormatBool(isVMEvictable(vmi)),
+				strconv.FormatBool(isVMIOutdated(vmi)),
 			},
 			Value: 1.0,
 		})
@@ -249,4 +261,9 @@ func isVMEvictable(vmi *k6tv1.VirtualMachineInstance) bool {
 
 	}
 	return true
+}
+
+func isVMIOutdated(vmi *k6tv1.VirtualMachineInstance) bool {
+	_, hasOutdatedLabel := vmi.Labels[k6tv1.OutdatedLauncherImageLabel]
+	return hasOutdatedLabel
 }

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -131,7 +131,7 @@ var _ = Describe("VMI Stats Collector", func() {
 				Expect(cr).ToNot(BeNil())
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(14))
+				Expect(cr.Labels).To(HaveLen(15))
 
 				Expect(cr.Labels[3]).To(Equal(getVMIPhase(vmis[i])))
 				os, workload, flavor := getSystemInfoFromAnnotations(vmis[i].Annotations)
@@ -163,7 +163,7 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(cr).ToNot(BeNil())
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(14))
+			Expect(cr.Labels).To(HaveLen(15))
 			Expect(cr.Labels[7]).To(Equal(expected))
 		},
 			Entry("with no instance type expect <none>", k6tv1.InstancetypeAnnotation, "", "<none>"),
@@ -196,7 +196,7 @@ var _ = Describe("VMI Stats Collector", func() {
 
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(14))
+			Expect(cr.Labels).To(HaveLen(15))
 			Expect(cr.Labels[8]).To(Equal(expected))
 		},
 			Entry("with no preference expect <none>", k6tv1.PreferenceAnnotation, "", "<none>"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

No metrics were mentioning which VMIs are outdated

After this PR:

`kubevirt_vmi_info` metric has a new 'outdated' label set to true if the VMI has an outdated launcher image

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a 'outdated' label to kubevirt_vmi_info metric
```

