### PR TITLE
[WIP] tests, storage: Fail if block storage not present

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -17,15 +17,16 @@ var (
 	SigMonitoring        = Label("sig-monitoring")
 
 	// HW
-	GPU         = Label("GPU")
-	VGPU        = Label("VGPU")
-	SEV         = Label("SEV")
-	SRIOV       = Label("SRIOV")
-	StorageReq  = Label("storage-req")
-	Multus      = Label("Multus")
-	Macvtap     = Label("Macvtap")
-	Invtsc      = Label("Invtsc")
-	KSMRequired = Label("KSM-required")
+	GPU                  = Label("GPU")
+	VGPU                 = Label("VGPU")
+	SEV                  = Label("SEV")
+	SRIOV                = Label("SRIOV")
+	StorageReq           = Label("storage-req")
+	BlockStorageRequired = Label("block-storage-required")
+	Multus               = Label("Multus")
+	Macvtap              = Label("Macvtap")
+	Invtsc               = Label("Invtsc")
+	KSMRequired          = Label("KSM-required")
 
 	// Features
 	Sysprep                              = Label("Sysprep")

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -396,15 +396,14 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			})
 
-			It("should migrate vmi and use Live Migration method with read-only disks", func() {
+			It("should migrate vmi and use Live Migration method with read-only disks", decorators.BlockStorageRequired, func() {
 				By("Defining a VMI with PVC disk and read-only CDRoms")
 				if !libstorage.HasCDI() {
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 				sc, exists := libstorage.GetRWXBlockStorageClass()
-				if !exists {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(exists).To(BeTrue(), "Block storage is not present")
+
 				dv := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
 					libdv.WithStorage(
@@ -920,11 +919,9 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("DisksNotLiveMigratable"))
 			})
-			It("[test_id:1479][storage-req] should migrate a vmi with a shared block disk", decorators.StorageReq, func() {
+			It("[test_id:1479][storage-req] should migrate a vmi with a shared block disk", decorators.StorageReq, decorators.BlockStorageRequired, func() {
 				sc, exists := libstorage.GetRWXBlockStorageClass()
-				if !exists {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(exists).To(BeTrue(), "Block storage is not present")
 
 				By("Starting the VirtualMachineInstance")
 				vmi := newVMIWithDataVolumeForMigration(cd.ContainerDiskAlpine, k8sv1.ReadWriteMany, sc)
@@ -980,15 +977,13 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				libmigration.ExpectMigrationToSucceedWithDefaultTimeout(virtClient, migration1)
 			})
 		})
-		Context("[storage-req]with an Alpine shared block volume PVC", decorators.StorageReq, func() {
+		Context("[storage-req]with an Alpine shared block volume PVC", decorators.StorageReq, decorators.BlockStorageRequired, func() {
 			var sc string
 			var exists bool
 
 			BeforeEach(func() {
 				sc, exists = libstorage.GetRWXBlockStorageClass()
-				if !exists {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(exists).To(BeTrue(), "Block storage is not present")
 			})
 
 			It("[test_id:1854]should migrate a VMI with shared and non-shared disks", func() {
@@ -1825,13 +1820,11 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				}
 			})
 		})
-		Context("[storage-req]with an Alpine non-shared block volume PVC", decorators.StorageReq, func() {
+		Context("[storage-req]with an Alpine non-shared block volume PVC", decorators.StorageReq, decorators.BlockStorageRequired, func() {
 
 			It("[test_id:1862][posneg:negative]should reject migrations for a non-migratable vmi", func() {
 				sc, exists := libstorage.GetRWOBlockStorageClass()
-				if !exists {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(exists).To(BeTrue(), "Block storage is not present")
 
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi := newVMIWithDataVolumeForMigration(cd.ContainerDiskAlpine, k8sv1.ReadWriteOnce, sc, libvmi.WithHostname(string(cd.ContainerDiskAlpine)))
@@ -1865,9 +1858,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				}
 
 				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteMany)
-				if !foundSC {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(foundSC).To(BeTrue(), "Block storage is not present")
 
 				dv := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), cdiv1.RegistryPullNode),
@@ -1940,7 +1931,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				libwait.WaitForMigrationToDisappearWithTimeout(migration, 240)
 			},
 				Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
-				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", decorators.StorageReq, newVirtualMachineInstanceWithFedoraRWXBlockDisk),
+				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", decorators.StorageReq, decorators.BlockStorageRequired, newVirtualMachineInstanceWithFedoraRWXBlockDisk),
 			)
 
 			It("[sig-compute][test_id:3241]Immediate migration cancellation after migration starts running cancel a migration by deleting vmim object", func() {

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -155,7 +155,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		return size - remainder
 	}
 
-	Context("[storage-req]PVC expansion", decorators.StorageReq, func() {
+	Context("[storage-req]PVC expansion", decorators.StorageReq, decorators.BlockStorageRequired, func() {
 		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
 			checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
 
@@ -163,9 +163,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			exists := false
 			if volumeMode == k8sv1.PersistentVolumeBlock {
 				sc, exists = libstorage.GetRWOBlockStorageClass()
-				if !exists {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(exists).To(BeTrue(), "Block storage is not present")
 			} else {
 				sc, exists = libstorage.GetRWOFileSystemStorageClass()
 				if !exists {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -942,16 +942,14 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 
-		Context("[rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component][storage-req] With Cirros BlockMode PVC", decorators.StorageReq, func() {
+		Context("[rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component][storage-req] With Cirros BlockMode PVC", decorators.StorageReq, decorators.BlockStorageRequired, func() {
 			var dataVolume *cdiv1.DataVolume
 			var err error
 
 			BeforeEach(func() {
 				// create a new PV and PVC (PVs can't be reused)
 				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
-				if !foundSC {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(foundSC).To(BeTrue(), "Block storage is not present")
 
 				dataVolume = libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
@@ -984,12 +982,10 @@ var _ = SIGDescribe("Storage", func() {
 
 		Context("[storage-req][rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component]With Alpine block volume PVC", decorators.StorageReq, func() {
 
-			It("[test_id:3139]should be successfully started", func() {
+			It("[test_id:3139]should be successfully started", decorators.BlockStorageRequired, func() {
 				By("Create a VMIWithPVC")
 				sc, exists := libstorage.GetRWXBlockStorageClass()
-				if !exists {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(exists).To(BeTrue(), "Block storage is not present")
 
 				// Start the VirtualMachineInstance with the PVC attached
 				dv := libdv.NewDataVolume(
@@ -1107,15 +1103,13 @@ var _ = SIGDescribe("Storage", func() {
 
 		})
 
-		Context("[storage-req] With a volumeMode block backed ephemeral disk", decorators.StorageReq, func() {
+		Context("[storage-req] With a volumeMode block backed ephemeral disk", decorators.StorageReq, decorators.BlockStorageRequired, func() {
 			var dataVolume *cdiv1.DataVolume
 			var err error
 
 			BeforeEach(func() {
 				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
-				if !foundSC {
-					Skip("Skip test when Block storage is not present")
-				}
+				Expect(foundSC).To(BeTrue(), "Block storage is not present")
 
 				dataVolume = libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2126,7 +2126,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 	})
 
-	Context("[rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache and io settings and PVC", decorators.SigStorage, decorators.StorageReq, func() {
+	Context("[rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache and io settings and PVC", decorators.SigStorage, decorators.StorageReq, decorators.BlockStorageRequired, func() {
 		var dataVolume *cdiv1.DataVolume
 		var err error
 
@@ -2136,9 +2136,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			}
 
 			sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
-			if !foundSC {
-				Skip("Skip test when Block storage is not present")
-			}
+			Expect(foundSC).To(BeTrue(), "Block storage is not present")
 
 			dataVolume = libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
@@ -2282,15 +2280,13 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 	Context("Block size configuration set", func() {
 
-		It("[test_id:6965]Should set BlockIO when using custom block sizes", decorators.SigStorage, func() {
+		It("[test_id:6965]Should set BlockIO when using custom block sizes", decorators.SigStorage, decorators.BlockStorageRequired, func() {
 			var dataVolume *cdiv1.DataVolume
 			var err error
 
 			By("creating a block volume")
 			sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
-			if !foundSC {
-				Skip("Skip test when Block storage is not present")
-			}
+			Expect(foundSC).To(BeTrue(), "Block storage is not present")
 
 			dataVolume = libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
@@ -2333,15 +2329,13 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(disks[0].BlockIO.PhysicalBlockSize).To(Equal(physicalSize))
 		})
 
-		It("[test_id:6966]Should set BlockIO when set to match volume block sizes on block devices", decorators.SigStorage, func() {
+		It("[test_id:6966]Should set BlockIO when set to match volume block sizes on block devices", decorators.SigStorage, decorators.BlockStorageRequired, func() {
 			var dataVolume *cdiv1.DataVolume
 			var err error
 
 			By("creating a block volume")
 			sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
-			if !foundSC {
-				Skip("Skip test when Block storage is not present")
-			}
+			Expect(foundSC).To(BeTrue(), "Block storage is not present")
 
 			dataVolume = libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),


### PR DESCRIPTION
WIP

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

