### PR TITLE
cleanup(virtctl,params): Add unit tests and apply cleanups

### DIFF
--- a/pkg/virtctl/create/params/BUILD.bazel
+++ b/pkg/virtctl/create/params/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,4 +6,22 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/create/params",
     visibility = ["//visibility:public"],
     deps = ["//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "params_suite_test.go",
+        "params_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/pointer:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+    ],
 )

--- a/pkg/virtctl/create/params/BUILD.bazel
+++ b/pkg/virtctl/create/params/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["params.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/create/params",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library"],
+    deps = [
+        "//pkg/pointer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/virtctl/create/params/params.go
+++ b/pkg/virtctl/create/params/params.go
@@ -195,7 +195,7 @@ func SplitPrefixedName(prefixedName string) (prefix string, name string, err err
 		prefix = s[0]
 		name = s[1]
 	default:
-		return "", "", fmt.Errorf("invalid count %d of slashes in prefix/name", l)
+		return "", "", fmt.Errorf("invalid count %d of slashes in prefix/name", l-1)
 	}
 
 	if name == "" {

--- a/pkg/virtctl/create/params/params.go
+++ b/pkg/virtctl/create/params/params.go
@@ -185,9 +185,11 @@ func apply(paramsMap map[string]string, obj interface{}) error {
 }
 
 // SplitPrefixedName splits prefixedName with "/" as a separator
-func SplitPrefixedName(prefixedName string) (prefix string, name string, err error) {
-	s := strings.Split(prefixedName, "/")
+func SplitPrefixedName(prefixedName string) (string, string, error) {
+	name := ""
+	prefix := ""
 
+	s := strings.Split(prefixedName, "/")
 	switch l := len(s); l {
 	case 1:
 		name = s[0]
@@ -202,7 +204,7 @@ func SplitPrefixedName(prefixedName string) (prefix string, name string, err err
 		return "", "", errors.New("name cannot be empty")
 	}
 
-	return
+	return prefix, name, nil
 }
 
 func GetParamByName(paramName, paramsStr string) (string, error) {

--- a/pkg/virtctl/create/params/params.go
+++ b/pkg/virtctl/create/params/params.go
@@ -174,6 +174,8 @@ func apply(paramsMap map[string]string, obj interface{}) error {
 				return fmt.Errorf("failed to parse param \"%s\": %w", k, err)
 			}
 			field.Set(reflect.ValueOf(&quantity))
+		case field.Kind() == reflect.Slice && field.Type().Elem().Kind() == reflect.String:
+			field.Set(reflect.ValueOf(strings.Split(v, ";")))
 		default:
 			return fmt.Errorf("unsupported struct field \"%s\" with kind \"%s\"", structField.Name, field.Kind())
 		}

--- a/pkg/virtctl/create/params/params.go
+++ b/pkg/virtctl/create/params/params.go
@@ -54,7 +54,7 @@ The functions below use reflection to automatically handle such flags.
 func Supported(obj interface{}) string {
 	objVal := reflect.ValueOf(obj)
 	if objVal.Kind() != reflect.Struct {
-		panic("passed in interface needs to be a struct")
+		panic(errors.New("passed in interface needs to be a struct"))
 	}
 
 	var params []string
@@ -135,12 +135,12 @@ func split(paramsStr string) (map[string]string, error) {
 func apply(paramsMap map[string]string, obj interface{}) error {
 	objVal := reflect.ValueOf(obj)
 	if objVal.Kind() != reflect.Ptr {
-		panic("passed in interface needs to be a pointer")
+		return errors.New("passed in interface needs to be a pointer")
 	}
 
 	objValElem := objVal.Elem()
 	if objValElem.Kind() != reflect.Struct {
-		panic("passed in pointer needs to point to a struct")
+		return errors.New("passed in pointer needs to point to a struct")
 	}
 
 	objValElemType := objValElem.Type()
@@ -175,7 +175,7 @@ func apply(paramsMap map[string]string, obj interface{}) error {
 			}
 			field.Set(reflect.ValueOf(&quantity))
 		default:
-			panic(fmt.Errorf("unsupported struct field \"%s\" with kind \"%s\"", structField.Name, field.Kind()))
+			return fmt.Errorf("unsupported struct field \"%s\" with kind \"%s\"", structField.Name, field.Kind())
 		}
 
 		delete(paramsMap, k)

--- a/pkg/virtctl/create/params/params_suite_test.go
+++ b/pkg/virtctl/create/params/params_suite_test.go
@@ -1,0 +1,11 @@
+package params_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestCreate(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/create/params/params_test.go
+++ b/pkg/virtctl/create/params/params_test.go
@@ -1,0 +1,262 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+package params_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virtctl/create/params"
+)
+
+var _ = Describe("params", func() {
+	const (
+		testParam    = "testParam"
+		flagName     = "testFlag"
+		parseFlagErr = "failed to parse \"--testFlag\" flag: "
+	)
+
+	Context("NotFoundError", func() {
+		It("should have correct message", func() {
+			err := params.NotFoundError{Name: testParam}
+			Expect(err.Error()).To(Equal(testParam + " must be specified"))
+		})
+
+		DescribeTable("should detect equal errors when passed as", func(target error) {
+			err := params.NotFoundError{Name: testParam}
+			Expect(err.Is(target)).To(BeTrue())
+		},
+			Entry("value", params.NotFoundError{Name: testParam}),
+			Entry("pointer", pointer.P(params.NotFoundError{Name: testParam})),
+		)
+
+		It("should detect unequal errors", func() {
+			err := params.NotFoundError{Name: testParam}
+			Expect(err.Is(os.ErrNotExist)).To(BeFalse())
+		})
+	})
+
+	Context("FlagErr", func() {
+		const (
+			format = "My wrapped test error: %s"
+			value  = "testvalue"
+		)
+
+		It("should have correct message", func() {
+			err := params.FlagErr(flagName, format, value)
+			Expect(err).To(MatchError(parseFlagErr + fmt.Sprintf(format, value)))
+		})
+
+		It("should produce wrapped errors", func() {
+			err := params.FlagErr("testFlag", format, value)
+			Expect(errors.Unwrap(err)).To(MatchError(fmt.Sprintf(format, value)))
+		})
+	})
+
+	Context("Supported", func() {
+		It("should panic on unsupported object", func() {
+			testFn := func() { params.Supported("something") }
+			Expect(testFn).To(PanicWith("passed in interface needs to be a struct"))
+		})
+
+		It("should detect fields with supported types and param tag", func() {
+			testStruct := struct {
+				Param1 string             `param:"param1"`
+				Param2 *uint              `param:"param2"`
+				Param3 *resource.Quantity `param:"param3"`
+				Param4 []string           `param:"param4"`
+			}{}
+			Expect(params.Supported(testStruct)).To(Equal("param1:string,param2:uint,param3:resource.Quantity,param4:[]string"))
+		})
+
+		It("should ignore fields without param tag", func() {
+			testStruct := struct {
+				Param                    string `param:"param"`
+				ParamWithSupportedType   *uint
+				ParamWithUnsupportedType bool
+			}{}
+			Expect(params.Supported(testStruct)).To(Equal("param:string"))
+		})
+
+		It("should panic on fields with unsupported types", func() {
+			testStruct := struct {
+				Param bool `param:"param"`
+			}{}
+			testFn := func() { params.Supported(testStruct) }
+			Expect(testFn).To(PanicWith(MatchError("unsupported struct field \"Param\" with kind \"bool\"")))
+		})
+	})
+
+	Context("Map", func() {
+		DescribeTable("should fail on invalid params", func(paramsStr, errMsg string) {
+			err := params.Map(flagName, paramsStr, "")
+			Expect(err).To(MatchError(parseFlagErr + errMsg))
+		},
+			Entry("empty params", "", "params may not be empty"),
+			Entry("param without colon", "nocolon", "params need to have at least one colon: nocolon"),
+		)
+
+		DescribeTable("should panic on invalid objects", func(obj interface{}, panicMsg string) {
+			testFn := func() { _ = params.Map(flagName, "param:value", obj) }
+			Expect(testFn).To(PanicWith(panicMsg))
+		},
+			Entry("not a pointer", "something", "passed in interface needs to be a pointer"),
+			Entry("not a struct", pointer.P("something"), "passed in pointer needs to point to a struct"),
+		)
+
+		It("should map supported parameters to supported fields with param tag", func() {
+			param1 := rand.String(10)
+			param2 := rand.Intn(10)
+			param3 := fmt.Sprintf("%dGi", rand.Intn(10))
+			paramsStr := fmt.Sprintf("param1:%s,param2:%d,param3:%s", param1, param2, param3)
+			testStruct := &struct {
+				Param1 string             `param:"param1"`
+				Param2 *uint              `param:"param2"`
+				Param3 *resource.Quantity `param:"param3"`
+			}{}
+			Expect(params.Map(flagName, paramsStr, testStruct)).To(Succeed())
+			Expect(testStruct.Param1).To(Equal(param1))
+			Expect(testStruct.Param2).To(PointTo(Equal(uint(param2))))
+			Expect(testStruct.Param3).To(PointTo(Equal(resource.MustParse(param3))))
+		})
+
+		It("should ignore fields without param tag", func() {
+			const paramsStr = "param:test"
+			testStruct := &struct {
+				Param                    string `param:"param"`
+				ParamWithSupportedType   *uint
+				ParamWithUnsupportedType bool
+			}{}
+			Expect(params.Map(flagName, paramsStr, testStruct)).To(Succeed())
+			Expect(testStruct.Param).To(Equal("test"))
+			Expect(testStruct.ParamWithSupportedType).To(BeNil())
+			Expect(testStruct.ParamWithUnsupportedType).To(BeFalse())
+		})
+
+		DescribeTable("should fail on params with invalid values", func(paramsStr, errMsg string) {
+			testStruct := &struct {
+				Uint     *uint              `param:"uint"`
+				Quantity *resource.Quantity `param:"quantity"`
+			}{}
+			err := params.Map(flagName, paramsStr, testStruct)
+			Expect(err).To(MatchError(parseFlagErr + errMsg))
+		},
+			Entry("uint negative", "uint:-1,quantity:1Gi", "failed to parse param \"uint\": strconv.ParseUint: parsing \"-1\": invalid syntax"),
+			Entry("uint too large", "uint:9999999999999,quantity:1Gi", "failed to parse param \"uint\": strconv.ParseUint: parsing \"9999999999999\": value out of range"),
+			Entry("quantity suffix invalid", "uint:8,quantity:1Gu", "failed to parse param \"quantity\": unable to parse quantity's suffix"),
+		)
+
+		It("should panic on unsupported fields with param tag", func() {
+			const paramsStr = "param:true"
+			testStruct := &struct {
+				Param bool `param:"param"`
+			}{}
+			testFn := func() { _ = params.Map(flagName, paramsStr, testStruct) }
+			Expect(testFn).To(PanicWith(MatchError("unsupported struct field \"Param\" with kind \"bool\"")))
+		})
+
+		It("should fail on single unknown param", func() {
+			const paramsStr = "param:test,unknown:test"
+			testStruct := &struct {
+				Param string `param:"param"`
+			}{}
+			err := params.Map(flagName, paramsStr, testStruct)
+			Expect(err).To(MatchError(parseFlagErr + "unknown param(s): unknown:test"))
+			// testStruct is modified anyway
+			Expect(testStruct.Param).To(Equal("test"))
+		})
+
+		It("should fail on multiple unknown params", func() {
+			const paramsStr = "param:test,unknown1:test,unknown2:test"
+			testStruct := &struct {
+				Param string `param:"param"`
+			}{}
+			err := params.Map(flagName, paramsStr, testStruct)
+			Expect(err).To(MatchError(ContainSubstring(parseFlagErr + "unknown param(s): ")))
+			Expect(err).To(MatchError(ContainSubstring("unknown1:test")))
+			Expect(err).To(MatchError(ContainSubstring("unknown2:test")))
+			// testStruct is modified anyway
+			Expect(testStruct.Param).To(Equal("test"))
+		})
+	})
+
+	Context("SplitPrefixedName", func() {
+		DescribeTable("should split valid strings", func(prefixedName, expectedpPrefix, expectedName string) {
+			prefix, name, err := params.SplitPrefixedName(prefixedName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prefix).To(Equal(expectedpPrefix))
+			Expect(name).To(Equal(expectedName))
+		},
+			Entry("with prefix", "testname", "", "testname"),
+			Entry("without prefix", "testns/testname", "testns", "testname"),
+		)
+
+		DescribeTable("should fail on invalid strings", func(prefixedName, errMsg string) {
+			prefix, name, err := params.SplitPrefixedName(prefixedName)
+			Expect(err).To(MatchError(errMsg))
+			Expect(prefix).To(BeEmpty())
+			Expect(name).To(BeEmpty())
+		},
+			Entry("more than one slash", "testns/testname/test", "invalid count 3 of slashes in prefix/name"),
+			Entry("empty string", "", "name cannot be empty"),
+			Entry("empty name after slash", "testns/", "name cannot be empty"),
+		)
+	})
+
+	Context("GetParamByName", func() {
+		DescribeTable("should fail on invalid params", func(paramsStr, errMsg string) {
+			value, err := params.GetParamByName(testParam, paramsStr)
+			Expect(err).To(MatchError(errMsg))
+			Expect(value).To(BeEmpty())
+		},
+			Entry("empty params", "", "params may not be empty"),
+			Entry("param without colon", "nocolon", "params need to have at least one colon: nocolon"),
+		)
+
+		DescribeTable("should get param value from params", func(paramsStrBase string) {
+			expectedValue := rand.String(10)
+			value, err := params.GetParamByName(testParam, paramsStrBase+expectedValue)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(value).To(Equal(expectedValue))
+		},
+			Entry("with single param", "testParam:"),
+			Entry("with multiple params", "anotherParam:test,testParam:"),
+		)
+
+		DescribeTable("should fail if param is not found", func(paramsStr string) {
+			value, err := params.GetParamByName(testParam, paramsStr)
+			Expect(err).To(MatchError("testParam must be specified"))
+			notFoundError := params.NotFoundError{Name: testParam}
+			Expect(notFoundError.Is(err)).To(BeTrue())
+			Expect(value).To(BeEmpty())
+		},
+			Entry("with single param", "anotherParam:test:"),
+			Entry("with multiple params", "anotherParam:test,someParam:test"),
+		)
+	})
+})

--- a/pkg/virtctl/create/params/params_test.go
+++ b/pkg/virtctl/create/params/params_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -133,16 +134,22 @@ var _ = Describe("params", func() {
 			param1 := rand.String(10)
 			param2 := rand.Intn(10)
 			param3 := fmt.Sprintf("%dGi", rand.Intn(10))
-			paramsStr := fmt.Sprintf("param1:%s,param2:%d,param3:%s", param1, param2, param3)
+			var param4 []string
+			for _ = range rand.IntnRange(1, 10) {
+				param4 = append(param4, rand.String(10))
+			}
+			paramsStr := fmt.Sprintf("param1:%s,param2:%d,param3:%s,param4:%s", param1, param2, param3, strings.Join(param4, ";"))
 			testStruct := &struct {
 				Param1 string             `param:"param1"`
 				Param2 *uint              `param:"param2"`
 				Param3 *resource.Quantity `param:"param3"`
+				Param4 []string           `param:"param4"`
 			}{}
 			Expect(params.Map(flagName, paramsStr, testStruct)).To(Succeed())
 			Expect(testStruct.Param1).To(Equal(param1))
 			Expect(testStruct.Param2).To(PointTo(Equal(uint(param2))))
 			Expect(testStruct.Param3).To(PointTo(Equal(resource.MustParse(param3))))
+			Expect(testStruct.Param4).To(Equal(param4))
 		})
 
 		It("should ignore fields without param tag", func() {

--- a/pkg/virtctl/create/params/params_test.go
+++ b/pkg/virtctl/create/params/params_test.go
@@ -222,7 +222,8 @@ var _ = Describe("params", func() {
 			Expect(prefix).To(BeEmpty())
 			Expect(name).To(BeEmpty())
 		},
-			Entry("more than one slash", "testns/testname/test", "invalid count 3 of slashes in prefix/name"),
+			Entry("two slashes", "testns/testname/test", "invalid count 2 of slashes in prefix/name"),
+			Entry("three slashes", "testns/testname/test/test2", "invalid count 3 of slashes in prefix/name"),
 			Entry("empty string", "", "name cannot be empty"),
 			Entry("empty name after slash", "testns/", "name cannot be empty"),
 		)

--- a/pkg/virtctl/create/vm/vm_test.go
+++ b/pkg/virtctl/create/vm/vm_test.go
@@ -1389,7 +1389,7 @@ chpasswd: { expire: False }`
 			paramsInvalidError     = "params need to have at least one colon: test=test"
 			paramsUnknownError     = "unknown param(s): test:test"
 			emptyNameError         = "name cannot be empty"
-			invalidSlashCountError = "invalid count 3 of slashes in prefix/name"
+			invalidSlashCountError = "invalid count 2 of slashes in prefix/name"
 
 			boolInvalidError          = "strconv.ParseBool: parsing \"not-a-bool\": invalid syntax"
 			bootOrderInvalidError     = "failed to parse param \"bootorder\": strconv.ParseUint: parsing \"10Gu\": invalid syntax"
@@ -1398,7 +1398,7 @@ chpasswd: { expire: False }`
 			sizeInvalidError          = "failed to parse param \"size\": unable to parse quantity's suffix"
 			sizeMissingError          = "size must be specified"
 			srcEmptyNameError         = "src invalid: name cannot be empty"
-			srcInvalidSlashCountError = "src invalid: invalid count 3 of slashes in prefix/name"
+			srcInvalidSlashCountError = "src invalid: invalid count 2 of slashes in prefix/name"
 			srcMissingError           = "src must be specified"
 
 			inferenceNoVolumeError = "at least one volume is needed to infer an instance type or preference"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Add unit tests for pkg/virtctl/create/params that capture the current
behavior of the module.

Then apply cleanups to the module:
- Do not panic in Map, since it is able to return an error. Supported now always panics with a wrapped error.
- Return the correct count of slashes in errors returned by params.SplitPrefixedName. It was off by one previously.
- Remove named return in params.SplitPrefixedName.
- Add the missing support for string slices in params.Map.

Also apply these minor cleanups to the module:
- Rename variables to make the code easier to read
- Name variables consistently
- Inline assignments if possible
- Use pointer.P
- Extend comment of params.Map to clarify its behavior

Before this PR:

pkg/virtctl/create/params has no unit tests and needs cleanups

After this PR:

pkg/virtctl/create/params is now tested by unit tests and cleanups were applied

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

