### PR TITLE
Fix check unassigned test

### DIFF
--- a/hack/check-unassigned-tests.sh
+++ b/hack/check-unassigned-tests.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
 main() {
-    skip="SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]|\\[sig-performance\\]|\\[sig-compute-realtime\\]|\\[sig-monitoring\\]"
+    skip="SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]|\\[sig-compute-migrations\\]|\\[sig-performance\\]|\\[sig-compute-realtime\\]|\\[sig-monitoring\\]"
     result=$(FUNC_TEST_ARGS="--dry-run --no-color -skip=${skip}" make functest)
+    total_tests=$(echo "${result}" | sed -n "s/.*Ran \([0-9]\+\) of .* Specs in .* seconds.*/\1/p")
+    if [ "${total_tests}" != "0" ]; then
+        echo "Found ${total_tests} tests not assigned to any SIG, please check: ${result}"
+        exit 1
+    fi
+    labels="!(SRIOV,GPU,sig-operator,sig-network,sig-storage,sig-compute,sig-compute-migrations,sig-performance,sig-compute-realtime,sig-monitoring)"
+    result=$(FUNC_TEST_ARGS="--dry-run --no-color --label-filter=${labels}" make functest)
     total_tests=$(echo "${result}" | sed -n "s/.*Ran \([0-9]\+\) of .* Specs in .* seconds.*/\1/p")
     if [ "${total_tests}" != "0" ]; then
         echo "Found ${total_tests} tests not assigned to any SIG, please check: ${result}"

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -15,6 +15,7 @@ var (
 	SigComputeRealtime   = Label("sig-compute-realtime")
 	SigComputeMigrations = Label("sig-compute-migrations")
 	SigMonitoring        = Label("sig-monitoring")
+	SigPerformance       = Label("sig-performance")
 
 	// HW
 	GPU         = Label("GPU")

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
+
+	"kubevirt.io/kubevirt/tests/decorators"
 )
 
 var (
@@ -54,7 +56,7 @@ func init() {
 }
 
 func SIGDescribe(text string, args ...interface{}) bool {
-	return Describe("[sig-performance][Serial] "+text, Serial, args)
+	return Describe("[sig-performance][Serial] "+text, decorators.SigPerformance, Serial, args)
 }
 
 func FSIGDescribe(text string, args ...interface{}) bool {
@@ -74,5 +76,5 @@ func skipIfNoRealtimePerformanceTests() {
 }
 
 func KWOKDescribe(text string, args ...interface{}) bool {
-	return Describe("[sig-performance]"+text, Label("KWOK", "sig-performance"), Serial, args)
+	return Describe("[sig-performance]"+text, Label("KWOK"), decorators.SigPerformance, Serial, args)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
`check-unassigned-tests` checks that there are no tests that are
not assigned to any sig.
To do that it ensures that every tests has `[sig-<sig_name>]` pattern
in the test descriptor.

This is not enough, since our `automation/test.sh` script is not
using file name based filtering anymore, but label filtering.

This means that, in case a test has the `[sig-<sig_name>]` string in
its name, but not the label, the check-unassigned-tests.sh passes but the
test is actually not executed.

Let's introduce the double check: the legacy file name based check and the
new label check.

Also, the `sig-compute-migrations` was not covered by this check, so introduced
it too.

This new check discovered that sig-performace tests were not properly labeled.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

