### PR TITLE
Expand archconverter usages

### DIFF
--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -76,7 +76,7 @@ var _ = Describe("AccessCredentials", func() {
 	expectIsolationDetectionForVMI := func(vmi *v1.VirtualMachineInstance) *api.DomainSpec {
 		domain := &api.Domain{}
 		c := &converter.ConverterContext{
-			Architecture:   runtime.GOARCH,
+			Architecture:   converter.NewArchConverter(runtime.GOARCH),
 			VirtualMachine: vmi,
 			AllowEmulation: true,
 			SMBios:         &cmdv1.SMBios{},

--- a/pkg/virt-launcher/virtwrap/converter/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/amd64.go
@@ -26,9 +26,13 @@ import (
 )
 
 // Ensure that there is a compile error should the struct not implement the archConverter interface anymore.
-var _ = archConverter(&archConverterAMD64{})
+var _ = ArchConverter(&archConverterAMD64{})
 
 type archConverterAMD64 struct{}
+
+func (archConverterAMD64) GetArchitecture() string {
+	return "amd64"
+}
 
 func (archConverterAMD64) addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext) {
 	// For AMD64 + EFI, use bochs. For BIOS, use VGA

--- a/pkg/virt-launcher/virtwrap/converter/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/amd64.go
@@ -91,3 +91,23 @@ func (archConverterAMD64) isUSBNeeded(vmi *v1.VirtualMachineInstance) bool {
 func (archConverterAMD64) supportCPUHotplug() bool {
 	return true
 }
+
+func (archConverterAMD64) isSMBiosNeeded() bool {
+	return true
+}
+
+func (archConverterAMD64) transitionalModelType(useVirtioTransitional bool) string {
+	return defaultTransitionalModelType(useVirtioTransitional)
+}
+
+func (archConverterAMD64) isROMTuningSupported() bool {
+	return true
+}
+
+func (archConverterAMD64) requiresMPXCPUValidation() bool {
+	return true
+}
+
+func (archConverterAMD64) shouldVerboseLogsBeEnabled() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/archconverter.go
+++ b/pkg/virt-launcher/virtwrap/converter/archconverter.go
@@ -29,14 +29,15 @@ const (
 	graphicsDeviceDefaultVRAM  uint = 16384
 )
 
-type archConverter interface {
+type ArchConverter interface {
+	GetArchitecture() string
 	addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext)
 	scsiController(c *ConverterContext, driver *api.ControllerDriver) api.Controller
 	isUSBNeeded(vmi *v1.VirtualMachineInstance) bool
 	supportCPUHotplug() bool
 }
 
-func newArchConverter(arch string) archConverter {
+func NewArchConverter(arch string) ArchConverter {
 	switch {
 	case isARM64(arch):
 		return archConverterARM64{}
@@ -56,7 +57,7 @@ func defaultSCSIController(c *ConverterContext, driver *api.ControllerDriver) ap
 	return api.Controller{
 		Type:   "scsi",
 		Index:  "0",
-		Model:  InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture),
+		Model:  InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture.GetArchitecture()),
 		Driver: driver,
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/archconverter.go
+++ b/pkg/virt-launcher/virtwrap/converter/archconverter.go
@@ -35,6 +35,11 @@ type ArchConverter interface {
 	scsiController(c *ConverterContext, driver *api.ControllerDriver) api.Controller
 	isUSBNeeded(vmi *v1.VirtualMachineInstance) bool
 	supportCPUHotplug() bool
+	isSMBiosNeeded() bool
+	transitionalModelType(useVirtioTransitional bool) string
+	isROMTuningSupported() bool
+	requiresMPXCPUValidation() bool
+	shouldVerboseLogsBeEnabled() bool
 }
 
 func NewArchConverter(arch string) ArchConverter {
@@ -60,4 +65,11 @@ func defaultSCSIController(c *ConverterContext, driver *api.ControllerDriver) ap
 		Model:  InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture.GetArchitecture()),
 		Driver: driver,
 	}
+}
+
+func defaultTransitionalModelType(useVirtioTransitional bool) string {
+	if useVirtioTransitional {
+		return "virtio-transitional"
+	}
+	return "virtio-non-transitional"
 }

--- a/pkg/virt-launcher/virtwrap/converter/archconverter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/archconverter_test.go
@@ -23,8 +23,8 @@ import (
 
 var _ = Describe("Arch Converter", func() {
 
-	DescribeTable("Should create a new archConverter for the correct architecture", func(arch string, result archConverter) {
-		ac := newArchConverter(arch)
+	DescribeTable("Should create a new archConverter for the correct architecture", func(arch string, result ArchConverter) {
+		ac := NewArchConverter(arch)
 
 		Expect(ac).To(Equal(result))
 	},

--- a/pkg/virt-launcher/virtwrap/converter/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arm64.go
@@ -72,3 +72,25 @@ func (archConverterARM64) isUSBNeeded(_ *v1.VirtualMachineInstance) bool {
 func (archConverterARM64) supportCPUHotplug() bool {
 	return false
 }
+
+func (archConverterARM64) isSMBiosNeeded() bool {
+	// ARM64 use UEFI boot by default, set SMBios is unnecessary.
+	return false
+}
+
+func (archConverterARM64) transitionalModelType(useVirtioTransitional bool) string {
+	return defaultTransitionalModelType(useVirtioTransitional)
+}
+
+func (archConverterARM64) isROMTuningSupported() bool {
+	return true
+}
+
+func (archConverterARM64) requiresMPXCPUValidation() bool {
+	// skip the mpx CPU feature validation for anything that is not x86 as it is not supported.
+	return false
+}
+
+func (archConverterARM64) shouldVerboseLogsBeEnabled() bool {
+	return false
+}

--- a/pkg/virt-launcher/virtwrap/converter/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arm64.go
@@ -24,9 +24,13 @@ import (
 )
 
 // Ensure that there is a compile error should the struct not implement the archConverter interface anymore.
-var _ = archConverter(&archConverterARM64{})
+var _ = ArchConverter(&archConverterARM64{})
 
 type archConverterARM64 struct{}
+
+func (archConverterARM64) GetArchitecture() string {
+	return "arm64"
+}
 
 func (archConverterARM64) addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, _ *ConverterContext) {
 	// For arm64, qemu-kvm only support virtio-gpu display device, so set it as default video device.

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -96,7 +96,7 @@ type EFIConfiguration struct {
 }
 
 type ConverterContext struct {
-	Architecture                    string
+	Architecture                    ArchConverter
 	AllowEmulation                  bool
 	Secrets                         map[string]*k8sv1.Secret
 	VirtualMachine                  *v1.VirtualMachineInstance
@@ -182,7 +182,7 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk 
 			disk.Address = addr
 		}
 		if diskDevice.Disk.Bus == v1.DiskBusVirtio {
-			disk.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture)
+			disk.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture.GetArchitecture())
 		}
 		disk.ReadOnly = toApiReadOnly(diskDevice.Disk.ReadOnly)
 		disk.Serial = diskDevice.Serial
@@ -814,7 +814,7 @@ func Convert_v1_DownwardMetricSource_To_api_Disk(disk *api.Disk, c *ConverterCon
 		Name: "qemu",
 	}
 	// This disk always needs `virtio`. Validation ensures that bus is unset or is already virtio
-	disk.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture)
+	disk.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture.GetArchitecture())
 	disk.Source = api.DiskSource{
 		File: config.DownwardMetricDisk,
 	}
@@ -902,7 +902,7 @@ func Convert_v1_Watchdog_To_api_Watchdog(source *v1.Watchdog, watchdog *api.Watc
 func Convert_v1_Rng_To_api_Rng(_ *v1.Rng, rng *api.Rng, c *ConverterContext) error {
 
 	// default rng model for KVM/QEMU virtualization
-	rng.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture)
+	rng.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture.GetArchitecture())
 
 	// default backend model, random
 	rng.Backend = &api.RngBackend{
@@ -1141,7 +1141,7 @@ func ConvertV1ToAPIBalloning(source *v1.Devices, ballooning *api.MemBalloon, c *
 		ballooning.Model = "none"
 		ballooning.Stats = nil
 	} else {
-		ballooning.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture)
+		ballooning.Model = InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture.GetArchitecture())
 		if c.MemBalloonStatsPeriod != 0 {
 			ballooning.Stats = &api.Stats{Period: c.MemBalloonStatsPeriod}
 		}
@@ -1415,7 +1415,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		CPUs:      cpuCount,
 	}
 	// set the maximum number of sockets here to allow hot-plug CPUs
-	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && newArchConverter(c.Architecture).supportCPUHotplug() {
+	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && c.Architecture.supportCPUHotplug() {
 		domainVCPUTopologyForHotplug(vmi, domain)
 	}
 
@@ -1490,7 +1490,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	// SMBios option does not work in Power, attempting to set it will result in the following error message:
 	// "Option not supported for this target" issued by qemu-system-ppc64, so don't set it in case GOARCH is ppc64le
 	// ARM64 use UEFI boot by default, set SMBios is unnecessory.
-	if isAMD64(c.Architecture) {
+	if isAMD64(c.Architecture.GetArchitecture()) {
 		domain.Spec.OS.SMBios = &api.SMBios{
 			Mode: "sysinfo",
 		}
@@ -1673,13 +1673,13 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		Index: "0",
 		Model: "none",
 	}
-	if newArchConverter(c.Architecture).isUSBNeeded(vmi) {
+	if c.Architecture.isUSBNeeded(vmi) {
 		usbController.Model = "qemu-xhci"
 	}
 	domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, usbController)
 
 	if needsSCSIController(vmi) {
-		scsiController := newArchConverter(c.Architecture).scsiController(c, controllerDriver)
+		scsiController := c.Architecture.scsiController(c, controllerDriver)
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, scsiController)
 	}
 
@@ -1743,7 +1743,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 
 		_, exists := existingFeatures["mpx"]
 		// skip the mpx CPU feature validation for anything that is not x86 as it is not supported.
-		if isAMD64(c.Architecture) && !exists && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
+		if isAMD64(c.Architecture.GetArchitecture()) && !exists && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
 			domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
 				Name:   "mpx",
 				Policy: "disable",
@@ -1782,7 +1782,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
 			Type:   "virtio-serial",
 			Index:  "0",
-			Model:  InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture),
+			Model:  InterpretTransitionalModelType(&c.UseVirtioTransitional, c.Architecture.GetArchitecture()),
 			Driver: controllerDriver,
 		})
 
@@ -1822,7 +1822,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == nil || *vmi.Spec.Domain.Devices.AutoattachGraphicsDevice {
-		newArchConverter(c.Architecture).addGraphicsDevice(vmi, domain, c)
+		c.Architecture.addGraphicsDevice(vmi, domain, c)
 		domain.Spec.Devices.Graphics = []api.Graphics{
 			{
 				Listen: &api.GraphicsListen{
@@ -1856,7 +1856,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 	}
 
-	if isAMD64(c.Architecture) {
+	if isAMD64(c.Architecture.GetArchitecture()) {
 		virtLauncherLogVerbosity, err := strconv.Atoi(os.Getenv(services.ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY))
 		if err == nil && virtLauncherLogVerbosity > services.EXT_LOG_VERBOSITY_THRESHOLD {
 			// isa-debugcon device is only for x86_64

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Converter", func() {
 			}),
 		)
 
-		It("Should add boot order when provided", func() {
+		DescribeTable("Should add boot order when provided", func(arch, expectedModel string) {
 			order := uint(1)
 			kubevirtDisk := &v1.Disk{
 				Name:      "mydisk",
@@ -206,22 +206,27 @@ var _ = Describe("Converter", func() {
 					},
 				},
 			}
-			var convertedDisk = `<Disk device="disk" type="" model="virtio-non-transitional">
+			convertedDisk := fmt.Sprintf(`<Disk device="disk" type="" model="%s">
   <source></source>
   <target bus="virtio" dev="vda"></target>
   <driver name="qemu" type="" discard="unmap"></driver>
   <alias name="ua-mydisk"></alias>
   <boot order="1"></boot>
-</Disk>`
-			xml := diskToDiskXML(kubevirtDisk)
+</Disk>`, expectedModel)
+			xml := diskToDiskXML(arch, kubevirtDisk)
 			Expect(xml).To(Equal(convertedDisk))
-		})
+		},
+			Entry("on amd64", "amd64", "virtio-non-transitional"),
+			Entry("on arm64", "arm64", "virtio-non-transitional"),
+			Entry("on ppc64le", "ppc64le", "virtio-non-transitional"),
+			Entry("on s390x", "s390x", "virtio"),
+		)
 
-		It("should set disk I/O mode if requested", func() {
+		DescribeTable("should set disk I/O mode if requested", func(arch string) {
 			v1Disk := &v1.Disk{
 				IO: "native",
 			}
-			xml := diskToDiskXML(v1Disk)
+			xml := diskToDiskXML(arch, v1Disk)
 			expectedXML := `<Disk device="" type="">
   <source></source>
   <target></target>
@@ -229,11 +234,16 @@ var _ = Describe("Converter", func() {
   <alias name="ua-"></alias>
 </Disk>`
 			Expect(xml).To(Equal(expectedXML))
-		})
+		},
+			Entry("on amd64", "amd64"),
+			Entry("on arm64", "arm64"),
+			Entry("on ppc64le", "ppc64le"),
+			Entry("on s390x", "s390x"),
+		)
 
-		It("should not set disk I/O mode if not requested", func() {
+		DescribeTable("should not set disk I/O mode if not requested", func(arch string) {
 			v1Disk := &v1.Disk{}
-			xml := diskToDiskXML(v1Disk)
+			xml := diskToDiskXML(arch, v1Disk)
 			expectedXML := `<Disk device="" type="">
   <source></source>
   <target></target>
@@ -241,9 +251,14 @@ var _ = Describe("Converter", func() {
   <alias name="ua-"></alias>
 </Disk>`
 			Expect(xml).To(Equal(expectedXML))
-		})
+		},
+			Entry("on amd64", "amd64"),
+			Entry("on arm64", "arm64"),
+			Entry("on ppc64le", "ppc64le"),
+			Entry("on s390x", "s390x"),
+		)
 
-		It("Should omit boot order when not provided", func() {
+		DescribeTable("Should omit boot order when not provided", func(arch, expectedModel string) {
 			kubevirtDisk := &v1.Disk{
 				Name: "mydisk",
 				DiskDevice: v1.DiskDevice{
@@ -252,15 +267,20 @@ var _ = Describe("Converter", func() {
 					},
 				},
 			}
-			var convertedDisk = `<Disk device="disk" type="" model="virtio-non-transitional">
+			var convertedDisk = fmt.Sprintf(`<Disk device="disk" type="" model="%s">
   <source></source>
   <target bus="virtio" dev="vda"></target>
   <driver name="qemu" type="" discard="unmap"></driver>
   <alias name="ua-mydisk"></alias>
-</Disk>`
-			xml := diskToDiskXML(kubevirtDisk)
+</Disk>`, expectedModel)
+			xml := diskToDiskXML(arch, kubevirtDisk)
 			Expect(xml).To(Equal(convertedDisk))
-		})
+		},
+			Entry("on amd64", "amd64", "virtio-non-transitional"),
+			Entry("on arm64", "arm64", "virtio-non-transitional"),
+			Entry("on ppc64le", "ppc64le", "virtio-non-transitional"),
+			Entry("on s390x", "s390x", "virtio"),
+		)
 
 		It("Should add blockio fields when custom sizes are provided", func() {
 			kubevirtDisk := &v1.Disk{
@@ -283,7 +303,7 @@ var _ = Describe("Converter", func() {
 			xml := string(data)
 			Expect(xml).To(Equal(expectedXML))
 		})
-		It("should set sharable and the cache if requested", func() {
+		DescribeTable("should set sharable and the cache if requested", func(arch, expectedModel string) {
 			v1Disk := &v1.Disk{
 				Name: "mydisk",
 				DiskDevice: v1.DiskDevice{
@@ -293,16 +313,21 @@ var _ = Describe("Converter", func() {
 				},
 				Shareable: True(),
 			}
-			var expectedXML = `<Disk device="disk" type="" model="virtio-non-transitional">
+			var expectedXML = fmt.Sprintf(`<Disk device="disk" type="" model="%s">
   <source></source>
   <target bus="virtio" dev="vda"></target>
   <driver cache="none" name="qemu" type="" discard="unmap"></driver>
   <alias name="ua-mydisk"></alias>
   <shareable></shareable>
-</Disk>`
-			xml := diskToDiskXML(v1Disk)
+</Disk>`, expectedModel)
+			xml := diskToDiskXML(arch, v1Disk)
 			Expect(xml).To(Equal(expectedXML))
-		})
+		},
+			Entry("on amd64", "amd64", "virtio-non-transitional"),
+			Entry("on arm64", "arm64", "virtio-non-transitional"),
+			Entry("on ppc64le", "ppc64le", "virtio-non-transitional"),
+			Entry("on s390x", "s390x", "virtio"),
+		)
 	})
 
 	Context("with v1.VirtualMachineInstance", func() {
@@ -659,15 +684,21 @@ var _ = Describe("Converter", func() {
 			}
 		})
 
-		It("should use virtio-transitional models if requested", func() {
+		DescribeTable("should use virtio-transitional models if requested", func(arch string) {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			vmi.Spec.Domain.Devices.DisableHotplug = false
 			c.UseVirtioTransitional = true
+			c.Architecture = NewArchConverter(arch)
 			vmi.Spec.Domain.Devices.UseVirtioTransitional = &c.UseVirtioTransitional
 			dom := vmiToDomain(vmi, c)
 			testutils.ExpectVirtioTransitionalOnly(&dom.Spec)
-		})
+		},
+			Entry("on amd64 with success", "amd64"),
+			Entry("on arm64 with success", "arm64"),
+			Entry("on ppc64le with success", "ppc64le"),
+			//TODO add s390x entry with custom check of model used (disks/interfaces/controllers/devices will use different models)
+		)
 
 		It("should handle float memory", func() {
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("2222222200m")
@@ -1043,7 +1074,8 @@ var _ = Describe("Converter", func() {
 			Expect(reserv.SourceReservations.Mode).To(Equal("client"))
 		})
 
-		It("should add a virtio-scsi controller if a scsci disk is present and iothreads set", func() {
+		DescribeTable("should add a virtio-scsi controller if a scsci disk is present and iothreads set", func(arch, expectedModel string) {
+			c.Architecture = NewArchConverter(arch)
 			one := uint(1)
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "scsi"
@@ -1052,15 +1084,21 @@ var _ = Describe("Converter", func() {
 			Expect(dom.Spec.Devices.Controllers).To(ContainElement(api.Controller{
 				Type:  "scsi",
 				Index: "0",
-				Model: "virtio-non-transitional",
+				Model: expectedModel,
 				Driver: &api.ControllerDriver{
 					IOThread: &one,
 					Queues:   &one,
 				},
 			}))
-		})
+		},
+			Entry("on amd64", "amd64", "virtio-non-transitional"),
+			Entry("on arm64", "arm64", "virtio-non-transitional"),
+			Entry("on ppc64le", "ppc64le", "virtio-non-transitional"),
+			Entry("on s390x", "s390x", "virtio-scsi"),
+		)
 
-		It("should add a virtio-scsi controller if a scsci disk is present and iothreads NOT set", func() {
+		DescribeTable("should add a virtio-scsi controller if a scsci disk is present and iothreads NOT set", func(arch, expectedModel string) {
+			c.Architecture = NewArchConverter(arch)
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "scsi"
 			vmi.Spec.Domain.IOThreadsPolicy = nil
@@ -1072,9 +1110,14 @@ var _ = Describe("Converter", func() {
 			Expect(dom.Spec.Devices.Controllers).To(ContainElement(api.Controller{
 				Type:  "scsi",
 				Index: "0",
-				Model: "virtio-non-transitional",
+				Model: expectedModel,
 			}))
-		})
+		},
+			Entry("on amd64", "amd64", "virtio-non-transitional"),
+			Entry("on arm64", "arm64", "virtio-non-transitional"),
+			Entry("on ppc64le", "ppc64le", "virtio-non-transitional"),
+			Entry("on s390x", "s390x", "virtio-scsi"),
+		)
 
 		It("should not add a virtio-scsi controller if no scsi disk is present", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -1088,9 +1131,10 @@ var _ = Describe("Converter", func() {
 			}))
 		})
 
-		It("should not disable usb controller when usb device is present", func() {
+		DescribeTable("usb controller", func(arch, bus string, matcher types.GomegaMatcher) {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			vmi.Spec.Domain.Devices.Inputs[0].Bus = "usb"
+			vmi.Spec.Domain.Devices.Inputs[0].Bus = v1.InputBus(bus)
+			c.Architecture = NewArchConverter(arch)
 			domain := vmiToDomain(vmi, c)
 			disabled := false
 			for _, controller := range domain.Spec.Devices.Controllers {
@@ -1099,22 +1143,17 @@ var _ = Describe("Converter", func() {
 				}
 			}
 
-			Expect(disabled).To(BeFalse(), "Expect controller not to be disabled")
-		})
-
-		It("should not disable usb controller when device with no bus is present", func() {
-			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			vmi.Spec.Domain.Devices.Inputs[0].Bus = ""
-			domain := vmiToDomain(vmi, c)
-			disabled := false
-			for _, controller := range domain.Spec.Devices.Controllers {
-				if controller.Type == "usb" && controller.Model == "none" {
-					disabled = true
-				}
-			}
-
-			Expect(disabled).To(BeFalse(), "Expect controller not to be disabled")
-		})
+			Expect(disabled).To(matcher, "Expect controller not to be disabled")
+		},
+			Entry("should not be disabled on amd64 usb device is present", "amd64", "usb", BeFalse()),
+			Entry("should not be disabled on amd64 when device with no bus is present", "amd64", "", BeFalse()),
+			Entry("should not be disabled on arm64 usb device is present", "arm64", "usb", BeFalse()),
+			Entry("should not be disabled on arm64 when device with no bus is present", "arm64", "", BeFalse()),
+			Entry("should not be disabled on ppc64le usb device is present", "ppc64le", "usb", BeFalse()),
+			Entry("should not be disabled on ppc64le when device with no bus is present", "ppc64le", "", BeFalse()),
+			Entry("should be disabled on s390x when usb device is present", "s390x", "usb", BeTrue()),
+			Entry("should be disabled on s390x when device with no bus is present", "s390x", "", BeTrue()),
+		)
 
 		It("should fail when input device is set to ps2 bus", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -1199,17 +1238,23 @@ var _ = Describe("Converter", func() {
 			}))
 		})
 
-		It("should enable usb redirection when number of USB client devices > 0", func() {
+		DescribeTable("usb redirection", func(arch string, expectedModel string) {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.ClientPassthrough = &v1.ClientPassthroughDevices{}
+			c.Architecture = NewArchConverter(arch)
 			domain := vmiToDomain(vmi, c)
 			Expect(domain.Spec.Devices.Redirs).To(HaveLen(4))
 			Expect(domain.Spec.Devices.Controllers).To(ContainElement(api.Controller{
 				Type:  "usb",
 				Index: "0",
-				Model: "qemu-xhci",
+				Model: expectedModel,
 			}))
-		})
+		},
+			Entry("should be enabled on amd64 when number of USB client devices > 0", "amd64", "qemu-xhci"),
+			Entry("should be enabled on ppc64le ", "ppc64le", "qemu-xhci"),
+			Entry("should be enabled on arm64 ", "arm64", "qemu-xhci"),
+			Entry("should be disabled on s390x", "s390x", "none"),
+		)
 
 		It("should not enable usb redirection when numberOfDevices == 0", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -2627,10 +2672,10 @@ var _ = Describe("Converter", func() {
 			Expect(domainSpec.OS.NVRam.NVRam).To(Equal("/var/lib/libvirt/qemu/nvram/testvmi_VARS.fd"))
 		})
 
-		DescribeTable("display device should be set to", func(bootloader v1.Bootloader, enableFG bool, expectedDevice string) {
+		DescribeTable("display device should be set to", func(arch string, bootloader v1.Bootloader, enableFG bool, expectedDevice string) {
 			vmi.Spec.Domain.Firmware = &v1.Firmware{Bootloader: &bootloader}
 			c = &ConverterContext{
-				Architecture:      NewArchConverter(runtime.GOARCH),
+				Architecture:      NewArchConverter(arch),
 				BochsForEFIGuests: enableFG,
 				VirtualMachine:    vmi,
 				AllowEmulation:    true,
@@ -2644,10 +2689,25 @@ var _ = Describe("Converter", func() {
 				Expect(domainSpec.Devices.Video[0].Model.VRam).To(BeNil())
 			}
 		},
-			Entry("VGA with BIOS and BochsDisplayForEFIGuests unset", v1.Bootloader{BIOS: &v1.BIOS{}}, false, "vga"),
-			Entry("VGA with BIOS and BochsDisplayForEFIGuests set", v1.Bootloader{BIOS: &v1.BIOS{}}, true, "vga"),
-			Entry("VGA with EFI and BochsDisplayForEFIGuests unset", v1.Bootloader{EFI: &v1.EFI{}}, false, "vga"),
-			Entry("Bochs with EFI and BochsDisplayForEFIGuests set", v1.Bootloader{EFI: &v1.EFI{}}, true, "bochs"),
+			Entry("VGA on amd64 with BIOS and BochsDisplayForEFIGuests unset", "amd64", v1.Bootloader{BIOS: &v1.BIOS{}}, false, "vga"),
+			Entry("VGA on amd64 with BIOS and BochsDisplayForEFIGuests set", "amd64", v1.Bootloader{BIOS: &v1.BIOS{}}, true, "vga"),
+			Entry("VGA on amd64 with EFI and BochsDisplayForEFIGuests unset", "amd64", v1.Bootloader{EFI: &v1.EFI{}}, false, "vga"),
+			Entry("Bochs on amd64 with EFI and BochsDisplayForEFIGuests set", "amd64", v1.Bootloader{EFI: &v1.EFI{}}, true, "bochs"),
+
+			Entry("VIRTIO on amd64 with BIOS and BochsDisplayForEFIGuests unset", "arm64", v1.Bootloader{BIOS: &v1.BIOS{}}, false, "virtio"),
+			Entry("VIRTIO on amd64 with BIOS and BochsDisplayForEFIGuests set", "arm64", v1.Bootloader{BIOS: &v1.BIOS{}}, true, "virtio"),
+			Entry("VIRTIO on amd64 with EFI and BochsDisplayForEFIGuests unset", "arm64", v1.Bootloader{EFI: &v1.EFI{}}, false, "virtio"),
+			Entry("VIRTIO on amd64 with EFI and BochsDisplayForEFIGuests set", "arm64", v1.Bootloader{EFI: &v1.EFI{}}, true, "virtio"),
+
+			Entry("VIRTIO on s390x with BIOS and BochsDisplayForEFIGuests unset", "s390x", v1.Bootloader{BIOS: &v1.BIOS{}}, false, "virtio"),
+			Entry("VIRTIO on s390x with BIOS and BochsDisplayForEFIGuests set", "s390x", v1.Bootloader{BIOS: &v1.BIOS{}}, true, "virtio"),
+			Entry("VIRTIO on s390x with EFI and BochsDisplayForEFIGuests unset", "s390x", v1.Bootloader{EFI: &v1.EFI{}}, false, "virtio"),
+			Entry("VIRTIO on s390x with EFI and BochsDisplayForEFIGuests set", "s390x", v1.Bootloader{EFI: &v1.EFI{}}, true, "virtio"),
+
+			Entry("VGA on ppc64le with BIOS and BochsDisplayForEFIGuests unset", "ppc64le", v1.Bootloader{BIOS: &v1.BIOS{}}, false, "vga"),
+			Entry("VGA on ppc64le with BIOS and BochsDisplayForEFIGuests set", "ppc64le", v1.Bootloader{BIOS: &v1.BIOS{}}, true, "vga"),
+			Entry("VGA on ppc64le with EFI and BochsDisplayForEFIGuests unset", "ppc64le", v1.Bootloader{EFI: &v1.EFI{}}, false, "vga"),
+			Entry("VGA on ppc64le with EFI and BochsDisplayForEFIGuests set", "ppc64le", v1.Bootloader{EFI: &v1.EFI{}}, true, "vga"),
 		)
 	})
 
@@ -2739,19 +2799,25 @@ var _ = Describe("Converter", func() {
 				}
 			})
 
-			It("should automatically add virtio-scsi controller", func() {
+			DescribeTable("should automatically add virtio-scsi controller", func(arch, expectedModel string) {
+				c.Architecture = NewArchConverter(arch)
 				domain := vmiToDomain(vmi, c)
 				Expect(domain.Spec.Devices.Controllers).To(HaveLen(3))
 				foundScsiController := false
 				for _, controller := range domain.Spec.Devices.Controllers {
 					if controller.Type == "scsi" {
 						foundScsiController = true
-						Expect(controller.Model).To(Equal("virtio-non-transitional"))
+						Expect(controller.Model).To(Equal(expectedModel))
 
 					}
 				}
 				Expect(foundScsiController).To(BeTrue(), "did not find SCSI controller when expected")
-			})
+			},
+				Entry("on amd64", "amd64", "virtio-non-transitional"),
+				Entry("on arm64", "arm64", "virtio-non-transitional"),
+				Entry("on ppc64le", "ppc64le", "virtio-non-transitional"),
+				Entry("on s390x", "s390x", "virtio-scsi"),
+			)
 
 			It("should not automatically add virtio-scsi controller, if hotplug disabled", func() {
 				vmi.Spec.Domain.Devices.DisableHotplug = true
@@ -3271,10 +3337,10 @@ var _ = Describe("SetDriverCacheMode", func() {
 	)
 })
 
-func diskToDiskXML(disk *v1.Disk) string {
+func diskToDiskXML(arch string, disk *v1.Disk) string {
 	devicePerBus := make(map[string]deviceNamer)
 	libvirtDisk := &api.Disk{}
-	Expect(Convert_v1_Disk_To_api_Disk(&ConverterContext{Architecture: NewArchConverter(runtime.GOARCH), UseVirtioTransitional: false}, disk, libvirtDisk, devicePerBus, nil, make(map[string]v1.VolumeStatus))).To(Succeed())
+	Expect(Convert_v1_Disk_To_api_Disk(&ConverterContext{Architecture: NewArchConverter(arch), UseVirtioTransitional: false}, disk, libvirtDisk, devicePerBus, nil, make(map[string]v1.VolumeStatus))).To(Succeed())
 	data, err := xml.MarshalIndent(libvirtDisk, "", "  ")
 	Expect(err).ToNot(HaveOccurred())
 	return string(data)

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -83,7 +83,7 @@ func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, c *ConverterContext)
 			domainIface.Type = "ethernet"
 			if iface.BootOrder != nil {
 				domainIface.BootOrder = &api.BootOrder{Order: *iface.BootOrder}
-			} else if !isS390X(vmi.Spec.Architecture) {
+			} else if NewArchConverter(vmi.Spec.Architecture).isROMTuningSupported() {
 				// s390x does not support setting ROM tuning, as it is for PCI Devices only
 				domainIface.Rom = &api.Rom{Enabled: "no"}
 			}

--- a/pkg/virt-launcher/virtwrap/converter/ppc64le.go
+++ b/pkg/virt-launcher/virtwrap/converter/ppc64le.go
@@ -24,11 +24,15 @@ import (
 )
 
 // Ensure that there is a compile error should the struct not implement the archConverter interface anymore.
-var _ = archConverter(&archConverterPPC64{})
+var _ = ArchConverter(&archConverterPPC64{})
 
 type archConverterPPC64 struct{}
 
-func (archConverterPPC64) addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext) {
+func (archConverterPPC64) GetArchitecture() string {
+	return "ppc64le"
+}
+
+func (archConverterPPC64) addGraphicsDevice(_ *v1.VirtualMachineInstance, domain *api.Domain, _ *ConverterContext) {
 	domain.Spec.Devices.Video = []api.Video{
 		{
 			Model: api.VideoModel{

--- a/pkg/virt-launcher/virtwrap/converter/ppc64le.go
+++ b/pkg/virt-launcher/virtwrap/converter/ppc64le.go
@@ -58,3 +58,26 @@ func (archConverterPPC64) isUSBNeeded(_ *v1.VirtualMachineInstance) bool {
 func (archConverterPPC64) supportCPUHotplug() bool {
 	return true
 }
+
+func (archConverterPPC64) isSMBiosNeeded() bool {
+	// SMBios option does not work in Power, attempting to set it will result in the following error message:
+	// "Option not supported for this target" issued by qemu-system-ppc64, so don't set it in case GOARCH is ppc64le
+	return false
+}
+
+func (archConverterPPC64) transitionalModelType(useVirtioTransitional bool) string {
+	return defaultTransitionalModelType(useVirtioTransitional)
+}
+
+func (archConverterPPC64) isROMTuningSupported() bool {
+	return true
+}
+
+func (archConverterPPC64) requiresMPXCPUValidation() bool {
+	// skip the mpx CPU feature validation for anything that is not x86 as it is not supported.
+	return false
+}
+
+func (archConverterPPC64) shouldVerboseLogsBeEnabled() bool {
+	return false
+}

--- a/pkg/virt-launcher/virtwrap/converter/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/s390x.go
@@ -24,11 +24,15 @@ import (
 )
 
 // Ensure that there is a compile error should the struct not implement the archConverter interface anymore.
-var _ = archConverter(&archConverterS390X{})
+var _ = ArchConverter(&archConverterS390X{})
 
 type archConverterS390X struct{}
 
-func (archConverterS390X) addGraphicsDevice(vmi *v1.VirtualMachineInstance, domain *api.Domain, _ *ConverterContext) {
+func (archConverterS390X) GetArchitecture() string {
+	return "s390x"
+}
+
+func (archConverterS390X) addGraphicsDevice(_ *v1.VirtualMachineInstance, domain *api.Domain, _ *ConverterContext) {
 	domain.Spec.Devices.Video = []api.Video{
 		{
 			Model: api.VideoModel{
@@ -39,7 +43,7 @@ func (archConverterS390X) addGraphicsDevice(vmi *v1.VirtualMachineInstance, doma
 	}
 }
 
-func (archConverterS390X) scsiController(c *ConverterContext, driver *api.ControllerDriver) api.Controller {
+func (archConverterS390X) scsiController(_ *ConverterContext, driver *api.ControllerDriver) api.Controller {
 	return api.Controller{
 		Type:   "scsi",
 		Index:  "0",

--- a/pkg/virt-launcher/virtwrap/converter/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/s390x.go
@@ -59,3 +59,26 @@ func (archConverterS390X) isUSBNeeded(_ *v1.VirtualMachineInstance) bool {
 func (archConverterS390X) supportCPUHotplug() bool {
 	return true
 }
+
+func (archConverterS390X) isSMBiosNeeded() bool {
+	return false
+}
+
+func (archConverterS390X) transitionalModelType(_ bool) string {
+	// "virtio-non-transitional" and "virtio-transitional" are both PCI devices, so they don't work on s390x.
+	// "virtio" is a generic model that can be either PCI or CCW depending on the machine type
+	return "virtio"
+}
+
+func (archConverterS390X) isROMTuningSupported() bool {
+	return false
+}
+
+func (archConverterS390X) requiresMPXCPUValidation() bool {
+	// skip the mpx CPU feature validation for anything that is not x86 as it is not supported.
+	return false
+}
+
+func (archConverterS390X) shouldVerboseLogsBeEnabled() bool {
+	return false
+}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1017,7 +1017,7 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 
 	// Map the VirtualMachineInstance to the Domain
 	c := &converter.ConverterContext{
-		Architecture:          runtime.GOARCH,
+		Architecture:          converter.NewArchConverter(runtime.GOARCH),
 		VirtualMachine:        vmi,
 		AllowEmulation:        allowEmulation,
 		CPUSet:                podCPUSet,
@@ -1119,7 +1119,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 	}
 
 	// Set defaults which are not coming from the cluster
-	api.NewDefaulter(c.Architecture).SetObjectDefaults_Domain(domain)
+	api.NewDefaulter(c.Architecture.GetArchitecture()).SetObjectDefaults_Domain(domain)
 
 	dom, err := l.lookupOrCreateVirDomain(domain, vmi, options)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -412,7 +412,7 @@ var _ = Describe("Manager", func() {
 		serialConsoleLogDisabled := clusterConfig.IsSerialConsoleLogDisabled()
 
 		c := &converter.ConverterContext{
-			Architecture:      runtime.GOARCH,
+			Architecture:      converter.NewArchConverter(runtime.GOARCH),
 			VirtualMachine:    vmi,
 			AllowEmulation:    true,
 			SMBios:            &cmdv1.SMBios{},

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -218,7 +218,7 @@ var _ = Describe("LibvirtHelper", func() {
 		v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 		domain := &api.Domain{}
 		c := &converter.ConverterContext{
-			Architecture:     runtime.GOARCH,
+			Architecture:     converter.NewArchConverter(runtime.GOARCH),
 			VirtualMachine:   vmi,
 			AllowEmulation:   true,
 			SMBios:           &cmdv1.SMBios{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the arch converter is used
to differentiate the behavior between
the arch.
To do so, it should be initialized every time
you want to use it (`newArchConverter(arch)`).

The converterContext has the architecture string
as field.

We can expand the latter to the archConverter, so
that we can use it directly.

Ideally, the archConverter should be the centralized 
place where all the different strategies are contained,
without the need to specify `isARM` or `isAMD` spread
in the codebase.
I'd expect to see something like `is<feature>Enabled()`
where the different archconverter handles it.

Following this, new methods are added to the archConverter interface:
- isSMBiosNeeded() bool
- transitionalModelType(useVirtioTransitional *bool) string
- isROMTuningSupported() bool
- requiresMPXCPUValidation() bool
- shouldVerboseLogsBeEnabled() bool

In this way, we can get rid of the specific arch if statements,
replacing them with more feature-oriented statements.

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

