### PR TITLE
[release-1.1] Allow modifications to VM spec during VM snapshot, except disks/volumes

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1538,6 +1538,17 @@ var _ = Describe("Validating VM Admitter", func() {
 
 	DescribeTable("when snapshot is in progress, should", func(mutateFn func(*v1.VirtualMachine) bool) {
 		vmi := api.NewMinimalVMI("testvmi")
+		vmi.Spec.Domain.Devices.Disks = []v1.Disk{
+			{
+				Name: "orginalvolume",
+			},
+		}
+		vmi.Spec.Volumes = []v1.Volume{
+			{
+				Name:         "orginalvolume",
+				VolumeSource: v1.VolumeSource{EmptyDisk: &v1.EmptyDiskSource{}},
+			},
+		}
 		vm := &v1.VirtualMachine{
 			Spec: v1.VirtualMachineSpec{
 				Running: &[]bool{false}[0],
@@ -1572,11 +1583,52 @@ var _ = Describe("Validating VM Admitter", func() {
 
 		if !allow {
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
-			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
+			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"), resp.Result.Details.Causes[0].Message)
 		}
 	},
-		Entry("reject update to spec", func(vm *v1.VirtualMachine) bool {
+		Entry("reject update to disks", func(vm *v1.VirtualMachine) bool {
+			vm.Spec.Template.Spec.Domain.Devices.Disks = []v1.Disk{
+				{
+					Name: "testvolume",
+				},
+			}
+			vm.Spec.Template.Spec.Volumes = []v1.Volume{
+				{
+					Name:         "testvolume",
+					VolumeSource: v1.VolumeSource{EmptyDisk: &v1.EmptyDiskSource{}},
+				},
+			}
+			return false
+		}),
+		Entry("reject adding volumes", func(vm *v1.VirtualMachine) bool {
+			vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testvolume",
+			})
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name:         "testvolume",
+				VolumeSource: v1.VolumeSource{EmptyDisk: &v1.EmptyDiskSource{}},
+			})
+			return false
+		}),
+		Entry("reject update to volumees", func(vm *v1.VirtualMachine) bool {
+			vm.Spec.Template.Spec.Volumes[0].VolumeSource = v1.VolumeSource{DataVolume: &v1.DataVolumeSource{Name: "fake"}}
+			return false
+		}),
+		Entry("accept update to spec, that is not volumes or running state", func(vm *v1.VirtualMachine) bool {
+			vm.Spec.Template.Spec.Affinity = &k8sv1.Affinity{}
+			return true
+		}),
+		Entry("reject update to running state", func(vm *v1.VirtualMachine) bool {
 			vm.Spec.Running = &[]bool{true}[0]
+			return false
+		}),
+		Entry("accept update to running state, if value doesn't change", func(vm *v1.VirtualMachine) bool {
+			vm.Spec.Running = &[]bool{false}[0]
+			return true
+		}),
+		Entry("reject update to running state, when switch state type", func(vm *v1.VirtualMachine) bool {
+			vm.Spec.Running = nil
+			vm.Spec.RunStrategy = &runStrategyManual
 			return false
 		}),
 		Entry("accept update to metadata", func(vm *v1.VirtualMachine) bool {


### PR DESCRIPTION
Manual backport of pull request #13001

```release-note
Relaxed check on modify VM spec during VM snapshot to only check disks/volumes
```