### PR TITLE
workqueue: use typed queue

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -211,7 +211,7 @@ type VMExportController struct {
 
 	KubevirtNamespace string
 
-	vmExportQueue workqueue.RateLimitingInterface
+	vmExportQueue workqueue.TypedRateLimitingInterface[string]
 
 	caCertManager *bootstrap.FileCertificateManager
 
@@ -262,7 +262,10 @@ func (ctrl *VMExportController) Init() error {
 	if err != nil {
 		return err
 	}
-	ctrl.vmExportQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-export-vmexport")
+	ctrl.vmExportQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-export-vmexport"},
+	)
 
 	_, err = ctrl.VMExportInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Export controller", func() {
 		virtClient                  *kubecli.MockKubevirtClient
 		vmExportClient              *kubevirtfake.Clientset
 		fakeVolumeSnapshotProvider  *MockVolumeSnapshotProvider
-		mockVMExportQueue           *testutils.MockWorkQueue
+		mockVMExportQueue           *testutils.MockWorkQueue[string]
 		routeCache                  cache.Store
 		ingressCache                cache.Store
 		certDir                     string

--- a/pkg/storage/export/export/pvc-source_test.go
+++ b/pkg/storage/export/export/pvc-source_test.go
@@ -91,7 +91,7 @@ var _ = Describe("PVC source", func() {
 		k8sClient                   *k8sfake.Clientset
 		vmExportClient              *kubevirtfake.Clientset
 		fakeVolumeSnapshotProvider  *MockVolumeSnapshotProvider
-		mockVMExportQueue           *testutils.MockWorkQueue
+		mockVMExportQueue           *testutils.MockWorkQueue[string]
 		routeCache                  cache.Store
 		ingressCache                cache.Store
 		certDir                     string

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -89,7 +89,7 @@ var _ = Describe("PVC source", func() {
 		k8sClient                   *k8sfake.Clientset
 		vmExportClient              *kubevirtfake.Clientset
 		fakeVolumeSnapshotProvider  *MockVolumeSnapshotProvider
-		mockVMExportQueue           *testutils.MockWorkQueue
+		mockVMExportQueue           *testutils.MockWorkQueue[string]
 		routeCache                  cache.Store
 		ingressCache                cache.Store
 		certDir                     string

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -92,7 +92,7 @@ var _ = Describe("VMSnapshot source", func() {
 		k8sClient                   *k8sfake.Clientset
 		vmExportClient              *kubevirtfake.Clientset
 		fakeVolumeSnapshotProvider  *MockVolumeSnapshotProvider
-		mockVMExportQueue           *testutils.MockWorkQueue
+		mockVMExportQueue           *testutils.MockWorkQueue[string]
 		routeCache                  cache.Store
 		ingressCache                cache.Store
 		certDir                     string

--- a/pkg/storage/snapshot/restore_base.go
+++ b/pkg/storage/snapshot/restore_base.go
@@ -59,14 +59,17 @@ type VMRestoreController struct {
 
 	Recorder record.EventRecorder
 
-	vmRestoreQueue workqueue.RateLimitingInterface
+	vmRestoreQueue workqueue.TypedRateLimitingInterface[string]
 
 	VMRestoreStatusUpdater *status.VMRestoreStatusUpdater
 }
 
 // Init initializes the restore controller
 func (ctrl *VMRestoreController) Init() error {
-	ctrl.vmRestoreQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-restore-vmrestore")
+	ctrl.vmRestoreQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-restore-vmrestore"},
+	)
 
 	_, err := ctrl.VMRestoreInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Restore controller", func() {
 		var stop chan struct{}
 		var controller *VMRestoreController
 		var recorder *record.FakeRecorder
-		var mockVMRestoreQueue *testutils.MockWorkQueue
+		var mockVMRestoreQueue *testutils.MockWorkQueue[string]
 		var fakeVolumeSnapshotProvider *MockVolumeSnapshotProvider
 
 		var kubevirtClient *kubevirtfake.Clientset

--- a/pkg/storage/snapshot/snapshot_base.go
+++ b/pkg/storage/snapshot/snapshot_base.go
@@ -84,11 +84,11 @@ type VMSnapshotController struct {
 
 	ResyncPeriod time.Duration
 
-	vmSnapshotQueue        workqueue.RateLimitingInterface
-	vmSnapshotContentQueue workqueue.RateLimitingInterface
-	crdQueue               workqueue.RateLimitingInterface
-	vmSnapshotStatusQueue  workqueue.RateLimitingInterface
-	vmQueue                workqueue.RateLimitingInterface
+	vmSnapshotQueue        workqueue.TypedRateLimitingInterface[string]
+	vmSnapshotContentQueue workqueue.TypedRateLimitingInterface[string]
+	crdQueue               workqueue.TypedRateLimitingInterface[string]
+	vmSnapshotStatusQueue  workqueue.TypedRateLimitingInterface[string]
+	vmQueue                workqueue.TypedRateLimitingInterface[string]
 
 	dynamicInformerMap map[string]*dynamicInformer
 	eventHandlerMap    map[string]cache.ResourceEventHandlerFuncs
@@ -101,11 +101,26 @@ var supportedCRDVersions = []string{"v1"}
 
 // Init initializes the snapshot controller
 func (ctrl *VMSnapshotController) Init() error {
-	ctrl.vmSnapshotQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-vmsnapshot")
-	ctrl.vmSnapshotContentQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-vmsnapshotcontent")
-	ctrl.crdQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-crd")
-	ctrl.vmSnapshotStatusQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-vmsnashotstatus")
-	ctrl.vmQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-vm")
+	ctrl.vmSnapshotQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-snapshot-vmsnapshot"},
+	)
+	ctrl.vmSnapshotContentQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-snapshot-vmsnapshotcontent"},
+	)
+	ctrl.crdQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-snapshot-crd"},
+	)
+	ctrl.vmSnapshotStatusQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-snapshot-vmsnashotstatus"},
+	)
+	ctrl.vmQueue = workqueue.NewTypedRateLimitingQueueWithConfig[string](
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-snapshot-vm"},
+	)
 
 	ctrl.dynamicInformerMap = map[string]*dynamicInformer{
 		volumeSnapshotCRD:      {informerFunc: controller.VolumeSnapshotInformer},

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -284,10 +284,10 @@ var _ = Describe("Snapshot controlleer", func() {
 		var stop chan struct{}
 		var controller *VMSnapshotController
 		var recorder *record.FakeRecorder
-		var mockVMSnapshotQueue *testutils.MockWorkQueue
-		var mockVMSnapshotContentQueue *testutils.MockWorkQueue
-		var mockCRDQueue *testutils.MockWorkQueue
-		var mockVMQueue *testutils.MockWorkQueue
+		var mockVMSnapshotQueue *testutils.MockWorkQueue[string]
+		var mockVMSnapshotContentQueue *testutils.MockWorkQueue[string]
+		var mockCRDQueue *testutils.MockWorkQueue[string]
+		var mockVMQueue *testutils.MockWorkQueue[string]
 
 		var vmSnapshotClient *kubevirtfake.Clientset
 		var k8sSnapshotClient *k8ssnapshotfake.Clientset

--- a/pkg/testutils/mock_queue.go
+++ b/pkg/testutils/mock_queue.go
@@ -33,16 +33,16 @@ enqueued three times an object. Since enqueing is typically the last
 action in listener callbacks, we can assume that the wanted scenario for
 a controller is set up, and an execution will process this scenario.
 */
-type MockWorkQueue struct {
-	workqueue.RateLimitingInterface
+type MockWorkQueue[T comparable] struct {
+	workqueue.TypedRateLimitingInterface[T]
 	addWG            *sync.WaitGroup
 	rateLimitedEnque int32
 	addAfterEnque    int32
 	wgLock           sync.Mutex
 }
 
-func (q *MockWorkQueue) Add(obj interface{}) {
-	q.RateLimitingInterface.Add(obj)
+func (q *MockWorkQueue[T]) Add(item T) {
+	q.TypedRateLimitingInterface.Add(item)
 	q.wgLock.Lock()
 	defer q.wgLock.Unlock()
 	if q.addWG != nil {
@@ -50,13 +50,13 @@ func (q *MockWorkQueue) Add(obj interface{}) {
 	}
 }
 
-func (q *MockWorkQueue) AddRateLimited(item interface{}) {
-	q.RateLimitingInterface.AddRateLimited(item)
+func (q *MockWorkQueue[T]) AddRateLimited(item T) {
+	q.TypedRateLimitingInterface.AddRateLimited(item)
 	atomic.AddInt32(&q.rateLimitedEnque, 1)
 }
 
-func (q *MockWorkQueue) AddAfter(item interface{}, duration time.Duration) {
-	q.RateLimitingInterface.AddAfter(item, duration)
+func (q *MockWorkQueue[T]) AddAfter(item T, duration time.Duration) {
+	q.TypedRateLimitingInterface.AddAfter(item, duration)
 	atomic.AddInt32(&q.addAfterEnque, 1)
 	q.wgLock.Lock()
 	defer q.wgLock.Unlock()
@@ -65,16 +65,16 @@ func (q *MockWorkQueue) AddAfter(item interface{}, duration time.Duration) {
 	}
 }
 
-func (q *MockWorkQueue) GetRateLimitedEnqueueCount() int {
+func (q *MockWorkQueue[T]) GetRateLimitedEnqueueCount() int {
 	return int(atomic.LoadInt32(&q.rateLimitedEnque))
 }
 
-func (q *MockWorkQueue) GetAddAfterEnqueueCount() int {
+func (q *MockWorkQueue[T]) GetAddAfterEnqueueCount() int {
 	return int(atomic.LoadInt32(&q.addAfterEnque))
 }
 
 // ExpectAdds allows setting the amount of expected enqueues.
-func (q *MockWorkQueue) ExpectAdds(diff int) {
+func (q *MockWorkQueue[T]) ExpectAdds(diff int) {
 	q.wgLock.Lock()
 	defer q.wgLock.Unlock()
 	q.addWG = &sync.WaitGroup{}
@@ -83,7 +83,7 @@ func (q *MockWorkQueue) ExpectAdds(diff int) {
 
 // Wait waits until the expected amount of ExpectedAdds has happened.
 // It will not block if there were no expectations set.
-func (q *MockWorkQueue) Wait() {
+func (q *MockWorkQueue[T]) Wait() {
 	q.wgLock.Lock()
 	wg := q.addWG
 	q.wgLock.Unlock()
@@ -95,8 +95,8 @@ func (q *MockWorkQueue) Wait() {
 	}
 }
 
-func NewMockWorkQueue(queue workqueue.RateLimitingInterface) *MockWorkQueue {
-	return &MockWorkQueue{queue, nil, 0, 0, sync.Mutex{}}
+func NewMockWorkQueue[T comparable](queue workqueue.TypedRateLimitingInterface[T]) *MockWorkQueue[T] {
+	return &MockWorkQueue[T]{queue, nil, 0, 0, sync.Mutex{}}
 }
 
 func NewFakeInformerFor(obj runtime.Object) (cache.SharedIndexInformer, *framework.FakeControllerSource) {
@@ -111,151 +111,151 @@ func NewFakeInformerWithIndexersFor(obj runtime.Object, indexers cache.Indexers)
 	return objInformer, objSource
 }
 
-type VirtualMachineFeeder struct {
-	MockQueue *MockWorkQueue
+type VirtualMachineFeeder[T comparable] struct {
+	MockQueue *MockWorkQueue[T]
 	Source    *framework.FakeControllerSource
 }
 
-func (v *VirtualMachineFeeder) Add(vmi *v1.VirtualMachineInstance) {
+func (v *VirtualMachineFeeder[T]) Add(vmi *v1.VirtualMachineInstance) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Add(vmi)
 	v.MockQueue.Wait()
 }
 
-func (v *VirtualMachineFeeder) Modify(vmi *v1.VirtualMachineInstance) {
+func (v *VirtualMachineFeeder[T]) Modify(vmi *v1.VirtualMachineInstance) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Modify(vmi)
 	v.MockQueue.Wait()
 }
 
-func (v *VirtualMachineFeeder) Delete(vmi *v1.VirtualMachineInstance) {
+func (v *VirtualMachineFeeder[T]) Delete(vmi *v1.VirtualMachineInstance) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Delete(vmi)
 	v.MockQueue.Wait()
 }
 
-func NewVirtualMachineFeeder(queue *MockWorkQueue, source *framework.FakeControllerSource) *VirtualMachineFeeder {
-	return &VirtualMachineFeeder{
+func NewVirtualMachineFeeder[T comparable](queue *MockWorkQueue[T], source *framework.FakeControllerSource) *VirtualMachineFeeder[T] {
+	return &VirtualMachineFeeder[T]{
 		MockQueue: queue,
 		Source:    source,
 	}
 }
 
-type PodFeeder struct {
-	MockQueue *MockWorkQueue
+type PodFeeder[T comparable] struct {
+	MockQueue *MockWorkQueue[T]
 	Source    *framework.FakeControllerSource
 }
 
-func (v *PodFeeder) Add(pod *k8sv1.Pod) {
+func (v *PodFeeder[T]) Add(pod *k8sv1.Pod) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Add(pod)
 	v.MockQueue.Wait()
 }
 
-func (v *PodFeeder) Modify(pod *k8sv1.Pod) {
+func (v *PodFeeder[T]) Modify(pod *k8sv1.Pod) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Modify(pod)
 	v.MockQueue.Wait()
 }
 
-func (v *PodFeeder) Delete(pod *k8sv1.Pod) {
+func (v *PodFeeder[T]) Delete(pod *k8sv1.Pod) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Delete(pod)
 	v.MockQueue.Wait()
 }
 
-func NewPodFeeder(queue *MockWorkQueue, source *framework.FakeControllerSource) *PodFeeder {
-	return &PodFeeder{
+func NewPodFeeder[T comparable](queue *MockWorkQueue[T], source *framework.FakeControllerSource) *PodFeeder[T] {
+	return &PodFeeder[T]{
 		MockQueue: queue,
 		Source:    source,
 	}
 }
 
-type PodDisruptionBudgetFeeder struct {
-	MockQueue *MockWorkQueue
+type PodDisruptionBudgetFeeder[T comparable] struct {
+	MockQueue *MockWorkQueue[T]
 	Source    *framework.FakeControllerSource
 }
 
-func (v *PodDisruptionBudgetFeeder) Add(pdb *policyv1.PodDisruptionBudget) {
+func (v *PodDisruptionBudgetFeeder[T]) Add(pdb *policyv1.PodDisruptionBudget) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Add(pdb)
 	v.MockQueue.Wait()
 }
 
-func (v *PodDisruptionBudgetFeeder) Modify(pdb *policyv1.PodDisruptionBudget) {
+func (v *PodDisruptionBudgetFeeder[T]) Modify(pdb *policyv1.PodDisruptionBudget) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Modify(pdb)
 	v.MockQueue.Wait()
 }
 
-func (v *PodDisruptionBudgetFeeder) Delete(pdb *policyv1.PodDisruptionBudget) {
+func (v *PodDisruptionBudgetFeeder[T]) Delete(pdb *policyv1.PodDisruptionBudget) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Delete(pdb)
 	v.MockQueue.Wait()
 }
 
-func NewPodDisruptionBudgetFeeder(queue *MockWorkQueue, source *framework.FakeControllerSource) *PodDisruptionBudgetFeeder {
-	return &PodDisruptionBudgetFeeder{
+func NewPodDisruptionBudgetFeeder[T comparable](queue *MockWorkQueue[T], source *framework.FakeControllerSource) *PodDisruptionBudgetFeeder[T] {
+	return &PodDisruptionBudgetFeeder[T]{
 		MockQueue: queue,
 		Source:    source,
 	}
 }
 
-type MigrationFeeder struct {
-	MockQueue *MockWorkQueue
+type MigrationFeeder[T comparable] struct {
+	MockQueue *MockWorkQueue[T]
 	Source    *framework.FakeControllerSource
 }
 
-func (v *MigrationFeeder) Add(migration *v1.VirtualMachineInstanceMigration) {
+func (v *MigrationFeeder[T]) Add(migration *v1.VirtualMachineInstanceMigration) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Add(migration)
 	v.MockQueue.Wait()
 }
 
-func (v *MigrationFeeder) Modify(migration *v1.VirtualMachineInstanceMigration) {
+func (v *MigrationFeeder[T]) Modify(migration *v1.VirtualMachineInstanceMigration) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Modify(migration)
 	v.MockQueue.Wait()
 }
 
-func (v *MigrationFeeder) Delete(migration *v1.VirtualMachineInstanceMigration) {
+func (v *MigrationFeeder[T]) Delete(migration *v1.VirtualMachineInstanceMigration) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Delete(migration)
 	v.MockQueue.Wait()
 }
 
-func NewMigrationFeeder(queue *MockWorkQueue, source *framework.FakeControllerSource) *MigrationFeeder {
-	return &MigrationFeeder{
+func NewMigrationFeeder[T comparable](queue *MockWorkQueue[T], source *framework.FakeControllerSource) *MigrationFeeder[T] {
+	return &MigrationFeeder[T]{
 		MockQueue: queue,
 		Source:    source,
 	}
 }
 
-type DomainFeeder struct {
-	MockQueue *MockWorkQueue
+type DomainFeeder[T comparable] struct {
+	MockQueue *MockWorkQueue[T]
 	Source    *framework.FakeControllerSource
 }
 
-func (v *DomainFeeder) Add(vmi *api.Domain) {
+func (v *DomainFeeder[T]) Add(vmi *api.Domain) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Add(vmi)
 	v.MockQueue.Wait()
 }
 
-func (v *DomainFeeder) Modify(vmi *api.Domain) {
+func (v *DomainFeeder[T]) Modify(vmi *api.Domain) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Modify(vmi)
 	v.MockQueue.Wait()
 }
 
-func (v *DomainFeeder) Delete(vmi *api.Domain) {
+func (v *DomainFeeder[T]) Delete(vmi *api.Domain) {
 	v.MockQueue.ExpectAdds(1)
 	v.Source.Delete(vmi)
 	v.MockQueue.Wait()
 }
 
-func NewDomainFeeder(queue *MockWorkQueue, source *framework.FakeControllerSource) *DomainFeeder {
-	return &DomainFeeder{
+func NewDomainFeeder[T comparable](queue *MockWorkQueue[T], source *framework.FakeControllerSource) *DomainFeeder[T] {
+	return &DomainFeeder[T]{
 		MockQueue: queue,
 		Source:    source,
 	}

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Clone", func() {
 	var (
 		controller *VMCloneController
 		recorder   *record.FakeRecorder
-		mockQueue  *testutils.MockWorkQueue
+		mockQueue  *testutils.MockWorkQueue[string]
 
 		client    *kubevirtfake.Clientset
 		k8sClient *k8sfake.Clientset

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -40,10 +40,10 @@ var _ = Describe("Disruptionbudget", func() {
 	var podInformer cache.SharedIndexInformer
 	var vmimInformer cache.SharedIndexInformer
 	var recorder *record.FakeRecorder
-	var mockQueue *testutils.MockWorkQueue
+	var mockQueue *testutils.MockWorkQueue[string]
 	var kubeClient *fake.Clientset
-	var pdbFeeder *testutils.PodDisruptionBudgetFeeder
-	var vmiFeeder *testutils.VirtualMachineFeeder
+	var pdbFeeder *testutils.PodDisruptionBudgetFeeder[string]
+	var vmiFeeder *testutils.VirtualMachineFeeder[string]
 	var config *virtconfig.ClusterConfig
 
 	var controller *disruptionbudget.DisruptionBudgetController

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -43,10 +43,10 @@ var _ = Describe("Evacuation", func() {
 	var podInformer cache.SharedIndexInformer
 	var podSource *framework.FakeControllerSource
 	var recorder *record.FakeRecorder
-	var mockQueue *testutils.MockWorkQueue
+	var mockQueue *testutils.MockWorkQueue[string]
 	var kubeClient *fake.Clientset
-	var migrationFeeder *testutils.MigrationFeeder
-	var vmiFeeder *testutils.VirtualMachineFeeder
+	var migrationFeeder *testutils.MigrationFeeder[string]
+	var vmiFeeder *testutils.VirtualMachineFeeder[string]
 
 	var controller *evacuation.EvacuationController
 

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Migration watcher", func() {
 	var (
 		controller    *Controller
 		recorder      *record.FakeRecorder
-		mockQueue     *testutils.MockWorkQueue
+		mockQueue     *testutils.MockWorkQueue[string]
 		virtClientset *kubevirtfake.Clientset
 		kubeClient    *fake.Clientset
 		networkClient *fakenetworkclient.Clientset

--- a/pkg/virt-controller/watch/node/node_test.go
+++ b/pkg/virt-controller/watch/node/node_test.go
@@ -42,10 +42,10 @@ var _ = Describe("Node controller with", func() {
 	var stop chan struct{}
 	var controller *Controller
 	var recorder *record.FakeRecorder
-	var mockQueue *testutils.MockWorkQueue
+	var mockQueue *testutils.MockWorkQueue[string]
 	var virtClient *kubecli.MockKubevirtClient
 	var kubeClient *fake.Clientset
-	var vmiFeeder *testutils.VirtualMachineFeeder
+	var vmiFeeder *testutils.VirtualMachineFeeder[string]
 
 	syncCaches := func(stop chan struct{}) {
 		go nodeInformer.Run(stop)

--- a/pkg/virt-controller/watch/pool/pool_test.go
+++ b/pkg/virt-controller/watch/pool/pool_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Pool", func() {
 
 		var controller *Controller
 		var recorder *record.FakeRecorder
-		var mockQueue *testutils.MockWorkQueue
+		var mockQueue *testutils.MockWorkQueue[string]
 		var fakeVirtClient *kubevirtfake.Clientset
 		var k8sClient *k8sfake.Clientset
 

--- a/pkg/virt-controller/watch/replicaset/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset/replicaset.go
@@ -62,7 +62,10 @@ const (
 func NewController(vmiInformer cache.SharedIndexInformer, vmiRSInformer cache.SharedIndexInformer, recorder record.EventRecorder, clientset kubecli.KubevirtClient, burstReplicas uint) (*Controller, error) {
 
 	c := &Controller{
-		Queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-replicaset"),
+		Queue: workqueue.NewTypedRateLimitingQueueWithConfig[string](
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "virt-controller-replicaset"},
+		),
 		vmiIndexer:    vmiInformer.GetIndexer(),
 		vmiRSIndexer:  vmiRSInformer.GetIndexer(),
 		recorder:      recorder,
@@ -100,7 +103,7 @@ func NewController(vmiInformer cache.SharedIndexInformer, vmiRSInformer cache.Sh
 
 type Controller struct {
 	clientset     kubecli.KubevirtClient
-	Queue         workqueue.RateLimitingInterface
+	Queue         workqueue.TypedRateLimitingInterface[string]
 	vmiIndexer    cache.Indexer
 	vmiRSIndexer  cache.Indexer
 	recorder      record.EventRecorder
@@ -137,7 +140,7 @@ func (c *Controller) Execute() bool {
 		return false
 	}
 	defer c.Queue.Done(key)
-	if err := c.execute(key.(string)); err != nil {
+	if err := c.execute(key); err != nil {
 		log.Log.Reason(err).Infof("re-enqueuing VirtualMachineInstanceReplicaSet %v", key)
 		c.Queue.AddRateLimited(key)
 	} else {

--- a/pkg/virt-controller/watch/replicaset/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset/replicaset_test.go
@@ -48,8 +48,8 @@ var _ = Describe("Replicaset", func() {
 		var stop chan struct{}
 		var controller *Controller
 		var recorder *record.FakeRecorder
-		var mockQueue *testutils.MockWorkQueue
-		var vmiFeeder *testutils.VirtualMachineFeeder
+		var mockQueue *testutils.MockWorkQueue[string]
+		var vmiFeeder *testutils.VirtualMachineFeeder[string]
 
 		syncCaches := func(stop chan struct{}) {
 			go vmiInformer.Run(stop)

--- a/pkg/virt-controller/watch/util/util.go
+++ b/pkg/virt-controller/watch/util/util.go
@@ -37,20 +37,14 @@ import (
 	typesutil "kubevirt.io/kubevirt/pkg/storage/types"
 )
 
-func ProcessWorkItem(queue workqueue.RateLimitingInterface, handler func(string) (time.Duration, error)) bool {
+func ProcessWorkItem(queue workqueue.TypedRateLimitingInterface[string], handler func(string) (time.Duration, error)) bool {
 	obj, shutdown := queue.Get()
 	if shutdown {
 		return false
 	}
 
-	err := func(obj interface{}) error {
+	err := func(key string) error {
 		defer queue.Done(obj)
-		key, ok := obj.(string)
-		if !ok {
-			queue.Forget(obj)
-			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
-			return nil
-		}
 
 		if requeueAfter, err := handler(key); requeueAfter > 0 || err != nil {
 			if requeueAfter > 0 {

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -70,7 +70,7 @@ var _ = Describe("VirtualMachine", func() {
 
 		var controller *Controller
 		var recorder *record.FakeRecorder
-		var mockQueue *testutils.MockWorkQueue
+		var mockQueue *testutils.MockWorkQueue[string]
 		var cdiClient *cdifake.Clientset
 		var k8sClient *k8sfake.Clientset
 		var virtClient *kubecli.MockKubevirtClient

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -68,7 +68,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 	var controller *Controller
 	var recorder *record.FakeRecorder
-	var mockQueue *testutils.MockWorkQueue
+	var mockQueue *testutils.MockWorkQueue[string]
 	var virtClientset *kubevirtfake.Clientset
 	var kubeClient *fake.Clientset
 	// We pass the store to backend storage and we don't have direct access

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Node-labeller ", func() {
 		nlController.queue = mockQueue
 
 		mockQueue.ExpectAdds(1)
-		nlController.queue.Add(node)
+		nlController.queue.Add(node.Name)
 		mockQueue.Wait()
 	})
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -82,15 +82,15 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 	var ctrl *gomock.Controller
 	var controller *VirtualMachineController
-	var mockQueue *testutils.MockWorkQueue
+	var mockQueue *testutils.MockWorkQueue[string]
 	var mockIsolationDetector *isolation.MockPodIsolationDetector
 	var mockIsolationResult *isolation.MockIsolationResult
 	var mockContainerDiskMounter *containerdisk.MockMounter
 	var mockHotplugVolumeMounter *hotplugvolume.MockVolumeMounter
 	var mockCgroupManager *cgroup.MockManager
 
-	var vmiFeeder *testutils.VirtualMachineFeeder
-	var domainFeeder *testutils.DomainFeeder
+	var vmiFeeder *testutils.VirtualMachineFeeder[string]
+	var domainFeeder *testutils.DomainFeeder[string]
 
 	var recorder *record.FakeRecorder
 

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -98,7 +98,7 @@ type KubeVirtTestData struct {
 
 	recorder *record.FakeRecorder
 
-	mockQueue      *testutils.MockWorkQueue
+	mockQueue      *testutils.MockWorkQueue[string]
 	virtClient     *kubecli.MockKubevirtClient
 	virtFakeClient *kubevirtfake.Clientset
 	kubeClient     *fake.Clientset
@@ -192,7 +192,7 @@ func (k *KubeVirtTestData) BeforeTest() {
 		ValidatingAdmissionPolicyEnabled:        true,
 	}
 	k.controller, _ = NewKubeVirtController(k.virtClient, k.apiServiceClient, k.recorder, config, informers, NAMESPACE)
-	k.controller.delayedQueueAdder = func(key interface{}, queue workqueue.RateLimitingInterface) {
+	k.controller.delayedQueueAdder = func(key string, queue workqueue.TypedRateLimitingInterface[string]) {
 		// no delay to speed up tests
 		queue.Add(key)
 	}

--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Apply", func() {
 		var stores util.Stores
 
 		operatorNamespace := "opNamespace"
-		queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+		queue := workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
 		duration := &metav1.Duration{
 			Duration: time.Hour,
 		}

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -522,7 +522,7 @@ func NewReconciler(kv *v1.KubeVirt, targetStrategy install.StrategyInterface, st
 	}, nil
 }
 
-func (r *Reconciler) Sync(queue workqueue.RateLimitingInterface) (bool, error) {
+func (r *Reconciler) Sync(queue workqueue.TypedRateLimitingInterface[string]) (bool, error) {
 	// Avoid log spam by logging this issue once early instead of for once each object created
 	if !util.IsValidLabel(r.kv.Spec.ProductVersion) {
 		log.Log.Errorf("invalid kubevirt.spec.productVersion: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or underscore")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Replace deprecated RateLimitingInterface and similar with the typed workqueue ones.
This allows us to drop some checks and type assertions. Converted the mockqueue using generics.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

