### PR TITLE
VMSnapshot: propagate freeze error failure

### DIFF
--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -343,6 +343,7 @@ func (s *vmSnapshotSource) Freeze() error {
 	err = s.controller.Client.VirtualMachineInstance(s.vm.Namespace).Freeze(context.Background(), s.vm.Name, getFailureDeadline(s.snapshot))
 	timeTrack(startTime, fmt.Sprintf("Freezing vmi %s", s.vm.Name))
 	if err != nil {
+		log.Log.Errorf("Freezing vm %s failed: %v", s.vm.Name, err.Error())
 		return err
 	}
 

--- a/staging/src/kubevirt.io/client-go/kubecli/handler.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/handler.go
@@ -229,7 +229,11 @@ func (v *virtHandlerConn) doRequest(req *http.Request) (response string, err err
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return "", fmt.Errorf("unexpected return code %d (%s)", resp.StatusCode, resp.Status)
+		responseBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("unexpected return code %d (%s)", resp.StatusCode, resp.Status)
+		}
+		return "", fmt.Errorf("unexpected return code %d (%s), message: %s", resp.StatusCode, resp.Status, string(responseBytes))
 	}
 
 	responseBytes, err := io.ReadAll(resp.Body)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -745,6 +745,27 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 				objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(30) * time.Second)
 				objectEventWatcher.WaitFor(context.Background(), watcher.WarningEvent, "FreezeError")
+				Eventually(func() *snapshotv1.VirtualMachineSnapshotStatus {
+					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return snapshot.Status
+				}, time.Minute, 2*time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Conditions": ContainElements(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Type":   Equal(snapshotv1.ConditionReady),
+							"Status": Equal(corev1.ConditionFalse),
+							"Reason": Equal("Not ready")}),
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Type":   Equal(snapshotv1.ConditionProgressing),
+							"Status": Equal(corev1.ConditionFalse),
+							"Reason": Equal("In error state")}),
+					),
+					"Phase": Equal(snapshotv1.InProgress),
+					"Error": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Message": gstruct.PointTo(ContainSubstring("command Freeze failed")),
+					})),
+					"CreationTime": BeNil(),
+				})))
 			})
 
 			It("Calling Velero hooks should freeze/unfreeze VM", func() {


### PR DESCRIPTION
    vmsnapshot: update error on content and snapshot if freeze fails
    
    Up until now if the freeze failed in the online
    snapshot it was not reflected on the snapshot object
    and eventually the deadline would exceed and the user
    would not understand what happened.
    Now in case freeze fails it will be marked as an error
    on the vmsnapshotcontent which is reflected also on the vmsnapshot.
    Remove logic of skiping volumesnapshots in case of error since
    error should be able to change and then continue with the snapshot
    with previous code if an error occured you will keep skipping
    and putting an error on the content without exiting the error state.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-48733

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMSnapshot: propagate freeze error failure
```

