### PR TITLE
tests/numa: add stdout to error description on failure

### DIFF
--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -118,7 +118,7 @@ func getQEMUPID(handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
 				fmt.Sprintf("grep -l '[g]uest=%s_%s' /proc/*/cmdline", vmi.Namespace, vmi.Name),
 			})
 		return err
-	}, 3*time.Second, 500*time.Millisecond).Should(Succeed(), stderr)
+	}, 3*time.Second, 500*time.Millisecond).Should(Succeed(), stderr, stdout)
 
 	strs := strings.Split(stdout, "\n")
 	Expect(strs).To(HaveLen(2), "more (or less?) than one matching process was found")


### PR DESCRIPTION
### What this PR does
adds stdout to the description failure on numa test when commands fails

example :

```
Expected success, but got an error:
    <exec.CodeExitError>: 
    command terminated with exit code 2
    {
        Err: <*errors.errorString | 0xc005fddab0>{
            s: "command terminated with exit code 2",
        },
        Code: 2,
    } 
```

### Release note
```release-note
None
```

