### PR TITLE
[release-1.4] volume migration tests: add decorators for tests that have block requirements

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -54,9 +54,12 @@ var (
 	RequiresHugepages2Mi                 = Label("requireHugepages2Mi")
 
 	// Storage classes
+	// Requires a storage class with support for snapshots
 	RequiresSnapshotStorageClass = Label("RequiresSnapshotStorageClass")
 	// Requires a storage class without support for snapshots
 	RequiresNoSnapshotStorageClass = Label("RequiresNoSnapshotStorageClass")
+	// Requires a storage class with ReadWriteMany Block support
+	RequiresRWXBlock = Label("RequiresRWXBlock")
 	// Kubernetes versions
 	Kubernetes130 = Label("kubernetes130")
 	// WG archs

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -60,6 +60,8 @@ var (
 	RequiresNoSnapshotStorageClass = Label("RequiresNoSnapshotStorageClass")
 	// Requires a storage class with ReadWriteMany Block support
 	RequiresRWXBlock = Label("RequiresRWXBlock")
+	// Requires a storage class with Block storage support
+	RequiresBlockStorage = Label("RequiresBlockStorage")
 	// Kubernetes versions
 	Kubernetes130 = Label("kubernetes130")
 	// WG archs

--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -163,10 +162,7 @@ func createPVC(pvc *k8sv1.PersistentVolumeClaim, namespace string) *k8sv1.Persis
 }
 
 func CreateFSPVC(name, namespace, size string, labels map[string]string) *k8sv1.PersistentVolumeClaim {
-	sc, exists := GetRWOFileSystemStorageClass()
-	if !exists {
-		Skip("Skip test when RWOFileSystem storage class is not present")
-	}
+	sc, _ := GetRWOFileSystemStorageClass()
 	pvc := NewPVC(name, size, sc)
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 	pvc.Spec.VolumeMode = &volumeMode
@@ -182,10 +178,7 @@ func CreateFSPVC(name, namespace, size string, labels map[string]string) *k8sv1.
 }
 
 func CreateBlockPVC(name, namespace, size string) *k8sv1.PersistentVolumeClaim {
-	sc, exists := GetRWOBlockStorageClass()
-	if !exists {
-		Skip("Skip test when RWOBlock storage class is not present")
-	}
+	sc, _ := GetRWOBlockStorageClass()
 	pvc := NewPVC(name, size, sc)
 	volumeMode := k8sv1.PersistentVolumeBlock
 	pvc.Spec.VolumeMode = &volumeMode
@@ -394,10 +387,7 @@ func CreateNFSPvAndPvc(name string, namespace string, size string, nfsTargetIP s
 func newNFSPV(name string, namespace string, size string, nfsTargetIP string, os string) *k8sv1.PersistentVolume {
 	quantity := resource.MustParse(size)
 
-	storageClass, exists := GetRWOFileSystemStorageClass()
-	if !exists {
-		Skip("Skip test when Filesystem storage is not present")
-	}
+	storageClass, _ := GetRWOFileSystemStorageClass()
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 
 	nfsTargetIP = ip.NormalizeIPAddress(nfsTargetIP)
@@ -431,10 +421,7 @@ func newNFSPVC(name string, namespace string, size string, os string) *k8sv1.Per
 	quantity, err := resource.ParseQuantity(size)
 	util.PanicOnError(err)
 
-	storageClass, exists := GetRWOFileSystemStorageClass()
-	if !exists {
-		Skip("Skip test when Filesystem storage is not present")
-	}
+	storageClass, _ := GetRWOFileSystemStorageClass()
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 
 	return &k8sv1.PersistentVolumeClaim{

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -275,7 +275,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		},
 			Entry("to a filesystem volume", fsPVC),
-			Entry("to a block volume", blockPVC),
+			Entry("to a block volume", decorators.RequiresBlockStorage, blockPVC),
 		)
 
 		It("should migrate the source volume from a source DV to a destination DV", func() {
@@ -331,7 +331,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		})
 
-		It("should migrate the source volume from a block source and filesystem destination DVs", func() {
+		It("should migrate the source volume from a block source and filesystem destination DVs", decorators.RequiresBlockStorage, func() {
 			volName := "disk0"
 			sc, exist := libstorage.GetRWOBlockStorageClass()
 			Expect(exist).To(BeTrue())

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -51,6 +51,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -293,7 +294,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		})
 
-		It("should migrate the source volume from a source and destination block RWX DVs", func() {
+		It("should migrate the source volume from a source and destination block RWX DVs", decorators.RequiresRWXBlock, func() {
 			volName := "disk0"
 			sc, exist := libstorage.GetRWXBlockStorageClass()
 			Expect(exist).To(BeTrue())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport of https://github.com/kubevirt/kubevirt/pull/13137

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

