### PR TITLE
[Tests]Remove migration test skips

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -117,3 +117,52 @@ docker run \
         --deploy-testing-infra \
         --path-to-testing-infra-manifests=data/manifests
 ```
+
+## Skipping tests when cluster requirements aren't met
+KubeVirt provides [tests decorators](https://github.com/kubevirt/kubevirt/blob/main/tests/decorators/decorators.go)
+to indicate the cluster requirements for certain tests. If your
+cluster doesn't meet these requirements, you can choose to skip
+the relevant tests by explicitly setting the `KUBEVIRT_E2E_SKIP`
+environment variable with the appropriate decorators.
+
+For example, to skip tests that require more than one schedulable node,
+which is useful for single-node clusters, run:
+
+``` bash
+export KUBEVIRT_E2E_SKIP=requires-two-schedulable-nodes
+```
+
+The `KUBEVIRT_E2E_SKIP` variable supports regular expressions.
+For example, to skip tests requiring two schedulable nodes
+and specific storage, run:
+
+``` bash
+export KUBEVIRT_E2E_SKIP=requires-two-schedulable-nodes|storage-req
+```
+
+For more information on filtering tests when using Ginkgo directly,
+refer to [Ginkgo documentation](https://onsi.github.io/ginkgo/#description-based-filtering).
+
+## Filtering tests by labels
+You can filter tests by labels using the `KUBEVIRT_LABEL_FILTER`
+environment variable. This variable allows you to specify labels
+that tests must have to be executed.  
+For example, to run only tests with the Conformance label, run:
+
+``` bash
+export KUBEVIRT_LABEL_FILTER=Conformance
+```
+
+The `KUBEVIRT_LABEL_FILTER` variable supports regular expressions.
+
+## Focusing on specific tests
+To focus on specific tests, you can use the `KUBEVIRT_E2E_FOCUS`
+environment variable. This variable supports regular expressions
+to match the test descriptions.  
+For example, to run only tests related to networking, run:
+
+``` bash  
+export KUBEVIRT_E2E_FOCUS=networking
+```  
+
+The `KUBEVIRT_LABEL_FILTER` variable supports regular expressions.

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -92,13 +92,6 @@ func SkipIfOpenShift4(message string) {
 	}
 }
 
-// Deprecated: SkipIfMigrationIsNotPossible should be converted to check & fail
-func SkipIfMigrationIsNotPossible() {
-	if !HasAtLeastTwoNodes() {
-		ginkgo.Skip("Migration tests require at least 2 nodes")
-	}
-}
-
 // Deprecated: SkipIfARM64 should be converted to check & fail
 func SkipIfARM64(arch string, message string) {
 	if IsARM64(arch) {

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -8,7 +8,6 @@ import (
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libmigration"
@@ -166,8 +165,6 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 		var virtClient kubecli.KubevirtClient
 
 		BeforeEach(func() {
-			checks.SkipIfMigrationIsNotPossible()
-
 			virtClient = kubevirt.Client()
 		})
 

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -161,7 +161,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 
 	})
 
-	Describe("VM instance migration", func() {
+	Describe("VM instance migration", decorators.RequiresTwoSchedulableNodes, func() {
 		var virtClient kubecli.KubevirtClient
 
 		BeforeEach(func() {

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -40,7 +40,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -60,7 +59,6 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
-		checks.SkipIfMigrationIsNotPossible()
 		virtClient = kubevirt.Client()
 	})
 

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -55,7 +55,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGMigrationDescribe("Live Migration", func() {
+var _ = SIGMigrationDescribe("Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -155,7 +155,6 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 	}
 
 	BeforeEach(func() {
-		checks.SkipIfMigrationIsNotPossible()
 		virtClient = kubevirt.Client()
 		migrationBandwidthLimit = resource.MustParse("1Ki")
 	})

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -104,7 +104,7 @@ const (
 	stressDefaultSleepDuration = 15
 )
 
-var _ = SIGMigrationDescribe("VM Live Migration", func() {
+var _ = SIGMigrationDescribe("VM Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
 	var (
 		virtClient              kubecli.KubevirtClient
 		migrationBandwidthLimit resource.Quantity

--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -37,8 +37,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 
-	"kubevirt.io/kubevirt/tests/framework/checks"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -60,7 +58,6 @@ var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", func() {
 	)
 
 	BeforeEach(func() {
-		checks.SkipIfMigrationIsNotPossible()
 		virtClient = kubevirt.Client()
 	})
 

--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -52,7 +52,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", func() {
+var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", decorators.RequiresTwoSchedulableNodes, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -45,6 +45,7 @@ import (
 	kvpointer "kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -59,7 +60,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
+var _ = SIGMigrationDescribe("VM Post Copy Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
 	var (
 		virtClient      kubecli.KubevirtClient
 		err             error

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -167,7 +167,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", Serial, decorators.SigMonitori
 		})
 	})
 
-	Context("VM migration metrics", func() {
+	Context("VM migration metrics", decorators.RequiresTwoSchedulableNodes, func() {
 		var nodes *corev1.NodeList
 
 		BeforeEach(func() {

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libmonitoring"
@@ -172,8 +171,6 @@ var _ = Describe("[sig-monitoring]VM Monitoring", Serial, decorators.SigMonitori
 		var nodes *corev1.NodeList
 
 		BeforeEach(func() {
-			checks.SkipIfMigrationIsNotPossible()
-
 			Eventually(func() []corev1.Node {
 				nodes = libnode.GetAllSchedulableNodes(virtClient)
 				return nodes.Items

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -35,7 +35,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
@@ -114,8 +113,6 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 
 	Context("VMI migration", func() {
 		var clientVMI *v1.VirtualMachineInstance
-
-		BeforeEach(checks.SkipIfMigrationIsNotPossible)
 
 		BeforeEach(func() {
 			clientVMI = libvmifact.NewAlpineWithTestTooling(

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -111,7 +111,7 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 		Expect(libnet.PingFromVMConsole(clientVMI, serverIPAddr)).To(Succeed())
 	})
 
-	Context("VMI migration", func() {
+	Context("VMI migration", decorators.RequiresTwoSchedulableNodes, func() {
 		var clientVMI *v1.VirtualMachineInstance
 
 		BeforeEach(func() {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -168,7 +168,7 @@ var istioTests = func(vmType VmType) {
 			By("Waiting for VMI to be ready")
 			libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 		})
-		Describe("Live Migration", decorators.SigComputeMigrations, func() {
+		Describe("Live Migration", decorators.RequiresTwoSchedulableNodes, decorators.SigComputeMigrations, func() {
 			var sourcePodName string
 			allContainersCompleted := func(podName string) error {
 				pod, err := virtClient.CoreV1().Pods(vmi.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/istio"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
@@ -183,9 +182,6 @@ var istioTests = func(vmType VmType) {
 				}
 				return nil
 			}
-			BeforeEach(func() {
-				checks.SkipIfMigrationIsNotPossible()
-			})
 			JustBeforeEach(func() {
 				sourcePod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -588,7 +588,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 		})
 
-		When("performing migration", func() {
+		When("performing migration", decorators.RequiresTwoSchedulableNodes, func() {
 			var vmi *v1.VirtualMachineInstance
 
 			ping := func(ipAddr string) error {

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -604,10 +604,6 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				return pod, nil
 			}
 
-			BeforeEach(func() {
-				checks.SkipIfMigrationIsNotPossible()
-			})
-
 			DescribeTable("[Conformance] preserves connectivity - IPv4", func(ports []v1.Port) {
 				libnet.SkipWhenClusterNotSupportIpv4()
 

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -68,7 +68,6 @@ import (
 var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
-		checks.SkipIfMigrationIsNotPossible()
 		virtClient = kubevirt.Client()
 		originalKv := libkubevirt.GetCurrentKv(virtClient)
 		updateStrategy := &virtv1.KubeVirtWorkloadUpdateStrategy{

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -41,7 +41,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -65,8 +64,6 @@ var _ = Describe("[sig-compute]SwapTest", Serial, decorators.SigCompute, func() 
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
-		checks.SkipIfMigrationIsNotPossible()
-
 		virtClient = kubevirt.Client()
 
 		nodes := libnode.GetAllSchedulableNodes(virtClient)

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -60,7 +60,7 @@ const (
 	bytesInKib          = 1024
 )
 
-var _ = Describe("[sig-compute]SwapTest", Serial, decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]SwapTest", decorators.RequiresTwoSchedulableNodes, Serial, decorators.SigCompute, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -223,7 +223,7 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 					fmt.Sprintf("container %s should terminate", sidecarContainerName))
 			})
 
-			DescribeTable("migrate VMI with sidecar", func(hookVersion string, sidecarShouldTerminate bool) {
+			DescribeTable("migrate VMI with sidecar", decorators.RequiresTwoSchedulableNodes, func(hookVersion string, sidecarShouldTerminate bool) {
 				vmi.ObjectMeta.Annotations = RenderSidecar(hookVersion)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, 360)
 

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -45,7 +45,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -225,8 +224,6 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 			})
 
 			DescribeTable("migrate VMI with sidecar", func(hookVersion string, sidecarShouldTerminate bool) {
-				checks.SkipIfMigrationIsNotPossible()
-
 				vmi.ObjectMeta.Annotations = RenderSidecar(hookVersion)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, 360)
 

--- a/tests/vmi_tpm_test.go
+++ b/tests/vmi_tpm_test.go
@@ -32,8 +32,6 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
-	"kubevirt.io/kubevirt/tests/framework/checks"
-
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
@@ -77,7 +75,6 @@ var _ = Describe("[sig-compute]vTPM", decorators.SigCompute, func() {
 			}, 300)).To(Succeed(), "PCR extension doesn't work correctly")
 
 			By("Migrating the VMI")
-			checks.SkipIfMigrationIsNotPossible()
 			migration := libmigration.New(vmi.Name, vmi.Namespace)
 			libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 

--- a/tests/vmi_tpm_test.go
+++ b/tests/vmi_tpm_test.go
@@ -48,7 +48,7 @@ var _ = Describe("[sig-compute]vTPM", decorators.SigCompute, func() {
 	})
 
 	Context("[rfe_id:5168][crit:high][vendor:cnv-qe@redhat.com][level:component] with TPM VMI option enabled", func() {
-		It("[test_id:8607] should expose a functional emulated TPM which persists across migrations", func() {
+		It("[test_id:8607] should expose a functional emulated TPM which persists across migrations", decorators.RequiresTwoSchedulableNodes, func() {
 			By("Creating a VMI with TPM enabled")
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{}

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -43,7 +43,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 
@@ -150,7 +149,6 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, decorators
 			Expect(domSpec2.Devices.VSOCK.CID.Address).To(Equal(*vmi2.Status.VSOCKCID))
 
 			By("Migrating the 2nd VMI")
-			checks.SkipIfMigrationIsNotPossible()
 			migration := libmigration.New(vmi2.Name, vmi2.Namespace)
 			libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
 

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -120,7 +120,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, decorators
 			}
 		}
 
-		It("should retain the CID for migration target", func() {
+		It("should retain the CID for migration target", decorators.RequiresTwoSchedulableNodes, func() {
 			By("Creating a VMI with VSOCK enabled")
 			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
 			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.P(true)


### PR DESCRIPTION
Removed explicit skipping from test code. Added documentation for skipping tests based on cluster requirements using the `KUBEVIRT_E2E_SKIP` variable. Also added a decorator for skipping tests requiring two schedulable nodes, which is useful for single-node clusters.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

