### PR TITLE
virtwrap, converter: Skip CPU Hotplug Setup for ARM64

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/amd64.go
@@ -83,3 +83,7 @@ func (archConverterAMD64) isUSBNeeded(vmi *v1.VirtualMachineInstance) bool {
 
 	return false
 }
+
+func (archConverterAMD64) supportCPUHotplug() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/archconverter.go
+++ b/pkg/virt-launcher/virtwrap/converter/archconverter.go
@@ -33,6 +33,7 @@ type archConverter interface {
 	addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext)
 	scsiController(c *ConverterContext, driver *api.ControllerDriver) api.Controller
 	isUSBNeeded(vmi *v1.VirtualMachineInstance) bool
+	supportCPUHotplug() bool
 }
 
 func newArchConverter(arch string) archConverter {

--- a/pkg/virt-launcher/virtwrap/converter/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arm64.go
@@ -64,3 +64,7 @@ func (archConverterARM64) scsiController(c *ConverterContext, driver *api.Contro
 func (archConverterARM64) isUSBNeeded(_ *v1.VirtualMachineInstance) bool {
 	return true
 }
+
+func (archConverterARM64) supportCPUHotplug() bool {
+	return false
+}

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1415,7 +1415,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		CPUs:      cpuCount,
 	}
 	// set the maximum number of sockets here to allow hot-plug CPUs
-	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 {
+	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && newArchConverter(c.Architecture).supportCPUHotplug() {
 		domainVCPUTopologyForHotplug(vmi, domain)
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -886,6 +886,24 @@ var _ = Describe("Converter", func() {
 				Expect(domainSpec.VCPUs.VCPU[5].Enabled).To(Equal("no"), "Expecting the 6th vcpu to be disabled")
 			})
 
+			It("should not define hotplugable topology for ARM64", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Architecture = "arm64"
+				vmi.Spec.Domain.Machine = &v1.Machine{Type: "virt"}
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Cores:      2,
+					MaxSockets: 3,
+					Sockets:    2,
+				}
+				c.Architecture = "arm64"
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(2)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(2)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(4)), "Expect vcpus")
+				Expect(domainSpec.VCPUs).To(BeNil(), "Expecting topology for hotplug")
+			})
+
 			DescribeTable("should convert CPU model", func(model string) {
 				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 				vmi.Spec.Domain.CPU = &v1.CPU{

--- a/pkg/virt-launcher/virtwrap/converter/ppc64le.go
+++ b/pkg/virt-launcher/virtwrap/converter/ppc64le.go
@@ -50,3 +50,7 @@ func (archConverterPPC64) isUSBNeeded(_ *v1.VirtualMachineInstance) bool {
 	//"unsupported configuration: USB is disabled for this domain, but USB devices are present in the domain XML"
 	return true
 }
+
+func (archConverterPPC64) supportCPUHotplug() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/s390x.go
@@ -51,3 +51,7 @@ func (archConverterS390X) scsiController(c *ConverterContext, driver *api.Contro
 func (archConverterS390X) isUSBNeeded(_ *v1.VirtualMachineInstance) bool {
 	return false
 }
+
+func (archConverterS390X) supportCPUHotplug() bool {
+	return true
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

According to the official KubeVirt documentation [1], vCPU hotplug is currently unsupported on the ARM64 architecture. However, this limitation is not enforced in the code. A VM configured with more than one socket will still have `n` CPUs set as both `enabled` and `hotpluggable`, as shown in the following code: https://github.com/kubevirt/kubevirt/blob/bb8e5ad91b890adfa5e930a2fd0519216632ce8f/pkg/virt-launcher/virtwrap/converter/converter.go#L2061-L2090. 

This setup results in a libvirt error [2] on the `aarch64` architecture.

[1] https://kubevirt.io/user-guide/compute/cpu_hotplug/#limitations  
[2] https://gitlab.com/libvirt/libvirt/-/blob/763381df53d5a67804f828cb8db661f694d35296/src/qemu/qemu_process.c#L6073-6082

**After this PR:**

This PR introduces a check to detect if the host architecture is ARM64. If so, it bypasses the hotplug configuration for the domain. A new test is also added to cover this case.

Fixes: https://github.com/kubevirt/kubevirt/issues/13118

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

