### PR TITLE
pkg/network/netbinding: Add linter coverage

### DIFF
--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -5,6 +5,7 @@ pkg/network/deviceinfo
 pkg/network/domainspec
 pkg/network/multus
 pkg/network/namescheme
+pkg/network/netbinding
 pkg/network/pod/annotations
 pkg/network/vmicontroller
 pkg/storage/pod/annotations

--- a/pkg/network/netbinding/memory.go
+++ b/pkg/network/netbinding/memory.go
@@ -29,7 +29,10 @@ import (
 
 type MemoryCalculator struct{}
 
-func (mc MemoryCalculator) Calculate(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) resource.Quantity {
+func (mc MemoryCalculator) Calculate(
+	vmi *v1.VirtualMachineInstance,
+	registeredPlugins map[string]v1.InterfaceBindingPlugin,
+) resource.Quantity {
 	return sumPluginsMemoryRequests(
 		filterUniquePlugins(vmi.Spec.Domain.Devices.Interfaces, registeredPlugins),
 	)

--- a/pkg/network/netbinding/memory_test.go
+++ b/pkg/network/netbinding/memory_test.go
@@ -41,12 +41,13 @@ var _ = Describe("Network Binding plugin compute resource overhead", func() {
 		plugin2name = "plugin2"
 	)
 
-	DescribeTable("Memory overhead should be zero", func(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) {
-		memoryCalculator := netbinding.MemoryCalculator{}
+	DescribeTable("Memory overhead should be zero",
+		func(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin) {
+			memoryCalculator := netbinding.MemoryCalculator{}
 
-		actualResult := memoryCalculator.Calculate(vmi, registeredPlugins)
-		Expect(actualResult.Value()).To(BeZero())
-	},
+			actualResult := memoryCalculator.Calculate(vmi, registeredPlugins)
+			Expect(actualResult.Value()).To(BeZero())
+		},
 		Entry("when the VMI does not have NICs and there aren't any registered plugins", libvmi.New(), nil),
 		Entry("when no binding plugin is used on the VMI and there aren't any registered plugins",
 			libvmi.New(
@@ -88,12 +89,13 @@ var _ = Describe("Network Binding plugin compute resource overhead", func() {
 		),
 	)
 
-	DescribeTable("It should calculate memory overhead", func(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin, expectedValue resource.Quantity) {
-		memoryCalculator := netbinding.MemoryCalculator{}
+	DescribeTable("It should calculate memory overhead",
+		func(vmi *v1.VirtualMachineInstance, registeredPlugins map[string]v1.InterfaceBindingPlugin, expectedValue resource.Quantity) {
+			memoryCalculator := netbinding.MemoryCalculator{}
 
-		actualResult := memoryCalculator.Calculate(vmi, registeredPlugins)
-		Expect(actualResult.Value()).To(Equal(expectedValue.Value()))
-	},
+			actualResult := memoryCalculator.Calculate(vmi, registeredPlugins)
+			Expect(actualResult.Value()).To(Equal(expectedValue.Value()))
+		},
 		Entry("when there is a single interface using a binding plugin",
 			libvmi.New(
 				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),

--- a/pkg/network/netbinding/netbinding_test.go
+++ b/pkg/network/netbinding/netbinding_test.go
@@ -42,16 +42,17 @@ var _ = Describe("Network Binding", func() {
 	)
 
 	Context("binding plugin sidecar list", func() {
-		DescribeTable("should create the correct sidecars", func(vmi *v1.VirtualMachineInstance, bindings map[string]v1.InterfaceBindingPlugin, expectedSidecars hooks.HookSidecarList) {
-			config := &v1.KubeVirtConfiguration{
-				NetworkConfiguration: &v1.NetworkConfiguration{
-					Binding: bindings,
-				},
-			}
-			sidecars, err := netbinding.NetBindingPluginSidecarList(vmi, config)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sidecars).To(ConsistOf(expectedSidecars))
-		},
+		DescribeTable("should create the correct sidecars",
+			func(vmi *v1.VirtualMachineInstance, bindings map[string]v1.InterfaceBindingPlugin, expectedSidecars hooks.HookSidecarList) {
+				config := &v1.KubeVirtConfiguration{
+					NetworkConfiguration: &v1.NetworkConfiguration{
+						Binding: bindings,
+					},
+				}
+				sidecars, err := netbinding.NetBindingPluginSidecarList(vmi, config)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sidecars).To(ConsistOf(expectedSidecars))
+			},
 			Entry("VMI has binding plugin but config image is empty",
 				libvmi.New(libvmi.WithInterface(v1.Interface{Name: testNetworkName1, Binding: &v1.PluginBinding{Name: testBindingName1}}),
 					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
@@ -69,7 +70,10 @@ var _ = Describe("Network Binding", func() {
 					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
 					libvmi.WithInterface(v1.Interface{Name: testNetworkName2, Binding: &v1.PluginBinding{Name: testBindingName2}}),
 					libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName3, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}),
+					libvmi.WithInterface(v1.Interface{
+						Name:                   testNetworkName3,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
+					}),
 					libvmi.WithNetwork(&v1.Network{Name: testNetworkName3}),
 				),
 				map[string]v1.InterfaceBindingPlugin{
@@ -78,7 +82,10 @@ var _ = Describe("Network Binding", func() {
 				},
 				hooks.HookSidecarList{{Image: testSidecarImage1, DownwardAPI: v1.DeviceInfo}, {Image: testSidecarImage2}}),
 			Entry("VMI has no plugin bindings",
-				libvmi.New(libvmi.WithInterface(v1.Interface{Name: testNetworkName1, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}),
+				libvmi.New(libvmi.WithInterface(v1.Interface{
+					Name:                   testNetworkName1,
+					InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
+				}),
 					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
 				),
 				nil,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- Break long lines
- Apply gofumpt

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

