### PR TITLE
Alert KubevirtVmHighMemoryUsage globally and not per VM

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -582,6 +582,7 @@ tests:
   # Memory utilization less than 50MB close to requested memory - based on memory working set
   - interval: 1m
     input_series:
+      # virt-launcher-testvm-123
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
@@ -589,22 +590,27 @@ tests:
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
 
+      # virt-launcher-testvm-456
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-456", container="compute", resource="memory", namespace="ns-test"}'
+        values: "67108864 67108864 67108864 67108864"
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-456", container="compute", namespace="ns-test"}'
+        values: "17185920 18234496 18234496 19283072"
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-456", container="compute", namespace="ns-test"}'
+        values: "19922944 18874368 18874368 17825792"
+
     alert_rule_test:
       - eval_time: 1m
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 50Mi and it is close to requested memory"
-              summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
+              description: "There are 2 VMs where free memory is less than 50Mi and it is close to requested memory"
+              summary: "VMs are at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
-              pod: "virt-launcher-testvm-123"
-              container: "compute"
-              namespace: "ns-test"
 
   # Memory utilization less than 50MB close to requested memory - based on memory RSS
   - interval: 1m
@@ -621,17 +627,14 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 50Mi and it is close to requested memory"
-              summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
+              description: "There are 1 VMs where free memory is less than 50Mi and it is close to requested memory"
+              summary: "VMs are at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
-              pod: "virt-launcher-testvm-123"
-              container: "compute"
-              namespace: "ns-test"
 
   # Memory utilization less than 50MB close to requested memory - based on memory RSS and memory working set
   - interval: 1m
@@ -648,17 +651,14 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 50Mi and it is close to requested memory"
-              summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
+              description: "There are 1 VMs where free memory is less than 50Mi and it is close to requested memory"
+              summary: "VMs are at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
-              pod: "virt-launcher-testvm-123"
-              container: "compute"
-              namespace: "ns-test"
 
   # Memory utilization more than 50MB close to requested memory
   - interval: 30s

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -31,11 +31,11 @@ var (
 	vmsAlerts = []promv1.Rule{
 		{
 			Alert: "KubevirtVmHighMemoryUsage",
-			Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 52428800 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 52428800"),
+			Expr:  intstr.FromString("count(kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 52428800 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 52428800)"),
 			For:   ptr.To(promv1.Duration("1m")),
 			Annotations: map[string]string{
-				"description": fmt.Sprintf("Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} free memory is less than %s and it is close to requested memory", fiftyMB.String()),
-				"summary":     "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime.",
+				"description": fmt.Sprintf("There are {{ $value }} VMs where free memory is less than %s and it is close to requested memory", fiftyMB.String()),
+				"summary":     "VMs are at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Some cluster had a lot of noise due to having many VMs with low free memory available

After this PR:

A single alert with the information of the number of VMs affected

jira-ticket: https://issues.redhat.com/browse/CNV-45063

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Alert KubevirtVmHighMemoryUsage globally and not per VM
```

