### PR TITLE
[bugFix]: Fix panic in virt-handler when process is not found during CPU housekeeping

### DIFF
--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -238,6 +238,8 @@ func getPPid(pid int) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-
+	if process == nil {
+		return -1, fmt.Errorf("failed to find process with pid: %d", pid)
+	}
 	return process.PPid(), nil
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -3048,6 +3048,9 @@ func (d *VirtualMachineController) configureHousekeepingCgroup(vmi *v1.VirtualMa
 			log.Log.Object(vmi).Errorf("Failure to find process: %s", err.Error())
 			return err
 		}
+		if proc == nil {
+			return fmt.Errorf("failed to find process with tid: %d", tid)
+		}
 		comm := proc.Executable()
 		if strings.Contains(comm, "CPU ") && strings.Contains(comm, "KVM") {
 			continue


### PR DESCRIPTION
The `FindProcess` function from the [`go-ps` package](github.com/mitchellh/go-ps) returns nil without error if a process isn't found, but our code incorrectly assumes an error. This commit adds a check to ensure the process is not nil before invoking its methods, preventing the panic.

Ideally, we should avoid using the [`go-ps` package](github.com/mitchellh/go-ps), as it is outdated and we don't want to keep it as a dependency.

Panics: https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.30-sig-compute/1768655952652800000 https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.30-sig-compute/1818665585588834304

Please review virt-handler logs for details on the panics.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

