### PR TITLE
cleanup(virtctl,create): Apply cleanups to create instancetype and create preference

### DIFF
--- a/pkg/virtctl/create/instancetype/instancetype.go
+++ b/pkg/virtctl/create/instancetype/instancetype.go
@@ -28,15 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/clientcmd"
 	v1 "kubevirt.io/api/core/v1"
-	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"sigs.k8s.io/yaml"
+
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/create/params"
 )
 
 const (
-	Instancetype = "instancetype"
-
 	CPUFlag             = "cpu"
 	MemoryFlag          = "memory"
 	GPUFlag             = "gpu"
@@ -45,10 +44,8 @@ const (
 	NameFlag            = "name"
 	NamespacedFlag      = "namespaced"
 
-	IOThreadErr   = "IOThread must be of value auto or shared"
-	NameErr       = "name must be specified"
-	DeviceNameErr = "deviceName must be specified"
-	CPUErr        = "cpu value must be greater than zero"
+	nameErr       = "name must be specified"
+	deviceNameErr = "deviceName must be specified"
 )
 
 type createInstancetype struct {
@@ -64,19 +61,17 @@ type createInstancetype struct {
 	clientConfig clientcmd.ClientConfig
 }
 
-type GPU struct {
+type gpu struct {
 	Name       string `param:"name"`
 	DeviceName string `param:"devicename"`
 }
 
-type HostDevice struct {
+type hostDevice struct {
 	Name       string `param:"name"`
 	DeviceName string `param:"devicename"`
 }
 
-type optionFn func(*createInstancetype, *instancetypev1beta1.VirtualMachineInstancetypeSpec) error
-
-var optFns = map[string]optionFn{
+var optFns = map[string]func(*createInstancetype, *instancetypev1beta1.VirtualMachineInstancetypeSpec) error{
 	GPUFlag:             withGPUs,
 	HostDeviceFlag:      withHostDevices,
 	IOThreadsPolicyFlag: withIOThreadsPolicy,
@@ -87,12 +82,10 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		clientConfig: clientConfig,
 	}
 	cmd := &cobra.Command{
-		Use:     Instancetype,
+		Use:     "instancetype",
 		Short:   "Create VirtualMachineInstancetype or VirtualMachineClusterInstancetype manifest.",
 		Example: c.usage(),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return c.run(cmd)
-		},
+		RunE:    c.run,
 	}
 	cmd.Flags().StringVar(&c.name, NameFlag, c.name, "Specify the name of the Instancetype.")
 	cmd.Flags().Uint32Var(&c.cpu, CPUFlag, c.cpu, "Specify the count of CPUs of the Instancetype.")
@@ -105,7 +98,6 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	if err := cmd.MarkFlagRequired(CPUFlag); err != nil {
 		panic(err)
 	}
-
 	if err := cmd.MarkFlagRequired(MemoryFlag); err != nil {
 		panic(err)
 	}
@@ -138,21 +130,19 @@ func (c *createInstancetype) setDefaults(cmd *cobra.Command) error {
 
 func withGPUs(c *createInstancetype, instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec) error {
 	for _, param := range c.gpus {
-		gpu := GPU{}
-
-		if err := params.Map(GPUFlag, param, &gpu); err != nil {
+		obj := gpu{}
+		if err := params.Map(GPUFlag, param, &obj); err != nil {
 			return err
 		}
 
-		if gpu.Name == "" {
-			return params.FlagErr(GPUFlag, NameErr)
+		if obj.Name == "" {
+			return params.FlagErr(GPUFlag, nameErr)
+		}
+		if obj.DeviceName == "" {
+			return params.FlagErr(GPUFlag, deviceNameErr)
 		}
 
-		if gpu.DeviceName == "" {
-			return params.FlagErr(GPUFlag, DeviceNameErr)
-		}
-
-		instancetypeSpec.GPUs = append(instancetypeSpec.GPUs, v1.GPU{Name: gpu.Name, DeviceName: gpu.DeviceName})
+		instancetypeSpec.GPUs = append(instancetypeSpec.GPUs, v1.GPU{Name: obj.Name, DeviceName: obj.DeviceName})
 	}
 
 	return nil
@@ -160,21 +150,19 @@ func withGPUs(c *createInstancetype, instancetypeSpec *instancetypev1beta1.Virtu
 
 func withHostDevices(c *createInstancetype, instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec) error {
 	for _, param := range c.hostDevices {
-		hostDevice := HostDevice{}
-
-		if err := params.Map(HostDeviceFlag, param, &hostDevice); err != nil {
+		obj := hostDevice{}
+		if err := params.Map(HostDeviceFlag, param, &obj); err != nil {
 			return err
 		}
 
-		if hostDevice.Name == "" {
-			return params.FlagErr(HostDeviceFlag, NameErr)
+		if obj.Name == "" {
+			return params.FlagErr(HostDeviceFlag, nameErr)
+		}
+		if obj.DeviceName == "" {
+			return params.FlagErr(HostDeviceFlag, deviceNameErr)
 		}
 
-		if hostDevice.DeviceName == "" {
-			return params.FlagErr(HostDeviceFlag, DeviceNameErr)
-		}
-
-		instancetypeSpec.HostDevices = append(instancetypeSpec.HostDevices, v1.HostDevice{Name: hostDevice.Name, DeviceName: hostDevice.DeviceName})
+		instancetypeSpec.HostDevices = append(instancetypeSpec.HostDevices, v1.HostDevice{Name: obj.Name, DeviceName: obj.DeviceName})
 	}
 
 	return nil
@@ -182,17 +170,16 @@ func withHostDevices(c *createInstancetype, instancetypeSpec *instancetypev1beta
 
 func withIOThreadsPolicy(c *createInstancetype, instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec) error {
 	var policy v1.IOThreadsPolicy
-
 	switch c.ioThreadsPolicy {
 	case string(v1.IOThreadsPolicyAuto):
 		policy = v1.IOThreadsPolicyAuto
 	case string(v1.IOThreadsPolicyShared):
 		policy = v1.IOThreadsPolicyShared
 	default:
-		return params.FlagErr(IOThreadsPolicyFlag, IOThreadErr)
+		return params.FlagErr(IOThreadsPolicyFlag, "IOThread must be of value auto or shared")
 	}
-
 	instancetypeSpec.IOThreadsPolicy = &policy
+
 	return nil
 }
 
@@ -213,7 +200,7 @@ func (c *createInstancetype) usage() string {
   {{ProgramName}} create instancetype --cpu 2 --memory 256Mi | kubectl create -f -`
 }
 
-func (c *createInstancetype) newInstancetype(_ *cobra.Command) *instancetypev1beta1.VirtualMachineInstancetype {
+func (c *createInstancetype) newInstancetype() *instancetypev1beta1.VirtualMachineInstancetype {
 	instancetype := &instancetypev1beta1.VirtualMachineInstancetype{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VirtualMachineInstancetype",
@@ -239,7 +226,7 @@ func (c *createInstancetype) newInstancetype(_ *cobra.Command) *instancetypev1be
 	return instancetype
 }
 
-func (c *createInstancetype) newClusterInstancetype(_ *cobra.Command) *instancetypev1beta1.VirtualMachineClusterInstancetype {
+func (c *createInstancetype) newClusterInstancetype() *instancetypev1beta1.VirtualMachineClusterInstancetype {
 	return &instancetypev1beta1.VirtualMachineClusterInstancetype{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VirtualMachineClusterInstancetype",
@@ -277,16 +264,13 @@ func (c *createInstancetype) validateFlags() error {
 	}
 
 	if c.cpu <= 0 {
-		return fmt.Errorf(CPUErr)
+		return fmt.Errorf("cpu value must be greater than zero")
 	}
 
 	return nil
 }
 
-func (c *createInstancetype) run(cmd *cobra.Command) error {
-	var out []byte
-	var err error
-
+func (c *createInstancetype) run(cmd *cobra.Command, _ []string) error {
 	if err := c.setDefaults(cmd); err != nil {
 		return err
 	}
@@ -295,8 +279,10 @@ func (c *createInstancetype) run(cmd *cobra.Command) error {
 		return err
 	}
 
+	var out []byte
+	var err error
 	if c.namespaced {
-		instancetype := c.newInstancetype(cmd)
+		instancetype := c.newInstancetype()
 
 		if err = c.applyFlags(cmd, &instancetype.Spec); err != nil {
 			return err
@@ -307,7 +293,7 @@ func (c *createInstancetype) run(cmd *cobra.Command) error {
 			return err
 		}
 	} else {
-		clusterInstancetype := c.newClusterInstancetype(cmd)
+		clusterInstancetype := c.newClusterInstancetype()
 
 		if err = c.applyFlags(cmd, &clusterInstancetype.Spec); err != nil {
 			return err

--- a/pkg/virtctl/create/instancetype/instancetype_test.go
+++ b/pkg/virtctl/create/instancetype/instancetype_test.go
@@ -19,8 +19,8 @@
 package instancetype_test
 
 import (
-	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -30,6 +30,7 @@ import (
 	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/api/instancetype"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
@@ -43,161 +44,171 @@ import (
 
 var _ = Describe("create instancetype", func() {
 	Context("should fail", func() {
-		DescribeTable("because of required cpu and memory", func(namespaced bool) {
-			args := []string{create.CREATE, Instancetype}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
-			Expect(cmd()).To(MatchError(`required flag(s) "cpu", "memory" not set`))
-		},
-			Entry("VirtualMachineInstancetype", true),
-			Entry("VirtualMachineClusterInstancetype", false),
+		const (
+			ioThreadErr   = "IOThread must be of value auto or shared"
+			nameErr       = "name must be specified"
+			deviceNameErr = "deviceName must be specified"
 		)
 
-		DescribeTable("invalid cpu and memory", func(cpu, memory, errMsg string, namespaced bool) {
-			cmd := clientcmd.NewRepeatableVirtctlCommand(create.CREATE, Instancetype,
+		DescribeTable("because of required cpu and memory", func(extraArgs ...string) {
+			_, err := runCmd(extraArgs...)
+			Expect(err).To(MatchError(`required flag(s) "cpu", "memory" not set`))
+		},
+			Entry("VirtualMachineInstancetype", setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterInstancetype"),
+		)
+
+		DescribeTable("invalid cpu and memory", func(cpu, memory, errMsg string, extraArgs ...string) {
+			args := append([]string{
 				setFlag(CPUFlag, cpu),
 				setFlag(MemoryFlag, memory),
-			)
-			Expect(cmd()).To(MatchError(ContainSubstring(errMsg)))
+			}, extraArgs...)
+			_, err := runCmd(args...)
+			Expect(err).To(MatchError(ContainSubstring(errMsg)))
 		},
-			Entry("VirtualMachineInstancetype invalid cpu string value", "two", "256Mi", `parsing "two": invalid syntax`, true),
-			Entry("VirtualMachineInstancetype invalid cpu negative value", "-2", "256Mi", `parsing "-2": invalid syntax`, true),
-			Entry("VirtualMachineInstancetype invalid memory value", "2", "256My", "quantities must match the regular expression", true),
-			Entry("VirtualMachineClusterInstancetype invalid cpu string value", "two", "256Mi", `parsing "two": invalid syntax`, false),
-			Entry("VirtualMachineClusterInstancetype invalid cpu negative value", "-2", "256Mi", `parsing "-2": invalid syntax`, false),
-			Entry("VirtualMachineClusterInstancetype invalid memory value", "2", "256My", "quantities must match the regular expression", false),
+			Entry("VirtualMachineInstancetype invalid cpu string value", "two", "256Mi", `parsing "two": invalid syntax`, setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype invalid cpu negative value", "-2", "256Mi", `parsing "-2": invalid syntax`, setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype invalid memory value", "2", "256My", "quantities must match the regular expression", setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterInstancetype invalid cpu string value", "two", "256Mi", `parsing "two": invalid syntax`),
+			Entry("VirtualMachineClusterInstancetype invalid cpu negative value", "-2", "256Mi", `parsing "-2": invalid syntax`),
+			Entry("VirtualMachineClusterInstancetype invalid memory value", "2", "256My", "quantities must match the regular expression"),
 		)
 
-		DescribeTable("with invalid arguments", func(flag, param, errMsg string, namespaced bool) {
-			args := []string{create.CREATE, Instancetype,
+		DescribeTable("with invalid arguments", func(errMsg string, extraArgs ...string) {
+			args := append([]string{
 				setFlag(CPUFlag, "1"),
 				setFlag(MemoryFlag, "128Mi"),
-				setFlag(flag, param),
-			}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
-			Expect(cmd()).To(MatchError(ContainSubstring(errMsg)))
+			}, extraArgs...)
+			_, err := runCmd(args...)
+			Expect(err).To(MatchError(ContainSubstring(errMsg)))
 		},
-			Entry("VirtualMachineInstancetype gpu missing name", GPUFlag, "devicename:nvidia", NameErr, true),
-			Entry("VirtualMachineInstancetype gpu missing deviceName", GPUFlag, "name:gpu1", DeviceNameErr, true),
-			Entry("VirtualMachineInstancetype hostdevice missing name", HostDeviceFlag, "devicename:intel", NameErr, true),
-			Entry("VirtualMachineInstancetype hostdevice missing deviceName", HostDeviceFlag, "name:device1", DeviceNameErr, true),
-			Entry("VirtualMachineInstancetype invalid IOThreadsPolicy", IOThreadsPolicyFlag, "invalid-policy", IOThreadErr, true),
-			Entry("VirtualMachineClusterInstancetype gpu missing name", GPUFlag, "devicename:nvidia", NameErr, false),
-			Entry("VirtualMachineClusterInstancetype gpu missing deviceName", GPUFlag, "name:gpu1", DeviceNameErr, false),
-			Entry("VirtualMachineClusterInstancetype hostdevice missing name", HostDeviceFlag, "devicename:intel", NameErr, false),
-			Entry("VirtualMachineClusterInstancetype hostdevice missing deviceName", HostDeviceFlag, "name:device1", DeviceNameErr, false),
-			Entry("VirtualMachineClusterInstancetype invalid IOThreadsPolicy", IOThreadsPolicyFlag, "invalid-policy", IOThreadErr, false),
+			Entry("VirtualMachineInstancetype gpu missing name", nameErr, setFlag(GPUFlag, "devicename:nvidia"), setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype gpu missing deviceName", deviceNameErr, setFlag(GPUFlag, "name:gpu1"), setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype hostdevice missing name", nameErr, setFlag(HostDeviceFlag, "devicename:intel"), setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype hostdevice missing deviceName", deviceNameErr, setFlag(HostDeviceFlag, "name:device1"), setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstancetype invalid IOThreadsPolicy", ioThreadErr, setFlag(IOThreadsPolicyFlag, "invalid-policy"), setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterInstancetype gpu missing name", nameErr, setFlag(GPUFlag, "devicename:nvidia")),
+			Entry("VirtualMachineClusterInstancetype gpu missing deviceName", deviceNameErr, setFlag(GPUFlag, "name:gpu1")),
+			Entry("VirtualMachineClusterInstancetype hostdevice missing name", nameErr, setFlag(HostDeviceFlag, "devicename:intel")),
+			Entry("VirtualMachineClusterInstancetype hostdevice missing deviceName", deviceNameErr, setFlag(HostDeviceFlag, "name:device1")),
+			Entry("VirtualMachineClusterInstancetype invalid IOThreadsPolicy", ioThreadErr, setFlag(IOThreadsPolicyFlag, "invalid-policy")),
 		)
 	})
 
 	Context("should succeed", func() {
-		DescribeTable("with defined cpu and memory", func(namespaced bool) {
-			args := []string{create.CREATE, Instancetype,
+		DescribeTable("with defined cpu and memory", func(extraArgs ...string) {
+			args := append([]string{
 				setFlag(CPUFlag, "2"),
 				setFlag(MemoryFlag, "256Mi"),
-			}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+			}, extraArgs...)
+			out, err := runCmd(args...)
 			Expect(err).ToNot(HaveOccurred())
 
-			spec, err := getInstancetypeSpec(bytes, namespaced)
-			Expect(err).ToNot(HaveOccurred())
+			spec := getInstancetypeSpec(out)
 			Expect(spec.CPU.Guest).To(Equal(uint32(2)))
 			Expect(spec.Memory.Guest).To(Equal(resource.MustParse("256Mi")))
 			Expect(validateInstancetypeSpec(spec)).To(BeEmpty())
 		},
-			Entry("VirtualMachineInstancetype", true),
-			Entry("VirtualMachineClusterInstancetype", false),
+			Entry("VirtualMachineInstancetype", setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterInstancetype"),
 		)
 
-		DescribeTable("with defined gpus", func(namespaced bool) {
-			args := []string{create.CREATE, Instancetype,
+		DescribeTable("with namespaced flag", func(namespaced bool) {
+			out, err := runCmd(
+				setFlag(CPUFlag, "2"),
+				setFlag(MemoryFlag, "256Mi"),
+				setFlag(NamespacedFlag, strconv.FormatBool(namespaced)),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), out)
+			Expect(err).ToNot(HaveOccurred())
+
+			var spec *instancetypev1beta1.VirtualMachineInstancetypeSpec
+			if namespaced {
+				instancetype, ok := decodedObj.(*instancetypev1beta1.VirtualMachineInstancetype)
+				Expect(ok).To(BeTrue())
+				spec = &instancetype.Spec
+			} else {
+				clusterInstancetype, ok := decodedObj.(*instancetypev1beta1.VirtualMachineClusterInstancetype)
+				Expect(ok).To(BeTrue())
+				spec = &clusterInstancetype.Spec
+			}
+
+			Expect(validateInstancetypeSpec(spec)).To(BeEmpty())
+		},
+			Entry("VirtualMachinePreference", true),
+			Entry("VirtualMachineClusterPreference", false),
+		)
+
+		DescribeTable("with defined gpus", func(extraArgs ...string) {
+			args := append([]string{
 				setFlag(CPUFlag, "1"),
 				setFlag(MemoryFlag, "128Mi"),
 				setFlag(GPUFlag, "name:gpu1,devicename:nvidia"),
-			}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+			}, extraArgs...)
+			out, err := runCmd(args...)
 			Expect(err).ToNot(HaveOccurred())
 
-			spec, err := getInstancetypeSpec(bytes, namespaced)
-			Expect(err).ToNot(HaveOccurred())
+			spec := getInstancetypeSpec(out)
 			Expect(spec.GPUs).To(HaveLen(1))
 			Expect(spec.GPUs[0].Name).To(Equal("gpu1"))
 			Expect(spec.GPUs[0].DeviceName).To(Equal("nvidia"))
 			Expect(validateInstancetypeSpec(spec)).To(BeEmpty())
 		},
-			Entry("VirtualMachineInstancetype", true),
-			Entry("VirtualMachineClusterInstancetype", false),
+			Entry("VirtualMachineInstancetype", setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterInstancetype"),
 		)
 
-		DescribeTable("with defined hostDevices", func(namespaced bool) {
-			args := []string{create.CREATE, Instancetype,
+		DescribeTable("with defined hostDevices", func(extraArgs ...string) {
+			args := append([]string{
 				setFlag(CPUFlag, "1"),
 				setFlag(MemoryFlag, "128Mi"),
 				setFlag(HostDeviceFlag, "name:device1,devicename:intel"),
-			}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+			}, extraArgs...)
+			out, err := runCmd(args...)
 			Expect(err).ToNot(HaveOccurred())
 
-			spec, err := getInstancetypeSpec(bytes, namespaced)
-			Expect(err).ToNot(HaveOccurred())
+			spec := getInstancetypeSpec(out)
 			Expect(spec.HostDevices).To(HaveLen(1))
 			Expect(spec.HostDevices[0].Name).To(Equal("device1"))
 			Expect(spec.HostDevices[0].DeviceName).To(Equal("intel"))
 			Expect(validateInstancetypeSpec(spec)).To(BeEmpty())
 		},
-			Entry("VirtualMachineInstancetype", true),
-			Entry("VirtualMachineClusterInstancetype", false),
+			Entry("VirtualMachineInstancetype", setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterInstancetype"),
 		)
 
-		DescribeTable("with valid IOThreadsPolicy", func(policy v1.IOThreadsPolicy, namespaced bool) {
-			args := []string{create.CREATE, Instancetype,
+		DescribeTable("with valid IOThreadsPolicy", func(policy v1.IOThreadsPolicy, extraArgs ...string) {
+			args := append([]string{
 				setFlag(CPUFlag, "1"),
 				setFlag(MemoryFlag, "128Mi"),
 				setFlag(IOThreadsPolicyFlag, string(policy)),
-			}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+			}, extraArgs...)
+			out, err := runCmd(args...)
 			Expect(err).ToNot(HaveOccurred())
 
-			spec, err := getInstancetypeSpec(bytes, namespaced)
-			Expect(err).ToNot(HaveOccurred())
+			spec := getInstancetypeSpec(out)
 			Expect(*spec.IOThreadsPolicy).To(Equal(policy))
 			Expect(validateInstancetypeSpec(spec)).To(BeEmpty())
 		},
-			Entry("VirtualMachineInstacetype set to auto", v1.IOThreadsPolicyAuto, true),
-			Entry("VirtualMachineInstacetype set to shared", v1.IOThreadsPolicyShared, true),
-			Entry("VirtualMachineClusterInstacetype set to auto", v1.IOThreadsPolicyAuto, false),
-			Entry("VirtualMachineClusterInstacetype set to shared", v1.IOThreadsPolicyShared, false),
+			Entry("VirtualMachineInstacetype set to auto", v1.IOThreadsPolicyAuto, setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineInstacetype set to shared", v1.IOThreadsPolicyShared, setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterInstacetype set to auto", v1.IOThreadsPolicyAuto),
+			Entry("VirtualMachineClusterInstacetype set to shared", v1.IOThreadsPolicyShared),
 		)
-
 	})
 
 	It("should create namespaced object and apply namespace when namespace is specified", func() {
 		const namespace = "my-namespace"
-		bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create.CREATE, Instancetype,
+		out, err := runCmd(
 			setFlag(CPUFlag, "1"),
 			setFlag(MemoryFlag, "128Mi"),
 			setFlag("namespace", namespace),
-		)()
+		)
 		Expect(err).ToNot(HaveOccurred())
 
-		decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), bytes)
+		decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), out)
 		Expect(err).ToNot(HaveOccurred())
 
 		instancetype, ok := decodedObj.(*instancetypev1beta1.VirtualMachineInstancetype)
@@ -210,22 +221,26 @@ func setFlag(flag, parameter string) string {
 	return fmt.Sprintf("--%s=%s", flag, parameter)
 }
 
-func getInstancetypeSpec(bytes []byte, namespaced bool) (*instancetypev1beta1.VirtualMachineInstancetypeSpec, error) {
+func runCmd(extraArgs ...string) ([]byte, error) {
+	args := append([]string{create.CREATE, "instancetype"}, extraArgs...)
+	return clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+}
+
+func getInstancetypeSpec(bytes []byte) *instancetypev1beta1.VirtualMachineInstancetypeSpec {
 	decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), bytes)
 	Expect(err).ToNot(HaveOccurred())
 
 	switch obj := decodedObj.(type) {
 	case *instancetypev1beta1.VirtualMachineInstancetype:
-		Expect(namespaced).To(BeTrue())
 		Expect(strings.ToLower(obj.Kind)).To(Equal(instancetype.SingularResourceName))
-		return &obj.Spec, nil
+		return &obj.Spec
 	case *instancetypev1beta1.VirtualMachineClusterInstancetype:
-		Expect(namespaced).To(BeFalse())
 		Expect(strings.ToLower(obj.Kind)).To(Equal(instancetype.ClusterSingularResourceName))
-		return &obj.Spec, nil
+		return &obj.Spec
+	default:
+		Fail("object must be VirtualMachineInstance or VirtualMachineClusterInstancetype")
+		return nil
 	}
-
-	return nil, errors.New("object must be VirtualMachineInstance or VirtualMachineClusterInstancetype")
 }
 
 func validateInstancetypeSpec(spec *instancetypev1beta1.VirtualMachineInstancetypeSpec) []k8sv1.StatusCause {

--- a/pkg/virtctl/create/preference/preference_test.go
+++ b/pkg/virtctl/create/preference/preference_test.go
@@ -20,6 +20,7 @@ package preference_test
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,100 +41,106 @@ import (
 )
 
 var _ = Describe("create preference", func() {
-	DescribeTable("should fail with invalid CPU topology values", func(topology string, namespaced bool) {
-		args := []string{create.CREATE, Preference,
+	DescribeTable("should fail with invalid CPU topology values", func(topology string, extraArgs ...string) {
+		args := append([]string{
 			setFlag(CPUTopologyFlag, topology),
-		}
-		if namespaced {
-			args = append(args, setFlag(NamespacedFlag, "true"))
-		}
-		cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
-		Expect(cmd()).To(MatchError(ContainSubstring(CPUTopologyErr)))
+		}, extraArgs...)
+		_, err := runCmd(args...)
+		Expect(err).To(MatchError(ContainSubstring("CPU topology must have a value of sockets, cores, threads or spread")))
 	},
-		Entry("VirtualMachinePreference", "invalidCPU", true),
-		Entry("VirtualMachineClusterPreference", "clusterInvalidCPU", false),
+		Entry("VirtualMachinePreference", "invalidCPU", setFlag(NamespacedFlag, "true")),
+		Entry("VirtualMachineClusterPreference", "clusterInvalidCPU"),
 	)
 
 	Context("should succeed", func() {
-		DescribeTable("without arguments", func(namespaced bool) {
-			args := []string{create.CREATE, Preference}
+		It("without flags", func() {
+			out, err := runCmd()
+			Expect(err).ToNot(HaveOccurred())
+
+			decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), out)
+			Expect(err).ToNot(HaveOccurred())
+			clusterPreference, ok := decodedObj.(*instancetypev1beta1.VirtualMachineClusterPreference)
+			Expect(ok).To(BeTrue())
+			Expect(validatePreferenceSpec(&clusterPreference.Spec)).To(BeEmpty())
+		})
+
+		DescribeTable("with namespaced flag", func(namespaced bool) {
+			out, err := runCmd(setFlag(NamespacedFlag, strconv.FormatBool(namespaced)))
+			Expect(err).ToNot(HaveOccurred())
+
+			decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), out)
+			Expect(err).ToNot(HaveOccurred())
+
+			var spec *instancetypev1beta1.VirtualMachinePreferenceSpec
 			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
+				preference, ok := decodedObj.(*instancetypev1beta1.VirtualMachinePreference)
+				Expect(ok).To(BeTrue())
+				spec = &preference.Spec
+			} else {
+				clusterPreference, ok := decodedObj.(*instancetypev1beta1.VirtualMachineClusterPreference)
+				Expect(ok).To(BeTrue())
+				spec = &clusterPreference.Spec
 			}
-			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
-			Expect(cmd()).To(Succeed())
+
+			Expect(validatePreferenceSpec(spec)).To(BeEmpty())
 		},
 			Entry("VirtualMachinePreference", true),
 			Entry("VirtualMachineClusterPreference", false),
 		)
 
-		DescribeTable("with defined preferred storage class", func(storageClass string, namespaced bool) {
-			args := []string{create.CREATE, Preference,
+		DescribeTable("with defined preferred storage class", func(storageClass string, extraArgs ...string) {
+			args := append([]string{
 				setFlag(VolumeStorageClassFlag, storageClass),
-			}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+			}, extraArgs...)
+			out, err := runCmd(args...)
 			Expect(err).ToNot(HaveOccurred())
 
-			spec, err := getPreferenceSpec(bytes, namespaced)
-			Expect(err).ToNot(HaveOccurred())
+			spec := getPreferenceSpec(out)
 			Expect(spec.Volumes.PreferredStorageClassName).To(Equal(storageClass))
 			Expect(validatePreferenceSpec(spec)).To(BeEmpty())
 		},
-			Entry("VirtualMachinePreference", "testing-storage", true),
-			Entry("VirtualMachineClusterPreference", "hostpath-provisioner", false),
+			Entry("VirtualMachinePreference", "testing-storage", setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterPreference", "hostpath-provisioner"),
 		)
 
-		DescribeTable("with defined machine type", func(machineType string, namespaced bool) {
-			args := []string{create.CREATE, Preference,
+		DescribeTable("with defined machine type", func(machineType string, extraArgs ...string) {
+			args := append([]string{
 				setFlag(MachineTypeFlag, machineType),
-			}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+			}, extraArgs...)
+			out, err := runCmd(args...)
 			Expect(err).ToNot(HaveOccurred())
 
-			spec, err := getPreferenceSpec(bytes, namespaced)
-			Expect(err).ToNot(HaveOccurred())
+			spec := getPreferenceSpec(out)
 			Expect(spec.Machine.PreferredMachineType).To(Equal(machineType))
 			Expect(validatePreferenceSpec(spec)).To(BeEmpty())
 		},
-			Entry("VirtualMachinePreference", "pc-i440fx-2.10", true),
-			Entry("VirtualMachineClusterPreference", "pc-q35-2.10", false),
+			Entry("VirtualMachinePreference", "pc-i440fx-2.10", setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterPreference", "pc-q35-2.10"),
 		)
 
-		DescribeTable("with defined CPU topology", func(topology instancetypev1beta1.PreferredCPUTopology, namespaced bool) {
-			args := []string{create.CREATE, Preference,
+		DescribeTable("with defined CPU topology", func(topology instancetypev1beta1.PreferredCPUTopology, extraArgs ...string) {
+			args := append([]string{
 				setFlag(CPUTopologyFlag, string(topology)),
-			}
-			if namespaced {
-				args = append(args, setFlag(NamespacedFlag, "true"))
-			}
-			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+			}, extraArgs...)
+			out, err := runCmd(args...)
 			Expect(err).ToNot(HaveOccurred())
 
-			spec, err := getPreferenceSpec(bytes, namespaced)
-			Expect(err).ToNot(HaveOccurred())
+			spec := getPreferenceSpec(out)
 			Expect(spec.CPU.PreferredCPUTopology).ToNot(BeNil())
 			Expect(*spec.CPU.PreferredCPUTopology).To(Equal(topology))
 			Expect(validatePreferenceSpec(spec)).To(BeEmpty())
 		},
-			Entry("VirtualMachinePreference", instancetypev1beta1.DeprecatedPreferCores, true),
-			Entry("VirtualMachineClusterPreference", instancetypev1beta1.DeprecatedPreferThreads, false),
+			Entry("VirtualMachinePreference", instancetypev1beta1.DeprecatedPreferCores, setFlag(NamespacedFlag, "true")),
+			Entry("VirtualMachineClusterPreference", instancetypev1beta1.DeprecatedPreferThreads),
 		)
 	})
 
 	It("should create namespaced object and apply namespace when namespace is specified", func() {
 		const namespace = "my-namespace"
-		bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create.CREATE, Preference,
-			setFlag("namespace", namespace),
-		)()
+		out, err := runCmd(setFlag("namespace", namespace))
 		Expect(err).ToNot(HaveOccurred())
 
-		decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), bytes)
+		decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), out)
 		Expect(err).ToNot(HaveOccurred())
 
 		preference, ok := decodedObj.(*instancetypev1beta1.VirtualMachinePreference)
@@ -146,22 +153,26 @@ func setFlag(flag, parameter string) string {
 	return fmt.Sprintf("--%s=%s", flag, parameter)
 }
 
-func getPreferenceSpec(bytes []byte, namespaced bool) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error) {
+func runCmd(extraArgs ...string) ([]byte, error) {
+	args := append([]string{create.CREATE, "preference"}, extraArgs...)
+	return clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+}
+
+func getPreferenceSpec(bytes []byte) *instancetypev1beta1.VirtualMachinePreferenceSpec {
 	decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), bytes)
 	Expect(err).ToNot(HaveOccurred())
 
 	switch obj := decodedObj.(type) {
 	case *instancetypev1beta1.VirtualMachinePreference:
-		Expect(namespaced).To(BeTrue())
 		Expect(strings.ToLower(obj.Kind)).To(Equal(instancetype.SingularPreferenceResourceName))
-		return &obj.Spec, nil
+		return &obj.Spec
 	case *instancetypev1beta1.VirtualMachineClusterPreference:
-		Expect(namespaced).To(BeFalse())
 		Expect(strings.ToLower(obj.Kind)).To(Equal(instancetype.ClusterSingularPreferenceResourceName))
-		return &obj.Spec, nil
+		return &obj.Spec
+	default:
+		Fail("object must be VirtualMachinePreference or VirtualMachineClusterPreference")
+		return nil
 	}
-
-	return nil, fmt.Errorf("object must be VirtualMachinePreference or VirtualMachineClusterPreference")
 }
 
 func validatePreferenceSpec(spec *instancetypev1beta1.VirtualMachinePreferenceSpec) []k8sv1.StatusCause {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This applies the following cleanups to the virtctl create preference
subcommand:

- Reorder imports
- Eliminate unnecessary consts
- Unexport struct fields not required to be exported
- Eliminate the optionFn custom type
- Avoid wrapper function by changing signature of run method
- Update examples to not use deprecated consts for cpu topology
- Check all returned errors
- Inline err checks
- Simplify unit tests a little and bring them closer to test structure
  of create vm
- Add test case for namespaced flag

and the following cleanups to the virtctl create instancetype
subcommand:

- Reorder imports
- Eliminate unnecessary consts
- Unexport structs not required to be exported
- Eliminate the optionFn custom type
- Avoid wrapper function by changing signature of run method
- Avoid variable/import naming collisions
- Drop unused cobra.Command arg from method signatures
- Simplify unit tests a little and bring them closer to test structure
  of create vm
- Add test case for namespaced flag

Furthermore it makes the helpers in virtctl create instancetype and virtctl create
preference methods of the respective command struct to be consistent
with virtctl create vm.

Before this PR:

virtctl create preference uses outdated constants in examples.
virtctl create instancetype and prefererence need some cleanups.

After this PR:

virtctl create preference uses up to date constants in examples.
Cleanups are applied to virtctl create instancetype and prefererence.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

