### PR TITLE
Conformance cloudinit

### DIFF
--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 	Describe("[rfe_id:151][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		Context("with cloudInitNoCloud", func() {
-			It("[test_id:1618]should take user-data from k8s secret", func() {
+			It("[test_id:1618]should take user-data from k8s secret", decorators.Conformance, func() {
 				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 				secretID := fmt.Sprintf("%s-test-secret", uuid.NewString())
 
@@ -154,7 +154,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		})
 
 		Context("with cloudInitConfigDrive", func() {
-			It("[test_id:3178]should have cloud-init data from userDataBase64 source", func() {
+			It("[test_id:3178]should have cloud-init data from userDataBase64 source", decorators.Conformance, func() {
 				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 				vmi := libvmifact.NewCirros(libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveUserData(userData)))
 


### PR DESCRIPTION
### What this PR does
1. Simplifies `tests/vmi_cloudinit_test.go`
2. CloudInit is standard way to configure VMs on launch
and therefore we should include this in our Conformance
suite.
3. Removes some duplicated e2e tests


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

