### PR TITLE
Graduation of VolumeUpdateStrategy and VolumeMigration

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -352,21 +352,6 @@ func validateLiveUpdateFeatures(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 		}
 	}
 
-	if spec.UpdateVolumesStrategy != nil && !config.VolumesUpdateStrategyEnabled() {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s feature gate is not enabled in kubevirt-config", virtconfig.VolumesUpdateStrategy),
-			Field:   "updateVolumesStrategy",
-		})
-	}
-	if spec.UpdateVolumesStrategy != nil && *spec.UpdateVolumesStrategy == v1.UpdateVolumesStrategyMigration && !config.VolumeMigrationEnabled() {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s feature gate is not enabled in kubevirt-config", virtconfig.VolumeMigration),
-			Field:   "updateVolumesStrategy",
-		})
-	}
-
 	return causes
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1825,43 +1825,6 @@ var _ = Describe("Validating VM Admitter", func() {
 			)
 		})
 
-		Context("Update volume strategy", func() {
-			It("should accept the VM with the feature gate enabled", func() {
-				enableFeatureGate(virtconfig.VolumesUpdateStrategy)
-				vm.Spec.UpdateVolumesStrategy = pointer.P(v1.UpdateVolumesStrategyReplacement)
-				resp := admitVm(vmsAdmitter, vm)
-				Expect(resp.Allowed).To(BeTrue())
-				Expect(resp.Result).To(BeNil())
-			})
-			It("should reject the VM creation if the feature gate isn't enabled", func() {
-				vm.Spec.UpdateVolumesStrategy = pointer.P(v1.UpdateVolumesStrategyReplacement)
-				resp := admitVm(vmsAdmitter, vm)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(ContainElement(metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Field:   "updateVolumesStrategy",
-					Message: fmt.Sprintf("%s feature gate is not enabled in kubevirt-config", virtconfig.VolumesUpdateStrategy),
-				}))
-			})
-			It("should accept the VM with the feature gate enabled for volume migration", func() {
-				enableFeatureGate(virtconfig.VolumesUpdateStrategy, virtconfig.VolumeMigration)
-				vm.Spec.UpdateVolumesStrategy = pointer.P(v1.UpdateVolumesStrategyMigration)
-				resp := admitVm(vmsAdmitter, vm)
-				Expect(resp.Allowed).To(BeTrue())
-				Expect(resp.Result).To(BeNil())
-			})
-			It("should reject the VM creation if the volume migration feature gate isn't enabled", func() {
-				enableFeatureGate(virtconfig.VolumesUpdateStrategy)
-				vm.Spec.UpdateVolumesStrategy = pointer.P(v1.UpdateVolumesStrategyMigration)
-				resp := admitVm(vmsAdmitter, vm)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(ContainElement(metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Field:   "updateVolumesStrategy",
-					Message: fmt.Sprintf("%s feature gate is not enabled in kubevirt-config", virtconfig.VolumeMigration),
-				}))
-			})
-		})
 	})
 
 	It("should raise a warning when Deprecated API is used", func() {

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -78,6 +78,13 @@ const (
 	// DockerSELinuxMCSWorkaround sets the SELinux level of all the non-compute virt-launcher containers to "s0".
 	DockerSELinuxMCSWorkaround = "DockerSELinuxMCSWorkaround"  // Deprecated
 	VirtIOFSGate               = "ExperimentalVirtiofsSupport" // Deprecated
+
+	// VolumesUpdateStrategy enables to specify the strategy on the volume updates.
+	// Introduced in v1.3.0
+	VolumesUpdateStrategy = "VolumesUpdateStrategy" // GA
+	// VolumeMigration enables to migrate the storage. It depends on the VolumesUpdateStrategy feature.
+	// Introduced in v1.3.0
+	VolumeMigration = "VolumeMigration" // GA
 )
 
 type FeatureGate struct {
@@ -108,6 +115,8 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})
 	RegisterFeatureGate(FeatureGate{Name: DockerSELinuxMCSWorkaround, State: Deprecated, Message: fmt.Sprintf("DockerSELinuxMCSWorkaround has been deprecated since v1.4.")})
 	RegisterFeatureGate(FeatureGate{Name: VirtIOFSGate, State: Deprecated, Message: VirtioFsFeatureGateDeprecationMessage})
+	RegisterFeatureGate(FeatureGate{Name: VolumesUpdateStrategy, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: VolumeMigration, State: GA})
 }
 
 // RegisterFeatureGate adds a given feature-gate to the FG list

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -63,10 +63,6 @@ const (
 	// AlignCPUsGate allows emulator thread to assign two extra CPUs if needed to complete even parity.
 	AlignCPUsGate = "AlignCPUs"
 
-	// VolumesUpdateStrategy enables to specify the strategy on the volume updates.
-	VolumesUpdateStrategy = "VolumesUpdateStrategy"
-	// VolumeMigration enables to migrate the storage. It depends on the VolumesUpdateStrategy feature.
-	VolumeMigration = "VolumeMigration"
 	// Owner: @xpivarc
 	// Alpha: v1.3.0
 	//
@@ -235,14 +231,6 @@ func (config *ClusterConfig) AutoResourceLimitsEnabled() bool {
 
 func (config *ClusterConfig) AlignCPUsEnabled() bool {
 	return config.isFeatureGateEnabled(AlignCPUsGate)
-}
-
-func (config *ClusterConfig) VolumesUpdateStrategyEnabled() bool {
-	return config.isFeatureGateEnabled(VolumesUpdateStrategy)
-}
-
-func (config *ClusterConfig) VolumeMigrationEnabled() bool {
-	return config.isFeatureGateEnabled(VolumeMigration)
 }
 
 func (config *ClusterConfig) NodeRestrictionEnabled() bool {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -973,9 +973,6 @@ func (c *Controller) handleVolumeRequests(vm *virtv1.VirtualMachine, vmi *virtv1
 }
 
 func (c *Controller) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
-	if !c.clusterConfig.VolumesUpdateStrategyEnabled() {
-		return nil
-	}
 	if vmi == nil {
 		return nil
 	}
@@ -1028,9 +1025,6 @@ func (c *Controller) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi *v
 			setRestartRequired(vm, "the volumes replacement is effective only after restart")
 		}
 	case *vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyMigration:
-		if !c.clusterConfig.VolumeMigrationEnabled() {
-			return nil
-		}
 		// Validate if the update volumes can be migrated
 		if err := volumemig.ValidateVolumes(vmi, vm); err != nil {
 			log.Log.Object(vm).Errorf("cannot migrate the VM. Volumes are invalid: %v", err)

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -6612,11 +6612,6 @@ var _ = Describe("VirtualMachine", func() {
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
 								VMRolloutStrategy: &liveUpdate,
-								DeveloperConfiguration: &v1.DeveloperConfiguration{
-									FeatureGates: []string{
-										virtconfig.VolumesUpdateStrategy,
-									},
-								},
 							},
 						},
 					})
@@ -6641,12 +6636,6 @@ var _ = Describe("VirtualMachine", func() {
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
 								VMRolloutStrategy: &liveUpdate,
-								DeveloperConfiguration: &v1.DeveloperConfiguration{
-									FeatureGates: []string{
-										virtconfig.VolumesUpdateStrategy,
-										virtconfig.VolumeMigration,
-									},
-								},
 							},
 						},
 					})

--- a/tests/libkubevirt/config/BUILD.bazel
+++ b/tests/libkubevirt/config/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",

--- a/tests/libkubevirt/config/kvconfig.go
+++ b/tests/libkubevirt/config/kvconfig.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
@@ -73,25 +72,6 @@ func patchKV(namespace, name string, patchSet *patch.PatchSet) error {
 	}
 	_, err = kubevirt.Client().KubeVirt(namespace).Patch(context.Background(), name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 	return err
-}
-
-func PatchWorkloadUpdateMethodAndRolloutStrategy(kvName string,
-	virtClient kubecli.KubevirtClient,
-	updateStrategy *v1.KubeVirtWorkloadUpdateStrategy,
-	rolloutStrategy *v1.VMRolloutStrategy, fgs []string,
-) {
-	patchWorkload, err := patch.New(
-		patch.WithAdd("/spec/workloadUpdateStrategy", updateStrategy),
-		patch.WithAdd("/spec/configuration/vmRolloutStrategy", rolloutStrategy),
-		patch.WithAdd("/spec/configuration/developerConfiguration/featureGates", fgs),
-	).GeneratePayload()
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	EventuallyWithOffset(1, func() error {
-		_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(
-			context.Background(), kvName, types.JSONPatchType,
-			patchWorkload, metav1.PatchOptions{})
-		return err
-	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
 // UpdateKubeVirtConfigValueAndWait updates the given configuration in the kubevirt custom resource


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Volume Migration was behind a feature gate

After this PR:
The VolumeUpdateStrategy and VolumeMigration features are consider stable and general available.

The `VolumeUpdateStrategy` and `VolumeMigration` feature gates were introduced in v1.3.0 by #11533.
    
Both feature gates have been present for 2 releases and since then, multiple issues have been reported and fixed.
With the graduation of the two feature gates, we want to indicate to KubeVirt users that the feature will remain and that the API may be considered stable for use.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Graduation of VolumeUpdateStrategy and VolumeMigration feature gates
```

