### PR TITLE
Improve network-status processing

### DIFF
--- a/pkg/network/deviceinfo/BUILD.bazel
+++ b/pkg/network/deviceinfo/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/network/deviceinfo",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/multus:go_default_library",
         "//pkg/network/namescheme:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",

--- a/pkg/network/deviceinfo/deviceinfo.go
+++ b/pkg/network/deviceinfo/deviceinfo.go
@@ -20,9 +20,6 @@
 package deviceinfo
 
 import (
-	"encoding/json"
-	"fmt"
-
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -32,13 +29,10 @@ import (
 )
 
 func MapNetworkNameToDeviceInfo(networks []v1.Network,
-	networkStatusAnnotationValue string,
 	interfaces []v1.Interface,
-) (map[string]*networkv1.DeviceInfo, error) {
-	multusInterfaceNameToNetworkStatus, err := mapMultusInterfaceNameToNetworkStatus(networkStatusAnnotationValue)
-	if err != nil {
-		return nil, err
-	}
+	networkStatuses []networkv1.NetworkStatus,
+) map[string]*networkv1.DeviceInfo {
+	multusInterfaceNameToNetworkStatus := multus.NetworkStatusesByPodIfaceName(networkStatuses)
 	networkNameScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, multusInterfaceNameToNetworkStatus)
 
 	networkDeviceInfo := map[string]*networkv1.DeviceInfo{}
@@ -51,17 +45,5 @@ func MapNetworkNameToDeviceInfo(networks []v1.Network,
 			// it may mean the interface is not plugged yet
 		}
 	}
-	return networkDeviceInfo, nil
-}
-
-func mapMultusInterfaceNameToNetworkStatus(networkStatusAnnotationValue string) (map[string]networkv1.NetworkStatus, error) {
-	if networkStatusAnnotationValue == "" {
-		return nil, fmt.Errorf("network-status annotation is not present")
-	}
-	var networkStatusList []networkv1.NetworkStatus
-	if err := json.Unmarshal([]byte(networkStatusAnnotationValue), &networkStatusList); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal network-status annotation: %v", err)
-	}
-
-	return multus.NetworkStatusesByPodIfaceName(networkStatusList), nil
+	return networkDeviceInfo
 }

--- a/pkg/network/deviceinfo/deviceinfo.go
+++ b/pkg/network/deviceinfo/deviceinfo.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/network/multus"
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 )
 
@@ -62,10 +63,5 @@ func mapMultusInterfaceNameToNetworkStatus(networkStatusAnnotationValue string) 
 		return nil, fmt.Errorf("failed to unmarshal network-status annotation: %v", err)
 	}
 
-	multusInterfaceNameToNetworkStatusMap := map[string]networkv1.NetworkStatus{}
-	for _, networkStatus := range networkStatusList {
-		multusInterfaceNameToNetworkStatusMap[networkStatus.Interface] = networkStatus
-	}
-
-	return multusInterfaceNameToNetworkStatusMap, nil
+	return multus.NetworkStatusesByPodIfaceName(networkStatusList), nil
 }

--- a/pkg/network/deviceinfo/deviceinfo.go
+++ b/pkg/network/deviceinfo/deviceinfo.go
@@ -33,11 +33,11 @@ func MapNetworkNameToDeviceInfo(networks []v1.Network,
 	networkStatuses []networkv1.NetworkStatus,
 ) map[string]*networkv1.DeviceInfo {
 	multusInterfaceNameToNetworkStatus := multus.NetworkStatusesByPodIfaceName(networkStatuses)
-	networkNameScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, multusInterfaceNameToNetworkStatus)
+	podIfaceNamesByNetworkName := namescheme.CreateFromNetworkStatuses(networks, networkStatuses)
 
 	networkDeviceInfo := map[string]*networkv1.DeviceInfo{}
 	for _, iface := range interfaces {
-		multusInterfaceName := networkNameScheme[iface.Name]
+		multusInterfaceName := podIfaceNamesByNetworkName[iface.Name]
 		networkStatusEntry, exist := multusInterfaceNameToNetworkStatus[multusInterfaceName]
 		if exist && networkStatusEntry.DeviceInfo != nil {
 			networkDeviceInfo[iface.Name] = networkStatusEntry.DeviceInfo

--- a/pkg/network/multus/status.go
+++ b/pkg/network/multus/status.go
@@ -40,19 +40,6 @@ func NetworkStatusesByPodIfaceName(networkStatuses []networkv1.NetworkStatus) ma
 	return statusesByPodIfaceName
 }
 
-func NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses []networkv1.NetworkStatus) map[string]networkv1.NetworkStatus {
-	indexedNetworkStatus := map[string]networkv1.NetworkStatus{}
-
-	for _, ns := range networkStatuses {
-		if ns.Default {
-			continue
-		}
-		indexedNetworkStatus[ns.Interface] = ns
-	}
-
-	return indexedNetworkStatus
-}
-
 func NetworkStatusesFromPod(pod *k8scorev1.Pod) []networkv1.NetworkStatus {
 	var networkStatuses []networkv1.NetworkStatus
 

--- a/pkg/network/multus/status.go
+++ b/pkg/network/multus/status.go
@@ -29,6 +29,17 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
+// NetworkStatusesByPodIfaceName creates a map of NetworkStatus objects by pod interface name.
+func NetworkStatusesByPodIfaceName(networkStatuses []networkv1.NetworkStatus) map[string]networkv1.NetworkStatus {
+	statusesByPodIfaceName := map[string]networkv1.NetworkStatus{}
+
+	for _, ns := range networkStatuses {
+		statusesByPodIfaceName[ns.Interface] = ns
+	}
+
+	return statusesByPodIfaceName
+}
+
 func NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses []networkv1.NetworkStatus) map[string]networkv1.NetworkStatus {
 	indexedNetworkStatus := map[string]networkv1.NetworkStatus{}
 

--- a/pkg/network/multus/status_test.go
+++ b/pkg/network/multus/status_test.go
@@ -33,6 +33,22 @@ import (
 )
 
 var _ = Describe("Network Status", func() {
+	Context("NetworkStatusesByPodIfaceName", func() {
+		It("Should map network statuses by pod interface name with multiple networks", func() {
+			networkStatuses := []networkv1.NetworkStatus{
+				{Name: "cluster-default", Interface: "eth0"},
+				{Name: "meganet", Interface: "pod7e0055a6880"},
+			}
+
+			expected := map[string]networkv1.NetworkStatus{
+				"eth0":           {Name: "cluster-default", Interface: "eth0"},
+				"pod7e0055a6880": {Name: "meganet", Interface: "pod7e0055a6880"},
+			}
+
+			Expect(multus.NetworkStatusesByPodIfaceName(networkStatuses)).To(Equal(expected))
+		})
+	})
+
 	Context("NonDefaultNetworkStatusIndexedByPodIfaceName", func() {
 		DescribeTable("It should return empty", func(networkStatuses []networkv1.NetworkStatus) {
 			Expect(multus.NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses)).To(BeEmpty())

--- a/pkg/network/multus/status_test.go
+++ b/pkg/network/multus/status_test.go
@@ -49,54 +49,6 @@ var _ = Describe("Network Status", func() {
 		})
 	})
 
-	Context("NonDefaultNetworkStatusIndexedByPodIfaceName", func() {
-		DescribeTable("It should return empty", func(networkStatuses []networkv1.NetworkStatus) {
-			Expect(multus.NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses)).To(BeEmpty())
-		},
-			Entry("when network-status is empty", []networkv1.NetworkStatus{}),
-			Entry("when network-status contains only pod network",
-				[]networkv1.NetworkStatus{
-					{
-						Name:    "k8s-pod-network",
-						IPs:     []string{"10.244.196.146", "fd10:244::c491"},
-						Default: true,
-						DNS:     networkv1.DNS{},
-					},
-				},
-			),
-		)
-
-		It("Should return a map of pod interface name to network status containing just secondary networks", func() {
-			networkStatuses := []networkv1.NetworkStatus{
-				{
-					Name:    "k8s-pod-network",
-					IPs:     []string{"10.244.196.146", "fd10:244::c491"},
-					Default: true,
-					DNS:     networkv1.DNS{},
-				},
-				{
-					Name:      "meganet",
-					Interface: "pod7e0055a6880",
-					Mac:       "8a:37:d9:e7:0f:18",
-					DNS:       networkv1.DNS{},
-				},
-			}
-
-			result := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses)
-
-			expectedResult := map[string]networkv1.NetworkStatus{
-				"pod7e0055a6880": {
-					Name:      "meganet",
-					Interface: "pod7e0055a6880",
-					Mac:       "8a:37:d9:e7:0f:18",
-					Default:   false,
-				},
-			}
-
-			Expect(result).To(Equal(expectedResult))
-		})
-	})
-
 	Context("NetworkStatusesFromPod", func() {
 		DescribeTable("should return an empty slice", func(podAnnotations map[string]string) {
 			Expect(multus.NetworkStatusesFromPod(newStubPod(podAnnotations))).To(BeEmpty())

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -134,6 +134,18 @@ func CreateNetworkNameSchemeByPodNetworkStatus(networks []v1.Network, networkSta
 	return CreateHashedNetworkNameScheme(networks)
 }
 
+// CreateFromNetworkStatuses creates a mapping of network name to pod interface name
+// based on the given VMI spec networks and pod network statuses.
+// In case the pod network status list has at least one interface with ordinal interface name -
+// the function will return an ordinal network name-scheme.
+func CreateFromNetworkStatuses(networks []v1.Network, networkStatuses []networkv1.NetworkStatus) map[string]string {
+	if PodHasOrdinalInterfaceName2(networkStatuses) {
+		return CreateOrdinalNetworkNameScheme(networks)
+	}
+
+	return CreateHashedNetworkNameScheme(networks)
+}
+
 // PodHasOrdinalInterfaceName check if the given pod network status has at least one pod interface with ordinal name
 func PodHasOrdinalInterfaceName(podNetworkStatus map[string]networkv1.NetworkStatus) bool {
 	for _, networkStatus := range podNetworkStatus {

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -122,18 +122,6 @@ func generateOrdinalInterfaceName(idx int) string {
 	return fmt.Sprintf("%s%d", ordinalIfacePrefix, idx)
 }
 
-// CreateNetworkNameSchemeByPodNetworkStatus create pod network name scheme according to the given VMI spec networks
-// and pod network status.
-// In case the pod network status has at least one interface with ordinal interface name it returns the ordinal network
-// name-scheme, Otherwise, returns the hashed network name scheme.
-func CreateNetworkNameSchemeByPodNetworkStatus(networks []v1.Network, networkStatus map[string]networkv1.NetworkStatus) map[string]string {
-	if PodHasOrdinalInterfaceName(networkStatus) {
-		return CreateOrdinalNetworkNameScheme(networks)
-	}
-
-	return CreateHashedNetworkNameScheme(networks)
-}
-
 // CreateFromNetworkStatuses creates a mapping of network name to pod interface name
 // based on the given VMI spec networks and pod network statuses.
 // In case the pod network status list has at least one interface with ordinal interface name -
@@ -144,16 +132,6 @@ func CreateFromNetworkStatuses(networks []v1.Network, networkStatuses []networkv
 	}
 
 	return CreateHashedNetworkNameScheme(networks)
-}
-
-// PodHasOrdinalInterfaceName check if the given pod network status has at least one pod interface with ordinal name
-func PodHasOrdinalInterfaceName(podNetworkStatus map[string]networkv1.NetworkStatus) bool {
-	for _, networkStatus := range podNetworkStatus {
-		if OrdinalSecondaryInterfaceName(networkStatus.Interface) {
-			return true
-		}
-	}
-	return false
 }
 
 // PodHasOrdinalInterfaceName2 checks if the given pod network status has at least one pod interface with ordinal name

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -127,15 +127,15 @@ func generateOrdinalInterfaceName(idx int) string {
 // In case the pod network status list has at least one interface with ordinal interface name -
 // the function will return an ordinal network name-scheme.
 func CreateFromNetworkStatuses(networks []v1.Network, networkStatuses []networkv1.NetworkStatus) map[string]string {
-	if PodHasOrdinalInterfaceName2(networkStatuses) {
+	if PodHasOrdinalInterfaceName(networkStatuses) {
 		return CreateOrdinalNetworkNameScheme(networks)
 	}
 
 	return CreateHashedNetworkNameScheme(networks)
 }
 
-// PodHasOrdinalInterfaceName2 checks if the given pod network status has at least one pod interface with ordinal name
-func PodHasOrdinalInterfaceName2(networkStatuses []networkv1.NetworkStatus) bool {
+// PodHasOrdinalInterfaceName checks if the given pod network status has at least one pod interface with ordinal name
+func PodHasOrdinalInterfaceName(networkStatuses []networkv1.NetworkStatus) bool {
 	for _, networkStatus := range networkStatuses {
 		if OrdinalSecondaryInterfaceName(networkStatus.Interface) {
 			return true

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -105,63 +105,6 @@ var _ = Describe("Network Name Scheme", func() {
 			}),
 	)
 
-	Context("CreateNetworkNameSchemeByPodNetworkStatus", func() {
-		const (
-			redNetworkName      = "red"
-			redIfaceHashedName  = "podb1f51a511f1"
-			redIfaceOrdinalName = "net1"
-
-			greenNetworkName      = "green"
-			greenIfaceHashedName  = "podba4788b226a"
-			greenIfaceOrdinalName = "net2"
-		)
-
-		DescribeTable("should return mapping between VMI networks and the pod interfaces names according to Multus network-status annotation",
-			func(networks []virtv1.Network, networkStatus map[string]networkv1.NetworkStatus, expectedNameScheme map[string]string) {
-				Expect(namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, networkStatus)).To(Equal(expectedNameScheme))
-			},
-			Entry("when Multus network-status annotation is absent",
-				multusNetworks(redNetworkName, greenNetworkName),
-				map[string]networkv1.NetworkStatus{},
-				map[string]string{
-					redNetworkName:   redIfaceHashedName,
-					greenNetworkName: greenIfaceHashedName,
-				},
-			),
-			Entry("given only pod network",
-				[]virtv1.Network{newPodNetwork()},
-				map[string]networkv1.NetworkStatus{
-					"default": {Interface: namescheme.PrimaryPodInterfaceName},
-				},
-				map[string]string{
-					"default": namescheme.PrimaryPodInterfaceName,
-				},
-			),
-			Entry("when the annotation reflects the pod interfaces naming is hashed",
-				multusNetworks(redNetworkName, greenNetworkName),
-				map[string]networkv1.NetworkStatus{
-					redNetworkName:   {Interface: redIfaceHashedName},
-					greenNetworkName: {Interface: greenIfaceHashedName},
-				},
-				map[string]string{
-					redNetworkName:   redIfaceHashedName,
-					greenNetworkName: greenIfaceHashedName,
-				},
-			),
-			Entry("when the annotation reflects the pod interface naming is ordinal",
-				multusNetworks(redNetworkName, greenNetworkName),
-				map[string]networkv1.NetworkStatus{
-					redNetworkName:   {Interface: redIfaceOrdinalName},
-					greenNetworkName: {Interface: greenIfaceOrdinalName},
-				},
-				map[string]string{
-					redNetworkName:   redIfaceOrdinalName,
-					greenNetworkName: greenIfaceOrdinalName,
-				},
-			),
-		)
-	})
-
 	Context("CreateFromNetworkStatuses", func() {
 		const (
 			network1Name         = "red"
@@ -197,37 +140,6 @@ var _ = Describe("Network Name Scheme", func() {
 				[]networkv1.NetworkStatus{{Interface: podIface1OrdinalName}, {Interface: podIface2OrdinalName}},
 				map[string]string{network1Name: podIface1OrdinalName, network2Name: podIface2OrdinalName},
 			),
-		)
-	})
-
-	Context("PodHasOrdinalInterfaceName", func() {
-		DescribeTable("should return TRUE, given network status with ordinal interface names",
-			func(podNetworkStatus map[string]networkv1.NetworkStatus) {
-				Expect(namescheme.PodHasOrdinalInterfaceName(podNetworkStatus)).To(BeTrue())
-			},
-			Entry("with primary pod network interface", map[string]networkv1.NetworkStatus{
-				"A": {Interface: "eth0"},
-				"B": {Interface: "net1"},
-				"C": {Interface: "net2"},
-			}),
-			Entry("without primary pod network interface", map[string]networkv1.NetworkStatus{
-				"A": {Interface: "net1"},
-				"B": {Interface: "net2"},
-			}),
-		)
-		DescribeTable("should return FALSE, given network status with hashed interface names",
-			func(podNetworkStatus map[string]networkv1.NetworkStatus) {
-				Expect(namescheme.PodHasOrdinalInterfaceName(podNetworkStatus)).To(BeFalse())
-			},
-			Entry("with primary pod network interface", map[string]networkv1.NetworkStatus{
-				"A": {Interface: "eth0"},
-				"B": {Interface: "podb1f51a511f1"},
-				"C": {Interface: "pod16477688c0e"},
-			}),
-			Entry("without primary pod network interface", map[string]networkv1.NetworkStatus{
-				"A": {Interface: "podb1f51a511f1"},
-				"B": {Interface: "pod16477688c0e"},
-			}),
 		)
 	})
 

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -143,10 +143,10 @@ var _ = Describe("Network Name Scheme", func() {
 		)
 	})
 
-	Context("PodHasOrdinalInterfaceName2", func() {
+	Context("PodHasOrdinalInterfaceName", func() {
 		DescribeTable("should return TRUE, given network status with ordinal interface names",
 			func(podNetworkStatuses []networkv1.NetworkStatus) {
-				Expect(namescheme.PodHasOrdinalInterfaceName2(podNetworkStatuses)).To(BeTrue())
+				Expect(namescheme.PodHasOrdinalInterfaceName(podNetworkStatuses)).To(BeTrue())
 			},
 			Entry("with primary pod network interface",
 				[]networkv1.NetworkStatus{
@@ -163,7 +163,7 @@ var _ = Describe("Network Name Scheme", func() {
 
 		DescribeTable("should return FALSE",
 			func(podNetworkStatuses []networkv1.NetworkStatus) {
-				Expect(namescheme.PodHasOrdinalInterfaceName2(podNetworkStatuses)).To(BeFalse())
+				Expect(namescheme.PodHasOrdinalInterfaceName(podNetworkStatuses)).To(BeFalse())
 			},
 			Entry("When networks statutes is empty", []networkv1.NetworkStatus{}),
 			Entry("when networks statutes has primary pod and hashed secondary network interface",

--- a/pkg/network/pod/annotations/BUILD.bazel
+++ b/pkg/network/pod/annotations/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/network/vmispec:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -80,7 +80,7 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 
 // GenerateFromSource generates ordinal pod interfaces naming scheme for a migration target in case the migration source pod uses it
 func (g Generator) GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8Scorev1.Pod) (map[string]string, error) {
-	if !namescheme.PodHasOrdinalInterfaceName2(multus.NetworkStatusesFromPod(sourcePod)) {
+	if !namescheme.PodHasOrdinalInterfaceName(multus.NetworkStatusesFromPod(sourcePod)) {
 		return nil, nil
 	}
 

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -26,8 +26,6 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
-	"kubevirt.io/client-go/log"
-
 	"kubevirt.io/kubevirt/pkg/network/deviceinfo"
 	"kubevirt.io/kubevirt/pkg/network/downwardapi"
 	"kubevirt.io/kubevirt/pkg/network/istio"
@@ -107,12 +105,7 @@ func (g Generator) GenerateFromActivePod(vmi *v1.VirtualMachineInstance, pod *k8
 		return iface.SRIOV != nil || vmispec.HasBindingPluginDeviceInfo(iface, g.clusterConfig.GetNetworkBindings())
 	})
 
-	networkStatusAnnotation := pod.Annotations[networkv1.NetworkStatusAnnot]
-	networkDeviceInfoMap, err := deviceinfo.MapNetworkNameToDeviceInfo(vmi.Spec.Networks, networkStatusAnnotation, ifaces)
-	if err != nil {
-		log.Log.Warningf("failed to create network device-info-map: %v", err)
-	}
-
+	networkDeviceInfoMap := deviceinfo.MapNetworkNameToDeviceInfo(vmi.Spec.Networks, ifaces, multus.NetworkStatusesFromPod(pod))
 	if len(networkDeviceInfoMap) == 0 {
 		return nil
 	}

--- a/pkg/network/vmicontroller/status.go
+++ b/pkg/network/vmicontroller/status.go
@@ -98,7 +98,7 @@ func calculateSecondaryIfaceStatuses(
 ) ([]v1.VirtualMachineInstanceNetworkInterface, error) {
 	var interfaceStatuses []v1.VirtualMachineInstanceNetworkInterface
 
-	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses)
+	networkStatusesByPodIfaceName := multus.NetworkStatusesByPodIfaceName(networkStatuses)
 	podIfaceNamesByNetworkName := namescheme.CreateFromNetworkStatuses(vmi.Spec.Networks, networkStatuses)
 	for _, network := range vmispec.FilterMultusNonDefaultNetworks(vmi.Spec.Networks) {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)
@@ -107,7 +107,7 @@ func calculateSecondaryIfaceStatuses(
 			return nil, fmt.Errorf("could not find the pod interface name for network [%s]", network.Name)
 		}
 
-		_, exists := indexedMultusStatusIfaces[podIfaceName]
+		_, exists := networkStatusesByPodIfaceName[podIfaceName]
 		switch {
 		case exists && vmiIfaceStatus == nil:
 			interfaceStatuses = append(interfaceStatuses, v1.VirtualMachineInstanceNetworkInterface{

--- a/pkg/network/vmicontroller/status.go
+++ b/pkg/network/vmicontroller/status.go
@@ -99,10 +99,10 @@ func calculateSecondaryIfaceStatuses(
 	var interfaceStatuses []v1.VirtualMachineInstanceNetworkInterface
 
 	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(networkStatuses)
-	ifaceNamingScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(vmi.Spec.Networks, indexedMultusStatusIfaces)
+	podIfaceNamesByNetworkName := namescheme.CreateFromNetworkStatuses(vmi.Spec.Networks, networkStatuses)
 	for _, network := range vmispec.FilterMultusNonDefaultNetworks(vmi.Spec.Networks) {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)
-		podIfaceName, wasFound := ifaceNamingScheme[network.Name]
+		podIfaceName, wasFound := podIfaceNamesByNetworkName[network.Name]
 		if !wasFound {
 			return nil, fmt.Errorf("could not find the pod interface name for network [%s]", network.Name)
 		}

--- a/pkg/virt-controller/network/vmcontroller.go
+++ b/pkg/virt-controller/network/vmcontroller.go
@@ -130,7 +130,7 @@ func (v *VMNetController) hasOrdinalNetworkInterfaces(vmi *v1.VirtualMachineInst
 		// This is an old virt-launcher that uses ordinal network interface names.
 		return true, nil
 	}
-	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName2(multus.NetworkStatusesFromPod(pod))
+	hasOrdinalIfaces := namescheme.PodHasOrdinalInterfaceName(multus.NetworkStatusesFromPod(pod))
 	return hasOrdinalIfaces, nil
 }
 

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -2175,9 +2175,8 @@ func (c *Controller) getVolumePhaseMessageReason(volume *virtv1.Volume, namespac
 func (c *Controller) updateMultusAnnotation(namespace string, interfaces []virtv1.Interface, networks []virtv1.Network, pod *k8sv1.Pod) error {
 	podAnnotations := pod.GetAnnotations()
 
-	indexedMultusStatusIfaces := multus.NonDefaultNetworkStatusIndexedByPodIfaceName(multus.NetworkStatusesFromPod(pod))
-	networkToPodIfaceMap := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, indexedMultusStatusIfaces)
-	multusAnnotations, err := multus.GenerateCNIAnnotationFromNameScheme(namespace, interfaces, networks, networkToPodIfaceMap, c.clusterConfig)
+	podIfaceNamesByNetworkName := namescheme.CreateFromNetworkStatuses(networks, multus.NetworkStatusesFromPod(pod))
+	multusAnnotations, err := multus.GenerateCNIAnnotationFromNameScheme(namespace, interfaces, networks, podIfaceNamesByNetworkName, c.clusterConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The value of the pod's `k8s.v1.cni.cncf.io/network-status` annotation is used for:
1. Updating the VMI's interfaces status.
2. Calculating the value of the `kubevirt.io/network-info` annotation.
3. Creating an ordinal naming scheme for a migration target pod in case the source pod uses it.
4. Discovering whether the VMI uses an ordinal naming scheme in VM Controller.

This PR:
1. Centralizes the logic responsible for parsing the value of the `k8s.v1.cni.cncf.io/network-status` annotation under `pkg/network/multus`.
2. Uses processed Go structs where applicable instead of raw strings.
3. Removes unnecessary mapping of NetworkStatus by pod interface name.
4. Cleans up after #13018.
 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note
None
```

