### PR TITLE
GA VMLiveUpdateFeatures feature-gate

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -1362,14 +1362,11 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		})
 	})
 
-	Context("when LiveUpdate and VMLiveUpdateFeatures is enabled", func() {
+	Context("when vmRolloutStrategy LiveUpdate is enabled", func() {
 		BeforeEach(func() {
 			kvCR := testutils.GetFakeKubeVirtClusterConfig(kvStore)
 			rolloutStrategy := v1.VMRolloutStrategyLiveUpdate
 			kvCR.Spec.Configuration.VMRolloutStrategy = &rolloutStrategy
-			kvCR.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
-				FeatureGates: []string{virtconfig.VMLiveUpdateFeaturesGate},
-			}
 			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvCR)
 		})
 		Context("configure CPU hotplug", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -860,7 +860,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 		It("should allow bigger guest memory than the memory limit if vmRolloutStrategy is set to LiveUpdate", func() {
 			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.VMLiveUpdateFeaturesGate}
 			kvConfig.Spec.Configuration.VMRolloutStrategy = ptr.To(v1.VMRolloutStrategyLiveUpdate)
 			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -308,7 +308,7 @@ var _ = Describe("test configuration", func() {
 		),
 	)
 
-	DescribeTable("when vmRolloutStrategy", func(vmRolloutStrategy *v1.VMRolloutStrategy, featureGates []string, expected bool) {
+	DescribeTable("when vmRolloutStrategy", func(vmRolloutStrategy *v1.VMRolloutStrategy, expected bool) {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKV(&v1.KubeVirt{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kubevirt",
@@ -316,9 +316,6 @@ var _ = Describe("test configuration", func() {
 			},
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
-					DeveloperConfiguration: &v1.DeveloperConfiguration{
-						FeatureGates: featureGates,
-					},
 					VMRolloutStrategy: vmRolloutStrategy,
 				},
 			},
@@ -328,17 +325,14 @@ var _ = Describe("test configuration", func() {
 		})
 		Expect(clusterConfig.IsVMRolloutStrategyLiveUpdate()).To(BeEquivalentTo(expected))
 	},
-		Entry("is nil, VMLiveUpdateFeaturesEnabled should return false",
-			nil, []string{virtconfig.VMLiveUpdateFeaturesGate}, false,
+		Entry("is nil, IsVMRolloutStrategyLiveUpdate should return false",
+			nil, false,
 		),
-		Entry("is Stage, VMLiveUpdateFeaturesEnabled should return false",
-			pointer.P(v1.VMRolloutStrategyStage), []string{virtconfig.VMLiveUpdateFeaturesGate}, false,
+		Entry("is Stage, IsVMRolloutStrategyLiveUpdate should return false",
+			pointer.P(v1.VMRolloutStrategyStage), false,
 		),
-		Entry("is LiveUpdate but the feature gate is not set, VMLiveUpdateFeaturesEnabled should return false",
-			pointer.P(v1.VMRolloutStrategyLiveUpdate), []string{}, false,
-		),
-		Entry("is LiveUpdate, VMLiveUpdateFeaturesEnabled should return true",
-			pointer.P(v1.VMRolloutStrategyLiveUpdate), []string{virtconfig.VMLiveUpdateFeaturesGate}, true,
+		Entry("is LiveUpdate, IsVMRolloutStrategyLiveUpdate should return true",
+			pointer.P(v1.VMRolloutStrategyLiveUpdate), true,
 		),
 	)
 

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -45,6 +45,8 @@ const (
 	CPUNodeDiscoveryGate   = "CPUNodeDiscovery"   // GA
 	NUMAFeatureGate        = "NUMA"               // GA
 	GPUGate                = "GPU"                // GA
+	// VMLiveUpdateFeaturesGate allows updating certain VM fields, such as CPU sockets to enable hot-plug functionality.
+	VMLiveUpdateFeaturesGate = "VMLiveUpdateFeatures" // GA
 	// Owner: @lyarwood
 	// Alpha: v1.1.0
 	// Beta:  v1.2.0
@@ -88,6 +90,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: GPUGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: HotplugNetworkIfacesGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: BochsDisplayForEFIGuests, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: VMLiveUpdateFeaturesGate, State: GA})
 
 	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Discontinued, Message: PasstDiscontinueMessage, VmiSpecUsed: passtApiUsed})
 	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -56,8 +56,6 @@ const (
 	// VMPersistentState enables persisting backend state files of VMs, such as the contents of the vTPM
 	VMPersistentState = "VMPersistentState"
 	MultiArchitecture = "MultiArchitecture"
-	// VMLiveUpdateFeaturesGate allows updating certain VM fields, such as CPU sockets to enable hot-plug functionality.
-	VMLiveUpdateFeaturesGate = "VMLiveUpdateFeatures"
 	// NetworkBindingPlugingsGate enables using a plugin to bind the pod and the VM network
 	// Alpha: v1.1.0
 	// Beta:  v1.4.0
@@ -225,10 +223,6 @@ func (config *ClusterConfig) VMPersistentStateEnabled() bool {
 
 func (config *ClusterConfig) MultiArchitectureEnabled() bool {
 	return config.isFeatureGateEnabled(MultiArchitecture)
-}
-
-func (config *ClusterConfig) VMLiveUpdateFeaturesEnabled() bool {
-	return config.isFeatureGateEnabled(VMLiveUpdateFeaturesGate)
 }
 
 func (config *ClusterConfig) NetworkBindingPlugingsEnabled() bool {

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -453,11 +453,7 @@ func (c *ClusterConfig) GetMaxHotplugRatio() uint32 {
 }
 
 func (c *ClusterConfig) IsVMRolloutStrategyLiveUpdate() bool {
-	if !c.VMLiveUpdateFeaturesEnabled() {
-		return false
-	}
 	liveConfig := c.GetConfig().VMRolloutStrategy
-
 	return liveConfig != nil && *liveConfig == v1.VMRolloutStrategyLiveUpdate
 }
 

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -46,7 +46,7 @@ var (
 	MigrationBasedHotplugNICs            = Label("migration-based-hotplug-NICs")
 	NetCustomBindingPlugins              = Label("netCustomBindingPlugins")
 	RequiresTwoSchedulableNodes          = Label("requires-two-schedulable-nodes")
-	VMLiveUpdateFeaturesGate             = Label("VMLiveUpdateFeaturesGate")
+	VMLiveUpdateRolloutStrategy          = Label("VMLiveUpdateRolloutStrategy")
 	USB                                  = Label("USB")
 	AutoResourceLimitsGate               = Label("AutoResourceLimitsGate")
 	RequiresTwoWorkerNodesWithCPUManager = Label("requires-two-worker-nodes-with-cpu-manager")

--- a/tests/hotplug/affinity.go
+++ b/tests/hotplug/affinity.go
@@ -30,7 +30,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateFeaturesGate, Serial, func() {
+var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -39,7 +39,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateFeaturesGate, Serial, func() {
+var _ = Describe("[sig-compute][Serial]CPU Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/hotplug/instancetype.go
+++ b/tests/hotplug/instancetype.go
@@ -32,7 +32,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute][Serial]Instance Type and Preference Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateFeaturesGate, Serial, func() {
+var _ = Describe("[sig-compute][Serial]Instance Type and Preference Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateFeaturesGate, Serial, func() {
+var _ = Describe("[sig-compute][Serial]Memory Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/hotplug/tolerations.go
+++ b/tests/hotplug/tolerations.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]VM Tolerations", decorators.SigCompute, decorators.VMLiveUpdateFeaturesGate, Serial, func() {
+var _ = Describe("[sig-compute]VM Tolerations", decorators.SigCompute, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -50,6 +50,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -63,7 +64,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
+var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
 		checks.SkipIfMigrationIsNotPossible()

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -74,7 +74,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 		}
 		rolloutStrategy := pointer.P(virtv1.VMRolloutStrategyLiveUpdate)
 		config.PatchWorkloadUpdateMethodAndRolloutStrategy(originalKv.Name, virtClient, updateStrategy, rolloutStrategy,
-			[]string{virtconfig.VMLiveUpdateFeaturesGate, virtconfig.VolumesUpdateStrategy, virtconfig.VolumeMigration})
+			[]string{virtconfig.VolumesUpdateStrategy, virtconfig.VolumeMigration})
 
 		currentKv := libkubevirt.GetCurrentKv(virtClient)
 		config.WaitForConfigToBePropagatedToComponent(

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -110,7 +110,6 @@ func AdjustKubeVirtResource() {
 		virtconfig.VMExportGate,
 		virtconfig.KubevirtSeccompProfile,
 		virtconfig.VMPersistentState,
-		virtconfig.VMLiveUpdateFeaturesGate,
 		virtconfig.AutoResourceLimitsGate,
 	)
 	if flags.DisableCustomSELinuxPolicy {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The `VMLiveUpdateFeatures` feature-gate has been introduced in KubeVirt v1.0.0 after being here for multiple releases and having undergone major cleanups and bug fixing I think is now ready to be GAed.

Note that this PR just GAs the feature-gate and doesn't change the default `vmRolloutStrategy` which remains `Stage`. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
GA the `VMLiveUpdateFeatures` feature-gate.
```

