### PR TITLE
Disable mpx only on x86

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1742,8 +1742,8 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		*/
 
 		_, exists := existingFeatures["mpx"]
-		// skip the mpx CPU feature validation for s390x as it is not supported.
-		if !isS390X(c.Architecture) && !exists && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
+		// skip the mpx CPU feature validation for anything that is not x86 as it is not supported.
+		if isAMD64(c.Architecture) && !exists && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
 			domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
 				Name:   "mpx",
 				Policy: "disable",

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -39,6 +39,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -921,20 +922,16 @@ var _ = Describe("Converter", func() {
 			})
 		})
 
-		DescribeTable("CPU mpx feature", func(arch string, hasMPX bool) {
+		DescribeTable("CPU mpx feature", func(arch string, matcher types.GomegaMatcher) {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			c.Architecture = arch
 			vmi.Spec.Domain.CPU = &v1.CPU{}
 			domain := vmiToDomain(vmi, c)
-			if hasMPX {
-				Expect(domain.Spec.CPU.Features).To(HaveExactElements(api.CPUFeature{Name: "mpx", Policy: "disable"}))
-			} else {
-				Expect(domain.Spec.CPU.Features).To(BeNil())
-			}
+			Expect(domain.Spec.CPU.Features).To(matcher)
 		},
-			Entry("should be nil for s390x", "s390x", false),
-			Entry("should be present for amd64", "amd64", true),
-			Entry("should be present for arm64", "arm64", true),
+			Entry("should be nil for s390x", "s390x", BeNil()),
+			Entry("should be present for amd64", "amd64", HaveExactElements(api.CPUFeature{Name: "mpx", Policy: "disable"})),
+			Entry("should be nil for arm64", "arm64", BeNil()),
 		)
 
 		Context("when downwardMetrics are exposed via virtio-serial", func() {


### PR DESCRIPTION
### What this PR does

User reported
```
{"component":"virt-launcher","kind":"","level":"error","msg":"Failed to start VirtualMachineInstance with flags 0.","name":"ygal","namespace":"default","pos":"manager.go:1246","reason":"virError(Code=67, Domain=31, Message='unsupported configuration: unknown CPU feature: mpx')","timestamp":"2024-10-25T14:17:53.539424Z","uid":"c16487ce-a18e-42b2-8713-e004691fd139"}
```
from ARM env that is running emulation.

This PR is fixing the issue.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

