### PR TITLE
Replaced the deprecated package with kubevirt one in `vendor` directory

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/BUILD.bazel
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
@@ -6,7 +6,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	utilpointer "k8s.io/utils/pointer"
 )
 
 // EnsureCustomResourceDefinitionV1Beta1 ensures that the existing matches the required.
@@ -63,6 +62,7 @@ func crd_SetDefaults_CustomResourceDefinitionSpec(obj *apiextensionsv1.CustomRes
 
 func crd_SetDefaults_ServiceReference(obj *apiextensionsv1.ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		port := int32(443)
+		obj.Port = &port
 	}
 }

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/BUILD.bazel
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
@@ -30,6 +31,5 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -56,6 +56,6 @@ func SetDefaults_CustomResourceDefinitionSpec(obj *CustomResourceDefinitionSpec)
 // SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		obj.Port = pointer.P(int32(443))
 	}
 }

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/BUILD.bazel
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     importpath = "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
@@ -30,6 +31,5 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults.go
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/defaults.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -70,13 +70,13 @@ func SetDefaults_CustomResourceDefinitionSpec(obj *CustomResourceDefinitionSpec)
 		obj.Conversion.ConversionReviewVersions = []string{SchemeGroupVersion.Version}
 	}
 	if obj.PreserveUnknownFields == nil {
-		obj.PreserveUnknownFields = utilpointer.BoolPtr(true)
+		obj.PreserveUnknownFields = pointer.P(true)
 	}
 }
 
 // SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		obj.Port = pointer.P(int32(443))
 	}
 }

--- a/vendor/k8s.io/client-go/tools/cache/BUILD.bazel
+++ b/vendor/k8s.io/client-go/tools/cache/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
     importpath = "k8s.io/client-go/tools/cache",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
@@ -55,7 +56,6 @@ go_library(
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/utils/buffer:go_default_library",
         "//vendor/k8s.io/utils/clock:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",
     ],

--- a/vendor/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/client-go/tools/cache/reflector.go
@@ -42,9 +42,9 @@ import (
 	"k8s.io/client-go/tools/pager"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	"k8s.io/utils/trace"
+	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 const defaultExpectedTypeName = "<unspecified>"
@@ -646,7 +646,7 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 		options := metav1.ListOptions{
 			ResourceVersion:      lastKnownRV,
 			AllowWatchBookmarks:  true,
-			SendInitialEvents:    pointer.Bool(true),
+			SendInitialEvents:    pointer.P(true),
 			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 			TimeoutSeconds:       &timeoutSeconds,
 		}
@@ -659,7 +659,7 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 			}
 			return nil, err
 		}
-		bookmarkReceived := pointer.Bool(false)
+		bookmarkReceived := pointer.P(false)
 		err = watchHandler(start, w, temporaryStore, r.expectedType, r.expectedGVK, r.name, r.typeDescription,
 			func(rv string) { resourceVersion = rv },
 			bookmarkReceived,

--- a/vendor/k8s.io/client-go/util/certificate/csr/BUILD.bazel
+++ b/vendor/k8s.io/client-go/util/certificate/csr/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "k8s.io/client-go/util/certificate/csr",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//vendor/k8s.io/api/certificates/v1:go_default_library",
         "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
@@ -21,6 +22,5 @@ go_library(
         "//vendor/k8s.io/client-go/tools/watch:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/vendor/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/vendor/k8s.io/client-go/util/certificate/csr/csr.go
@@ -39,7 +39,7 @@ import (
 	watchtools "k8s.io/client-go/tools/watch"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 // RequestCertificate will either use an existing (if this process has run
@@ -90,7 +90,7 @@ func RequestCertificate(client clientset.Interface, csrData []byte, name, signer
 }
 
 func DurationToExpirationSeconds(duration time.Duration) *int32 {
-	return pointer.Int32(int32(duration / time.Second))
+	return pointer.P(int32(duration / time.Second))
 }
 
 func ExpirationSecondsToDuration(expirationSeconds int32) time.Duration {

--- a/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/BUILD.bazel
+++ b/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/BUILD.bazel
@@ -16,12 +16,12 @@ go_library(
     importpath = "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/defaults.go
+++ b/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/defaults.go
@@ -18,7 +18,7 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	utilpointer "k8s.io/utils/pointer"
+	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -28,6 +28,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 // SetDefaults_ServiceReference sets defaults for AuditSync Webhook's ServiceReference
 func SetDefaults_ServiceReference(obj *ServiceReference) {
 	if obj.Port == nil {
-		obj.Port = utilpointer.Int32Ptr(443)
+		obj.Port = pointer.P(int32(443))
 	}
 }


### PR DESCRIPTION
Replaced the deprecated package `k8s.io/utils/pointer` with kubevirt package `kubevirt.io/kubevirt/pkg/pointer` in the `vendor` directory.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
- In the `vendor` we used `k8s.io/utils/pointer` package which is deprecated. 

After this PR:
- Now, it is replaced with kubevirt package `kubevirt.io/kubevirt/pkg/pointer`
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Ref #12949

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```