### PR TITLE
[release-1.3]  Use usable size instead of requested capacity in disk expansion logic

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -39,6 +39,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	virtcache "kubevirt.io/kubevirt/tools/cache"
@@ -883,22 +884,52 @@ func possibleGuestSize(disk api.Disk) (int64, bool) {
 		log.DefaultLogger().Error("No disk capacity")
 		return 0, false
 	}
-	preferredSize := *disk.Capacity
 	if disk.FilesystemOverhead == nil {
 		log.DefaultLogger().Errorf("No filesystem overhead found for disk %v", disk)
 		return 0, false
 	}
+
 	filesystemOverhead, err := strconv.ParseFloat(string(*disk.FilesystemOverhead), 64)
 	if err != nil {
 		log.DefaultLogger().Reason(err).Error("Failed to parse filesystem overhead as float")
 		return 0, false
 	}
-	size := int64((1 - filesystemOverhead) * float64(preferredSize))
+	if filesystemOverhead < 0 || filesystemOverhead > 1 {
+		log.DefaultLogger().Errorf("Invalid filesystem overhead %f (must be between 0 and 1)", filesystemOverhead)
+		return 0, false
+	}
+
+	usableSize, err := getUsableDiskSize(getSourceFile(disk))
+	if err != nil {
+		log.DefaultLogger().Reason(err).Error("Failed to get total usable space, using disk capacity instead")
+		usableSize = *disk.Capacity
+	}
+	preferredSize := float64(min(usableSize, *disk.Capacity))
+
+	size := int64((1 - filesystemOverhead) * preferredSize)
 	size = kutil.AlignImageSizeTo1MiB(size, log.DefaultLogger())
 	if size == 0 {
 		return 0, false
 	}
 	return size, true
+}
+
+func getUsableDiskSize(path string) (int64, error) {
+	var statfs syscall.Statfs_t
+	err := syscall.Statfs(path, &statfs)
+	if err != nil {
+		return int64(-1), err
+	}
+	availableSize := int64(statfs.Bavail) * int64(statfs.Bsize)
+
+	var stat syscall.Stat_t
+	err = syscall.Stat(path, &stat)
+	if err != nil {
+		return int64(-1), err
+	}
+	actualSize := int64(stat.Size)
+
+	return actualSize + availableSize, nil
 }
 
 func shouldExpandOffline(disk api.Disk) bool {

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -21,8 +21,10 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual backport of https://github.com/kubevirt/kubevirt/pull/12733.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Fix disk expansion logic by checking usable size instead of requested capacity
```

