### PR TITLE
Re-add finalizer update RBAC that was accidentally dropped

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -579,6 +579,7 @@ spec:
           - virtualmachinesnapshots/status
           - virtualmachinesnapshotcontents
           - virtualmachinesnapshotcontents/status
+          - virtualmachinesnapshotcontents/finalizers
           - virtualmachinerestores
           - virtualmachinerestores/status
           verbs:
@@ -624,6 +625,12 @@ spec:
           - '*'
           verbs:
           - '*'
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines/finalizers
+          verbs:
+          - update
         - apiGroups:
           - subresources.kubevirt.io
           resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -581,6 +581,7 @@ rules:
   - virtualmachinesnapshots/status
   - virtualmachinesnapshotcontents
   - virtualmachinesnapshotcontents/status
+  - virtualmachinesnapshotcontents/finalizers
   - virtualmachinerestores
   - virtualmachinerestores/status
   verbs:
@@ -626,6 +627,12 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines/finalizers
+  verbs:
+  - update
 - apiGroups:
   - subresources.kubevirt.io
   resources:

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -318,6 +318,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"virtualmachinesnapshots/status",
 					"virtualmachinesnapshotcontents",
 					"virtualmachinesnapshotcontents/status",
+					"virtualmachinesnapshotcontents/finalizers",
 					"virtualmachinerestores",
 					"virtualmachinerestores/status",
 				},
@@ -368,6 +369,18 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{
 					"*",
+				},
+			},
+			// Implied by asterisk but prefer adding explicitly since it's crucial for OwnerReferencesPermissionEnforcement
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachines/finalizers",
+				},
+				Verbs: []string{
+					"update",
 				},
 			},
 			{

--- a/pkg/virt-operator/resource/generate/rbac/controller_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller_test.go
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2021 Red Hat, Inc.
+ * Copyright 2024 The KubeVirt Authors.
+ *
  */
 
 package rbac
@@ -52,6 +53,8 @@ var _ = Describe("RBAC", func() {
 			Entry("for vmclones", "clone.kubevirt.io", "virtualmachineclones"),
 			Entry("for vmexports", "export.kubevirt.io", "virtualmachineexports"),
 			Entry("for vmpools", "pool.kubevirt.io", "virtualmachinepools"),
+			Entry("for vmsnapshotcontents", "snapshot.kubevirt.io", "virtualmachinesnapshotcontents"),
+			Entry("for vms", "kubevirt.io", "virtualmachines"),
 		)
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Basically, OpenShift deploys enforcement that says we
```cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on```
https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
We recently removed this unintentionally in https://github.com/kubevirt/kubevirt/commit/8d58ba50801dd4e3fed649bc8346e013ad7f2578.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: VMSnapshots broken on OpenShift
```

