### PR TITLE
Vmrestore - add options to handle cases when target is not ready

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19865,6 +19865,9 @@
       "default": {},
       "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"
      },
+     "targetReadinessPolicy": {
+      "type": "string"
+     },
      "virtualMachineSnapshotName": {
       "type": "string",
       "default": ""

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -634,6 +634,7 @@ spec:
         - apiGroups:
           - subresources.kubevirt.io
           resources:
+          - virtualmachines/stop
           - virtualmachineinstances/addvolume
           - virtualmachineinstances/removevolume
           - virtualmachineinstances/freeze

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -636,6 +636,7 @@ rules:
 - apiGroups:
   - subresources.kubevirt.io
   resources:
+  - virtualmachines/stop
   - virtualmachineinstances/addvolume
   - virtualmachineinstances/removevolume
   - virtualmachineinstances/freeze

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -439,16 +439,6 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 	}
 
 	log.Log.Object(t.vmRestore).V(3).Info("Checking VM ready")
-
-	rs, err := t.vm.RunStrategy()
-	if err != nil {
-		return false, err
-	}
-
-	if rs != kubevirtv1.RunStrategyHalted {
-		return false, fmt.Errorf("invalid RunStrategy %q", rs)
-	}
-
 	vmiKey, err := controller.KeyFunc(t.vm)
 	if err != nil {
 		return false, err

--- a/pkg/storage/snapshot/util.go
+++ b/pkg/storage/snapshot/util.go
@@ -75,6 +75,15 @@ func newFailureCondition(status corev1.ConditionStatus, reason string) snapshotv
 	}
 }
 
+func hasConditionType(conditions []snapshotv1.Condition, condType snapshotv1.ConditionType) bool {
+	for _, cond := range conditions {
+		if cond.Type == condType {
+			return true
+		}
+	}
+	return false
+}
+
 func updateCondition(conditions []snapshotv1.Condition, c snapshotv1.Condition, includeReason bool) []snapshotv1.Condition {
 	found := false
 	for i := range conditions {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -35,7 +35,6 @@ import (
 
 	"kubevirt.io/api/core"
 
-	v1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -198,30 +197,6 @@ func (admitter *VMRestoreAdmitter) validateCreateVM(ctx context.Context, field *
 
 	if err != nil {
 		return nil, nil, false, err
-	}
-
-	rs, err := vm.RunStrategy()
-	if err != nil {
-		return nil, nil, true, err
-	}
-
-	if rs != v1.RunStrategyHalted {
-		var cause metav1.StatusCause
-		targetField := field.Child("target")
-		if vm.Spec.Running != nil && *vm.Spec.Running {
-			cause = metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("VirtualMachine %q is not stopped", vmName),
-				Field:   targetField.String(),
-			}
-		} else {
-			cause = metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("VirtualMachine %q run strategy has to be %s", vmName, v1.RunStrategyHalted),
-				Field:   targetField.String(),
-			}
-		}
-		causes = append(causes, cause)
 	}
 
 	return causes, &vm.UID, true, nil

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				}
 			})
 
-			It("should reject when VM is running", func() {
+			It("should allow when VM is running", func() {
 				restore := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "restore",
@@ -281,12 +281,10 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(HaveLen(1))
-				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
+				Expect(resp.Allowed).To(BeTrue())
 			})
 
-			It("should reject when VM run strategy is not halted", func() {
+			It("should allow when VM run strategy is not halted", func() {
 				restore := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "restore",
@@ -306,10 +304,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(HaveLen(1))
-				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
-				Expect(resp.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("VirtualMachine %q run strategy has to be %s", vmName, v1.RunStrategyHalted)))
+				Expect(resp.Allowed).To(BeTrue())
 			})
 
 			It("should reject when snapshot does not exist", func() {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -24120,6 +24120,11 @@ var CRDsValidation map[string]string = map[string]string{
           - name
           type: object
           x-kubernetes-map-type: atomic
+        targetReadinessPolicy:
+          description: |-
+            TargetReadinessPolicy defines how to handle the restore in case
+            the target is not ready
+          type: string
         virtualMachineSnapshotName:
           type: string
       required:

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -388,6 +388,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"subresources.kubevirt.io",
 				},
 				Resources: []string{
+					"virtualmachines/stop",
 					"virtualmachineinstances/addvolume",
 					"virtualmachineinstances/removevolume",
 					"virtualmachineinstances/freeze",

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/deepcopy_generated.go
@@ -223,6 +223,11 @@ func (in *VirtualMachineRestoreList) DeepCopyObject() runtime.Object {
 func (in *VirtualMachineRestoreSpec) DeepCopyInto(out *VirtualMachineRestoreSpec) {
 	*out = *in
 	in.Target.DeepCopyInto(&out.Target)
+	if in.TargetReadinessPolicy != nil {
+		in, out := &in.TargetReadinessPolicy, &out.TargetReadinessPolicy
+		*out = new(TargetReadinessPolicy)
+		**out = **in
+	}
 	if in.Patches != nil {
 		in, out := &in.Patches, &out.Patches
 		*out = make([]string, len(*in))

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types_swagger_generated.go
@@ -139,9 +139,10 @@ func (VirtualMachineRestore) SwaggerDoc() map[string]string {
 
 func (VirtualMachineRestoreSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":        "VirtualMachineRestoreSpec is the spec for a VirtualMachineRestoreresource",
-		"target":  "initially only VirtualMachine type supported",
-		"patches": "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be\napplied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}\n\n+optional\n+listType=atomic",
+		"":                      "VirtualMachineRestoreSpec is the spec for a VirtualMachineRestoreresource",
+		"target":                "initially only VirtualMachine type supported",
+		"targetReadinessPolicy": "+optional",
+		"patches":               "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be\napplied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}\n\n+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -33063,6 +33063,12 @@ func schema_kubevirtio_api_snapshot_v1beta1_VirtualMachineRestoreSpec(ref common
 							Format:  "",
 						},
 					},
+					"targetReadinessPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"patches": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/events"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/libvmops"
 
@@ -63,8 +64,10 @@ const (
 	macAddressCloningPatchPattern   = `{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "%s"}`
 	firmwareUUIDCloningPatchPattern = `{"op": "replace", "path": "/spec/template/spec/domain/firmware/uuid", "value": "%s"}`
 
-	onlineSnapshot = true
-	offlineSnaphot = false
+	onlineSnapshot      = true
+	offlineSnaphot      = false
+	stopVMBeforeRestore = true
+	stopVMAfterRestore  = false
 )
 
 var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
@@ -392,16 +395,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(vm.Spec).To(Equal(*origSpec))
 
 				deleteRestore(restore)
-			})
-
-			It("[test_id:5257]should reject restore if VM running", func() {
-				Expect(virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})).To(Succeed())
-
-				restore := createRestoreDef(vm.Name, snapshot.Name)
-
-				_, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("VirtualMachine %q run strategy has to be %s", vm.Name, v1.RunStrategyHalted)))
 			})
 
 			It("[test_id:5258]should reject restore if another in progress", func() {
@@ -925,7 +918,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(newVM.Spec.DataVolumeTemplates).To(HaveLen(len(vm.Spec.DataVolumeTemplates)))
 			}
 
-			doRestoreNoVMStart := func(device string, login console.LoginToFunction, onlineSnapshot bool, targetVMName string) {
+			createSnapshotAndRestore := func(device string, login console.LoginToFunction, onlineSnapshot bool, targetVMName string, stopVMBeforeRestore bool) {
 				isRestoreToDifferentVM := targetVMName != vm.Name
 
 				var targetUID *types.UID
@@ -956,8 +949,10 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					updateMessage(device, onlineSnapshot, vmi)
 				}
 
-				By(stoppingVM)
-				vm = libvmops.StopVirtualMachine(vm)
+				if stopVMBeforeRestore {
+					By(stoppingVM)
+					vm = libvmops.StopVirtualMachine(vm)
+				}
 
 				By("Restoring VM")
 				restore = createRestoreDefWithMacAddressPatch(vm, targetVMName, snapshot.Name)
@@ -968,7 +963,21 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
+				if !stopVMBeforeRestore {
+					events.ExpectEvent(restore, corev1.EventTypeNormal, "RestoreTargetNotReady")
+					By(stoppingVM)
+					vm = libvmops.StopVirtualMachine(vm)
+				}
+
 				restore = waitRestoreComplete(restore, targetVMName, targetUID)
+			}
+
+			doRestoreNoVMStart := func(device string, login console.LoginToFunction, onlineSnapshot bool, targetVMName string) {
+				createSnapshotAndRestore(device, login, onlineSnapshot, targetVMName, stopVMBeforeRestore)
+			}
+
+			doRestoreStopVMAfterRestoreCreate := func(device string, login console.LoginToFunction, onlineSnapshot bool, targetVMName string) {
+				createSnapshotAndRestore(device, login, onlineSnapshot, targetVMName, stopVMAfterRestore)
 			}
 
 			startVMAfterRestore := func(targetVMName, device string, login console.LoginToFunction) {
@@ -1413,15 +1422,26 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				vm = createVMWithCloudInit(cd.ContainerDiskCirros, snapshotStorageClass)
 				vm.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{}
 				vm, vmi = createAndStartVM(vm)
+				targetVMName := getTargetVMName(restoreToNewVM, newVmName)
+				login := console.LoginToCirros
 
-				doRestore("", console.LoginToCirros, onlineSnapshot, getTargetVMName(restoreToNewVM, newVmName))
+				if !restoreToNewVM {
+					// Expect to get event in case we stop
+					// the VM after we created the restore.
+					// Once VM is stopped the VMRestore will
+					// continue and complete successfully
+					doRestoreStopVMAfterRestoreCreate("", login, onlineSnapshot, targetVMName)
+				} else {
+					doRestoreNoVMStart("", login, onlineSnapshot, targetVMName)
+				}
+				startVMAfterRestore(targetVMName, "", login)
 				Expect(restore.Status.Restores).To(HaveLen(1))
 				if restoreToNewVM {
 					checkNewVMEquality()
 				}
 
 			},
-				Entry("[test_id:6053] to the same VM", false),
+				Entry("[test_id:6053] to the same VM, stop VM after create restore", false),
 				Entry("to a new VM", true),
 			)
 


### PR DESCRIPTION
### What this PR does
Before this PR:
If VMRestore was initiated when VM is still running the VMRestore webhook would have failed the creation of the object.
If somehow there was a race and the VM became running just after the webhook let the request pass then the reconcile loop will mark the restore in progress and then add a condition that the target of the restore is not ready.

After this PR:
The check of the VM state was removed from the webhook since this is a racefull check and not eventual consistent.
Moved the check of the VM state in the reconcile loop to be before marking the restore in progess.
Added to the restore TargetNotReadyPolicy that will define how to act if restore was initiated when the target is not ready yet.
The default option is wait a default grace period of 5min and if in that time the target is not ready then we fail the restore.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
Jira-ticket: https://issues.redhat.com/browse/CNV-41558


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Vmrestore - add options to handle cases when target is not ready
```

