### PR TITLE
virt-config, feature-gates: Graduate the network-binding-plugins to Beta

### DIFF
--- a/docs/network/network-binding-plugin.md
+++ b/docs/network/network-binding-plugin.md
@@ -1,5 +1,5 @@
 # Network Binding Plugin
-[v1.1.0, Alpha feature]
+[v1.4.0, Beta feature]
 
 A modular plugin framework which integrates with Kubevirt to implement a
 network binding.

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -65,6 +65,8 @@ const (
 	// When BochsDisplayForEFIGuests is enabled, EFI guests will be started with Bochs display instead of VGA
 	BochsDisplayForEFIGuests = "BochsDisplayForEFIGuests"
 	// NetworkBindingPlugingsGate enables using a plugin to bind the pod and the VM network
+	// Alpha: v1.1.0
+	// Beta:  v1.4.0
 	NetworkBindingPlugingsGate = "NetworkBindingPlugins"
 	// AutoResourceLimitsGate enables automatic setting of vmi limits if there is a ResourceQuota with limits associated with the vmi namespace.
 	AutoResourceLimitsGate = "AutoResourceLimitsGate"


### PR DESCRIPTION
### What this PR does

The network binding plugins feature has been introduce back in v1.1.0, over a year ago.
Since, it has seen wide adoption in the community with multiple plugin vendors that introduced various network bindings through it.

It seems that the feature has reached a level of maturity, allowing it to graduate to Beta and be targeted for GA in the next release.

The network binding plugins feature has a Feature Gate which is now marked as Beta in the next Kubevirt release (v1.4).

User guide has been updated here: https://github.com/kubevirt/user-guide/pull/842

The following limited support notice has been added to the documentation:

> Kubevirt provides regular support for the network binding plugin infrastructure for plugin authors. However, individual network plugin bindings are subject to limited, best-effort support from the Kubevirt community.
> 
> Clusters with Kubevirt deployments that utilize a network binding plugin should contact the plugin vendor for support on any issue that may be encountered, be it network or other issue.
> 
> In order to request support from the Kubevirt core project and its community, please use a setup without any network binding plugin. The plugin examples listet below are an exception to this rule, as they are maintained by the Kubevirt network core maintainers.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Network binding plugins feature is declared as Beta.
```