### PR TITLE
Remove force restart test from quarantine

### DIFF
--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -222,7 +222,7 @@ var _ = Describe("[sig-compute]Subresource Api", decorators.SigCompute, func() {
 			Expect(err).To(MatchError(ContainSubstring("VM is not running")))
 		})
 
-		It("[test_id:3007][QUARANTINE] Should force restart a VM with terminationGracePeriodSeconds>0", decorators.Quarantine, func() {
+		It("[test_id:3007] Should force restart a VM with terminationGracePeriodSeconds>0", func() {
 			By("getting a VM with high TerminationGracePeriod")
 			vm := libvmi.NewVirtualMachine(libvmifact.NewFedora(libvmi.WithTerminationGracePeriod(600)))
 			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})


### PR DESCRIPTION
### What this PR does
"Should force restart a VM with terminationGracePeriodSeconds>0" is no longer in quarantine.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

