### PR TITLE
vol-mig: improve error report when the destination is too small

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -625,6 +625,13 @@ func (m *migrationMonitor) startMonitor() {
 			if strings.Contains(m.migrationFailedWithError.Error(), "canceled by client") {
 				abortStatus = v1.MigrationAbortSucceeded
 			}
+			// Improve the error message when the volume migration fails because the destination size is smaller then the source volume
+			if len(vmi.Status.MigratedVolumes) > 0 && strings.Contains(m.migrationFailedWithError.Error(),
+				"has to be smaller or equal to the actual size of the containing file") {
+				m.l.setMigrationResult(true, fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller then the source volume: %v",
+					m.migrationFailedWithError), abortStatus)
+				return
+			}
 			m.l.setMigrationResult(true, fmt.Sprintf("Live migration failed %v", m.migrationFailedWithError), abortStatus)
 			return
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In the case, the destination image is smaller then the source volume, then the volume migration cannot be performed. In this case, the live migration fails with this obscure error message:
```
Live migration failed error encountered during MigrateToURI3 libvirt api call: virError(Code=1, Domain=10, message='internal error: process exited while connecting to monitor: 2024-11-20T09:00:01.341094Z qemu-system-x86_64: -blockdev {\"driver\":\"raw\",\"file\":\"libvirt-2-storage\",\"offset\":0,\"size\" :1073741824,\"node-name\":\"libvirt-2-slice-sto\",\"read-only\":false,\"discard\" :\"unmap\",\"cache\":{\"direct\":true,\"no-flush\":false}}: The sum of offset (0) and size (0) has to be smaller or equal to the  actual size of the containing file  (1006632960)')
```

This change makes the error message more intuitive and now you can see in the VMI Migration object:
```yaml
 migrationState:
  failed: true
  failureReason: 'Volume migration cannot be performed because the destination volume
      is smaller then the source volume: error encountered during MigrateToURI3 libvirt
      api call: [..]
```

Partially Fixes: https://github.com/kubevirt/kubevirt/issues/12875

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

