### PR TITLE
conformance: mark for vmstate file

### DIFF
--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -194,7 +194,7 @@ var _ = Describe("[sig-compute]VM state", func() {
 			Entry("TPM across migration and restart", decorators.SigCompute, decorators.NoFlakeCheck, tpm, !efi, rwo, "migrate", "restart"),
 			Entry("TPM across restart and migration", decorators.SigCompute, decorators.NoFlakeCheck, tpm, !efi, rwo, "restart", "migrate"),
 			Entry("EFI across migration and restart", decorators.SigCompute, decorators.NoFlakeCheck, !tpm, efi, rwo, "migrate", "restart"),
-			Entry("TPM+EFI across migration and restart", decorators.SigCompute, decorators.NoFlakeCheck, tpm, efi, rwo, "migrate", "restart"),
+			Entry("TPM+EFI across migration and restart", decorators.SigCompute, decorators.NoFlakeCheck, decorators.Conformance, tpm, efi, rwo, "migrate", "restart"),
 		)
 		It("should remove persistent storage PVC if VMI is not owned by a VM", decorators.SigCompute, func() {
 			By("Creating a VMI with persistent TPM enabled")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
KV defaults to rwo in vmstorageclass is not specified, so it was chosen the entry with RWO and TPM+EFI.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @xpivarc @jean-edouard 
