### PR TITLE
Device plugin should be able to register multiple identical PCI devices in an IOMMU group

### DIFF
--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -252,7 +252,8 @@ func formatVFIODeviceSpecs(devID string) []*v1beta1.DeviceSpec {
 		Permissions:   "mrw",
 	})
 
-	vfioDevice := filepath.Join(vfioDevicePath, devID)
+	iommuGroup := strings.Split(devID, deviceIDSeparator)[0]
+	vfioDevice := filepath.Join(vfioDevicePath, iommuGroup)
 	devSpecs = append(devSpecs, &v1beta1.DeviceSpec{
 		HostPath:      vfioDevice,
 		ContainerPath: vfioDevice,

--- a/pkg/virt-handler/device-manager/mediated_device_test.go
+++ b/pkg/virt-handler/device-manager/mediated_device_test.go
@@ -26,6 +26,7 @@ const (
 	fakeMdevResourceName      = "example.org/fake123"
 	fakeMdevUUID              = "53764d0e-85a0-42b4-af5c-2046b460b1dc"
 	fakeIntelMdevUUID         = "54444d0e-85a0-42b4-af5c-2046b4bbb1aa"
+	fakeAddress               = "0000:00:00.0"
 )
 
 var _ = Describe("Mediated Device", func() {

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -1,8 +1,8 @@
 package device_manager
 
 import (
-	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/golang/mock/gomock"
@@ -19,13 +19,13 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
 )
 
 const (
 	fakeName       = "example.org/deadbeef"
 	fakeID         = "dead:beef"
 	fakeDriver     = "vfio-pci"
-	fakeAddress    = "0000:00:00.0"
 	fakeIommuGroup = "0"
 	fakeNumaNode   = 0
 )
@@ -36,30 +36,35 @@ var _ = Describe("PCI Device", func() {
 	var fakePermittedHostDevices v1.PermittedHostDevices
 	var ctrl *gomock.Controller
 	var clientTest *fake.Clientset
+	var fakeAddress string
+	var pciAddresses []string
 
 	BeforeEach(func() {
 		clientTest = fake.NewSimpleClientset()
-		By("making sure the environment has a PCI device at " + fakeAddress)
-		_, err := os.Stat("/sys/bus/pci/devices/" + fakeAddress)
-		if errors.Is(err, os.ErrNotExist) {
-			Skip("No PCI device found at " + fakeAddress + ", can't run PCI tests")
+		By("making sure the environment has a PCI device")
+		err := filepath.Walk(pciBasePath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				pciAddresses = append(pciAddresses, info.Name())
+			}
+			return nil
+		})
+		if err != nil || len(pciAddresses) == 0 {
+			Skip("No PCI devices found")
 		}
+		fakeAddress = pciAddresses[0]
 
 		By("mocking PCI functions to simulate a vfio-pci device at " + fakeAddress)
 		ctrl = gomock.NewController(GinkgoT())
 		mockPCI = NewMockDeviceHandler(ctrl)
 		Handler = mockPCI
-		// Force pre-defined returned values and ensure the function only get called exacly once each on 0000:00:00.0
+		// Force pre-defined returned values and ensure the function only get called exacly once each for the address
 		mockPCI.EXPECT().GetDeviceIOMMUGroup(pciBasePath, fakeAddress).Return(fakeIommuGroup, nil).Times(1)
 		mockPCI.EXPECT().GetDeviceDriver(pciBasePath, fakeAddress).Return(fakeDriver, nil).Times(1)
 		mockPCI.EXPECT().GetDeviceNumaNode(pciBasePath, fakeAddress).Return(fakeNumaNode).Times(1)
 		mockPCI.EXPECT().GetDevicePCIID(pciBasePath, fakeAddress).Return(fakeID, nil).Times(1)
-		// Allow the regular functions to be called for all the other devices, they're harmless.
-		// Just force the driver to NOT vfio-pci to ensure they all get ignored.
-		mockPCI.EXPECT().GetDeviceIOMMUGroup(pciBasePath, gomock.Any()).AnyTimes()
-		mockPCI.EXPECT().GetDeviceDriver(pciBasePath, gomock.Any()).Return("definitely-not-vfio-pci", nil).AnyTimes()
-		mockPCI.EXPECT().GetDeviceNumaNode(pciBasePath, gomock.Any()).AnyTimes()
-		mockPCI.EXPECT().GetDevicePCIID(pciBasePath, gomock.Any()).AnyTimes()
 
 		By("creating a list of fake device using the yaml decoder")
 		fakePermittedHostDevicesConfig = `
@@ -75,6 +80,7 @@ pciHostDevices:
 	})
 
 	It("Should parse the permitted devices and find 1 matching PCI device", func() {
+		allowAnyDeviceCalls(*mockPCI)
 		supportedPCIDeviceMap := make(map[string]string)
 		for _, pciDev := range fakePermittedHostDevices.PciHostDevices {
 			// do not add a device plugin for this resource if it's being provided via an external device plugin
@@ -83,7 +89,7 @@ pciHostDevices:
 			}
 		}
 		// discoverPermittedHostPCIDevices() will walk real PCI devices wherever the tests are running
-		// It's assumed here that it will find a PCI device at 0000:00:00.0
+		// It's assumed here that it will find a PCI device
 		devices := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)
 		Expect(devices).To(HaveLen(1), "only one PCI device is expected to be found")
 		Expect(devices[fakeName]).To(HaveLen(1), "only one PCI device is expected to be found")
@@ -95,6 +101,7 @@ pciHostDevices:
 	})
 
 	It("Should validate DPI devices", func() {
+		allowAnyDeviceCalls(*mockPCI)
 		iommuToPCIMap := make(map[string]string)
 		supportedPCIDeviceMap := make(map[string]string)
 		for _, pciDev := range fakePermittedHostDevices.PciHostDevices {
@@ -104,13 +111,57 @@ pciHostDevices:
 			}
 		}
 		// discoverPermittedHostPCIDevices() will walk real PCI devices wherever the tests are running
-		// It's assumed here that it will find a PCI device at 0000:00:00.0
+		// It's assumed here that it will find a PCI device
 		pciDevices := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)
 		devs := constructDPIdevices(pciDevices[fakeName], iommuToPCIMap)
-		Expect(devs[0].ID).To(Equal(fakeIommuGroup))
+		Expect(devs[0].ID).To(Equal(strings.Join([]string{fakeIommuGroup, fakeAddress}, deviceIDSeparator)))
 		Expect(devs[0].Topology.Nodes[0].ID).To(Equal(int64(fakeNumaNode)))
 	})
+
+	It("Should validate multiple devices in IOMMU group", func() {
+		By("making sure the environment has at least 2 PCI devices")
+		if len(pciAddresses) < 2 {
+			Skip("the second PCI device was not found")
+		}
+		secondFakeAddress := pciAddresses[1]
+		By("mocking PCI functions to simulate a vfio-pci device at " + secondFakeAddress)
+		mockPCI.EXPECT().GetDeviceIOMMUGroup(pciBasePath, secondFakeAddress).Return(fakeIommuGroup, nil).Times(1)
+		mockPCI.EXPECT().GetDeviceDriver(pciBasePath, secondFakeAddress).Return(fakeDriver, nil).Times(1)
+		mockPCI.EXPECT().GetDeviceNumaNode(pciBasePath, secondFakeAddress).Return(fakeNumaNode).Times(1)
+		mockPCI.EXPECT().GetDevicePCIID(pciBasePath, secondFakeAddress).Return(fakeID, nil).Times(1)
+		allowAnyDeviceCalls(*mockPCI)
+
+		iommuToPCIMap := make(map[string]string)
+		supportedPCIDeviceMap := make(map[string]string)
+		for _, pciDev := range fakePermittedHostDevices.PciHostDevices {
+			// do not add a device plugin for this resource if it's being provided via an external device plugin
+			if !pciDev.ExternalResourceProvider {
+				supportedPCIDeviceMap[pciDev.PCIVendorSelector] = pciDev.ResourceName
+			}
+		}
+
+		pciDevices := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)
+		Expect(pciDevices[fakeName]).To(HaveLen(2), "two PCI device are expected to be found for: "+fakeName)
+		devs := constructDPIdevices(pciDevices[fakeName], iommuToPCIMap)
+		Expect(devs).To(HaveLen(2))
+		Expect(iommuToPCIMap).To(HaveLen(2))
+		devID := strings.Join([]string{fakeIommuGroup, fakeAddress}, deviceIDSeparator)
+		secondDevID := strings.Join([]string{fakeIommuGroup, secondFakeAddress}, deviceIDSeparator)
+		Expect(iommuToPCIMap).To(HaveKeyWithValue(devID, fakeAddress))
+		Expect(iommuToPCIMap).To(HaveKeyWithValue(secondDevID, secondFakeAddress))
+
+		devSpec := formatVFIODeviceSpecs(devID)
+		Expect(devSpec).To(HaveLen(2))
+		vfioDevice := filepath.Join(vfioDevicePath, fakeIommuGroup)
+		Expect(devSpec).To(ContainElement(&v1beta1.DeviceSpec{
+			HostPath:      vfioDevice,
+			ContainerPath: vfioDevice,
+			Permissions:   "mrw",
+		}))
+	})
+
 	It("Should update the device list according to the configmap", func() {
+		allowAnyDeviceCalls(*mockPCI)
 		By("creating a cluster config")
 		kv := &v1.KubeVirt{
 			ObjectMeta: metav1.ObjectMeta{
@@ -174,3 +225,12 @@ pciHostDevices:
 		Ω(disabledDevicePlugins).Should(HaveKey(fakeName))
 	})
 })
+
+// Allow the regular functions to be called for all the other devices, they're harmless.
+// Just force the driver to NOT vfio-pci to ensure they all get ignored.
+func allowAnyDeviceCalls(mockPCI MockDeviceHandler) {
+	mockPCI.EXPECT().GetDeviceIOMMUGroup(pciBasePath, gomock.Any()).AnyTimes()
+	mockPCI.EXPECT().GetDeviceDriver(pciBasePath, gomock.Any()).Return("definitely-not-vfio-pci", nil).AnyTimes()
+	mockPCI.EXPECT().GetDeviceNumaNode(pciBasePath, gomock.Any()).AnyTimes()
+	mockPCI.EXPECT().GetDevicePCIID(pciBasePath, gomock.Any()).AnyTimes()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
This PR is based on the draft PR #11620 by @henviso

### What this PR does
This PR is fixing a bug in the `virt-handler` device manager.

Before this PR:
When multiple identical PCI devices on the node are sharing an IOMMU group, only one of those PCI devices will be registered and allocatable.

After this PR:
Multiple identical PCI devices on the node registered individually and made allocatable.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #7755 and #11412

### Why we need it and why it was done in this way
Consider the following case(the screen shots are from the real system):
One of the cluster nodes reveals the following PCI devices in IOMMU group 13:
```
...
IOMMU Group 13 46:1f.0 PCI bridge [0604]: Broadcom / LSI PEX880xx PCIe Gen 4 Switch [1000:c010] (rev b0)
        Kernel driver in use: pcieport
IOMMU Group 13 47:00.0 3D controller [0302]: NVIDIA Corporation GA100 [A100 SXM4 40GB] [10de:20b0] (rev a1)
        Subsystem: NVIDIA Corporation Device [10de:134f]
        Kernel driver in use: vfio-pci
        Kernel modules: nouveau
IOMMU Group 13 4c:00.0 PCI bridge [0604]: Broadcom / LSI PEX880xx PCIe Gen 4 Switch [1000:c010] (rev b0)
        Kernel driver in use: pcieport
IOMMU Group 13 4d:00.0 3D controller [0302]: NVIDIA Corporation GA100 [A100 SXM4 40GB] [10de:20b0] (rev a1)
        Subsystem: NVIDIA Corporation Device [10de:134f]
        Kernel driver in use: vfio-pci
        Kernel modules: nouveau
IOMMU Group 13 52:00.0 PCI bridge [0604]: Broadcom / LSI PEX880xx PCIe Gen 4 Switch [1000:c010] (rev b0)
...
```
The devices at `47:00.0` and `4d:00.0` are identical GPU devices with a resource name: `nvidia.com/GA100_A100_SXM4_40GB` and a vendor selector: `10de:20b0`,
and the following kubevirt CR setting is used:
```
permittedHostDevices:
      pciHostDevices:
      - pciVendorSelector: 10de:20b0
        resourceName: nvidia.com/GA100_A100_SXM4_40GB
```
With the current virt-handler device manager implementation only one of the 2 devices will be allocatable and the node Capacity\Allocatable sections will look as follows:
```
  cpu:                              256
  devices.kubevirt.io/kvm:          1k
  devices.kubevirt.io/tun:          1k
  devices.kubevirt.io/vhost-net:    1k
  ephemeral-storage:                1873933640Ki
  hugepages-1Gi:                    700Gi
  hugepages-2Mi:                    0
  memory:                           1056633552Ki
  nvidia.com/GA100_A100_SXM4_40GB:  1
  pods:                             250
```
After this PR we will get `nvidia.com/GA100_A100_SXM4_40GB:  2` as expected.
Note that this issue doesn't exist in case of the same 2 PCI devices in different IOMMU groups.
The root cause for the bug is that the virt-handle device manager PCIDevicePlugin assumes that each PCI device with the given resourceName/pciVendorSelector belongs to a different IOMMU group, so the IOMMU group number can be used as a unique  key for mapping PCI devices.
The PR proposal is to change the mapping key and to use iommuGroup+separator+pciAddress as a unique key for each PCI device.

The code was successfully tested fixing the issue above.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

