### PR TITLE
virt-handler: Improve unit test to catch corruption

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
     deps = [
         "//pkg/certificates:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/controller/testing:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/network/cache:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
With https://github.com/kubevirt/kubevirt/pull/13068 we can prevent the cache corruption in virt-handler.

Also, improved event expectations using `Receive()` gomega matcher

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

