### PR TITLE
net annotations-gen: Cleanup NIC hotplug / unplug logic

### DIFF
--- a/pkg/network/pod/annotations/BUILD.bazel
+++ b/pkg/network/pod/annotations/BUILD.bazel
@@ -29,9 +29,11 @@ go_test(
     deps = [
         ":go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/libvmi/status:go_default_library",
         "//pkg/network/downwardapi:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/multus:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -117,7 +117,7 @@ func (g Generator) GenerateFromActivePod(vmi *v1.VirtualMachineInstance, pod *k8
 }
 
 func (g Generator) generateMultusAnnotation(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) (string, bool) {
-	vmiSpecIfaces, vmiSpecNets, dynamicIfacesExist := vmispec.CalculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi)
+	vmiSpecIfaces, vmiSpecNets, dynamicIfacesExist := calculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi)
 	if !dynamicIfacesExist {
 		return "", false
 	}
@@ -169,4 +169,32 @@ func shouldAddIstioKubeVirtAnnotation(vmi *v1.VirtualMachineInstance) bool {
 	})
 
 	return len(interfacesWithMasqueradeBinding) > 0
+}
+
+func calculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi *v1.VirtualMachineInstance) ([]v1.Interface, []v1.Network, bool) {
+	vmiNonAbsentSpecIfaces := vmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
+		return iface.State != v1.InterfaceStateAbsent
+	})
+	ifacesToHotUnplugExist := len(vmi.Spec.Domain.Devices.Interfaces) > len(vmiNonAbsentSpecIfaces)
+
+	ifacesStatusByName := vmispec.IndexInterfaceStatusByName(vmi.Status.Interfaces, nil)
+	ifacesToAnnotate := vmispec.FilterInterfacesSpec(vmiNonAbsentSpecIfaces, func(iface v1.Interface) bool {
+		_, ifaceInStatus := ifacesStatusByName[iface.Name]
+		sriovIfaceNotPlugged := iface.SRIOV != nil && !ifaceInStatus
+		return !sriovIfaceNotPlugged
+	})
+
+	networksToAnnotate := vmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, ifacesToAnnotate)
+
+	ifacesToHotplug := vmispec.FilterInterfacesSpec(ifacesToAnnotate, func(iface v1.Interface) bool {
+		_, inStatus := ifacesStatusByName[iface.Name]
+		return !inStatus
+	})
+	ifacesToHotplugExist := len(ifacesToHotplug) > 0
+
+	isIfaceChangeRequired := ifacesToHotplugExist || ifacesToHotUnplugExist
+	if !isIfaceChangeRequired {
+		return nil, nil, false
+	}
+	return ifacesToAnnotate, networksToAnnotate, isIfaceChangeRequired
 }

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -117,8 +117,8 @@ func (g Generator) GenerateFromActivePod(vmi *v1.VirtualMachineInstance, pod *k8
 }
 
 func (g Generator) generateMultusAnnotation(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) (string, bool) {
-	vmiSpecIfaces, vmiSpecNets, dynamicIfacesExist := calculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi)
-	if !dynamicIfacesExist {
+	vmiSpecIfaces, vmiSpecNets, ifaceChangeRequired := ifacesAndNetsForMultusAnnotationUpdate(vmi)
+	if !ifaceChangeRequired {
 		return "", false
 	}
 
@@ -171,7 +171,7 @@ func shouldAddIstioKubeVirtAnnotation(vmi *v1.VirtualMachineInstance) bool {
 	return len(interfacesWithMasqueradeBinding) > 0
 }
 
-func calculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi *v1.VirtualMachineInstance) ([]v1.Interface, []v1.Network, bool) {
+func ifacesAndNetsForMultusAnnotationUpdate(vmi *v1.VirtualMachineInstance) ([]v1.Interface, []v1.Network, bool) {
 	vmiNonAbsentSpecIfaces := vmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
 		return iface.State != v1.InterfaceStateAbsent
 	})
@@ -192,9 +192,9 @@ func calculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi *v1.VirtualMach
 	})
 	ifacesToHotplugExist := len(ifacesToHotplug) > 0
 
-	isIfaceChangeRequired := ifacesToHotplugExist || ifacesToHotUnplugExist
-	if !isIfaceChangeRequired {
+	ifaceChangeRequired := ifacesToHotplugExist || ifacesToHotUnplugExist
+	if !ifaceChangeRequired {
 		return nil, nil, false
 	}
-	return ifacesToAnnotate, networksToAnnotate, isIfaceChangeRequired
+	return ifacesToAnnotate, networksToAnnotate, ifaceChangeRequired
 }

--- a/pkg/network/pod/annotations/generator_test.go
+++ b/pkg/network/pod/annotations/generator_test.go
@@ -520,6 +520,22 @@ var _ = Describe("Annotations Generator", func() {
 			clusterConfig = newClusterConfig(kv)
 		})
 
+		It("Should not generate network attachment annotation when there are no networks", func() {
+			vmi := libvmi.New(
+				libvmi.WithNamespace(testNamespace),
+				libvmi.WithAutoAttachPodInterface(false),
+			)
+
+			pod := newStubVirtLauncherPod(vmi, map[string]string{
+				networkv1.NetworkStatusAnnot: multusNetworkStatusWithPrimaryNet,
+			})
+
+			generator := annotations.NewGenerator(clusterConfig)
+
+			annotations := generator.GenerateFromActivePod(vmi, pod)
+			Expect(annotations).ToNot(HaveKey(networkv1.NetworkAttachmentAnnot))
+		})
+
 		DescribeTable("Should not generate network attachment annotation", func(podAnnotations map[string]string) {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),

--- a/pkg/network/vmispec/BUILD.bazel
+++ b/pkg/network/vmispec/BUILD.bazel
@@ -30,10 +30,7 @@ go_test(
         "//pkg/libvmi/status:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/network/vmispec/hotplug.go
+++ b/pkg/network/vmispec/hotplug.go
@@ -25,34 +25,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-func CalculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi *v1.VirtualMachineInstance) ([]v1.Interface, []v1.Network, bool) {
-	vmiNonAbsentSpecIfaces := FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
-		return iface.State != v1.InterfaceStateAbsent
-	})
-	ifacesToHotUnplugExist := len(vmi.Spec.Domain.Devices.Interfaces) > len(vmiNonAbsentSpecIfaces)
-
-	ifacesStatusByName := IndexInterfaceStatusByName(vmi.Status.Interfaces, nil)
-	ifacesToAnnotate := FilterInterfacesSpec(vmiNonAbsentSpecIfaces, func(iface v1.Interface) bool {
-		_, ifaceInStatus := ifacesStatusByName[iface.Name]
-		sriovIfaceNotPlugged := iface.SRIOV != nil && !ifaceInStatus
-		return !sriovIfaceNotPlugged
-	})
-
-	networksToAnnotate := FilterNetworksByInterfaces(vmi.Spec.Networks, ifacesToAnnotate)
-
-	ifacesToHotplug := FilterInterfacesSpec(ifacesToAnnotate, func(iface v1.Interface) bool {
-		_, inStatus := ifacesStatusByName[iface.Name]
-		return !inStatus
-	})
-	ifacesToHotplugExist := len(ifacesToHotplug) > 0
-
-	isIfaceChangeRequired := ifacesToHotplugExist || ifacesToHotUnplugExist
-	if !isIfaceChangeRequired {
-		return nil, nil, false
-	}
-	return ifacesToAnnotate, networksToAnnotate, isIfaceChangeRequired
-}
-
 func NetworksToHotplugWhosePodIfacesAreReady(vmi *v1.VirtualMachineInstance) []v1.Network {
 	var networksToHotplug []v1.Network
 	interfacesToHoplug := IndexInterfaceStatusByName(

--- a/pkg/network/vmispec/hotplug_test.go
+++ b/pkg/network/vmispec/hotplug_test.go
@@ -98,7 +98,6 @@ var _ = Describe("utilitary funcs to identify attachments to hotplug", func() {
 				Expect(nets).To(Equal(expNets))
 				Expect(exists).To(Equal(expToChange))
 			},
-			Entry("when no interfaces exist, change is not required", libvmi.New(), nil, nil, nil, expectNoChange),
 			Entry("when vmi interfaces match pod multus annotation and status, change is not required",
 				libvmi.New(
 					libvmi.WithInterface(v1.Interface{Name: testNetworkName1}),

--- a/pkg/network/vmispec/hotplug_test.go
+++ b/pkg/network/vmispec/hotplug_test.go
@@ -123,29 +123,6 @@ var _ = Describe("utilitary funcs to identify attachments to hotplug", func() {
 				[]v1.Network{{Name: testNetworkName1}, {Name: testNetworkName2}, {Name: testNetworkName3}},
 				expectToChange,
 			),
-			Entry("when vmi interfaces have an extra SRIOV interface which requires hotplug, change is not required since SRIOV hotplug to a pod is not supported",
-				libvmi.New(
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName1}),
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName2, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}),
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName3, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName3}),
-					withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName1}),
-					withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName2}),
-				),
-				&k8sv1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						networkv1.NetworkStatusAnnot: `[
-						{"interface":"net1", "name":"red-net", "namespace": "default"},
-						{"interface":"net2", "name":"blue-net", "namespace": "default"}
-					]`,
-					}},
-				},
-				nil,
-				nil,
-				expectNoChange,
-			),
 			Entry("when a vmi interface has state set to `absent`, requiring hotunplug",
 				libvmi.New(
 					libvmi.WithInterface(v1.Interface{Name: testNetworkName1}),

--- a/pkg/network/vmispec/hotplug_test.go
+++ b/pkg/network/vmispec/hotplug_test.go
@@ -23,11 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	k8sv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
@@ -80,97 +75,4 @@ var _ = Describe("utilitary funcs to identify attachments to hotplug", func() {
 			),
 		)
 	})
-
-	Context("CalculateInterfacesAndNetworksForMultusAnnotationUpdate", func() {
-		const (
-			expectNoChange = false
-			expectToChange = !expectNoChange
-
-			testNetworkName1 = "testnet1"
-			testNetworkName2 = "testnet2"
-			testNetworkName3 = "testnet3"
-			testNetworkName4 = "testnet4"
-		)
-		DescribeTable("calculate if changes are required",
-			func(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod, expIfaces []v1.Interface, expNets []v1.Network, expToChange bool) {
-				ifaces, nets, exists := vmispec.CalculateInterfacesAndNetworksForMultusAnnotationUpdate(vmi)
-				Expect(ifaces).To(Equal(expIfaces))
-				Expect(nets).To(Equal(expNets))
-				Expect(exists).To(Equal(expToChange))
-			},
-			Entry("when vmi interfaces have an extra interface which requires hotplug",
-				libvmi.New(
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName1, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}),
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName2}),
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName3}),
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName4, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName3}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName4}),
-					withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName1}),
-					withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName2}),
-				),
-				&k8sv1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						networkv1.NetworkStatusAnnot: `[
-						{"interface":"net1", "name":"red-net", "namespace": "default"},
-						{"interface":"net2", "name":"blue-net", "namespace": "default"}
-					]`,
-					}},
-				},
-				[]v1.Interface{{Name: testNetworkName1, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}, {Name: testNetworkName2}, {Name: testNetworkName3}},
-				[]v1.Network{{Name: testNetworkName1}, {Name: testNetworkName2}, {Name: testNetworkName3}},
-				expectToChange,
-			),
-			Entry("when a vmi interface has state set to `absent`, requiring hotunplug",
-				libvmi.New(
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName1}),
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName2, State: v1.InterfaceStateAbsent}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
-					withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName1}),
-					withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName2}),
-				),
-				&k8sv1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						networkv1.NetworkStatusAnnot: `[
-						{"interface":"pod1", "name":"red-net", "namespace": "default"},
-						{"interface":"pod2", "name":"blue-net", "namespace": "default"}
-					]`,
-					}},
-				},
-				[]v1.Interface{{Name: testNetworkName1}},
-				[]v1.Network{{Name: testNetworkName1}},
-				expectToChange,
-			),
-			Entry("when vmi interfaces have an interface to hotplug and one to hot-unplug, given hashed names",
-				libvmi.New(
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName1, State: v1.InterfaceStateAbsent}),
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName2}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
-					withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName1}),
-				),
-				&k8sv1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						networkv1.NetworkStatusAnnot: `[
-						{"interface":"pod1a2b3c", "name":"red-net", "namespace": "default"}
-					]`,
-					}},
-				},
-				[]v1.Interface{{Name: testNetworkName2}},
-				[]v1.Network{{Name: testNetworkName2}},
-				expectToChange,
-			),
-		)
-	})
 })
-
-func withInterfaceStatus(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) libvmi.Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Status.Interfaces = append(
-			vmi.Status.Interfaces, ifaceStatus,
-		)
-	}
-}

--- a/pkg/network/vmispec/hotplug_test.go
+++ b/pkg/network/vmispec/hotplug_test.go
@@ -98,20 +98,6 @@ var _ = Describe("utilitary funcs to identify attachments to hotplug", func() {
 				Expect(nets).To(Equal(expNets))
 				Expect(exists).To(Equal(expToChange))
 			},
-			Entry("when vmi interfaces match pod multus annotation and status, change is not required",
-				libvmi.New(
-					libvmi.WithInterface(v1.Interface{Name: testNetworkName1}),
-					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
-					withInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: testNetworkName1}),
-				),
-				&k8sv1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-						networkv1.NetworkStatusAnnot: `[
-						{"interface":"net1", "name":"red-net", "namespace": "default"}
-					]`,
-					}},
-				}, nil, nil, expectNoChange,
-			),
 			Entry("when vmi interfaces have an extra interface which requires hotplug",
 				libvmi.New(
 					libvmi.WithInterface(v1.Interface{Name: testNetworkName1, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
PR #13235 had moved the NIC hotplug / unplug logic under the network annotations generator.
- Move `CalculateInterfacesAndNetworksForMultusAnnotationUpdate` from `pkg/network/vmispec` closer to its only caller.
- Drop `CalculateInterfacesAndNetworksForMultusAnnotationUpdate`'s unit tests in favor of testing it in the context of its caller.
- Rename `CalculateInterfacesAndNetworksForMultusAnnotationUpdate`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

