### PR TITLE
lint: Add tests/infrastructure to linter

### DIFF
--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -11,6 +11,7 @@ pkg/network/vmicontroller
 pkg/storage/pod/annotations
 pkg/virtctl/credentials
 tests/console
+tests/infrastructure
 tests/instancetype
 tests/libconfigmap
 tests/libinstancetype

--- a/tests/infrastructure/cluster-profiler.go
+++ b/tests/infrastructure/cluster-profiler.go
@@ -30,9 +30,7 @@ import (
 )
 
 var _ = DescribeSerialInfra("cluster profiler for pprof data aggregation", func() {
-	var (
-		virtClient kubecli.KubevirtClient
-	)
+	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 	})

--- a/tests/infrastructure/crds.go
+++ b/tests/infrastructure/crds.go
@@ -37,18 +37,15 @@ import (
 )
 
 var _ = DescribeInfra("CRDs", func() {
-	var (
-		virtClient kubecli.KubevirtClient
-	)
+	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 	})
 
 	It("[test_id:5177]Should have structural schema", func() {
-		ourCRDs := []string{crds.VIRTUALMACHINE, crds.VIRTUALMACHINEINSTANCE, crds.VIRTUALMACHINEINSTANCEPRESET,
-			crds.VIRTUALMACHINEINSTANCEREPLICASET, crds.VIRTUALMACHINEPOOL,
-			crds.VIRTUALMACHINEINSTANCEMIGRATION, crds.MIGRATIONPOLICY,
-			crds.KUBEVIRT,
+		ourCRDs := []string{
+			crds.VIRTUALMACHINE, crds.VIRTUALMACHINEINSTANCE, crds.VIRTUALMACHINEINSTANCEPRESET,
+			crds.VIRTUALMACHINEINSTANCEREPLICASET, crds.VIRTUALMACHINEINSTANCEMIGRATION, crds.KUBEVIRT,
 			crds.VIRTUALMACHINESNAPSHOT, crds.VIRTUALMACHINESNAPSHOTCONTENT,
 			crds.VIRTUALMACHINECLONE,
 			crds.VIRTUALMACHINEEXPORT,

--- a/tests/infrastructure/crds.go
+++ b/tests/infrastructure/crds.go
@@ -52,7 +52,8 @@ var _ = DescribeInfra("CRDs", func() {
 		}
 
 		for _, name := range ourCRDs {
-			crd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), name, metav1.GetOptions{})
+			crd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(
+				context.Background(), name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(crd).To(matcher.HaveConditionMissingOrFalse(v1ext.NonStructuralSchema))

--- a/tests/infrastructure/downward-metrics.go
+++ b/tests/infrastructure/downward-metrics.go
@@ -42,16 +42,13 @@ import (
 )
 
 var _ = DescribeInfra("downwardMetrics", func() {
-	var (
-		virtClient kubecli.KubevirtClient
-	)
+	var virtClient kubecli.KubevirtClient
 	const vmiStartTimeout = 180
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 	})
 
 	DescribeTable("should start a vmi and get the metrics", func(via libvmi.Option, metricsGetter libinfra.MetricsGetter) {
-
 		vmi := libvmifact.NewFedora(via)
 		vmi = libvmops.RunVMIAndExpectLaunch(vmi, vmiStartTimeout)
 		Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -68,7 +65,6 @@ var _ = DescribeInfra("downwardMetrics", func() {
 			return libinfra.GetTimeFromMetrics(metrics)
 		}, 10*time.Second, 1*time.Second).ShouldNot(Equal(timestamp))
 		Expect(libinfra.GetHostnameFromMetrics(metrics)).To(Equal(vmi.Status.NodeName))
-
 	},
 		Entry("[test_id:6535]using a disk", libvmi.WithDownwardMetricsVolume("vhostmd"), libinfra.GetDownwardMetricsDisk),
 		Entry("using a virtio serial device", libvmi.WithDownwardMetricsChannel(), libinfra.GetDownwardMetricsVirtio),

--- a/tests/infrastructure/downward-metrics.go
+++ b/tests/infrastructure/downward-metrics.go
@@ -45,6 +45,7 @@ var _ = DescribeInfra("downwardMetrics", func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)
+	const vmiStartTimeout = 180
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 	})
@@ -52,7 +53,7 @@ var _ = DescribeInfra("downwardMetrics", func() {
 	DescribeTable("should start a vmi and get the metrics", func(via libvmi.Option, metricsGetter libinfra.MetricsGetter) {
 
 		vmi := libvmifact.NewFedora(via)
-		vmi = libvmops.RunVMIAndExpectLaunch(vmi, 180)
+		vmi = libvmops.RunVMIAndExpectLaunch(vmi, vmiStartTimeout)
 		Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 		metrics, err := metricsGetter(vmi)
@@ -75,7 +76,7 @@ var _ = DescribeInfra("downwardMetrics", func() {
 
 	It("metric ResourceProcessorLimit should be present", func() {
 		vmi := libvmifact.NewFedora(libvmi.WithCPUCount(1, 1, 1), libvmi.WithDownwardMetricsVolume("vhostmd"))
-		vmi = libvmops.RunVMIAndExpectLaunch(vmi, 180)
+		vmi = libvmops.RunVMIAndExpectLaunch(vmi, vmiStartTimeout)
 		Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 		metrics, err := libinfra.GetDownwardMetricsDisk(vmi)

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -51,9 +51,10 @@ import (
 
 var _ = DescribeSerialInfra("Node-labeller", func() {
 
+	const trueStr = "true"
+
 	var (
 		virtClient               kubecli.KubevirtClient
-		err                      error
 		nodesWithKVM             []*k8sv1.Node
 		nonExistingCPUModelLabel = v1.CPUModelLabel + "someNonExistingCPUModel"
 	)
@@ -77,14 +78,14 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 
 		for _, node := range nodesWithKVM {
 			Eventually(func() error {
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+				nodeObj, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				if _, exists := node.Labels[nonExistingCPUModelLabel]; exists {
+				if _, exists := nodeObj.Labels[nonExistingCPUModelLabel]; exists {
 					return fmt.Errorf("node %s is expected to not have label key %s", node.Name, nonExistingCPUModelLabel)
 				}
 
-				if _, exists := node.Annotations[v1.LabellerSkipNodeAnnotation]; exists {
+				if _, exists := nodeObj.Annotations[v1.LabellerSkipNodeAnnotation]; exists {
 					return fmt.Errorf("node %s is expected to not have annotation key %s", node.Name, v1.LabellerSkipNodeAnnotation)
 				}
 
@@ -106,7 +107,7 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 		}, 30*time.Second, 2*time.Second).Should(BeTrue(), errorMsg)
 	}
 
-	Context("basic labelling", func() {
+	Context("basic labeling", func() {
 
 		type patch struct {
 			Op    string            `json:"op"`
@@ -117,7 +118,7 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 		It("skip node reconciliation when node has skip annotation", func() {
 
 			for i, node := range nodesWithKVM {
-				node.Labels[nonExistingCPUModelLabel] = "true"
+				node.Labels[nonExistingCPUModelLabel] = trueStr
 				p := []patch{
 					{
 						Op:    "add",
@@ -126,7 +127,7 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 					},
 				}
 				if i == 0 {
-					node.Annotations[v1.LabellerSkipNodeAnnotation] = "true"
+					node.Annotations[v1.LabellerSkipNodeAnnotation] = trueStr
 
 					p = append(p, patch{
 						Op:    "add",
@@ -160,12 +161,11 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 
 		It("[test_id:6246] label nodes with cpu model, cpu features and host cpu model", func() {
 			for _, node := range nodesWithKVM {
-				Expect(err).ToNot(HaveOccurred())
 				cpuModelLabelPresent := false
 				cpuFeatureLabelPresent := false
 				hyperVLabelPresent := false
-				hostCpuModelPresent := false
-				hostCpuRequiredFeaturesPresent := false
+				hostCPUModelPresent := false
+				hostCPURequiredFeaturesPresent := false
 				for key := range node.Labels {
 					if strings.Contains(key, v1.CPUModelLabel) {
 						cpuModelLabelPresent = true
@@ -177,14 +177,14 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 						hyperVLabelPresent = true
 					}
 					if strings.Contains(key, v1.HostModelCPULabel) {
-						hostCpuModelPresent = true
+						hostCPUModelPresent = true
 					}
 					if strings.Contains(key, v1.HostModelRequiredFeaturesLabel) {
-						hostCpuRequiredFeaturesPresent = true
+						hostCPURequiredFeaturesPresent = true
 					}
 
-					if cpuModelLabelPresent && cpuFeatureLabelPresent && hyperVLabelPresent && hostCpuModelPresent &&
-						hostCpuRequiredFeaturesPresent {
+					if cpuModelLabelPresent && cpuFeatureLabelPresent && hyperVLabelPresent && hostCPUModelPresent &&
+						hostCPURequiredFeaturesPresent {
 						break
 					}
 				}
@@ -193,8 +193,8 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 				Expect(cpuModelLabelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "cpu"))
 				Expect(cpuFeatureLabelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "feature"))
 				Expect(hyperVLabelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "hyperV"))
-				Expect(hostCpuModelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "host cpu model"))
-				Expect(hostCpuRequiredFeaturesPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "host cpu required featuers"))
+				Expect(hostCPUModelPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "host cpu model"))
+				Expect(hostCPURequiredFeaturesPresent).To(BeTrue(), fmt.Sprintf(errorMessageTemplate, "host cpu required featuers"))
 			}
 		})
 
@@ -203,10 +203,11 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 			kvConfig.Spec.Configuration.ObsoleteCPUModels = nil
 			config.UpdateKubeVirtConfigValueAndWait(kvConfig.Spec.Configuration)
 			node := nodesWithKVM[0]
+			timeout := 30 * time.Second
 			Eventually(func() error {
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+				nodeObj, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				for key := range node.Labels {
+				for key := range nodeObj.Labels {
 					if strings.Contains(key, v1.CPUModelLabel) {
 						model := strings.TrimPrefix(key, v1.CPUModelLabel)
 						if _, ok := nodelabellerutil.DefaultObsoleteCPUModels[model]; ok {
@@ -215,21 +216,21 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 					}
 				}
 				return nil
-			}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).ShouldNot(HaveOccurred())
+			}).WithTimeout(timeout).WithPolling(1 * time.Second).ShouldNot(HaveOccurred())
 		})
 
 		It("[test_id:6995]should expose tsc frequency and tsc scalability", func() {
 			node := nodesWithKVM[0]
 			Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-frequency"))
 			Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-scalable"))
-			Expect(node.Labels["cpu-timer.node.kubevirt.io/tsc-scalable"]).To(Or(Equal("true"), Equal("false")))
+			Expect(node.Labels["cpu-timer.node.kubevirt.io/tsc-scalable"]).To(Or(Equal(trueStr), Equal("false")))
 			val, err := strconv.ParseInt(node.Labels["cpu-timer.node.kubevirt.io/tsc-frequency"], 10, 64)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(val).To(BeNumerically(">", 0))
 		})
 	})
 
-	Context("advanced labelling", func() {
+	Context("advanced labeling", func() {
 		var originalKubeVirt *v1.KubeVirt
 
 		BeforeEach(func() {
@@ -334,23 +335,25 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
 			Eventually(func() error {
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+				nodeObj, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, exists := node.Annotations[v1.LabellerSkipNodeAnnotation]
+				_, exists := nodeObj.Annotations[v1.LabellerSkipNodeAnnotation]
 				if exists {
 					return fmt.Errorf("node %s is expected to not have annotation %s", node.Name, v1.LabellerSkipNodeAnnotation)
 				}
 
 				obsoleteModelLabelFound := false
-				for labelKey := range node.Labels {
+				for labelKey := range nodeObj.Labels {
 					if strings.Contains(labelKey, v1.NodeHostModelIsObsoleteLabel) {
 						obsoleteModelLabelFound = true
 						break
 					}
 				}
 				if !obsoleteModelLabelFound {
-					return fmt.Errorf("node %s is expected to have a label with %s substring. this means node-labeller is not enabled for the node", node.Name, v1.NodeHostModelIsObsoleteLabel)
+					return fmt.Errorf(
+						"node %s is expected to have a label with %s substring. node-labeller is not enabled for the node",
+						node.Name, v1.NodeHostModelIsObsoleteLabel)
 				}
 
 				return nil
@@ -362,18 +365,20 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 			config.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
 			Eventually(func() error {
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+				nodeObj, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 
 				obsoleteHostModelLabel := false
-				for labelKey := range node.Labels {
+				for labelKey := range nodeObj.Labels {
 					if strings.HasPrefix(labelKey, v1.NodeHostModelIsObsoleteLabel) {
 						obsoleteHostModelLabel = true
 						break
 					}
 				}
 				if obsoleteHostModelLabel {
-					return fmt.Errorf("node %s is expected to have a label with %s prefix. this means node-labeller is not enabled for the node", node.Name, v1.HostModelCPULabel)
+					return fmt.Errorf(
+						"node %s is expected to have a label with %s prefix. node-labeller is not enabled for the node",
+						node.Name, v1.HostModelCPULabel)
 				}
 
 				return nil
@@ -394,9 +399,10 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 
 			By("Checking that the VMI failed")
 			Eventually(func() bool {
-				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+				vmiObj, err := virtClient.VirtualMachineInstance(
+					testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				for _, condition := range vmi.Status.Conditions {
+				for _, condition := range vmiObj.Status.Conditions {
 					if condition.Type == v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled) && condition.Status == k8sv1.ConditionFalse {
 						return strings.Contains(condition.Message, "didn't match Pod's node affinity/selector")
 					}

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -50,7 +50,6 @@ import (
 )
 
 var _ = DescribeSerialInfra("Node-labeller", func() {
-
 	const trueStr = "true"
 
 	var (
@@ -108,7 +107,6 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 	}
 
 	Context("basic labeling", func() {
-
 		type patch struct {
 			Op    string            `json:"op"`
 			Path  string            `json:"path"`
@@ -116,7 +114,6 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 		}
 
 		It("skip node reconciliation when node has skip annotation", func() {
-
 			for i, node := range nodesWithKVM {
 				node.Labels[nonExistingCPUModelLabel] = trueStr
 				p := []patch{
@@ -317,7 +314,6 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 	})
 
 	Context("[Serial]node with obsolete host-model cpuModel", Serial, func() {
-
 		var node *k8sv1.Node
 		var obsoleteModel string
 		var kvConfig *v1.KubeVirtConfiguration
@@ -414,6 +410,5 @@ var _ = DescribeSerialInfra("Node-labeller", func() {
 			// Remove as Node is persistent
 			events.DeleteEvents(node, k8sv1.EventTypeWarning, "HostModelIsObsolete")
 		})
-
 	})
 })

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -68,10 +68,7 @@ const (
 )
 
 var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus scraped metrics", func() {
-
-	var (
-		virtClient kubecli.KubevirtClient
-	)
+	var virtClient kubecli.KubevirtClient
 
 	// start a VMI, wait for it to run and return the node it runs on
 	startVMI := func(vmi *v1.VirtualMachineInstance) string {
@@ -108,7 +105,6 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 	*/
 
 	It("[test_id:4135]should find VMI namespace on namespace label of the metric", func() {
-
 		/*
 			This test is required because in cases of misconfigurations on
 			monitoring objects (such for the ServiceMonitor), our rules will
@@ -171,7 +167,8 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 				`query=kubevirt_vmi_memory_resident_bytes{namespace=%q,name=%q}`,
 				vmi.Namespace,
 				vmi.Name,
-			)}
+			),
+		}
 
 		stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(&op, "virt-operator", cmd)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(remoteCmdErrPattern, strings.Join(cmd, " "), stdout, stderr, err))
@@ -192,7 +189,6 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 })
 
 var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints", func() {
-
 	var (
 		virtClient kubecli.KubevirtClient
 		err        error

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -42,10 +42,7 @@ import (
 )
 
 var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulableNodes, decorators.Kubernetes130, func() {
-
-	var (
-		virtClient kubecli.KubevirtClient
-	)
+	var virtClient kubecli.KubevirtClient
 	const minNodesWithVirtHandler = 2
 
 	BeforeEach(func() {
@@ -78,7 +75,8 @@ var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulabl
 		token, err := exec.ExecuteCommandOnPod(
 			pod,
 			"virt-handler",
-			[]string{"cat",
+			[]string{
+				"cat",
 				"/var/run/secrets/kubernetes.io/serviceaccount/token",
 			},
 		)
@@ -106,5 +104,4 @@ var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulabl
 			ContainSubstring("Node restriction, virt-handler is only allowed to modify VMIs it owns"),
 		))
 	})
-
 })

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -46,6 +46,7 @@ var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulabl
 	var (
 		virtClient kubecli.KubevirtClient
 	)
+	const minNodesWithVirtHandler = 2
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -54,12 +55,13 @@ var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulabl
 
 	It("Should disallow to modify VMs on different node", func() {
 		nodes := libnode.GetAllSchedulableNodes(virtClient).Items
-		if len(nodes) < 2 {
+		if len(nodes) < minNodesWithVirtHandler {
 			Fail("Requires multiple nodes with virt-handler running")
 		}
+		startTimeout := 60
 
 		vmi := libvmifact.NewAlpine()
-		vmi = libvmops.RunVMIAndExpectLaunch(vmi, 60)
+		vmi = libvmops.RunVMIAndExpectLaunch(vmi, startTimeout)
 
 		node := vmi.Status.NodeName
 
@@ -87,7 +89,7 @@ var _ = DescribeSerialInfra("Node Restriction", decorators.RequiresTwoSchedulabl
 			TLSClientConfig: rest.TLSClientConfig{
 				Insecure: true,
 			},
-			BearerToken: string(token),
+			BearerToken: token,
 		})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -45,7 +45,6 @@ import (
 )
 
 var _ = DescribeSerialInfra("tls configuration", func() {
-
 	var virtClient kubecli.KubevirtClient
 
 	// FIPS-compliant so we can test on different platforms (otherwise won't revert properly)
@@ -70,7 +69,6 @@ var _ = DescribeSerialInfra("tls configuration", func() {
 		newKv := libkubevirt.GetCurrentKv(virtClient)
 		Expect(newKv.Spec.Configuration.TLSConfiguration.MinTLSVersion).To(BeEquivalentTo(v1.VersionTLS12))
 		Expect(newKv.Spec.Configuration.TLSConfiguration.Ciphers).To(BeEquivalentTo([]string{cipher.Name}))
-
 	})
 
 	It("[test_id:9306]should result only connections with the correct client-side tls configurations are accepted by the components", func() {

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -87,9 +87,12 @@ var _ = DescribeSerialInfra("tls configuration", func() {
 			func(i int, pod k8sv1.Pod) {
 				stopChan := make(chan struct{})
 				defer close(stopChan)
-				Expect(libpod.ForwardPorts(&pod, []string{fmt.Sprintf("844%d:%d", i, 8443)}, stopChan, 10*time.Second)).To(Succeed())
+				expectTimeout := 10 * time.Second
+				portNumber := 8443
+				Expect(libpod.ForwardPorts(&pod, []string{fmt.Sprintf("844%d:%d", i, portNumber)}, stopChan, expectTimeout)).To(Succeed())
 
 				acceptedTLSConfig := &tls.Config{
+					//nolint:gosec
 					InsecureSkipVerify: true,
 					MaxVersion:         tls.VersionTLS12,
 					CipherSuites:       kvtls.CipherSuiteIds([]string{cipher.Name}),
@@ -101,6 +104,7 @@ var _ = DescribeSerialInfra("tls configuration", func() {
 				Expect(conn.ConnectionState().CipherSuite).To(BeEquivalentTo(cipher.ID), "Configure Cipher should be used")
 
 				rejectedTLSConfig := &tls.Config{
+					//nolint:gosec
 					InsecureSkipVerify: true,
 					MaxVersion:         tls.VersionTLS11,
 				}

--- a/tests/infrastructure/virt-controller-leader-election.go
+++ b/tests/infrastructure/virt-controller-leader-election.go
@@ -56,14 +56,17 @@ var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {
 		It("[test_id:4642]should elect a new controller pod", func() {
 			By("Deleting the virt-controller leader pod")
 			leaderPodName := libinfra.GetLeader()
-			Expect(virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(context.Background(), leaderPodName, metav1.DeleteOptions{})).To(Succeed())
+			Expect(virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(
+				context.Background(), leaderPodName,
+				metav1.DeleteOptions{})).To(Succeed())
 
 			By("Expecting a new leader to get elected")
 			Eventually(libinfra.GetLeader, 30*time.Second, 5*time.Second).ShouldNot(Equal(leaderPodName))
 
 			By("Starting a new VirtualMachineInstance")
 			vmi := libvmifact.NewAlpine()
-			obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Get()
+			obj, err := virtClient.RestClient().Post().Resource(
+				"virtualmachineinstances").Namespace(testsuite.GetTestNamespace(vmi)).Body(vmi).Do(context.Background()).Get()
 			Expect(err).ToNot(HaveOccurred())
 			vmiObj, ok := obj.(*v1.VirtualMachineInstance)
 			Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")

--- a/tests/infrastructure/virt-controller-leader-election.go
+++ b/tests/infrastructure/virt-controller-leader-election.go
@@ -43,10 +43,7 @@ import (
 )
 
 var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {
-
-	var (
-		virtClient kubecli.KubevirtClient
-	)
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -73,5 +70,4 @@ var _ = DescribeSerialInfra("Start a VirtualMachineInstance", func() {
 			libwait.WaitForSuccessfulVMIStart(vmiObj)
 		})
 	})
-
 })

--- a/tests/infrastructure/virt-handler.go
+++ b/tests/infrastructure/virt-handler.go
@@ -34,6 +34,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
@@ -42,12 +43,12 @@ import (
 )
 
 var _ = DescribeSerialInfra("virt-handler", func() {
-
 	var (
 		virtClient       kubecli.KubevirtClient
 		originalKubeVirt *v1.KubeVirt
 		nodesToEnableKSM []string
 	)
+	const trueStr = "true"
 
 	getNodesWithKSMAvailable := func(virtCli kubecli.KubevirtClient) []string {
 		nodes := libnode.GetAllSchedulableNodes(virtCli)
@@ -65,7 +66,7 @@ var _ = DescribeSerialInfra("virt-handler", func() {
 
 	forceMemoryPressureOnNodes := func(nodes []string) {
 		for _, node := range nodes {
-			data := []byte(fmt.Sprintf(`{"metadata": { "annotations": {"%s": "%s", "%s": "%s"}}}`,
+			data := []byte(fmt.Sprintf(`{"metadata": { "annotations": {%q: %q, %q: %q}}}`,
 				v1.KSMFreePercentOverride, "1.0",
 				v1.KSMPagesDecayOverride, "-300",
 			))
@@ -76,9 +77,13 @@ var _ = DescribeSerialInfra("virt-handler", func() {
 
 	restoreNodes := func(nodes []string) {
 		for _, node := range nodes {
-			patchBytes := []byte(fmt.Sprintf(`[{"op": "remove", "path": "/metadata/annotations/%s"}, {"op": "remove", "path": "/metadata/annotations/%s"}]`,
-				strings.ReplaceAll(v1.KSMFreePercentOverride, "/", "~1"), strings.ReplaceAll(v1.KSMPagesDecayOverride, "/", "~1")))
-			_, err := virtClient.CoreV1().Nodes().Patch(context.Background(), node, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+			patchSet := patch.New(patch.WithRemove(fmt.Sprintf("/metadata/annotations/%s",
+				strings.ReplaceAll(v1.KSMFreePercentOverride, "/", "~1"))))
+			patchSet.AddOption(patch.WithRemove(fmt.Sprintf("/metadata/annotations/%s",
+				strings.ReplaceAll(v1.KSMPagesDecayOverride, "/", "~1"))))
+			patchBytes, err := patchSet.GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), node, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 			if err != nil {
 				node2, err2 := virtClient.CoreV1().Nodes().Get(context.Background(), node, metav1.GetOptions{})
 				Expect(err2).NotTo(HaveOccurred())
@@ -128,7 +133,7 @@ var _ = DescribeSerialInfra("virt-handler", func() {
 					return false, err
 				}
 				value, found := node.GetAnnotations()[v1.KSMHandlerManagedAnnotation]
-				return found && value == "true", nil
+				return found && value == trueStr, nil
 			}, 3*time.Minute, 2*time.Second).Should(BeTrue(), fmt.Sprintf("Node %s should have %s annotation", node, v1.KSMHandlerManagedAnnotation))
 		}
 
@@ -152,8 +157,10 @@ var _ = DescribeSerialInfra("virt-handler", func() {
 					return false, err
 				}
 				value, found := node.GetAnnotations()[v1.KSMHandlerManagedAnnotation]
-				return found && value == "true", nil
-			}, 3*time.Minute, 2*time.Second).Should(BeFalse(), fmt.Sprintf("Annotation %s should be removed from the node %s", v1.KSMHandlerManagedAnnotation, node))
+				return found && value == trueStr, nil
+			}, 3*time.Minute, 2*time.Second).Should(BeFalse(), fmt.Sprintf(
+				"Annotation %s should be removed from the node %s",
+				v1.KSMHandlerManagedAnnotation, node))
 		}
 	})
 })


### PR DESCRIPTION

### What this PR does

Add tests/infrastructure to linter and fix resulting lint issues. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

