### PR TITLE
Cleanups to virtctl create vm and its unit and func tests

### DIFF
--- a/pkg/virtctl/create/vm/BUILD.bazel
+++ b/pkg/virtctl/create/vm/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["vm.go"],
+    srcs = [
+        "vm.go",
+        "volume.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/create/vm",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/virtctl/create/vm/BUILD.bazel
+++ b/pkg/virtctl/create/vm/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/create/vm",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//pkg/virtctl/create/params:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -44,7 +45,6 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -106,30 +106,6 @@ type createVM struct {
 	memoryChanged                 bool
 }
 
-type cloneVolume struct {
-	Name      string             `param:"name"`
-	Source    string             `param:"src"`
-	BootOrder *uint              `param:"bootorder"`
-	Size      *resource.Quantity `param:"size"`
-}
-
-type containerdiskVolume struct {
-	Name      string `param:"name"`
-	Source    string `param:"src"`
-	BootOrder *uint  `param:"bootorder"`
-}
-
-type pvcVolume struct {
-	Name      string `param:"name"`
-	Source    string `param:"src"`
-	BootOrder *uint  `param:"bootorder"`
-}
-
-type blankVolume struct {
-	Name string             `param:"name"`
-	Size *resource.Quantity `param:"size"`
-}
-
 var optFns = map[string]func(*createVM, *v1.VirtualMachine) error{
 	RunStrategyFlag:          withRunStrategy,
 	InstancetypeFlag:         withInstancetype,
@@ -160,87 +136,6 @@ var flags = []string{
 	VolumeImportFlag,
 	CloudInitUserDataFlag,
 	CloudInitNetworkDataFlag,
-}
-
-type dataVolumeSourceBlank struct {
-	Size *resource.Quantity `param:"size"`
-	Type string             `param:"type"`
-	Name string             `param:"name"`
-}
-
-type dataVolumeSourceGcs struct {
-	SecretRef string             `param:"secretref"`
-	URL       string             `param:"url"`
-	Size      *resource.Quantity `param:"size"`
-	Type      string             `param:"type"`
-	Name      string             `param:"name"`
-}
-
-type dataVolumeSourceHttp struct {
-	CertConfigMap      string             `param:"certconfigmap"`
-	ExtraHeaders       []string           `param:"extraheaders"`
-	SecretExtraHeaders []string           `param:"secretextraheaders"`
-	SecretRef          string             `param:"secretref"`
-	URL                string             `param:"url"`
-	Size               *resource.Quantity `param:"size"`
-	Type               string             `param:"type"`
-	Name               string             `param:"name"`
-}
-
-type dataVolumeSourceImageIO struct {
-	CertConfigMap string             `param:"certconfigmap"`
-	DiskId        string             `param:"diskid"`
-	SecretRef     string             `param:"secretref"`
-	URL           string             `param:"url"`
-	Size          *resource.Quantity `param:"size"`
-	Type          string             `param:"type"`
-	Name          string             `param:"name"`
-}
-
-type dataVolumeSourcePVC struct {
-	Name   string             `param:"name"`
-	Source string             `param:"src"`
-	Size   *resource.Quantity `param:"size"`
-	Type   string             `param:"type"`
-}
-
-type dataVolumeSourceRegistry struct {
-	CertConfigMap string             `param:"certconfigmap"`
-	ImageStream   string             `param:"imagestream"`
-	PullMethod    string             `param:"pullmethod"`
-	SecretRef     string             `param:"secretref"`
-	URL           string             `param:"url"`
-	Size          *resource.Quantity `param:"size"`
-	Type          string             `param:"type"`
-	Name          string             `param:"name"`
-}
-
-type dataVolumeSourceS3 struct {
-	CertConfigMap string             `param:"certconfigmap"`
-	SecretRef     string             `param:"secretref"`
-	URL           string             `param:"url"`
-	Size          *resource.Quantity `param:"size"`
-	Type          string             `param:"type"`
-	Name          string             `param:"name"`
-}
-
-type dataVolumeSourceVDDK struct {
-	BackingFile  string             `param:"backingfile"`
-	InitImageUrl string             `param:"initimageurl"`
-	SecretRef    string             `param:"secretref"`
-	ThumbPrint   string             `param:"thumbprint"`
-	URL          string             `param:"url"`
-	UUID         string             `param:"uuid"`
-	Size         *resource.Quantity `param:"size"`
-	Type         string             `param:"type"`
-	Name         string             `param:"name"`
-}
-
-type dataVolumeSourceSnapshot struct {
-	Name   string             `param:"name"`
-	Source string             `param:"src"`
-	Size   *resource.Quantity `param:"size"`
-	Type   string             `param:"type"`
 }
 
 var volumeImportOptions = map[string]func(string) (*cdiv1.DataVolumeSource, error){

--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -64,7 +64,7 @@ const (
 	InferPreferenceFromFlag    = "infer-preference-from"
 	VolumeImportFlag           = "volume-import"
 
-	cloudInitDisk = "cloudinitdisk"
+	CloudInitDisk = "cloudinitdisk"
 	blank         = "blank"
 	gcs           = "gcs"
 	http          = "http"
@@ -886,7 +886,7 @@ func withCloudInitNetworkData(c *createVM, vm *v1.VirtualMachine) error {
 
 func withCloudInitData(flag string, c *createVM, vm *v1.VirtualMachine) error {
 	// Make sure cloudInitDisk does not already exist
-	if err := volumeShouldNotExist(flag, vm, cloudInitDisk); err != nil {
+	if err := volumeShouldNotExist(flag, vm, CloudInitDisk); err != nil {
 		return err
 	}
 
@@ -900,7 +900,7 @@ func withCloudInitData(flag string, c *createVM, vm *v1.VirtualMachine) error {
 		cloudInitNoCloud.UserDataBase64 = c.cloudInitUserData
 	}
 	vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
-		Name: cloudInitDisk,
+		Name: CloudInitDisk,
 		VolumeSource: v1.VolumeSource{
 			CloudInitNoCloud: cloudInitNoCloud,
 		},

--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -130,9 +130,7 @@ type blankVolume struct {
 	Size *resource.Quantity `param:"size"`
 }
 
-type optionFn func(*createVM, *v1.VirtualMachine) error
-
-var optFns = map[string]optionFn{
+var optFns = map[string]func(*createVM, *v1.VirtualMachine) error{
 	RunStrategyFlag:          withRunStrategy,
 	InstancetypeFlag:         withInstancetype,
 	PreferenceFlag:           withPreference,
@@ -245,9 +243,7 @@ type dataVolumeSourceSnapshot struct {
 	Type   string             `param:"type"`
 }
 
-type volumeImportFn func(string) (*cdiv1.DataVolumeSource, error)
-
-var volumeImportOptions = map[string]volumeImportFn{
+var volumeImportOptions = map[string]func(string) (*cdiv1.DataVolumeSource, error){
 	blank:    withVolumeSourceBlank,
 	gcs:      withVolumeSourceGcs,
 	http:     withVolumeSourceHttp,

--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -31,10 +31,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/api/instancetype"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"sigs.k8s.io/yaml"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/create/params"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"

--- a/pkg/virtctl/create/vm/vm_test.go
+++ b/pkg/virtctl/create/vm/vm_test.go
@@ -10,8 +10,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
-
 	v1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	generatedscheme "kubevirt.io/client-go/kubevirt/scheme"
@@ -494,7 +492,7 @@ var _ = Describe("create vm", func() {
 			Entry("with imageio source", "type:imageio,size:256Mi,url:http://url.com,diskid:1,secretref:secret-ref", "256Mi", &cdiv1.DataVolumeSource{Imageio: &cdiv1.DataVolumeSourceImageIO{DiskID: "1", SecretRef: "secret-ref", URL: "http://url.com"}}),
 			Entry("with PVC source", "type:pvc,size:256Mi,src:default/pvc,name:imported-volume", "256Mi", &cdiv1.DataVolumeSource{PVC: &cdiv1.DataVolumeSourcePVC{Name: "pvc", Namespace: "default"}}),
 			Entry("with PVC source without size", "type:pvc,src:default/pvc,name:imported-volume", "", &cdiv1.DataVolumeSource{PVC: &cdiv1.DataVolumeSourcePVC{Name: "pvc", Namespace: "default"}}),
-			Entry("with registry source", "type:registry,size:256Mi,certconfigmap:my-cert,pullmethod:pod,url:http://url.com,secretref:secret-ref,name:imported-volume", "256Mi", &cdiv1.DataVolumeSource{Registry: &cdiv1.DataVolumeSourceRegistry{CertConfigMap: ptr.To("my-cert"), PullMethod: (*cdiv1.RegistryPullMethod)(ptr.To("pod")), URL: ptr.To("http://url.com"), SecretRef: ptr.To("secret-ref")}}),
+			Entry("with registry source", "type:registry,size:256Mi,certconfigmap:my-cert,pullmethod:pod,url:http://url.com,secretref:secret-ref,name:imported-volume", "256Mi", &cdiv1.DataVolumeSource{Registry: &cdiv1.DataVolumeSourceRegistry{CertConfigMap: pointer.P("my-cert"), PullMethod: (*cdiv1.RegistryPullMethod)(pointer.P("pod")), URL: pointer.P("http://url.com"), SecretRef: pointer.P("secret-ref")}}),
 			Entry("with S3 source", "type:s3,size:256Mi,url:http://url.com,certconfigmap:my-cert,secretref:secret-ref", "256Mi", &cdiv1.DataVolumeSource{S3: &cdiv1.DataVolumeSourceS3{CertConfigMap: "my-cert", SecretRef: "secret-ref", URL: "http://url.com"}}),
 			Entry("with VDDK source", "type:vddk,size:256Mi,backingfile:backing-file,initimageurl:http://url.com,uuid:123e-11,url:http://url.com,thumbprint:test-thumbprint,secretref:test-credentials", "256Mi", &cdiv1.DataVolumeSource{VDDK: &cdiv1.DataVolumeSourceVDDK{BackingFile: "backing-file", InitImageURL: "http://url.com", UUID: "123e-11", URL: "http://url.com", Thumbprint: "test-thumbprint", SecretRef: "test-credentials"}}),
 			Entry("with Snapshot source", "type:snapshot,size:256Mi,src:default/snapshot,name:imported-volume", "256Mi", &cdiv1.DataVolumeSource{Snapshot: &cdiv1.DataVolumeSourceSnapshot{Name: "snapshot", Namespace: "default"}}),

--- a/pkg/virtctl/create/vm/volume.go
+++ b/pkg/virtctl/create/vm/volume.go
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package vm
+
+import "k8s.io/apimachinery/pkg/api/resource"
+
+type cloneVolume struct {
+	Name      string             `param:"name"`
+	Source    string             `param:"src"`
+	BootOrder *uint              `param:"bootorder"`
+	Size      *resource.Quantity `param:"size"`
+}
+
+type containerdiskVolume struct {
+	Name      string `param:"name"`
+	Source    string `param:"src"`
+	BootOrder *uint  `param:"bootorder"`
+}
+
+type pvcVolume struct {
+	Name      string `param:"name"`
+	Source    string `param:"src"`
+	BootOrder *uint  `param:"bootorder"`
+}
+
+type blankVolume struct {
+	Name string             `param:"name"`
+	Size *resource.Quantity `param:"size"`
+}
+
+type dataVolumeSourceBlank struct {
+	Size *resource.Quantity `param:"size"`
+	Type string             `param:"type"`
+	Name string             `param:"name"`
+}
+
+type dataVolumeSourceGcs struct {
+	SecretRef string             `param:"secretref"`
+	URL       string             `param:"url"`
+	Size      *resource.Quantity `param:"size"`
+	Type      string             `param:"type"`
+	Name      string             `param:"name"`
+}
+
+type dataVolumeSourceHttp struct {
+	CertConfigMap      string             `param:"certconfigmap"`
+	ExtraHeaders       []string           `param:"extraheaders"`
+	SecretExtraHeaders []string           `param:"secretextraheaders"`
+	SecretRef          string             `param:"secretref"`
+	URL                string             `param:"url"`
+	Size               *resource.Quantity `param:"size"`
+	Type               string             `param:"type"`
+	Name               string             `param:"name"`
+}
+
+type dataVolumeSourceImageIO struct {
+	CertConfigMap string             `param:"certconfigmap"`
+	DiskId        string             `param:"diskid"`
+	SecretRef     string             `param:"secretref"`
+	URL           string             `param:"url"`
+	Size          *resource.Quantity `param:"size"`
+	Type          string             `param:"type"`
+	Name          string             `param:"name"`
+}
+
+type dataVolumeSourcePVC struct {
+	Name   string             `param:"name"`
+	Source string             `param:"src"`
+	Size   *resource.Quantity `param:"size"`
+	Type   string             `param:"type"`
+}
+
+type dataVolumeSourceRegistry struct {
+	CertConfigMap string             `param:"certconfigmap"`
+	ImageStream   string             `param:"imagestream"`
+	PullMethod    string             `param:"pullmethod"`
+	SecretRef     string             `param:"secretref"`
+	URL           string             `param:"url"`
+	Size          *resource.Quantity `param:"size"`
+	Type          string             `param:"type"`
+	Name          string             `param:"name"`
+}
+
+type dataVolumeSourceS3 struct {
+	CertConfigMap string             `param:"certconfigmap"`
+	SecretRef     string             `param:"secretref"`
+	URL           string             `param:"url"`
+	Size          *resource.Quantity `param:"size"`
+	Type          string             `param:"type"`
+	Name          string             `param:"name"`
+}
+
+type dataVolumeSourceVDDK struct {
+	BackingFile  string             `param:"backingfile"`
+	InitImageUrl string             `param:"initimageurl"`
+	SecretRef    string             `param:"secretref"`
+	ThumbPrint   string             `param:"thumbprint"`
+	URL          string             `param:"url"`
+	UUID         string             `param:"uuid"`
+	Size         *resource.Quantity `param:"size"`
+	Type         string             `param:"type"`
+	Name         string             `param:"name"`
+}
+
+type dataVolumeSourceSnapshot struct {
+	Name   string             `param:"name"`
+	Source string             `param:"src"`
+	Size   *resource.Quantity `param:"size"`
+	Type   string             `param:"type"`
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR applies several cleanups to virtctl create and its unit and func tests in preparation for adding new features to the command. (see https://github.com/kubevirt/kubevirt/pull/13008)

Applied cleanups:

- Inline types used only once
- Move volume type definitions into separate file
- Reorganize imports
- Use kubevirt.io/kubevirt/pkg/pointer
- Drop no longer needed comment
- Remove wrapper around run method, pass it directly to RunE
- Simplify passing flags by using variadic args
- Reorder tests to resemble order of flags in code
- Name tests consistently
- Reusing existing consts
- Reorder tests and remove unnecessary nesting

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

