### PR TITLE
virt-config, fg: Graduate the Network Binding Plugin feature to GA

### DIFF
--- a/pkg/network/admitter/admit_suite_test.go
+++ b/pkg/network/admitter/admit_suite_test.go
@@ -52,7 +52,3 @@ func (s stubClusterConfigChecker) MacvtapEnabled() bool {
 func (s stubClusterConfigChecker) PasstEnabled() bool {
 	return s.passtFeatureGateEnabled
 }
-
-func (s stubClusterConfigChecker) NetworkBindingPlugingsEnabled() bool {
-	return s.bindingPluginFGEnabled
-}

--- a/pkg/network/admitter/binding.go
+++ b/pkg/network/admitter/binding.go
@@ -40,7 +40,6 @@ func validateInterfaceBinding(
 		causes = append(causes, validateInterfaceBindingExists(fieldPath, idx, iface)...)
 		causes = append(causes, validateMasqueradeBinding(fieldPath, idx, iface, networksByName[iface.Name])...)
 		causes = append(causes, validateBridgeBinding(fieldPath, idx, iface, networksByName[iface.Name], config)...)
-		causes = append(causes, validateBindingPlugin(fieldPath, idx, iface, config)...)
 		causes = append(causes, validateMacvtapBinding(fieldPath, idx, iface, networksByName[iface.Name], config)...)
 		causes = append(causes, validatePasstBinding(fieldPath, idx, iface, networksByName[iface.Name], config)...)
 	}
@@ -93,17 +92,6 @@ func validateBridgeBinding(
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: "Bridge on pod network configuration is not enabled under kubevirt-config",
-			Field:   fieldPath.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
-		}}
-	}
-	return nil
-}
-
-func validateBindingPlugin(fieldPath *field.Path, idx int, iface v1.Interface, config clusterConfigChecker) []metav1.StatusCause {
-	if iface.Binding != nil && !config.NetworkBindingPlugingsEnabled() {
-		return []metav1.StatusCause{{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Binding plugins feature gate is not enabled",
 			Field:   fieldPath.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
 		}}
 	}

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -135,22 +135,4 @@ var _ = Describe("Validating core binding", func() {
 			Field:   "fake.domain.devices.interfaces[0].name",
 		}))
 	})
-
-	It("should reject networks with a binding plugin interface when network-binding-plugin feature gate disabled", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:    "default",
-			Binding: &v1.PluginBinding{Name: "testplugin"},
-		}}
-		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
-
-		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
-			Message: "Binding plugins feature gate is not enabled",
-			Field:   "fake.domain.devices.interfaces[0].name",
-		}))
-	})
 })

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -33,7 +33,6 @@ type clusterConfigChecker interface {
 	IsBridgeInterfaceOnPodNetworkEnabled() bool
 	MacvtapEnabled() bool
 	PasstEnabled() bool
-	NetworkBindingPlugingsEnabled() bool
 }
 
 type Validator struct {

--- a/pkg/network/multus/annotation.go
+++ b/pkg/network/multus/annotation.go
@@ -69,7 +69,7 @@ func GenerateCNIAnnotationFromNameScheme(
 				NewAnnotationData(namespace, interfaces, network, podInterfaceName))
 		}
 
-		if config != nil && config.NetworkBindingPlugingsEnabled() {
+		if config != nil {
 			if iface := vmispec.LookupInterfaceByName(interfaces, network.Name); iface.Binding != nil {
 				bindingPluginAnnotationData, err := newBindingPluginAnnotationData(
 					config.GetConfig(), iface.Binding.Name, namespace, network.Name)

--- a/pkg/virt-config/deprecation/feature-gates.go
+++ b/pkg/virt-config/deprecation/feature-gates.go
@@ -64,6 +64,12 @@ const (
 	// When BochsDisplayForEFIGuests is enabled, EFI guests will be started with Bochs display instead of VGA
 	BochsDisplayForEFIGuests = "BochsDisplayForEFIGuests" // GA
 
+	// NetworkBindingPlugingsGate enables using a plugin to bind the pod and the VM network
+	// Alpha: v1.1.0
+	// Beta:  v1.4.0
+	// GA:    v1.5.0
+	NetworkBindingPlugingsGate = "NetworkBindingPlugins" // GA
+
 	PasstGate   = "Passt"   // Deprecated
 	MacvtapGate = "Macvtap" // Deprecated
 	// DockerSELinuxMCSWorkaround sets the SELinux level of all the non-compute virt-launcher containers to "s0".
@@ -91,6 +97,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: HotplugNetworkIfacesGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: BochsDisplayForEFIGuests, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VMLiveUpdateFeaturesGate, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: NetworkBindingPlugingsGate, State: GA})
 
 	RegisterFeatureGate(FeatureGate{Name: PasstGate, State: Discontinued, Message: PasstDiscontinueMessage, VmiSpecUsed: passtApiUsed})
 	RegisterFeatureGate(FeatureGate{Name: MacvtapGate, State: Discontinued, Message: MacvtapDiscontinueMessage, VmiSpecUsed: macvtapApiUsed})

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -56,10 +56,6 @@ const (
 	// VMPersistentState enables persisting backend state files of VMs, such as the contents of the vTPM
 	VMPersistentState = "VMPersistentState"
 	MultiArchitecture = "MultiArchitecture"
-	// NetworkBindingPlugingsGate enables using a plugin to bind the pod and the VM network
-	// Alpha: v1.1.0
-	// Beta:  v1.4.0
-	NetworkBindingPlugingsGate = "NetworkBindingPlugins"
 	// AutoResourceLimitsGate enables automatic setting of vmi limits if there is a ResourceQuota with limits associated with the vmi namespace.
 	AutoResourceLimitsGate = "AutoResourceLimitsGate"
 
@@ -223,10 +219,6 @@ func (config *ClusterConfig) VMPersistentStateEnabled() bool {
 
 func (config *ClusterConfig) MultiArchitectureEnabled() bool {
 	return config.isFeatureGateEnabled(MultiArchitecture)
-}
-
-func (config *ClusterConfig) NetworkBindingPlugingsEnabled() bool {
-	return config.isFeatureGateEnabled(NetworkBindingPlugingsGate)
 }
 
 func (config *ClusterConfig) AutoResourceLimitsEnabled() bool {

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -31,7 +31,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -45,11 +44,6 @@ import (
 )
 
 var _ = SIGDescribe("[Serial]network binding plugin", Serial, decorators.NetCustomBindingPlugins, func() {
-
-	BeforeEach(func() {
-		config.EnableFeatureGate(virtconfig.NetworkBindingPlugingsGate)
-	})
-
 	Context("with CNI and Sidecar", func() {
 		BeforeEach(func() {
 			const passtBindingName = "passt"

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -34,7 +34,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -54,10 +53,6 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 		macvtapLowerDevice = "eth0"
 		macvtapNetworkName = "net1"
 	)
-
-	BeforeEach(func() {
-		config.EnableFeatureGate(virtconfig.NetworkBindingPlugingsGate)
-	})
 
 	BeforeEach(func() {
 		const macvtapBindingName = "macvtap"

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -37,7 +37,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -55,10 +54,6 @@ import (
 
 var _ = SIGDescribe("[Serial] VirtualMachineInstance with passt network binding plugin", decorators.NetCustomBindingPlugins, Serial, func() {
 	var err error
-
-	BeforeEach(func() {
-		config.EnableFeatureGate(virtconfig.NetworkBindingPlugingsGate)
-	})
 
 	BeforeEach(func() {
 		const passtBindingName = "passt"

--- a/tests/network/bindingplugin_slirp.go
+++ b/tests/network/bindingplugin_slirp.go
@@ -35,7 +35,6 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
@@ -51,10 +50,6 @@ import (
 var _ = SIGDescribe("Slirp", decorators.Networking, decorators.NetCustomBindingPlugins, Serial, func() {
 
 	BeforeEach(libnet.SkipWhenClusterNotSupportIpv4)
-
-	BeforeEach(func() {
-		config.EnableFeatureGate(virtconfig.NetworkBindingPlugingsGate)
-	})
 
 	const slirpBindingName = "slirp"
 

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -44,7 +44,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/network/istio"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -468,10 +467,6 @@ var istioTestsWithMasqueradeBinding = func() {
 }
 
 var istioTestsWithPasstBinding = func() {
-	BeforeEach(func() {
-		config.EnableFeatureGate(virtconfig.NetworkBindingPlugingsGate)
-	})
-
 	BeforeEach(func() {
 		const passtBindingName = "passt"
 		passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")


### PR DESCRIPTION
### What this PR does

The network binding plugins feature has been introduce back in v1.1.0, over a year ago.
Since, it has seen wide adoption in the community with multiple plugin vendors that introduced various network bindings through it.

The feature has reached a level of maturity, allowing it to be declared GA for the coming release.

The network binding plugins feature has a Feature Gate which is now marked as GA in the next Kubevirt release (v1.5).

Production and e2e testing code no longer depend on it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Network Binding Plugin feature is declared GA
```

