### PR TITLE
Fix cluster-up path: ./cluster-up/ -> ./kubevirtci/cluster-up/

### DIFF
--- a/kubevirtci/cluster-up/cluster/README_VGPU.md
+++ b/kubevirtci/cluster-up/cluster/README_VGPU.md
@@ -16,7 +16,7 @@ make cluster-up
 The cluster can be accessed as usual:
 
 ```bash
-$ cluster-up/kubectl.sh get nodes
+$ kubevirtci/cluster-up/kubectl.sh get nodes
 NAME                  STATUS   ROLES    AGE     VERSION
 vgpu-control-plane   Ready    master   6m14s   v1.x.y
 ```

--- a/kubevirtci/cluster-up/cluster/kind-1.28/README.md
+++ b/kubevirtci/cluster-up/cluster/kind-1.28/README.md
@@ -16,7 +16,7 @@ make cluster-up
 The cluster can be accessed as usual:
 
 ```bash
-$ cluster-up/kubectl.sh get nodes
+$ kubevirtci/cluster-up/kubectl.sh get nodes
 NAME                  STATUS   ROLES    AGE
 kind-x.yz-control-plane   Ready    master   6m14s
 ```

--- a/kubevirtci/cluster-up/cluster/kind-sriov/README.md
+++ b/kubevirtci/cluster-up/cluster/kind-sriov/README.md
@@ -21,24 +21,24 @@ export KUBEVIRT_PROVIDER=kind-1.23-sriov
 export KUBEVIRT_NUM_NODES=3
 make cluster-up
 
-$ cluster-up/kubectl.sh get nodes
+$ kubevirtci/cluster-up/kubectl.sh get nodes
 NAME                  STATUS   ROLES                  AGE   VERSION
 sriov-control-plane   Ready    control-plane,master   20h   v1.23.13
 sriov-worker          Ready    worker                 20h   v1.23.13
 sriov-worker2         Ready    worker                 20h   v1.23.13
 
-$ cluster-up/kubectl.sh get pods -n kube-system -l app=multus
+$ kubevirtci/cluster-up/kubectl.sh get pods -n kube-system -l app=multus
 NAME                         READY   STATUS    RESTARTS   AGE
 kube-multus-ds-amd64-d45n4   1/1     Running   0          20h
 kube-multus-ds-amd64-g26xh   1/1     Running   0          20h
 kube-multus-ds-amd64-mfh7c   1/1     Running   0          20h
 
-$ cluster-up/kubectl.sh get pods -n sriov -l app=sriov-cni
+$ kubevirtci/cluster-up/kubectl.sh get pods -n sriov -l app=sriov-cni
 NAME                            READY   STATUS    RESTARTS   AGE
 kube-sriov-cni-ds-amd64-fv5cr   1/1     Running   0          20h
 kube-sriov-cni-ds-amd64-q95q9   1/1     Running   0          20h
 
-$ cluster-up/kubectl.sh get pods -n sriov -l app=sriovdp
+$ kubevirtci/cluster-up/kubectl.sh get pods -n sriov -l app=sriovdp
 NAME                                   READY   STATUS    RESTARTS   AGE
 kube-sriov-device-plugin-amd64-h7h84   1/1     Running   0          20h
 kube-sriov-device-plugin-amd64-xrr5z   1/1     Running   0          20h


### PR DESCRIPTION
### What this PR does
The path changed as part of https://github.com/kubevirt/kubevirt/pull/12872.

Before this PR:
Documentation points to the wrong path.

After this PR:
Documentation points to the right path.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```