### PR TITLE
Fix volume migration tests against ceph rbd

### DIFF
--- a/tests/libdv/dv.go
+++ b/tests/libdv/dv.go
@@ -266,6 +266,11 @@ func StorageWithBlockVolumeMode() storageOption {
 	return StorageWithVolumeMode(corev1.PersistentVolumeBlock)
 }
 
+// StorageWithFilesystemVolumeMode adds the PersistentVolumeBlock volume mode to the DV
+func StorageWithFilesystemVolumeMode() storageOption {
+	return StorageWithVolumeMode(corev1.PersistentVolumeFilesystem)
+}
+
 // StorageWithAccessMode overrides the DV default access mode (ReadWriteOnce) with the accessMode parameter
 func StorageWithAccessMode(accessMode corev1.PersistentVolumeAccessMode) storageOption {
 	return func(storage *v1beta1.StorageSpec) {

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -92,9 +92,10 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			destPVC string
 		)
 		const (
-			fsPVC    = "filesystem"
-			blockPVC = "block"
-			size     = "1Gi"
+			fsPVC            = "filesystem"
+			blockPVC         = "block"
+			size             = "1Gi"
+			sizeWithOverhead = "1.2Gi"
 		)
 
 		waitMigrationToNotExist := func(vmiName, ns string) {
@@ -131,6 +132,7 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
 					libdv.StorageWithVolumeSize(size),
+					libdv.StorageWithFilesystemVolumeMode(),
 				),
 			)
 			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
@@ -254,7 +256,8 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			// Create dest PVC
 			switch mode {
 			case fsPVC:
-				libstorage.CreateFSPVC(destPVC, ns, size, nil)
+				// Add some overhead to the target PVC for filesystem.
+				libstorage.CreateFSPVC(destPVC, ns, sizeWithOverhead, nil)
 			case blockPVC:
 				libstorage.CreateBlockPVC(destPVC, ns, size)
 			default:
@@ -854,6 +857,8 @@ func createBlankDV(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.Da
 		libdv.WithBlankImageSource(),
 		libdv.WithStorage(libdv.StorageWithStorageClass(sc),
 			libdv.StorageWithVolumeSize(size),
+			libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
+			libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
 		),
 	)
 	_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Fix some volume migration tests if run in an environment that has ceph-rbd volumes properly configured.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://issues.redhat.com/browse/CNV-51448

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

