### PR TITLE
Unconditionally disable libvirt's VMPort feature which is relevant for VMWare only

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -1538,6 +1538,11 @@ func (in *Features) DeepCopyInto(out *Features) {
 		*out = new(FeatureState)
 		**out = **in
 	}
+	if in.VMPort != nil {
+		in, out := &in.VMPort, &out.VMPort
+		*out = new(FeatureState)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -15,28 +15,28 @@ type Defaulter struct {
 	Architecture string
 }
 
-func (d *Defaulter) IsPPC64() bool {
+func (d *Defaulter) isPPC64() bool {
 	return d.Architecture == "ppc64le"
 }
 
-func (d *Defaulter) IsARM64() bool {
+func (d *Defaulter) isARM64() bool {
 	return d.Architecture == "arm64"
 }
 
-func (d *Defaulter) IsS390X() bool {
+func (d *Defaulter) isS390X() bool {
 	return d.Architecture == "s390x"
 }
 
-func (d *Defaulter) SetDefaults_OSType(ostype *OSType) {
+func (d *Defaulter) setDefaults_OSType(ostype *OSType) {
 	ostype.OS = "hvm"
 
 	if ostype.Arch == "" {
 		switch {
-		case d.IsPPC64():
+		case d.isPPC64():
 			ostype.Arch = "ppc64le"
-		case d.IsARM64():
+		case d.isARM64():
 			ostype.Arch = "aarch64"
-		case d.IsS390X():
+		case d.isS390X():
 			ostype.Arch = "s390x"
 		default:
 			ostype.Arch = "x86_64"
@@ -47,11 +47,11 @@ func (d *Defaulter) SetDefaults_OSType(ostype *OSType) {
 	// TODO: we probably want to select concrete type in the future for "future-backwards" compatibility.
 	if ostype.Machine == "" {
 		switch {
-		case d.IsPPC64():
+		case d.isPPC64():
 			ostype.Machine = "pseries"
-		case d.IsARM64():
+		case d.isARM64():
 			ostype.Machine = "virt"
-		case d.IsS390X():
+		case d.isS390X():
 			ostype.Machine = "s390-ccw-virtio"
 		default:
 			ostype.Machine = "q35"
@@ -59,20 +59,20 @@ func (d *Defaulter) SetDefaults_OSType(ostype *OSType) {
 	}
 }
 
-func (d *Defaulter) SetDefaults_DomainSpec(spec *DomainSpec) {
+func (d *Defaulter) setDefaults_DomainSpec(spec *DomainSpec) {
 	spec.XmlNS = "http://libvirt.org/schemas/domain/qemu/1.0"
 	if spec.Type == "" {
 		spec.Type = "kvm"
 	}
 }
 
-func (d *Defaulter) SetDefaults_SysInfo(sysinfo *SysInfo) {
+func (d *Defaulter) setDefaults_SysInfo(sysinfo *SysInfo) {
 	if sysinfo.Type == "" {
 		sysinfo.Type = "smbios"
 	}
 }
 
-func (d *Defaulter) SetDefaults_Features(spec *DomainSpec) {
+func (d *Defaulter) setDefaults_Features(spec *DomainSpec) {
 	if spec.Features == nil {
 		spec.Features = &Features{}
 	}
@@ -81,10 +81,10 @@ func (d *Defaulter) SetDefaults_Features(spec *DomainSpec) {
 }
 
 func (d *Defaulter) SetObjectDefaults_Domain(in *Domain) {
-	d.SetDefaults_DomainSpec(&in.Spec)
-	d.SetDefaults_OSType(&in.Spec.OS.Type)
+	d.setDefaults_DomainSpec(&in.Spec)
+	d.setDefaults_OSType(&in.Spec.OS.Type)
 	if in.Spec.SysInfo != nil {
-		d.SetDefaults_SysInfo(in.Spec.SysInfo)
+		d.setDefaults_SysInfo(in.Spec.SysInfo)
 	}
-	d.SetDefaults_Features(&in.Spec)
+	d.setDefaults_Features(&in.Spec)
 }

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -72,10 +72,19 @@ func (d *Defaulter) SetDefaults_SysInfo(sysinfo *SysInfo) {
 	}
 }
 
+func (d *Defaulter) SetDefaults_Features(spec *DomainSpec) {
+	if spec.Features == nil {
+		spec.Features = &Features{}
+	}
+
+	spec.Features.VMPort = &FeatureState{State: "off"}
+}
+
 func (d *Defaulter) SetObjectDefaults_Domain(in *Domain) {
 	d.SetDefaults_DomainSpec(&in.Spec)
 	d.SetDefaults_OSType(&in.Spec.OS.Type)
 	if in.Spec.SysInfo != nil {
 		d.SetDefaults_SysInfo(in.Spec.SysInfo)
 	}
+	d.SetDefaults_Features(&in.Spec)
 }

--- a/pkg/virt-launcher/virtwrap/api/defaults_test.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults_test.go
@@ -9,7 +9,7 @@ var _ = ginkgo.Describe("ArchSpecificDefaults", func() {
 
 	ginkgo.DescribeTable("should set architecture", func(arch string, targetArch string) {
 		domain := &Domain{}
-		NewDefaulter(arch).SetDefaults_OSType(&domain.Spec.OS.Type)
+		NewDefaulter(arch).setDefaults_OSType(&domain.Spec.OS.Type)
 		Expect(domain.Spec.OS.Type.Arch).To(Equal(targetArch))
 	},
 		ginkgo.Entry("to ppc64le", "ppc64le", "ppc64le"),
@@ -19,7 +19,7 @@ var _ = ginkgo.Describe("ArchSpecificDefaults", func() {
 
 	ginkgo.DescribeTable("should set machine type and hvm domain type", func(arch string, machineType string) {
 		domain := &Domain{}
-		NewDefaulter(arch).SetDefaults_OSType(&domain.Spec.OS.Type)
+		NewDefaulter(arch).setDefaults_OSType(&domain.Spec.OS.Type)
 		Expect(domain.Spec.OS.Type.Machine).To(Equal(machineType))
 	},
 		ginkgo.Entry("to pseries", "ppc64le", "pseries"),
@@ -29,7 +29,7 @@ var _ = ginkgo.Describe("ArchSpecificDefaults", func() {
 
 	ginkgo.DescribeTable("should set libvirt namespace and use QEMU as emulator", func(arch string) {
 		domain := &Domain{}
-		NewDefaulter(arch).SetDefaults_DomainSpec(&domain.Spec)
+		NewDefaulter(arch).setDefaults_DomainSpec(&domain.Spec)
 		Expect(domain.Spec.XmlNS).To(Equal("http://libvirt.org/schemas/domain/qemu/1.0"))
 		Expect(domain.Spec.Type).To(Equal("kvm"))
 	},

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -312,6 +312,7 @@ type Features struct {
 	KVM        *FeatureKVM        `xml:"kvm,omitempty"`
 	PVSpinlock *FeaturePVSpinlock `xml:"pvspinlock,omitempty"`
 	PMU        *FeatureState      `xml:"pmu,omitempty"`
+	VMPort     *FeatureState      `xml:"vmport,omitempty"`
 }
 
 const HypervModePassthrough = "passthrough"

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -161,6 +161,7 @@ var _ = ginkgo.Describe("Schema", func() {
 			},
 			PVSpinlock: &FeaturePVSpinlock{State: "off"},
 			PMU:        &FeatureState{State: "off"},
+			VMPort:     &FeatureState{State: "off"},
 		}
 		exampleDomain.Spec.SysInfo = &SysInfo{
 			Type: "smbios",

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_arm64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_arm64.xml.tmpl
@@ -66,6 +66,7 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_ppc64le.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_ppc64le.xml.tmpl
@@ -66,6 +66,7 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_x86_64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_x86_64.xml.tmpl
@@ -66,6 +66,7 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_arm64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_arm64.xml.tmpl
@@ -181,6 +181,7 @@
       <hidden state="on"></hidden>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="host-passthrough">
     <topology sockets="1" cores="1" threads="1"></topology>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_ppc64le.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_ppc64le.xml.tmpl
@@ -178,6 +178,7 @@
       <hidden state="on"></hidden>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="host-model">
     <topology sockets="1" cores="1" threads="1"></topology>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml.tmpl
@@ -178,6 +178,7 @@
       <hidden state="on"></hidden>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="host-model">
     <topology sockets="1" cores="1" threads="1"></topology>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64.xml.tmpl
@@ -179,6 +179,7 @@
       <hidden state="on"></hidden>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="host-model">
     <topology sockets="1" cores="1" threads="1"></topology>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64_root.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_x86_64_root.xml.tmpl
@@ -192,6 +192,7 @@
       <hidden state="on"></hidden>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
+    <vmport state="off"></vmport>
   </features>
   <cpu mode="host-model">
     <topology sockets="1" cores="1" threads="1"></topology>

--- a/pkg/virt-launcher/virtwrap/libvirtxml/convert.go
+++ b/pkg/virt-launcher/virtwrap/libvirtxml/convert.go
@@ -300,6 +300,7 @@ func ConvertKubeVirtFeaturesToDomainFeatureList(features *api.Features) *libvirt
 	f.PMU = setDomainFeatureState(features.PMU)
 	f.HyperV = ConvertKubeVirtFeatureHypervToDomainFeatureHyperV(features.Hyperv)
 	f.KVM = ConverKubeVirtFeatureKVMToDomainFeatureKVM(features.KVM)
+	f.VMPort = setDomainFeatureState(features.VMPort)
 	return f
 
 }


### PR DESCRIPTION
### What this PR does
According to https://libvirt.org/formatdomain.html, the `VMPort` feature exists to enable emulation of the VMWare IO port, for vmmouse and so forth. Libvirt defaults it to on, but containers generally don't make use of the port, so it is better to explicitly disable this feature without even bothering to export it to users.

This is a continuation of https://github.com/kubevirt/kubevirt/pull/11197.

Before this PR:
The virt-launcher API builds libvirt XML without the feature (`<vmport state=.../>`). In this case, libvirt defaults to `state="on"`, but that spends resources on exposing features that will never be used in the scope of Kubevirt.

After this PR:
libvirt XML is generated with explicit `<vmport state="off">`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unconditionally disable libvirt's VMPort feature which is relevant for VMWare only
```

