### PR TITLE
Fix kubevirt_virt_controller_ready metric

### DIFF
--- a/pkg/monitoring/rules/recordingrules/virt.go
+++ b/pkg/monitoring/rules/recordingrules/virt.go
@@ -53,7 +53,7 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 			},
 			MetricType: operatormetrics.GaugeType,
 			Expr: intstr.FromString(
-				fmt.Sprintf("sum(kubevirt_virt_controller_ready_status{namespace='%s'}) or vector(0)", namespace),
+				fmt.Sprintf("sum(kubevirt_virt_controller_ready_status{namespace='%s'}) unless(changes(kubevirt_virt_controller_ready_status{namespace='%s'}[1m]) > 0) or vector(0)", namespace, namespace),
 			),
 		},
 		{


### PR DESCRIPTION
Fix kubevirt_virt_controller_ready metric to show new value only if exists more then 1 minute 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
When scaling the controllers pods immediately 2 new controller pods are created. so for something between 10-40 seconds Prometheus still thinks the old pods are up - since it takes few seconds for them to be to be deleted, and also the new pods that are created counted as up. this is why it shows 4 pods for a few seconds and then gets back to 2 pods. so we can't catch the time it was 0 since there is no such time- the 2 new pods immediately created once the other are scaled. but we can ignore the seconds Prometheus thinks it's 4 pods by using `unless (changes(kubevirt_virt_controller_ready_status{namespace='%s'}[1m]) > 0`: this will make sure to increase/decrease the number of ready pods only if for at least 1m the number is still higher/lower.

from what I saw the maximum time all pods is up are 40 sec but I took 1 minute to be sure. 

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # jira-ticket: https://issues.redhat.com/browse/CNV-46600

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None

```

