### PR TITLE
e2e,compute: Add [Serial] label to sig-compute tests with serial decorator

### DIFF
--- a/tests/hotplug/affinity.go
+++ b/tests/hotplug/affinity.go
@@ -30,7 +30,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]VM Affinity", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
+var _ = Describe("[Serial][sig-compute]VM Affinity", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/hotplug/tolerations.go
+++ b/tests/hotplug/tolerations.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]VM Tolerations", decorators.SigCompute, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
+var _ = Describe("[Serial][sig-compute]VM Tolerations", decorators.SigCompute, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/infrastructure/crds.go
+++ b/tests/infrastructure/crds.go
@@ -38,7 +38,7 @@ import (
 	crds "kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )
 
-var _ = DescribeInfra("CRDs", Serial, decorators.SigCompute, func() {
+var _ = DescribeInfra("[Serial]CRDs", Serial, decorators.SigCompute, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -89,8 +89,8 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		testsuite.EnsureKVMPresent()
 	})
 
-	Context("when virt-handler is deleted", Serial, decorators.WgS390x, func() {
-		It("[Serial][test_id:4716]should label the node with kubevirt.io/schedulable=false", func() {
+	Context("[Serial]when virt-handler is deleted", Serial, decorators.WgS390x, func() {
+		It("[test_id:4716]should label the node with kubevirt.io/schedulable=false", func() {
 			pods, err := kubevirt.Client().CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"),
 			})

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -55,7 +55,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
+var _ = Describe("[Serial][sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 


### PR DESCRIPTION
### What this PR does

The [Serial] label is still used for the splitting of sig-copmute tests between parallel and serial[1]

Include this label on sig-compute tests that have the serial decorator

[1] https://github.com/kubevirt/kubevirt/blob/08417a74594779672949f21803589e14fb274276/automation/test.sh#L437C1-L443C71
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

