### PR TITLE
storagetypes: use built-in `min` function

### DIFF
--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -300,13 +300,6 @@ func GetDisksByName(vmiSpec *virtv1.VirtualMachineInstanceSpec) map[string]*virt
 	return disks
 }
 
-func Min(one, two int64) int64 {
-	if one < two {
-		return one
-	}
-	return two
-}
-
 // Get expected disk capacity - a minimum between the request and the PVC capacity.
 // Returns nil when we have insufficient data to calculate this minimum.
 func GetDiskCapacity(pvcInfo *virtv1.PersistentVolumeClaimInfo) *int64 {
@@ -329,7 +322,7 @@ func GetDiskCapacity(pvcInfo *virtv1.PersistentVolumeClaimInfo) *int64 {
 		logger.Infof("Failed to convert storage request %+v to int64", storageRequestResource)
 		return nil
 	}
-	preferredSize := Min(storageRequest, storageCapacity)
+	preferredSize := min(storageRequest, storageCapacity)
 	return &preferredSize
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -70,7 +70,6 @@ go_test(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
-        "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/virt-controller/services:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -59,7 +59,6 @@ import (
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	kubevirtpointer "kubevirt.io/kubevirt/pkg/pointer"
-	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	sev "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/launchsecurity"
 )
 
@@ -163,7 +162,7 @@ var _ = Describe("Converter", func() {
 			}
 			Convert_v1_Disk_To_api_Disk(context, &v1Disk, &apiDisk, devicePerBus, &numQueues, volumeStatusMap)
 			Expect(apiDisk.Capacity).ToNot(BeNil())
-			Expect(*apiDisk.Capacity).To(Equal(storagetypes.Min(capacity, requests)))
+			Expect(*apiDisk.Capacity).To(Equal(min(capacity, requests)))
 		},
 			Entry("Higher request than capacity", int64(9999), int64(1111)),
 			Entry("Lower request than capacity", int64(1111), int64(9999)),

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Converter", func() {
 	})
 
 	Context("with v1.Disk", func() {
-		DescribeTable("Should define disk capacity as the minimum of capacity and request", func(requests, capacity int64) {
+		DescribeTable("Should define disk capacity as the minimum of capacity and request", func(requests, capacity, expected int64) {
 			context := &ConverterContext{Architecture: NewArchConverter(runtime.GOARCH)}
 			v1Disk := v1.Disk{
 				Name: "myvolume",
@@ -162,10 +162,10 @@ var _ = Describe("Converter", func() {
 			}
 			Convert_v1_Disk_To_api_Disk(context, &v1Disk, &apiDisk, devicePerBus, &numQueues, volumeStatusMap)
 			Expect(apiDisk.Capacity).ToNot(BeNil())
-			Expect(*apiDisk.Capacity).To(Equal(min(capacity, requests)))
+			Expect(*apiDisk.Capacity).To(Equal(expected))
 		},
-			Entry("Higher request than capacity", int64(9999), int64(1111)),
-			Entry("Lower request than capacity", int64(1111), int64(9999)),
+			Entry("Higher request than capacity", int64(9999), int64(1111), int64(1111)),
+			Entry("Lower request than capacity", int64(1111), int64(9999), int64(1111)),
 		)
 
 		DescribeTable("Should assign scsi controller to", func(diskDevice v1.DiskDevice) {


### PR DESCRIPTION
### What this PR does

We can use the built-in `min` function since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

