### PR TITLE
tests/infrastructure: Simplify virt controller recovery test

### DIFF
--- a/tests/infrastructure/virt-controller-leader-election.go
+++ b/tests/infrastructure/virt-controller-leader-election.go
@@ -34,7 +34,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {
@@ -51,13 +50,10 @@ var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {
 			Eventually(libinfra.GetLeader, 30*time.Second, 5*time.Second).ShouldNot(Equal(leaderPodName))
 
 			By("Starting a new VirtualMachineInstance")
-			vmi := libvmifact.NewAlpine()
-			obj, err := virtClient.RestClient().Post().Resource(
-				"virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Get()
+			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(
+				context.Background(), libvmifact.NewGuestless(), metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			vmiObj, ok := obj.(*v1.VirtualMachineInstance)
-			Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
-			libwait.WaitForSuccessfulVMIStart(vmiObj)
+			libwait.WaitForSuccessfulVMIStart(vmi)
 		})
 	})
 })

--- a/tests/infrastructure/virt-controller-leader-election.go
+++ b/tests/infrastructure/virt-controller-leader-election.go
@@ -37,20 +37,14 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
 var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {
-	var virtClient kubecli.KubevirtClient
-
-	BeforeEach(func() {
-		virtClient = kubevirt.Client()
-	})
-
 	Context("when the controller pod is not running and an election happens", func() {
 		It("[test_id:4642]should elect a new controller pod", func() {
+			virtClient := kubevirt.Client()
 			By("Deleting the virt-controller leader pod")
 			leaderPodName := libinfra.GetLeader()
 			Expect(virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(

--- a/tests/infrastructure/virt-controller-leader-election.go
+++ b/tests/infrastructure/virt-controller-leader-election.go
@@ -23,22 +23,18 @@ import (
 	"context"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libinfra"
 	"kubevirt.io/kubevirt/tests/libvmifact"
-
-	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-
+	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/kubevirt/tests/libwait"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
-
-	"kubevirt.io/kubevirt/tests/flags"
 )
 
 var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {


### PR DESCRIPTION
This PR makes test_id:4642 slightly simpler and ever-so-slightly faster

/kind cleanup

```release-note
NONE
```

