### PR TITLE
monitoring/vmstats_collector: add machine_type label for vm_info

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -45,6 +45,9 @@ var (
 			// VM annotations
 			"os", "workload", "flavor",
 
+			// VM Machine Type
+			"machine_type",
+
 			// Instance type
 			"instance_type", "preference",
 
@@ -167,9 +170,13 @@ func CollectVMsInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResu
 	var results []operatormetrics.CollectorResult
 
 	for _, vm := range vms {
-		os, workload, flavor := none, none, none
+		os, workload, flavor, machineType := none, none, none, none
 		if vm.Spec.Template != nil {
 			os, workload, flavor = getSystemInfoFromAnnotations(vm.Spec.Template.ObjectMeta.Annotations)
+
+			if vm.Spec.Template.Spec.Domain.Machine != nil {
+				machineType = vm.Spec.Template.Spec.Domain.Machine.Type
+			}
 		}
 
 		instanceType := getVMInstancetype(vm)
@@ -179,7 +186,7 @@ func CollectVMsInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResu
 			Metric: vmInfo,
 			Labels: []string{
 				vm.Name, vm.Namespace,
-				os, workload, flavor,
+				os, workload, flavor, machineType,
 				instanceType, preference,
 				string(vm.Status.PrintableStatus), getVMStatusGroup(vm.Status.PrintableStatus),
 			},

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -102,7 +102,7 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(cr).To(BeEmpty())
 		})
 
-		It("should show annotation types correctly", func() {
+		It("should show annotation types and machine_type labels correctly", func() {
 			vms := []*k6tv1.VirtualMachine{
 				{
 					Spec: k6tv1.VirtualMachineSpec{
@@ -113,6 +113,13 @@ var _ = Describe("VM Stats Collector", func() {
 									annotationPrefix + "workload": "server",
 									annotationPrefix + "flavor":   "tiny",
 									"other":                       "other",
+								},
+							},
+							Spec: k6tv1.VirtualMachineInstanceSpec{
+								Domain: k6tv1.DomainSpec{
+									Machine: &k6tv1.Machine{
+										Type: "q35",
+									},
 								},
 							},
 						},
@@ -132,6 +139,13 @@ var _ = Describe("VM Stats Collector", func() {
 									annotationPrefix + "phase":    "dummy",
 								},
 							},
+							Spec: k6tv1.VirtualMachineInstanceSpec{
+								Domain: k6tv1.DomainSpec{
+									Machine: &k6tv1.Machine{
+										Type: "q35",
+									},
+								},
+							},
 						},
 					},
 					Status: k6tv1.VirtualMachineStatus{
@@ -147,7 +161,7 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr).ToNot(BeNil())
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(9))
+				Expect(cr.Labels).To(HaveLen(10))
 
 				Expect(cr.GetLabelValue("name")).To(Equal(vms[i].ObjectMeta.Name))
 				Expect(cr.GetLabelValue("namespace")).To(Equal(vms[i].ObjectMeta.Namespace))
@@ -156,6 +170,8 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr.GetLabelValue("os")).To(Equal(os))
 				Expect(cr.GetLabelValue("workload")).To(Equal(workload))
 				Expect(cr.GetLabelValue("flavor")).To(Equal(flavor))
+
+				Expect(cr.GetLabelValue("machine_type")).To(Equal(vms[i].Spec.Template.Spec.Domain.Machine.Type))
 
 				Expect(cr.GetLabelValue("status")).To(Equal("CrashLoopBackOff"))
 				Expect(cr.GetLabelValue("status_group")).To(Equal("error"))
@@ -179,7 +195,7 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(cr).ToNot(BeNil())
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(9))
+			Expect(cr.Labels).To(HaveLen(10))
 			Expect(cr.GetLabelValue("instance_type")).To(Equal(expected))
 		},
 			Entry("with no instance type expect <none>", "VirtualMachineInstancetype", "", "<none>"),
@@ -207,7 +223,7 @@ var _ = Describe("VM Stats Collector", func() {
 
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(9))
+			Expect(cr.Labels).To(HaveLen(10))
 			Expect(cr.GetLabelValue("preference")).To(Equal(expected))
 		},
 			Entry("with no preference expect <none>", "VirtualMachinePreference", "", "<none>"),


### PR DESCRIPTION
Adding the label `machine_type` to the `kubevirt_vm_info` metric would help detect if stopped VMS which don't have active VMI resource are using an outdated machine type.

This ensures the detection logic doesn't solely depend on the kubevirt_vmi_info metrics stored in the Prometheus database

example for the metric output with example/vm-cirros.yaml deployed:

```
kubevirt_vm_info{container="virt-controller", endpoint="metrics", flavor="<none>",
instance="10.244.196.134:8443", instance_type="<none>", job="kubevirt-prometheus-metrics",
machine_type="q35", name="vm-cirros", namespace="default", os="<none>",
pod="virt-controller-5cd9584758-9rvdk", preference="<none>", service="kubevirt-prometheus-metrics", 
status="Stopped", status_group="non_running", workload="<none>"}
```

Fixes #

### Release note
```release-note
Add 'machine_type' label for kubevirt_vm_info metric
```

