### PR TITLE
github: Introduce a feature graduation tracker template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_lifecycle.md
+++ b/.github/ISSUE_TEMPLATE/feature_lifecycle.md
@@ -1,0 +1,38 @@
+---
+name: Feature Graduation Tracker
+about: Track a feature through graduation from Alpha to GA
+title: ''
+labels: kind/tracker, kind/enhancement
+assignees: ''
+---
+<!-- Please refer to https://github.com/kubevirt/community/blob/main/design-proposals/feature-lifecycle.md 
+-->
+
+**Primary contact (assignee)**:
+Handle of the current contact for the feature.
+
+**Current Feature Stage**:
+The current stage of the feature, should be one of Deprecated, Alpha, Beta or GA.
+
+**Feature Gate**:
+The full name of the feature gate controlling feature visibility before GA.
+
+**Responsible SIGs (optional)**:
+Optional primary SIG and any additional SIGs responsible for the feature.
+
+**Design proposal link (optional)**:
+Optional link to any design proposal PRs for this feature.
+
+**Timeline**:
+
+<!-- See https://github.com/kubevirt/community/blob/main/design-proposals/feature-lifecycle.md#releases for more context, please include links to relevant PRs
+-->
+
+* [] Alpha (v1.5.0)
+* [] Beta (v1.6.0)
+  * [] Additional Beta criteria
+* [] GA (v1.7.0)
+  * [] Additional GA criteria
+
+**Additional context**:
+Add any other context about the feature here.


### PR DESCRIPTION
/cc @xpivarc 
/cc @vladikr 
/cc @EdDev 

### What this PR does
As discussed at the unconference for v1.5.0 [1] we need to track existing and new FGs through the various graduation phases to GA moving forward.  This commit introduces a simple GitHub template to help folks start this process.

[1] https://unconference.kubevirt.io/D62SngbSRXO1uhTAc8Ikqg#xpivarc-Feature-lifecycleFuture-of-proposals---1-1-1-1

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

