### PR TITLE
Debugger support for virt-controller

### DIFF
--- a/hack/build-virt-controller-debug.sh
+++ b/hack/build-virt-controller-debug.sh
@@ -1,0 +1,42 @@
+#!/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2024 Red Hat, Inc.
+#
+set -e
+
+source hack/common.sh
+source hack/bootstrap.sh
+source hack/config.sh
+
+
+bazel build \
+    --config=${ARCHITECTURE} \
+    --@io_bazel_rules_go//go/config:gc_goopts=-N,-l \
+    --strip=never \
+    --define container_prefix= \
+    --define image_prefix= \
+    --define container_tag= \
+    //cmd/virt-controller:virt-controller-image
+
+bazel run \
+    --config=${ARCHITECTURE} \
+    --@io_bazel_rules_go//go/config:gc_goopts=-N,-l \
+    --strip=never \
+    --define container_prefix=${docker_prefix} \
+    --define image_prefix=${image_prefix} \
+    --define container_tag=debug \
+    //:push-virt-controller

--- a/hack/patch-virt-controller-debug.sh
+++ b/hack/patch-virt-controller-debug.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2024 Red Hat, Inc.
+
+# Scale down the virt-operator deployment so it won't override the patch deployed later
+cluster-up/kubectl.sh --namespace kubevirt scale deployment virt-operator --replicas=0
+cluster-up/kubectl.sh --namespace kubevirt wait --for=delete pod -l kubevirt.io=virt-operator
+
+# Patch the virt-controller deployment mainly to add a dlv container and use the debug image
+cluster-up/kubectl.sh --namespace kubevirt patch deployment virt-controller --type='json' -p '[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/-",
+    "value": {
+      "name": "dlv-debugger",
+      "image": "golang:1.23-alpine",
+      "command": [
+        "sh",
+        "-c",
+        "apk add --no-cache git bash && go install github.com/go-delve/delve/cmd/dlv@latest && \
+        dlv attach $(pgrep virt-controller) --headless --accept-multiclient --api-version 2 --listen=:2345"
+      ],
+      "securityContext": {
+        "seccompProfile": {
+          "type": "Unconfined"
+        },
+        "runAsUser": 0
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/template/spec/shareProcessNamespace",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/spec/template/spec/containers/0/image",
+    "value": "registry:5000/kubevirt/virt-controller:debug"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/replicas",
+    "value": 1
+  },
+  {
+    "op": "replace",
+    "path": "/spec/template/spec/containers/0/imagePullPolicy",
+    "value": "Always"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/template/spec/containers/0/securityContext",
+    "value": {
+      "runAsUser": 0
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/template/spec/securityContext",
+    "value": {}
+  },
+  {
+    "op": "remove",
+    "path": "/spec/template/spec/containers/0/readinessProbe"
+  },
+  {
+    "op": "remove",
+    "path": "/spec/template/spec/containers/0/livenessProbe"
+  }
+]'
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
It was hard to debug virt-controller using a debugger
After this PR:
Scripts are added such that once executed, a developer can simply use `kubectl port-forward <virt-controller pod> 2345` , point an IDE debugger to `localhost:2345`,  set a breakpoint and start debugging  
**Note** that scripts must be executed with `hack/dockerized`
Once this PR is finalized, supporting documentation  will be added
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:
The scripts do "clutter" the `hack` directory, perhaps they belong elsewhere. Please LMK
The build script needs to be and will be generic and not hardcoded to vitr-controller
As for the patch, it might not be applicable to generalize it

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


![Screenshot from 2024-10-20 18-25-26](https://github.com/user-attachments/assets/0aef631a-fec3-4191-b089-c1a8294bf6dd)
![Screenshot from 2024-10-20 18-24-14](https://github.com/user-attachments/assets/5cba3e06-b4e4-4554-b05e-75a5fba652f3)


