### PR TITLE
Add description to migration failures [test_id:2303]

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1452,7 +1452,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 						}
 						vmi = migratingVMI
 						return true
-					}, 60*time.Second, 1*time.Second).Should(BeTrue())
+					}, 60*time.Second, 1*time.Second).Should(BeTrue(), "Timed out waiting for migration state to include TargetNodeAddress and TargetDirectMigrationNodePorts")
 
 					By("checking if we fail to connect with our own cert")
 					tlsConfig := temporaryTLSConfig()


### PR DESCRIPTION
### What this PR does
This PR adds a description to the eventually block failure at [test_id:2303]
without description it's hard to understand the cause of failure

Example:
```tests/migration/migration.go:1517
Timed out after 60.000s.
Expected
    <bool>: false
to be true
tests/migration/migration.go:1552
```

### Release note
```release-note
None
```

