### PR TITLE
Controllers: Improve unit test to catch corruption

### DIFF
--- a/pkg/controller/testing/BUILD.bazel
+++ b/pkg/controller/testing/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["testing.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/controller/testing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)

--- a/pkg/controller/testing/testing.go
+++ b/pkg/controller/testing/testing.go
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+package testing
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/onsi/gomega"
+)
+
+type interf interface {
+	Execute() bool
+}
+
+func deepCopyList(objects []interface{}) []interface{} {
+	for i := range objects {
+		objects[i] = objects[i].(runtime.Object).DeepCopyObject()
+	}
+	return objects
+}
+
+func SanityExecute(c interf, stores []cache.Store, g gomega.Gomega) {
+	listOfObjects := [][]interface{}{}
+
+	for _, store := range stores {
+		listOfObjects = append(listOfObjects, deepCopyList(store.List()))
+	}
+
+	c.Execute()
+
+	for i, objects := range listOfObjects {
+		g.ExpectWithOffset(1, stores[i].List()).To(gomega.ConsistOf(objects...))
+	}
+}

--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/controller/testing:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
@@ -63,6 +64,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
@@ -44,6 +45,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
+	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -245,6 +247,13 @@ var _ = Describe("Clone", func() {
 		virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
 	})
 
+	sanityExecute := func() {
+		controllertesting.SanityExecute(controller, []cache.Store{
+			controller.vmCloneIndexer, controller.snapshotContentStore, controller.restoreStore, controller.vmStore,
+			controller.snapshotContentStore, controller.pvcStore,
+		}, Default)
+	}
+
 	Context("basic controller operations", func() {
 		Context("with source VM", func() {
 			DescribeTable("should create snapshot if not exists yet", func(phase clonev1alpha1.VirtualMachineClonePhase) {
@@ -253,7 +262,7 @@ var _ = Describe("Clone", func() {
 				addVM(sourceVM)
 				addClone(vmClone)
 
-				controller.Execute()
+				sanityExecute()
 				expectEvent(SnapshotCreated)
 				expectSnapshotExists()
 				expectCloneBeInPhase(clonev1alpha1.SnapshotInProgress)
@@ -279,7 +288,7 @@ var _ = Describe("Clone", func() {
 					addClone(vmClone)
 					addSnapshot(snapshot)
 
-					controller.Execute()
+					sanityExecute()
 					Expect(recorder.Events).To(BeEmpty())
 					expectCloneBeInPhase(clonev1alpha1.SnapshotInProgress)
 					expectRestoreDoesNotExist()
@@ -298,7 +307,7 @@ var _ = Describe("Clone", func() {
 					addSnapshot(snapshot)
 					addSnapshotContent(snapshotContent)
 
-					controller.Execute()
+					sanityExecute()
 					expectEvent(SnapshotReady)
 					expectEvent(RestoreCreated)
 					expectCloneBeInPhase(clonev1alpha1.RestoreInProgress)
@@ -330,7 +339,7 @@ var _ = Describe("Clone", func() {
 					addSnapshot(snapshot)
 					addRestore(restore)
 
-					controller.Execute()
+					sanityExecute()
 					Expect(recorder.Events).To(BeEmpty())
 					expectCloneBeInPhase(clonev1alpha1.RestoreInProgress)
 				})
@@ -347,7 +356,7 @@ var _ = Describe("Clone", func() {
 					addSnapshot(snapshot)
 					addRestore(restore)
 
-					controller.Execute()
+					sanityExecute()
 					expectEvent(RestoreReady)
 					expectCloneBeInPhase(clonev1alpha1.CreatingTargetVM)
 				})
@@ -375,7 +384,7 @@ var _ = Describe("Clone", func() {
 					addSnapshot(snapshot)
 					addRestore(restore)
 
-					controller.Execute()
+					sanityExecute()
 					Expect(recorder.Events).To(BeEmpty())
 					expectCloneBeInPhase(clonev1alpha1.CreatingTargetVM)
 				})
@@ -390,7 +399,7 @@ var _ = Describe("Clone", func() {
 					addSnapshot(snapshot)
 					addRestore(restore)
 
-					controller.Execute()
+					sanityExecute()
 					expectEvent(TargetVMCreated)
 					expectCloneBeInPhase(clonev1alpha1.Succeeded)
 					expectSnapshotDoesNotExist()
@@ -434,7 +443,7 @@ var _ = Describe("Clone", func() {
 				})
 
 				It("if not all the PVCs are bound, nothing should happen", func() {
-					controller.Execute()
+					sanityExecute()
 					Expect(recorder.Events).To(BeEmpty())
 					expectCloneBeInPhase(clonev1alpha1.Succeeded)
 					expectSnapshotExists()
@@ -444,7 +453,7 @@ var _ = Describe("Clone", func() {
 				It("if all the pvc are bound, snapshot and restore should be deleted", func() {
 					pvc = createPVC(sourceVM.Namespace, k8sv1.ClaimBound)
 					addPVC(pvc)
-					controller.Execute()
+					sanityExecute()
 					expectEvent(PVCBound)
 					expectSnapshotDoesNotExist()
 					expectRestoreDoesNotExist()
@@ -463,7 +472,7 @@ var _ = Describe("Clone", func() {
 				addClone(vmClone)
 				addRestore(restore)
 
-				controller.Execute()
+				sanityExecute()
 				expectEvent(SnapshotDeleted)
 				expectCloneBeInPhase(clonev1alpha1.Failed)
 				expectSnapshotDoesNotExist()
@@ -478,7 +487,7 @@ var _ = Describe("Clone", func() {
 				snapshot := createVirtualMachineSnapshot(sourceVM)
 				addSnapshot(snapshot)
 
-				controller.Execute()
+				sanityExecute()
 				expectCloneBeInPhase(clonev1alpha1.SnapshotInProgress)
 			})
 
@@ -498,7 +507,7 @@ var _ = Describe("Clone", func() {
 					addSnapshot(snapshot)
 					addRestore(restore)
 
-					controller.Execute()
+					sanityExecute()
 					expectCloneBeInPhase(clonev1alpha1.RestoreInProgress)
 					expectEvent(SnapshotReady)
 				})
@@ -521,7 +530,7 @@ var _ = Describe("Clone", func() {
 					addSnapshot(snapshot)
 					addSnapshotContent(snapshotContent)
 
-					controller.Execute()
+					sanityExecute()
 					expectCloneBeInPhase(clonev1alpha1.RestoreInProgress)
 					expectEvent(SnapshotReady)
 					expectEvent(RestoreCreationFailed)
@@ -537,7 +546,7 @@ var _ = Describe("Clone", func() {
 					addClone(vmClone)
 					//no target vm added => target vm deleted
 
-					controller.Execute()
+					sanityExecute()
 					expectCloneDeletion()
 				})
 			})
@@ -557,7 +566,7 @@ var _ = Describe("Clone", func() {
 				addClone(vmClone)
 				addSnapshot(snapshot)
 
-				controller.Execute()
+				sanityExecute()
 				Expect(recorder.Events).To(BeEmpty())
 				expectCloneBeInPhase(clonev1alpha1.SnapshotInProgress)
 				expectRestoreDoesNotExist()
@@ -573,7 +582,7 @@ var _ = Describe("Clone", func() {
 				addSnapshot(snapshot)
 				addSnapshotContent(snapshotContent)
 
-				controller.Execute()
+				sanityExecute()
 				expectEvent(SnapshotReady)
 				expectEvent(RestoreCreated)
 				expectCloneBeInPhase(clonev1alpha1.RestoreInProgress)
@@ -595,7 +604,7 @@ var _ = Describe("Clone", func() {
 				addSnapshot(snapshot)
 				addRestore(restore)
 
-				controller.Execute()
+				sanityExecute()
 				expectCloneBeInPhase(clonev1alpha1.RestoreInProgress)
 			})
 		})
@@ -686,7 +695,7 @@ var _ = Describe("Clone", func() {
 				expectedInterfaces := expectedVM.Spec.Template.Spec.Domain.Devices.Interfaces
 				expectedInterfaces[0].MacAddress = ""
 
-				controller.Execute()
+				sanityExecute()
 				expectVMCreationFromPatches(expectedVM)
 			})
 
@@ -705,7 +714,7 @@ var _ = Describe("Clone", func() {
 				expectedInterfaces := expectedVM.Spec.Template.Spec.Domain.Devices.Interfaces
 				expectedInterfaces[0].MacAddress = newMacAddress
 
-				controller.Execute()
+				sanityExecute()
 				expectVMCreationFromPatches(expectedVM)
 			})
 
@@ -743,7 +752,7 @@ var _ = Describe("Clone", func() {
 				expectedVM := sourceVM.DeepCopy()
 				expectedVM.Spec.Template.Spec.Domain.Devices.Interfaces = expectedInterfaces
 
-				controller.Execute()
+				sanityExecute()
 				expectVMCreationFromPatches(expectedVM)
 			})
 		})
@@ -769,14 +778,14 @@ var _ = Describe("Clone", func() {
 			It("should delete smbios serial if serial is not provided", func() {
 				addClone(vmClone)
 
-				controller.Execute()
+				sanityExecute()
 				expectSMbiosSerial(emptySerial)
 			})
 
 			It("if serial is defined in clone spec - should use the one in clone spec", func() {
 				vmClone.Spec.NewSMBiosSerial = pointer.P(manuallySetSerial)
 				addClone(vmClone)
-				controller.Execute()
+				sanityExecute()
 				expectSMbiosSerial(manuallySetSerial)
 			})
 		})
@@ -824,7 +833,7 @@ var _ = Describe("Clone", func() {
 					vmClone.Spec.AnnotationFilters = filters
 				}
 				addClone(vmClone)
-				controller.Execute()
+				sanityExecute()
 				expectLabelsOrAnnotations(map[string]string{
 					"prefix1/something1":    trueStr,
 					"somePrefix2/something": trueStr,
@@ -845,7 +854,7 @@ var _ = Describe("Clone", func() {
 				addVM(sourceVM)
 				addClone(vmClone)
 
-				controller.Execute()
+				sanityExecute()
 				restore, err := client.SnapshotV1beta1().VirtualMachineRestores(metav1.NamespaceDefault).Get(context.TODO(), testRestoreName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(restore.Spec.VirtualMachineSnapshotName).To(Equal(testSnapshotName))
@@ -867,7 +876,7 @@ var _ = Describe("Clone", func() {
 				addVM(sourceVM)
 				addClone(vmClone)
 
-				controller.Execute()
+				sanityExecute()
 				restore, err := client.SnapshotV1beta1().VirtualMachineRestores(metav1.NamespaceDefault).Get(context.TODO(), testRestoreName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(restore.Spec.VirtualMachineSnapshotName).To(Equal(testSnapshotName))
@@ -893,7 +902,7 @@ var _ = Describe("Clone", func() {
 				Expect(expectedFirmware).ShouldNot(BeNil())
 
 				expectedFirmware.UUID = ""
-				controller.Execute()
+				sanityExecute()
 				expectVMCreationFromPatches(expectedVM)
 			})
 		})

--- a/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
@@ -33,9 +33,10 @@ go_test(
         "disruptionbudget_suite_test.go",
         "disruptionbudget_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/controller/testing:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -1,4 +1,4 @@
-package disruptionbudget_test
+package disruptionbudget
 
 import (
 	"fmt"
@@ -23,9 +23,9 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/disruptionbudget"
 )
 
 var _ = Describe("Disruptionbudget", func() {
@@ -46,7 +46,7 @@ var _ = Describe("Disruptionbudget", func() {
 	var vmiFeeder *testutils.VirtualMachineFeeder
 	var config *virtconfig.ClusterConfig
 
-	var controller *disruptionbudget.DisruptionBudgetController
+	var controller *DisruptionBudgetController
 
 	syncCaches := func(stop chan struct{}) {
 		go vmiInformer.Run(stop)
@@ -120,7 +120,7 @@ var _ = Describe("Disruptionbudget", func() {
 	initController := func(kvConfig *v1.KubeVirtConfiguration) {
 		config, _, _ = testutils.NewFakeClusterConfigUsingKVConfig(kvConfig)
 
-		controller, _ = disruptionbudget.NewDisruptionBudgetController(vmiInformer, pdbInformer, podInformer, vmimInformer, recorder, virtClient, config)
+		controller, _ = NewDisruptionBudgetController(vmiInformer, pdbInformer, podInformer, vmimInformer, recorder, virtClient, config)
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
 		controller.Queue = mockQueue
 		pdbFeeder = testutils.NewPodDisruptionBudgetFeeder(mockQueue, pdbSource)
@@ -153,11 +153,17 @@ var _ = Describe("Disruptionbudget", func() {
 
 	})
 
+	sanityExecute := func() {
+		controllertesting.SanityExecute(controller, []cache.Store{
+			controller.vmiStore, controller.pdbIndexer, controller.podIndexer, controller.migrationIndexer,
+		}, Default)
+	}
+
 	Context("A VirtualMachineInstance given which does not want to live-migrate on evictions", func() {
 
 		It("should do nothing, if no pdb exists", func() {
 			addVirtualMachine(nonMigratableVirtualMachine())
-			controller.Execute()
+			sanityExecute()
 		})
 
 		It("should remove the pdb, if it is added to the cache", func() {
@@ -167,8 +173,8 @@ var _ = Describe("Disruptionbudget", func() {
 			pdbFeeder.Add(pdb)
 
 			shouldExpectPDBDeletion(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodDisruptionBudgetReason)
 		})
 	})
 
@@ -183,8 +189,8 @@ var _ = Describe("Disruptionbudget", func() {
 			addVirtualMachine(vmi)
 
 			shouldExpectPDBCreation(vmi.UID)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulCreatePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodDisruptionBudgetReason)
 		})
 	})
 
@@ -196,7 +202,7 @@ var _ = Describe("Disruptionbudget", func() {
 			pdb := newPodDisruptionBudget(vmi, 1)
 			pdbFeeder.Add(pdb)
 
-			controller.Execute()
+			sanityExecute()
 		},
 			Entry("with LiveMigrate eviction strategy and non-migratable VMI", v1.EvictionStrategyLiveMigrate, nonMigratableVirtualMachine()),
 			Entry("with External eviction strategy and non-migratable VMI", v1.EvictionStrategyExternal, nonMigratableVirtualMachine()),
@@ -212,12 +218,12 @@ var _ = Describe("Disruptionbudget", func() {
 			pdb := newPodDisruptionBudget(vmi, 1)
 			pdbFeeder.Add(pdb)
 
-			controller.Execute()
+			sanityExecute()
 
 			vmiFeeder.Delete(vmi)
 			shouldExpectPDBDeletion(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodDisruptionBudgetReason)
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),
@@ -231,8 +237,8 @@ var _ = Describe("Disruptionbudget", func() {
 			pdbFeeder.Add(pdb)
 
 			shouldExpectPDBDeletion(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodDisruptionBudgetReason)
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),
@@ -246,20 +252,20 @@ var _ = Describe("Disruptionbudget", func() {
 			pdb := newPodDisruptionBudget(vmi, 1)
 			pdbFeeder.Add(pdb)
 
-			controller.Execute()
+			sanityExecute()
 
 			vmiFeeder.Delete(vmi)
 			shouldExpectPDBDeletion(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodDisruptionBudgetReason)
 
 			pdbFeeder.Delete(pdb)
 			vmi.UID = "45356"
 			vmiFeeder.Add(vmi)
 			shouldExpectPDBCreation(vmi.UID)
-			controller.Execute()
+			sanityExecute()
 
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulCreatePodDisruptionBudgetReason)
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodDisruptionBudgetReason)
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),
@@ -276,8 +282,8 @@ var _ = Describe("Disruptionbudget", func() {
 			addVirtualMachine(vmi)
 
 			shouldExpectPDBDeletion(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodDisruptionBudgetReason)
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),
@@ -291,10 +297,10 @@ var _ = Describe("Disruptionbudget", func() {
 			vmi.DeletionTimestamp = &now
 			addVirtualMachine(vmi)
 
-			controller.Execute()
+			sanityExecute()
 
 			vmiFeeder.Delete(vmi)
-			controller.Execute()
+			sanityExecute()
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),
@@ -308,13 +314,13 @@ var _ = Describe("Disruptionbudget", func() {
 			pdb := newPodDisruptionBudget(vmi, 1)
 			pdbFeeder.Add(pdb)
 
-			controller.Execute()
+			sanityExecute()
 
 			vmi.Spec.EvictionStrategy = nil
 			vmiFeeder.Modify(vmi)
 			shouldExpectPDBDeletion(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodDisruptionBudgetReason)
 		})
 
 		DescribeTable("should remove the pdb if the VMI reached Final state", func(vmiPhase v1.VirtualMachineInstancePhase) {
@@ -328,8 +334,8 @@ var _ = Describe("Disruptionbudget", func() {
 			vmiFeeder.Add(vmi)
 
 			shouldExpectPDBDeletion(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodDisruptionBudgetReason)
 		},
 			Entry("with Succeeded vmi phase", v1.Succeeded),
 			Entry("with Failed vmi phase", v1.Failed),
@@ -341,8 +347,8 @@ var _ = Describe("Disruptionbudget", func() {
 			addVirtualMachine(vmi)
 
 			shouldExpectPDBCreation(vmi.UID)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulCreatePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodDisruptionBudgetReason)
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),
@@ -355,12 +361,12 @@ var _ = Describe("Disruptionbudget", func() {
 			addVirtualMachine(vmi)
 			pdb := newPodDisruptionBudget(vmi, 1)
 			pdbFeeder.Add(pdb)
-			controller.Execute()
+			sanityExecute()
 
 			shouldExpectPDBCreation(vmi.UID)
 			pdbFeeder.Delete(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulCreatePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodDisruptionBudgetReason)
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),
@@ -373,14 +379,14 @@ var _ = Describe("Disruptionbudget", func() {
 			addVirtualMachine(vmi)
 			pdb := newPodDisruptionBudget(vmi, 1)
 			pdbFeeder.Add(pdb)
-			controller.Execute()
+			sanityExecute()
 
 			shouldExpectPDBCreation(vmi.UID)
 			newPdb := pdb.DeepCopy()
 			newPdb.OwnerReferences = nil
 			pdbFeeder.Modify(newPdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulCreatePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodDisruptionBudgetReason)
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),
@@ -404,8 +410,8 @@ var _ = Describe("Disruptionbudget", func() {
 
 			shouldExpectPDBPatch(vmi)
 
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulUpdatePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulUpdatePodDisruptionBudgetReason)
 		})
 
 		It("should shrink the PDB after migration object is gone", func() {
@@ -421,8 +427,8 @@ var _ = Describe("Disruptionbudget", func() {
 
 			shouldExpectPDBPatch(vmi)
 
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulUpdatePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulUpdatePodDisruptionBudgetReason)
 		})
 
 		It("should not shrink the PDB while migration is running", func() {
@@ -438,7 +444,7 @@ var _ = Describe("Disruptionbudget", func() {
 			pdbFeeder.Add(pdb)
 			addMigration(vmim)
 
-			controller.Execute()
+			sanityExecute()
 		})
 
 		DescribeTable("should delete a PDB created by an old migration-controller", func(evictionStrategy v1.EvictionStrategy) {
@@ -454,8 +460,8 @@ var _ = Describe("Disruptionbudget", func() {
 			pdbFeeder.Add(pdb)
 
 			shouldExpectPDBDeletion(pdb)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodDisruptionBudgetReason)
 		},
 			Entry("with LiveMigrate eviction strategy", v1.EvictionStrategyLiveMigrate),
 			Entry("with LiveMigrateIfPossible eviction strategy", v1.EvictionStrategyLiveMigrateIfPossible),

--- a/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/controller/testing:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -1,4 +1,4 @@
-package evacuation_test
+package evacuation
 
 import (
 	"context"
@@ -24,9 +24,9 @@ import (
 
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 
+	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation"
 )
 
 var _ = Describe("Evacuation", func() {
@@ -48,7 +48,7 @@ var _ = Describe("Evacuation", func() {
 	var migrationFeeder *testutils.MigrationFeeder
 	var vmiFeeder *testutils.VirtualMachineFeeder
 
-	var controller *evacuation.EvacuationController
+	var controller *EvacuationController
 
 	syncCaches := func(stop chan struct{}) {
 		go vmiInformer.Run(stop)
@@ -95,7 +95,7 @@ var _ = Describe("Evacuation", func() {
 		recorder.IncludeObject = true
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
-		controller, _ = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
+		controller, _ = NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
 		controller.Queue = mockQueue
 		migrationFeeder = testutils.NewMigrationFeeder(mockQueue, migrationSource)
@@ -115,9 +115,16 @@ var _ = Describe("Evacuation", func() {
 		syncCaches(stop)
 	})
 
+	sanityExecute := func() {
+		controllertesting.SanityExecute(controller, []cache.Store{
+			controller.vmiIndexer, controller.vmiPodIndexer, controller.migrationStore, controller.nodeStore,
+		}, Default)
+
+	}
+
 	Context("migration object creation", func() {
 		It("should have expected values and annotations", func() {
-			migration := evacuation.GenerateNewMigration("my-vmi", "somenode")
+			migration := GenerateNewMigration("my-vmi", "somenode")
 			Expect(migration.Spec.VMIName).To(Equal("my-vmi"))
 			Expect(migration.Annotations[v1.EvacuationMigrationAnnotation]).To(Equal("somenode"))
 		})
@@ -132,7 +139,7 @@ var _ = Describe("Evacuation", func() {
 			vmi := newVirtualMachine("testvm", node.Name)
 			vmiFeeder.Add(vmi)
 
-			controller.Execute()
+			sanityExecute()
 		})
 
 		It("should do nothing if the target node is not evicting", func() {
@@ -145,7 +152,7 @@ var _ = Describe("Evacuation", func() {
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
 			vmiFeeder.Add(vmi)
 
-			controller.Execute()
+			sanityExecute()
 		})
 	})
 
@@ -162,8 +169,8 @@ var _ = Describe("Evacuation", func() {
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
 			vmiFeeder.Add(vmi)
 
-			controller.Execute()
-			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
 		})
 
@@ -184,10 +191,10 @@ var _ = Describe("Evacuation", func() {
 			vmi1.Status.Conditions = nil
 			vmiFeeder.Add(vmi1)
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder,
-				evacuation.FailedCreateVirtualMachineInstanceMigrationReason,
-				evacuation.FailedCreateVirtualMachineInstanceMigrationReason,
+				FailedCreateVirtualMachineInstanceMigrationReason,
+				FailedCreateVirtualMachineInstanceMigrationReason,
 			)
 		})
 
@@ -209,7 +216,7 @@ var _ = Describe("Evacuation", func() {
 			migrationFeeder.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
 			migrationFeeder.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
 
-			controller.Execute()
+			sanityExecute()
 
 		})
 
@@ -231,13 +238,13 @@ var _ = Describe("Evacuation", func() {
 			vmi3 := newVirtualMachineMarkedForEviction("testvmi3", node.Name)
 			vmiFeeder.Add(vmi3)
 
-			controller.Execute()
+			sanityExecute()
 
 			migration2.Status.Phase = v1.MigrationSucceeded
 			migrationFeeder.Modify(migration2)
 
-			controller.Execute()
-			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
 		})
 	})
@@ -251,8 +258,8 @@ var _ = Describe("Evacuation", func() {
 			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
 			vmi.Status.EvacuationNodeName = node.Name
 			vmiFeeder.Add(vmi)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
 		})
 
@@ -275,8 +282,8 @@ var _ = Describe("Evacuation", func() {
 			}
 			vmi.Status.EvacuationNodeName = vmi.Status.NodeName
 			vmiFeeder.Add(vmi)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, evacuation.FailedCreateVirtualMachineInstanceMigrationReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, FailedCreateVirtualMachineInstanceMigrationReason)
 		})
 
 		It("Should not evict VMI if max migrations are in progress", func() {
@@ -297,7 +304,7 @@ var _ = Describe("Evacuation", func() {
 			migrationFeeder.Add(newMigration("mig3", vmi.Name, v1.MigrationRunning))
 			migrationFeeder.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
 			migrationFeeder.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
-			controller.Execute()
+			sanityExecute()
 		})
 
 		It("Shound do nothing when active migrations exceed the configured concurrent maximum", func() {
@@ -314,7 +321,7 @@ var _ = Describe("Evacuation", func() {
 			nodeName := "node01"
 			addNode(newNode(nodeName))
 
-			controller, _ = evacuation.
+			controller, _ =
 				NewEvacuationController(
 					vmiInformer,
 					migrationInformer,
@@ -330,7 +337,7 @@ var _ = Describe("Evacuation", func() {
 				migrationFeeder.Add(newMigration(fmt.Sprintf("mig%d", i), vmiName, v1.MigrationRunning))
 			}
 
-			controller.Execute()
+			sanityExecute()
 		})
 
 		It("Should not create a migration if one is already in progress", func() {
@@ -352,7 +359,7 @@ var _ = Describe("Evacuation", func() {
 
 			migrationFeeder.Add(migration)
 
-			controller.Execute()
+			sanityExecute()
 		})
 
 		It("should evict the VMI if only one pod is running", func() {
@@ -376,8 +383,8 @@ var _ = Describe("Evacuation", func() {
 
 			vmiFeeder.Add(vmi)
 
-			controller.Execute()
-			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
 		})
 
@@ -400,14 +407,14 @@ var _ = Describe("Evacuation", func() {
 
 			vmiFeeder.Add(vmi)
 
-			controller.Execute()
+			sanityExecute()
 		})
 
 		It("should migrate the VMI if EvictionStrategy is set in the cluster config", func() {
 			config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 				EvictionStrategy: newEvictionStrategyLiveMigrate(),
 			})
-			controller, _ = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
+			controller, _ = NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
 
 			node := newNode("testnode")
 			node1 := newNode("anothernode")
@@ -418,8 +425,8 @@ var _ = Describe("Evacuation", func() {
 			vmi := newVirtualMachine("testvm", node.Name)
 			vmiFeeder.Add(vmi)
 
-			controller.Execute()
-			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
 		})
 
@@ -427,7 +434,7 @@ var _ = Describe("Evacuation", func() {
 			config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 				EvictionStrategy: newEvictionStrategyLiveMigrate(),
 			})
-			controller, _ = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
+			controller, _ = NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
 
 			node := newNode("testnode")
 			node1 := newNode("anothernode")
@@ -439,7 +446,7 @@ var _ = Describe("Evacuation", func() {
 			vmi.Spec.EvictionStrategy = newEvictionStrategyNone()
 			vmiFeeder.Add(vmi)
 
-			controller.Execute()
+			sanityExecute()
 		})
 
 		It("Should create new evictions up to the configured maximum migrations per outbound node", func() {
@@ -454,7 +461,7 @@ var _ = Describe("Evacuation", func() {
 				},
 			})
 
-			controller, _ = evacuation.
+			controller, _ =
 				NewEvacuationController(
 					vmiInformer,
 					migrationInformer,
@@ -482,9 +489,9 @@ var _ = Describe("Evacuation", func() {
 
 			By(fmt.Sprintf("Expect only one new migration from node %s although cluster capacity allows more candidates", nodeName))
 
-			controller.Execute()
+			sanityExecute()
 
-			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
 		})
 
@@ -500,7 +507,7 @@ var _ = Describe("Evacuation", func() {
 				},
 			})
 
-			controller, _ = evacuation.
+			controller, _ =
 				NewEvacuationController(
 					vmiInformer,
 					migrationInformer,
@@ -524,9 +531,9 @@ var _ = Describe("Evacuation", func() {
 			vmiName := fmt.Sprintf("testvmi%d", pendingMigrations+1)
 			vmiFeeder.Add(newVirtualMachineMarkedForEviction(vmiName, nodeName))
 
-			controller.Execute()
+			sanityExecute()
 
-			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
 
 		})

--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/controller/testing:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
@@ -75,6 +76,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],

--- a/pkg/virt-controller/watch/node/BUILD.bazel
+++ b/pkg/virt-controller/watch/node/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/controller/testing:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-controller/watch/testing:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/node/node_test.go
+++ b/pkg/virt-controller/watch/node/node_test.go
@@ -27,6 +27,7 @@ import (
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/testing"
 
+	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	watchtesting "kubevirt.io/kubevirt/pkg/virt-controller/watch/testing"
 )
@@ -115,6 +116,12 @@ var _ = Describe("Node controller with", func() {
 		Expect(updatedVMI.Status.Reason).To(Equal(NodeUnresponsiveReason))
 	}
 
+	sanityExecute := func() {
+		controllertesting.SanityExecute(controller, []cache.Store{
+			controller.vmiStore, controller.nodeStore,
+		}, Default)
+	}
+
 	Context("pods and vmis given", func() {
 		It("should only select stuck vmis", func() {
 			node := NewHealthyNode("test")
@@ -149,7 +156,7 @@ var _ = Describe("Node controller with", func() {
 
 			addNode(node)
 
-			controller.Execute()
+			sanityExecute()
 		})
 	})
 
@@ -167,7 +174,7 @@ var _ = Describe("Node controller with", func() {
 				return true, nil, nil
 			})
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 		})
 		DescribeTable("should set a vmi without a pod to failed state if the vmi is in ", func(phase v1.VirtualMachineInstancePhase) {
@@ -224,7 +231,7 @@ var _ = Describe("Node controller with", func() {
 				return true, &k8sv1.PodList{}, nil
 			})
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 			expectVMIToFailedStatus(vmi.Name)
 		})
@@ -257,7 +264,7 @@ var _ = Describe("Node controller with", func() {
 				return true, &k8sv1.PodList{}, nil
 			})
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 			expectVMIToFailedStatus(vmi.Name)
 		})
@@ -277,7 +284,7 @@ var _ = Describe("Node controller with", func() {
 				return true, &k8sv1.PodList{}, nil
 			})
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 			expectVMIToFailedStatus(vmi.Name)
 		})
@@ -297,7 +304,7 @@ var _ = Describe("Node controller with", func() {
 				return true, &k8sv1.PodList{}, nil
 			})
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 			expectVMIToFailedStatus(vmi.Name)
 		})
@@ -317,7 +324,7 @@ var _ = Describe("Node controller with", func() {
 				return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewUnhealthyPodForVirtualMachine("whatever", vmi)}}, nil
 			})
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 			expectVMIToFailedStatus(vmi.Name)
 		})

--- a/pkg/virt-controller/watch/pool/BUILD.bazel
+++ b/pkg/virt-controller/watch/pool/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/controller/testing:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-controller/watch/common:go_default_library",

--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/controller/testing:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",
@@ -88,7 +89,6 @@ go_test(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -15,7 +15,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +42,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -311,9 +311,10 @@ var _ = Describe("VirtualMachine", func() {
 		}
 
 		sanityExecute := func(vm *v1.VirtualMachine) {
-			added := vm.DeepCopy()
-			controller.Execute()
-			Expect(equality.Semantic.DeepEqual(vm, added)).To(BeTrue(), "A cached VM was modified")
+			controllertesting.SanityExecute(controller, []cache.Store{
+				controller.vmiIndexer, controller.vmIndexer, controller.dataSourceStore, controller.dataVolumeStore,
+				controller.namespaceStore, controller.pvcStore, controller.crIndexer,
+			}, Default)
 		}
 
 		It("should update conditions when failed creating DataVolume for virtualMachineInstance", func() {

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/controller/testing:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/BUILD.bazel
+++ b/pkg/virt-controller/watch/workload-updater/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/controller/testing:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -25,6 +25,7 @@ import (
 	"kubevirt.io/client-go/testing"
 
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
@@ -60,6 +61,12 @@ var _ = Describe("Workload Updater", func() {
 			}
 			return false, nil, nil
 		})
+	}
+
+	sanityExecute := func() {
+		controllertesting.SanityExecute(controller, []cache.Store{
+			controller.vmiStore, controller.podIndexer, controller.migrationStore, controller.kubeVirtStore,
+		}, Default)
 	}
 
 	BeforeEach(func() {
@@ -120,7 +127,7 @@ var _ = Describe("Workload Updater", func() {
 			controller.podIndexer.Add(pod)
 			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			migrations, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(k8sv1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -140,7 +147,7 @@ var _ = Describe("Workload Updater", func() {
 			controller.podIndexer.Add(pod)
 			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
 
-			controller.Execute()
+			sanityExecute()
 			Expect(recorder.Events).To(BeEmpty())
 			Expect(fakeVirtClient.Actions()).To(BeEmpty())
 		})
@@ -192,7 +199,7 @@ var _ = Describe("Workload Updater", func() {
 			evictionCount := 0
 			shouldExpectMultiplePodEvictions(&evictionCount)
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder, reasons...)
 
 			By("Checking prometheus metric")
@@ -243,7 +250,7 @@ var _ = Describe("Workload Updater", func() {
 			evictionCount := 0
 			shouldExpectMultiplePodEvictions(&evictionCount)
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder, reasons...)
 
 			Expect(evictionCount).To(Equal(defaultBatchDeletionCount))
@@ -284,7 +291,7 @@ var _ = Describe("Workload Updater", func() {
 
 			waitForNumberOfInstancesOnVMIInformerCache(controller, desiredNumberOfVMs)
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder, reasons...)
 
 			migrations, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(k8sv1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
@@ -327,7 +334,7 @@ var _ = Describe("Workload Updater", func() {
 			evictionCount := 0
 			shouldExpectMultiplePodEvictions(&evictionCount)
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder, reasons...)
 			Expect(evictionCount).To(Equal(1))
 
@@ -356,7 +363,7 @@ var _ = Describe("Workload Updater", func() {
 			waitForNumberOfInstancesOnVMIInformerCache(controller, totalVMs)
 			kv := newKubeVirt(totalVMs)
 			addKubeVirt(kv)
-			controller.Execute()
+			sanityExecute()
 			Expect(fakeVirtClient.Actions()).To(BeEmpty())
 		})
 
@@ -381,7 +388,7 @@ var _ = Describe("Workload Updater", func() {
 			evictionCount := 0
 			shouldExpectMultiplePodEvictions(&evictionCount)
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder, reasons...)
 			Expect(evictionCount).To(Equal(defaultBatchDeletionCount))
 
@@ -409,7 +416,7 @@ var _ = Describe("Workload Updater", func() {
 
 			waitForNumberOfInstancesOnVMIInformerCache(controller, desiredNumberOfVMs)
 
-			controller.Execute()
+			sanityExecute()
 			Expect(recorder.Events).To(BeEmpty())
 		})
 
@@ -436,7 +443,7 @@ var _ = Describe("Workload Updater", func() {
 			evictionCount := 0
 			shouldExpectMultiplePodEvictions(&evictionCount)
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder, reasons...)
 			Expect(evictionCount).To(Equal(batchDeletions))
 		})
@@ -467,12 +474,12 @@ var _ = Describe("Workload Updater", func() {
 			shouldExpectMultiplePodEvictions(&evictionCount)
 
 			addKubeVirt(kv)
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder, reasons...)
 
 			// Should do nothing this second execute due to interval
 			addKubeVirt(kv)
-			controller.Execute()
+			sanityExecute()
 			Expect(recorder.Events).To(BeEmpty())
 
 			// Shift time for batch interval
@@ -480,7 +487,7 @@ var _ = Describe("Workload Updater", func() {
 
 			// Should execute another batch of deletions after sleep
 			addKubeVirt(kv)
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvents(recorder, reasons...)
 			Expect(evictionCount).To(Equal(batchDeletions * 2))
 		})
@@ -563,7 +570,7 @@ var _ = Describe("Workload Updater", func() {
 			vmi := createVM(withoutAnnotation, withoutMemoryChangeCondition)
 			mig := createMig(vmi.Name, phase)
 
-			controller.Execute()
+			sanityExecute()
 			if mig.IsFinal() {
 				Expect(recorder.Events).To(BeEmpty())
 			} else {
@@ -584,7 +591,7 @@ var _ = Describe("Workload Updater", func() {
 				mig = createMig(vmi.Name, v1.MigrationRunning)
 			}
 			changeAborted := hasMig && !hasCond
-			controller.Execute()
+			sanityExecute()
 			if changeAborted {
 				testutils.ExpectEvent(recorder, SuccessfulChangeAbortionReason)
 				_, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(mig.Namespace).Get(context.Background(), mig.Name, metav1.GetOptions{})
@@ -601,7 +608,7 @@ var _ = Describe("Workload Updater", func() {
 		DescribeTable("should always cancel the migration when the testWorkloadUpdateMigrationAbortion annotation is present", func(hasCond bool) {
 			vmi := createVM(withAnnotation, hasCond)
 			mig := createMig(vmi.Name, v1.MigrationRunning)
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, SuccessfulChangeAbortionReason)
 			_, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(mig.Namespace).Get(context.Background(), mig.Name, metav1.GetOptions{})
 			Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
@@ -617,7 +624,7 @@ var _ = Describe("Workload Updater", func() {
 				return true, nil, fmt.Errorf("some error")
 			})
 
-			controller.Execute()
+			sanityExecute()
 			testutils.ExpectEvent(recorder, FailedChangeAbortionReason)
 			_, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(mig.Namespace).Get(context.Background(), mig.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -643,7 +650,7 @@ var _ = Describe("Workload Updater", func() {
 			)
 			controller.vmiStore.Add(vmi)
 			createMig(vmi.Name, v1.MigrationRunning)
-			controller.Execute()
+			sanityExecute()
 			Expect(recorder.Events).To(BeEmpty())
 			// Ensure that the deletion operation isn't called. The test reproduces the race when the migration operation
 			// was completed, but the migration object was still in running phase and it was accidentally deleted.


### PR DESCRIPTION
### What this PR does
The new `SanityExecute` makes sure that all objects in the cache are not modified.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

