### PR TITLE
virtctl, guestfs: Get rid of globals

### DIFF
--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -44,47 +44,40 @@ const (
 	tmpDirVolumeName  = "libguestfs-tmp-dir"
 	tmpDirPath        = "/tmp/guestfs"
 	pullPolicyDefault = corev1.PullIfNotPresent
-)
-
-var (
-	pvc        string
-	image      string
-	ImagePtr   = &image
-	timeout    = 500 * time.Second
-	pullPolicy string
-	kvm        bool
-	podName    string
-	root       bool
-	fsGroup    string
-	uid        string
-	gid        string
+	timeout           = 500 * time.Second
 )
 
 type guestfsCommand struct {
 	clientConfig clientcmd.ClientConfig
+	pvc          string
+	image        string
+	kvm          bool
+	root         bool
+	fsGroup      string
+	uid          string
+	gid          string
+	pullPolicy   string
 }
 
 // NewGuestfsShellCommand returns a cobra.Command for starting libguestfs-tool pod and attach it to a pvc
 func NewGuestfsShellCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	c := guestfsCommand{clientConfig: clientConfig}
 	cmd := &cobra.Command{
 		Use:     "guestfs",
 		Short:   "Start a shell into the libguestfs pod",
 		Long:    `Create a pod with libguestfs-tools, mount the pvc and attach a shell to it. The pvc is mounted under the /disks directory inside the pod for filesystem-based pvcs, or as /dev/vda for block-based pvcs`,
 		Args:    cobra.ExactArgs(1),
 		Example: usage(),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := guestfsCommand{clientConfig: clientConfig}
-			return c.run(cmd, args)
-		},
+		RunE:    c.run,
 	}
-	cmd.PersistentFlags().StringVar(&image, "image", "", "libguestfs-tools container image")
-	cmd.PersistentFlags().StringVar(&pullPolicy, "pull-policy", string(pullPolicyDefault), "pull policy for the libguestfs image")
-	cmd.PersistentFlags().BoolVar(&kvm, "kvm", true, "Use kvm for the libguestfs-tools container")
-	cmd.PersistentFlags().BoolVar(&root, "root", false, "Set uid 0 for the libguestfs-tool container")
-	cmd.PersistentFlags().StringVar(&uid, "uid", "", "Set uid for the libguestfs-tool container. It doesn't work with root")
-	cmd.PersistentFlags().StringVar(&gid, "gid", "", "Set gid for the libguestfs-tool container. This works only combined when the uid is manually set")
+	cmd.PersistentFlags().StringVar(&c.image, "image", "", "libguestfs-tools container image")
+	cmd.PersistentFlags().StringVar(&c.pullPolicy, "pull-policy", string(pullPolicyDefault), "pull policy for the libguestfs image")
+	cmd.PersistentFlags().BoolVar(&c.kvm, "kvm", true, "Use kvm for the libguestfs-tools container")
+	cmd.PersistentFlags().BoolVar(&c.root, "root", false, "Set uid 0 for the libguestfs-tool container")
+	cmd.PersistentFlags().StringVar(&c.uid, "uid", "", "Set uid for the libguestfs-tool container. It doesn't work with root")
+	cmd.PersistentFlags().StringVar(&c.gid, "gid", "", "Set gid for the libguestfs-tool container. This works only combined when the uid is manually set")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
-	cmd.PersistentFlags().StringVar(&fsGroup, "fsGroup", "", "Set the fsgroup for the libguestfs-tool container")
+	cmd.PersistentFlags().StringVar(&c.fsGroup, "fsGroup", "", "Set the fsgroup for the libguestfs-tool container")
 
 	return cmd
 }
@@ -126,7 +119,7 @@ func SetDefaulAttacher() {
 }
 
 // ImageSet is a function to set the setImage
-type ImageSet func(virtClient kubecli.KubevirtClient) error
+type ImageSet func(virtClient kubecli.KubevirtClient) (string, error)
 
 // ImageInfoGet is a function to get image info
 type ImageInfoGet func(virtClient kubecli.KubevirtClient) (*kubecli.GuestfsInfo, error)
@@ -161,17 +154,17 @@ func init() {
 	SetDefaultImageInfoGetFunc()
 }
 
-func (c *guestfsCommand) run(cmd *cobra.Command, args []string) error {
-	pvc = args[0]
+func (c *guestfsCommand) run(_ *cobra.Command, args []string) error {
+	c.pvc = args[0]
 	namespace, _, err := c.clientConfig.Namespace()
 	if err != nil {
 		return err
 	}
 
-	if pullPolicy != string(corev1.PullAlways) &&
-		pullPolicy != string(corev1.PullNever) &&
-		pullPolicy != string(corev1.PullIfNotPresent) {
-		return fmt.Errorf("Invalid pull policy: %s", pullPolicy)
+	if c.pullPolicy != string(corev1.PullAlways) &&
+		c.pullPolicy != string(corev1.PullNever) &&
+		c.pullPolicy != string(corev1.PullIfNotPresent) {
+		return fmt.Errorf("Invalid pull policy: %s", c.pullPolicy)
 	}
 	var inUse bool
 	conf, err := c.clientConfig.ClientConfig()
@@ -182,29 +175,30 @@ func (c *guestfsCommand) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if image == "" {
-		if err = ImageSetFunc(client.VirtClient); err != nil {
+	if c.image == "" {
+		c.image, err = ImageSetFunc(client.VirtClient)
+		if err != nil {
 			return err
 		}
 	}
-	fmt.Printf("Use image: %s \n", image)
-	exist, _ := client.existsPVC(pvc, namespace)
+	fmt.Printf("Use image: %s \n", c.image)
+	exist, _ := client.existsPVC(c.pvc, namespace)
 	if !exist {
-		return fmt.Errorf("The PVC %s doesn't exist", pvc)
+		return fmt.Errorf("The PVC %s doesn't exist", c.pvc)
 	}
-	inUse, err = client.isPVCinUse(pvc, namespace)
+	inUse, err = client.isPVCinUse(c.pvc, namespace)
 	if err != nil {
 		return err
 	}
 	if inUse {
-		return fmt.Errorf("PVC %s is used by another pod", pvc)
+		return fmt.Errorf("PVC %s is used by another pod", c.pvc)
 	}
-	isBlock, err := client.isPVCVolumeBlock(pvc, namespace)
+	isBlock, err := client.isPVCVolumeBlock(c.pvc, namespace)
 	if err != nil {
 		return err
 	}
-	defer client.removePod(namespace)
-	return client.createInteractivePodWithPVC(pvc, image, namespace, "/entrypoint.sh", []string{}, isBlock)
+	defer client.removePod(namespace, genPodName(c.pvc))
+	return c.createInteractivePodWithPVC(client, namespace, "/entrypoint.sh", []string{}, isBlock)
 }
 
 // K8sClient holds the information of the Kubernetes client
@@ -215,16 +209,15 @@ type K8sClient struct {
 }
 
 // setImage sets the image name based on the information retrieved by the KubeVirt server.
-func setImage(virtClient kubecli.KubevirtClient) error {
+func setImage(virtClient kubecli.KubevirtClient) (string, error) {
 	var imageName string
 	info, err := ImageInfoGetFunc(virtClient)
 	if err != nil {
-		return fmt.Errorf("could not get guestfs image info: %v", err)
+		return "", fmt.Errorf("could not get guestfs image info: %v", err)
 	}
 	if info.GsImage != "" {
 		// custom image set, no need to assemble url
-		image = info.GsImage
-		return nil
+		return info.GsImage, nil
 	}
 	// Set image name including prefix if available
 	imageName = fmt.Sprintf("%s%s", info.ImagePrefix, defaultImageName)
@@ -234,16 +227,16 @@ func setImage(virtClient kubecli.KubevirtClient) error {
 	} else if info.Tag != "" {
 		imageName = fmt.Sprintf("%s:%s", imageName, info.Tag)
 	} else {
-		return fmt.Errorf("Neither the digest nor the tag for the image has been specified")
+		return "", fmt.Errorf("Neither the digest nor the tag for the image has been specified")
 	}
 
 	// Set the registry
-	image = imageName
+	image := imageName
 	if info.Registry != "" {
 		image = fmt.Sprintf("%s/%s", info.Registry, imageName)
 	}
 
-	return nil
+	return image, nil
 }
 
 // getImageInfo gets the image info based on the information on KubeVirt CR
@@ -316,7 +309,7 @@ func (client *K8sClient) isPVCinUse(pvc, ns string) (bool, error) {
 	return false, nil
 }
 
-func (client *K8sClient) waitForContainerRunning(pod, cont, ns string, timeout time.Duration) error {
+func (client *K8sClient) waitForContainerRunning(podName, ns string, timeout time.Duration) error {
 	terminated := "Terminated"
 	chTerm := make(chan os.Signal, 1)
 	c := make(chan string, 1)
@@ -324,13 +317,13 @@ func (client *K8sClient) waitForContainerRunning(pod, cont, ns string, timeout t
 	// if the user killed the guestfs command, the libguestfs-tools pod is also removed
 	go func() {
 		<-chTerm
-		client.removePod(ns)
+		client.removePod(ns, podName)
 		c <- terminated
 	}()
 
 	go func() {
 		for {
-			pod, err := client.Client.CoreV1().Pods(ns).Get(context.TODO(), pod, metav1.GetOptions{})
+			pod, err := client.Client.CoreV1().Pods(ns).Get(context.TODO(), podName, metav1.GetOptions{})
 			if err != nil {
 				c <- err.Error()
 			}
@@ -354,9 +347,8 @@ func (client *K8sClient) waitForContainerRunning(pod, cont, ns string, timeout t
 		}
 		return fmt.Errorf("Pod is not in running state but got %s", res)
 	case <-time.After(timeout):
-		return fmt.Errorf("timeout in waiting for the containers to be started in pod %s", pod)
+		return fmt.Errorf("timeout in waiting for the containers to be started in pod %s", podName)
 	}
-
 }
 
 func (client *K8sClient) getPodsForPVC(pvcName, ns string) ([]corev1.Pod, error) {
@@ -378,35 +370,35 @@ func (client *K8sClient) getPodsForPVC(pvcName, ns string) ([]corev1.Pod, error)
 	return pods, nil
 }
 
-func setFSGroupLibguestfs() (*int64, error) {
-	if root && fsGroup != "" {
+func (c *guestfsCommand) setFSGroupLibguestfs() (*int64, error) {
+	if c.root && c.fsGroup != "" {
 		return nil, fmt.Errorf("cannot set fsGroup id with root")
 	}
-	if fsGroup != "" {
-		n, err := strconv.ParseInt(fsGroup, 10, 64)
+	if c.fsGroup != "" {
+		n, err := strconv.ParseInt(c.fsGroup, 10, 64)
 		if err != nil {
 			return nil, err
 		}
 		return &n, nil
 	}
-	if root {
+	if c.root {
 		var rootFsID int64 = 0
 		return &rootFsID, nil
 	}
 	return nil, nil
 }
 
-// setUIDLibugestfs returns the guestfs uid
-func setUIDLibugestfs() (*int64, error) {
+// setUIDLibguestfs returns the guestfs uid
+func (c *guestfsCommand) setUIDLibguestfs() (*int64, error) {
 	switch {
-	case root:
+	case c.root:
 		var zero int64
-		if uid != "" {
+		if c.uid != "" {
 			return nil, fmt.Errorf("cannot set uid if root is true")
 		}
 		return &zero, nil
-	case uid != "":
-		n, err := strconv.ParseInt(uid, 10, 64)
+	case c.uid != "":
+		n, err := strconv.ParseInt(c.uid, 10, 64)
 		if err != nil {
 			return nil, err
 		}
@@ -416,48 +408,47 @@ func setUIDLibugestfs() (*int64, error) {
 	}
 }
 
-func setGIDLibguestfs() (*int64, error) {
+func (c *guestfsCommand) setGIDLibguestfs() (*int64, error) {
 	// The GID can only be specified together with the uid. See comment at: https://github.com/kubernetes/cri-api/blob/2b5244cefaeace624cb160d6b3d85dd3fd14baea/pkg/apis/runtime/v1/api.proto#L307-L309
-	if gid != "" && uid == "" {
+	if c.gid != "" && c.uid == "" {
 		return nil, fmt.Errorf("gid requires the uid to be set")
 	}
 
-	if root && gid != "" {
+	if c.root && c.gid != "" {
 		return nil, fmt.Errorf("cannot set gid id with root")
 	}
-	if gid != "" {
-		n, err := strconv.ParseInt(gid, 10, 64)
+	if c.gid != "" {
+		n, err := strconv.ParseInt(c.gid, 10, 64)
 		if err != nil {
 			return nil, err
 		}
 		return &n, nil
 	}
-	if root {
+	if c.root {
 		var rootGID int64 = 0
 		return &rootGID, nil
 	}
 	return nil, nil
 }
 
-func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock bool) (*corev1.Pod, error) {
+func (c *guestfsCommand) createLibguestfsPod(cmd string, args []string, isBlock bool) (*corev1.Pod, error) {
 	var resources corev1.ResourceRequirements
-	podName = fmt.Sprintf("%s-%s", podNamePrefix, pvc)
-	if kvm {
+	if c.kvm {
 		resources = corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				KvmDevice: resource.MustParse("1"),
 			},
 		}
 	}
-	u, err := setUIDLibugestfs()
+	u, err := c.setUIDLibguestfs()
 	if err != nil {
 		return nil, err
 	}
-	g, err := setGIDLibguestfs()
+	g, err := c.setGIDLibguestfs()
 	if err != nil {
 		return nil, err
 	}
-	f, err := setFSGroupLibguestfs()
+	f, err := c.setFSGroupLibguestfs()
 	if err != nil {
 		return nil, err
 	}
@@ -469,7 +460,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 		},
 	}
 	securityContext := &corev1.PodSecurityContext{
-		RunAsNonRoot: pointer.P(!root),
+		RunAsNonRoot: pointer.P(!c.root),
 		RunAsUser:    u,
 		RunAsGroup:   g,
 		FSGroup:      f,
@@ -477,9 +468,9 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
-	c := &corev1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
+			Name: genPodName(c.pvc),
 		},
 		Spec: corev1.PodSpec{
 			SecurityContext: securityContext,
@@ -488,7 +479,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 					Name: volume,
 					VolumeSource: corev1.VolumeSource{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvc,
+							ClaimName: c.pvc,
 							ReadOnly:  false,
 						},
 					},
@@ -510,7 +501,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 			Containers: []corev1.Container{
 				{
 					Name:    contName,
-					Image:   image,
+					Image:   c.image,
 					Command: []string{cmd},
 					Args:    args,
 					// Set env variable to start libguestfs:
@@ -548,7 +539,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 							MountPath: guestfsHome,
 						},
 					},
-					ImagePullPolicy: corev1.PullPolicy(pullPolicy),
+					ImagePullPolicy: corev1.PullPolicy(c.pullPolicy),
 					Stdin:           true,
 					TTY:             true,
 					Resources:       resources,
@@ -558,24 +549,24 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 		},
 	}
 	if isBlock {
-		c.Spec.Containers[0].VolumeDevices = append(c.Spec.Containers[0].VolumeDevices, corev1.VolumeDevice{
+		pod.Spec.Containers[0].VolumeDevices = append(pod.Spec.Containers[0].VolumeDevices, corev1.VolumeDevice{
 			Name:       volume,
 			DevicePath: diskPath,
 		})
 		fmt.Printf("The PVC has been mounted at %s \n", diskPath)
-		return c, nil
+		return pod, nil
 	}
 	// PVC volume mode is filesystem
-	c.Spec.Containers[0].VolumeMounts = append(c.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:      volume,
 		ReadOnly:  false,
 		MountPath: diskDir,
 	})
 
-	c.Spec.Containers[0].WorkingDir = diskDir
+	pod.Spec.Containers[0].WorkingDir = diskDir
 	fmt.Printf("The PVC has been mounted at %s \n", diskDir)
 
-	return c, nil
+	return pod, nil
 }
 
 // createAttacher attaches the stdin, stdout, and stderr to the container shell
@@ -614,8 +605,8 @@ func createAttacher(client *K8sClient, p *corev1.Pod, command string) error {
 		"If you don't see a command prompt, try pressing enter.", resChan)
 }
 
-func (client *K8sClient) createInteractivePodWithPVC(pvc, image, ns, command string, args []string, isblock bool) error {
-	pod, err := createLibguestfsPod(pvc, image, command, args, kvm, isblock)
+func (c *guestfsCommand) createInteractivePodWithPVC(client *K8sClient, ns, command string, args []string, isblock bool) error {
+	pod, err := c.createLibguestfsPod(command, args, isblock)
 	if err != nil {
 		return err
 	}
@@ -623,13 +614,17 @@ func (client *K8sClient) createInteractivePodWithPVC(pvc, image, ns, command str
 	if err != nil {
 		return err
 	}
-	err = client.waitForContainerRunning(podName, contName, ns, timeout)
+	err = client.waitForContainerRunning(genPodName(c.pvc), ns, timeout)
 	if err != nil {
 		return err
 	}
 	return createAttacherFunc(client, p, command)
 }
 
-func (client *K8sClient) removePod(ns string) error {
+func (client *K8sClient) removePod(ns, podName string) error {
 	return client.Client.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+}
+
+func genPodName(pvc string) string {
+	return fmt.Sprintf("%s-%s", podNamePrefix, pvc)
 }

--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -32,8 +32,8 @@ func fakeAttacherCreator(client *guestfs.K8sClient, p *corev1.Pod, command strin
 	return nil
 }
 
-func fakeSetImage(virtClient kubecli.KubevirtClient) error {
-	return nil
+func fakeSetImage(virtClient kubecli.KubevirtClient) (string, error) {
+	return "", nil
 }
 
 var _ = Describe("Guestfs shell", func() {
@@ -192,20 +192,17 @@ var _ = Describe("Guestfs shell", func() {
 
 		It("Image prefix from kubevirt config not discarded", func() {
 			guestfs.SetImageInfoGetFunc(fakeGetImageInfoNoCustomURL)
-			guestfs.ImageSetFunc(kubevirtClient)
-			Expect(*guestfs.ImagePtr).To(Equal("someregistry.io/kubevirt/some-prefix-libguestfs-tools@89af657d3c226ac3083a0986e19efe70c9ccd7e7278137e9df24b9b430182aa7"))
+			Expect(guestfs.ImageSetFunc(kubevirtClient)).Should(HaveValue(Equal("someregistry.io/kubevirt/some-prefix-libguestfs-tools@89af657d3c226ac3083a0986e19efe70c9ccd7e7278137e9df24b9b430182aa7")))
 		})
 
 		It("Image override alone is enough to assemble url", func() {
 			guestfs.SetImageInfoGetFunc(fakeGetImageInfoWithCustomURL)
-			guestfs.ImageSetFunc(kubevirtClient)
-			Expect(*guestfs.ImagePtr).To(Equal("someregistry.io/kubevirt/libguestfs-tools-centos9@sha256:128736c7736a8791fb8a8de7d92a4f9be886dc6d8e77d01db8bd55253399099b"))
+			Expect(guestfs.ImageSetFunc(kubevirtClient)).To(HaveValue(Equal("someregistry.io/kubevirt/libguestfs-tools-centos9@sha256:128736c7736a8791fb8a8de7d92a4f9be886dc6d8e77d01db8bd55253399099b")))
 		})
 
 		It("Image override takes precedence over registry specifics", func() {
 			guestfs.SetImageInfoGetFunc(fakeGetImageInfoWithCustomURLAndRegistrySpecifics)
-			guestfs.ImageSetFunc(kubevirtClient)
-			Expect(*guestfs.ImagePtr).To(Equal("someregistry.io/kubevirt/libguestfs-tools-centos9@sha256:128736c7736a8791fb8a8de7d92a4f9be886dc6d8e77d01db8bd55253399099b"))
+			Expect(guestfs.ImageSetFunc(kubevirtClient)).Should(HaveValue(Equal("someregistry.io/kubevirt/libguestfs-tools-centos9@sha256:128736c7736a8791fb8a8de7d92a4f9be886dc6d8e77d01db8bd55253399099b")))
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does
Remove globals, and some unused variables.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

