### PR TITLE
monitoring/vmistats_collector: update guest_os_machine label in vmi_info

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -131,7 +131,7 @@ var _ = Describe("VMI Stats Collector", func() {
 				Expect(cr).ToNot(BeNil())
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(15))
+				Expect(cr.Labels).To(HaveLen(16))
 
 				Expect(cr.Labels[3]).To(Equal(getVMIPhase(vmis[i])))
 				os, workload, flavor := getSystemInfoFromAnnotations(vmis[i].Annotations)
@@ -163,7 +163,7 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(cr).ToNot(BeNil())
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(15))
+			Expect(cr.Labels).To(HaveLen(16))
 			Expect(cr.Labels[7]).To(Equal(expected))
 		},
 			Entry("with no instance type expect <none>", k6tv1.InstancetypeAnnotation, "", "<none>"),
@@ -196,7 +196,7 @@ var _ = Describe("VMI Stats Collector", func() {
 
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(15))
+			Expect(cr.Labels).To(HaveLen(16))
 			Expect(cr.Labels[8]).To(Equal(expected))
 		},
 			Entry("with no preference expect <none>", k6tv1.PreferenceAnnotation, "", "<none>"),

--- a/pkg/monitoring/rules/recordingrules/vmi.go
+++ b/pkg/monitoring/rules/recordingrules/vmi.go
@@ -29,7 +29,7 @@ var vmiRecordingRules = []operatorrules.RecordingRule{
 			Help: "Sum of VMIs per phase and node. `phase` can be one of the following: [`Pending`, `Scheduling`, `Scheduled`, `Running`, `Succeeded`, `Failed`, `Unknown`].",
 		},
 		MetricType: operatormetrics.GaugeType,
-		Expr:       intstr.FromString("sum by (node, phase, os, workload, flavor, instance_type, preference, guest_os_kernel_release, guest_os_machine, guest_os_name, guest_os_version_id) (kubevirt_vmi_info)"),
+		Expr:       intstr.FromString("sum by (node, phase, os, workload, flavor, instance_type, preference, guest_os_kernel_release, guest_os_machine, guest_os_arch, guest_os_name, guest_os_version_id) (kubevirt_vmi_info)"),
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -304,10 +304,12 @@ var _ = Describe("[Serial][sig-monitoring]VM Monitoring", Serial, decorators.Sig
 			Expect(agentVMI.Status.GuestOSInfo.Machine).ToNot(BeEmpty())
 			Expect(agentVMI.Status.GuestOSInfo.Name).ToNot(BeEmpty())
 			Expect(agentVMI.Status.GuestOSInfo.VersionID).ToNot(BeEmpty())
+			Expect(agentVMI.Status.Machine.Type).ToNot(BeEmpty())
 
 			labels := map[string]string{
 				"guest_os_kernel_release": agentVMI.Status.GuestOSInfo.KernelRelease,
-				"guest_os_machine":        agentVMI.Status.GuestOSInfo.Machine,
+				"guest_os_arch":           agentVMI.Status.GuestOSInfo.Machine,
+				"guest_os_machine":        agentVMI.Status.Machine.Type,
 				"guest_os_name":           agentVMI.Status.GuestOSInfo.Name,
 				"guest_os_version_id":     agentVMI.Status.GuestOSInfo.VersionID,
 			}


### PR DESCRIPTION
### What this PR does
Before this PR:
the value from `GuestOSInfo.Machine` being evaluated by the guest-agent is actually the system-arch (e.g x86_64) and not the actual machine-type-name from the domain-xml

After this PR:
The system arch which was the value of `vmi.status.guestOSInfo.machine` is being labeled as guest_os_arch and the machine type value is taken from the `vmi.status.machine.type`

example for metric output when deploying examples/vmi-fedora.yaml:

```
kubevirt_vmi_info{container="virt-controller", endpoint="metrics", 
evictable="true", flavor="<none>", guest_os_arch="x86_64",
guest_os_kernel_release="5.14.10-300.fc35.x86_64",
guest_os_machine="pc-q35-rhel9.4.0", guest_os_name="Fedora Linux",
guest_os_version_id="35", instance="10.244.196.178:8443", 
instance_type="<none>",  job="kubevirt-prometheus-metrics",
name="vmi-fedora", namespace="kubevirt", node="node01", os="<none>", 
phase="running", pod="virt-controller-6fdcc548cd-5qk9m",
preference="<none>", service="kubevirt-prometheus-metrics", workload="<none>"}
```

Fixes #

### Why we need it and why it was done in this way
in order to track machine type in the vmi-info metric

### Release note
```release-note
None
```

