### PR TITLE
[release-1.2] Allow modifications to VM spec during VM snapshot, except disks/volumes

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -713,10 +713,17 @@ func validateSnapshotStatus(ar *admissionv1.AdmissionRequest, vm *v1.VirtualMach
 		}}
 	}
 
-	if !equality.Semantic.DeepEqual(oldVM.Spec, vm.Spec) {
+	if !compareVolumes(oldVM.Spec.Template.Spec.Volumes, vm.Spec.Template.Spec.Volumes) {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueNotSupported,
-			Message: fmt.Sprintf("Cannot update VM spec until snapshot %q completes", *vm.Status.SnapshotInProgress),
+			Message: fmt.Sprintf("Cannot update VM disks or volumes until snapshot %q completes", *vm.Status.SnapshotInProgress),
+			Field:   k8sfield.NewPath("spec").String(),
+		}}
+	}
+	if !compareRunningSpec(&oldVM.Spec, &vm.Spec) {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: fmt.Sprintf("Cannot update VM running state until snapshot %q completes", *vm.Status.SnapshotInProgress),
 			Field:   k8sfield.NewPath("spec").String(),
 		}}
 	}
@@ -735,4 +742,34 @@ func (admitter *VMsAdmitter) isMigrationInProgress(vmi *v1.VirtualMachineInstanc
 		return fmt.Errorf("cannot update while VMI migration is in progress: %v", err)
 	}
 	return nil
+}
+
+func compareVolumes(old, new []v1.Volume) bool {
+	if len(old) != len(new) {
+		return false
+	}
+
+	for i, volume := range old {
+		if !equality.Semantic.DeepEqual(volume, new[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func compareRunningSpec(old, new *v1.VirtualMachineSpec) bool {
+	if old == nil || new == nil {
+		// This should never happen, but just in case return false
+		return false
+	}
+
+	// Its impossible to get here while both running and RunStrategy are nil.
+	if old.Running != nil && new.Running != nil {
+		return *old.Running == *new.Running
+	}
+	if old.RunStrategy != nil && new.RunStrategy != nil {
+		return *old.RunStrategy == *new.RunStrategy
+	}
+	return false
 }


### PR DESCRIPTION
Manual backport of pull request #13001

```release-note
Relaxed check on modify VM spec during VM snapshot to only check disks/volumes
```