### PR TITLE
feat(virtctl,create): Add flags to generate cloud-init config 

### DIFF
--- a/pkg/virtctl/create/vm/BUILD.bazel
+++ b/pkg/virtctl/create/vm/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/tests/libssh/BUILD.bazel
+++ b/tests/libssh/BUILD.bazel
@@ -7,6 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tests/errorhandling:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/golang.org/x/crypto/ssh:go_default_library",
     ],
 )

--- a/tests/libssh/ssh.go
+++ b/tests/libssh/ssh.go
@@ -9,6 +9,9 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"golang.org/x/crypto/ssh"
 
 	"kubevirt.io/kubevirt/tests/errorhandling"
@@ -53,4 +56,16 @@ mkdir -p /root/.ssh/
 echo "%s" > /root/.ssh/authorized_keys
 chown -R root:root /root/.ssh
 `, string(ssh.MarshalAuthorizedKey(key)))
+}
+
+// DisableSSHAgent allows disabling the SSH agent to not influence test results
+func DisableSSHAgent() {
+	const sshAuthSock = "SSH_AUTH_SOCK"
+	val, present := os.LookupEnv(sshAuthSock)
+	if present {
+		Expect(os.Unsetenv(sshAuthSock)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(os.Setenv(sshAuthSock, val)).To(Succeed())
+		})
+	}
 }

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -3,7 +3,6 @@ package virtctl
 import (
 	"context"
 	"crypto/ecdsa"
-	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -72,8 +71,7 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		// Disable SSH_AGENT to not influence test results
-		Expect(os.Setenv("SSH_AUTH_SOCK", "/dev/null")).To(Succeed())
+		libssh.DisableSSHAgent()
 		keyFile = filepath.Join(GinkgoT().TempDir(), "id_rsa")
 		var err error
 		var priv *ecdsa.PrivateKey


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This adds flags to virtctl create vm which allow creating a basic
cloud-init config so the created VMs become more useful.

The added flags allow to:

- Set the username
- Read the password for the user from a file
- Add one or more SSH authorized keys for the user
- Enable qemu-guest-agent to write to the authorized_keys file of the
  user (SELinux bool)

Furthermore, this addresses a TODO by extending the support cloud-init
data source types, so both noCloud and configDrive types are supported
now.

Before this PR:

cloud-init config cannot be generated with virtctl create vm

After this PR:

Basic cloud-init config can be generated with virtctl create vm

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl: Allow creating a basic cloud-init config with virtctl create vm
```

