### PR TITLE
Persistent firmware UUID

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -2056,7 +2056,6 @@ func hasStopRequestForVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineI
 }
 
 // no special meaning, randomly generated on my box.
-// TODO: do we want to use another constants? see examples in RFC4122
 const magicUUID = "6a1a24a1-4061-4607-8bf4-a3963d0c5895"
 
 var firmwareUUIDns = uuid.MustParse(magicUUID)


### PR DESCRIPTION
### What this PR does
Before this PR:
KubeVirt regenerated Firmware.UUID for VMI whenever the VM is started.

After this PR:
KubeVirt generated the Firmware.UUID once and persists in vm.Spec. Eventually, all VMs would have Firmware.UUID persisted, and we would be free to fix https://github.com/kubevirt/kubevirt/issues/13156

Fixes #

### Why we need it and why it was done in this way
We need to generate a Firmware.UUID that is universally unique AND keeps the identity of existing VMs.
This PR is one step for the fix of https://github.com/kubevirt/kubevirt/issues/13156 . Another fix would follow once we are certain that all supported KubeVirt VMs have Firmware.UUID persisted in their spec.

### Special notes for your reviewer

We can expedite the fix for new VMs by adding a mutating webhook that generates a good UUID for new VMs: https://github.com/kubevirt/kubevirt/pull/12085. I prefer not to do this right now because webhooks are slow and fragile, a liability that we'd rather avoid.


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
If Firmware.UUID is missing in vm.Spec, it is generated and persisted to ensure that the identification of existing VMs would not change once we fix UUID generation logic.
```

