### PR TITLE
vmi-create-admitter_test refactor: refactor vmi metadata context tests

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -394,9 +394,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	Context("with VirtualMachineInstance metadata", func() {
 		DescribeTable(
 			"Should allow VMI creation with kubevirt.io/ labels only for kubevirt service accounts",
-			func(vmiLabels map[string]string, userAccount string, positive bool) {
-				vmi := api.NewMinimalVMI("testvmi")
-				vmi.Labels = vmiLabels
+			func(labels map[string]string, userAccount string, positive bool) {
+				vmi := newBaseVmi()
+				vmi.Labels = labels
 
 				ar, err := newAdmissionReviewForVMICreation(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -438,10 +438,8 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			),
 		)
 		DescribeTable("should reject annotations which require feature gate enabled", func(annotations map[string]string, expectedMsg string) {
-			vmi := api.NewMinimalVMI("testvmi")
-			vmi.ObjectMeta = metav1.ObjectMeta{
-				Annotations: annotations,
-			}
+			vmi := newBaseVmi()
+			vmi.Annotations = annotations
 
 			ar, err := newAdmissionReviewForVMICreation(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -462,13 +460,10 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				fmt.Sprintf("invalid entry metadata.annotations.%s", hooks.HookSidecarListAnnotationName),
 			),
 		)
-
 		DescribeTable("should accept annotations which require feature gate enabled", func(annotations map[string]string, featureGate string) {
 			enableFeatureGate(featureGate)
-			vmi := api.NewMinimalVMI("testvmi")
-			vmi.ObjectMeta = metav1.ObjectMeta{
-				Annotations: annotations,
-			}
+			vmi := newBaseVmi()
+			vmi.Annotations = annotations
 
 			ar, err := newAdmissionReviewForVMICreation(vmi)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


### What this PR does
**Before this PR:**

The tests in the "with VirtualMachineInstance metadata" context instantiated VMIs using functions that didn't leverage `libvmi` as well as didn't make use of the `newAdmissionReviewForVMICreation` function to create admission reviews.

**After this PR:**

The tests in the "with VirtualMachineInstance metadata" context now instantiate VMIs using libvmi and use the `newAdmissionReviewForVMICreation` function to create admission reviews.

Partially addresses: https://github.com/kubevirt/kubevirt/issues/13407

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

