### PR TITLE
[release-1.4] net, setup: Set const name for tap associated with VM's primary iface

### DIFF
--- a/pkg/network/domainspec/generators.go
+++ b/pkg/network/domainspec/generators.go
@@ -41,12 +41,14 @@ type LibvirtSpecGenerator interface {
 
 func NewTapLibvirtSpecGenerator(
 	iface *v1.Interface,
+	network v1.Network,
 	domain *api.Domain,
 	podInterfaceName string,
 	handler netdriver.NetworkHandler,
 ) *TapLibvirtSpecGenerator {
 	return &TapLibvirtSpecGenerator{
 		vmiSpecIface:     iface,
+		vmiSpecNetwork:   network,
 		domain:           domain,
 		podInterfaceName: podInterfaceName,
 		handler:          handler,
@@ -55,6 +57,7 @@ func NewTapLibvirtSpecGenerator(
 
 type TapLibvirtSpecGenerator struct {
 	vmiSpecIface     *v1.Interface
+	vmiSpecNetwork   v1.Network
 	domain           *api.Domain
 	podInterfaceName string
 	handler          netdriver.NetworkHandler
@@ -108,7 +111,7 @@ func (b *TapLibvirtSpecGenerator) discoverDomainIfaceSpec() (*api.Interface, err
 // The method tries to find a tap device based on the hashed network name
 // in case such device doesn't exist, the pod interface is used as the target
 func (b *TapLibvirtSpecGenerator) getTargetName() (string, error) {
-	tapName := virtnetlink.GenerateTapDeviceName(b.podInterfaceName)
+	tapName := virtnetlink.GenerateTapDeviceName(b.podInterfaceName, b.vmiSpecNetwork)
 	if _, err := b.handler.LinkByName(tapName); err != nil {
 		var linkNotFoundErr netlink.LinkNotFoundError
 		if errors.As(err, &linkNotFoundErr) {

--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -81,7 +81,12 @@ var _ = Describe("Pod Network", func() {
 				tapInterface = &netlink.GenericLink{LinkAttrs: netlink.LinkAttrs{Name: tapName}}
 				mockNetwork.EXPECT().LinkByName(primaryPodIfaceName).Return(iface, nil)
 				specGenerator = NewTapLibvirtSpecGenerator(
-					&vmi.Spec.Domain.Devices.Interfaces[0], domain, primaryPodIfaceName, mockNetwork)
+					&vmi.Spec.Domain.Devices.Interfaces[0],
+					vmi.Spec.Networks[0],
+					domain,
+					primaryPodIfaceName,
+					mockNetwork,
+				)
 			})
 
 			It("Should use the tap device as the target", func() {

--- a/pkg/network/link/BUILD.bazel
+++ b/pkg/network/link/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/network/driver:go_default_library",
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/netmachinery:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/network/link/names.go
+++ b/pkg/network/link/names.go
@@ -23,11 +23,20 @@ import (
 	"fmt"
 	"strings"
 
+	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-func GenerateTapDeviceName(podInterfaceName string) string {
-	return "tap" + podInterfaceName[3:]
+const tapNameForPrimaryIface = "tap0"
+
+func GenerateTapDeviceName(podInterfaceName string, network v1.Network) string {
+	if vmispec.IsSecondaryMultusNetwork(network) {
+		return "tap" + podInterfaceName[3:]
+	}
+
+	return tapNameForPrimaryIface
 }
 
 func GenerateBridgeName(podInterfaceName string) string {

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -341,6 +341,7 @@ func (n NetPod) bridgeBindingSpec(podIfaceName string, vmiIfaceIndex int, ifaceS
 	)
 
 	vmiNetworkName := n.vmiSpecIfaces[vmiIfaceIndex].Name
+	vmiNetwork := vmispec.LookupNetworkByName(n.vmiSpecNets, vmiNetworkName)
 
 	bridgeIface := nmstate.Interface{
 		Name:     link.GenerateBridgeName(podIfaceName),
@@ -381,7 +382,7 @@ func (n NetPod) bridgeBindingSpec(podIfaceName string, vmiIfaceIndex int, ifaceS
 	}
 
 	tapIface := nmstate.Interface{
-		Name:       link.GenerateTapDeviceName(podIfaceName),
+		Name:       link.GenerateTapDeviceName(podIfaceName, *vmiNetwork),
 		TypeName:   nmstate.TypeTap,
 		State:      nmstate.IfaceStateUp,
 		MTU:        podStatusIface.MTU,
@@ -461,7 +462,7 @@ func (n NetPod) masqueradeBindingSpec(podIfaceName string, vmiIfaceIndex int, if
 	}
 
 	tapIface := nmstate.Interface{
-		Name:       link.GenerateTapDeviceName(podIfaceName),
+		Name:       link.GenerateTapDeviceName(podIfaceName, *vmiNetwork),
 		TypeName:   nmstate.TypeTap,
 		State:      nmstate.IfaceStateUp,
 		MTU:        podIface.MTU,
@@ -480,6 +481,7 @@ func (n NetPod) masqueradeBindingSpec(podIfaceName string, vmiIfaceIndex int, if
 func (n NetPod) managedTapSpec(podIfaceName string, vmiIfaceIndex int, ifaceStatusByName map[string]nmstate.Interface) ([]nmstate.Interface, error) {
 
 	vmiNetworkName := n.vmiSpecIfaces[vmiIfaceIndex].Name
+	vmiNetwork := vmispec.LookupNetworkByName(n.vmiSpecNets, vmiNetworkName)
 
 	podIfaceAlternativeName := link.GenerateNewBridgedVmiInterfaceName(podIfaceName)
 	podStatusIface, exist := ifaceStatusByName[podIfaceAlternativeName]
@@ -508,7 +510,7 @@ func (n NetPod) managedTapSpec(podIfaceName string, vmiIfaceIndex int, ifaceStat
 	}
 
 	tapIface := nmstate.Interface{
-		Name:       link.GenerateTapDeviceName(podIfaceName),
+		Name:       link.GenerateTapDeviceName(podIfaceName, *vmiNetwork),
 		TypeName:   nmstate.TypeTap,
 		State:      nmstate.IfaceStateUp,
 		MTU:        podStatusIface.MTU,

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -534,7 +534,7 @@ var _ = Describe("netpod", func() {
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:       "tapt-iface",
+						Name:       "tap0",
 						TypeName:   nmstate.TypeTap,
 						State:      nmstate.IfaceStateUp,
 						MTU:        1500,

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -137,7 +137,7 @@ func (l *podNIC) newDHCPConfigurator() dhcpconfigurator.Configurator {
 
 func (l *podNIC) newLibvirtSpecGenerator(domain *api.Domain, domainAttachment string) domainspec.LibvirtSpecGenerator {
 	if domainAttachment == string(v1.Tap) {
-		return domainspec.NewTapLibvirtSpecGenerator(l.vmiSpecIface, domain, l.podInterfaceName, l.handler)
+		return domainspec.NewTapLibvirtSpecGenerator(l.vmiSpecIface, *l.vmiSpecNetwork, domain, l.podInterfaceName, l.handler)
 	}
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/nichotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug_test.go
@@ -202,22 +202,25 @@ var _ = Describe("nic hot-unplug on virt-launcher", func() {
 	hashedDevice := "tap" + namescheme.GenerateHashedInterfaceName(networkName)[3:]
 
 	DescribeTable("domain interfaces to hot-unplug",
-		func(vmiSpecIfaces []v1.Interface, domainSpecIfaces []api.Interface, expectedDomainSpecIfaces []api.Interface) {
-			Expect(interfacesToHotUnplug(vmiSpecIfaces, domainSpecIfaces)).To(ConsistOf(expectedDomainSpecIfaces))
+		func(vmiSpecIfaces []v1.Interface, vmiSpecNets []v1.Network, domainSpecIfaces []api.Interface, expectedDomainSpecIfaces []api.Interface) {
+			Expect(interfacesToHotUnplug(vmiSpecIfaces, vmiSpecNets, domainSpecIfaces)).To(ConsistOf(expectedDomainSpecIfaces))
 		},
-		Entry("given no VMI interfaces and no domain interfaces", nil, nil, nil),
+		Entry("given no VMI interfaces and no domain interfaces", nil, nil, nil, nil),
 		Entry("given no VMI interfaces and 1 domain interface",
+			nil,
 			nil,
 			[]api.Interface{{Alias: api.NewUserDefinedAlias(networkName)}},
 			nil,
 		),
 		Entry("given 1 VMI non-absent interface and an associated interface in the domain",
 			[]v1.Interface{{Name: networkName}},
+			[]v1.Network{{Name: networkName, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}}}},
 			[]api.Interface{{Alias: api.NewUserDefinedAlias(networkName)}},
 			nil,
 		),
 		Entry("given 1 VMI absent interface and an associated interface in the domain is using ordinal device",
 			[]v1.Interface{{Name: networkName, State: v1.InterfaceStateAbsent, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}},
+			[]v1.Network{{Name: networkName, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}}}},
 			[]api.Interface{
 				{Target: &api.InterfaceTarget{Device: ordinalDevice}, Alias: api.NewUserDefinedAlias(networkName)},
 			},
@@ -225,6 +228,7 @@ var _ = Describe("nic hot-unplug on virt-launcher", func() {
 		),
 		Entry("given 1 VMI absent interface and an associated interface in the domain is using hashed device",
 			[]v1.Interface{{Name: networkName, State: v1.InterfaceStateAbsent, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}},
+			[]v1.Network{{Name: networkName, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}}}},
 			[]api.Interface{{
 				Target: &api.InterfaceTarget{Device: hashedDevice}, Alias: api.NewUserDefinedAlias(networkName)},
 			},


### PR DESCRIPTION
Automatic cherry-pick of #13374.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

