### PR TITLE
feat: propagate VMExport labels and annotations to associated pod

### DIFF
--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -97,6 +97,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/uuid"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -71,9 +73,14 @@ import (
 )
 
 const (
-	testNamespace  = "default"
-	ingressSecret  = "ingress-secret"
-	currentVersion = "v1beta1"
+	testNamespace   = "default"
+	ingressSecret   = "ingress-secret"
+	currentVersion  = "v1beta1"
+	vmExportName    = "test"
+	labelKey        = "label-key"
+	labelValue      = "label-value"
+	annotationKey   = "annotation-key"
+	annotationValue = "annotation-value"
 )
 
 var (
@@ -743,6 +750,10 @@ var _ = Describe("Export controller", func() {
 			service.Status.Conditions[0].Type = "test"
 			Expect(service.GetName()).To(Equal(controller.getExportServiceName(testVMExport)))
 			Expect(service.GetNamespace()).To(Equal(testNamespace))
+			Expect(service.Labels).To(And(
+				HaveKeyWithValue(virtv1.AppLabel, "virt-exporter"),
+				HaveKeyWithValue(labelKey, labelValue)))
+			Expect(service.Annotations).To(HaveKeyWithValue(annotationKey, annotationValue))
 			return true, service, nil
 		})
 
@@ -914,7 +925,14 @@ var _ = Describe("Export controller", func() {
 			Name:       testPVC.Name,
 			DevicePath: fmt.Sprintf("%s/%s", blockVolumeMountPath, testPVC.Name),
 		}))
-		Expect(pod.Annotations[annCertParams]).To(Equal("{\"Duration\":7200000000000,\"RenewBefore\":3600000000000}"))
+		Expect(pod.Labels).To(And(
+			HaveKeyWithValue(exportServiceLabel, controller.getExportLabelValue(testVMExport)),
+			HaveKeyWithValue(labelKey, labelValue)))
+		Expect(pod.Annotations).To(And(
+			HaveKeyWithValue(annCertParams, fmt.Sprintf("{\"Duration\":%d,\"RenewBefore\":%d}",
+				metav1.Duration{Duration: 2 * time.Hour}.Nanoseconds(),
+				metav1.Duration{Duration: 1 * time.Hour}.Nanoseconds())),
+			HaveKeyWithValue(annotationKey, annotationValue)))
 		Expect(pod.Spec.Containers[0].Env).To(ContainElements(expectedPodEnvVars))
 		Expect(pod.Spec.Containers[0].Resources.Requests.Cpu()).ToNot(BeNil())
 		Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()).To(Equal(int64(100)))
@@ -1498,21 +1516,28 @@ func writeCertsToDir(dir string) {
 	Expect(os.WriteFile(filepath.Join(dir, bootstrap.KeyBytesValue), key, 0777)).To(Succeed())
 }
 
+func createVMExportMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:              name,
+		Namespace:         testNamespace,
+		UID:               uuid.NewUUID(),
+		CreationTimestamp: metav1.Now(),
+		Labels:            map[string]string{labelKey: labelValue},
+		Annotations:       map[string]string{annotationKey: annotationValue},
+	}
+}
+
 func createPVCVMExport() *exportv1.VirtualMachineExport {
-	return createPVCVMExportWithName("test")
+	return createPVCVMExportWithName(vmExportName)
 }
 
 func createPVCVMExportLongName() *exportv1.VirtualMachineExport {
-	return createPVCVMExportWithName("test" + strings.Repeat("a", 63))
+	return createPVCVMExportWithName(vmExportName + strings.Repeat("a", 63))
 }
 
 func createPVCVMExportWithName(name string) *exportv1.VirtualMachineExport {
 	return &exportv1.VirtualMachineExport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              name,
-			Namespace:         testNamespace,
-			CreationTimestamp: metav1.Now(),
-		},
+		ObjectMeta: createVMExportMeta(name),
 		Spec: exportv1.VirtualMachineExportSpec{
 			Source: k8sv1.TypedLocalObjectReference{
 				APIGroup: &k8sv1.SchemeGroupVersion.Group,
@@ -1526,10 +1551,7 @@ func createPVCVMExportWithName(name string) *exportv1.VirtualMachineExport {
 
 func createPVCVMExportWithoutSecret() *exportv1.VirtualMachineExport {
 	return &exportv1.VirtualMachineExport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-no-secret",
-			Namespace: testNamespace,
-		},
+		ObjectMeta: createVMExportMeta(vmExportName),
 		Spec: exportv1.VirtualMachineExportSpec{
 			Source: k8sv1.TypedLocalObjectReference{
 				APIGroup: &k8sv1.SchemeGroupVersion.Group,
@@ -1542,12 +1564,7 @@ func createPVCVMExportWithoutSecret() *exportv1.VirtualMachineExport {
 
 func createSnapshotVMExport() *exportv1.VirtualMachineExport {
 	return &exportv1.VirtualMachineExport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "test",
-			Namespace:         testNamespace,
-			UID:               "11111-22222-33333",
-			CreationTimestamp: metav1.Now(),
-		},
+		ObjectMeta: createVMExportMeta(vmExportName),
 		Spec: exportv1.VirtualMachineExportSpec{
 			Source: k8sv1.TypedLocalObjectReference{
 				APIGroup: &snapshotv1.SchemeGroupVersion.Group,
@@ -1561,12 +1578,7 @@ func createSnapshotVMExport() *exportv1.VirtualMachineExport {
 
 func createVMVMExport() *exportv1.VirtualMachineExport {
 	return &exportv1.VirtualMachineExport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "test",
-			Namespace:         testNamespace,
-			UID:               "44444-555555-666666",
-			CreationTimestamp: metav1.Now(),
-		},
+		ObjectMeta: createVMExportMeta(vmExportName),
 		Spec: exportv1.VirtualMachineExportSpec{
 			Source: k8sv1.TypedLocalObjectReference{
 				APIGroup: &virtv1.SchemeGroupVersion.Group,

--- a/pkg/virtctl/memorydump/memorydump.go
+++ b/pkg/virtctl/memorydump/memorydump.go
@@ -339,7 +339,8 @@ func downloadMemoryDump(namespace, vmName string, virtClient kubecli.KubevirtCli
 		LocalPort:    localPort,
 		// Using 2 as retry count to help mitigate a bug that might happen when creating the
 		// exporter pod just after the hotplug pod is deleted: https://issues.redhat.com/browse/CNV-39141
-		DownloadRetries: 2,
+		DownloadRetries:  2,
+		ReadinessTimeout: vmexport.DefaultProcessingWaitTotal,
 	}
 
 	if portForward {


### PR DESCRIPTION
### What this PR does
**Before this PR:**
- A VM export CR and pod are created in the same namespace as the VM, not necessarily on the same network, or reachable by the kubelet doing the readiness probe.
- A VM export server deployed using `virtctl` has a hardcoded 2-minutes readiness timeout, not taking into account a new node may have to be scheduled for this pod

**After this PR:**
- End user can label or annotate the VM export object or ask for it through `virtctl vmexport` arguments, the generated export server will inherit from VM export labels and annotations
- End user can define the VM Export readiness timeout
- Expected VM export labels and annotations are now unit tested

### Why we need it and why it was done in this way
- **Scenario 1:** End user can schedule the VM export object on a specific node through labels
- **Scenario 2:** End user can set a Multus (or CNI-related) annotation to get VM Export server on a specific network reachable by kubelet
- **Scenario 3:** A new node is being scheduled (e.g. on AWS, at least 90s to spin up an EC2), the existing VM export readiness timeout can now be configured to not hit the default value (2 minutes)

### Special notes for your reviewer
- Tested in a k8s cluster (virtctl and label/annotation propagation)
- Open to discussion on what would be relevant to update in the user guide (if needed)
   - updating virtctl download/create args mentioned as comments?
   - a use case using Multus network annotation on VM export object?

### Checklist

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required (no design change)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Conversation started on Slack #kubevirt-dev [here](https://kubernetes.slack.com/archives/C0163DT0R8X/p1727784027682779)

### Release note
```release-note
Added labels, annotations to VM Export resources and configurable pod readiness timeout
```

