### PR TITLE
Add dynamic pod iface naming feature gate

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -362,7 +362,7 @@ func (app *virtHandlerApp) Run() {
 		&capabilities,
 		hostCpuModel,
 		netsetup.NewNetConf(app.clusterConfig),
-		netsetup.NewNetStat(),
+		netsetup.NewNetStat(app.clusterConfig),
 		netbinding.MemoryCalculator{},
 	)
 	if err != nil {

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -47,8 +47,9 @@ var _ = Describe("netconf", func() {
 		vmi      *v1.VirtualMachineInstance
 		stateMap map[string]*netpod.State
 
-		stateCache stateCacheStub
-		ns         nsExecutorStub
+		stateCache        stateCacheStub
+		ns                nsExecutorStub
+		clusterConfigurer cConfigStub
 	)
 
 	const launcherPid = 0
@@ -57,7 +58,8 @@ var _ = Describe("netconf", func() {
 		stateCache = newConfigStateCacheStub()
 		ns = nsExecutorStub{}
 		stateMap = map[string]*netpod.State{}
-		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsNoopFactory, &tempCacheCreator{}, stateMap, cConfigStub{})
+		clusterConfigurer = cConfigStub{dynamicPodInterfaceNamingEnabled: false}
+		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsNoopFactory, &tempCacheCreator{}, stateMap, clusterConfigurer)
 		vmi = &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{UID: "123", Name: "vmi1"}}
 	})
 
@@ -213,8 +215,14 @@ func (n nsExecutorStub) Do(f func() error) error {
 	return f()
 }
 
-type cConfigStub struct{}
+type cConfigStub struct {
+	dynamicPodInterfaceNamingEnabled bool
+}
 
 func (c cConfigStub) GetNetworkBindings() map[string]v1.InterfaceBindingPlugin {
 	return map[string]v1.InterfaceBindingPlugin{}
+}
+
+func (c cConfigStub) DynamicPodInterfaceNamingEnabled() bool {
+	return c.dynamicPodInterfaceNamingEnabled
 }

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -46,6 +46,10 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
+type clusterConfigChecker interface {
+	DynamicPodInterfaceNamingEnabled() bool
+}
+
 type nmstateAdapter interface {
 	Apply(spec *nmstate.Spec) error
 	Read() (*nmstate.Status, error)

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -81,6 +81,8 @@ const (
 	// This feature requires following Kubernetes feature gate "ServiceAccountTokenPodNodeInfo". The feature gate is available
 	// in Kubernetes 1.30 as Beta.
 	NodeRestrictionGate = "NodeRestriction"
+	// DynamicPodInterfaceNaming enables a mechanism to dynamically determine the primary pod interface for KuveVirt virtual machines.
+	DynamicPodInterfaceNamingGate = "DynamicPodInterfaceNaming"
 )
 
 func (config *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
@@ -251,4 +253,8 @@ func (config *ClusterConfig) VolumeMigrationEnabled() bool {
 
 func (config *ClusterConfig) NodeRestrictionEnabled() bool {
 	return config.isFeatureGateEnabled(NodeRestrictionGate)
+}
+
+func (config *ClusterConfig) DynamicPodInterfaceNamingEnabled() bool {
+	return config.isFeatureGateEnabled(DynamicPodInterfaceNamingGate)
 }

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
         "//pkg/storage/export/export:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch/clone:go_default_library",
         "//pkg/virt-controller/watch/drain/disruptionbudget:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -655,7 +655,9 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.clusterConfig,
 		topologyHinter,
 		netAnnotationsGenerator,
-		netvmicontroller.UpdateStatus,
+		func(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) error {
+			return netvmicontroller.UpdateStatus(clusterConfig, vmi, pod)
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -54,6 +54,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/storage/export/export"
 	"kubevirt.io/kubevirt/pkg/storage/snapshot"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/clone"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/disruptionbudget"
@@ -147,7 +148,7 @@ var _ = Describe("Application", func() {
 			config,
 			topology.NewTopologyHinter(&cache.FakeCustomStore{}, &cache.FakeCustomStore{}, nil),
 			nil,
-			func(_ *v1.VirtualMachineInstance, _ *k8sv1.Pod) error { return nil },
+			func(_ *virtconfig.ClusterConfig, _ *v1.VirtualMachineInstance, _ *k8sv1.Pod) error { return nil },
 		)
 		app.rsController, _ = replicaset.NewController(vmiInformer, rsInformer, recorder, virtClient, uint(10))
 		app.vmController, _ = vm.NewController(vmiInformer,

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -178,7 +178,7 @@ type annotationsGenerator interface {
 	GenerateFromActivePod(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) map[string]string
 }
 
-type statusUpdater func(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error
+type statusUpdater func(clusterConfig *virtconfig.ClusterConfig, vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error
 
 type Controller struct {
 	templateService         services.TemplateService
@@ -588,7 +588,7 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 					return err
 				}
 
-				if err := c.updateNetworkStatus(vmiCopy, pod); err != nil {
+				if err := c.updateNetworkStatus(c.clusterConfig, vmiCopy, pod); err != nil {
 					log.Log.Errorf("failed to update the interface status: %v", err)
 				}
 
@@ -652,7 +652,7 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 			return err
 		}
 
-		if err := c.updateNetworkStatus(vmiCopy, pod); err != nil {
+		if err := c.updateNetworkStatus(c.clusterConfig, vmiCopy, pod); err != nil {
 			log.Log.Errorf("failed to update the interface status: %v", err)
 		}
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -239,7 +239,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		nsInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		var qemuGid int64 = 107
 
-		stubNetStatusUpdate := func(vmi *virtv1.VirtualMachineInstance, _ *k8sv1.Pod) error {
+		stubNetStatusUpdate := func(clusterConfig *virtconfig.ClusterConfig, vmi *virtv1.VirtualMachineInstance, _ *k8sv1.Pod) error {
 			vmi.Status.Interfaces = append(vmi.Status.Interfaces, virtv1.VirtualMachineInstanceNetworkInterface{Name: "stubNetStatusUpdate"})
 			return nil
 		}

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -38,9 +38,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	network "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -56,7 +58,7 @@ var _ = SIGDescribe("Infosource", func() {
 		virtClient = kubevirt.Client()
 	})
 
-	Context("VMI with 3 interfaces", func() {
+	Context("[Serial] VMI with 3 interfaces", Serial, func() {
 		var vmi *kvirtv1.VirtualMachineInstance
 
 		const (
@@ -75,6 +77,8 @@ var _ = SIGDescribe("Infosource", func() {
 		secondaryNetwork2 := libvmi.MultusNetwork(secondaryInterface2Name, nadName)
 
 		BeforeEach(func() {
+			config.EnableFeatureGate(virtconfig.DynamicPodInterfaceNamingGate)
+
 			By("Create NetworkAttachmentDefinition")
 			Expect(libnet.CreateNAD(testsuite.NamespaceTestDefault, nadName)).To(Succeed())
 


### PR DESCRIPTION
### What this PR does
Before this PR:
The dynamic pod interface name discovery mechanism implemented at [1] was running unconditionally.

After this PR:
To enable the pod interface name discovery the feature gate related to it has to be enabled.

### Why we need it and why it was done in this way
The dynamic pod interface naming need to be well tested, with the feature gate is disabled by default and only activated at testing scenarios.

### Release note
```release-note
Add dynamic pod interface name feature gate
```

