### PR TITLE
Use ManualRecoveryRequired as a Condition

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17788,10 +17788,6 @@
    "v1.VolumeMigrationState": {
     "type": "object",
     "properties": {
-     "manualRecoveryRequired": {
-      "description": "ManualRecoveryRequired indicates if the update due to the migration failed and the volumes set needs to be manually restored",
-      "type": "boolean"
-     },
      "migratedVolumes": {
       "description": "MigratedVolumes lists the source and destination volumes during the volume migration",
       "type": "array",

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -478,8 +478,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("VM is already running")), response)
 		return
 	}
-	if controller.NewVirtualMachineConditionManager().HasConditionWithStatus(vm,
-		v1.VirtualMachineConditionType(v1.VirtualMachineInstanceVolumesChange), v12.ConditionTrue) {
+	if controller.NewVirtualMachineConditionManager().HasConditionWithStatus(vm, v1.VirtualMachineManualRecoveryRequired, v12.ConditionTrue) {
 		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf(volumeMigrationManualRecoveryRequiredErr)), response)
 		return
 	}

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1678,7 +1678,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmi := libvmi.New()
 			vm := libvmi.NewVirtualMachine(vmi)
 			controller.NewVirtualMachineConditionManager().UpdateCondition(vm, &v1.VirtualMachineCondition{
-				Type:   v1.VirtualMachineConditionType(v1.VirtualMachineInstanceVolumesChange),
+				Type:   v1.VirtualMachineManualRecoveryRequired,
 				Status: k8sv1.ConditionTrue,
 			})
 			request.PathParameters()["name"] = vm.Name

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/liveupdate/memory:go_default_library",
         "//pkg/network/admitter:go_default_library",
         "//pkg/network/vmispec:go_default_library",
-        "//pkg/pointer:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -7014,6 +7014,21 @@ var _ = Describe("VirtualMachine", func() {
 			})
 		})
 
+		Context("startVMI", func() {
+			It("should not start the VMI if the VM has the ManualRecoveryRequiredCondition set", func() {
+				vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(metav1.NamespaceDefault)), libvmistatus.WithVMStatus(libvmistatus.NewVMStatus(libvmistatus.WithVMCondition(v1.VirtualMachineCondition{
+					Type:   v1.VirtualMachineManualRecoveryRequired,
+					Status: k8sv1.ConditionTrue,
+				}))))
+				vmCopy, err := controller.startVMI(vm)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vm).To(Equal(vmCopy))
+				vmiList, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmiList.Items).To(BeEmpty())
+			})
+		})
+
 	})
 	Context("syncConditions", func() {
 		var vm *v1.VirtualMachine

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -40,6 +40,7 @@ import (
 	kvtesting "kubevirt.io/client-go/testing"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	"kubevirt.io/kubevirt/pkg/controller"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -7166,35 +7167,38 @@ var _ = Describe("VirtualMachine", func() {
 				Reason: reason,
 			}
 		}
-		DescribeTable("", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, expectedVolumeMigrationState *v1.VolumeMigrationState) {
+		DescribeTable("", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, expectedVolumeMigrationState *v1.VolumeMigrationState, expectCond bool) {
 			syncVolumeMigration(vm, vmi)
 			Expect(vm.Status.VolumeUpdateState.VolumeMigrationState).To(Equal(expectedVolumeMigrationState))
+			Expect(controller.NewVirtualMachineConditionManager().HasConditionWithStatus(vm,
+				v1.VirtualMachineManualRecoveryRequired, k8sv1.ConditionTrue)).To(Equal(expectCond))
 		},
-			Entry("without any volume migration in progress", libvmi.NewVirtualMachine(libvmi.New(), libvmistatus.WithVMStatus(libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(&v1.VolumeUpdateState{})))), libvmi.New(), nil),
+			Entry("without any volume migration in progress", libvmi.NewVirtualMachine(libvmi.New(), libvmistatus.WithVMStatus(libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(&v1.VolumeUpdateState{})))), libvmi.New(), nil, false),
 			Entry("with volume migration in progress but no vmi", libvmi.NewVirtualMachine(libvmi.New(), libvmistatus.WithVMStatus(
 				libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(&v1.VolumeUpdateState{VolumeMigrationState: &v1.VolumeMigrationState{
 					MigratedVolumes: withMigVols(volName, "dv0", "dv1")}},
 				), libvmistatus.WithVMCondition(withVMCondVolumeMigInProgress(k8sv1.ConditionTrue, ""))),
 			)),
-				nil, nil),
+				nil, nil, false),
 			Entry("with recovered volumes", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv0")), libvmistatus.WithVMStatus(
 				libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(
-					&v1.VolumeUpdateState{VolumeMigrationState: &v1.VolumeMigrationState{
-						MigratedVolumes:        withMigVols(volName, "dv0", "dv1"),
-						ManualRecoveryRequired: pointer.P(true)}},
+					&v1.VolumeUpdateState{VolumeMigrationState: &v1.VolumeMigrationState{MigratedVolumes: withMigVols(volName, "dv0", "dv1")}},
 				)))),
-				libvmi.New(libvmi.WithDataVolume(volName, "dv0")), nil),
+				libvmi.New(libvmi.WithDataVolume(volName, "dv0")), nil, false),
 			Entry("with volumes still to be recovered", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")), libvmistatus.WithVMStatus(
-				libvmistatus.NewVMStatus(libvmistatus.WithVMVolumeUpdateState(
-					&v1.VolumeUpdateState{VolumeMigrationState: &v1.VolumeMigrationState{
-						MigratedVolumes:        withMigVols(volName, "dv0", "dv1"),
-						ManualRecoveryRequired: pointer.P(true),
-					}},
-				)))),
+				libvmistatus.NewVMStatus(
+					libvmistatus.WithVMCondition(v1.VirtualMachineCondition{
+						Type:   v1.VirtualMachineManualRecoveryRequired,
+						Status: k8sv1.ConditionTrue,
+					}),
+					libvmistatus.WithVMVolumeUpdateState(
+						&v1.VolumeUpdateState{VolumeMigrationState: &v1.VolumeMigrationState{
+							MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
+						}},
+					)))),
 				libvmi.New(libvmi.WithDataVolume(volName, "dv0")), &v1.VolumeMigrationState{
-					MigratedVolumes:        withMigVols(volName, "dv0", "dv1"),
-					ManualRecoveryRequired: pointer.P(true),
-				},
+					MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
+				}, true,
 			),
 			Entry("with volume change", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(
@@ -7207,7 +7211,7 @@ var _ = Describe("VirtualMachine", func() {
 						libvmistatus.New(libvmistatus.WithCondition(
 							withVMICondVolumeMigInProgress(k8sv1.ConditionTrue, "")))),
 				),
-				&v1.VolumeMigrationState{MigratedVolumes: withMigVols(volName, "dv0", "dv1")},
+				&v1.VolumeMigrationState{MigratedVolumes: withMigVols(volName, "dv0", "dv1")}, false,
 			),
 			Entry("with volume change cancellation", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(
@@ -7220,7 +7224,7 @@ var _ = Describe("VirtualMachine", func() {
 						libvmistatus.New(libvmistatus.WithCondition(
 							withVMICondVolumeMigInProgress(k8sv1.ConditionFalse, v1.VirtualMachineInstanceReasonVolumesChangeCancellation)))),
 				),
-				nil,
+				nil, false,
 			),
 			Entry("with a failed volume migration", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(
@@ -7233,9 +7237,8 @@ var _ = Describe("VirtualMachine", func() {
 						libvmistatus.New(libvmistatus.WithCondition(
 							withVMICondVolumeMigInProgress(k8sv1.ConditionFalse, "")))),
 				), &v1.VolumeMigrationState{
-					MigratedVolumes:        withMigVols(volName, "dv0", "dv1"),
-					ManualRecoveryRequired: pointer.P(true),
-				},
+					MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
+				}, true,
 			),
 			Entry("with volume migration in progress and vmi disappeared", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(
@@ -7244,9 +7247,8 @@ var _ = Describe("VirtualMachine", func() {
 					}}), libvmistatus.WithVMCondition(withVMCondVolumeMigInProgress(k8sv1.ConditionTrue, "")),
 					))),
 				nil, &v1.VolumeMigrationState{
-					MigratedVolumes:        withMigVols(volName, "dv0", "dv1"),
-					ManualRecoveryRequired: pointer.P(true),
-				},
+					MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
+				}, true,
 			),
 		)
 	})

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -7238,7 +7238,7 @@ var _ = Describe("VirtualMachine", func() {
 							withVMICondVolumeMigInProgress(k8sv1.ConditionFalse, "")))),
 				), &v1.VolumeMigrationState{
 					MigratedVolumes: withMigVols(volName, "dv0", "dv1"),
-				}, true,
+				}, false,
 			),
 			Entry("with volume migration in progress and vmi disappeared", libvmi.NewVirtualMachine(libvmi.New(libvmi.WithDataVolume(volName, "dv1")),
 				libvmistatus.WithVMStatus(

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8437,11 +8437,6 @@ var CRDsValidation map[string]string = map[string]string{
               description: VolumeMigrationState tracks the information related to
                 the volume migration
               properties:
-                manualRecoveryRequired:
-                  description: ManualRecoveryRequired indicates if the update due
-                    to the migration failed and the volumes set needs to be manually
-                    restored
-                  type: boolean
                 migratedVolumes:
                   description: MigratedVolumes lists the source and destination volumes
                     during the volume migration
@@ -28969,11 +28964,6 @@ var CRDsValidation map[string]string = map[string]string{
                           description: VolumeMigrationState tracks the information
                             related to the volume migration
                           properties:
-                            manualRecoveryRequired:
-                              description: ManualRecoveryRequired indicates if the
-                                update due to the migration failed and the volumes
-                                set needs to be manually restored
-                              type: boolean
                             migratedVolumes:
                               description: MigratedVolumes lists the source and destination
                                 volumes during the volume migration

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -1284,8 +1284,7 @@
               "filesystemOverhead": "filesystemOverheadValue"
             }
           }
-        ],
-        "manualRecoveryRequired": true
+        ]
       }
     }
   }

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -856,7 +856,6 @@ status:
     reason: reasonValue
   volumeUpdateState:
     volumeMigrationState:
-      manualRecoveryRequired: true
       migratedVolumes:
       - destinationPVCInfo:
           accessModes:

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -5993,11 +5993,6 @@ func (in *VolumeMigrationState) DeepCopyInto(out *VolumeMigrationState) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.ManualRecoveryRequired != nil {
-		in, out := &in.ManualRecoveryRequired, &out.ManualRecoveryRequired
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1701,8 +1701,6 @@ type VolumeMigrationState struct {
 	// +listType=atomic
 	// +optional
 	MigratedVolumes []StorageMigratedVolumeInfo `json:"migratedVolumes,omitempty"`
-	// ManualRecoveryRequired indicates if the update due to the migration failed and the volumes set needs to be manually restored
-	ManualRecoveryRequired *bool `json:"manualRecoveryRequired,omitempty"`
 }
 
 type VolumeSnapshotStatus struct {
@@ -1761,6 +1759,9 @@ const (
 
 	// VirtualMachineRestartRequired is added when changes made to the VM can't be live-propagated to the VMI
 	VirtualMachineRestartRequired VirtualMachineConditionType = "RestartRequired"
+
+	// VirtualMachineManualRecoveryRequired is added when the VM spec needs to be manually recovered by the user
+	VirtualMachineManualRecoveryRequired VirtualMachineConditionType = "ManualRecoveryRequired"
 )
 
 type HostDiskType string

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -415,8 +415,7 @@ func (VolumeUpdateState) SwaggerDoc() map[string]string {
 
 func (VolumeMigrationState) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"migratedVolumes":        "MigratedVolumes lists the source and destination volumes during the volume migration\n+listType=atomic\n+optional",
-		"manualRecoveryRequired": "ManualRecoveryRequired indicates if the update due to the migration failed and the volumes set needs to be manually restored",
+		"migratedVolumes": "MigratedVolumes lists the source and destination volumes during the volume migration\n+listType=atomic\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -26944,13 +26944,6 @@ func schema_kubevirtio_api_core_v1_VolumeMigrationState(ref common.ReferenceCall
 							},
 						},
 					},
-					"manualRecoveryRequired": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ManualRecoveryRequired indicates if the update due to the migration failed and the volumes set needs to be manually restored",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The ManualRecoveryRequiered was a filed in the VolumeMigrationState.

After this PR:
Now the manual recovery required information has been converted to a condition.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
[Discussion on the mailing list](https://groups.google.com/g/kubevirt-dev/c/emTYi5OuC_4)


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed the ManualRecoveryRequired field from the VolumeMigrationState and convert it to the VM condition ManualRecoveryRequired
```

