### PR TITLE
Improve information displayed for existance matchers

### DIFF
--- a/tests/framework/matcher/existence.go
+++ b/tests/framework/matcher/existence.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 
 	"kubevirt.io/kubevirt/tests/framework/matcher/helper"
@@ -31,12 +32,35 @@ func (e existMatcher) Match(actual interface{}) (success bool, err error) {
 	return true, nil
 }
 
+func formatObject(actual interface{}) string {
+	if helper.IsNil(actual) {
+		return fmt.Sprintf("%v", actual)
+	}
+	if !helper.IsStruct(helper.DeferPointer(actual)) {
+		return fmt.Sprintf("%v", actual)
+	}
+	obj := reflect.ValueOf(helper.ToPointer(actual)).Elem()
+	metadata := obj.FieldByName("ObjectMeta")
+	if metadata.IsZero() {
+		return fmt.Sprintf("%v", actual)
+	}
+
+	// Optional
+	status := obj.FieldByName("Status")
+
+	// Too much data to display and is only helpful in later stages
+	metadata.FieldByName("ManagedFields").SetZero()
+
+	return fmt.Sprintf("%s\nmetadata: %s \nstatus: %s", reflect.TypeOf(actual), format.Object(metadata.Interface(), 0), format.Object(status.Interface(), 0))
+}
+
 func (e existMatcher) FailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("expected object to still exist, but it is gone: %v", actual)
+
+	return fmt.Sprintf("expected object to still exist, but it is gone: %s", formatObject(actual))
 }
 
 func (e existMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("expected object to be gone, but it still exists: %v", actual)
+	return fmt.Sprintf("expected object to be gone, but it still exists: %s", formatObject(actual))
 }
 
 type goneMatcher struct {
@@ -53,9 +77,9 @@ func (g goneMatcher) Match(actual interface{}) (success bool, err error) {
 }
 
 func (g goneMatcher) FailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("expected object to be gone, but it still exists: %v", actual)
+	return fmt.Sprintf("expected object to be gone, but it still exists: %s", formatObject(actual))
 }
 
 func (g goneMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("expected object to still exist, but it is gone: %v", actual)
+	return fmt.Sprintf("expected object to still exist, but it is gone: %s", formatObject(actual))
 }

--- a/tests/framework/matcher/existence_test.go
+++ b/tests/framework/matcher/existence_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Existence matchers", func() {
@@ -33,4 +34,33 @@ var _ = Describe("Existence matchers", func() {
 		Entry("an object pointing to nil", toNilPointer, true),
 		Entry("a pod", &v1.Pod{}, false),
 	)
+
+	It("formating", func() {
+		obj := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "HI",
+				ManagedFields: []metav1.ManagedFieldsEntry{
+					{
+						Manager: "something",
+					},
+				},
+			},
+		}
+		Expect(BeGone().FailureMessage(obj.DeepCopy())).To(
+			SatisfyAll(
+				ContainSubstring("metadata"),
+				ContainSubstring("status"),
+				Not(ContainSubstring("something")),
+				Not(ContainSubstring("Spec")),
+			),
+		)
+		Expect(BeGone().NegatedFailureMessage(obj.DeepCopy())).To(
+			SatisfyAll(
+				ContainSubstring("metadata"),
+				ContainSubstring("status"),
+				Not(ContainSubstring("something")),
+				Not(ContainSubstring("Spec")),
+			),
+		)
+	})
 })

--- a/tests/framework/matcher/helper/reflect.go
+++ b/tests/framework/matcher/helper/reflect.go
@@ -17,6 +17,11 @@ func IsSlice(actual interface{}) bool {
 	return val.Kind() == reflect.Array || val.Kind() == reflect.Slice
 }
 
+func IsStruct(actual interface{}) bool {
+	val := reflect.ValueOf(actual)
+	return val.Kind() == reflect.Struct
+}
+
 // ToPointer returns a new pointer to the provided interface{}, if the
 // provided value is not already a pointer. if the original value is already a pointer it gets
 // returned directly.
@@ -25,6 +30,14 @@ func ToPointer(actual interface{}) interface{} {
 		p := reflect.New(reflect.TypeOf(actual))
 		p.Elem().Set(reflect.ValueOf(actual))
 		actual = p.Interface()
+	}
+	return actual
+}
+
+func DeferPointer(actual interface{}) interface{} {
+	value := reflect.ValueOf(actual)
+	if value.Kind() == reflect.Ptr {
+		actual = value.Elem()
 	}
 	return actual
 }


### PR DESCRIPTION
### What this PR does
Before:
```
expected object to be gone, but it still exists: &Pod{ObjectMeta:{virt-launcher-testvmi-n28r4-hmc9s virt-launcher-testvmi-n28r4- kubevirt-test-default3  ca309a13-5d0b-44d5-83cb-74322d66588d 12215 0 2024-10-21 12:09:14 +0000 UTC 2024-10-21 12:09:52 +0000 UTC 0xc0011e0e60 map[kubevirt.io:virt-launcher kubevirt.io/created-by:7f38c5ef-4f60-479e-a814-4bed0dbc1492 kubevirt.io/nodeName:node01 vm.kubevirt.io/name:testvmi-n28r4] map[cni.projectcalico.org/podIP:10.244.196.170/32 cni.projectcalico.org/podIPs:10.244.196.170/32,fd10:244::c4a9/128 descheduler.alpha.kubernetes.io/request-evict-only: k8s.v1.cni.cncf.io/network-status:[{
    "name": "k8s-pod-network",
    "ips": [
        "10.244.196.170",
        "fd10:244::c4a9"
    ],
    "default": true,
    "dns": {}
}] kubectl.kubernetes.io/default-container:compute kubevirt.io/created-by-test:[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIlifecycle [rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance's Pod (API) [test_id:1650]should result in the VirtualMachineInstance moving to a finalized state kubevirt.io/domain:testvmi-n28r4 kubevirt.io/migrationTransportUnix:true post.hook.backup.velero.io/command:["/usr/bin/virt-freezer", "--unfreeze", "--name", "testvmi-n28r4", "--namespace", "kubevirt-test-default3"] post.hook.backup.velero.io/container:compute pre.hook.backup.velero.io/command:["/usr/bin/virt-freezer", "--freeze", "--name", "testvmi-n28r4", "--namespace", "kubevirt-test-default3"] pre.hook.backup.velero.io/container:compute] [{kubevirt.io/v1 VirtualMachineInstance testvmi-n28r4 7f38c5ef-4f60-479e-a814-4bed0dbc1492 0xc0011e17fd 0xc0011e17fe}] [] [{calico Update v1 2024-10-21 12:09:14 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{"f:cni.projectcalico.org/podIP":{},"f:cni.projectcalico.org/podIPs":{}}}} status} {multus-daemon Update v1 2024-10-21 12:09:14 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{"f:k8s.v1.cni.cncf.io/network-status":{}}}} status} {virt-controller Update v1 2024-10-21 12:09:14 +0000 UTC FieldsV1 {"f:status":{"f:conditions":{"k:{\"type\":\"kubevirt.io/virtual-machine-unpaused\"}":{".":{},"f:lastProbeTime":{},"f:lastTransitionTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}}}}} status} {kubelet Update v1 2024-10-21 12:09:20 +0000 UTC FieldsV1 {"f:status":{"f:conditions":{"k:{\"type\":\"ContainersReady\"}":{".":{},"f:lastProbeTime":{},"f:lastTransitionTime":{},"f:status":{},"f:type":{}},"k:{\"type\":\"Initialized\"}":{".":{},"f:lastProbeTime":{},"f:lastTransitionTime":{},"f:status":{},"f:type":{}},"k:{\"type\":\"PodReadyToStartContainers\"}":{".":{},"f:lastProbeTime":{},"f:lastTransitionTime":{},"f:status":{},"f:type":{}},"k:{\"type\":\"Ready\"}":{".":{},"f:lastProbeTime":{},"f:lastTransitionTime":{},"f:status":{},"f:type":{}}},"f:containerStatuses":{},"f:hostIP":{},"f:hostIPs":{},"f:initContainerStatuses":{},"f:phase":{},"f:podIP":{},"f:podIPs":{".":{},"k:{\"ip\":\"10.244.196.170\"}":{".":{},"f:ip":{}},"k:{\"ip\":\"fd10:244::c4a9\"}":{".":{},"f:ip":{}}},"f:startTime":{}}} status} {virt-controller Update v1 2024-10-21 12:09:20 +0000 UTC FieldsV1 {"f:metadata":{"f:annotations":{".":{},"f:descheduler.alpha.kubernetes.io/request-evict-only":{},"f:kubectl.kubernetes.io/default-container":{},"f:kubevirt.io/created-by-test":{},"f:kubevirt.io/domain":{},"f:kubevirt.io/migrationTransportUnix":{},"f:post.hook.backup.velero.io/command":{},"f:post.hook.backup.velero.io/container":{},"f:pre.hook.backup.velero.io/command":{},"f:pre.hook.backup.velero.io/container":{}},"f:generateName":{},"f:labels":{".":{},"f:kubevirt.io":{},"f:kubevirt.io/created-by":{},"f:kubevirt.io/nodeName":{},"f:vm.kubevirt.io/name":{}},"f:ownerReferences":{".":{},"k:{\"uid\":\"7f38c5ef-4f60-479e-a814-4bed0dbc1492\"}":{}}},"f:spec":{"f:affinity":{".":{},"f:nodeAffinity":{".":{},"f:requiredDuringSchedulingIgnoredDuringExecution":{}}},"f:automountServiceAccountToken":{},"f:containers":{"k:{\"name\":\"compute\"}":{".":{},"f:command":{},"f:env":{".":{},"k:{\"name\":\"POD_NAME\"}":{".":{},"f:name":{},"f:valueFrom":{".":{},"f:fieldRef":{}}},"k:{\"name\":\"XDG_CACHE_HOME\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"XDG_CONFIG_HOME\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"XDG_RUNTIME_DIR\"}":{".":{},"f:name":{},"f:value":{}}},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:resources":{".":{},"f:limits":{".":{},"f:devices.kubevirt.io/kvm":{},"f:devices.kubevirt.io/tun":{},"f:devices.kubevirt.io/vhost-net":{}},"f:requests":{".":{},"f:cpu":{},"f:devices.kubevirt.io/kvm":{},"f:devices.kubevirt.io/tun":{},"f:devices.kubevirt.io/vhost-net":{},"f:ephemeral-storage":{},"f:memory":{}}},"f:securityContext":{".":{},"f:allowPrivilegeEscalation":{},"f:capabilities":{".":{},"f:add":{},"f:drop":{}},"f:privileged":{},"f:runAsGroup":{},"f:runAsNonRoot":{},"f:runAsUser":{}},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{},"f:volumeMounts":{".":{},"k:{\"mountPath\":\"/var/run/kubevirt\"}":{".":{},"f:mountPath":{},"f:name":{}},"k:{\"mountPath\":\"/var/run/kubevirt-ephemeral-disks\"}":{".":{},"f:mountPath":{},"f:name":{}},"k:{\"mountPath\":\"/var/run/kubevirt-private\"}":{".":{},"f:mountPath":{},"f:name":{}},"k:{\"mountPath\":\"/var/run/kubevirt/container-disks\"}":{".":{},"f:mountPath":{},"f:mountPropagation":{},"f:name":{}},"k:{\"mountPath\":\"/var/run/kubevirt/hotplug-disks\"}":{".":{},"f:mountPath":{},"f:mountPropagation":{},"f:name":{}},"k:{\"mountPath\":\"/var/run/kubevirt/sockets\"}":{".":{},"f:mountPath":{},"f:name":{}},"k:{\"mountPath\":\"/var/run/libvirt\"}":{".":{},"f:mountPath":{},"f:name":{}}}},"k:{\"name\":\"guest-console-log\"}":{".":{},"f:args":{},"f:command":{},"f:env":{".":{},"k:{\"name\":\"VIRT_LAUNCHER_LOG_VERBOSITY\"}":{".":{},"f:name":{},"f:value":{}}},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:resources":{".":{},"f:limits":{".":{},"f:cpu":{},"f:memory":{}},"f:requests":{".":{},"f:cpu":{},"f:memory":{}}},"f:securityContext":{".":{},"f:allowPrivilegeEscalation":{},"f:capabilities":{".":{},"f:drop":{}},"f:runAsNonRoot":{},"f:runAsUser":{}},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{},"f:volumeMounts":{".":{},"k:{\"mountPath\":\"/var/run/kubevirt-private\"}":{".":{},"f:mountPath":{},"f:name":{},"f:readOnly":{}}}},"k:{\"name\":\"volumedisk0\"}":{".":{},"f:args":{},"f:command":{},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:resources":{".":{},"f:limits":{".":{},"f:cpu":{},"f:memory":{}},"f:requests":{".":{},"f:cpu":{},"f:ephemeral-storage":{},"f:memory":{}}},"f:securityContext":{".":{},"f:allowPrivilegeEscalation":{},"f:capabilities":{".":{},"f:drop":{}},"f:runAsNonRoot":{},"f:runAsUser":{}},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{},"f:volumeMounts":{".":{},"k:{\"mountPath\":\"/usr/bin\"}":{".":{},"f:mountPath":{},"f:name":{}},"k:{\"mountPath\":\"/var/run/kubevirt-ephemeral-disks/container-disk-data/7f38c5ef-4f60-479e-a814-4bed0dbc1492\"}":{".":{},"f:mountPath":{},"f:name":{}}}}},"f:dnsPolicy":{},"f:enableServiceLinks":{},"f:hostname":{},"f:initContainers":{".":{},"k:{\"name\":\"container-disk-binary\"}":{".":{},"f:command":{},"f:env":{".":{},"k:{\"name\":\"XDG_CACHE_HOME\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"XDG_CONFIG_HOME\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"XDG_RUNTIME_DIR\"}":{".":{},"f:name":{},"f:value":{}}},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:resources":{".":{},"f:limits":{".":{},"f:cpu":{},"f:memory":{}},"f:requests":{".":{},"f:cpu":{},"f:memory":{}}},"f:securityContext":{".":{},"f:allowPrivilegeEscalation":{},"f:capabilities":{".":{},"f:drop":{}},"f:privileged":{},"f:runAsGroup":{},"f:runAsNonRoot":{},"f:runAsUser":{}},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{},"f:volumeMounts":{".":{},"k:{\"mountPath\":\"/init/usr/bin\"}":{".":{},"f:mountPath":{},"f:name":{}}}},"k:{\"name\":\"volumedisk0-init\"}":{".":{},"f:args":{},"f:command":{},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:resources":{".":{},"f:limits":{".":{},"f:cpu":{},"f:memory":{}},"f:requests":{".":{},"f:cpu":{},"f:ephemeral-storage":{},"f:memory":{}}},"f:securityContext":{".":{},"f:allowPrivilegeEscalation":{},"f:capabilities":{".":{},"f:drop":{}},"f:runAsNonRoot":{},"f:runAsUser":{}},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{},"f:volumeMounts":{".":{},"k:{\"mountPath\":\"/usr/bin\"}":{".":{},"f:mountPath":{},"f:name":{}},"k:{\"mountPath\":\"/var/run/kubevirt-ephemeral-disks/container-disk-data/7f38c5ef-4f60-479e-a814-4bed0dbc1492\"}":{".":{},"f:mountPath":{},"f:name":{}}}}},"f:nodeSelector":{},"f:readinessGates":{},"f:restartPolicy":{},"f:schedulerName":{},"f:securityContext":{".":{},"f:fsGroup":{},"f:runAsGroup":{},"f:runAsNonRoot":{},"f:runAsUser":{},"f:seccompProfile":{".":{},"f:localhostProfile":{},"f:type":{}}},"f:terminationGracePeriodSeconds":{},"f:volumes":{".":{},"k:{\"name\":\"container-disks\"}":{".":{},"f:emptyDir":{},"f:name":{}},"k:{\"name\":\"ephemeral-disks\"}":{".":{},"f:emptyDir":{},"f:name":{}},"k:{\"name\":\"hotplug-disks\"}":{".":{},"f:emptyDir":{},"f:name":{}},"k:{\"name\":\"libvirt-runtime\"}":{".":{},"f:emptyDir":{},"f:name":{}},"k:{\"name\":\"private\"}":{".":{},"f:emptyDir":{},"f:name":{}},"k:{\"name\":\"public\"}":{".":{},"f:emptyDir":{},"f:name":{}},"k:{\"name\":\"sockets\"}":{".":{},"f:emptyDir":{},"f:name":{}},"k:{\"name\":\"virt-bin-share-dir\"}":{".":{},"f:emptyDir":{},"f:name":{}}}}} }]},Spec:PodSpec{Volumes:[]Volume{Volume{Name:private,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},Volume{Name:public,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},Volume{Name:sockets,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},Volume{Name:virt-bin-share-dir,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},Volume{Name:libvirt-runtime,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},Volume{Name:ephemeral-disks,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},Volume{Name:container-disks,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},Volume{Name:hotplug-disks,VolumeSource:VolumeSource{HostPath:nil,EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,},GCEPersistentDisk:nil,AWSElasticBlockStore:nil,GitRepo:nil,Secret:nil,NFS:nil,ISCSI:nil,Glusterfs:nil,PersistentVolumeClaim:nil,RBD:nil,FlexVolume:nil,Cinder:nil,CephFS:nil,Flocker:nil,DownwardAPI:nil,FC:nil,AzureFile:nil,ConfigMap:nil,VsphereVolume:nil,Quobyte:nil,AzureDisk:nil,PhotonPersistentDisk:nil,PortworxVolume:nil,ScaleIO:nil,Projected:nil,StorageOS:nil,CSI:nil,Ephemeral:nil,Image:nil,},},},Containers:[]Container{Container{Name:compute,Image:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,Command:[/usr/bin/virt-launcher-monitor --qemu-timeout 347s --name testvmi-n28r4 --uid 7f38c5ef-4f60-479e-a814-4bed0dbc1492 --namespace kubevirt-test-default3 --kubevirt-share-dir /var/run/kubevirt --ephemeral-disk-dir /var/run/kubevirt-ephemeral-disks --container-disk-dir /var/run/kubevirt/container-disks --grace-period-seconds 15 --hook-sidecars 0 --ovmf-path /usr/share/OVMF --run-as-nonroot],Args:[],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{EnvVar{Name:XDG_CACHE_HOME,Value:/var/run/kubevirt-private,ValueFrom:nil,},EnvVar{Name:XDG_CONFIG_HOME,Value:/var/run/kubevirt-private,ValueFrom:nil,},EnvVar{Name:XDG_RUNTIME_DIR,Value:/var/run,ValueFrom:nil,},EnvVar{Name:POD_NAME,Value:,ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,},},},Resources:ResourceRequirements{Limits:ResourceList{devices.kubevirt.io/kvm: {{1 0} {<nil>} 1 DecimalSI},devices.kubevirt.io/tun: {{1 0} {<nil>} 1 DecimalSI},devices.kubevirt.io/vhost-net: {{1 0} {<nil>} 1 DecimalSI},},Requests:ResourceList{cpu: {{100 -3} {<nil>} 100m DecimalSI},devices.kubevirt.io/kvm: {{1 0} {<nil>} 1 DecimalSI},devices.kubevirt.io/tun: {{1 0} {<nil>} 1 DecimalSI},devices.kubevirt.io/vhost-net: {{1 0} {<nil>} 1 DecimalSI},ephemeral-storage: {{50 6} {<nil>} 50M DecimalSI},memory: {{388235264 0} {<nil>}  BinarySI},},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:private,ReadOnly:false,MountPath:/var/run/kubevirt-private,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},VolumeMount{Name:public,ReadOnly:false,MountPath:/var/run/kubevirt,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},VolumeMount{Name:ephemeral-disks,ReadOnly:false,MountPath:/var/run/kubevirt-ephemeral-disks,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},VolumeMount{Name:container-disks,ReadOnly:false,MountPath:/var/run/kubevirt/container-disks,SubPath:,MountPropagation:*HostToContainer,SubPathExpr:,RecursiveReadOnly:nil,},VolumeMount{Name:libvirt-runtime,ReadOnly:false,MountPath:/var/run/libvirt,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},VolumeMount{Name:sockets,ReadOnly:false,MountPath:/var/run/kubevirt/sockets,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},VolumeMount{Name:hotplug-disks,ReadOnly:false,MountPath:/var/run/kubevirt/hotplug-disks,SubPath:,MountPropagation:*HostToContainer,SubPathExpr:,RecursiveReadOnly:nil,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:/dev/termination-log,ImagePullPolicy:IfNotPresent,SecurityContext:&SecurityContext{Capabilities:&Capabilities{Add:[NET_BIND_SERVICE],Drop:[ALL],},Privileged:*false,SELinuxOptions:nil,RunAsUser:*107,RunAsNonRoot:*true,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:*false,RunAsGroup:*107,ProcMount:nil,WindowsOptions:nil,SeccompProfile:nil,AppArmorProfile:nil,},Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:File,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,},Container{Name:volumedisk0,Image:registry:5000/kubevirt/alpine-container-disk-demo:devel,Command:[/usr/bin/container-disk],Args:[--copy-path /var/run/kubevirt-ephemeral-disks/container-disk-data/7f38c5ef-4f60-479e-a814-4bed0dbc1492/disk_0],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{},Resources:ResourceRequirements{Limits:ResourceList{cpu: {{10 -3} {<nil>} 10m DecimalSI},memory: {{40 6} {<nil>} 40M DecimalSI},},Requests:ResourceList{cpu: {{1 -3} {<nil>} 1m DecimalSI},ephemeral-storage: {{50 6} {<nil>} 50M DecimalSI},memory: {{1 6} {<nil>} 1M DecimalSI},},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:container-disks,ReadOnly:false,MountPath:/var/run/kubevirt-ephemeral-disks/container-disk-data/7f38c5ef-4f60-479e-a814-4bed0dbc1492,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},VolumeMount{Name:virt-bin-share-dir,ReadOnly:false,MountPath:/usr/bin,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:/dev/termination-log,ImagePullPolicy:IfNotPresent,SecurityContext:&SecurityContext{Capabilities:&Capabilities{Add:[],Drop:[ALL],},Privileged:nil,SELinuxOptions:nil,RunAsUser:*107,RunAsNonRoot:*true,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:*false,RunAsGroup:nil,ProcMount:nil,WindowsOptions:nil,SeccompProfile:nil,AppArmorProfile:nil,},Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:File,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,},Container{Name:guest-console-log,Image:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,Command:[/usr/bin/virt-tail],Args:[--logfile /var/run/kubevirt-private/7f38c5ef-4f60-479e-a814-4bed0dbc1492/virt-serial0-log],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{EnvVar{Name:VIRT_LAUNCHER_LOG_VERBOSITY,Value:2,ValueFrom:nil,},},Resources:ResourceRequirements{Limits:ResourceList{cpu: {{15 -3} {<nil>} 15m DecimalSI},memory: {{60 6} {<nil>} 60M DecimalSI},},Requests:ResourceList{cpu: {{5 -3} {<nil>} 5m DecimalSI},memory: {{35 6} {<nil>} 35M DecimalSI},},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:private,ReadOnly:true,MountPath:/var/run/kubevirt-private,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:/dev/termination-log,ImagePullPolicy:IfNotPresent,SecurityContext:&SecurityContext{Capabilities:&Capabilities{Add:[],Drop:[ALL],},Privileged:nil,SELinuxOptions:nil,RunAsUser:*107,RunAsNonRoot:*true,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:*false,RunAsGroup:nil,ProcMount:nil,WindowsOptions:nil,SeccompProfile:nil,AppArmorProfile:nil,},Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:File,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,},},RestartPolicy:Never,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{kubernetes.io/arch: amd64,kubevirt.io/schedulable: true,},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:node01,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:*107,RunAsNonRoot:*true,SupplementalGroups:[],FSGroup:*107,RunAsGroup:*107,Sysctls:[]Sysctl{},WindowsOptions:nil,FSGroupChangePolicy:nil,SeccompProfile:&SeccompProfile{Type:Localhost,LocalhostProfile:*kubevirt/kubevirt.json,},AppArmorProfile:nil,SupplementalGroupsPolicy:nil,},ImagePullSecrets:[]LocalObjectReference{},Hostname:testvmi-n28r4,Subdomain:,Affinity:&Affinity{NodeAffinity:&NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution:&NodeSelector{NodeSelectorTerms:[]NodeSelectorTerm{NodeSelectorTerm{MatchExpressions:[]NodeSelectorRequirement{NodeSelectorRequirement{Key:node-labeller.kubevirt.io/obsolete-host-model,Operator:DoesNotExist,Values:[],},},MatchFields:[]NodeSelectorRequirement{},},},},PreferredDuringSchedulingIgnoredDuringExecution:[]PreferredSchedulingTerm{},},PodAffinity:nil,PodAntiAffinity:nil,},SchedulerName:default-scheduler,InitContainers:[]Container{Container{Name:container-disk-binary,Image:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,Command:[/usr/bin/cp /usr/bin/container-disk /init/usr/bin/container-disk],Args:[],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{EnvVar{Name:XDG_CACHE_HOME,Value:/var/run/kubevirt-private,ValueFrom:nil,},EnvVar{Name:XDG_CONFIG_HOME,Value:/var/run/kubevirt-private,ValueFrom:nil,},EnvVar{Name:XDG_RUNTIME_DIR,Value:/var/run,ValueFrom:nil,},},Resources:ResourceRequirements{Limits:ResourceList{cpu: {{100 -3} {<nil>} 100m DecimalSI},memory: {{40 6} {<nil>} 40M DecimalSI},},Requests:ResourceList{cpu: {{10 -3} {<nil>} 10m DecimalSI},memory: {{1 6} {<nil>} 1M DecimalSI},},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:virt-bin-share-dir,ReadOnly:false,MountPath:/init/usr/bin,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:/dev/termination-log,ImagePullPolicy:IfNotPresent,SecurityContext:&SecurityContext{Capabilities:&Capabilities{Add:[],Drop:[ALL],},Privileged:*false,SELinuxOptions:nil,RunAsUser:*107,RunAsNonRoot:*true,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:*false,RunAsGroup:*107,ProcMount:nil,WindowsOptions:nil,SeccompProfile:nil,AppArmorProfile:nil,},Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:File,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,},Container{Name:volumedisk0-init,Image:registry:5000/kubevirt/alpine-container-disk-demo:devel,Command:[/usr/bin/container-disk],Args:[--no-op],WorkingDir:,Ports:[]ContainerPort{},Env:[]EnvVar{},Resources:ResourceRequirements{Limits:ResourceList{cpu: {{10 -3} {<nil>} 10m DecimalSI},memory: {{40 6} {<nil>} 40M DecimalSI},},Requests:ResourceList{cpu: {{1 -3} {<nil>} 1m DecimalSI},ephemeral-storage: {{50 6} {<nil>} 50M DecimalSI},memory: {{1 6} {<nil>} 1M DecimalSI},},Claims:[]ResourceClaim{},},VolumeMounts:[]VolumeMount{VolumeMount{Name:container-disks,ReadOnly:false,MountPath:/var/run/kubevirt-ephemeral-disks/container-disk-data/7f38c5ef-4f60-479e-a814-4bed0dbc1492,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},VolumeMount{Name:virt-bin-share-dir,ReadOnly:false,MountPath:/usr/bin,SubPath:,MountPropagation:nil,SubPathExpr:,RecursiveReadOnly:nil,},},LivenessProbe:nil,ReadinessProbe:nil,Lifecycle:nil,TerminationMessagePath:/dev/termination-log,ImagePullPolicy:IfNotPresent,SecurityContext:&SecurityContext{Capabilities:&Capabilities{Add:[],Drop:[ALL],},Privileged:nil,SELinuxOptions:nil,RunAsUser:*107,RunAsNonRoot:*true,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:*false,RunAsGroup:nil,ProcMount:nil,WindowsOptions:nil,SeccompProfile:nil,AppArmorProfile:nil,},Stdin:false,StdinOnce:false,TTY:false,EnvFrom:[]EnvFromSource{},TerminationMessagePolicy:File,VolumeDevices:[]VolumeDevice{},StartupProbe:nil,ResizePolicy:[]ContainerResizePolicy{},RestartPolicy:nil,},},AutomountServiceAccountToken:*false,Tolerations:[]Toleration{Toleration{Key:node.kubernetes.io/not-ready,Operator:Exists,Value:,Effect:NoExecute,TolerationSeconds:*300,},Toleration{Key:node.kubernetes.io/unreachable,Operator:Exists,Value:,Effect:NoExecute,TolerationSeconds:*300,},},HostAliases:[]HostAlias{},PriorityClassName:,Priority:*0,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[]PodReadinessGate{PodReadinessGate{ConditionType:kubevirt.io/virtual-machine-unpaused,},},RuntimeClassName:nil,EnableServiceLinks:*false,PreemptionPolicy:*PreemptLowerPriority,Overhead:ResourceList{},TopologySpreadConstraints:[]TopologySpreadConstraint{},EphemeralContainers:[]EphemeralContainer{},SetHostnameAsFQDN:nil,OS:nil,HostUsers:nil,SchedulingGates:[]PodSchedulingGate{},ResourceClaims:[]PodResourceClaim{},},Status:PodStatus{Phase:Running,Conditions:[]PodCondition{PodCondition{Type:kubevirt.io/virtual-machine-unpaused,Status:True,LastProbeTime:2024-10-21 12:09:14 +0000 UTC,LastTransitionTime:2024-10-21 12:09:14 +0000 UTC,Reason:NotPaused,Message:the virtual machine is not paused,},PodCondition{Type:PodReadyToStartContainers,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-10-21 12:09:15 +0000 UTC,Reason:,Message:,},PodCondition{Type:Initialized,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-10-21 12:09:18 +0000 UTC,Reason:,Message:,},PodCondition{Type:Ready,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-10-21 12:09:20 +0000 UTC,Reason:,Message:,},PodCondition{Type:ContainersReady,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-10-21 12:09:20 +0000 UTC,Reason:,Message:,},PodCondition{Type:PodScheduled,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-10-21 12:09:14 +0000 UTC,Reason:,Message:,},},Message:,Reason:,HostIP:192.168.66.101,PodIP:10.244.196.170,StartTime:2024-10-21 12:09:14 +0000 UTC,ContainerStatuses:[]ContainerStatus{ContainerStatus{Name:compute,State:ContainerState{Waiting:nil,Running:&ContainerStateRunning{StartedAt:2024-10-21 12:09:18 +0000 UTC,},Terminated:nil,},LastTerminationState:ContainerState{Waiting:nil,Running:nil,Terminated:nil,},Ready:true,RestartCount:0,Image:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,ImageID:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,ContainerID:cri-o://08b1f89d8bc6b2a2b43d6bfb045735357878a4754921ef0214993f694de7a083,Started:*true,AllocatedResources:ResourceList{},Resources:nil,VolumeMounts:[]VolumeMountStatus{VolumeMountStatus{Name:private,MountPath:/var/run/kubevirt-private,ReadOnly:false,RecursiveReadOnly:nil,},VolumeMountStatus{Name:public,MountPath:/var/run/kubevirt,ReadOnly:false,RecursiveReadOnly:nil,},VolumeMountStatus{Name:ephemeral-disks,MountPath:/var/run/kubevirt-ephemeral-disks,ReadOnly:false,RecursiveReadOnly:nil,},VolumeMountStatus{Name:container-disks,MountPath:/var/run/kubevirt/container-disks,ReadOnly:false,RecursiveReadOnly:nil,},VolumeMountStatus{Name:libvirt-runtime,MountPath:/var/run/libvirt,ReadOnly:false,RecursiveReadOnly:nil,},VolumeMountStatus{Name:sockets,MountPath:/var/run/kubevirt/sockets,ReadOnly:false,RecursiveReadOnly:nil,},VolumeMountStatus{Name:hotplug-disks,MountPath:/var/run/kubevirt/hotplug-disks,ReadOnly:false,RecursiveReadOnly:nil,},},User:nil,AllocatedResourcesStatus:[]ResourceStatus{},},ContainerStatus{Name:guest-console-log,State:ContainerState{Waiting:nil,Running:&ContainerStateRunning{StartedAt:2024-10-21 12:09:19 +0000 UTC,},Terminated:nil,},LastTerminationState:ContainerState{Waiting:nil,Running:nil,Terminated:nil,},Ready:true,RestartCount:0,Image:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,ImageID:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,ContainerID:cri-o://ccb9d66e22532be464804c3f7a1ac230f7f79df1cd2e7739dc943fc29e002a75,Started:*true,AllocatedResources:ResourceList{},Resources:nil,VolumeMounts:[]VolumeMountStatus{VolumeMountStatus{Name:private,MountPath:/var/run/kubevirt-private,ReadOnly:true,RecursiveReadOnly:*Disabled,},},User:nil,AllocatedResourcesStatus:[]ResourceStatus{},},ContainerStatus{Name:volumedisk0,State:ContainerState{Waiting:nil,Running:&ContainerStateRunning{StartedAt:2024-10-21 12:09:19 +0000 UTC,},Terminated:nil,},LastTerminationState:ContainerState{Waiting:nil,Running:nil,Terminated:nil,},Ready:true,RestartCount:0,Image:registry:5000/kubevirt/alpine-container-disk-demo:devel,ImageID:registry:5000/kubevirt/alpine-container-disk-demo@sha256:32648932f70172e29e3d09e0d2ef80b1c33df9a5b18cf7ed446eed076c72a452,ContainerID:cri-o://3e04452f76d37bdf3e32f965a8443ee2bfc836726a0e8d8098e31ec38edbfdf5,Started:*true,AllocatedResources:ResourceList{},Resources:nil,VolumeMounts:[]VolumeMountStatus{VolumeMountStatus{Name:container-disks,MountPath:/var/run/kubevirt-ephemeral-disks/container-disk-data/7f38c5ef-4f60-479e-a814-4bed0dbc1492,ReadOnly:false,RecursiveReadOnly:nil,},VolumeMountStatus{Name:virt-bin-share-dir,MountPath:/usr/bin,ReadOnly:false,RecursiveReadOnly:nil,},},User:nil,AllocatedResourcesStatus:[]ResourceStatus{},},},QOSClass:Burstable,InitContainerStatuses:[]ContainerStatus{ContainerStatus{Name:container-disk-binary,State:ContainerState{Waiting:nil,Running:nil,Terminated:&ContainerStateTerminated{ExitCode:0,Signal:0,Reason:Completed,Message:,StartedAt:2024-10-21 12:09:14 +0000 UTC,FinishedAt:2024-10-21 12:09:15 +0000 UTC,ContainerID:cri-o://a9cf6fb3ed71ffb516c045278999a693d071c92208d1e8c701d542532fcdf968,},},LastTerminationState:ContainerState{Waiting:nil,Running:nil,Terminated:nil,},Ready:true,RestartCount:0,Image:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,ImageID:registry:5000/kubevirt/virt-launcher@sha256:c633153c04721985ef71bd524a0aa531c4ab98f0dd8dfb84269a9e0c9f5ed514,ContainerID:cri-o://a9cf6fb3ed71ffb516c045278999a693d071c92208d1e8c701d542532fcdf968,Started:*false,AllocatedResources:ResourceList{},Resources:nil,VolumeMounts:[]VolumeMountStatus{VolumeMountStatus{Name:virt-bin-share-dir,MountPath:/init/usr/bin,ReadOnly:false,RecursiveReadOnly:nil,},},User:nil,AllocatedResourcesStatus:[]ResourceStatus{},},ContainerStatus{Name:volumedisk0-init,State:ContainerState{Waiting:nil,Running:nil,Terminated:&ContainerStateTerminated{ExitCode:0,Signal:0,Reason:Completed,Message:,StartedAt:2024-10-21 12:09:15 +0000 UTC,FinishedAt:2024-10-21 12:09:17 +0000 UTC,ContainerID:cri-o://184e06e3cfb88ba0604213836c6a95890b375441f955d138e16d2bb4071c858d,},},LastTerminationState:ContainerState{Waiting:nil,Running:nil,Terminated:nil,},Ready:true,RestartCount:0,Image:registry:5000/kubevirt/alpine-container-disk-demo:devel,ImageID:registry:5000/kubevirt/alpine-container-disk-demo@sha256:32648932f70172e29e3d09e0d2ef80b1c33df9a5b18cf7ed446eed076c72a452,ContainerID:cri-o://184e06e3cfb88ba0604213836c6a95890b375441f955d138e16d2bb4071c858d,Started:*false,AllocatedResources:ResourceList{},Resources:nil,VolumeMounts:[]VolumeMountStatus{VolumeMountStatus{Name:container-disks,MountPath:/var/run/kubevirt-ephemeral-disks/container-disk-data/7f38c5ef-4f60-479e-a814-4bed0dbc1492,ReadOnly:false,RecursiveReadOnly:nil,},VolumeMountStatus{Name:virt-bin-share-dir,MountPath:/usr/bin,ReadOnly:false,RecursiveReadOnly:nil,},},User:nil,AllocatedResourcesStatus:[]ResourceStatus{},},},NominatedNodeName:,PodIPs:[]PodIP{PodIP{IP:10.244.196.170,},PodIP{IP:fd10:244::c4a9,},},EphemeralContainerStatuses:[]ContainerStatus{},Resize:,ResourceClaimStatuses:[]PodResourceClaimStatus{},HostIPs:[]HostIP{HostIP{IP:192.168.66.101,},},},}
tests/vmi_lifecycle_test.go:1491}
```
After:

```
expected object to be gone, but it still exists:  *v1.VirtualMachineInstance
  metadata: <v1.ObjectMeta>: {
      Name: testvmi-txhzt,
      GenerateName: ,
      Namespace: ,
      SelfLink: /apis/kubevirt.io/v1/namespaces//virtualmachineinstances/testvmi-txhzt,
      UID: ,
      ResourceVersion: ,
      Generation: 0,
      CreationTimestamp: {
          Time: 0001-01-01T00:00:00Z,
      },
      DeletionTimestamp: nil,
      DeletionGracePeriodSeconds: nil,
      Labels: nil,
      Annotations: {
          "kubevirt.io/created-by-test": "[sig-network] [crit:high][arm64][vendor:cnv-qe@redhat.com][level:component] [crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance when virt-handler is responsive [Serial]VMIs shouldn't fail after the kubelet restarts [sig-network]with bridge networking",
      },
      OwnerReferences: nil,
      Finalizers: nil,
      ManagedFields: nil,
  } 
  status: <v1.VirtualMachineInstanceStatus>: {
      NodeName: ,
      Reason: ,
      Conditions: nil,
      Phase: ,
      PhaseTransitionTimestamps: nil,
      Interfaces: nil,
      GuestOSInfo: {Name: "", KernelRelease: "", Version: "", PrettyName: "", VersionID: "", KernelVersion: "", Machine: "", ID: ""},
      MigrationState: nil,
      MigrationMethod: ,
      MigrationTransport: ,
      QOSClass: nil,
      LauncherContainerImageVersion: ,
      EvacuationNodeName: ,
      ActivePods: nil,
      VolumeStatus: nil,
      KernelBootStatus: nil,
      FSFreezeStatus: ,
      TopologyHints: nil,
      VirtualMachineRevisionName: ,
      RuntimeUser: 0,
      VSOCKCID: nil,
      SelinuxContext: ,
      Machine: nil,
      CurrentCPUTopology: nil,
      Memory: nil,
      MigratedVolumes: nil,
  }

```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Special notes for your reviewer

<!-- optional -->



### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

