### PR TITLE
VMRestore: remove VMSnapshot logic from vmrestore webhook

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -89,7 +89,7 @@ func vmSnapshotError(vmSnapshot *snapshotv1.VirtualMachineSnapshot) *snapshotv1.
 }
 
 func vmSnapshotFailed(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
-	return vmSnapshot.Status != nil && vmSnapshot.Status.Phase == snapshotv1.Failed
+	return vmSnapshot != nil && vmSnapshot.Status != nil && vmSnapshot.Status.Phase == snapshotv1.Failed
 }
 
 func vmSnapshotSucceeded(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -27,9 +27,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/cache"
 
@@ -77,11 +75,9 @@ func (admitter *VMRestoreAdmitter) Admit(ctx context.Context, ar *admissionv1.Ad
 	}
 
 	var causes []metav1.StatusCause
-	var targetVMExists bool
 
 	switch ar.Request.Operation {
 	case admissionv1.Create:
-		var targetUID *types.UID
 		targetField := k8sfield.NewPath("spec", "target")
 
 		if vmRestore.Spec.Target.APIGroup == nil {
@@ -97,10 +93,7 @@ func (admitter *VMRestoreAdmitter) Admit(ctx context.Context, ar *admissionv1.Ad
 			case core.GroupName:
 				switch vmRestore.Spec.Target.Kind {
 				case "VirtualMachine":
-					causes, targetUID, targetVMExists, err = admitter.validateCreateVM(ctx, k8sfield.NewPath("spec"), vmRestore)
-					if err != nil {
-						return webhookutils.ToAdmissionResponseError(err)
-					}
+					causes = admitter.validatePatches(vmRestore.Spec.Patches, k8sfield.NewPath("spec", "patches"))
 				default:
 					causes = []metav1.StatusCause{
 						{
@@ -121,18 +114,6 @@ func (admitter *VMRestoreAdmitter) Admit(ctx context.Context, ar *admissionv1.Ad
 			}
 		}
 
-		snapshotCauses, err := admitter.validateSnapshot(
-			ctx,
-			k8sfield.NewPath("spec", "virtualMachineSnapshotName"),
-			ar.Request.Namespace,
-			vmRestore.Spec.VirtualMachineSnapshotName,
-			targetUID,
-			targetVMExists,
-		)
-		if err != nil {
-			return webhookutils.ToAdmissionResponseError(err)
-		}
-
 		objects, err := admitter.VMRestoreInformer.GetIndexer().ByIndex(cache.NamespaceIndex, ar.Request.Namespace)
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
@@ -150,8 +131,6 @@ func (admitter *VMRestoreAdmitter) Admit(ctx context.Context, ar *admissionv1.Ad
 				causes = append(causes, cause)
 			}
 		}
-
-		causes = append(causes, snapshotCauses...)
 
 	case admissionv1.Update:
 		prevObj := &snapshotv1.VirtualMachineRestore{}
@@ -181,25 +160,6 @@ func (admitter *VMRestoreAdmitter) Admit(ctx context.Context, ar *admissionv1.Ad
 		Allowed: true,
 	}
 	return &reviewResponse
-}
-
-func (admitter *VMRestoreAdmitter) validateCreateVM(ctx context.Context, field *k8sfield.Path, vmRestore *snapshotv1.VirtualMachineRestore) (causes []metav1.StatusCause, uid *types.UID, targetVMExists bool, err error) {
-	vmName := vmRestore.Spec.Target.Name
-	namespace := vmRestore.Namespace
-
-	causes = admitter.validatePatches(vmRestore.Spec.Patches, field.Child("patches"))
-
-	vm, err := admitter.Client.VirtualMachine(namespace).Get(ctx, vmName, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		// If the target VM does not exist it would be automatically created by the restore controller
-		return nil, nil, false, nil
-	}
-
-	if err != nil {
-		return nil, nil, false, err
-	}
-
-	return causes, &vm.UID, true, nil
 }
 
 func (admitter *VMRestoreAdmitter) validatePatches(patches []string, field *k8sfield.Path) (causes []metav1.StatusCause) {
@@ -237,53 +197,4 @@ func (admitter *VMRestoreAdmitter) validatePatches(patches []string, field *k8sf
 	}
 
 	return causes
-}
-
-func (admitter *VMRestoreAdmitter) validateSnapshot(ctx context.Context, field *k8sfield.Path, namespace, name string, targetUID *types.UID, targetVMExists bool) ([]metav1.StatusCause, error) {
-	snapshot, err := admitter.Client.VirtualMachineSnapshot(namespace).Get(ctx, name, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		return []metav1.StatusCause{
-			{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("VirtualMachineSnapshot %q does not exist", name),
-				Field:   field.String(),
-			},
-		}, nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	var causes []metav1.StatusCause
-
-	if snapshot.Status != nil && snapshot.Status.Phase == snapshotv1.Failed {
-		cause := metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("VirtualMachineSnapshot %q has failed and is invalid to use", name),
-			Field:   field.String(),
-		}
-		causes = append(causes, cause)
-	}
-
-	if snapshot.Status == nil || snapshot.Status.ReadyToUse == nil || !*snapshot.Status.ReadyToUse {
-		cause := metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("VirtualMachineSnapshot %q is not ready to use", name),
-			Field:   field.String(),
-		}
-		causes = append(causes, cause)
-	}
-
-	sourceTargetVmsAreDifferent := targetUID != nil && snapshot.Status != nil && snapshot.Status.SourceUID != nil && *targetUID != *snapshot.Status.SourceUID
-	if sourceTargetVmsAreDifferent && targetVMExists {
-		cause := metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("when snapshot source and restore target VMs are different - target VM must not exist"),
-			Field:   field.String(),
-		}
-		causes = append(causes, cause)
-	}
-
-	return causes, nil
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -22,7 +22,6 @@ package admitters
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -153,7 +152,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target.apiGroup"))
 		})
 
-		It("should reject when snapshot does not exist", func() {
+		It("should accept when snapshot does not exist", func() {
 			restore := &snapshotv1.VirtualMachineRestore{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "restore",
@@ -171,9 +170,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 
 			ar := createRestoreAdmissionReview(restore)
 			resp := createTestVMRestoreAdmitter(config, nil).Admit(context.Background(), ar)
-			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Details.Causes).To(HaveLen(1))
-			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
+			Expect(resp.Allowed).To(BeTrue())
 		})
 
 		It("should reject spec update", func() {
@@ -307,85 +304,6 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				Expect(resp.Allowed).To(BeTrue())
 			})
 
-			It("should reject when snapshot does not exist", func() {
-				restore := &snapshotv1.VirtualMachineRestore{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "restore",
-						Namespace: "default",
-					},
-					Spec: snapshotv1.VirtualMachineRestoreSpec{
-						Target: corev1.TypedLocalObjectReference{
-							APIGroup: &apiGroup,
-							Kind:     "VirtualMachine",
-							Name:     vmName,
-						},
-						VirtualMachineSnapshotName: vmSnapshotName,
-					},
-				}
-
-				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
-
-				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm).Admit(context.Background(), ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(HaveLen(1))
-				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
-			})
-
-			It("should reject when snapshot has failed", func() {
-				restore := &snapshotv1.VirtualMachineRestore{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "restore",
-						Namespace: "default",
-					},
-					Spec: snapshotv1.VirtualMachineRestoreSpec{
-						Target: corev1.TypedLocalObjectReference{
-							APIGroup: &apiGroup,
-							Kind:     "VirtualMachine",
-							Name:     vmName,
-						},
-						VirtualMachineSnapshotName: vmSnapshotName,
-					},
-				}
-
-				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
-				s := snapshot.DeepCopy()
-				s.Status.Phase = snapshotv1.Failed
-
-				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, s).Admit(context.Background(), ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(HaveLen(1))
-				Expect(resp.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("VirtualMachineSnapshot %q has failed and is invalid to use", vmSnapshotName)))
-			})
-
-			It("should reject when snapshot not ready", func() {
-				restore := &snapshotv1.VirtualMachineRestore{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "restore",
-						Namespace: "default",
-					},
-					Spec: snapshotv1.VirtualMachineRestoreSpec{
-						Target: corev1.TypedLocalObjectReference{
-							APIGroup: &apiGroup,
-							Kind:     "VirtualMachine",
-							Name:     vmName,
-						},
-						VirtualMachineSnapshotName: vmSnapshotName,
-					},
-				}
-
-				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
-				s := snapshot.DeepCopy()
-				s.Status.ReadyToUse = pointer.P(false)
-
-				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, s).Admit(context.Background(), ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(HaveLen(1))
-				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
-			})
-
 			It("should reject invalid kind", func() {
 				restore := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
@@ -495,43 +413,6 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeTrue())
 			})
-
-			DescribeTable("when target VM is different from source VM", func(doesTargetExist bool) {
-				const targetVMName = "new-test-vm"
-
-				var targetVM *v1.VirtualMachine
-				if doesTargetExist {
-					targetVM = vm.DeepCopy()
-					targetVM.Name = targetVMName
-					targetVM.UID = "new-uid"
-				}
-
-				restore := &snapshotv1.VirtualMachineRestore{
-					Spec: snapshotv1.VirtualMachineRestoreSpec{
-						Target: corev1.TypedLocalObjectReference{
-							APIGroup: &apiGroup,
-							Kind:     "VirtualMachine",
-							Name:     targetVMName,
-						},
-						VirtualMachineSnapshotName: vmSnapshotName,
-					},
-				}
-
-				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, targetVM, snapshot).Admit(context.Background(), ar)
-
-				if doesTargetExist {
-					Expect(resp.Allowed).To(BeFalse())
-					Expect(resp.Result.Details.Causes).To(HaveLen(1))
-					Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
-					Expect(resp.Result.Details.Causes[0].Message).To(ContainSubstring("target VM must not exist"))
-				} else {
-					Expect(resp.Allowed).To(BeTrue())
-				}
-			},
-				Entry("should allow if target doesn't exist", false),
-				Entry("should reject if target exists", true),
-			)
 
 			Context("when using Patches", func() {
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -300,18 +300,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			deleteVM(vm)
 		})
 
-		Context("and no snapshot", func() {
-			It("[test_id:5255]should reject restore", func() {
-				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				restore := createRestoreDef(vm.Name, "foobar")
-
-				_, err := virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("VirtualMachineSnapshot \"foobar\" does not exist"))
-			})
-		})
-
 		Context("with run strategy and snapshot", func() {
 			var err error
 			var snapshot *snapshotv1.VirtualMachineSnapshot


### PR DESCRIPTION
Having in webhooks checks of other objects is raceful and not eventual consistent.
This PR makes sure all the relevant logic and check of a valid vmsnapshot exists in the restore controller and deletes it logic from the webhook.


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # Jira-ticket: https://issues.redhat.com/browse/CNV-41559

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMRestore: remove VMSnapshot logic from vmrestore webhook
```