### PR TITLE
docs, debug: explain how to use dlv debugger 

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -71,5 +71,16 @@ journalctl -u kubelet
 This shows the basic principle on how remote debugging can be done.
 
  - Add delve to the container
- - Start delve on a specific port ( `dlv attach <pid> --headless --listen=0.0.0.0:1234`)
+ - Start delve on a specific port ( `dlv attach <pid> --headless=true --api-version=2 --listen=:1234`)
  - Use kube-proxy to forward the port to your machine
+
+## Local execution of the kubevirt process
+Not all processses can easily be executed locally, since some of the processes require specific 
+dependencies that exist in the runtime pod and node
+For processes that are easily executed locally, such as `virt-controler`, the following program arguments
+can be passed to virt-controller `--kubeconfig /path/to/kubeconfig --leader-elect-lease-duration 99h` in order 
+to successfully debug.
+> **Note** `/path/to/kubeconfig` must point to a running kubrenetes cluster with kubevirt installed
+> 
+> **Note** It is recommended to scale down both `virt-controller` and also `virt-operator` deployments to
+0 replicas, because otherwise it will override the `virt-controller` deployment manifest.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -74,13 +74,46 @@ This shows the basic principle on how remote debugging can be done.
  - Start delve on a specific port ( `dlv attach <pid> --headless=true --api-version=2 --listen=:1234`)
  - Use kube-proxy to forward the port to your machine
 
+A go debugger can be attached to kubevirt processes in the following manners:
 ## Local execution of the kubevirt process
 Not all processses can easily be executed locally, since some of the processes require specific 
 dependencies that exist in the runtime pod and node
 For processes that are easily executed locally, such as `virt-controler`, the following program arguments
 can be passed to virt-controller `--kubeconfig /path/to/kubeconfig --leader-elect-lease-duration 99h` in order 
-to successfully debug.
+to successfully debug. Since virt-contoller and other control plane components rely on leader election to achive
+consensus among multiple replicas, and we only want our local replica to be the leader, even in the absence of other 
+replicas, we can temporarily grant control to our local replica by specifying the `--leader-elect-lease-duration` 
+argument, as shown above, with an example value of `99h`, granting the lease for 99 hours.    
 > **Note** `/path/to/kubeconfig` must point to a running kubrenetes cluster with kubevirt installed
 > 
 > **Note** It is recommended to scale down both `virt-controller` and also `virt-operator` deployments to
 0 replicas, because otherwise it will override the `virt-controller` deployment manifest.
+## Remote debugging running pods
+Remote debugging may be more complex to setup, but has the advantage of executing the procesess in its
+real runtime environment, where all dependencies ae satisfied, therefore it can work for any go process 
+### Step 1 - recompile go code, build and publish container image
+Compile the required go [cmd](https://github.com/kubevirt/kubevirt/tree/main/cmd) with `-gcflags='all=-N -l'` to produce 
+a debuggable binary.  
+Validate that it is in fact debuggable by running `file <binary file>` and expect to see `with debug_info, not stripped`
+in the output.
+For `Bazel` based build, add `--@io_bazel_rules_go//go/config:gc_goopts=-N,-l --strip=never` to the bazel 
+build command.
+Build a container image, with the compiled binary and publish to a registry that is accessible to the cluster
+consider adding `dlv` executable to the image for step 2
+### Step 2 - modify workload manifest to consume debug container image and execute delve
+Having scaled down virt-operator, patch or edit the respetive k8s workload manifest 
+(e.g. `virt-controller` Deployment, `virt-handler` Daemonset ) to:
+- Consume the debug image
+- Execute `dlv`, either in a separate container, and attach to the debugged process as shown above.
+  [kubectl debug](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_debug/) can be used, to easily
+  add another containr to the pod. 
+  Note that `shareProcessNamespace: true` is necessary, for dlv to be able to debug a process running in another container.
+  The other alternative is to modify the app container `cmd` to have `dlv` `exec` the process in the same container:
+  `dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec <binary>`
+- Turn off probes, tweak securityContext and anything else that could interfere with slow execution
+
+### Step 3 - port-forward a local port to the target pod desgnated debug port
+`kubectl port-forward <pod> 2345`
+
+### Step 4 - connect to localhost:2345 with your debugger
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Describe how to use a `delve` debugger with kubevirt go processes
Commits are incremented in steps of "depth", reviewers may choose to include only the first one or two commits 
replaces https://github.com/kubevirt/kubevirt/pull/13099


Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

