### PR TITLE
tests, network: Format codebase using `gofumpt`

### DIFF
--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -192,9 +192,11 @@ var _ = SIGDescribe("network binding plugin", Serial, decorators.NetCustomBindin
 			)
 			primaryNetwork := v1.Network{
 				Name: "mynet1",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{
-					NetworkName: fmt.Sprintf("%s/%s", namespace, linuxBridgeNADName),
-					Default:     true},
+				NetworkSource: v1.NetworkSource{
+					Multus: &v1.MultusNetwork{
+						NetworkName: fmt.Sprintf("%s/%s", namespace, linuxBridgeNADName),
+						Default:     true,
+					},
 				},
 			}
 			primaryIface.MacAddress = "de:ad:00:00:be:af"

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -189,7 +189,7 @@ var _ = SIGDescribe("VirtualMachineInstance with macvtap network binding plugin"
 	})
 })
 
-func waitForPodCompleted(podNamespace string, podName string) error {
+func waitForPodCompleted(podNamespace, podName string) error {
 	pod, err := kubevirt.Client().CoreV1().Pods(podNamespace).Get(context.Background(), podName, metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -58,7 +58,7 @@ var _ = SIGDescribe(" VirtualMachineInstance with passt network binding plugin",
 	BeforeEach(func() {
 		const passtBindingName = "passt"
 
-		var passtComputeMemoryOverheadWhenAllPortsAreForwarded = resource.MustParse("500Mi")
+		passtComputeMemoryOverheadWhenAllPortsAreForwarded := resource.MustParse("500Mi")
 
 		passtSidecarImage := libregistry.GetUtilityImageFromRegistry("network-passt-binding")
 
@@ -133,7 +133,7 @@ var _ = SIGDescribe(" VirtualMachineInstance with passt network binding plugin",
 			}
 
 			Context("TCP", func() {
-				verifyClientServerConnectivity := func(clientVMI *v1.VirtualMachineInstance, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
+				verifyClientServerConnectivity := func(clientVMI, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
 					serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
 					err := libnet.PingFromVMConsole(clientVMI, serverIP)
 					if err != nil {

--- a/tests/network/bindingplugin_slirp.go
+++ b/tests/network/bindingplugin_slirp.go
@@ -48,7 +48,6 @@ import (
 )
 
 var _ = SIGDescribe("Slirp", decorators.Networking, decorators.NetCustomBindingPlugins, Serial, func() {
-
 	BeforeEach(libnet.SkipWhenClusterNotSupportIpv4)
 
 	const slirpBindingName = "slirp"

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -296,7 +296,7 @@ var _ = SIGDescribe("bridge nic-hotunplug", func() {
 	})
 })
 
-func createBridgeNetworkAttachmentDefinition(namespace, networkName string, bridgeName string) error {
+func createBridgeNetworkAttachmentDefinition(namespace, networkName, bridgeName string) error {
 	const (
 		bridgeCNIType  = "bridge"
 		linuxBridgeNAD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"name\": \"mynet\", \"plugins\": [{\"type\": \"%s\", \"bridge\": \"%s\"}]}"}}`

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -45,7 +45,6 @@ import (
 )
 
 var _ = SIGDescribe(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
-
 	sriovResourceName := readSRIOVResourceName()
 
 	BeforeEach(func() {
@@ -120,7 +119,7 @@ var _ = SIGDescribe(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 	})
 })
 
-func createSRIOVNetworkAttachmentDefinition(namespace, networkName string, sriovResourceName string) error {
+func createSRIOVNetworkAttachmentDefinition(namespace, networkName, sriovResourceName string) error {
 	return libnet.CreateNetworkAttachmentDefinition(
 		networkName,
 		namespace,

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -84,7 +84,6 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 				assertHTTPPingFailed(clientVMI, serverVMI, 80)
 				assertHTTPPingFailed(clientVMI, serverVMI, 81)
 			})
-
 		})
 
 		Context("and vms limited by allow same namespace networkpolicy", func() {
@@ -111,7 +110,6 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			When("client vmi is on default namespace", func() {
-
 				BeforeEach(func() {
 					var err error
 					clientVMI, err = createClientVmi(testsuite.NamespaceTestDefault, virtClient)
@@ -272,7 +270,6 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 				assertHTTPPingFailed(clientVMI, serverVMI, 81)
 			})
 		})
-
 	})
 })
 
@@ -288,7 +285,6 @@ func assertPingSucceed(fromVmi, toVmi *v1.VirtualMachineInstance) {
 }
 
 func assertPingFail(fromVmi, toVmi *v1.VirtualMachineInstance) {
-
 	EventuallyWithOffset(1, func() error {
 		var err error
 		for _, toIp := range toVmi.Status.Interfaces[0].IPs {

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -51,9 +51,7 @@ import (
 const skipIPv6Message = "port-forwarding over ipv6 is not supported yet. Tracking issue https://github.com/kubevirt/kubevirt/issues/7276"
 
 var _ = SIGDescribe("Port-forward", func() {
-	var (
-		virtClient kubecli.KubevirtClient
-	)
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -134,7 +134,6 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 						return libnet.ValidateVMIandPodIPMatch(vmi, vmiPod)
 					}, 5*time.Second, time.Second).Should(Succeed())
 				})
-
 			})
 
 			When("no Guest Agent exists", func() {

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -296,7 +296,7 @@ func createReadyAlpineVMIWithLivenessProbe(probe *v1.Probe) *v1.VirtualMachineIn
 	return libvmops.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }
 
-func createTCPProbe(period int32, initialSeconds int32, port int) *v1.Probe {
+func createTCPProbe(period, initialSeconds int32, port int) *v1.Probe {
 	httpHandler := v1.Handler{
 		TCPSocket: &k8sv1.TCPSocketAction{
 			Port: intstr.FromInt(port),
@@ -305,7 +305,7 @@ func createTCPProbe(period int32, initialSeconds int32, port int) *v1.Probe {
 	return createProbeSpecification(period, initialSeconds, 1, httpHandler)
 }
 
-func createGuestAgentPingProbe(period int32, initialSeconds int32) *v1.Probe {
+func createGuestAgentPingProbe(period, initialSeconds int32) *v1.Probe {
 	handler := v1.Handler{GuestAgentPing: &v1.GuestAgentPing{}}
 	return createProbeSpecification(period, initialSeconds, 1, handler)
 }
@@ -319,7 +319,7 @@ func patchProbeWithIPAddr(existingProbe *v1.Probe, ipHostIP string) *v1.Probe {
 	return existingProbe
 }
 
-func createHTTPProbe(period int32, initialSeconds int32, port int) *v1.Probe {
+func createHTTPProbe(period, initialSeconds int32, port int) *v1.Probe {
 	httpHandler := v1.Handler{
 		HTTPGet: &k8sv1.HTTPGetAction{
 			Port: intstr.FromInt(port),
@@ -328,12 +328,12 @@ func createHTTPProbe(period int32, initialSeconds int32, port int) *v1.Probe {
 	return createProbeSpecification(period, initialSeconds, 1, httpHandler)
 }
 
-func createExecProbe(period int32, initialSeconds int32, timeoutSeconds int32, command ...string) *v1.Probe {
+func createExecProbe(period, initialSeconds, timeoutSeconds int32, command ...string) *v1.Probe {
 	execHandler := v1.Handler{Exec: &k8sv1.ExecAction{Command: command}}
 	return createProbeSpecification(period, initialSeconds, timeoutSeconds, execHandler)
 }
 
-func createProbeSpecification(period int32, initialSeconds int32, timeoutSeconds int32, handler v1.Handler) *v1.Probe {
+func createProbeSpecification(period, initialSeconds, timeoutSeconds int32, handler v1.Handler) *v1.Probe {
 	return &v1.Probe{
 		PeriodSeconds:       period,
 		InitialDelaySeconds: initialSeconds,

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -80,12 +80,11 @@ const (
 )
 
 var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
-
 	var virtClient kubecli.KubevirtClient
 
 	sriovResourceName := readSRIOVResourceName()
 
-	createSriovNetworkAttachmentDefinition := func(networkName string, namespace string, networkAttachmentDefinition string) error {
+	createSriovNetworkAttachmentDefinition := func(networkName, namespace, networkAttachmentDefinition string) error {
 		sriovNad := fmt.Sprintf(networkAttachmentDefinition, networkName, namespace, sriovResourceName)
 		return libnet.CreateNetworkAttachmentDefinition(networkName, namespace, sriovNad)
 	}
@@ -165,7 +164,6 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 
 			By("checking cloudinit meta-data")
 			tests.CheckCloudInitMetaData(vmi, "openstack/latest/meta_data.json", string(buf))
-
 		})
 
 		It("should have cloud-init meta_data with tagged sriov nics", func() {
@@ -320,7 +318,6 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 		})
 
 		Context("migration", func() {
-
 			BeforeEach(func() {
 				if err := validateSRIOVSetup(virtClient, sriovResourceName, 2); err != nil {
 					Skip("Migration tests require at least 2 nodes: " + err.Error())
@@ -450,7 +447,7 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 			ipB, err := libnet.CidrToIP(cidrB)
 			Expect(err).ToNot(HaveOccurred())
 
-			//create two vms on the same sriov network
+			// create two vms on the same sriov network
 			vmi1, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, cidrA)
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi1)

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -170,9 +170,7 @@ var istioTests = func(vmType VmType) {
 			libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 		})
 		Describe("Live Migration", decorators.SigComputeMigrations, func() {
-			var (
-				sourcePodName string
-			)
+			var sourcePodName string
 			allContainersCompleted := func(podName string) error {
 				pod, err := virtClient.CoreV1().Pods(vmi.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 				if err != nil {
@@ -389,10 +387,9 @@ var istioTests = func(vmType VmType) {
 				ingressGatewayService, err := virtClient.CoreV1().Services(istioNamespace).Get(context.TODO(), "istio-ingressgateway", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				ingressGatewayServiceIP = ingressGatewayService.Spec.ClusterIP
-
 			})
 
-			checkHTTPServiceReturnCode := func(ingressGatewayAddress string, returnCode string) error {
+			checkHTTPServiceReturnCode := func(ingressGatewayAddress, returnCode string) error {
 				return console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: console.PromptExpression},
@@ -497,7 +494,6 @@ func istioServiceMeshDeployed() bool {
 func newVMIWithIstioSidecar(ports []v1.Port, vmType VmType) (*v1.VirtualMachineInstance, error) {
 	if vmType == Masquerade {
 		return createMasqueradeVm(ports), nil
-
 	}
 	if vmType == Passt {
 		return createPasstVm(ports), nil

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -96,7 +96,6 @@ const (
 )
 
 var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -148,7 +147,7 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 		},
 	}
 
-	createBridgeNetworkAttachmentDefinition := func(namespace, networkName string, bridgeCNIType string, bridgeName string, vlan int, ipam string, macSpoofCheck bool) error {
+	createBridgeNetworkAttachmentDefinition := func(namespace, networkName, bridgeCNIType, bridgeName string, vlan int, ipam string, macSpoofCheck bool) error {
 		bridgeNad := fmt.Sprintf(linuxBridgeConfNAD, networkName, namespace, bridgeCNIType, bridgeName, vlan, ipam, macSpoofCheck)
 		return libnet.CreateNetworkAttachmentDefinition(networkName, namespace, bridgeNad)
 	}
@@ -250,7 +249,8 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{
 					defaultInterface,
-					{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+					{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+				}
 				detachedVMI.Spec.Networks = []v1.Network{
 					defaultNetwork,
 					{Name: "ptp", NetworkSource: v1.NetworkSource{
@@ -300,7 +300,8 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 						Multus: &v1.MultusNetwork{
 							NetworkName: fmt.Sprintf("%s/%s", testsuite.GetTestNamespace(nil), ptpConf1),
 							Default:     true,
-						}}},
+						},
+					}},
 				}
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), detachedVMI, metav1.CreateOptions{})
@@ -396,7 +397,7 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 				return "", fmt.Errorf("couldn't find iface %s on vmi %s", networkName, vmiName)
 			}
 
-			generateIPAMConfig := func(ipamType string, subnet string) string {
+			generateIPAMConfig := func(ipamType, subnet string) string {
 				return fmt.Sprintf("\\\"type\\\": \\\"%s\\\", \\\"subnet\\\": \\\"%s\\\"", ipamType, subnet)
 			}
 
@@ -559,7 +560,6 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 					re := regexp.MustCompile("\r\n[0-9]+\r\n")
 					mtu := strings.TrimSpace(re.FindString(res[0].Match[0]))
 					return mtu
-
 				}
 
 				vmi := libvmifact.NewFedora(
@@ -576,7 +576,6 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 		})
 
 		Context("VirtualMachineInstance with invalid MAC address", func() {
-
 			It("[test_id:1713]should failed to start with invalid MAC address", func() {
 				By("Start VMI")
 				linuxBridgeIfIdx := 1
@@ -675,7 +674,6 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 
 	Describe("[rfe_id:1758][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance definition", func() {
 		Context("with qemu guest agent", func() {
-
 			It("[test_id:1757] should report guest interfaces in VMI status", func() {
 				interfaces := []v1.Interface{
 					defaultInterface,
@@ -756,7 +754,7 @@ var _ = SIGDescribe("Multus", Serial, decorators.Multus, func() {
 	})
 })
 
-func changeInterfaceMACAddress(vmi *v1.VirtualMachineInstance, interfaceName string, newMACAddress string) error {
+func changeInterfaceMACAddress(vmi *v1.VirtualMachineInstance, interfaceName, newMACAddress string) error {
 	const maxCommandTimeout = 5 * time.Second
 
 	commands := []string{

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -62,7 +62,6 @@ import (
 )
 
 var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", decorators.Networking, func() {
-
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
@@ -476,7 +475,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
 			const cidrWithLeadingZeros = "10.10.010.0/24"
 
-			verifyClientServerConnectivity := func(clientVMI *v1.VirtualMachineInstance, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
+			verifyClientServerConnectivity := func(clientVMI, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
 				serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
 				err := libnet.PingFromVMConsole(clientVMI, serverIP)
 				if err != nil {
@@ -903,8 +902,10 @@ func newNodeAffinity(selector k8sv1.NodeSelectorOperator, nodeName string) *k8sv
 		Operator: selector,
 		Values:   []string{nodeName},
 	}
-	term := []k8sv1.NodeSelectorTerm{{
-		MatchExpressions: []k8sv1.NodeSelectorRequirement{req}},
+	term := []k8sv1.NodeSelectorTerm{
+		{
+			MatchExpressions: []k8sv1.NodeSelectorRequirement{req},
+		},
 	}
 	return &k8sv1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
 		NodeSelectorTerms: term,

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -73,7 +73,7 @@ var _ = SIGDescribe("Subdomain", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		DescribeTable("VMI should have the expected FQDN", func(f func() *v1.VirtualMachineInstance, subdom string, hostname string) {
+		DescribeTable("VMI should have the expected FQDN", func(f func() *v1.VirtualMachineInstance, subdom, hostname string) {
 			vmiSpec := f()
 			var expectedFQDN, domain string
 			if subdom != "" {
@@ -114,8 +114,10 @@ var _ = SIGDescribe("Subdomain", func() {
 			vmiSpec.Spec.DNSPolicy = "None"
 			vmiSpec.Spec.DNSConfig = &k8sv1.PodDNSConfig{
 				Nameservers: []string{dnsServerIP},
-				Searches: []string{testsuite.NamespaceTestDefault + ".svc.cluster.local",
-					"svc.cluster.local", "cluster.local", testsuite.NamespaceTestDefault + ".this.is.just.a.very.long.dummy"},
+				Searches: []string{
+					testsuite.NamespaceTestDefault + ".svc.cluster.local",
+					"svc.cluster.local", "cluster.local", testsuite.NamespaceTestDefault + ".this.is.just.a.very.long.dummy",
+				},
 			}
 
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmiSpec, metav1.CreateOptions{})


### PR DESCRIPTION
### What this PR does

Cover the tests/network folder with the gofumpt formatter.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
NONE
```
