### PR TITLE
lint: Increase linter coverage of tests packages 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ format:
 fmt: format
 
 lint:
-	if [ $$(wc -l < tests/utils.go) -gt 1401 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
+	if [ $$(wc -l < tests/utils.go) -gt 350 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 	hack/dockerized "hack/golangci-lint.sh"
 	hack/dockerized "monitoringlinter ./pkg/..."
 

--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -16,4 +16,5 @@ tests/libnet
 tests/libnode
 tests/libpod
 tests/libsecret
+tests/libssh
 tests/libvmifact

--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -15,6 +15,7 @@ tests/libinstancetype
 tests/libnet
 tests/libnode
 tests/libpod
+tests/libregistry
 tests/libsecret
 tests/libssh
 tests/libvmifact

--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -18,3 +18,4 @@ tests/libpod
 tests/libsecret
 tests/libssh
 tests/libvmifact
+tests/libwait

--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -20,3 +20,4 @@ tests/libsecret
 tests/libssh
 tests/libvmifact
 tests/libwait
+tests/scale

--- a/tests/libssh/ssh.go
+++ b/tests/libssh/ssh.go
@@ -35,14 +35,14 @@ func DumpPrivateKey(privateKey *ecdsa.PrivateKey, file string) error {
 		Type:  "EC PRIVATE KEY",
 		Bytes: privateKeyBytes,
 	}
-	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY, 0600)
+	const filePermissions = 0o600
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY, filePermissions)
 	if err != nil {
 		return err
 	}
 	defer errorhandling.SafelyCloseFile(f)
 	if err = pem.Encode(f, privateKeyBlock); err != nil {
 		return fmt.Errorf("error when encode private pem: %s", err)
-
 	}
 	return nil
 }

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -26,7 +26,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 	var virtClient kubecli.KubevirtClient
 	numberOfNodes := 0
 
-	setccs := func(ccs v1.CustomizeComponents, kvNamespace string, kvName string) error {
+	setccs := func(ccs v1.CustomizeComponents, kvNamespace, kvName string) error {
 		patchPayload, err := patch.New(patch.WithReplace("/spec/customizeComponents", ccs)).GeneratePayload()
 		if err != nil {
 			return err
@@ -35,9 +35,12 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 		return err
 	}
 
-	getApiReplicas := func() int32 {
+	getAPIReplicas := func() int32 {
 		By("Finding out virt-api replica number")
-		apiDeployment, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), components.VirtAPIName, metav1.GetOptions{})
+		apiDeployment, err := virtClient.AppsV1().Deployments(
+			flags.KubeVirtInstallNamespace).Get(context.Background(),
+			components.VirtAPIName,
+			metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(apiDeployment.Spec.Replicas).ToNot(BeNil(), "The number of replicas in the virt-api deployment should not be nil")
 
@@ -77,7 +80,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 	It("virt-api replicas should be scaled as expected", func() {
 		By("Finding out nodes count")
 		Eventually(func() int32 {
-			return getApiReplicas()
+			return getAPIReplicas()
 		}, 1*time.Minute, 5*time.Second).Should(Equal(calcExpectedReplicas(numberOfNodes)), "number of virt API should be as expected")
 	})
 
@@ -100,8 +103,7 @@ var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func()
 		DeferCleanup(setccs, originalKv.Spec.CustomizeComponents, originalKv.Namespace, originalKv.Name)
 
 		Eventually(func() int32 {
-			return getApiReplicas()
+			return getAPIReplicas()
 		}, 1*time.Minute, 5*time.Second).Should(Equal(expectedResult), "number of virt API should be as expected")
 	})
-
 })


### PR DESCRIPTION
### What this PR does

Increase linter coverage of tests packages 

Adds the following to linter:
- tests/libssh
- tests/libwait
- tests/libregistry
- tests/scale

Also decrease the number of lines allowed in test utils to reflect what is currently there. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

