### PR TITLE
fix quarantined [test_id:6980] test

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1696,8 +1696,8 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				vmi := libvmifact.NewFedora(
 					libnet.WithMasqueradeNetworking(),
 					libvmi.WithResourceMemory("1Gi"),
-					// this annotation causes virt launcher to immediately fail a migration
-					libvmi.WithAnnotation(v1.FuncTestForceLauncherMigrationFailureAnnotation, ""),
+					// this annotation prevents virt launcher from finishing the target pod preparation.
+					libvmi.WithAnnotation(v1.FuncTestBlockLauncherPrepareMigrationTargetAnnotation, ""),
 				)
 
 				By("Starting the VirtualMachineInstance")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
During cleanup in #12838, in the test [test_id:6980] it was used the wrong annotation resulting in unstable behavior.
It was used `FuncTestForceLauncherMigrationFailureAnnotation` instead of `FuncTestBlockLauncherPrepareMigrationTargetAnnotation`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/13143
Quarantine PR: https://github.com/kubevirt/kubevirt/pull/13192

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/kind-flake
/cc @xpivarc @dhiller @brianmcarey 