### PR TITLE
net, hotplug: Graduate network hotplug feature to GA

### DIFF
--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -53,6 +53,12 @@ const (
 	// CommonInstancetypesDeploymentGate enables the deployment of common-instancetypes by virt-operator
 	CommonInstancetypesDeploymentGate = "CommonInstancetypesDeploymentGate" // GA
 
+	// HotplugNetworkIfacesGate controls the network interface hotplug feature lifecycle.
+	// Alpha: v1.1.0
+	// Beta:  v1.3.0
+	// GA:    v1.4.0
+	HotplugNetworkIfacesGate = "HotplugNICs"
+
 	PasstGate   = "Passt"   // Deprecated
 	MacvtapGate = "Macvtap" // Deprecated
 	// DockerSELinuxMCSWorkaround sets the SELinux level of all the non-compute virt-launcher containers to "s0".
@@ -77,6 +83,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: NUMAFeatureGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: CommonInstancetypesDeploymentGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: GPUGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: HotplugNetworkIfacesGate, State: GA})
 
 	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Discontinued, Message: PasstDiscontinueMessage, VmiSpecUsed: passtApiUsed})
 	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -51,10 +51,6 @@ const (
 	// DisableMediatedDevicesHandling disables the handling of mediated
 	// devices, its creation and deletion
 	DisableMediatedDevicesHandling = "DisableMDEVConfiguration"
-	// HotplugNetworkIfacesGate enables the virtio network interface hotplug feature
-	// Alpha: v1.1.0
-	// Beta: v1.3.0
-	HotplugNetworkIfacesGate = "HotplugNICs"
 	// PersistentReservation enables the use of the SCSI persistent reservation with the pr-helper daemon
 	PersistentReservation = "PersistentReservation"
 	// VMPersistentState enables persisting backend state files of VMs, such as the contents of the vTPM
@@ -208,7 +204,7 @@ func (config *ClusterConfig) KubevirtSeccompProfileEnabled() bool {
 }
 
 func (config *ClusterConfig) HotplugNetworkInterfacesEnabled() bool {
-	return config.isFeatureGateEnabled(HotplugNetworkIfacesGate)
+	return config.isFeatureGateEnabled(deprecation.HotplugNetworkIfacesGate)
 }
 
 func (config *ClusterConfig) PersistentReservationEnabled() bool {

--- a/pkg/virt-controller/network/vmcontroller.go
+++ b/pkg/virt-controller/network/vmcontroller.go
@@ -39,14 +39,9 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-type clusterConfigChecker interface {
-	HotplugNetworkInterfacesEnabled() bool
-}
-
 type VMNetController struct {
-	clientset     kubevirt.Interface
-	clusterConfig clusterConfigChecker
-	podGetter     podFromVMIGetter
+	clientset kubevirt.Interface
+	podGetter podFromVMIGetter
 }
 
 type podFromVMIGetter interface {
@@ -74,18 +69,14 @@ const (
 	hotPlugNetworkInterfaceErrorReason = "HotPlugNetworkInterfaceError"
 )
 
-func NewVMNetController(clientset kubevirt.Interface, clusterConfig clusterConfigChecker, podGetter podFromVMIGetter) *VMNetController {
+func NewVMNetController(clientset kubevirt.Interface, podGetter podFromVMIGetter) *VMNetController {
 	return &VMNetController{
-		clientset:     clientset,
-		clusterConfig: clusterConfig,
-		podGetter:     podGetter,
+		clientset: clientset,
+		podGetter: podGetter,
 	}
 }
 
 func (v *VMNetController) Sync(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) (*v1.VirtualMachine, error) {
-	if !v.clusterConfig.HotplugNetworkInterfacesEnabled() {
-		return vm, nil
-	}
 	if vmi == nil || vmi.DeletionTimestamp != nil {
 		return vm, nil
 	}

--- a/pkg/virt-controller/network/vmcontroller_test.go
+++ b/pkg/virt-controller/network/vmcontroller_test.go
@@ -43,12 +43,12 @@ import (
 
 var _ = Describe("VM Network Controller", func() {
 	It("sync does nothing when the hotplug FG is unset", func() {
-		c := network.NewVMNetController(fake.NewSimpleClientset(), stubClusterConfig{}, stubPodGetter{})
+		c := network.NewVMNetController(fake.NewSimpleClientset(), stubPodGetter{})
 		Expect(c.Sync(newEmptyVM(), libvmi.New())).To(Equal(newEmptyVM()))
 	})
 
 	DescribeTable("sync does nothing when", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, podGetter stubPodGetter) {
-		c := network.NewVMNetController(fake.NewSimpleClientset(), stubClusterConfig{netHotplugEnabled: true}, podGetter)
+		c := network.NewVMNetController(fake.NewSimpleClientset(), podGetter)
 		originalVM := vm.DeepCopy()
 		Expect(c.Sync(vm, vmi)).To(Equal(originalVM))
 	},
@@ -83,7 +83,6 @@ var _ = Describe("VM Network Controller", func() {
 	It("sync fails when pod fetching returns an error", func() {
 		c := network.NewVMNetController(
 			fake.NewSimpleClientset(),
-			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{err: errors.New("test")},
 		)
 		updatedVM, err := c.Sync(newEmptyVM(), libvmi.New())
@@ -95,7 +94,6 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := network.NewVMNetController(
 			clientset,
-			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: &k8sv1.Pod{}},
 		)
 
@@ -128,7 +126,6 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := network.NewVMNetController(
 			clientset,
-			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: &k8sv1.Pod{}},
 		)
 		vmi := libvmi.New(
@@ -161,7 +158,6 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := network.NewVMNetController(
 			clientset,
-			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: &k8sv1.Pod{}},
 		)
 		unpluggedIface := libvmi.InterfaceDeviceWithBridgeBinding("foonet")
@@ -199,7 +195,6 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := network.NewVMNetController(
 			clientset,
-			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: nil},
 		)
 		vmi := libvmi.New(
@@ -252,7 +247,6 @@ var _ = Describe("VM Network Controller", func() {
 		}
 		c := network.NewVMNetController(
 			clientset,
-			stubClusterConfig{netHotplugEnabled: true},
 			stubPodGetter{pod: pod},
 		)
 		vmi := libvmi.New(
@@ -292,14 +286,6 @@ var _ = Describe("VM Network Controller", func() {
 		Expect(iface.State).NotTo(Equal(v1.InterfaceStateAbsent))
 	})
 })
-
-type stubClusterConfig struct {
-	netHotplugEnabled bool
-}
-
-func (s stubClusterConfig) HotplugNetworkInterfacesEnabled() bool {
-	return s.netHotplugEnabled
-}
 
 type stubPodGetter struct {
 	pod *k8sv1.Pod

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -744,7 +744,6 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 		vca.clusterConfig,
 		network.NewVMNetController(
 			vca.clientSet.GeneratedKubeVirtClient(),
-			vca.clusterConfig,
 			controller.NewPodCacheStore(vca.kvPodInformer.GetIndexer()),
 		),
 	)

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -311,6 +311,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			Entry("with NonRoot", deprecation.NonRoot, fmt.Sprintf(deprecation.WarningPattern, deprecation.NonRoot, deprecation.GA)),
 			Entry("with PSA", deprecation.PSA, fmt.Sprintf(deprecation.WarningPattern, deprecation.PSA, deprecation.GA)),
 			Entry("with CPUNodeDiscoveryGate", deprecation.CPUNodeDiscoveryGate, fmt.Sprintf(deprecation.WarningPattern, deprecation.CPUNodeDiscoveryGate, deprecation.GA)),
+			Entry("with HotplugNICs", deprecation.HotplugNetworkIfacesGate, fmt.Sprintf(deprecation.WarningPattern, deprecation.HotplugNetworkIfacesGate, deprecation.GA)),
 			Entry("with Passt", deprecation.PasstGate, deprecation.PasstDiscontinueMessage),
 			Entry("with MacvtapGate", deprecation.MacvtapGate, deprecation.MacvtapDiscontinueMessage),
 		)

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -37,11 +37,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -65,10 +62,6 @@ var _ = SIGDescribe("bridge nic-hotplug", func() {
 		ifaceName = "iface1"
 		nadName   = "skynet"
 	)
-
-	BeforeEach(func() {
-		Expect(checks.HasFeature(virtconfig.HotplugNetworkIfacesGate)).To(BeTrue())
-	})
 
 	Context("a running VM", func() {
 		const guestSecondaryIfaceName = "eth1"
@@ -238,10 +231,6 @@ var _ = SIGDescribe("bridge nic-hotunplug", func() {
 
 		nadName = "skynet"
 	)
-
-	BeforeEach(func() {
-		Expect(checks.HasFeature(virtconfig.HotplugNetworkIfacesGate)).To(BeTrue())
-	})
 
 	Context("a running VM", func() {
 		var vm *v1.VirtualMachine

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -35,11 +35,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -50,12 +47,6 @@ import (
 var _ = SIGDescribe("[Serial] SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 
 	sriovResourceName := readSRIOVResourceName()
-
-	BeforeEach(func() {
-		if !checks.HasFeature(virtconfig.HotplugNetworkIfacesGate) {
-			Skip("HotplugNICs feature gate is disabled.")
-		}
-	})
 
 	BeforeEach(func() {
 		// Check if the hardware supports SRIOV

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -109,7 +109,6 @@ func AdjustKubeVirtResource() {
 		virtconfig.WorkloadEncryptionSEV,
 		virtconfig.VMExportGate,
 		virtconfig.KubevirtSeccompProfile,
-		virtconfig.HotplugNetworkIfacesGate,
 		virtconfig.VMPersistentState,
 		virtconfig.VMLiveUpdateFeaturesGate,
 		virtconfig.AutoResourceLimitsGate,


### PR DESCRIPTION
### What this PR does

The network hotplug feature, limited to bridge and SR-IOV bindings interfaces has not changed since v1.1. There has been no rejections from the community so far and no special additions are foreseen at the moment

The network hotplug feature had a Feature Gate which is dropped by marking it as GA in the next Kubevirt release (v1.4).

User guide has been updated here: https://github.com/kubevirt/user-guide/pull/841

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network hotplug feature is declared as GA.
```

