### PR TITLE
virt-controller: use controller.NamespacedKey() instead of manual strings

### DIFF
--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/controller"
 
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -92,7 +93,8 @@ func pvcForMigrationTargetFromStore(pvcStore cache.Store, migration *corev1.Virt
 
 func PVCForMigrationTarget(pvcStore cache.Store, migration *corev1.VirtualMachineInstanceMigration) *v1.PersistentVolumeClaim {
 	if migration.Status.MigrationState != nil && migration.Status.MigrationState.TargetPersistentStatePVCName != "" {
-		obj, exists, err := pvcStore.GetByKey(migration.Namespace + "/" + migration.Status.MigrationState.TargetPersistentStatePVCName)
+		key := controller.NamespacedKey(migration.Namespace, migration.Status.MigrationState.TargetPersistentStatePVCName)
+		obj, exists, err := pvcStore.GetByKey(key)
 		if err != nil || !exists {
 			return nil
 		}
@@ -418,7 +420,7 @@ func (bs *BackendStorage) IsPVCReady(vmi *corev1.VirtualMachineInstance, pvcName
 		return true, nil
 	}
 
-	obj, exists, err := bs.pvcStore.GetByKey(vmi.Namespace + "/" + pvcName)
+	obj, exists, err := bs.pvcStore.GetByKey(controller.NamespacedKey(vmi.Namespace, pvcName))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -201,7 +201,7 @@ func (c *EvacuationController) addMigration(obj interface{}) {
 		c.migrationExpectations.CreationObserved(key)
 		node = key
 	} else {
-		o, exists, err := c.vmiIndexer.GetByKey(migration.Namespace + "/" + migration.Spec.VMIName)
+		o, exists, err := c.vmiIndexer.GetByKey(controller.NamespacedKey(migration.Namespace, migration.Spec.VMIName))
 		if err != nil {
 			return
 		}
@@ -242,7 +242,7 @@ func (c *EvacuationController) enqueueMigration(obj interface{}) {
 			return
 		}
 	}
-	o, exists, err := c.vmiIndexer.GetByKey(migration.Namespace + "/" + migration.Spec.VMIName)
+	o, exists, err := c.vmiIndexer.GetByKey(controller.NamespacedKey(migration.Namespace, migration.Spec.VMIName))
 	if err != nil {
 		return
 	}
@@ -271,7 +271,7 @@ func (c *EvacuationController) resolveControllerRef(namespace string, controller
 	if controllerRef == nil || controllerRef.Kind != virtv1.VirtualMachineInstanceGroupVersionKind.Kind {
 		return nil
 	}
-	vmi, exists, err := c.vmiIndexer.GetByKey(namespace + "/" + controllerRef.Name)
+	vmi, exists, err := c.vmiIndexer.GetByKey(controller.NamespacedKey(namespace, controllerRef.Name))
 	if err != nil {
 		return nil
 	}

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1580,7 +1580,7 @@ func (c *Controller) resolveControllerRef(namespace string, controllerRef *v1.Ow
 	if controllerRef.Kind != virtv1.VirtualMachineInstanceMigrationGroupVersionKind.Kind {
 		return nil
 	}
-	migration, exists, err := c.migrationIndexer.GetByKey(namespace + "/" + controllerRef.Name)
+	migration, exists, err := c.migrationIndexer.GetByKey(controller.NamespacedKey(namespace, controllerRef.Name))
 	if err != nil {
 		return nil
 	}
@@ -1779,7 +1779,7 @@ func (c *Controller) addPVC(obj interface{}) {
 	if !exists {
 		return
 	}
-	migrationKey := pvc.Namespace + "/" + migrationName
+	migrationKey := controller.NamespacedKey(pvc.Namespace, migrationName)
 	c.pvcExpectations.CreationObserved(migrationKey)
 	c.Queue.Add(migrationKey)
 }
@@ -1959,7 +1959,8 @@ func (c *Controller) deleteVMI(obj interface{}) {
 func (c *Controller) outboundMigrationsOnNode(node string, runningMigrations []*virtv1.VirtualMachineInstanceMigration) (int, error) {
 	sum := 0
 	for _, migration := range runningMigrations {
-		if vmi, exists, _ := c.vmiStore.GetByKey(migration.Namespace + "/" + migration.Spec.VMIName); exists {
+		key := controller.NamespacedKey(migration.Namespace, migration.Spec.VMIName)
+		if vmi, exists, _ := c.vmiStore.GetByKey(key); exists {
 			if vmi.(*virtv1.VirtualMachineInstance).Status.NodeName == node {
 				sum = sum + 1
 			}
@@ -1981,7 +1982,8 @@ func (c *Controller) findRunningMigrations() ([]*virtv1.VirtualMachineInstanceMi
 			runningMigrations = append(runningMigrations, migration)
 			continue
 		}
-		vmi, exists, err := c.vmiStore.GetByKey(migration.Namespace + "/" + migration.Spec.VMIName)
+		key := controller.NamespacedKey(migration.Namespace, migration.Spec.VMIName)
+		vmi, exists, err := c.vmiStore.GetByKey(key)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/virt-controller/watch/pool/pool.go
+++ b/pkg/virt-controller/watch/pool/pool.go
@@ -141,7 +141,7 @@ func (c *Controller) resolveVMIControllerRef(namespace string, controllerRef *v1
 	if controllerRef.Kind != virtv1.VirtualMachineGroupVersionKind.Kind {
 		return nil
 	}
-	vm, exists, err := c.vmIndexer.GetByKey(namespace + "/" + controllerRef.Name)
+	vm, exists, err := c.vmIndexer.GetByKey(controller.NamespacedKey(namespace, controllerRef.Name))
 	if err != nil {
 		return nil
 	}
@@ -379,7 +379,7 @@ func (c *Controller) resolveControllerRef(namespace string, controllerRef *metav
 	if controllerRef.Kind != poolv1.VirtualMachinePoolKind {
 		return nil
 	}
-	pool, exists, err := c.poolIndexer.GetByKey(namespace + "/" + controllerRef.Name)
+	pool, exists, err := c.poolIndexer.GetByKey(controller.NamespacedKey(namespace, controllerRef.Name))
 	if err != nil {
 		return nil
 	}

--- a/pkg/virt-controller/watch/replicaset/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset/replicaset.go
@@ -739,7 +739,7 @@ func (c *Controller) resolveControllerRef(namespace string, controllerRef *metav
 	if controllerRef.Kind != virtv1.VirtualMachineInstanceReplicaSetGroupVersionKind.Kind {
 		return nil
 	}
-	rs, exists, err := c.vmiRSIndexer.GetByKey(namespace + "/" + controllerRef.Name)
+	rs, exists, err := c.vmiRSIndexer.GetByKey(controller.NamespacedKey(namespace, controllerRef.Name))
 	if err != nil {
 		return nil
 	}

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3446,7 +3446,7 @@ func (c *Controller) resolveControllerRef(namespace string, controllerRef *metav
 	if controllerRef.Kind != virtv1.VirtualMachineGroupVersionKind.Kind {
 		return nil
 	}
-	vm, exists, err := c.vmIndexer.GetByKey(namespace + "/" + controllerRef.Name)
+	vm, exists, err := c.vmIndexer.GetByKey(controller.NamespacedKey(namespace, controllerRef.Name))
 	if err != nil {
 		return nil
 	}

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -440,7 +440,7 @@ func (c *Controller) hasOwnerVM(vmi *virtv1.VirtualMachineInstance) bool {
 		return false
 	}
 
-	obj, exists, _ := c.vmStore.GetByKey(vmi.Namespace + "/" + controllerRef.Name)
+	obj, exists, _ := c.vmStore.GetByKey(controller.NamespacedKey(vmi.Namespace, controllerRef.Name))
 	if !exists {
 		return false
 	}
@@ -1159,7 +1159,7 @@ func (c *Controller) addPVC(obj interface{}) {
 
 	persistentStateFor, exists := pvc.Labels[backendstorage.PVCPrefix]
 	if exists {
-		vmiKey := pvc.Namespace + "/" + persistentStateFor
+		vmiKey := controller.NamespacedKey(pvc.Namespace, persistentStateFor)
 		c.pvcExpectations.CreationObserved(vmiKey)
 		c.Queue.Add(vmiKey)
 		return // The PVC is a backend-storage PVC, won't be listed by `c.listVMIsMatchingDV()`
@@ -1439,7 +1439,7 @@ func (c *Controller) enqueueVirtualMachine(obj interface{}) {
 func (c *Controller) resolveControllerRef(namespace string, controllerRef *v1.OwnerReference) *virtv1.VirtualMachineInstance {
 	if controllerRef != nil && controllerRef.Kind == "Pod" {
 		// This could be an attachment pod, look up the pod, and check if it is owned by a VMI.
-		obj, exists, err := c.podIndexer.GetByKey(namespace + "/" + controllerRef.Name)
+		obj, exists, err := c.podIndexer.GetByKey(controller.NamespacedKey(namespace, controllerRef.Name))
 		if err != nil {
 			return nil
 		}
@@ -1454,7 +1454,7 @@ func (c *Controller) resolveControllerRef(namespace string, controllerRef *v1.Ow
 	if controllerRef == nil || controllerRef.Kind != virtv1.VirtualMachineInstanceGroupVersionKind.Kind {
 		return nil
 	}
-	vmi, exists, err := c.vmiIndexer.GetByKey(namespace + "/" + controllerRef.Name)
+	vmi, exists, err := c.vmiIndexer.GetByKey(controller.NamespacedKey(namespace, controllerRef.Name))
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
### What this PR does
Before this PR:
Many calls to `GetByKey()` use manually built strings with `namespace + "/" + name`

After this PR:
Those calls now use `controller.NamespacedKey()` instead

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

