### PR TITLE
tests, network, vmi_networking: Combine redundant tests of VMIs without network

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
-        "//pkg/pointer:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/pointer"
-
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -285,35 +283,24 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 	})
 
-	Context("VirtualMachineInstance with no networks and disabled automatic attachment of interfaces", func() {
-		It("[test_id:1774]should not configure any external interfaces", func() {
-			vmi := libvmifact.NewAlpine(libvmi.WithAutoAttachPodInterface(false))
+	It("[test_id:1774]should not configure any external interfaces when a VMI has no networks and auto attachment is disabled", func() {
+		vmi := libvmifact.NewAlpine(libvmi.WithAutoAttachPodInterface(false))
 
-			var err error
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
+		var err error
+		vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
-			Expect(vmi.Spec.Domain.Devices.Interfaces).To(BeEmpty())
+		Expect(vmi.Spec.Domain.Devices.Interfaces).To(BeEmpty())
 
-			By("checking that loopback is the only guest interface")
-			err = console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "ls /sys/class/net/ | wc -l\n"},
-				&expect.BExp{R: "1"},
-			}, 15)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("[test_id:1775]should start a VMI with no network", func() {
-			vmi := libvmifact.NewAlpine()
-			vmi.Spec.Domain.Devices.AutoattachPodInterface = pointer.P(false)
-			var err error
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
-		})
+		By("checking that loopback is the only guest interface")
+		err = console.SafeExpectBatch(vmi, []expect.Batcher{
+			&expect.BSnd{S: "\n"},
+			&expect.BExp{R: console.PromptExpression},
+			&expect.BSnd{S: "ls /sys/class/net/ | wc -l\n"},
+			&expect.BExp{R: "1"},
+		}, 15)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("VMI with an interface that has ACPI Index set", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
There were 2 tests that created an Alpine VMI without networking and `AutoattachPodInterface=false`. One of which counted the number of interfaces in the guest and the other one just waited for the VMI to launch
After this PR:
Improve the more detailed test and delete the redundant one 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

