### PR TITLE
tests/libnode/node: rename NodeNameWithHandler

### DIFF
--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -271,7 +271,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 		BeforeEach(func() {
 			virtClient = kubevirt.Client()
 
-			nodeName = libnode.NodeNameWithHandler()
+			nodeName = libnode.GetNodeNameWithHandler()
 			Expect(nodeName).ToNot(BeEmpty())
 
 			checkCmd := []string{"ls", sevDevicePath}

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -333,7 +333,7 @@ func GetNodeWithHugepages(virtClient kubecli.KubevirtClient, hugepages k8sv1.Res
 	return nil
 }
 
-func NodeNameWithHandler() string {
+func GetNodeNameWithHandler() string {
 	listOptions := k8smetav1.ListOptions{LabelSelector: v1.AppLabel + "=virt-handler"}
 	virtClient := kubevirt.Client()
 	virtHandlerPods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), listOptions)

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -62,7 +62,7 @@ var _ = SIGDescribe("[Serial]K8s IO events", Serial, func() {
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 
-		nodeName = libnode.NodeNameWithHandler()
+		nodeName = libnode.GetNodeNameWithHandler()
 		createFaultyDisk(nodeName, deviceName)
 		var err error
 		pv, pvc, err = CreatePVandPVCwithFaultyDisk(nodeName, "/dev/mapper/"+deviceName, testsuite.GetTestNamespace(nil))

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1865,7 +1865,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 
 		BeforeEach(func() {
-			nodeName = libnode.NodeNameWithHandler()
+			nodeName = libnode.GetNodeNameWithHandler()
 			address, device = CreateSCSIDisk(nodeName, []string{})
 			By(fmt.Sprintf("Create PVC with SCSI disk %s", device))
 			pv, pvc, err = CreatePVandPVCwithSCSIDisk(nodeName, device, testsuite.NamespaceTestDefault, "scsi-disks", "scsipv", "scsipvc")

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -163,7 +163,7 @@ var _ = SIGDescribe("Storage", func() {
 			}
 
 			BeforeEach(func() {
-				nodeName = libnode.NodeNameWithHandler()
+				nodeName = libnode.GetNodeNameWithHandler()
 				address, device = CreateErrorDisk(nodeName)
 				pv, pvc, err = CreatePVandPVCwithFaultyDisk(nodeName, device, testsuite.GetTestNamespace(nil))
 				Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for faulty disk")
@@ -1334,7 +1334,7 @@ var _ = SIGDescribe("Storage", func() {
 			}
 
 			BeforeEach(func() {
-				nodeName = libnode.NodeNameWithHandler()
+				nodeName = libnode.GetNodeNameWithHandler()
 				address, device = CreateSCSIDisk(nodeName, []string{})
 			})
 

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -44,7 +44,7 @@ var _ = Describe("[Serial][sig-compute][USB] host USB Passthrough", Serial, deco
 		kv := libkubevirt.GetCurrentKv(virtClient)
 		config = kv.Spec.Configuration
 
-		nodeName := libnode.NodeNameWithHandler()
+		nodeName := libnode.GetNodeNameWithHandler()
 		Expect(nodeName).ToNot(BeEmpty())
 
 		// Emulated USB devices only on c9s providers. Remove this when sig-compute 1.26 is the


### PR DESCRIPTION
Per @0xFelix's request, make the function fit better into its new location in libnode.

```release-note
NONE
```

