### PR TITLE
Improve virt-launcher logging

### DIFF
--- a/cmd/virt-launcher-monitor/virt-launcher-monitor.go
+++ b/cmd/virt-launcher-monitor/virt-launcher-monitor.go
@@ -142,6 +142,7 @@ func main() {
 		log.Log.Reason(err).Error("monitoring virt-launcher failed")
 		os.Exit(1)
 	}
+	log.Log.Info("virt-launcher-monitor: Exiting...")
 
 	os.Exit(exitCode)
 }
@@ -194,14 +195,13 @@ func RunAndMonitor(containerDiskDir, uid string) (int, error) {
 				if err != nil {
 					log.Log.Reason(err).Errorf("Failed to reap process %d", wpid)
 				}
-
-				log.Log.Infof("Reaped pid %d with status %d", wpid, int(wstatus))
 				if wpid == cmd.Process.Pid {
+					log.Log.Infof("Reaped Launcher main pid")
 					exitStatus <- wstatus.ExitStatus()
 				}
-
+				log.Log.Infof("Reaped pid %d with status %d", wpid, int(wstatus))
 			default:
-				log.Log.V(3).Log("signalling virt-launcher to shut down")
+				log.Log.Infof("signalling virt-launcher to shut down")
 				err := cmd.Process.Signal(syscall.SIGTERM)
 				sig.Signal()
 				if err != nil {
@@ -230,6 +230,7 @@ func RunAndMonitor(containerDiskDir, uid string) (int, error) {
 	}
 
 	if pid > 0 {
+		log.Log.Infof("Killing QEMU gracefully.")
 		p, err := os.FindProcess(pid)
 		if err != nil {
 			return 1, err


### PR DESCRIPTION
- Changed signaling of virt-launcher to always log (instead of only at high verbosity) because it doesn't happen often and won’t spam the logs.

- Added a log when the virt-launcher monitor process (main compute container) exits to show when the compute container should no longer be ready.

- Added a log when the main compute process terminates so the launcher monitor knows it should stop too.

- Added a log when delaying the shutdown of the launcher monitor to give qemu time to shut down properly.

Related Flake: These logs may help in solving the following flake: [Flake Details](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/13278/pull-kubevirt-e2e-k8s-1.31-sig-network/1859202840329719808).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

