### PR TITLE
tests/scale/virt-api: introduce KubeVirtSpecCustomization decorator

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -27,6 +27,9 @@ var (
 	Invtsc      = Label("Invtsc")
 	KSMRequired = Label("KSM-required")
 
+	// Customization
+	KubeVirtSpecCustomization = Label("kubevirt-spec-customization")
+
 	// Features
 	Sysprep                              = Label("Sysprep")
 	Windows                              = Label("Windows")

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -22,7 +22,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 )
 
-var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, func() {
+var _ = Describe("[sig-compute] virt-api scaling", decorators.SigCompute, decorators.KubeVirtSpecCustomization, func() {
 	var virtClient kubecli.KubevirtClient
 	numberOfNodes := 0
 


### PR DESCRIPTION
This PR introduces a new decorator, KubeVirtSpecCustomization. The purpose of this decorator is to mark tests that specifically perform customizations on the KubeVirt resource.
Some of these customizations are not supported when KubeVirt is deployed with HCO, such as on OpenShift. With this new label, it will be possible to filter these specific tests.

### Release note
```release-note
none
```

