### PR TITLE
virt-launcher/virtwrap - run unit tests in parallel

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@kubevirt//tools/ginkgo:ginkgo.bzl", "ginkgo_test")
 
 go_library(
     name = "go_default_library",
@@ -80,6 +81,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     embedsrcs = ["testdata/migration_domain.xml"],
+    tags = ["cov"],
     deps = [
         "//pkg/cloud-init:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",
@@ -115,4 +117,11 @@ go_test(
         "//vendor/libvirt.org/go/libvirt:go_default_library",
         "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
+)
+
+ginkgo_test(
+    name = "go_parallel_test",
+    ginkgo_args = ["-p"],
+    go_test = ":go_default_test",
+    tags = ["nocov"],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

Some unit test suites take longer times to run than others when not cached, to name a few:
`virt-launcher/virtwrap` - 44.8s 
`virt-operator/resource/generate/install` - 18.2s
`virtctl/pause` - 18.1s
`instancetype` - 17.7s
`virt-handler/cache` - 15.5s
`storage/snapshot` - 15.5s
`notify-client` - 11.6s
`util/openapi` - 11.5s

**After this PR:**

Make use of the `ginkgo_test` target[1] to run tests in parallel for `virt-launcher/virtwrap`. From multiple experiments it cut down the time to around ~8s instead of ~44s.

Other packages remain to be tested, I specifically chose virtwrap as it serves as a prominent component within KubeVirt with a relatively large test suite.

[1] https://github.com/kubevirt/kubevirt/pull/5749

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

