### PR TITLE
Support Dynamic Primary Pod NIC Name

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16915,6 +16915,10 @@
       "description": "Name of the interface, corresponds to name of the network assigned to the interface",
       "type": "string"
      },
+     "podInterfaceName": {
+      "description": "PodInterfaceName represents the name of the pod network interface",
+      "type": "string"
+     },
      "queueCount": {
       "description": "Specifies how many queues are allocated by MultiQueue",
       "type": "integer",

--- a/pkg/network/link/discovery.go
+++ b/pkg/network/link/discovery.go
@@ -36,8 +36,8 @@ import (
 // If link not found, it will try to get the link using the pod interface's ordinal name (net1, net2,...)
 // based on the subject network position in the given networks slice.
 // If no link is found, a nil link will be returned.
-func DiscoverByNetwork(handler driver.NetworkHandler, networks []v1.Network, subjectNetwork v1.Network) (netlink.Link, error) {
-	ifaceNames, err := networkInterfaceNames(networks, subjectNetwork)
+func DiscoverByNetwork(handler driver.NetworkHandler, networks []v1.Network, subjectNetwork v1.Network, ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface) (netlink.Link, error) {
+	ifaceNames, err := networkInterfaceNames(networks, subjectNetwork, ifaceStatuses)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +45,8 @@ func DiscoverByNetwork(handler driver.NetworkHandler, networks []v1.Network, sub
 	return linkByNames(handler, ifaceNames)
 }
 
-func networkInterfaceNames(networks []v1.Network, subjectNetwork v1.Network) ([]string, error) {
-	ifaceName := namescheme.HashedPodInterfaceName(subjectNetwork)
+func networkInterfaceNames(networks []v1.Network, subjectNetwork v1.Network, ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface) ([]string, error) {
+	ifaceName := namescheme.HashedPodInterfaceName(subjectNetwork, ifaceStatuses)
 	ordinalIfaceName := namescheme.OrdinalPodInterfaceName(subjectNetwork.Name, networks)
 	if ordinalIfaceName == "" {
 		return nil, fmt.Errorf("could not find the pod interface ordinal name for network [%s]", subjectNetwork.Name)

--- a/pkg/network/multus/status.go
+++ b/pkg/network/multus/status.go
@@ -53,3 +53,13 @@ func NetworkStatusesFromPod(pod *k8scorev1.Pod) []networkv1.NetworkStatus {
 
 	return networkStatuses
 }
+
+func LookupPodPrimaryIfaceName(networkStatuses []networkv1.NetworkStatus) string {
+	for _, ns := range networkStatuses {
+		if ns.Default && ns.Interface != "" {
+			return ns.Interface
+		}
+	}
+
+	return ""
+}

--- a/pkg/network/multus/status.go
+++ b/pkg/network/multus/status.go
@@ -29,10 +29,10 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-func NonDefaultNetworkStatusIndexedByIfaceName(pod *k8scorev1.Pod) map[string]networkv1.NetworkStatus {
+func NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses []networkv1.NetworkStatus) map[string]networkv1.NetworkStatus {
 	indexedNetworkStatus := map[string]networkv1.NetworkStatus{}
 
-	for _, ns := range NetworkStatusesFromPod(pod) {
+	for _, ns := range networkStatuses {
 		if ns.Default {
 			continue
 		}

--- a/pkg/network/multus/status.go
+++ b/pkg/network/multus/status.go
@@ -22,28 +22,17 @@ package multus
 import (
 	"encoding/json"
 
-	k8Scorev1 "k8s.io/api/core/v1"
+	k8scorev1 "k8s.io/api/core/v1"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	"kubevirt.io/client-go/log"
 )
 
-func NonDefaultNetworkStatusIndexedByIfaceName(pod *k8Scorev1.Pod) map[string]networkv1.NetworkStatus {
+func NonDefaultNetworkStatusIndexedByIfaceName(pod *k8scorev1.Pod) map[string]networkv1.NetworkStatus {
 	indexedNetworkStatus := map[string]networkv1.NetworkStatus{}
-	podNetworkStatus, found := pod.Annotations[networkv1.NetworkStatusAnnot]
 
-	if !found {
-		return indexedNetworkStatus
-	}
-
-	var networkStatus []networkv1.NetworkStatus
-	if err := json.Unmarshal([]byte(podNetworkStatus), &networkStatus); err != nil {
-		log.Log.Errorf("failed to unmarshall pod network status: %v", err)
-		return indexedNetworkStatus
-	}
-
-	for _, ns := range networkStatus {
+	for _, ns := range NetworkStatusesFromPod(pod) {
 		if ns.Default {
 			continue
 		}
@@ -51,4 +40,16 @@ func NonDefaultNetworkStatusIndexedByIfaceName(pod *k8Scorev1.Pod) map[string]ne
 	}
 
 	return indexedNetworkStatus
+}
+
+func NetworkStatusesFromPod(pod *k8scorev1.Pod) []networkv1.NetworkStatus {
+	var networkStatuses []networkv1.NetworkStatus
+
+	if rawNetworkStatus := pod.Annotations[networkv1.NetworkStatusAnnot]; rawNetworkStatus != "" {
+		if err := json.Unmarshal([]byte(rawNetworkStatus), &networkStatuses); err != nil {
+			log.Log.Errorf("failed to unmarshall pod network status: %v", err)
+		}
+	}
+
+	return networkStatuses
 }

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -138,6 +138,16 @@ func PodHasOrdinalInterfaceName(podNetworkStatus map[string]networkv1.NetworkSta
 	return false
 }
 
+// PodHasOrdinalInterfaceName2 checks if the given pod network status has at least one pod interface with ordinal name
+func PodHasOrdinalInterfaceName2(networkStatuses []networkv1.NetworkStatus) bool {
+	for _, networkStatus := range networkStatuses {
+		if OrdinalSecondaryInterfaceName(networkStatus.Interface) {
+			return true
+		}
+	}
+	return false
+}
+
 // OrdinalSecondaryInterfaceName check if the given name is in form of the ordinal
 // name scheme (e.g.: net1, net2..).
 // Primary iface name (eth0) is treated as non-ordinal interface name.

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -158,4 +159,25 @@ func OrdinalSecondaryInterfaceName(name string) bool {
 		return false
 	}
 	return match
+}
+
+func UpdatePrimaryPodIfaceNameFromVMIStatus(
+	podIfaceNamesByNetworkName map[string]string,
+	networks []v1.Network,
+	ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface,
+) map[string]string {
+	primaryNetwork := vmispec.LookUpDefaultNetwork(networks)
+	if primaryNetwork == nil {
+		return podIfaceNamesByNetworkName
+	}
+
+	primaryIfaceStatus := vmispec.LookupInterfaceStatusByName(ifaceStatuses, primaryNetwork.Name)
+	if primaryIfaceStatus == nil || primaryIfaceStatus.PodInterfaceName == "" {
+		return podIfaceNamesByNetworkName
+	}
+
+	updatedPodIfaceNamesByNetworkName := maps.Clone(podIfaceNamesByNetworkName)
+	updatedPodIfaceNamesByNetworkName[primaryNetwork.Name] = primaryIfaceStatus.PodInterfaceName
+
+	return updatedPodIfaceNamesByNetworkName
 }

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -56,9 +56,14 @@ func CreateHashedNetworkNameScheme(vmiNetworks []v1.Network) map[string]string {
 	return networkNameSchemeMap
 }
 
-func HashedPodInterfaceName(network v1.Network) string {
+func HashedPodInterfaceName(network v1.Network, ifaceStatuses []v1.VirtualMachineInstanceNetworkInterface) string {
 	if vmispec.IsSecondaryMultusNetwork(network) {
 		return GenerateHashedInterfaceName(network.Name)
+	}
+
+	if primaryIfaceStatus := vmispec.LookupInterfaceStatusByName(ifaceStatuses, network.Name); primaryIfaceStatus != nil &&
+		primaryIfaceStatus.PodInterfaceName != "" {
+		return primaryIfaceStatus.PodInterfaceName
 	}
 
 	return PrimaryPodInterfaceName

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -191,6 +191,44 @@ var _ = Describe("Network Name Scheme", func() {
 			}),
 		)
 	})
+
+	Context("PodHasOrdinalInterfaceName2", func() {
+		DescribeTable("should return TRUE, given network status with ordinal interface names",
+			func(podNetworkStatuses []networkv1.NetworkStatus) {
+				Expect(namescheme.PodHasOrdinalInterfaceName2(podNetworkStatuses)).To(BeTrue())
+			},
+			Entry("with primary pod network interface",
+				[]networkv1.NetworkStatus{
+					{Interface: "eth0"},
+					{Interface: "net1"},
+					{Interface: "net2"},
+				}),
+			Entry("without primary pod network interface",
+				[]networkv1.NetworkStatus{
+					{Interface: "net1"},
+					{Interface: "net2"},
+				}),
+		)
+
+		DescribeTable("should return FALSE",
+			func(podNetworkStatuses []networkv1.NetworkStatus) {
+				Expect(namescheme.PodHasOrdinalInterfaceName2(podNetworkStatuses)).To(BeFalse())
+			},
+			Entry("When networks statutes is empty", []networkv1.NetworkStatus{}),
+			Entry("when networks statutes has primary pod and hashed secondary network interface",
+				[]networkv1.NetworkStatus{
+					{Interface: "eth0"},
+					{Interface: "podb1f51a511f1"},
+					{Interface: "pod16477688c0e"},
+				}),
+			Entry("when networks statutes has hashed secondary network interface",
+				[]networkv1.NetworkStatus{
+					{Interface: "podb1f51a511f1"},
+					{Interface: "pod16477688c0e"},
+				}),
+		)
+	})
+
 	Context("HashedPodInterfaceName", func() {
 		DescribeTable("should return the given network name's hashed pod interface name",
 			func(network virtv1.Network, expectedPodIfaceName string) {

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Network Name Scheme", func() {
 	Context("HashedPodInterfaceName", func() {
 		DescribeTable("should return the given network name's hashed pod interface name",
 			func(network virtv1.Network, expectedPodIfaceName string) {
-				Expect(namescheme.HashedPodInterfaceName(network)).To(Equal(expectedPodIfaceName))
+				Expect(namescheme.HashedPodInterfaceName(network, []virtv1.VirtualMachineInstanceNetworkInterface{})).To(Equal(expectedPodIfaceName))
 			},
 			Entry("given default network name when default is pod network",
 				newPodNetwork(),

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -84,7 +84,8 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 func (g Generator) GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8Scorev1.Pod) (map[string]string, error) {
 	annotations := map[string]string{}
 
-	if namescheme.PodHasOrdinalInterfaceName(multus.NonDefaultNetworkStatusIndexedByIfaceName(sourcePod)) {
+	secondaryNetworkStatusesByPodIfaceName := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(multus.NetworkStatusesFromPod(sourcePod))
+	if namescheme.PodHasOrdinalInterfaceName(secondaryNetworkStatusesByPodIfaceName) {
 		ordinalNameScheme := namescheme.CreateOrdinalNetworkNameScheme(vmi.Spec.Networks)
 		multusNetworksAnnotation, err := multus.GenerateCNIAnnotationFromNameScheme(
 			vmi.Namespace,

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -84,8 +84,7 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 func (g Generator) GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8Scorev1.Pod) (map[string]string, error) {
 	annotations := map[string]string{}
 
-	secondaryNetworkStatusesByPodIfaceName := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(multus.NetworkStatusesFromPod(sourcePod))
-	if namescheme.PodHasOrdinalInterfaceName(secondaryNetworkStatusesByPodIfaceName) {
+	if namescheme.PodHasOrdinalInterfaceName2(multus.NetworkStatusesFromPod(sourcePod)) {
 		ordinalNameScheme := namescheme.CreateOrdinalNetworkNameScheme(vmi.Spec.Networks)
 		multusNetworksAnnotation, err := multus.GenerateCNIAnnotationFromNameScheme(
 			vmi.Namespace,

--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -113,6 +113,7 @@ func (c *NetConf) Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, l
 		netpod.WithMasqueradeAdapter(newMasqueradeAdapter(vmi)),
 		netpod.WithCacheCreator(c.cacheCreator),
 		netpod.WithLogger(log.Log.Object(vmi)),
+		netpod.WithVMIIfaceStatuses(vmi.Status.Interfaces),
 	)
 
 	if err := netpod.Setup(); err != nil {

--- a/pkg/network/setup/netpod/discover.go
+++ b/pkg/network/setup/netpod/discover.go
@@ -37,7 +37,7 @@ import (
 // the relevant data (for recovery and data sharing).
 func (n NetPod) discover(currentStatus *nmstate.Status) error {
 	podIfaceStatusByName := ifaceStatusByName(currentStatus.Interfaces)
-	podIfaceNameByVMINetwork := createNetworkNameScheme(n.vmiSpecNets, currentStatus.Interfaces)
+	podIfaceNameByVMINetwork := createNetworkNameScheme(n.vmiSpecNets, n.vmiIfaceStatuses, currentStatus.Interfaces)
 
 	for _, vmiSpecIface := range n.vmiSpecIfaces {
 		podIfaceName := podIfaceNameByVMINetwork[vmiSpecIface.Name]

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -603,7 +603,7 @@ func (n NetPod) clearCache(nets []v1.Network) error {
 			unplugErrors = append(unplugErrors, err)
 		}
 
-		podInterfaceName := namescheme.HashedPodInterfaceName(net)
+		podInterfaceName := namescheme.HashedPodInterfaceName(net, n.vmiIfaceStatuses)
 		err = cache.DeleteDHCPInterfaceCache(n.cacheCreator, strconv.Itoa(n.podPID), podInterfaceName)
 		if err != nil {
 			unplugErrors = append(unplugErrors, err)

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -110,8 +110,8 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, "", []string{secondaryPodIPv4, secondaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}), "the pod IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -135,7 +135,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, int32(queueCount)),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, int32(queueCount)),
 			}), "queue count and the pod IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -169,8 +169,8 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secondaryNetworkName, nil, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, "", nil, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 			}), "the pod & guest-agent IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -193,7 +193,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryGaIPv4, primaryGaIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryGaIPv4, primaryGaIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 			}), "the guest-agent IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -236,8 +236,8 @@ var _ = Describe("netstat", func() {
 			infoSourceDomainGAMultus := netvmispec.NewInfoSource(
 				netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent, netvmispec.InfoSourceMultusStatus)
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, secondaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, "", []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, secondaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
 			}), "the pod IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -268,7 +268,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "eth0", netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "eth0", netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 			}), "the pod IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -301,7 +301,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, newDomainMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, newDomainMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}), "the pod IP/s should be reported in the status")
 		})
 
@@ -364,7 +364,7 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(primaryNetworkName, nil, origMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+			newVMIStatusIface(primaryNetworkName, "", nil, origMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 		}), "the pod IP/s should be reported in the status")
 	})
 
@@ -385,7 +385,7 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(networkName, nil, ifaceMAC, "", netvmispec.InfoSourceDomain, netsetup.UnknownInterfaceQueueCount),
+			newVMIStatusIface(networkName, "", nil, ifaceMAC, "", netvmispec.InfoSourceDomain, netsetup.UnknownInterfaceQueueCount),
 		}), "the SR-IOV interface should be reported in the status.")
 	})
 
@@ -414,8 +414,8 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-			newVMIStatusIface(networkName, nil, "", "", netvmispec.InfoSourceDomain, netsetup.UnknownInterfaceQueueCount),
+			newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+			newVMIStatusIface(networkName, "", nil, "", "", netvmispec.InfoSourceDomain, netsetup.UnknownInterfaceQueueCount),
 		}), "the SR-IOV interface should be reported in the status.")
 	})
 
@@ -439,7 +439,7 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(networkName, nil, ifaceMAC, guestIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.UnknownInterfaceQueueCount),
+			newVMIStatusIface(networkName, "", nil, ifaceMAC, guestIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.UnknownInterfaceQueueCount),
 		}), "the SR-IOV interface should be reported in the status, associated to the network")
 	})
 
@@ -492,10 +492,10 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(ConsistOf([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface("", []string{primaryGaIPv4, primaryGaIPv6}, newMAC1, primaryIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
-				newVMIStatusIface("", []string{secondaryGaIPv4, secondaryGaIPv6}, newMAC2, secondaryIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, "", []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface("", "", []string{primaryGaIPv4, primaryGaIPv6}, newMAC1, primaryIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
+				newVMIStatusIface("", "", []string{secondaryGaIPv4, secondaryGaIPv6}, newMAC2, secondaryIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
 			}))
 		})
 
@@ -513,9 +513,9 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(ConsistOf([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface("", []string{newGaIPv4, newGaIPv6}, newMAC1, newIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, "", []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface("", "", []string{newGaIPv4, newGaIPv6}, newMAC1, newIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
 			}))
 		})
 
@@ -523,8 +523,8 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(ConsistOf([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, "", []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 	})
@@ -555,7 +555,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, nil, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", nil, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 
@@ -578,7 +578,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 	})
@@ -635,9 +635,9 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(prNetworkName, []string{podIP}, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secNetworkName1, []string{podIP}, MAC1, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusIface(secNetworkName2, []string{podIP}, MAC2, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(prNetworkName, "", []string{podIP}, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secNetworkName1, "", []string{podIP}, MAC1, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secNetworkName2, "", []string{podIP}, MAC2, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		},
 			Entry("primary interface defined first in spec", []int{PRIMARY_IFACE_IND, SECONDARY_IFACE1_IND, SECONDARY_IFACE2_IND}),
@@ -682,8 +682,8 @@ var _ = Describe("netstat", func() {
 		infoSourceDomainGAMultus := netvmispec.NewInfoSource(
 			netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent, netvmispec.InfoSourceMultusStatus)
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
-			newVMIStatusIface(secondaryNetworkName, nil, "", "", netvmispec.InfoSourceMultusStatus, 0),
+			newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
+			newVMIStatusIface(secondaryNetworkName, "", nil, "", "", netvmispec.InfoSourceMultusStatus, 0),
 		}), "primary and secondary ifaces should exist in status, where secondary iface have multus-status only")
 	})
 
@@ -721,9 +721,61 @@ var _ = Describe("netstat", func() {
 		infoSourceDomainGAMultus := netvmispec.NewInfoSource(
 			netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent, netvmispec.InfoSourceMultusStatus)
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
+			newVMIStatusIface(primaryNetworkName, "", []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
 		}), "only primary should exist in status since secondary iface not exist in spec")
 	})
+
+	It("VMI with custom primary interface name", func() {
+		const (
+			primaryNetworkName  = "primary"
+			primaryPodIPv4      = "1.1.1.1"
+			primaryPodIPv6      = "fd10:244::8c4c"
+			primaryMAC          = "1C:CE:C0:01:BE:E7"
+			primaryIfaceName    = "eth0"
+			primaryPodIfaceName = "custom-iface"
+		)
+
+		Expect(
+			setup.addNetworkInterface(
+				newVMISpecIfaceWithBridgeBinding(primaryNetworkName),
+				newVMISpecPodNetwork(primaryNetworkName),
+				newDomainSpecIface(primaryNetworkName, primaryMAC),
+				primaryPodIPv4, primaryPodIPv6,
+			),
+		).To(Succeed())
+
+		setup.addGuestAgentInterfaces(
+			newDomainStatusIface([]string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName),
+		)
+
+		setup.Vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
+			{Name: primaryNetworkName, PodInterfaceName: primaryPodIfaceName},
+		}
+
+		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+		infoSourceDomainGA := netvmispec.NewInfoSource(
+			netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent,
+		)
+		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
+			newVMIStatusIface(primaryNetworkName, primaryPodIfaceName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, infoSourceDomainGA, netsetup.DefaultInterfaceQueueCount),
+		}))
+	})
+
+	DescribeTable("VMI with primary interface status reported should keep the prev PodInterfaceName", func(primaryPodIfaceName string) {
+		const primaryNetworkName = "default"
+
+		setup.Vmi.Spec.Domain.Devices.Interfaces = append(setup.Vmi.Spec.Domain.Devices.Interfaces, newVMISpecIfaceWithBridgeBinding(primaryNetworkName))
+		setup.Vmi.Spec.Networks = append(setup.Vmi.Spec.Networks, newVMISpecPodNetwork(primaryNetworkName))
+		setup.Vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{{Name: primaryNetworkName, PodInterfaceName: primaryPodIfaceName}}
+		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{{Name: primaryNetworkName, PodInterfaceName: primaryPodIfaceName}}))
+	},
+		Entry("When existing pod interface name is empty", ""),
+		Entry("When existing pod interface name has the default value", "eth0"),
+		Entry("When existing pod interface name has a custom value", "custom-iface"),
+	)
 
 	Context("misc scenario", func() {
 		const (
@@ -737,7 +789,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(networkName, nil, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(networkName, "", nil, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 
@@ -758,7 +810,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusIface(networkName, nil, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(networkName, "", nil, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 
@@ -913,19 +965,20 @@ func newDomainStatusIface(IPs []string, mac, interfaceName string) api.Interface
 	}
 }
 
-func newVMIStatusIface(name string, IPs []string, mac, ifaceName string, infoSource string, queueCount int32) v1.VirtualMachineInstanceNetworkInterface {
+func newVMIStatusIface(name, podIfaceName string, IPs []string, mac, ifaceName string, infoSource string, queueCount int32) v1.VirtualMachineInstanceNetworkInterface {
 	var ip string
 	if len(IPs) > 0 {
 		ip = IPs[0]
 	}
 	return v1.VirtualMachineInstanceNetworkInterface{
-		Name:          name,
-		InterfaceName: ifaceName,
-		IP:            ip,
-		IPs:           IPs,
-		MAC:           mac,
-		InfoSource:    infoSource,
-		QueueCount:    queueCount,
+		Name:             name,
+		PodInterfaceName: podIfaceName,
+		InterfaceName:    ifaceName,
+		IP:               ip,
+		IPs:              IPs,
+		MAC:              mac,
+		InfoSource:       infoSource,
+		QueueCount:       queueCount,
 	}
 }
 

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -57,7 +57,7 @@ func newPhase2PodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, iface 
 		return nil, err
 	}
 
-	ifaceLink, err := link.DiscoverByNetwork(podnic.handler, podnic.vmi.Spec.Networks, *podnic.vmiSpecNetwork)
+	ifaceLink, err := link.DiscoverByNetwork(podnic.handler, podnic.vmi.Spec.Networks, *podnic.vmiSpecNetwork, vmi.Status.Interfaces)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/vmicontroller/BUILD.bazel
+++ b/pkg/network/vmicontroller/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         ":go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",
+        "//pkg/network/multus:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/network/vmicontroller/BUILD.bazel
+++ b/pkg/network/vmicontroller/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/network/vmicontroller/status.go
+++ b/pkg/network/vmicontroller/status.go
@@ -32,7 +32,7 @@ import (
 )
 
 func UpdateStatus(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) error {
-	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByIfaceName(pod)
+	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(multus.NetworkStatusesFromPod(pod))
 	ifaceNamingScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(vmi.Spec.Networks, indexedMultusStatusIfaces)
 	for _, network := range vmi.Spec.Networks {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)

--- a/pkg/network/vmicontroller/status.go
+++ b/pkg/network/vmicontroller/status.go
@@ -24,6 +24,8 @@ import (
 
 	k8scorev1 "k8s.io/api/core/v1"
 
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/multus"
@@ -32,28 +34,47 @@ import (
 )
 
 func UpdateStatus(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) error {
-	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(multus.NetworkStatusesFromPod(pod))
+	interfaceStatuses, err := calculateSecondaryIfaceStatuses(vmi, multus.NetworkStatusesFromPod(pod))
+	if err != nil {
+		return err
+	}
+
+	vmi.Status.Interfaces = interfaceStatuses
+	return nil
+}
+
+func calculateSecondaryIfaceStatuses(
+	vmi *v1.VirtualMachineInstance,
+	networkStatuses []networkv1.NetworkStatus,
+) ([]v1.VirtualMachineInstanceNetworkInterface, error) {
+	var interfaceStatuses []v1.VirtualMachineInstanceNetworkInterface
+
+	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses)
 	ifaceNamingScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(vmi.Spec.Networks, indexedMultusStatusIfaces)
 	for _, network := range vmi.Spec.Networks {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)
 		podIfaceName, wasFound := ifaceNamingScheme[network.Name]
 		if !wasFound {
-			return fmt.Errorf("could not find the pod interface name for network [%s]", network.Name)
+			return nil, fmt.Errorf("could not find the pod interface name for network [%s]", network.Name)
 		}
 
 		_, exists := indexedMultusStatusIfaces[podIfaceName]
 		switch {
 		case exists && vmiIfaceStatus == nil:
-			vmi.Status.Interfaces = append(vmi.Status.Interfaces, v1.VirtualMachineInstanceNetworkInterface{
+			interfaceStatuses = append(interfaceStatuses, v1.VirtualMachineInstanceNetworkInterface{
 				Name:       network.Name,
 				InfoSource: vmispec.InfoSourceMultusStatus,
 			})
 		case exists && vmiIfaceStatus != nil:
-			vmiIfaceStatus.InfoSource = vmispec.AddInfoSource(vmiIfaceStatus.InfoSource, vmispec.InfoSourceMultusStatus)
+			updatedIfaceStatus := *vmiIfaceStatus
+			updatedIfaceStatus.InfoSource = vmispec.AddInfoSource(updatedIfaceStatus.InfoSource, vmispec.InfoSourceMultusStatus)
+			interfaceStatuses = append(interfaceStatuses, updatedIfaceStatus)
 		case !exists && vmiIfaceStatus != nil:
-			vmiIfaceStatus.InfoSource = vmispec.RemoveInfoSource(vmiIfaceStatus.InfoSource, vmispec.InfoSourceMultusStatus)
+			updatedIfaceStatus := *vmiIfaceStatus
+			updatedIfaceStatus.InfoSource = vmispec.RemoveInfoSource(updatedIfaceStatus.InfoSource, vmispec.InfoSourceMultusStatus)
+			interfaceStatuses = append(interfaceStatuses, updatedIfaceStatus)
 		}
 	}
 
-	return nil
+	return interfaceStatuses, nil
 }

--- a/pkg/virt-controller/network/vmcontroller.go
+++ b/pkg/virt-controller/network/vmcontroller.go
@@ -139,8 +139,7 @@ func (v *VMNetController) hasOrdinalNetworkInterfaces(vmi *v1.VirtualMachineInst
 		// This is an old virt-launcher that uses ordinal network interface names.
 		return true, nil
 	}
-	secondaryNetworkStatusesByPodIfaceName := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(multus.NetworkStatusesFromPod(pod))
-	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName(secondaryNetworkStatusesByPodIfaceName)
+	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName2(multus.NetworkStatusesFromPod(pod))
 	return hasOrdinalIfaces, nil
 }
 

--- a/pkg/virt-controller/network/vmcontroller.go
+++ b/pkg/virt-controller/network/vmcontroller.go
@@ -139,7 +139,8 @@ func (v *VMNetController) hasOrdinalNetworkInterfaces(vmi *v1.VirtualMachineInst
 		// This is an old virt-launcher that uses ordinal network interface names.
 		return true, nil
 	}
-	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName(multus.NonDefaultNetworkStatusIndexedByIfaceName(pod))
+	secondaryNetworkStatusesByPodIfaceName := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(multus.NetworkStatusesFromPod(pod))
+	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName(secondaryNetworkStatusesByPodIfaceName)
 	return hasOrdinalIfaces, nil
 }
 

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -2137,7 +2137,7 @@ func (c *Controller) getVolumePhaseMessageReason(volume *virtv1.Volume, namespac
 func (c *Controller) updateMultusAnnotation(namespace string, interfaces []virtv1.Interface, networks []virtv1.Network, pod *k8sv1.Pod) error {
 	podAnnotations := pod.GetAnnotations()
 
-	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByIfaceName(pod)
+	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(multus.NetworkStatusesFromPod(pod))
 	networkToPodIfaceMap := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, indexedMultusStatusIfaces)
 	multusAnnotations, err := multus.GenerateCNIAnnotationFromNameScheme(namespace, interfaces, networks, networkToPodIfaceMap, c.clusterConfig)
 	if err != nil {

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -117,6 +117,8 @@ func getTapDevices(vmi *v1.VirtualMachineInstance, networkBindings map[string]v1
 	}
 
 	networkNameScheme := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
+	networkNameScheme = namescheme.UpdatePrimaryPodIfaceNameFromVMIStatus(networkNameScheme, vmi.Spec.Networks, vmi.Status.Interfaces)
+
 	tapDevices := map[string]string{}
 	for _, net := range vmi.Spec.Networks {
 		_, isTapNetwork := tapNetworks[net.Name]

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -13341,6 +13341,10 @@ var CRDsValidation map[string]string = map[string]string{
                 description: Name of the interface, corresponds to name of the network
                   assigned to the interface
                 type: string
+              podInterfaceName:
+                description: PodInterfaceName represents the name of the pod network
+                  interface
+                type: string
               queueCount:
                 description: Specifies how many queues are allocated by MultiQueue
                 format: int32

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -896,6 +896,7 @@
         "ipAddresses": [
           "ipAddressesValue"
         ],
+        "podInterfaceName": "podInterfaceNameValue",
         "interfaceName": "interfaceNameValue",
         "infoSource": "infoSourceValue",
         "queueCount": -10

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -609,6 +609,7 @@ status:
     - ipAddressesValue
     mac: macValue
     name: nameValue
+    podInterfaceName: podInterfaceNameValue
     queueCount: -10
   kernelBootStatus:
     initrdInfo:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -696,6 +696,8 @@ type VirtualMachineInstanceNetworkInterface struct {
 	Name string `json:"name,omitempty"`
 	// List of all IP addresses of a Virtual Machine interface
 	IPs []string `json:"ipAddresses,omitempty"`
+	// PodInterfaceName represents the name of the pod network interface
+	PodInterfaceName string `json:"podInterfaceName,omitempty"`
 	// The interface name inside the Virtual Machine
 	InterfaceName string `json:"interfaceName,omitempty"`
 	// Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -187,13 +187,14 @@ func (VirtualMachineInstanceMigrationCondition) SwaggerDoc() map[string]string {
 
 func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"ipAddress":     "IP address of a Virtual Machine interface. It is always the first item of\nIPs",
-		"mac":           "Hardware address of a Virtual Machine interface",
-		"name":          "Name of the interface, corresponds to name of the network assigned to the interface",
-		"ipAddresses":   "List of all IP addresses of a Virtual Machine interface",
-		"interfaceName": "The interface name inside the Virtual Machine",
-		"infoSource":    "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",
-		"queueCount":    "Specifies how many queues are allocated by MultiQueue",
+		"ipAddress":        "IP address of a Virtual Machine interface. It is always the first item of\nIPs",
+		"mac":              "Hardware address of a Virtual Machine interface",
+		"name":             "Name of the interface, corresponds to name of the network assigned to the interface",
+		"ipAddresses":      "List of all IP addresses of a Virtual Machine interface",
+		"podInterfaceName": "PodInterfaceName represents the name of the pod network interface",
+		"interfaceName":    "The interface name inside the Virtual Machine",
+		"infoSource":       "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",
+		"queueCount":       "Specifies how many queues are allocated by MultiQueue",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25420,6 +25420,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceNetworkInterface(ref co
 							},
 						},
 					},
+					"podInterfaceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PodInterfaceName represents the name of the pod network interface",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"interfaceName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The interface name inside the Virtual Machine",

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/libvmi/replicaset:go_default_library",
         "//pkg/network/istio:go_default_library",
+        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -35,6 +35,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	network "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 
@@ -104,10 +105,11 @@ var _ = SIGDescribe("Infosource", func() {
 
 			expectedInterfaces := []kvirtv1.VirtualMachineInstanceNetworkInterface{
 				{
-					InfoSource: netvmispec.InfoSourceDomain,
-					MAC:        primaryInterfaceMac,
-					Name:       primaryNetwork,
-					QueueCount: network.DefaultInterfaceQueueCount,
+					InfoSource:       netvmispec.InfoSourceDomain,
+					MAC:              primaryInterfaceMac,
+					Name:             primaryNetwork,
+					PodInterfaceName: namescheme.PrimaryPodInterfaceName,
+					QueueCount:       network.DefaultInterfaceQueueCount,
 				},
 				{
 					InfoSource:    infoSourceDomainAndGAAndMultusStatus,
@@ -159,7 +161,7 @@ var _ = SIGDescribe("Infosource", func() {
 				vmi.Status.Interfaces[i].IPs = nil
 			}
 
-			Expect(expectedInterfaces).To(ConsistOf(vmi.Status.Interfaces))
+			Expect(vmi.Status.Interfaces).To(ConsistOf(expectedInterfaces))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Add a mechanism to dynamically determine the primary pod interface for KuveVirt virtual machines.
The goal is to move away from the hard coded eth0 interface and allow flexible, environment-driven interface
selection.

A new field is added to `v1.VirtualMachineInstanceNetworkInterface` in order to report the matching pod interface name.

VMI controller's network `UpdateStatus` logic is adjusted to report the primary pod interface name inferred from the pod's `k8s.v1.cni.cncf.io/network-status` annotation, with a fallback to the default `eth0`.

virt-handler's network status reporting logic is adjusted to preserve the primary pod interface name.
virt-handler and virt-launcher network setup logic is adjusted to consume a custom primary pod interface name.

Additionally, a small change is made to the network e2e tests to account for addition of the new field.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
Design proposal: https://github.com/kubevirt/community/pull/324

### Special notes for your reviewer
~~Depends on PR #13038, please skip the first two commits.~~
First three commits are small refactoring.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support Dynamic Primary Pod NIC Name
```

