### PR TITLE
e2e, network: Unify IP report in status tests

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -105,21 +105,6 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					Eventually(vmiIPs, 2*time.Minute, 5*time.Second).Should(Equal(podIPs), "should contain VMI Status IP as Pod status IPs")
 				})
 			})
-			When("no Guest Agent exists", func() {
-				var vmi *v1.VirtualMachineInstance
-
-				BeforeEach(func() {
-					vmi = setupVMI(
-						virtClient,
-						libvmifact.NewAlpine(
-							libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-							libvmi.WithNetwork(v1.DefaultPodNetwork()),
-						),
-					)
-				})
-
-				It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
-			})
 		})
 
 		Context("VMI connected to the pod network using masquerade binding", func() {

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -61,16 +61,6 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			Expect(libnet.ValidateVMIandPodIPMatch(vmi, vmiPod)).To(Succeed(), "Should have matching IP/s between pod and vmi")
 		}
 
-		Context("VMI connected to the pod network using the default (implicit) binding", func() {
-			var vmi *v1.VirtualMachineInstance
-
-			BeforeEach(func() {
-				vmi = setupVMI(virtClient, libvmifact.NewAlpine())
-			})
-
-			It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
-		})
-
 		Context("VMI connected to the pod network using bridge binding", func() {
 			When("Guest Agent exists", func() {
 				var (

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -117,6 +117,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				vmiPod, err := libpod.GetPodByVirtualMachineInstance(outboundVMI, outboundVMI.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
+				Expect(libnet.ValidateVMIandPodIPMatch(outboundVMI, vmiPod)).To(Succeed(), "Should have matching IP/s between pod and vmi")
+
 				var mtu int
 				for _, ifaceName := range []string{"k6t-eth0", "tap0"} {
 					By(fmt.Sprintf("checking %s MTU inside the pod", ifaceName))
@@ -175,9 +177,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					Expect(vmi.Status.Interfaces[0].MAC).To(Equal(vmi.Spec.Domain.Devices.Interfaces[0].MacAddress))
 				}
 				Expect(libnet.CheckMacAddress(vmi, "eth0", vmi.Status.Interfaces[0].MAC)).To(Succeed())
-
 			},
-				Entry("[test_id:1539]the Inbound VirtualMachineInstance", &inboundVMI),
+				Entry("[test_id:1539]the Inbound VirtualMachineInstance with default (implicit) binding", &inboundVMI),
 				Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", &inboundVMIWithPodNetworkSet),
 				Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", &inboundVMIWithCustomMacAddress),
 			)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Currently there are two tests that verifies VMI with bridge binding report the pod IP in status at test/network/primary_pod_network.go.
Both tests use Alpine VM which doesnt have QEMU guest-agent installed.

After this PR:
The are unified into the "multiple VM with bridge binding" test at tests/network/vmi_networking.go.
This test use Cirros VM which doesnt have QEMU guest-agent installed as well.

This PR change tests that perform connectivity check cross nodes to not skip silently but fail loudly, with a informative message.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

