### PR TITLE
Test cleanup: Move ephemeral volume test to unit tests

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/downwardmetrics:go_default_library",
         "//pkg/ephemeral-disk/fake:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "//pkg/storage/velero:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
-        "//pkg/virt-launcher/virtwrap/converter:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virtctl/guestfs:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -1132,25 +1131,6 @@ var _ = SIGDescribe("Storage", func() {
 				libstorage.DeleteDataVolume(&dataVolume)
 			})
 
-			It("should generate the block backingstore disk within the domain", func() {
-				vmi = libvmifact.NewGuestless(
-					libvmi.WithEphemeralPersistentVolumeClaim("disk0", dataVolume.Name),
-				)
-
-				By("Initializing the VM")
-				vmi = libvmops.RunVMIAndExpectLaunch(vmi, 90)
-
-				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				disks := runningVMISpec.Devices.Disks
-
-				By("Checking if the disk backing store type is block")
-				Expect(disks[0].BackingStore).ToNot(BeNil())
-				Expect(disks[0].BackingStore.Type).To(Equal("block"))
-				By("Checking if the disk backing store device path is appropriately configured")
-				Expect(disks[0].BackingStore.Source.Dev).To(Equal(converter.GetBlockDeviceVolumePath("disk0")))
-			})
 			It("should generate the pod with the volumeDevice", func() {
 				vmi = libvmifact.NewGuestless(
 					libvmi.WithEphemeralPersistentVolumeClaim("disk0", dataVolume.Name),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This functional test only checks for converter behavior, which could easily be covered with unit tests.

This PR aims to move the test from functional to unit tests, in the same fashion as in the test here: https://github.com/kubevirt/kubevirt/pull/13051:

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

