### PR TITLE
fix: add darwin implementation for safepath

### DIFF
--- a/pkg/safepath/safepath_darwin.go
+++ b/pkg/safepath/safepath_darwin.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package safepath
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+	"os"
+	"path/filepath"
+)
+
+// openat helps traversing a path without following symlinks
+// to ensure safe path references on user-owned paths by privileged processes
+func openat(dirfd int, path string) (fd int, err error) {
+	if err := isSingleElement(path); err != nil {
+		return -1, err
+	}
+	return unix.Openat(dirfd, path, unix.O_SYMLINK|unix.O_NOFOLLOW, 0)
+}
+
+// mknodat creates a filesystem node (file, device special file, or named pipe) at the given directory file descriptor.
+// "/dev/fd" is the equivalent for "/proc/self/fd" on Linux (directory containing symbolic links to all open file descriptors of the current process)
+func mknodat(dirfd int, path string, mode uint32, dev uint64) (err error) {
+	if err := isSingleElement(path); err != nil {
+		return err
+	}
+
+	// Change directory to dirfd to ensure proper path creation
+	cwd, err := os.Open(symlinkPath(dirfd))
+	if err != nil {
+		return err
+	}
+	defer cwd.Close()
+
+	// Create the node
+	return unix.Mknod(filepath.Join(symlinkPath(dirfd), path), mode, int(dev))
+}
+
+// open safely opens a file descriptor to a given path without following symlinks.
+func open(path string) (fd int, err error) {
+	return unix.Open(path, unix.O_SYMLINK|unix.O_NOFOLLOW, 0)
+}
+
+// path returns the file path associated with the given file descriptor by formatting the path as /proc/self/fd/<fd>.
+func symlinkPath(fd int) string {
+	return fmt.Sprintf("/dev/fd/%d", fd)
+}

--- a/pkg/safepath/safepath_linux.go
+++ b/pkg/safepath/safepath_linux.go
@@ -1,71 +1,14 @@
-//go:build linux
+//go:build darwin
 
 package safepath
 
 import (
-	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
-	"syscall"
-
 	"golang.org/x/sys/unix"
 )
 
-const pathSeparator = string(os.PathSeparator)
-const pathRoot = string(os.PathSeparator)
-
-// advance will try to add the child to the parent. If it is a relative symlink it will resolve it
-// and return the parent with the new symlink. If it is an absolute symlink, parent will be reset to '/'
-// and returned together with the absolute symlink. If the joined result is no symlink, the joined result will
-// be returned as the new parent.
-func advance(rootBase string, parent string, child string) (string, string, error) {
-	// Ensure parent is absolute and never empty
-	parent = filepath.Clean(parent)
-	if !filepath.IsAbs(parent) {
-		return "", "", fmt.Errorf("parent path %v must be absolute", parent)
-	}
-
-	if strings.Contains(child, pathSeparator) {
-		return "", "", fmt.Errorf("child %q must not contain a path separator", child)
-	}
-
-	// Deal with relative path elements like '.', '//' and '..'
-	// Since parent is absolute, worst case we get '/' as result
-	path := filepath.Join(parent, child)
-
-	if path == rootBase {
-		// don't evaluate the root itself, since rootBase is allowed to be a symlink
-		return path, "", nil
-	}
-
-	fi, err := os.Lstat(filepath.Join(rootBase, path))
-	if err != nil {
-		return "", "", err
-	}
-
-	if fi.Mode()&fs.ModeSymlink == 0 {
-		// no symlink, we are done, return the joined result of parent and child
-		return filepath.Clean(path), "", nil
-	}
-
-	link, err := os.Readlink(filepath.Join(rootBase, path))
-	if err != nil {
-		return "", "", err
-	}
-
-	if filepath.IsAbs(link) {
-		// the link is absolute, let's reset the parent and the discovered link path
-		return pathRoot, filepath.Clean(link), nil
-	} else {
-		// on relative links, don't advance parent and return the link
-		return parent, filepath.Clean(link), nil
-	}
-}
-
 // openat helps traversing a path without following symlinks
 // to ensure safe path references on user-owned paths by privileged processes
+// OS-specific: unix.O_PATH
 func openat(dirfd int, path string) (fd int, err error) {
 	if err := isSingleElement(path); err != nil {
 		return -1, err
@@ -73,20 +16,7 @@ func openat(dirfd int, path string) (fd int, err error) {
 	return unix.Openat(dirfd, path, unix.O_NOFOLLOW|unix.O_PATH, 0)
 }
 
-func unlinkat(dirfd int, path string, flags int) error {
-	if err := isSingleElement(path); err != nil {
-		return err
-	}
-	return unix.Unlinkat(dirfd, path, flags)
-}
-
-func touchat(dirfd int, path string, mode uint32) (fd int, err error) {
-	if err := isSingleElement(path); err != nil {
-		return -1, err
-	}
-	return unix.Openat(dirfd, path, unix.O_NOFOLLOW|syscall.O_CREAT|syscall.O_EXCL, mode)
-}
-
+// OS-specific: unix.Mknodat
 func mknodat(dirfd int, path string, mode uint32, dev uint64) (err error) {
 	if err := isSingleElement(path); err != nil {
 		return err
@@ -94,10 +24,12 @@ func mknodat(dirfd int, path string, mode uint32, dev uint64) (err error) {
 	return unix.Mknodat(dirfd, path, mode, int(dev))
 }
 
+// OS-specific: unix.O_PATH
 func open(path string) (fd int, err error) {
-	return syscall.Open(path, unix.O_PATH, 0)
+	return unix.Open(path, unix.O_PATH, 0)
 }
 
-func path(fd int) string {
+// path returns the file path associated with the given file descriptor by formatting the path as /proc/self/fd/<fd>.
+func symlinkPath(fd int) string {
 	return fmt.Sprintf("/proc/self/fd/%d", fd)
 }

--- a/pkg/safepath/safepath_test.go
+++ b/pkg/safepath/safepath_test.go
@@ -3,13 +3,12 @@ package safepath
 import (
 	"fmt"
 	"io/fs"
+	"kubevirt.io/kubevirt/pkg/unsafepath"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"syscall"
-
-	"kubevirt.io/kubevirt/pkg/unsafepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
### What this PR does
Before this PR:
- project compilation is failing: missing functions / syscalls specific to Linux

After this PR:
- project is compiling on macOS

### Why we need it and why it was done in this way
- simplifying life of contributors running on macOS

### Checklist
- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```

