### PR TITLE
Allow modifications to VM spec during VM snapshot, except disks/volumes

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -857,30 +857,22 @@ func validateSnapshotStatus(ar *admissionv1.AdmissionRequest, vm *v1.VirtualMach
 		}}
 	}
 
-	if !compareDisks(oldVM.Spec.Template.Spec.Domain.Devices.Disks, vm.Spec.Template.Spec.Domain.Devices.Disks) ||
-		!compareVolumes(oldVM.Spec.Template.Spec.Volumes, vm.Spec.Template.Spec.Volumes) {
+	if !compareVolumes(oldVM.Spec.Template.Spec.Volumes, vm.Spec.Template.Spec.Volumes) {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueNotSupported,
 			Message: fmt.Sprintf("Cannot update VM disks or volumes until snapshot %q completes", *vm.Status.SnapshotInProgress),
 			Field:   k8sfield.NewPath("spec").String(),
 		}}
 	}
+	if !compareRunningSpec(&oldVM.Spec, &vm.Spec) {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: fmt.Sprintf("Cannot update VM running state until snapshot %q completes", *vm.Status.SnapshotInProgress),
+			Field:   k8sfield.NewPath("spec").String(),
+		}}
+	}
 
 	return nil
-}
-
-func compareDisks(old, new []v1.Disk) bool {
-	if len(old) != len(new) {
-		return false
-	}
-
-	for i, disk := range old {
-		if !equality.Semantic.DeepEqual(disk, new[i]) {
-			return false
-		}
-	}
-
-	return true
 }
 
 func compareVolumes(old, new []v1.Volume) bool {
@@ -895,4 +887,20 @@ func compareVolumes(old, new []v1.Volume) bool {
 	}
 
 	return true
+}
+
+func compareRunningSpec(old, new *v1.VirtualMachineSpec) bool {
+	if old == nil || new == nil {
+		// This should never happen, but just in case return false
+		return false
+	}
+
+	// Its impossible to get here while both running and RunStrategy are nil.
+	if old.Running != nil && new.Running != nil {
+		return *old.Running == *new.Running
+	}
+	if old.RunStrategy != nil && new.RunStrategy != nil {
+		return *old.RunStrategy == *new.RunStrategy
+	}
+	return false
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -857,13 +857,42 @@ func validateSnapshotStatus(ar *admissionv1.AdmissionRequest, vm *v1.VirtualMach
 		}}
 	}
 
-	if !equality.Semantic.DeepEqual(oldVM.Spec, vm.Spec) {
+	if !compareDisks(oldVM.Spec.Template.Spec.Domain.Devices.Disks, vm.Spec.Template.Spec.Domain.Devices.Disks) ||
+		!compareVolumes(oldVM.Spec.Template.Spec.Volumes, vm.Spec.Template.Spec.Volumes) {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueNotSupported,
-			Message: fmt.Sprintf("Cannot update VM spec until snapshot %q completes", *vm.Status.SnapshotInProgress),
+			Message: fmt.Sprintf("Cannot update VM disks or volumes until snapshot %q completes", *vm.Status.SnapshotInProgress),
 			Field:   k8sfield.NewPath("spec").String(),
 		}}
 	}
 
 	return nil
+}
+
+func compareDisks(old, new []v1.Disk) bool {
+	if len(old) != len(new) {
+		return false
+	}
+
+	for i, disk := range old {
+		if !equality.Semantic.DeepEqual(disk, new[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func compareVolumes(old, new []v1.Volume) bool {
+	if len(old) != len(new) {
+		return false
+	}
+
+	for i, volume := range old {
+		if !equality.Semantic.DeepEqual(volume, new[i]) {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Any modification attempt to the VM spec is rejected while a VM snapshot status is set. This can cause the finalizer to not be allowed to be set after the status is updated. For instance with an older VM spec that doesn't contain the architecture field. There is a mutating webhook that automatically adds the architecture field to the spec. However the status indicates that a snapshot is in progress and it will reject changes to the VM spec.

Now the snapshot can never complete because it can't get a 'lock' on the VM (which requires the finalizer).

After this PR:
Relaxed the requirement that any changes to the VM spec are rejected. Only changes to the disks/volumes are rejected. This prevents the above scenario from happening. 


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-48769

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Relaxed check on modify VM spec during VM snapshot to only check disks/volumes
```

