### PR TITLE
[release-1.3] backend-storage: address VMI cache corruption

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -511,6 +511,8 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 
 	c.aggregateDataVolumesConditions(vmiCopy, dataVolumes)
 
+	c.backendStorage.UpdateVolumeStatus(vmiCopy)
+
 	switch {
 	case vmi.IsUnprocessed():
 		if vmiPodExists {
@@ -1049,7 +1051,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 		// do not return; just log the error
 	}
 
-	err := c.backendStorage.CreateIfNeededAndUpdateVolumeStatus(vmi)
+	err := c.backendStorage.CreateIfNeeded(vmi)
 	if err != nil {
 		return &syncErrorImpl{err, controller.FailedBackendStorageCreateReason}
 	}


### PR DESCRIPTION
### What this PR does
This is a manual backport of [`f97415f` (#12629)](https://github.com/kubevirt/kubevirt/pull/12629/commits/f97415f55a212f955dac7fbcc6d92a9c91ac323e)

```release-note
NONE
```

