### PR TITLE
windows tests: remove code manually releasing PV

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -380,6 +380,7 @@ spec:
     server: "nfs"
     path: /
   storageClassName: windows
+  persistentVolumeReclaimPolicy: Recycle
 EOF
 fi
 

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -470,6 +470,10 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     add_to_label_filter "(!PERIODIC)" "&&"
   fi
 
+  if [[ ! $TARGET =~ windows.* ]]; then
+    add_to_label_filter "(!Windows)" "&&"
+  fi
+
 fi
 
 # No lane currently supports loading a custom policy

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -87,9 +87,14 @@ func WithEmptyDisk(diskName string, bus v1.DiskBus, capacity resource.Quantity) 
 
 // WithCDRom specifies a CDRom drive backed by a PVC to be used.
 func WithCDRom(cdRomName string, bus v1.DiskBus, claimName string) Option {
+	return WithCDRomAndVolume(bus, newPersistentVolumeClaimVolume(cdRomName, claimName))
+}
+
+// WithCDRomAndVolume specifies a CDRom drive backed by given volume and given bus.
+func WithCDRomAndVolume(bus v1.DiskBus, volume v1.Volume) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addDisk(vmi, newCDRom(cdRomName, bus))
-		addVolume(vmi, newPersistentVolumeClaimVolume(cdRomName, claimName))
+		addDisk(vmi, newCDRom(volume.Name, bus))
+		addVolume(vmi, volume)
 	}
 }
 

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -145,17 +145,6 @@ func SkipTestIfNotSEVESCapable() {
 	ginkgo.Skip("no node capable of running SEV-ES workloads detected", 1)
 }
 
-func RecycleImageOrFail(virtClient kubecli.KubevirtClient, imageName string) {
-	windowsPv, err := virtClient.CoreV1().PersistentVolumes().Get(context.Background(), imageName, metav1.GetOptions{})
-	if err != nil || windowsPv.Status.Phase == k8sv1.VolumePending || windowsPv.Status.Phase == k8sv1.VolumeFailed {
-		ginkgo.Fail(fmt.Sprintf("Skip tests that requires PV %s", imageName))
-	} else if windowsPv.Status.Phase == k8sv1.VolumeReleased {
-		windowsPv.Spec.ClaimRef = nil
-		_, err = virtClient.CoreV1().PersistentVolumes().Update(context.Background(), windowsPv, metav1.UpdateOptions{})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	}
-}
-
 // Deprecated: SkipIfNoRhelImage should be converted to check & fail
 func SkipIfNoRhelImage(virtClient kubecli.KubevirtClient) {
 	rhelPv, err := virtClient.CoreV1().PersistentVolumes().Get(context.Background(), diskRhel, metav1.GetOptions{})

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -145,11 +145,10 @@ func SkipTestIfNotSEVESCapable() {
 	ginkgo.Skip("no node capable of running SEV-ES workloads detected", 1)
 }
 
-// Deprecated: SkipIfMissingRequiredImage should be converted to check & fail
-func SkipIfMissingRequiredImage(virtClient kubecli.KubevirtClient, imageName string) {
+func RecycleImageOrFail(virtClient kubecli.KubevirtClient, imageName string) {
 	windowsPv, err := virtClient.CoreV1().PersistentVolumes().Get(context.Background(), imageName, metav1.GetOptions{})
 	if err != nil || windowsPv.Status.Phase == k8sv1.VolumePending || windowsPv.Status.Phase == k8sv1.VolumeFailed {
-		ginkgo.Skip(fmt.Sprintf("Skip tests that requires PV %s", imageName))
+		ginkgo.Fail(fmt.Sprintf("Skip tests that requires PV %s", imageName))
 	} else if windowsPv.Status.Phase == k8sv1.VolumeReleased {
 		windowsPv.Spec.ClaimRef = nil
 		_, err = virtClient.CoreV1().PersistentVolumes().Update(context.Background(), windowsPv, metav1.UpdateOptions{})

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -40,7 +40,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libconfigmap"
 	"kubevirt.io/kubevirt/tests/libregistry"
@@ -250,7 +249,6 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 	BeforeEach(func() {
 		const OSWindowsSysprep = "windows-sysprep"
 		virtClient = kubevirt.Client()
-		checks.RecycleImageOrFail(virtClient, diskWindowsSysprep)
 		libstorage.CreatePVC(OSWindowsSysprep, testsuite.GetTestNamespace(nil), "35Gi", libstorage.Config.StorageClassWindows, true)
 
 		// TODO: Figure out why we have both Autounattend and Unattend

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -307,14 +307,13 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 		checks.SkipIfMissingRequiredImage(virtClient, diskWindowsSysprep)
 		libstorage.CreatePVC(OSWindowsSysprep, testsuite.GetTestNamespace(nil), "35Gi", libstorage.Config.StorageClassWindows, true)
 		answerFileWithKey := insertProductKeyToAnswerFileTemplate(answerFileTemplate)
-		windowsVMI = libvmi.New(libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		windowsVMI = libvmi.New(libvmi.WithInterface(e1000DefaultInterface()),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()))
 		windowsVMI.Spec = getWindowsSysprepVMISpec()
 		windowsVMI.ObjectMeta.Namespace = testsuite.GetTestNamespace(windowsVMI)
 		cm := libconfigmap.New("sysprepautounattend", map[string]string{"Autounattend.xml": answerFileWithKey, "Unattend.xml": answerFileWithKey})
 		cm, err := virtClient.CoreV1().ConfigMaps(windowsVMI.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
 	Context("[ref_id:5105]should create the Admin user as specified in the Autounattend.xml", func() {

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -217,14 +217,6 @@ func insertProductKeyToAnswerFileTemplate(answerFileTemplate string) string {
 	return fmt.Sprintf(answerFileTemplate, productKey)
 }
 
-// addExplicitPodNetworkInterface
-//
-// Deprecated: Use libvmi
-func addExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-}
-
 // Deprecated: Use libvmi
 func getWindowsSysprepVMISpec() v1.VirtualMachineInstanceSpec {
 	gracePeriod := int64(0)
@@ -315,13 +307,13 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 		checks.SkipIfMissingRequiredImage(virtClient, diskWindowsSysprep)
 		libstorage.CreatePVC(OSWindowsSysprep, testsuite.GetTestNamespace(nil), "35Gi", libstorage.Config.StorageClassWindows, true)
 		answerFileWithKey := insertProductKeyToAnswerFileTemplate(answerFileTemplate)
-		windowsVMI = libvmi.New()
+		windowsVMI = libvmi.New(libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()))
 		windowsVMI.Spec = getWindowsSysprepVMISpec()
 		windowsVMI.ObjectMeta.Namespace = testsuite.GetTestNamespace(windowsVMI)
 		cm := libconfigmap.New("sysprepautounattend", map[string]string{"Autounattend.xml": answerFileWithKey, "Unattend.xml": answerFileWithKey})
 		cm, err := virtClient.CoreV1().ConfigMaps(windowsVMI.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		addExplicitPodNetworkInterface(windowsVMI)
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -250,7 +250,7 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 	BeforeEach(func() {
 		const OSWindowsSysprep = "windows-sysprep"
 		virtClient = kubevirt.Client()
-		checks.SkipIfMissingRequiredImage(virtClient, diskWindowsSysprep)
+		checks.RecycleImageOrFail(virtClient, diskWindowsSysprep)
 		libstorage.CreatePVC(OSWindowsSysprep, testsuite.GetTestNamespace(nil), "35Gi", libstorage.Config.StorageClassWindows, true)
 
 		// TODO: Figure out why we have both Autounattend and Unattend

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -294,8 +294,6 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 			}),
 			withFirmwareUID(types.UID(libvmifact.WindowsFirmware)),
 		)
-
-		windowsVMI.ObjectMeta.Namespace = testsuite.GetTestNamespace(windowsVMI)
 	})
 
 	Context("[ref_id:5105]should create the Admin user as specified in the Autounattend.xml", func() {

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -243,7 +243,6 @@ const (
 )
 
 var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", Serial, decorators.Sysprep, decorators.SigCompute, func() {
-	var err error
 	var virtClient kubecli.KubevirtClient
 
 	var windowsVMI *v1.VirtualMachineInstance
@@ -304,6 +303,7 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 
 		BeforeEach(func() {
 			By("Creating winrm-cli pod for the future use")
+			var err error
 			winrmcliPod, err = virtClient.CoreV1().Pods(testsuite.NamespaceTestDefault).Create(context.Background(), winRMCliPod(), metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -311,11 +311,9 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 			windowsVMI, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), windowsVMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			libwait.WaitForSuccessfulVMIStart(windowsVMI,
+			windowsVMI = libwait.WaitForSuccessfulVMIStart(windowsVMI,
 				libwait.WithTimeout(720),
 			)
-
-			windowsVMI, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Get(context.Background(), windowsVMI.Name, metav1.GetOptions{})
 		})
 
 		It("[test_id:5843]Should run echo command on machine using the credentials specified in the Autounattend.xml file", func() {

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -28,7 +28,6 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 
 	"kubevirt.io/kubevirt/tests/exec"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -68,7 +67,6 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, 
 	BeforeEach(func() {
 		const OSWindows = "windows"
 		virtClient = kubevirt.Client()
-		checks.RecycleImageOrFail(virtClient, libvmifact.WindowsPVCName)
 		libstorage.CreatePVC(OSWindows, testsuite.GetTestNamespace(nil), "30Gi", libstorage.Config.StorageClassWindows, true)
 	})
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -68,7 +68,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, 
 	BeforeEach(func() {
 		const OSWindows = "windows"
 		virtClient = kubevirt.Client()
-		checks.SkipIfMissingRequiredImage(virtClient, libvmifact.WindowsPVCName)
+		checks.RecycleImageOrFail(virtClient, libvmifact.WindowsPVCName)
 		libstorage.CreatePVC(OSWindows, testsuite.GetTestNamespace(nil), "30Gi", libstorage.Config.StorageClassWindows, true)
 	})
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -292,12 +292,16 @@ func removeTSCFrequencyFromNode(node k8sv1.Node) {
 func withDefaultE1000Networking() libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		libvmi.WithNetwork(v1.DefaultPodNetwork())(vmi)
-		libvmi.WithInterface(v1.Interface{
-			Name: "default",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{
-				Masquerade: &v1.InterfaceMasquerade{},
-			},
-			Model: "e1000",
-		})(vmi)
+		libvmi.WithInterface(e1000DefaultInterface())(vmi)
+	}
+}
+
+func e1000DefaultInterface() v1.Interface {
+	return v1.Interface{
+		Name: "default",
+		InterfaceBindingMethod: v1.InterfaceBindingMethod{
+			Masquerade: &v1.InterfaceMasquerade{},
+		},
+		Model: "e1000",
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Follow up for https://github.com/kubevirt/kubevirt/pull/12987;
We don't have to manually do this since recycling is achievable via the PV API
https://kubernetes.io/docs/tasks/administer-cluster/change-pv-reclaim-policy/

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

