### PR TITLE
Add virt-handler cpu and memory usage metrics

### DIFF
--- a/hack/kwok-perftests.sh
+++ b/hack/kwok-perftests.sh
@@ -18,7 +18,7 @@
 
 set -e
 
-kubectl() { KUBEVIRTCI_VERBOSE=false cluster-up/kubectl.sh "$@"; }
+kubectl() { KUBEVIRTCI_VERBOSE=false kubevirtci/cluster-up/kubectl.sh "$@"; }
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
 DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
@@ -60,7 +60,7 @@ echo 'ARTIFACTS ' "${ARTIFACTS}"
 echo 'TESTS_OUT_DIR ' "${TESTS_OUT_DIR}"
 
 function perftest() {
-    _out/tests/ginkgo -r -slow-spec-threshold=60s "$@" _out/tests/tests.test -- "${extra_args}" -kubeconfig="${kubeconfig}" -container-tag="${docker_tag}" -container-tag-alt="${docker_tag_alt}" -container-prefix="${perftest_docker_prefix}" -image-prefix-alt="${image_prefix_alt}" -oc-path="${oc}" -kubectl-path="${kubectl}" -gocli-path="${gocli}" -installed-namespace="${namespace}" -previous-release-tag="${PREVIOUS_RELEASE_TAG}" -previous-release-registry="${previous_release_registry}" -deploy-testing-infra="${deploy_testing_infra}" -config="${KUBEVIRT_DIR}"/tests/default-config.json -deploy-fake-kwok-nodes=true --artifacts="${ARTIFACTS}"
+    _out/tests/ginkgo -r -slow-spec-threshold=60s "$@" _out/tests/tests.test -- ${extra_args} -kubeconfig="${kubeconfig}" -container-tag="${docker_tag}" -container-tag-alt="${docker_tag_alt}" -container-prefix="${perftest_docker_prefix}" -image-prefix-alt="${image_prefix_alt}" -oc-path="${oc}" -kubectl-path="${kubectl}" -gocli-path="${gocli}" -installed-namespace="${namespace}" -previous-release-tag="${PREVIOUS_RELEASE_TAG}" -previous-release-registry="${previous_release_registry}" -deploy-testing-infra="${deploy_testing_infra}" -config="${KUBEVIRT_DIR}"/tests/default-config.json -deploy-fake-kwok-nodes=true --artifacts="${ARTIFACTS}"
 }
 
 function perfaudit() {
@@ -75,10 +75,10 @@ fi
 
 additional_test_args=""
 if [ -n "$KUBEVIRT_E2E_LABEL_FILTER" ]; then
-    additional_test_args="${additional_test_args} --label-filter=${KUBEVIRT_E2E_LABEL_FILTER}"
+    additional_test_args+="--label-filter=${KUBEVIRT_E2E_LABEL_FILTER}"
 fi
 
-perftest "${additional_test_args}" "${FUNC_TEST_ARGS}"
+perftest ${additional_test_args} ${FUNC_TEST_ARGS}
 
 echo 'Delete kubevirt related kwok manifests'
 kubectl delete -k tests/performance/manifests/kwok

--- a/tools/perfscale-audit/api/api.go
+++ b/tools/perfscale-audit/api/api.go
@@ -109,14 +109,20 @@ const (
 	// container_memory_rss
 	ResultTypeAvgVirtAPIMemoryUsageInMB        ResultType = "avgVirtAPIMemoryUsageInMB"
 	ResultTypeAvgVirtControllerMemoryUsageInMB ResultType = "avgVirtControllerMemoryUsageInMB"
+	ResultTypeAvgVirtHandlerMemoryUsageInMB    ResultType = "avgVirtHandlerMemoryUsageInMB"
 	ResultTypeMinVirtAPIMemoryUsageInMB        ResultType = "minVirtAPIMemoryUsageInMB"
 	ResultTypeMaxVirtAPIMemoryUsageInMB        ResultType = "maxVirtAPIMemoryUsageInMB"
 	ResultTypeMinVirtControllerMemoryUsageInMB ResultType = "minVirtControllerMemoryUsageInMB"
 	ResultTypeMaxVirtControllerMemoryUsageInMB ResultType = "maxVirtControllerMemoryUsageInMB"
+	ResultTypeMinVirtHandlerMemoryUsageInMB    ResultType = "minVirtHandlerMemoryUsageInMB"
+	ResultTypeMaxVirtHandlerMemoryUsageInMB    ResultType = "maxVirtHandlerMemoryUsageInMB"
 
 	// container_cpu_usage_seconds_total
 	ResultTypeAvgVirtAPICPUUsage        ResultType = "avgVirtAPICPUUsage"
 	ResultTypeAvgVirtControllerCPUUsage ResultType = "avgVirtControllerCPUUsage"
+	ResultTypeAvgVirtHandlerCPUUsage    ResultType = "avgVirtHandlerCPUUsage"
+	ResultTypeMinVirtHandlerCPUUsage    ResultType = "minVirtHandlerCPUUsage"
+	ResultTypeMaxVirtHandlerCPUUsage    ResultType = "maxVirtHandlerCPUUsage"
 )
 
 const (

--- a/tools/perfscale-audit/metric-client/metric-client.go
+++ b/tools/perfscale-audit/metric-client/metric-client.go
@@ -59,6 +59,13 @@ const (
 	minVirtControllerMemUsageInMB = `max(min_over_time(container_memory_rss{pod=~"virt-controller.*", container!="POD", container!=""}[%ds]))/1024/1024`
 	maxVirtControllerMemUsageInMB = `max(max_over_time(container_memory_rss{pod=~"virt-controller.*", container!="POD", container!=""}[%ds]))/1024/1024`
 	avgVirtControllerCPUUsage     = `max(rate(container_cpu_usage_seconds_total{namespace="kubevirt",pod=~"virt-controller.*", container!="",container!="POD"}[%ds]))`
+	// avg_over_time gives the average memory utilization of the virt-handler pod per node over time, the outside max, min, avg gives the pods with highest, lowest and average avg_over_time values respectively
+	avgVirtHandlerMemUsageInMB = `avg(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
+	maxVirtHandlerMemUsageInMB = `max(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
+	minVirtHandlerMemUsageInMB = `min(avg_over_time((sum by (node) (container_memory_rss{pod=~"virt-handler.*", container="virt-handler"}) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"}))[%ds:]))/1024/1024`
+	avgVirtHandlerCPUUsage     = `avg((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))`
+	maxVirtHandlerCPUUsage     = `max((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))`
+	minVirtHandlerCPUUsage     = `min((sum(rate(container_cpu_usage_seconds_total{pod=~"virt-handler.*", container="virt-handler"}[%ds])) by (node) / sum by (node) (kubevirt_vmi_phase_count{node != "", node != "<no value>"})))`
 )
 
 type metricUsage struct {
@@ -404,6 +411,30 @@ func (m *MetricClient) getCPUAndMemoryUsageOfComponents(r *audit_api.Result, ran
 		{
 			query: fmt.Sprintf(minVirtControllerMemUsageInMB, int(rangeVector.Seconds())),
 			t:     audit_api.ResultTypeMinVirtControllerMemoryUsageInMB,
+		},
+		{
+			query: fmt.Sprintf(avgVirtHandlerCPUUsage, int(rangeVector.Seconds())),
+			t:     audit_api.ResultTypeAvgVirtHandlerCPUUsage,
+		},
+		{
+			query: fmt.Sprintf(avgVirtHandlerMemUsageInMB, int(rangeVector.Seconds())),
+			t:     audit_api.ResultTypeAvgVirtHandlerMemoryUsageInMB,
+		},
+		{
+			query: fmt.Sprintf(minVirtHandlerMemUsageInMB, int(rangeVector.Seconds())),
+			t:     audit_api.ResultTypeMinVirtHandlerMemoryUsageInMB,
+		},
+		{
+			query: fmt.Sprintf(maxVirtHandlerMemUsageInMB, int(rangeVector.Seconds())),
+			t:     audit_api.ResultTypeMaxVirtHandlerMemoryUsageInMB,
+		},
+		{
+			query: fmt.Sprintf(minVirtHandlerCPUUsage, int(rangeVector.Seconds())),
+			t:     audit_api.ResultTypeMinVirtHandlerCPUUsage,
+		},
+		{
+			query: fmt.Sprintf(maxVirtHandlerCPUUsage, int(rangeVector.Seconds())),
+			t:     audit_api.ResultTypeMaxVirtHandlerCPUUsage,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
There are no metrics exported for virt-handler memory utilization

After this PR:
metrics for  the number of vmi scheduled per node 
metrics for the avg, min, max CPU and memory utilization of virt-handler pods

Removed double quotes in the shellscript because
use of quotes around ${extra_args} making it treat as a single variable, if it is empty or has space it is showing unexpected behaviour. As the args passed contain the space at the begining and "&&" it is showing unexpected behaviour https://github.com/kubevirt/kubevirt/blob/65e1db9516b52ecc4c7879ec72fcf2b0b3d39e6e/hack/kwok-perftests.sh#L78 .
Removed the quotes around when dealing with multi-word or special character arguments.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13196

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add virt-handler cpu and memory usage metrics
```

