### PR TITLE
[release-1.3] migration block->fs test: use storage API to accommodate user scenario

### DIFF
--- a/tests/libdv/dv.go
+++ b/tests/libdv/dv.go
@@ -69,14 +69,37 @@ func WithName(name string) dvOption {
 }
 
 type pvcOption func(*corev1.PersistentVolumeClaimSpec)
+type storageOption func(*cdiv1.StorageSpec)
 
-// WithPVC is a dvOption to add a PVCOption spec to the DataVolume
-// The function receives an optional list of pvcOption, to override the defaults
+// WithStorage is a dvOption to add a StorageOption spec to the DataVolume
+// The function receives an optional list of StorageOption, to override the defaults
 //
 // The default values are:
 // * no storage class
-// * access mode of ReadWriteOnce
+// * access mode from the StorgeProfile
 // * volume size of cd.CirrosVolumeSize
+// * volume mode from the storageProfile
+func WithStorage(options ...storageOption) dvOption {
+	storage := &cdiv1.StorageSpec{
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				"storage": resource.MustParse(cd.CirrosVolumeSize),
+			},
+		},
+	}
+
+	for _, opt := range options {
+		opt(storage)
+	}
+
+	return func(dv *cdiv1.DataVolume) {
+		dv.Spec.Storage = storage
+	}
+}
+
+// WithPVC is a dvOption to add a PVCOption spec to the DataVolume
+// The function receives an optional list of pvcOption, to override the defaults
+// * access mode of ReadWriteOnce
 // * no volume mode. kubernetes default is PersistentVolumeFilesystem
 func WithPVC(options ...pvcOption) dvOption {
 	pvc := &corev1.PersistentVolumeClaimSpec{
@@ -87,7 +110,6 @@ func WithPVC(options ...pvcOption) dvOption {
 			},
 		},
 	}
-
 	for _, opt := range options {
 		opt(pvc)
 	}
@@ -156,11 +178,11 @@ func randName() string {
 }
 
 // PVC Options
-
 // PVCWithStorageClass add the sc storage class name to the DV
 func PVCWithStorageClass(sc string) pvcOption {
 	return func(pvc *corev1.PersistentVolumeClaimSpec) {
 		if pvc == nil {
+			// TODO: Fail here instead? This is programmer error
 			return
 		}
 
@@ -210,4 +232,64 @@ func PVCWithAccessMode(accessMode corev1.PersistentVolumeAccessMode) pvcOption {
 // PVCWithReadWriteManyAccessMode set the DV access mode to ReadWriteMany
 func PVCWithReadWriteManyAccessMode() pvcOption {
 	return PVCWithAccessMode(corev1.ReadWriteMany)
+}
+
+// Storage Options
+// StorageWithStorageClass add the sc storage class name to the DV
+func StorageWithStorageClass(sc string) storageOption {
+	return func(storage *cdiv1.StorageSpec) {
+		if storage == nil {
+			// TODO: Fail here instead? This is programmer error
+			return
+		}
+
+		storage.StorageClassName = &sc
+	}
+}
+
+// StorageWithVolumeSize overrides the default volume size (cd.CirrosVolumeSize), with the size parameter
+// The size parameter must be in parsable valid quantity string.
+func StorageWithVolumeSize(size string) storageOption {
+	return func(storage *cdiv1.StorageSpec) {
+		if storage == nil {
+			// TODO: Fail here instead? This is programmer error
+			return
+		}
+
+		storage.Resources.Requests = corev1.ResourceList{"storage": resource.MustParse(size)}
+	}
+}
+
+// StorageWithVolumeMode adds the volume mode to the DV
+func StorageWithVolumeMode(volumeMode corev1.PersistentVolumeMode) storageOption {
+	return func(storage *cdiv1.StorageSpec) {
+		if storage == nil {
+			// TODO: Fail here instead? This is programmer error
+			return
+		}
+
+		storage.VolumeMode = &volumeMode
+	}
+}
+
+// StorageWithBlockVolumeMode adds the PersistentVolumeBlock volume mode to the DV
+func StorageWithBlockVolumeMode() storageOption {
+	return StorageWithVolumeMode(corev1.PersistentVolumeBlock)
+}
+
+// StorageWithAccessMode overrides the DV default access mode (ReadWriteOnce) with the accessMode parameter
+func StorageWithAccessMode(accessMode corev1.PersistentVolumeAccessMode) storageOption {
+	return func(storage *cdiv1.StorageSpec) {
+		if storage == nil {
+			// TODO: Fail here instead? This is programmer error
+			return
+		}
+
+		storage.AccessModes = []corev1.PersistentVolumeAccessMode{accessMode}
+	}
+}
+
+// StorageWithReadWriteManyAccessMode set the DV access mode to ReadWriteMany
+func StorageWithReadWriteManyAccessMode() storageOption {
+	return StorageWithAccessMode(corev1.ReadWriteMany)
 }

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -331,9 +331,9 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			Expect(exist).To(BeTrue())
 			srcDV := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
-				libdv.WithPVC(libdv.PVCWithStorageClass(sc),
-					libdv.PVCWithVolumeSize(size),
-					libdv.PVCWithVolumeMode(k8sv1.PersistentVolumeBlock),
+				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
+					libdv.StorageWithVolumeSize(size),
+					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeBlock),
 				),
 			)
 			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
@@ -344,9 +344,9 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			Expect(exist).To(BeTrue())
 			destDV := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
-				libdv.WithPVC(libdv.PVCWithStorageClass(sc),
-					libdv.PVCWithVolumeSize(size),
-					libdv.PVCWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
+				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
+					libdv.StorageWithVolumeSize(size),
+					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
 				),
 			)
 			_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In the wild, provisioners outright lie about the usable capacity for
filesystem volumes. So a 1Gi PVC has less than that usable.
Using the storage API inflates the sizes and thus should accommodate this
scenario.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

