### PR TITLE
Add linter coverage to pkg/network/multus

### DIFF
--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -3,6 +3,7 @@ pkg/libvmi
 pkg/network/admitter
 pkg/network/deviceinfo
 pkg/network/domainspec
+pkg/network/multus
 pkg/network/namescheme
 pkg/network/pod/annotations
 pkg/network/vmicontroller

--- a/pkg/network/multus/BUILD.bazel
+++ b/pkg/network/multus/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )
 
@@ -41,5 +42,6 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )

--- a/pkg/network/multus/annotation.go
+++ b/pkg/network/multus/annotation.go
@@ -38,11 +38,22 @@ import (
 // The value of this annotation should be a NetworkAttachmentDefinition's name
 const DefaultNetworkCNIAnnotation = "v1.multus-cni.io/default-network"
 
-func GenerateCNIAnnotation(namespace string, interfaces []v1.Interface, networks []v1.Network, config *virtconfig.ClusterConfig) (string, error) {
+func GenerateCNIAnnotation(
+	namespace string,
+	interfaces []v1.Interface,
+	networks []v1.Network,
+	config *virtconfig.ClusterConfig,
+) (string, error) {
 	return GenerateCNIAnnotationFromNameScheme(namespace, interfaces, networks, namescheme.CreateHashedNetworkNameScheme(networks), config)
 }
 
-func GenerateCNIAnnotationFromNameScheme(namespace string, interfaces []v1.Interface, networks []v1.Network, networkNameScheme map[string]string, config *virtconfig.ClusterConfig) (string, error) {
+func GenerateCNIAnnotationFromNameScheme(
+	namespace string,
+	interfaces []v1.Interface,
+	networks []v1.Network,
+	networkNameScheme map[string]string,
+	config *virtconfig.ClusterConfig,
+) (string, error) {
 	multusNetworkAnnotationPool := NetworkAnnotationPool{}
 
 	for _, network := range networks {
@@ -92,7 +103,12 @@ func (nap *NetworkAnnotationPool) ToString() (string, error) {
 	return string(multusNetworksAnnotation), nil
 }
 
-func NewAnnotationData(namespace string, interfaces []v1.Interface, network v1.Network, podInterfaceName string) networkv1.NetworkSelectionElement {
+func NewAnnotationData(
+	namespace string,
+	interfaces []v1.Interface,
+	network v1.Network,
+	podInterfaceName string,
+) networkv1.NetworkSelectionElement {
 	multusIface := vmispec.LookupInterfaceByName(interfaces, network.Name)
 	namespace, networkName := GetNamespaceAndNetworkName(namespace, network.Multus.NetworkName)
 	var multusIfaceMac string
@@ -107,7 +123,10 @@ func NewAnnotationData(namespace string, interfaces []v1.Interface, network v1.N
 	}
 }
 
-func newBindingPluginAnnotationData(kvConfig *v1.KubeVirtConfiguration, pluginName, namespace, networkName string) (*networkv1.NetworkSelectionElement, error) {
+func newBindingPluginAnnotationData(
+	kvConfig *v1.KubeVirtConfiguration,
+	pluginName, namespace, networkName string,
+) (*networkv1.NetworkSelectionElement, error) {
 	plugin := netbinding.ReadNetBindingPluginConfiguration(kvConfig, pluginName)
 	if plugin == nil {
 		return nil, fmt.Errorf("unable to find the network binding plugin '%s' in Kubevirt configuration", pluginName)

--- a/pkg/network/multus/annotation.go
+++ b/pkg/network/multus/annotation.go
@@ -110,7 +110,7 @@ func NewAnnotationData(
 	podInterfaceName string,
 ) networkv1.NetworkSelectionElement {
 	multusIface := vmispec.LookupInterfaceByName(interfaces, network.Name)
-	namespace, networkName := GetNamespaceAndNetworkName(namespace, network.Multus.NetworkName)
+	nadNamespacedName := NetAttachDefNamespacedName(namespace, network.Multus.NetworkName)
 	var multusIfaceMac string
 	if multusIface != nil {
 		multusIfaceMac = multusIface.MacAddress
@@ -118,8 +118,8 @@ func NewAnnotationData(
 	return networkv1.NetworkSelectionElement{
 		InterfaceRequest: podInterfaceName,
 		MacRequest:       multusIfaceMac,
-		Namespace:        namespace,
-		Name:             networkName,
+		Namespace:        nadNamespacedName.Namespace,
+		Name:             nadNamespacedName.Name,
 	}
 }
 
@@ -135,15 +135,15 @@ func newBindingPluginAnnotationData(
 	if plugin.NetworkAttachmentDefinition == "" {
 		return nil, nil
 	}
-	netAttachDefNamespace, netAttachDefName := GetNamespaceAndNetworkName(namespace, plugin.NetworkAttachmentDefinition)
+	nadNamespacedName := NetAttachDefNamespacedName(namespace, plugin.NetworkAttachmentDefinition)
 
 	// cniArgNetworkName is the CNI arg name for the VM spec network logical name.
 	// The binding plugin CNI should read this arg and realize which logical network it should modify.
 	const cniArgNetworkName = "logicNetworkName"
 
 	return &networkv1.NetworkSelectionElement{
-		Namespace: netAttachDefNamespace,
-		Name:      netAttachDefName,
+		Namespace: nadNamespacedName.Namespace,
+		Name:      nadNamespacedName.Name,
 		CNIArgs: &map[string]interface{}{
 			cniArgNetworkName: networkName,
 		},

--- a/pkg/network/multus/annotation_test.go
+++ b/pkg/network/multus/annotation_test.go
@@ -38,9 +38,11 @@ var _ = Describe("Multus annotations", func() {
 			It("should fail if the specified network binding plugin is not registered (specified in Kubevirt config)", func() {
 				vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"}}
 				vmi.Spec.Networks = []v1.Network{
-					{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+					{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+				}
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}}}
+					{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}},
+				}
 
 				config := testsClusterConfig(map[string]v1.InterfaceBindingPlugin{
 					"another-test-binding": {NetworkAttachmentDefinition: "another-test-binding-net"},
@@ -60,7 +62,9 @@ var _ = Describe("Multus annotations", func() {
 				}
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
 					{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}},
-					{Name: "blue"}, {Name: "red"}}
+					{Name: "blue"},
+					{Name: "red"},
+				}
 
 				config := testsClusterConfig(map[string]v1.InterfaceBindingPlugin{
 					"test-binding": {NetworkAttachmentDefinition: "test-binding-net"},
@@ -80,13 +84,16 @@ var _ = Describe("Multus annotations", func() {
 					vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"}}
 					vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 					vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-						{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}}}
+						{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}},
+					}
 
 					config := testsClusterConfig(map[string]v1.InterfaceBindingPlugin{
 						"test-binding": {NetworkAttachmentDefinition: netAttachDefRawName},
 					})
 
-					Expect(multus.GenerateCNIAnnotation(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, config)).To(MatchJSON(expectedAnnot))
+					Expect(
+						multus.GenerateCNIAnnotation(vmi.Namespace, vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, config),
+					).To(MatchJSON(expectedAnnot))
 				},
 				Entry("name with no namespace", "my-binding",
 					`[{"namespace": "default", "name": "my-binding", "cni-args": {"logicNetworkName": "default"}}]`),

--- a/pkg/network/multus/nad.go
+++ b/pkg/network/multus/nad.go
@@ -22,14 +22,23 @@ package multus
 import (
 	"strings"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"kubevirt.io/client-go/precond"
 )
 
-func GetNamespaceAndNetworkName(namespace, fullNetworkName string) (string, string) {
+func NetAttachDefNamespacedName(namespace, fullNetworkName string) types.NamespacedName {
 	if strings.Contains(fullNetworkName, "/") {
 		const twoParts = 2
 		res := strings.SplitN(fullNetworkName, "/", twoParts)
-		return res[0], res[1]
+		return types.NamespacedName{
+			Namespace: res[0],
+			Name:      res[1],
+		}
 	}
-	return precond.MustNotBeEmpty(namespace), fullNetworkName
+
+	return types.NamespacedName{
+		Namespace: precond.MustNotBeEmpty(namespace),
+		Name:      fullNetworkName,
+	}
 }

--- a/pkg/network/multus/nad.go
+++ b/pkg/network/multus/nad.go
@@ -25,9 +25,10 @@ import (
 	"kubevirt.io/client-go/precond"
 )
 
-func GetNamespaceAndNetworkName(namespace string, fullNetworkName string) (string, string) {
+func GetNamespaceAndNetworkName(namespace, fullNetworkName string) (string, string) {
 	if strings.Contains(fullNetworkName, "/") {
-		res := strings.SplitN(fullNetworkName, "/", 2)
+		const twoParts = 2
+		res := strings.SplitN(fullNetworkName, "/", twoParts)
 		return res[0], res[1]
 	}
 	return precond.MustNotBeEmpty(namespace), fullNetworkName

--- a/pkg/network/multus/nad_test.go
+++ b/pkg/network/multus/nad_test.go
@@ -9,7 +9,8 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  *
  * Copyright 2024 Red Hat, Inc.

--- a/pkg/network/multus/nad_test.go
+++ b/pkg/network/multus/nad_test.go
@@ -24,24 +24,23 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/multus"
 )
 
-var _ = Describe("GetNamespaceAndNetworkName", func() {
+var _ = Describe("NetAttachDefNamespacedName", func() {
 	It("should return vmi namespace when namespace is implicit", func() {
 		vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "testns"}}
-		namespace, networkName := multus.GetNamespaceAndNetworkName(vmi.Namespace, "testnet")
-		Expect(namespace).To(Equal("testns"))
-		Expect(networkName).To(Equal("testnet"))
+		nadNamespacedName := multus.NetAttachDefNamespacedName(vmi.Namespace, "testnet")
+		Expect(nadNamespacedName).To(Equal(types.NamespacedName{Namespace: "testns", Name: "testnet"}))
 	})
 
 	It("should return namespace from networkName when namespace is explicit", func() {
 		vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "testns"}}
-		namespace, networkName := multus.GetNamespaceAndNetworkName(vmi.Namespace, "otherns/testnet")
-		Expect(namespace).To(Equal("otherns"))
-		Expect(networkName).To(Equal("testnet"))
+		nadNamespacedName := multus.NetAttachDefNamespacedName(vmi.Namespace, "otherns/testnet")
+		Expect(nadNamespacedName).To(Equal(types.NamespacedName{Namespace: "otherns", Name: "testnet"}))
 	})
 })

--- a/pkg/virt-controller/network/render.go
+++ b/pkg/virt-controller/network/render.go
@@ -39,10 +39,10 @@ func GetNetworkToResourceMap(virtClient kubecli.KubevirtClient, vmi *v1.VirtualM
 	networkToResourceMap = make(map[string]string)
 	for _, network := range vmi.Spec.Networks {
 		if network.Multus != nil {
-			namespace, networkName := multus.GetNamespaceAndNetworkName(vmi.Namespace, network.Multus.NetworkName)
-			crd, err := virtClient.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Get(context.Background(), networkName, metav1.GetOptions{})
+			nadNamespacedName := multus.NetAttachDefNamespacedName(vmi.Namespace, network.Multus.NetworkName)
+			crd, err := virtClient.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(nadNamespacedName.Namespace).Get(context.Background(), nadNamespacedName.Name, metav1.GetOptions{})
 			if err != nil {
-				return map[string]string{}, fmt.Errorf("Failed to locate network attachment definition %s/%s", namespace, networkName)
+				return map[string]string{}, fmt.Errorf("failed to locate network attachment definition %s", nadNamespacedName.String())
 			}
 			networkToResourceMap[network.Name] = getResourceNameForNetwork(crd)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

