### PR TITLE
net binding plugin: Introduce a new `managedTap` `domainAttachmentType`

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14201,7 +14201,7 @@
       "$ref": "#/definitions/v1.ResourceRequirementsWithoutClaims"
      },
      "domainAttachmentType": {
-      "description": "DomainAttachmentType is a standard domain network attachment method kubevirt supports. Supported values: \"tap\". The standard domain attachment can be used instead or in addition to the sidecarImage. version: 1alphav1",
+      "description": "DomainAttachmentType is a standard domain network attachment method kubevirt supports. Supported values: \"tap\", \"managedTap\" (since v1.4). The standard domain attachment can be used instead or in addition to the sidecarImage. version: 1alphav1",
       "type": "string"
      },
      "downwardAPI": {

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -361,7 +361,7 @@ func (app *virtHandlerApp) Run() {
 		downwardMetricsManager,
 		&capabilities,
 		hostCpuModel,
-		netsetup.NewNetConf(),
+		netsetup.NewNetConf(app.clusterConfig),
 		netsetup.NewNetStat(),
 		netbinding.MemoryCalculator{},
 	)

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -681,7 +681,7 @@ spec:
                             domainAttachmentType:
                               description: |-
                                 DomainAttachmentType is a standard domain network attachment method kubevirt supports.
-                                Supported values: "tap".
+                                Supported values: "tap", "managedTap" (since v1.4).
                                 The standard domain attachment can be used instead or in addition to the sidecarImage.
                                 version: 1alphav1
                               type: string
@@ -3921,7 +3921,7 @@ spec:
                             domainAttachmentType:
                               description: |-
                                 DomainAttachmentType is a standard domain network attachment method kubevirt supports.
-                                Supported values: "tap".
+                                Supported values: "tap", "managedTap" (since v1.4).
                                 The standard domain attachment can be used instead or in addition to the sidecarImage.
                                 version: 1alphav1
                               type: string

--- a/pkg/network/domainspec/interface.go
+++ b/pkg/network/domainspec/interface.go
@@ -52,6 +52,10 @@ func DomainAttachmentByInterfaceName(vmiSpecIfaces []v1.Interface, networkBindin
 			domainAttachmentByInterfaceName[iface.Name] = string(v1.Tap)
 		} else if iface.Binding != nil {
 			if domainAttachmentType, exist := domainAttachmentByPluginName[iface.Binding.Name]; exist {
+				// For domain consumption, handle the `managedTap` type as `tap`.
+				if domainAttachmentType == string(v1.ManagedTap) {
+					domainAttachmentType = string(v1.Tap)
+				}
 				domainAttachmentByInterfaceName[iface.Name] = domainAttachmentType
 			}
 		}

--- a/pkg/network/domainspec/interface_test.go
+++ b/pkg/network/domainspec/interface_test.go
@@ -107,6 +107,14 @@ var _ = Describe("VMI interfaces", func() {
 			}
 			Expect(domainspec.DomainAttachmentByInterfaceName(vmiSpecIfaces, networkBindings)).To(Equal(expectedMap))
 		})
+
+		It("should consider a managedTap type as a tap type", func() {
+			vmiIfaces := []v1.Interface{{Name: iface1, Binding: &v1.PluginBinding{Name: binding1}}}
+			netBindings := map[string]v1.InterfaceBindingPlugin{binding1: {DomainAttachmentType: v1.ManagedTap}}
+			Expect(domainspec.DomainAttachmentByInterfaceName(vmiIfaces, netBindings)).To(Equal(
+				map[string]string{iface1: string(v1.Tap)},
+			))
+		})
 	})
 
 	Context("BindingMigrationByInterfaceName", func() {

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -57,7 +57,7 @@ var _ = Describe("netconf", func() {
 		stateCache = newConfigStateCacheStub()
 		ns = nsExecutorStub{}
 		stateMap = map[string]*netpod.State{}
-		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsNoopFactory, &tempCacheCreator{}, stateMap)
+		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsNoopFactory, &tempCacheCreator{}, stateMap, cConfigStub{})
 		vmi = &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{UID: "123", Name: "vmi1"}}
 	})
 
@@ -82,7 +82,7 @@ var _ = Describe("netconf", func() {
 	})
 
 	DescribeTable("setup ignores specific network bindings", func(binding v1.InterfaceBindingMethod) {
-		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsFailureFactory, &tempCacheCreator{}, stateMap)
+		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsFailureFactory, &tempCacheCreator{}, stateMap, cConfigStub{})
 
 		stateMap[string(vmi.UID)] = netpod.NewState(stateCache, ns)
 
@@ -112,7 +112,7 @@ var _ = Describe("netconf", func() {
 	})
 
 	It("fails the setup run", func() {
-		netConf := netsetup.NewNetConfWithCustomFactoryAndConfigState(nsFailureFactory, &tempCacheCreator{}, stateMap)
+		netConf := netsetup.NewNetConfWithCustomFactoryAndConfigState(nsFailureFactory, &tempCacheCreator{}, stateMap, cConfigStub{})
 		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
 			Name:                   testNetworkName,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
@@ -125,7 +125,7 @@ var _ = Describe("netconf", func() {
 	})
 
 	It("fails the teardown run", func() {
-		netConf := netsetup.NewNetConfWithCustomFactoryAndConfigState(nil, failingCacheCreator{}, stateMap)
+		netConf := netsetup.NewNetConfWithCustomFactoryAndConfigState(nil, failingCacheCreator{}, stateMap, cConfigStub{})
 		Expect(netConf.Teardown(vmi)).NotTo(Succeed())
 	})
 })
@@ -211,4 +211,10 @@ type nsExecutorStub struct {
 func (n nsExecutorStub) Do(f func() error) error {
 	Expect(n.shouldNotBeExecuted).To(BeFalse(), "The namespace executor shouldn't be invoked")
 	return f()
+}
+
+type cConfigStub struct{}
+
+func (c cConfigStub) GetNetworkBindings() map[string]v1.InterfaceBindingPlugin {
+	return map[string]v1.InterfaceBindingPlugin{}
 }

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -77,6 +77,8 @@ type NetPod struct {
 	cacheCreator cacheCreator
 	state        *State
 
+	bindingPluginsByName map[string]v1.InterfaceBindingPlugin
+
 	log *log.FilteredLogger
 }
 
@@ -95,7 +97,8 @@ func NewNetPod(vmiNetworks []v1.Network, vmiIfaces []v1.Interface, vmiUID string
 		nmstateAdapter:    nmstate.New(),
 		masqueradeAdapter: masquerade.New(),
 
-		cacheCreator: cache.CacheCreator{},
+		cacheCreator:         cache.CacheCreator{},
+		bindingPluginsByName: map[string]v1.InterfaceBindingPlugin{},
 
 		log: log.Log,
 	}
@@ -120,6 +123,12 @@ func WithMasqueradeAdapter(h masqueradeAdapter) option {
 func WithCacheCreator(c cacheCreator) option {
 	return func(n *NetPod) {
 		n.cacheCreator = c
+	}
+}
+
+func WithBindingPlugins(bindings map[string]v1.InterfaceBindingPlugin) option {
+	return func(n *NetPod) {
+		n.bindingPluginsByName = bindings
 	}
 }
 
@@ -286,6 +295,14 @@ func (n NetPod) composeDesiredSpec(currentStatus *nmstate.Status) (*nmstate.Spec
 			}
 		case iface.SRIOV != nil:
 		case iface.Binding != nil:
+			bindingPlugin, exists := n.bindingPluginsByName[iface.Binding.Name]
+			if exists && bindingPlugin.DomainAttachmentType == v1.ManagedTap {
+				if _, exists := podIfaceStatusByName[podIfaceName]; !exists {
+					return nil, fmt.Errorf("pod link (%s) is missing", podIfaceName)
+				}
+				ifacesSpec, err = n.managedTapSpec(podIfaceName, ifIndex, podIfaceStatusByName)
+			}
+
 		// Passt is removed in v1.3. This scenario is tracking old VMIs that are still processed in the reconcile loop.
 		case iface.DeprecatedPasst != nil:
 			spec.LinuxStack.IPv4.PingGroupRange = []int{107, 107}
@@ -447,6 +464,63 @@ func (n NetPod) masqueradeBindingSpec(podIfaceName string, vmiIfaceIndex int, if
 	}
 
 	return []nmstate.Interface{bridgeIface, tapIface}, nil
+}
+
+func (n NetPod) managedTapSpec(podIfaceName string, vmiIfaceIndex int, ifaceStatusByName map[string]nmstate.Interface) ([]nmstate.Interface, error) {
+
+	vmiNetworkName := n.vmiSpecIfaces[vmiIfaceIndex].Name
+
+	podIfaceAlternativeName := link.GenerateNewBridgedVmiInterfaceName(podIfaceName)
+	podStatusIface, exist := ifaceStatusByName[podIfaceAlternativeName]
+	if !exist {
+		podStatusIface = ifaceStatusByName[podIfaceName]
+	}
+
+	bridgeIface := nmstate.Interface{
+		Name:     link.GenerateBridgeName(podIfaceName),
+		TypeName: nmstate.TypeBridge,
+		State:    nmstate.IfaceStateUp,
+		Ethtool:  nmstate.Ethtool{Feature: nmstate.Feature{TxChecksum: pointer.P(false)}},
+		Metadata: &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
+	}
+
+	podIface := nmstate.Interface{
+		Index:       podStatusIface.Index,
+		Name:        podIfaceAlternativeName,
+		State:       nmstate.IfaceStateUp,
+		CopyMacFrom: bridgeIface.Name,
+		Controller:  bridgeIface.Name,
+		IPv4:        nmstate.IP{Enabled: pointer.P(false)},
+		IPv6:        nmstate.IP{Enabled: pointer.P(false)},
+		LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+		Metadata:    &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
+	}
+
+	tapIface := nmstate.Interface{
+		Name:       link.GenerateTapDeviceName(podIfaceName),
+		TypeName:   nmstate.TypeTap,
+		State:      nmstate.IfaceStateUp,
+		MTU:        podStatusIface.MTU,
+		Controller: bridgeIface.Name,
+		Tap: &nmstate.TapDevice{
+			Queues: n.networkQueues(vmiIfaceIndex),
+			UID:    n.ownerID,
+			GID:    n.ownerID,
+		},
+		Metadata: &nmstate.IfaceMetadata{Pid: n.podPID, NetworkName: vmiNetworkName},
+	}
+
+	dummyIface := nmstate.Interface{
+		Name:       podIfaceName,
+		TypeName:   nmstate.TypeDummy,
+		MacAddress: podStatusIface.MacAddress,
+		MTU:        podStatusIface.MTU,
+		IPv4:       podStatusIface.IPv4,
+		IPv6:       podStatusIface.IPv6,
+		Metadata:   &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
+	}
+
+	return []nmstate.Interface{bridgeIface, podIface, tapIface, dummyIface}, nil
 }
 
 func (n NetPod) setupNAT(desiredSpec *nmstate.Spec, currentStatus *nmstate.Status) error {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1306,7 +1306,7 @@ var CRDsValidation map[string]string = map[string]string{
                       domainAttachmentType:
                         description: |-
                           DomainAttachmentType is a standard domain network attachment method kubevirt supports.
-                          Supported values: "tap".
+                          Supported values: "tap", "managedTap" (since v1.4).
                           The standard domain attachment can be used instead or in addition to the sidecarImage.
                           version: 1alphav1
                         type: string

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2869,7 +2869,7 @@ type InterfaceBindingPlugin struct {
 	// version: 1alphav1
 	NetworkAttachmentDefinition string `json:"networkAttachmentDefinition,omitempty"`
 	// DomainAttachmentType is a standard domain network attachment method kubevirt supports.
-	// Supported values: "tap".
+	// Supported values: "tap", "managedTap" (since v1.4).
 	// The standard domain attachment can be used instead or in addition to the sidecarImage.
 	// version: 1alphav1
 	DomainAttachmentType DomainAttachmentType `json:"domainAttachmentType,omitempty"`
@@ -2909,6 +2909,9 @@ const (
 	// Tap domain attachment type is a generic way to bind ethernet connection into guests using tap device
 	// https://libvirt.org/formatdomain.html#generic-ethernet-connection.
 	Tap DomainAttachmentType = "tap"
+	// ManagedTap domain attachment type is binding an ethernet connection into guests using a tap device.
+	// The tap device is created (unless already present) on the network pod interface with a Linux bridge.
+	ManagedTap DomainAttachmentType = "managedTap"
 )
 
 type NetworkBindingDownwardAPIType string

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -956,7 +956,7 @@ func (InterfaceBindingPlugin) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"sidecarImage":                "SidecarImage references a container image that runs in the virt-launcher pod.\nThe sidecar handles (libvirt) domain configuration and optional services.\nversion: 1alphav1",
 		"networkAttachmentDefinition": "NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object.\nFormat: <name>, <namespace>/<name>.\nIf namespace is not specified, VMI namespace is assumed.\nversion: 1alphav1",
-		"domainAttachmentType":        "DomainAttachmentType is a standard domain network attachment method kubevirt supports.\nSupported values: \"tap\".\nThe standard domain attachment can be used instead or in addition to the sidecarImage.\nversion: 1alphav1",
+		"domainAttachmentType":        "DomainAttachmentType is a standard domain network attachment method kubevirt supports.\nSupported values: \"tap\", \"managedTap\" (since v1.4).\nThe standard domain attachment can be used instead or in addition to the sidecarImage.\nversion: 1alphav1",
 		"migration":                   "Migration means the VM using the plugin can be safely migrated\nversion: 1alphav1",
 		"downwardAPI":                 "DownwardAPI specifies what kind of data should be exposed to the binding plugin sidecar.\nSupported values: \"device-info\"\nversion: v1alphav1\n+optional",
 		"computeResourceOverhead":     "ComputeResourceOverhead specifies the resource overhead that should be added to the compute container when using the binding.\nversion: v1alphav1\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20385,7 +20385,7 @@ func schema_kubevirtio_api_core_v1_InterfaceBindingPlugin(ref common.ReferenceCa
 					},
 					"domainAttachmentType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DomainAttachmentType is a standard domain network attachment method kubevirt supports. Supported values: \"tap\". The standard domain attachment can be used instead or in addition to the sidecarImage. version: 1alphav1",
+							Description: "DomainAttachmentType is a standard domain network attachment method kubevirt supports. Supported values: \"tap\", \"managedTap\" (since v1.4). The standard domain attachment can be used instead or in addition to the sidecarImage. version: 1alphav1",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
### What this PR does

`managedTap` is added as a core domain attachment type to ease the
creation of simple network bindings.
As its name hints, it also creates the `tap` device (if missing) with a
Linux bridge that connects it to the pod interface.

This solution implements the `tap` + `bridge` alternative of the [Primary Network Binding for seamless migration](https://github.com/kubevirt/community/pull/325) design proposal.

A binding plugin that implements a bridge binding without IPAM:

```mermaid
graph LR;
    subgraph virt-launcher
    VM <--> tap0
    tap0 <--> bridge0
    bridge0 <--> eth0
    end
    subgraph Node
    eth0 <--> veth123
    end
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
network binding plugin: Introduce a new `managedTap` `domainAttachmentType`
```

