### PR TITLE
virt-controller, vm: Set domain firmware UUID based on namespace, name and UID to avoid collisions

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -2077,7 +2077,7 @@ func setupStableFirmwareUUID(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachi
 		return
 	}
 
-	vmi.Spec.Domain.Firmware.UUID = types.UID(uuid.NewSHA1(firmwareUUIDns, []byte(vmi.ObjectMeta.Name)).String())
+	vmi.Spec.Domain.Firmware.UUID = types.UID(uuid.NewSHA1(firmwareUUIDns, []byte(vmi.ObjectMeta.Namespace+"/"+vmi.ObjectMeta.Name+"/"+string(vmi.ObjectMeta.UID))).String())
 }
 
 // listControllerFromNamespace takes a namespace and returns all VirtualMachines

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -2594,6 +2594,12 @@ var _ = Describe("VirtualMachine", func() {
 			vm3, _ := watchtesting.DefaultVirtualMachineWithNames(true, "testvm3", "testvmi3")
 			vmi3 := controller.setupVMIFromVM(vm3)
 			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi3.Spec.Domain.Firmware.UUID))
+
+			// same VM name and VMI name as vm1, but different namespace
+			vm4, _ := watchtesting.DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
+			vm4.Namespace = "different-namespace"
+			vmi4 := controller.setupVMIFromVM(vm4)
+			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi4.Spec.Domain.Firmware.UUID))
 		})
 
 		It("should honour any firmware UUID present in the template", func() {


### PR DESCRIPTION
Hello,

In my company, we use Red Hat Satellite and have automation in place to automatically register OpenShift Virtualization VMs created by customers to Satellite. However, one issue we've encountered is that, occasionally, some VMIs have duplicate firmware host UUIDs. This duplication disrupts our automation, as Satellite relies on the host UUID for registration. When a new VM tries to register with a host UUID that matches an existing VM, registration fails.

After thorough investigation, I found this issue reported on GitHub ([kubevirt/kubevirt#11166](https://github.com/kubevirt/kubevirt/issues/11166)), where I also shared my findings.

For our use case, manually setting the `spec.domain.firmware.uuid` property in the VM manifest is not feasible. IMHO, this value should be generated automatically by the KubeVirt VM controller. To address this, I have created this PR to enhance automatic UUID generation.

**PR Summary**:
To prevent firmware UUID collisions for VMs, the firmware UUID generation now includes the namespace, VM name, and the Kubernetes-assigned UID. This ensures that each VM has a unique firmware UUID across the entire cluster, even when VMs with the same name exist in different namespaces.

- Update `setupStableFirmwareUUID` to use `vmi.ObjectMeta.Namespace`, `vmi.ObjectMeta.Name`, and `vmi.ObjectMeta.UID` to add more entropy and ensure uniqueness.
- Add a test case to verify that VMs with the same name in different namespaces receive different firmware UUIDs.

Please let me know if there are any additional details or changes needed, and whether this approach makes sense to you. I am happy to contribute and help. Thank you!