### PR TITLE
tests/io_utils: move *FaultyDisk functions to their only user

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -18,7 +17,6 @@ go_library(
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
-        "//tests/framework/matcher:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
         "//tests/testsuite:go_default_library",


### PR DESCRIPTION
Similarly to tests/utils, tests/io_utils is a problematic file as it lumps together unrelated functions and dumps them in a catch-all package "tests". This PR moves two of these functions to the only test files that uses them.

```release-note
NONE
```

/kind cleanup
/cc @alromeros