### PR TITLE
virt-operator: Add a service component to virt-controller

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -84,8 +84,8 @@ const (
 
 	NAMESPACE = "kubevirt-test"
 
-	resourceCount = 77
-	patchCount    = 50
+	resourceCount = 78
+	patchCount    = 51
 	updateCount   = 28
 )
 
@@ -1216,6 +1216,7 @@ func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymen
 	all = append(all, components.NewOperatorWebhookService(NAMESPACE))
 	all = append(all, components.NewPrometheusService(NAMESPACE))
 	all = append(all, components.NewApiServerService(NAMESPACE))
+	all = append(all, components.NewControllerService(NAMESPACE))
 	all = append(all, components.NewExportProxyService(NAMESPACE))
 
 	apiDeployment, _ := getDefaultVirtApiDeployment(NAMESPACE, config)
@@ -2406,7 +2407,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kvTestData.controller.stores.RoleCache.List()).To(HaveLen(5))
 			Expect(kvTestData.controller.stores.RoleBindingCache.List()).To(HaveLen(5))
 			Expect(kvTestData.controller.stores.OperatorCrdCache.List()).To(HaveLen(16))
-			Expect(kvTestData.controller.stores.ServiceCache.List()).To(HaveLen(4))
+			Expect(kvTestData.controller.stores.ServiceCache.List()).To(HaveLen(5))
 			Expect(kvTestData.controller.stores.DeploymentCache.List()).To(HaveLen(1))
 			Expect(kvTestData.controller.stores.DaemonSetCache.List()).To(BeEmpty())
 			Expect(kvTestData.controller.stores.ValidationWebhookCache.List()).To(HaveLen(3))

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -118,6 +118,38 @@ func NewApiServerService(namespace string) *corev1.Service {
 	}
 }
 
+func NewControllerService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      VirtControllerName,
+			Labels: map[string]string{
+				virtv1.AppLabel: VirtControllerName,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				virtv1.AppLabel: VirtControllerName,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Port: 443,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 8443,
+					},
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+}
+
 func NewExportProxyService(namespace string) *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -561,6 +561,7 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 
 	strategy.services = append(strategy.services, components.NewPrometheusService(config.GetNamespace()))
 	strategy.services = append(strategy.services, components.NewApiServerService(config.GetNamespace()))
+	strategy.services = append(strategy.services, components.NewControllerService(config.GetNamespace()))
 	strategy.services = append(strategy.services, components.NewOperatorWebhookService(operatorNamespace))
 	strategy.services = append(strategy.services, components.NewExportProxyService(config.GetNamespace()))
 	apiDeployment, err := components.NewApiServerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), productName, productVersion, productComponent, config.VirtApiImage, config.GetImagePullPolicy(), config.GetImagePullSecrets(), config.GetVerbosity(), config.GetExtraEnv())


### PR DESCRIPTION
### What this PR does
Before this PR:
the virt-controller didn't have a service 

After this PR:
adding a `Service` component to virt-controller will help an outside components like hco-controller to access endpoints like `/metrics` to collect metrics when Prometheus is not deployed in the cluster.

### Release note
```release-note
add a service component for virt-controller
```

