### PR TITLE
tests: quarantine guest console log tests

### DIFF
--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -123,7 +123,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
    http://cirros-cloud.net
 `
 
-			It("it should fetch logs for a running VM with logs API", func() {
+			It("[QUARANTINE] it should fetch logs for a running VM with logs API", decorators.Quarantine, func() {
 				vmi = libvmops.RunVMIAndExpectLaunch(cirrosVmi, cirrosStartupTimeout)
 
 				By("Finding virt-launcher pod")
@@ -192,7 +192,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				Expect(strings.Count(outputString, "virt-serial0-log")).To(Equal(4 + 1))
 			})
 
-			It("it should not skip any log line even trying to flood the serial console for QOSGuaranteed VMs", decorators.Periodic, func() {
+			It("[QUARANTINE] it should not skip any log line even trying to flood the serial console for QOSGuaranteed VMs", decorators.Quarantine, decorators.Periodic, func() {
 				cirrosVmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
 						k8sv1.ResourceCPU:    resource.MustParse("1000m"),


### PR DESCRIPTION
### What this PR does
These tests seem to be sporadically failing due to a suspected libvirt bug:
- `Guest console log container fetch logs it should not skip any log line even trying to flood the serial console for QOSGuaranteed VMs` - failed 16 times over 619 executions: 2.58% failing rate
- `Guest console log container fetch logs it should fetch logs for a running VM with logs API` - failed 11 times over 631 executions: 1.74% failing rate

Per discussion with @tiraboschi and @kmajcher-rh, we decided to quarantine until the issue is resolved.

### Release note
```release-note
NONE
```

