### PR TITLE
access-credentials: test: Fix race in unit test

### DIFF
--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -273,9 +273,7 @@ var _ = Describe("AccessCredentials", func() {
 		mockDomain.EXPECT().Free().Times(1)
 
 		Expect(manager.HandleQemuAgentAccessCredentials(vmi)).To(Succeed())
-		DeferCleanup(func() {
-			manager.Stop()
-		})
+		defer manager.Stop()
 
 		// Wait until ssh keys reload is detected
 		Eventually(keysLoaded, 5*time.Second, 50*time.Millisecond).Should(BeClosed())


### PR DESCRIPTION
### What this PR does
One unintuitive but intentional behavior in Ginkgo is that all `DeferCleanup()` blocks are executed after all `AfterEach()` blocks. This causes a race in this test case, because `AfterEach()` removes a file that is being watched by a goroutine inside `HandleQemuAgentAccessCredentials()`. If the goroutine is faster, it will call `LookupDomainByName()` second time and panic.

Using `defer` instead of `DeferCleanup()` should fix the race.

For context, that this is intentional behavior in ginkgo: https://github.com/onsi/ginkgo/issues/1360#issuecomment-1949181004

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
None
```

