### PR TITLE
OWNERS: Move AlonaKaplan to the emeritus approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@ aliases:
     - rmohr
     - stu-gott
     - fabiand
-    - AlonaKaplan
     - jean-edouard
     - mhenriks
     - enp0s3
@@ -25,6 +24,7 @@ aliases:
     - ashleyschuett
     - zcahana
     - dhiller # 2024-03-15
+    - AlonaKaplan
   code-reviewers:
     - stu-gott
     - vladikr
@@ -54,8 +54,9 @@ aliases:
     - xpivarc
     - acardace
     - dhiller
-    - AlonaKaplan
     - 0xFelix
+  sig-test-emeritus_approvers:
+    - AlonaKaplan
 
   #
   # SIG Network
@@ -66,8 +67,9 @@ aliases:
     - RamLavi
     - ormergi
   sig-network-approvers:
-    - AlonaKaplan
     - EdDev
+  sig-network-emeritus_approvers:
+    - AlonaKaplan
 
   #
   # SIG Scale


### PR DESCRIPTION
### What this PR does

Based on the project governance [1], maintainers that are idle for 6 months or more are to be moved to the emeritus list.

Unfortunately, it seems Alona has changed focus and is no longer active [2] in the project.
Therefore, Alona is moved to the emeritus approvers list.

[1] https://github.com/kubevirt/community/blob/main/GOVERNANCE.md#removing-maintainers
[2] https://github.com/AlonaKaplan?tab=overview&from=2024-05-10&org=kubevirt

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This is a sad PR :/

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```