### PR TITLE
Avoid NPE when getting filesystem overhead

### DIFF
--- a/pkg/storage/types/BUILD.bazel
+++ b/pkg/storage/types/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cdi_test.go",
         "dv_test.go",
         "pvc_test.go",
         "types_suite_test.go",

--- a/pkg/storage/types/cdi.go
+++ b/pkg/storage/types/cdi.go
@@ -40,18 +40,21 @@ const (
 var ErrFailedToFindCdi error = errors.New("No CDI instances found")
 var ErrMultipleCdiInstances error = errors.New("Detected more than one CDI instance")
 
-func GetFilesystemOverhead(volumeMode *k8sv1.PersistentVolumeMode, storageClass *string, cdiConfig *cdiv1.CDIConfig) virtv1.Percent {
+func GetFilesystemOverhead(volumeMode *k8sv1.PersistentVolumeMode, storageClass *string, cdiConfig *cdiv1.CDIConfig) (virtv1.Percent, error) {
 	if IsPVCBlock(volumeMode) {
-		return "0"
+		return "0", nil
+	}
+	if cdiConfig.Status.FilesystemOverhead == nil {
+		return "0", errors.New("CDI config not initialized")
 	}
 	if storageClass == nil {
-		return virtv1.Percent(cdiConfig.Status.FilesystemOverhead.Global)
+		return virtv1.Percent(cdiConfig.Status.FilesystemOverhead.Global), nil
 	}
 	fsOverhead, ok := cdiConfig.Status.FilesystemOverhead.StorageClass[*storageClass]
 	if !ok {
-		return virtv1.Percent(cdiConfig.Status.FilesystemOverhead.Global)
+		return virtv1.Percent(cdiConfig.Status.FilesystemOverhead.Global), nil
 	}
-	return virtv1.Percent(fsOverhead)
+	return virtv1.Percent(fsOverhead), nil
 }
 
 func roundUpToUnit(size, unit float64) float64 {
@@ -80,6 +83,9 @@ func GetSizeIncludingDefaultFSOverhead(size *resource.Quantity) (*resource.Quant
 }
 
 func GetSizeIncludingFSOverhead(size *resource.Quantity, storageClass *string, volumeMode *k8sv1.PersistentVolumeMode, cdiConfig *cdiv1.CDIConfig) (*resource.Quantity, error) {
-	cdiFSOverhead := GetFilesystemOverhead(volumeMode, storageClass, cdiConfig)
+	cdiFSOverhead, err := GetFilesystemOverhead(volumeMode, storageClass, cdiConfig)
+	if err != nil {
+		return nil, err
+	}
 	return GetSizeIncludingGivenOverhead(size, cdiFSOverhead)
 }

--- a/pkg/storage/types/cdi_test.go
+++ b/pkg/storage/types/cdi_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2018 Red Hat, Inc.
+ * Copyright The KubeVirt Authors
  *
  */
 

--- a/pkg/storage/types/cdi_test.go
+++ b/pkg/storage/types/cdi_test.go
@@ -1,0 +1,101 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package types
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+var _ = Describe("CDI utils test", func() {
+	It("should return 0 with block volume mode", func() {
+		volumeMode := corev1.PersistentVolumeBlock
+		storageClass := "sc"
+		cdiConfig := &cdiv1.CDIConfig{
+			Status: cdiv1.CDIConfigStatus{
+				FilesystemOverhead: &cdiv1.FilesystemOverhead{
+					Global: "10",
+				},
+			},
+		}
+		overhead, err := GetFilesystemOverhead(&volumeMode, &storageClass, cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(overhead).To(Equal(virtv1.Percent("0")))
+	})
+
+	It("should return error with uninitialized cdi config", func() {
+		volumeMode := corev1.PersistentVolumeFilesystem
+		storageClass := "sc"
+		cdiConfig := &cdiv1.CDIConfig{}
+		overhead, err := GetFilesystemOverhead(&volumeMode, &storageClass, cdiConfig)
+		Expect(err).To(HaveOccurred())
+		Expect(overhead).To(Equal(virtv1.Percent("0")))
+	})
+
+	It("should return global overhead with nil storage class", func() {
+		volumeMode := corev1.PersistentVolumeFilesystem
+		cdiConfig := &cdiv1.CDIConfig{
+			Status: cdiv1.CDIConfigStatus{
+				FilesystemOverhead: &cdiv1.FilesystemOverhead{
+					Global: "10",
+				},
+			},
+		}
+		overhead, err := GetFilesystemOverhead(&volumeMode, nil, cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(overhead).To(Equal(virtv1.Percent("10")))
+	})
+
+	It("should return global overhead with unknown storage class", func() {
+		volumeMode := corev1.PersistentVolumeFilesystem
+		storageClass := "sc"
+		cdiConfig := &cdiv1.CDIConfig{
+			Status: cdiv1.CDIConfigStatus{
+				FilesystemOverhead: &cdiv1.FilesystemOverhead{
+					Global: "10",
+				},
+			},
+		}
+		overhead, err := GetFilesystemOverhead(&volumeMode, &storageClass, cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(overhead).To(Equal(virtv1.Percent("10")))
+	})
+
+	It("should return storage class overhead", func() {
+		volumeMode := corev1.PersistentVolumeFilesystem
+		storageClass := "sc"
+		cdiConfig := &cdiv1.CDIConfig{
+			Status: cdiv1.CDIConfigStatus{
+				FilesystemOverhead: &cdiv1.FilesystemOverhead{
+					Global:       "10",
+					StorageClass: map[string]cdiv1.Percent{"sc": "20"},
+				},
+			},
+		}
+		overhead, err := GetFilesystemOverhead(&volumeMode, &storageClass, cdiConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(overhead).To(Equal(virtv1.Percent("20")))
+	})
+})

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -2138,7 +2138,7 @@ func (c *Controller) getFilesystemOverhead(pvc *k8sv1.PersistentVolumeClaim) (vi
 		return "0", fmt.Errorf("Failed to convert CDIConfig object %v to type CDIConfig", cdiConfigInterface)
 	}
 
-	return storagetypes.GetFilesystemOverhead(pvc.Spec.VolumeMode, pvc.Spec.StorageClassName, cdiConfig), nil
+	return storagetypes.GetFilesystemOverhead(pvc.Spec.VolumeMode, pvc.Spec.StorageClassName, cdiConfig)
 }
 
 func (c *Controller) canMoveToAttachedPhase(currentPhase virtv1.VolumePhase) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: 

NPE

After this PR:

Error

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid NPE when getting filesystem overhead
```

