### PR TITLE
pkg/network/vmispec: Add linter coverage

### DIFF
--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -8,6 +8,7 @@ pkg/network/multus
 pkg/network/namescheme
 pkg/network/netbinding
 pkg/network/pod/annotations
+pkg/network/vmispec
 pkg/storage/pod/annotations
 pkg/virtctl/credentials
 tests/console

--- a/pkg/network/vmispec/defaults.go
+++ b/pkg/network/vmispec/defaults.go
@@ -25,12 +25,12 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-type netClusterConfiger interface {
+type netClusterConfigurer interface {
 	GetDefaultNetworkInterface() string
 	IsBridgeInterfaceOnPodNetworkEnabled() bool
 }
 
-func SetDefaultNetworkInterface(config netClusterConfiger, spec *v1.VirtualMachineInstanceSpec) error {
+func SetDefaultNetworkInterface(config netClusterConfigurer, spec *v1.VirtualMachineInstanceSpec) error {
 	if autoAttach := spec.Domain.Devices.AutoattachPodInterface; autoAttach != nil && !*autoAttach {
 		return nil
 	}

--- a/pkg/network/vmispec/hotplug_test.go
+++ b/pkg/network/vmispec/hotplug_test.go
@@ -68,9 +68,15 @@ var _ = Describe("utilitary funcs to identify attachments to hotplug", func() {
 				libvmi.New(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(networkName)),
 					libvmi.WithNetwork(libvmi.MultusNetwork(networkName, nadName)),
-					libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-						Name: networkName, InterfaceName: guestIfaceName, InfoSource: vmispec.NewInfoSource(vmispec.InfoSourceDomain, vmispec.InfoSourceMultusStatus),
-					}))),
+					libvmistatus.WithStatus(
+						libvmistatus.New(libvmistatus.WithInterfaceStatus(
+							v1.VirtualMachineInstanceNetworkInterface{
+								Name:          networkName,
+								InterfaceName: guestIfaceName,
+								InfoSource:    vmispec.NewInfoSource(vmispec.InfoSourceDomain, vmispec.InfoSourceMultusStatus),
+							},
+						)),
+					),
 				),
 			),
 		)

--- a/pkg/network/vmispec/infosource.go
+++ b/pkg/network/vmispec/infosource.go
@@ -8,13 +8,13 @@ const (
 	InfoSourceMultusStatus string = "multus-status"
 	InfoSourceDomainAndGA  string = InfoSourceDomain + ", " + InfoSourceGuestAgent
 
-	seperator = ", "
+	separator = ", "
 )
 
 func AddInfoSource(infoSourceData, name string) string {
 	var infoSources []string
 	if infoSourceData != "" {
-		infoSources = strings.Split(infoSourceData, seperator)
+		infoSources = strings.Split(infoSourceData, separator)
 	}
 	for _, infoSourceName := range infoSources {
 		if infoSourceName == name {
@@ -27,7 +27,7 @@ func AddInfoSource(infoSourceData, name string) string {
 
 func RemoveInfoSource(infoSourceData, name string) string {
 	var newInfoSources []string
-	infoSources := strings.Split(infoSourceData, seperator)
+	infoSources := strings.Split(infoSourceData, separator)
 	for _, infoSourceName := range infoSources {
 		if infoSourceName != name {
 			newInfoSources = append(newInfoSources, infoSourceName)
@@ -37,7 +37,7 @@ func RemoveInfoSource(infoSourceData, name string) string {
 }
 
 func ContainsInfoSource(infoSourceData, name string) bool {
-	infoSources := strings.Split(infoSourceData, seperator)
+	infoSources := strings.Split(infoSourceData, separator)
 	for _, infoSourceName := range infoSources {
 		if infoSourceName == name {
 			return true
@@ -47,5 +47,5 @@ func ContainsInfoSource(infoSourceData, name string) bool {
 }
 
 func NewInfoSource(names ...string) string {
-	return strings.Join(names, seperator)
+	return strings.Join(names, separator)
 }

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -109,23 +109,6 @@ func IsPodNetworkWithBridgeBindingInterface(networks []v1.Network, ifaces []v1.I
 	return true
 }
 
-func PopInterfaceByNetwork(
-	statusIfaces []v1.VirtualMachineInstanceNetworkInterface,
-	network *v1.Network,
-) (*v1.VirtualMachineInstanceNetworkInterface, []v1.VirtualMachineInstanceNetworkInterface) {
-	if network == nil {
-		return nil, statusIfaces
-	}
-	for index, currStatusIface := range statusIfaces {
-		if currStatusIface.Name == network.Name {
-			primaryIface := statusIfaces[index]
-			statusIfaces = append(statusIfaces[:index], statusIfaces[index+1:]...)
-			return &primaryIface, statusIfaces
-		}
-	}
-	return nil, statusIfaces
-}
-
 func LookupInterfaceStatusByMac(
 	interfaces []v1.VirtualMachineInstanceNetworkInterface,
 	macAddress string,

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -64,15 +64,22 @@ func VerifyVMIMigratable(vmi *v1.VirtualMachineInstance, bindingPlugins map[stri
 	if allowPodBridgeNetworkLiveMigration && IsPodNetworkWithBridgeBindingInterface(vmi.Spec.Networks, ifaces) {
 		return nil
 	}
-	if IsPodNetworkWithMasqueradeBindingInterface(vmi.Spec.Networks, ifaces) || IsPodNetworkWithMigratableBindingPlugin(vmi.Spec.Networks, ifaces, bindingPlugins) {
+	if IsPodNetworkWithMasqueradeBindingInterface(vmi.Spec.Networks, ifaces) ||
+		IsPodNetworkWithMigratableBindingPlugin(vmi.Spec.Networks, ifaces, bindingPlugins) {
 		return nil
 	}
 
-	return fmt.Errorf("cannot migrate VMI which does not use masquerade, bridge with %s VM annotation or a migratable plugin to connect to the pod network", v1.AllowPodBridgeNetworkLiveMigrationAnnotation)
-
+	return fmt.Errorf(
+		"cannot migrate VMI which does not use masquerade, bridge with %s VM annotation or a migratable plugin to connect to the pod network",
+		v1.AllowPodBridgeNetworkLiveMigrationAnnotation,
+	)
 }
 
-func IsPodNetworkWithMigratableBindingPlugin(networks []v1.Network, ifaces []v1.Interface, bindingPlugins map[string]v1.InterfaceBindingPlugin) bool {
+func IsPodNetworkWithMigratableBindingPlugin(
+	networks []v1.Network,
+	ifaces []v1.Interface,
+	bindingPlugins map[string]v1.InterfaceBindingPlugin,
+) bool {
 	if podNetwork := LookupPodNetwork(networks); podNetwork != nil {
 		if podInterface := LookupInterfaceByName(ifaces, podNetwork.Name); podInterface != nil {
 			if podInterface.Binding != nil {
@@ -102,7 +109,10 @@ func IsPodNetworkWithBridgeBindingInterface(networks []v1.Network, ifaces []v1.I
 	return true
 }
 
-func PopInterfaceByNetwork(statusIfaces []v1.VirtualMachineInstanceNetworkInterface, network *v1.Network) (*v1.VirtualMachineInstanceNetworkInterface, []v1.VirtualMachineInstanceNetworkInterface) {
+func PopInterfaceByNetwork(
+	statusIfaces []v1.VirtualMachineInstanceNetworkInterface,
+	network *v1.Network,
+) (*v1.VirtualMachineInstanceNetworkInterface, []v1.VirtualMachineInstanceNetworkInterface) {
 	if network == nil {
 		return nil, statusIfaces
 	}
@@ -116,7 +126,10 @@ func PopInterfaceByNetwork(statusIfaces []v1.VirtualMachineInstanceNetworkInterf
 	return nil, statusIfaces
 }
 
-func LookupInterfaceStatusByMac(interfaces []v1.VirtualMachineInstanceNetworkInterface, macAddress string) *v1.VirtualMachineInstanceNetworkInterface {
+func LookupInterfaceStatusByMac(
+	interfaces []v1.VirtualMachineInstanceNetworkInterface,
+	macAddress string,
+) *v1.VirtualMachineInstanceNetworkInterface {
 	for index := range interfaces {
 		if interfaces[index].MAC == macAddress {
 			return &interfaces[index]
@@ -125,7 +138,10 @@ func LookupInterfaceStatusByMac(interfaces []v1.VirtualMachineInstanceNetworkInt
 	return nil
 }
 
-func LookupInterfaceStatusByName(interfaces []v1.VirtualMachineInstanceNetworkInterface, name string) *v1.VirtualMachineInstanceNetworkInterface {
+func LookupInterfaceStatusByName(
+	interfaces []v1.VirtualMachineInstanceNetworkInterface,
+	name string,
+) *v1.VirtualMachineInstanceNetworkInterface {
 	for index := range interfaces {
 		if interfaces[index].Name == name {
 			return &interfaces[index]
@@ -151,7 +167,10 @@ func LookupInterfaceByName(ifaces []v1.Interface, name string) *v1.Interface {
 	return nil
 }
 
-func IndexInterfaceStatusByName(interfaces []v1.VirtualMachineInstanceNetworkInterface, p func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool) map[string]v1.VirtualMachineInstanceNetworkInterface {
+func IndexInterfaceStatusByName(
+	interfaces []v1.VirtualMachineInstanceNetworkInterface,
+	p func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool,
+) map[string]v1.VirtualMachineInstanceNetworkInterface {
 	indexedInterfaceStatus := map[string]v1.VirtualMachineInstanceNetworkInterface{}
 	for _, iface := range interfaces {
 		if p == nil || p(iface) {

--- a/pkg/network/vmispec/interface_test.go
+++ b/pkg/network/vmispec/interface_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 var _ = Describe("VMI network spec", func() {
-
 	Context("pod network", func() {
 		const podNet0 = "podnet0"
 
@@ -69,11 +68,11 @@ var _ = Describe("VMI network spec", func() {
 		})
 
 		It("finds two SR-IOV interfaces in list", func() {
-			sriov_net1 := v1.Interface{
+			sriovNet1 := v1.Interface{
 				Name:                   "sriov-net1",
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
 			}
-			sriov_net2 := v1.Interface{
+			sriovNet2 := v1.Interface{
 				Name:                   "sriov-net2",
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
 			}
@@ -83,11 +82,11 @@ var _ = Describe("VMI network spec", func() {
 					Name:                   "masq-net0",
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				},
-				sriov_net1,
-				sriov_net2,
+				sriovNet1,
+				sriovNet2,
 			}
 
-			Expect(netvmispec.FilterSRIOVInterfaces(ifaces)).To(Equal([]v1.Interface{sriov_net1, sriov_net2}))
+			Expect(netvmispec.FilterSRIOVInterfaces(ifaces)).To(Equal([]v1.Interface{sriovNet1, sriovNet2}))
 			Expect(netvmispec.SRIOVInterfaceExist(ifaces)).To(BeTrue())
 		})
 	})
@@ -208,15 +207,16 @@ var _ = Describe("VMI network spec", func() {
 				)
 				Expect(netvmispec.VerifyVMIMigratable(vmi, bindingPlugins)).To(Succeed())
 			})
-			It("should allow migration if the VMI use bridge to connect to the pod network and has AllowLiveMigrationBridgePodNetwork annotation", func() {
-				network := podNetwork(podNet0)
-				vmi := libvmi.New(
-					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-					libvmi.WithNetwork(&network),
-					libvmi.WithAnnotation(v1.AllowPodBridgeNetworkLiveMigrationAnnotation, ""),
-				)
-				Expect(netvmispec.VerifyVMIMigratable(vmi, bindingPlugins)).To(Succeed())
-			})
+			It("should allow migration if the VMI use bridge to connect to the pod network and has AllowLiveMigrationBridgePodNetwork annotation",
+				func() {
+					network := podNetwork(podNet0)
+					vmi := libvmi.New(
+						libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+						libvmi.WithNetwork(&network),
+						libvmi.WithAnnotation(v1.AllowPodBridgeNetworkLiveMigrationAnnotation, ""),
+					)
+					Expect(netvmispec.VerifyVMIMigratable(vmi, bindingPlugins)).To(Succeed())
+				})
 			It("should allow migration if the VMI use migratable binding plugin to connect to the pod network", func() {
 				network := podNetwork(podNet0)
 				vmi := libvmi.New(

--- a/pkg/network/vmispec/interface_test.go
+++ b/pkg/network/vmispec/interface_test.go
@@ -91,41 +91,6 @@ var _ = Describe("VMI network spec", func() {
 		})
 	})
 
-	const iface1, iface2 = "iface1", "iface2"
-
-	Context("pop interface by network", func() {
-		const netName = "net1"
-		network := podNetwork(netName)
-		expectedStatusIfaces := vmiStatusInterfaces(iface1, iface2)
-
-		It("has no network", func() {
-			statusIface, statusIfaces := netvmispec.PopInterfaceByNetwork(vmiStatusInterfaces(iface1, iface2), nil)
-			Expect(statusIface).To(BeNil())
-			Expect(statusIfaces).To(Equal(expectedStatusIfaces))
-		})
-
-		It("has no interfaces", func() {
-			statusIface, _ := netvmispec.PopInterfaceByNetwork(nil, &network)
-			Expect(statusIface).To(BeNil())
-		})
-
-		It("interface not found", func() {
-			statusIface, _ := netvmispec.PopInterfaceByNetwork(vmiStatusInterfaces(iface1, iface2), &network)
-			Expect(statusIface).To(BeNil())
-		})
-
-		DescribeTable("pop interface from position", func(statusIfaces []v1.VirtualMachineInstanceNetworkInterface) {
-			expectedStatusIface := v1.VirtualMachineInstanceNetworkInterface{Name: netName}
-			statusIface, statusIfaces := netvmispec.PopInterfaceByNetwork(statusIfaces, &network)
-			Expect(*statusIface).To(Equal(expectedStatusIface))
-			Expect(statusIfaces).To(Equal(expectedStatusIfaces))
-		},
-			Entry("first", vmiStatusInterfaces(netName, iface1, iface2)),
-			Entry("last", vmiStatusInterfaces(iface1, iface2, netName)),
-			Entry("mid", vmiStatusInterfaces(iface1, netName, iface2)),
-		)
-	})
-
 	Context("migratable", func() {
 		const (
 			migratablePlugin    = "mig"
@@ -298,13 +263,4 @@ func interfaceWithBindingPlugin(name, pluginName string) v1.Interface {
 		Name:    name,
 		Binding: &v1.PluginBinding{Name: pluginName},
 	}
-}
-
-func vmiStatusInterfaces(names ...string) []v1.VirtualMachineInstanceNetworkInterface {
-	var statusInterfaces []v1.VirtualMachineInstanceNetworkInterface
-	for _, name := range names {
-		iface := v1.VirtualMachineInstanceNetworkInterface{Name: name}
-		statusInterfaces = append(statusInterfaces, iface)
-	}
-	return statusInterfaces
 }

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1798,9 +1798,6 @@ const (
 	DeprecatedSlirpInterface NetworkInterfaceType = "slirp"
 	// Virtual machine instance masquerade interface
 	MasqueradeInterface NetworkInterfaceType = "masquerade"
-	// Virtual machine instance passt interface is deprecated
-	// Deprecated: Removed in v1.3.
-	DeprecatedPasstInterface NetworkInterfaceType = "passt"
 )
 
 type DriverCache string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- Break long lines
- Apply gofumpt
- Remove redundant newlines
- Fix typos
- Convert snake_case to camelCase

Added a case to `SetDefaultNetworkInterface` in order to also consider `v1.DeprecatedPasstInterface`.

Propose an alternative implementation for `PopInterfaceByNetwork`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

