### PR TITLE
test: increase destination size for migrating block to fs

### DIFF
--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -363,6 +363,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 
 		It("should migrate the source volume from a block source and filesystem destination DVs", func() {
 			volName := "disk0"
+			dstSize := "1.2Gi"
 			sc, exist := libstorage.GetRWOBlockStorageClass()
 			Expect(exist).To(BeTrue())
 			srcDV := libdv.NewDataVolume(
@@ -381,7 +382,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			destDV := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
-					libdv.StorageWithVolumeSize(size),
+					libdv.StorageWithVolumeSize(dstSize),
 					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
 				),
 			)


### PR DESCRIPTION
Migrating for a storage class to another could create some mistmatches in the size. We detected the failure:

```
Live migration failed error encountered during MigrateToURI3 libvirt api call: virError(Code=1, Domain=10, Message='internal error: process exited while connecting to monitor: 2024-10-29T00:13:55.746105Z qemu-kvm: -blockdev {\"driver\":\"raw\",\"file\":\"libvirt-2-storage\",\"offset\":0,\"size\":1073741824,\"node-name\":\"libvirt-2-slice-sto\",\"read-only\":false,\"discard\":\"unmap\",\"cache\":{\"direct\":true,\"no-flush\":false}}: The sum of offset (0) and size (0) has to be smaller or equal to the  actual size of the containing file (947912704)')
```

Therefore, increase the size of the destination in the test to be sure that we don't have these mistmatches in the destination.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

