### PR TITLE
vmi-create-admitter refactor: change tests to test behavior instead of implementation details

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -129,14 +129,16 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	})
 
 	It("should allow Clock without Timer", func() {
-		vmi := api.NewMinimalVMI("testvmi")
-		vmi.Spec.Domain.Clock = &v1.Clock{
-			ClockOffset: v1.ClockOffset{
-				UTC: &v1.ClockOffsetUTC{
-					OffsetSeconds: pointer.P(5),
+		const offsetSeconds = 5
+		vmi := newBaseVmi(withDomainClock(
+			&v1.Clock{
+				ClockOffset: v1.ClockOffset{
+					UTC: &v1.ClockOffsetUTC{
+						OffsetSeconds: pointer.P(offsetSeconds),
+					},
 				},
 			},
-		}
+		))
 
 		ar, err := newAdmissionReviewForVMICreation(vmi)
 		Expect(err).ToNot(HaveOccurred())
@@ -4433,4 +4435,10 @@ func newAdmissionReviewForVMICreation(vmi *v1.VirtualMachineInstance) (*admissio
 			Operation: admissionv1.Create,
 		},
 	}, err
+}
+
+func withDomainClock(clock *v1.Clock) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Clock = clock
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

The vmi-create-admitter tests are currently somewhat inconsistent, with many tests focusing on implementation details rather than actual behavior. Additionally, different approaches are used for object instantiation, such as `newBaseVmi` (which relies on `libvmi`) and `api.NewMinimalVMI` (which does not).

**After this PR:**

This PR lays the groundwork for refactoring the vmi-create-admitter tests based on the following criteria:
* Refocus all test cases on behavior rather than implementation details.
* Remove code redundancy (e.g., duplicate AdmissionReview instantiations).
* Standardize VMI instantiation using `libvmi`, establishing it as the primary method for VMI construction.

This PR specifically addresses tests outside of any Context, applying all the outlined changes. The ultimate goal is to achieve a more concise, consistent, and organized set of tests.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

