### PR TITLE
[docs]: adding functest section to the coding conventions guide

### DIFF
--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -320,6 +320,45 @@ coding conventions](#detailed-coding-conventions).
       subdirectories.
 - Document directories and filenames should use dashes rather than underscores.
 
+## Functional tests conventions
+
+- Avoid using constants imported from product code package. Instead, define the expected
+  constant values in the test suite. This refers to any aspect of the test suite.
+
+### Bad example
+
+```go
+    Context("Testing mydeployment", func() {
+        It("deployment should have 2 replicas", func() {
+            deployment, err := kclient.
+                AppsV1().
+                Deployments("default").
+                Get(ctx, prod_package.DeploymentName, metav1.GetOptions{})
+            Expect(err).ToNot(HaveOccurred())
+            Expect(deployment.Spec.Replicas).
+                To(PointTo(Equal(prod_package.NumOfReplicas)))
+        })
+    })
+```
+
+### Good example
+
+```go
+    Context("Testing mydeployment", func() {
+        It("deployment should have 2 replicas", func() {
+            const expectedDeploymentName = "mydeployment"
+            const expectedNumOfReplicas = 2
+            deployment, err := kclient.
+                AppsV1().
+                Deployments("default").
+                Get(ctx, expectedDeploymentName, metav1.GetOptions{})
+            Expect(err).ToNot(HaveOccurred())
+            Expect(deployment.Spec.Replicas).
+                To(PointTo(Equal(expectedNumOfReplicas)))
+        })
+    })
+```
+
 # Additional conventions (for scripts, etc.)
 
 - Avoid relying on Docker Hub.


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

Before this PR:
The coding convention guide was missing some rules regarding functional testing
best practice

After this PR:
Functional testing best practice was added, starting with a rule to not rely on constants
imported from a product code while writing the test, but explicitly define the constants in the
test suite itself.
With that approach we protect ourselves from refactoring issues, where someone can change
a constant w/o paying attention to the importance of the original value.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
None
```

