### PR TITLE
Graduate the DynamicPodInterfaceNaming FG

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -362,7 +362,7 @@ func (app *virtHandlerApp) Run() {
 		&capabilities,
 		hostCpuModel,
 		netsetup.NewNetConf(app.clusterConfig),
-		netsetup.NewNetStat(app.clusterConfig),
+		netsetup.NewNetStat(),
 		netbinding.MemoryCalculator{},
 	)
 	if err != nil {

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -47,9 +47,8 @@ var _ = Describe("netconf", func() {
 		vmi      *v1.VirtualMachineInstance
 		stateMap map[string]*netpod.State
 
-		stateCache        stateCacheStub
-		ns                nsExecutorStub
-		clusterConfigurer cConfigStub
+		stateCache stateCacheStub
+		ns         nsExecutorStub
 	)
 
 	const launcherPid = 0
@@ -58,8 +57,7 @@ var _ = Describe("netconf", func() {
 		stateCache = newConfigStateCacheStub()
 		ns = nsExecutorStub{}
 		stateMap = map[string]*netpod.State{}
-		clusterConfigurer = cConfigStub{dynamicPodInterfaceNamingEnabled: false}
-		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsNoopFactory, &tempCacheCreator{}, stateMap, clusterConfigurer)
+		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsNoopFactory, &tempCacheCreator{}, stateMap, cConfigStub{})
 		vmi = &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{UID: "123", Name: "vmi1"}}
 	})
 
@@ -215,14 +213,8 @@ func (n nsExecutorStub) Do(f func() error) error {
 	return f()
 }
 
-type cConfigStub struct {
-	dynamicPodInterfaceNamingEnabled bool
-}
+type cConfigStub struct{}
 
 func (c cConfigStub) GetNetworkBindings() map[string]v1.InterfaceBindingPlugin {
 	return map[string]v1.InterfaceBindingPlugin{}
-}
-
-func (c cConfigStub) DynamicPodInterfaceNamingEnabled() bool {
-	return c.dynamicPodInterfaceNamingEnabled
 }

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -46,10 +46,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-type clusterConfigChecker interface {
-	DynamicPodInterfaceNamingEnabled() bool
-}
-
 type nmstateAdapter interface {
 	Apply(spec *nmstate.Spec) error
 	Read() (*nmstate.Status, error)

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -47,19 +47,16 @@ type NetStat struct {
 	// key is the file path, value is the contents.
 	// if key exists, then don't read directly from file.
 	podInterfaceVolatileCache sync.Map
-
-	clusterConfigurer clusterConfigurer
 }
 
-func NewNetStat(clusterConfigurer clusterConfigurer) *NetStat {
-	return NewNetStateWithCustomFactory(cache.CacheCreator{}, clusterConfigurer)
+func NewNetStat() *NetStat {
+	return NewNetStateWithCustomFactory(cache.CacheCreator{})
 }
 
-func NewNetStateWithCustomFactory(cacheCreator cacheCreator, clusterConfigurer clusterConfigurer) *NetStat {
+func NewNetStateWithCustomFactory(cacheCreator cacheCreator) *NetStat {
 	return &NetStat{
 		cacheCreator:              cacheCreator,
 		podInterfaceVolatileCache: sync.Map{},
-		clusterConfigurer:         clusterConfigurer,
 	}
 }
 
@@ -117,11 +114,8 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 	interfacesStatus = ifacesStatusFromGuestAgent(interfacesStatus, domain.Status.Interfaces)
 
 	primaryNetwork := netvmispec.LookupPodNetwork(vmi.Spec.Networks)
-	if c.clusterConfigurer.DynamicPodInterfaceNamingEnabled() {
-		interfacesStatus = restorePodIfaceNameForPrimaryIface(interfacesStatus, primaryNetwork, vmi.Status.Interfaces)
-	}
-	var primaryInterfaceStatus *v1.VirtualMachineInstanceNetworkInterface
-	primaryInterfaceStatus, interfacesStatus = netvmispec.PopInterfaceByNetwork(interfacesStatus, primaryNetwork)
+	interfacesStatus = restorePodIfaceNameForPrimaryIface(interfacesStatus, primaryNetwork, vmi.Status.Interfaces)
+	primaryInterfaceStatus, interfacesStatus := netvmispec.PopInterfaceByNetwork(interfacesStatus, primaryNetwork)
 	if primaryInterfaceStatus != nil {
 		interfacesStatus = append([]v1.VirtualMachineInstanceNetworkInterface{*primaryInterfaceStatus}, interfacesStatus...)
 	}

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -34,9 +34,7 @@ import (
 )
 
 var _ = Describe("netstat", func() {
-	var (
-		setup testSetup
-	)
+	var setup testSetup
 
 	BeforeEach(func() {
 		setup = newTestSetup()
@@ -754,7 +752,6 @@ var _ = Describe("netstat", func() {
 			{Name: primaryNetworkName, PodInterfaceName: primaryPodIfaceName},
 		}
 
-		setup.NetStat = netsetup.NewNetStateWithCustomFactory(&tempCacheCreator{}, cConfigStub{dynamicPodInterfaceNamingEnabled: true})
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		infoSourceDomainGA := netvmispec.NewInfoSource(
@@ -767,7 +764,7 @@ var _ = Describe("netstat", func() {
 
 	DescribeTable("VMI with primary interface status reported should keep the prev PodInterfaceName", func(primaryPodIfaceName string) {
 		const primaryNetworkName = "default"
-		setup.NetStat = netsetup.NewNetStateWithCustomFactory(&tempCacheCreator{}, cConfigStub{dynamicPodInterfaceNamingEnabled: true})
+
 		setup.Vmi.Spec.Domain.Devices.Interfaces = append(setup.Vmi.Spec.Domain.Devices.Interfaces, newVMISpecIfaceWithBridgeBinding(primaryNetworkName))
 		setup.Vmi.Spec.Networks = append(setup.Vmi.Spec.Networks, newVMISpecPodNetwork(primaryNetworkName))
 		setup.Vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{{Name: primaryNetworkName, PodInterfaceName: primaryPodIfaceName}}
@@ -852,10 +849,7 @@ func newTestSetupWithVolatileCache() testSetup {
 }
 
 func newTestSetup() testSetup {
-	var (
-		cacheCreator      tempCacheCreator
-		clusterConfigurer = cConfigStub{dynamicPodInterfaceNamingEnabled: false}
-	)
+	var cacheCreator tempCacheCreator
 	const uid = "123"
 	vmi := &v1.VirtualMachineInstance{}
 	vmi.UID = uid
@@ -864,7 +858,7 @@ func newTestSetup() testSetup {
 	return testSetup{
 		Vmi:           vmi,
 		Domain:        &api.Domain{},
-		NetStat:       netsetup.NewNetStateWithCustomFactory(&cacheCreator, &clusterConfigurer),
+		NetStat:       netsetup.NewNetStateWithCustomFactory(&cacheCreator),
 		cacheCreator:  &cacheCreator,
 		podIfaceCache: cache.NewPodInterfaceCache(&cacheCreator, uid),
 	}

--- a/pkg/network/vmicontroller/status_test.go
+++ b/pkg/network/vmicontroller/status_test.go
@@ -90,16 +90,13 @@ var _ = Describe("Status Update", func() {
 		customIfaceName = "custom-iface"
 	)
 
-	dynamicPodInterfaceNamingEnabled := stubClusterConfigChecker{dynamicPodInterfaceNamingEnabled: true}
-	dynamicPodInterfaceNamingDisabled := stubClusterConfigChecker{dynamicPodInterfaceNamingEnabled: false}
-
 	DescribeTable("Shouldn't generate interface status for a VMI without interfaces", func(podAnnotations map[string]string) {
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
 			libvmi.WithAutoAttachPodInterface(false),
 		)
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 		Expect(vmi.Status.Interfaces).To(BeEmpty())
 	},
 		Entry("When the Multus network-status annotation is absent", nil),
@@ -115,7 +112,7 @@ var _ = Describe("Status Update", func() {
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingEnabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: defaultNetworkName, PodInterfaceName: "eth0"},
@@ -144,7 +141,7 @@ var _ = Describe("Status Update", func() {
 			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
 		)
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingEnabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: defaultNetworkName, PodInterfaceName: "eth0", InfoSource: vmispec.InfoSourceDomainAndGA},
@@ -169,27 +166,13 @@ var _ = Describe("Status Update", func() {
 		)
 
 		annotations := map[string]string{networkv1.NetworkStatusAnnot: multusNetworkStatusWithCustomPrimaryNet}
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingEnabled, vmi, newPodFromVMI(vmi, annotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, annotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: defaultNetworkName, PodInterfaceName: customIfaceName},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
-	})
-
-	It("Should not report custom pod primary interface name with dynamic pod naming"+
-		"feature gate disabled", func() {
-		vmi := libvmi.New(
-			libvmi.WithNamespace(testNamespace),
-			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		)
-
-		annotations := map[string]string{networkv1.NetworkStatusAnnot: multusNetworkStatusWithCustomPrimaryNet}
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, annotations))).To(Succeed())
-
-		Expect(vmi.Status.Interfaces).To(BeEmpty())
 	})
 
 	DescribeTable("Should generate interface status for Multus default network (not matched on status)",
@@ -208,8 +191,7 @@ var _ = Describe("Status Update", func() {
 				}),
 			)
 
-			Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingEnabled,
-				vmi, newPodFromVMI(vmi, map[string]string{}))).To(Succeed())
+			Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, map[string]string{}))).To(Succeed())
 
 			expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 				{Name: alternativeNetworkName, PodInterfaceName: "eth0"},
@@ -254,7 +236,7 @@ var _ = Describe("Status Update", func() {
 			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
 		)
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingEnabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: alternativeNetworkName, PodInterfaceName: "eth0", InfoSource: vmispec.InfoSourceDomainAndGA},
@@ -290,7 +272,7 @@ var _ = Describe("Status Update", func() {
 
 		podAnnotations := map[string]string{networkv1.NetworkAttachmentAnnot: multusNetworksAnnotation}
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		Expect(vmi.Status.Interfaces).To(BeEmpty())
 	})
@@ -303,7 +285,7 @@ var _ = Describe("Status Update", func() {
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			)
 
-			Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+			Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 			expectedInterfaces := []v1.VirtualMachineInstanceNetworkInterface{
 				{Name: secondaryNetworkName, InfoSource: vmispec.InfoSourceMultusStatus},
@@ -335,7 +317,7 @@ var _ = Describe("Status Update", func() {
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			)
 
-			Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingEnabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+			Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 			expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 				{Name: defaultNetworkName, PodInterfaceName: expectedPrimaryInterfaceName},
@@ -360,40 +342,33 @@ var _ = Describe("Status Update", func() {
 		),
 	)
 
-	DescribeTable("Should add the primary interface status for an existing VMI with primary and secondary networks",
-		func(clusterConfig stubClusterConfigChecker, expectedPrimaryInterface *v1.VirtualMachineInstanceNetworkInterface) {
-			existingInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-				{Name: secondaryNetworkName, PodInterfaceName: "", InfoSource: vmispec.InfoSourceMultusStatus},
-			}
+	It("Should add the primary interface status for an existing VMI with primary and secondary networks", func() {
+		existingInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
+			{Name: secondaryNetworkName, PodInterfaceName: "", InfoSource: vmispec.InfoSourceMultusStatus},
+		}
 
-			vmi := libvmi.New(
-				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
-				libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
-			)
+		vmi := libvmi.New(
+			libvmi.WithNamespace(testNamespace),
+			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
+			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
+		)
 
-			podAnnotations := map[string]string{
-				networkv1.NetworkAttachmentAnnot: multusNetworksAnnotation,
-				networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndSecondaryNets,
-			}
-			Expect(vmicontroller.UpdateStatus(&clusterConfig, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		podAnnotations := map[string]string{
+			networkv1.NetworkAttachmentAnnot: multusNetworksAnnotation,
+			networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndSecondaryNets,
+		}
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
-			expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{}
-			if expectedPrimaryInterface != nil {
-				expectedInterfacesStatus = append(expectedInterfacesStatus, *expectedPrimaryInterface)
-			}
-			expectedInterfacesStatus = append(expectedInterfacesStatus,
-				v1.VirtualMachineInstanceNetworkInterface{Name: secondaryNetworkName, PodInterfaceName: "", InfoSource: vmispec.InfoSourceMultusStatus})
+		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
+			{Name: defaultNetworkName, PodInterfaceName: "eth0"},
+			{Name: secondaryNetworkName, PodInterfaceName: "", InfoSource: vmispec.InfoSourceMultusStatus},
+		}
 
-			Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
-		},
-		Entry("with dynamic pod interface naming enabled",
-			dynamicPodInterfaceNamingEnabled, &v1.VirtualMachineInstanceNetworkInterface{Name: defaultNetworkName, PodInterfaceName: "eth0"}),
-		Entry("without dynamic pod interface naming enabled", dynamicPodInterfaceNamingDisabled, nil),
-	)
+		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
+	})
 
 	It("Should keep the Multus info source when VMI.status has an interface and it is reported by Multus network-status", func() {
 		existingInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
@@ -412,7 +387,7 @@ var _ = Describe("Status Update", func() {
 			networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndSecondaryNets,
 		}
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: secondaryNetworkName, InfoSource: vmispec.InfoSourceMultusStatus},
@@ -437,7 +412,7 @@ var _ = Describe("Status Update", func() {
 			networkv1.NetworkStatusAnnot: multusNetworkStatusWithPrimaryNet,
 		}
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: secondaryNetworkName},
@@ -462,7 +437,7 @@ var _ = Describe("Status Update", func() {
 			networkv1.NetworkStatusAnnot: multusNetworkStatusWithPrimaryNet,
 		}
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: secondaryNetworkName, InfoSource: vmispec.InfoSourceGuestAgent},
@@ -488,7 +463,7 @@ var _ = Describe("Status Update", func() {
 			networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndSecondaryNets,
 		}
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: secondaryNetworkName, InfoSource: vmispec.InfoSourceMultusStatus},
@@ -514,7 +489,7 @@ var _ = Describe("Status Update", func() {
 			networkv1.NetworkStatusAnnot: multusNetworkStatusWithPrimaryNet,
 		}
 
-		Expect(vmicontroller.UpdateStatus(&dynamicPodInterfaceNamingDisabled, vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
+		Expect(vmicontroller.UpdateStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: secondaryNetworkName},
@@ -538,12 +513,4 @@ func WithInterfacesStatus(interfaces []v1.VirtualMachineInstanceNetworkInterface
 	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
 		vmiStatus.Interfaces = interfaces
 	}
-}
-
-type stubClusterConfigChecker struct {
-	dynamicPodInterfaceNamingEnabled bool
-}
-
-func (s stubClusterConfigChecker) DynamicPodInterfaceNamingEnabled() bool {
-	return s.dynamicPodInterfaceNamingEnabled
 }

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -70,6 +70,9 @@ const (
 	// GA:    v1.5.0
 	NetworkBindingPlugingsGate = "NetworkBindingPlugins" // GA
 
+	// DynamicPodInterfaceNamingGate enables a mechanism to dynamically determine the primary pod interface for KubeVirt virtual machines.
+	DynamicPodInterfaceNamingGate = "DynamicPodInterfaceNaming" // GA
+
 	PasstGate   = "Passt"   // Deprecated
 	MacvtapGate = "Macvtap" // Deprecated
 	// DockerSELinuxMCSWorkaround sets the SELinux level of all the non-compute virt-launcher containers to "s0".
@@ -98,6 +101,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: BochsDisplayForEFIGuests, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VMLiveUpdateFeaturesGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: NetworkBindingPlugingsGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: DynamicPodInterfaceNamingGate, State: GA})
 
 	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Discontinued, Message: PasstDiscontinueMessage, VmiSpecUsed: passtApiUsed})
 	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -73,8 +73,7 @@ const (
 	// This feature requires following Kubernetes feature gate "ServiceAccountTokenPodNodeInfo". The feature gate is available
 	// in Kubernetes 1.30 as Beta.
 	NodeRestrictionGate = "NodeRestriction"
-	// DynamicPodInterfaceNaming enables a mechanism to dynamically determine the primary pod interface for KuveVirt virtual machines.
-	DynamicPodInterfaceNamingGate = "DynamicPodInterfaceNaming"
+
 	// Owner: @lyarwood
 	// Alpha: v1.4.0
 	//
@@ -239,8 +238,4 @@ func (config *ClusterConfig) VolumeMigrationEnabled() bool {
 
 func (config *ClusterConfig) NodeRestrictionEnabled() bool {
 	return config.isFeatureGateEnabled(NodeRestrictionGate)
-}
-
-func (config *ClusterConfig) DynamicPodInterfaceNamingEnabled() bool {
-	return config.isFeatureGateEnabled(DynamicPodInterfaceNamingGate)
 }

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -80,7 +80,6 @@ go_test(
         "//pkg/storage/export/export:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/testutils:go_default_library",
-        "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch/clone:go_default_library",
         "//pkg/virt-controller/watch/drain/disruptionbudget:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -657,9 +657,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.clusterConfig,
 		topologyHinter,
 		netAnnotationsGenerator,
-		func(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) error {
-			return netvmicontroller.UpdateStatus(clusterConfig, vmi, pod)
-		},
+		netvmicontroller.UpdateStatus,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -54,7 +54,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/storage/export/export"
 	"kubevirt.io/kubevirt/pkg/storage/snapshot"
 	"kubevirt.io/kubevirt/pkg/testutils"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/clone"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/disruptionbudget"
@@ -148,7 +147,7 @@ var _ = Describe("Application", func() {
 			config,
 			topology.NewTopologyHinter(&cache.FakeCustomStore{}, &cache.FakeCustomStore{}, nil),
 			nil,
-			func(_ *virtconfig.ClusterConfig, _ *v1.VirtualMachineInstance, _ *k8sv1.Pod) error { return nil },
+			func(_ *v1.VirtualMachineInstance, _ *k8sv1.Pod) error { return nil },
 		)
 		app.rsController, _ = replicaset.NewController(vmiInformer, rsInformer, recorder, virtClient, uint(10))
 		app.vmController, _ = vm.NewController(vmiInformer,

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -176,7 +176,7 @@ type annotationsGenerator interface {
 	GenerateFromActivePod(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) map[string]string
 }
 
-type statusUpdater func(clusterConfig *virtconfig.ClusterConfig, vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error
+type statusUpdater func(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error
 
 type Controller struct {
 	templateService         services.TemplateService
@@ -591,7 +591,7 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 					return err
 				}
 
-				if err := c.updateNetworkStatus(c.clusterConfig, vmiCopy, pod); err != nil {
+				if err := c.updateNetworkStatus(vmiCopy, pod); err != nil {
 					log.Log.Errorf("failed to update the interface status: %v", err)
 				}
 
@@ -655,7 +655,7 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 			return err
 		}
 
-		if err := c.updateNetworkStatus(c.clusterConfig, vmiCopy, pod); err != nil {
+		if err := c.updateNetworkStatus(vmiCopy, pod); err != nil {
 			log.Log.Errorf("failed to update the interface status: %v", err)
 		}
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -210,7 +210,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		nsInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
 		var qemuGid int64 = 107
 
-		stubNetStatusUpdate := func(clusterConfig *virtconfig.ClusterConfig, vmi *virtv1.VirtualMachineInstance, _ *k8sv1.Pod) error {
+		stubNetStatusUpdate := func(vmi *virtv1.VirtualMachineInstance, _ *k8sv1.Pod) error {
 			vmi.Status.Interfaces = append(vmi.Status.Interfaces, virtv1.VirtualMachineInstanceNetworkInterface{Name: "stubNetStatusUpdate"})
 			return nil
 		}

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "//pkg/pointer:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",
-        "//pkg/virt-config:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -38,11 +38,9 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	network "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -58,7 +56,7 @@ var _ = SIGDescribe("Infosource", func() {
 		virtClient = kubevirt.Client()
 	})
 
-	Context("[Serial] VMI with 3 interfaces", Serial, func() {
+	Context("VMI with 3 interfaces", func() {
 		var vmi *kvirtv1.VirtualMachineInstance
 
 		const (
@@ -77,8 +75,6 @@ var _ = SIGDescribe("Infosource", func() {
 		secondaryNetwork2 := libvmi.MultusNetwork(secondaryInterface2Name, nadName)
 
 		BeforeEach(func() {
-			config.EnableFeatureGate(virtconfig.DynamicPodInterfaceNamingGate)
-
 			By("Create NetworkAttachmentDefinition")
 			Expect(libnet.CreateNAD(testsuite.NamespaceTestDefault, nadName)).To(Succeed())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The DynamicPodInterfaceNaming feature-gate was introduced in v1.4 by PR  https://github.com/kubevirt/kubevirt/pull/13078.

The feature works well for at least two projects.
No negative feedbacks were received from the community on the implementation other than the fact that is does
not support migration between two different primary interface names (in this case the migration will fail).

This scenario is not supposed to be supported for the foreseeable future.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

