### PR TITLE
Replace deprecated package with kubevirt package in rest of the file

### DIFF
--- a/pkg/virtctl/guestfs/BUILD.bazel
+++ b/pkg/virtctl/guestfs/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/guestfs",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
         "//pkg/virtctl/utils:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -18,7 +19,6 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -22,8 +22,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
-	"k8s.io/utils/pointer"
-
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 	"kubevirt.io/kubevirt/pkg/virtctl/utils"
 )
@@ -470,7 +469,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 		},
 	}
 	securityContext := &corev1.PodSecurityContext{
-		RunAsNonRoot: pointer.Bool(!root),
+		RunAsNonRoot: pointer.P(!root),
 		RunAsUser:    u,
 		RunAsGroup:   g,
 		FSGroup:      f,

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/containerizeddataimporter/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -64,7 +65,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/pkg/virtctl/vm/start_test.go
+++ b/pkg/virtctl/vm/start_test.go
@@ -27,10 +27,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 )
 
@@ -55,7 +55,7 @@ var _ = Describe("Start command", func() {
 
 	It("with dry-run parameter should not start VM", func() {
 		vm := kubecli.NewMinimalVM(vmName)
-		vm.Spec.Running = pointer.Bool(false)
+		vm.Spec.Running = pointer.P(false)
 
 		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).Times(1)
 		vmInterface.EXPECT().Start(context.Background(), vm.Name, &v1.StartOptions{DryRun: []string{k8smetav1.DryRunAll}}).Return(nil).Times(1)
@@ -80,7 +80,7 @@ var _ = Describe("Start command", func() {
 
 		It("with spec:running:true", func() {
 			vm := kubecli.NewMinimalVM(vmName)
-			vm.Spec.Running = pointer.Bool(false)
+			vm.Spec.Running = pointer.P(false)
 
 			kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).Times(1)
 			vmInterface.EXPECT().Start(context.Background(), vm.Name, &v1.StartOptions{Paused: false, DryRun: nil}).Return(nil).Times(1)

--- a/pkg/virtctl/vm/stop_test.go
+++ b/pkg/virtctl/vm/stop_test.go
@@ -27,10 +27,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 )
 
@@ -55,7 +55,7 @@ var _ = Describe("Stop command", func() {
 
 	It("with dry-run parameter should not stop VM", func() {
 		vm := kubecli.NewMinimalVM(vmName)
-		vm.Spec.Running = pointer.Bool(true)
+		vm.Spec.Running = pointer.P(true)
 
 		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).Times(1)
 		vmInterface.EXPECT().Stop(context.Background(), vm.Name, &v1.StopOptions{DryRun: []string{k8smetav1.DryRunAll}}).Return(nil).Times(1)
@@ -103,12 +103,12 @@ var _ = Describe("Stop command", func() {
 			"stop", vmName),
 		Entry("with spec:running:false",
 			func(vm *v1.VirtualMachine) {
-				vm.Spec.Running = pointer.Bool(true)
+				vm.Spec.Running = pointer.P(true)
 			},
 			"stop", vmName),
 		Entry("with spec:running:false when it's false already",
 			func(vm *v1.VirtualMachine) {
-				vm.Spec.Running = pointer.Bool(false)
+				vm.Spec.Running = pointer.P(false)
 			},
 			"stop", vmName),
 	)

--- a/staging/src/kubevirt.io/client-go/api/defaults_test.go
+++ b/staging/src/kubevirt.io/client-go/api/defaults_test.go
@@ -95,7 +95,6 @@ var _ = Describe("Defaults", func() {
 				Domain: v1.DomainSpec{},
 			},
 		}
-		pointer.BoolPtr(true)
 		vmi.Spec.Domain.Features = &v1.Features{
 			ACPI: v1.FeatureState{Enabled: pointer.BoolPtr(true)},
 			APIC: &v1.FeatureAPIC{Enabled: pointer.BoolPtr(false)},


### PR DESCRIPTION
Replaced the deprecated package `k8s.io/utils/pointer` with kubevirt package `kubevirt.io/kubevirt/pkg/pointer` in the rest of the file.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
- In some remaining file  we used `k8s.io/utils/pointer` package which is deprecated. 

After this PR:
- Now, it is replaced with kubevirt package `kubevirt.io/kubevirt/pkg/pointer`
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
fixes #12949

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

