### PR TITLE
Feat: Adds bazel caching while running `make generate` to reduce setting up times

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,3 +37,6 @@ coverage --test_tag_filters=-nocov,-fuzz
 
 # Import user settings which may override the defaults
 try-import user.bazelrc
+
+# Caching the 'make generate' results
+build --disk_cache=~/.cache/bazel-disk-cache

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,10 @@ bazel-test:
 gen-proto:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/gen-proto.sh"
 
-generate:
+bazel-generate-cache:
+	hack/dockerized "./hack/bazel-generate-cache.sh"
+
+generate: bazel-generate-cache
 	hack/dockerized hack/build-ginkgo.sh
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/generate.sh"
 	SYNC_VENDOR=true hack/dockerized "./hack/bazel-generate.sh && hack/bazel-fmt.sh"
@@ -270,4 +273,5 @@ update-generated-api-testdata:
 	lint \
 	lint-metrics \
 	update-generated-api-testdata \
+	bazel-generate-cache \
 	$(NULL)

--- a/hack/bazel-generate-cache.sh
+++ b/hack/bazel-generate-cache.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+source hack/common.sh
+source hack/bootstrap.sh
+source hack/config.sh
+
+#Creating temp dir
+
+CACHE_DIR=$(mktemp -d)
+
+export BAZEL_CACHE_DIR=$CACHE_DIR
+
+#Bulding with the bazel cache enabled
+bazel build \
+    --config=${ARCHITECTURE} \
+    --disk_cache=$BAZEL_CACHE_DIR \
+    //...
+
+#Cleaning up the temp dir
+rm -rf $CACHE_DIR

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -7,3 +7,6 @@ if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
     git diff
     exit 1
 fi
+
+
+bazel build --config=${ARCHITECTURE} //...


### PR DESCRIPTION
### What this PR does

Fixes #8165

Before this PR:
- Running `make generate` could take significant time, and repeated runs would take roughly the same time, even if no files had changed.

After this PR:
- Results from `make generate` will supposedly be cached using Bazel, allowing faster completion if no files have changed since the last run. This optimizes the process and reduces redundant generation time.

Fixes #

### Why we need it and why it was done in this way
Caching the `make generate` results with Bazel prevents unnecessary rebuilds when files remain unchanged, improving efficiency. The following tradeoffs were made:
- Bazel caching was added specifically for `make generate` to focus on speeding up the most time-consuming parts.
  
The following alternatives were considered:
- None
Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailing list, ... -->

### Special notes for your reviewer
- The cache directory is set to `~/.cache/bazel-disk-cache` and will populate on the first run.
- I'm still new to this, so kindly let me know if some other approach was supposed to be followed here.
 
### Checklist
- [x] PR: The PR description is expressive enough and will help future contributors
- [x ] Code: Write code that humans can understand and keep it simple
- [ ] Refactor: Followed the "Boy Scout Rule" and left the code cleaner than I found it
- [ ] Testing: New caching mechanism was manually tested, and performance was checked
- [ ] Documentation: Updated internal documentation regarding Bazel caching in `make generate`

### Release note
```release-note
Optimized `make generate` by caching results with Bazel, reducing redundant processing time.
```
