### PR TITLE
tests/libnode: merge two execs

### DIFF
--- a/tests/infrastructure/virt-handler.go
+++ b/tests/infrastructure/virt-handler.go
@@ -55,7 +55,7 @@ var _ = DescribeInfra("virt-handler", func() {
 		nodesWithKSM := make([]string, 0)
 		for _, node := range nodes.Items {
 			command := []string{"cat", "/sys/kernel/mm/ksm/run"}
-			_, err := libnode.ExecuteCommandInVirtHandlerPod(node.Name, command)
+			_, _, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(node.Name, command)
 			if err == nil {
 				nodesWithKSM = append(nodesWithKSM, node.Name)
 			}
@@ -114,7 +114,7 @@ var _ = DescribeInfra("virt-handler", func() {
 		for _, node := range nodesToEnableKSM {
 			Eventually(func() (string, error) {
 				command := []string{"cat", "/sys/kernel/mm/ksm/run"}
-				ksmValue, err := libnode.ExecuteCommandInVirtHandlerPod(node, command)
+				ksmValue, _, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(node, command)
 				if err != nil {
 					return "", err
 				}
@@ -138,7 +138,7 @@ var _ = DescribeInfra("virt-handler", func() {
 		for _, node := range nodesToEnableKSM {
 			Eventually(func() (string, error) {
 				command := []string{"cat", "/sys/kernel/mm/ksm/run"}
-				ksmValue, err := libnode.ExecuteCommandInVirtHandlerPod(node, command)
+				ksmValue, _, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(node, command)
 				if err != nil {
 					return "", err
 				}

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -275,14 +275,14 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			Expect(nodeName).ToNot(BeEmpty())
 
 			checkCmd := []string{"ls", sevDevicePath}
-			_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, checkCmd)
+			_, _, err = libnode.ExecuteCommandOnNodeThroughVirtHandler(nodeName, checkCmd)
 			isDevicePresent = (err == nil)
 
 			if !isDevicePresent {
 				By(fmt.Sprintf("Creating a fake SEV device on %s", nodeName))
 				mknodCmd := []string{"mknod", sevDevicePath, "c", "10", "124"}
-				_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, mknodCmd)
-				Expect(err).ToNot(HaveOccurred())
+				_, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(nodeName, mknodCmd)
+				Expect(err).ToNot(HaveOccurred(), stderr)
 			}
 
 			Eventually(func() bool {
@@ -297,8 +297,8 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			if !isDevicePresent {
 				By(fmt.Sprintf("Removing the fake SEV device from %s", nodeName))
 				rmCmd := []string{"rm", "-f", sevDevicePath}
-				_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, rmCmd)
-				Expect(err).ToNot(HaveOccurred())
+				_, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(nodeName, rmCmd)
+				Expect(err).ToNot(HaveOccurred(), stderr)
 			}
 		})
 

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -468,11 +468,3 @@ func ExecuteCommandOnNodeThroughVirtHandler(nodeName string, command []string) (
 	}
 	return exec.ExecuteCommandOnPodWithResults(virtHandlerPod, components.VirtHandlerName, command)
 }
-
-func ExecuteCommandInVirtHandlerPod(nodeName string, args []string) (stdout string, err error) {
-	stdout, stderr, err := ExecuteCommandOnNodeThroughVirtHandler(nodeName, args)
-	if err != nil {
-		return stdout, fmt.Errorf("failed excuting command=%v, error=%v, stdout=%s, stderr=%s", args, err, stdout, stderr)
-	}
-	return stdout, nil
-}

--- a/tests/storage/reservation.go
+++ b/tests/storage/reservation.go
@@ -330,11 +330,11 @@ var _ = SIGDescribe("[Serial]SCSI persistent reservation", Serial, func() {
 
 			nodes := libnode.GetAllSchedulableNodes(virtClient)
 			for _, node := range nodes.Items {
-				output, err := libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"mount"})
-				Expect(err).ToNot(HaveOccurred())
+				output, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(node.Name, []string{"mount"})
+				Expect(err).ToNot(HaveOccurred(), stderr)
 				Expect(output).ToNot(ContainSubstring("kubevirt/daemons/pr"))
-				output, err = libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"ls", reservation.GetPrHelperSocketDir()})
-				Expect(err).ToNot(HaveOccurred())
+				output, stderr, err = libnode.ExecuteCommandOnNodeThroughVirtHandler(node.Name, []string{"ls", reservation.GetPrHelperSocketDir()})
+				Expect(err).ToNot(HaveOccurred(), stderr)
 				Expect(output).To(BeEmpty())
 			}
 		})

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -50,8 +50,8 @@ var _ = Describe("[Serial][sig-compute][USB] host USB Passthrough", Serial, deco
 		// Emulated USB devices only on c9s providers. Remove this when sig-compute 1.26 is the
 		// oldest sig-compute with test with.
 		// See: https://github.com/kubevirt/project-infra/pull/2922
-		stdout, err := libnode.ExecuteCommandInVirtHandlerPod(nodeName, []string{"dmesg"})
-		Expect(err).ToNot(HaveOccurred())
+		stdout, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(nodeName, []string{"dmesg"})
+		Expect(err).ToNot(HaveOccurred(), stderr)
 		if strings.Count(stdout, "idVendor=46f4") == 0 {
 			Skip("No emulated USB devices present for functional test.")
 		}
@@ -120,8 +120,8 @@ var _ = Describe("[Serial][sig-compute][USB] host USB Passthrough", Serial, deco
 				addr := hostDevice.Source.Address
 				path := fmt.Sprintf("%sdev/bus/usb/00%s/00%s", pkgUtil.HostRootMount, addr.Bus, addr.Device)
 				cmd := []string{"stat", "--printf", `"%u %g"`, path}
-				stdout, err := libnode.ExecuteCommandInVirtHandlerPod(vmi.Status.NodeName, cmd)
-				Expect(err).ToNot(HaveOccurred())
+				stdout, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(vmi.Status.NodeName, cmd)
+				Expect(err).ToNot(HaveOccurred(), stderr)
 				Expect(stdout).Should(Equal(`"107 107"`))
 			}
 		},

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -3423,17 +3423,17 @@ func withSerialBIOS() libvmi.Option {
 	}
 }
 
-func getKvmPitMask(qemupid, nodeName string) (output string, err error) {
+func getKvmPitMask(qemupid, nodeName string) (string, error) {
 	kvmpitcomm := "kvm-pit/" + qemupid
 	args := []string{"pgrep", "-f", kvmpitcomm}
-	output, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, args)
-	Expect(err).ToNot(HaveOccurred())
+	output, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(nodeName, args)
+	Expect(err).ToNot(HaveOccurred(), stderr)
 
 	kvmpitpid := strings.TrimSpace(output)
 	tasksetcmd := "taskset -c -p " + kvmpitpid + " | cut -f2 -d:"
 	args = []string{"/bin/bash", "-c", tasksetcmd}
-	output, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, args)
-	Expect(err).ToNot(HaveOccurred())
+	output, stderr, err = libnode.ExecuteCommandOnNodeThroughVirtHandler(nodeName, args)
+	Expect(err).ToNot(HaveOccurred(), stderr)
 
 	return strings.TrimSpace(output), err
 }


### PR DESCRIPTION
Merge `libnode.ExecuteCommandInVirtHandlerPod` into `libnode.ExecuteCommandOnNodeThroughVirtHandler`.
    
The two functions are confusingly similar. I chose to keep `ExecuteCommandOnNodeThroughVirtHandler` because it's semantics is similar to `exec.ExecuteCommandOnPodWithResults`.

```release-note
NONE
```

