### PR TITLE
chore(tests,virtctl): Add virtctl label and VirtctlDescribe

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -66,6 +66,8 @@ var (
 	Kubernetes130 = Label("kubernetes130")
 	// WG archs
 	WgS390x = Label("wg-s390x")
+	// Virtctl related tests
+	Virtctl = Label("virtctl")
 
 	// NoFlakeChecker decorates tests that are not compatible with the check-tests-for-flakes test lane.
 	// This should only be used for legitimate purposes, like on tests that have a flake-checker-friendly clone.

--- a/tests/virtctl/BUILD.bazel
+++ b/tests/virtctl/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cmd.go",
         "create_vm.go",
+        "framework.go",
         "guestfs.go",
         "imageupload.go",
         "memorydump.go",

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -67,7 +67,7 @@ const (
 	size = "128Mi"
 )
 
-var _ = Describe("[sig-compute][virtctl]create vm", decorators.SigCompute, func() {
+var _ = VirtctlDescribe("[sig-compute]create vm", decorators.SigCompute, func() {
 	const (
 		importedVolumeRegexp = `imported-volume-\w{5}`
 		sysprepDisk          = "sysprepdisk"

--- a/tests/virtctl/framework.go
+++ b/tests/virtctl/framework.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package virtctl
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"kubevirt.io/kubevirt/tests/decorators"
+)
+
+func VirtctlDescribe(text string, args ...interface{}) bool {
+	return Describe("[virtctl] "+text, decorators.Virtctl, args)
+}
+
+func FVirtctlDescribe(text string, args ...interface{}) bool {
+	return FDescribe("[virtctl] "+text, decorators.Virtctl, args)
+}

--- a/tests/virtctl/guestfs.go
+++ b/tests/virtctl/guestfs.go
@@ -40,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-storage][virtctl]Guestfs", decorators.SigStorage, func() {
+var _ = VirtctlDescribe("[sig-storage]Guestfs", decorators.SigStorage, func() {
 	var (
 		pvcClaim string
 		done     chan struct{}

--- a/tests/virtctl/imageupload.go
+++ b/tests/virtctl/imageupload.go
@@ -53,7 +53,7 @@ const (
 	pvcSize = "100Mi"
 )
 
-var _ = Describe("[sig-storage][virtctl]ImageUpload", decorators.SigStorage, Serial, func() {
+var _ = VirtctlDescribe("[sig-storage]ImageUpload", decorators.SigStorage, Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		imagePath  string

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -50,7 +50,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-storage][virtctl]Memory dump", decorators.SigStorage, func() {
+var _ = VirtctlDescribe("[sig-storage]Memory dump", decorators.SigStorage, func() {
 	const (
 		claimNameFlag   = "--claim-name"
 		createClaimFlag = "--create-claim"

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -45,7 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
+var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 	var pub ssh.PublicKey
 	var keyFile string
 	var virtClient kubecli.KubevirtClient

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
+var _ = VirtctlDescribe("[sig-compute]SSH", decorators.SigCompute, func() {
 	var pub ssh.PublicKey
 	var keyFile string
 	var virtClient kubecli.KubevirtClient

--- a/tests/virtctl/vnc.go
+++ b/tests/virtctl/vnc.go
@@ -45,7 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute][virtctl]VNC", decorators.SigCompute, func() {
+var _ = VirtctlDescribe("[sig-compute]VNC", decorators.SigCompute, func() {
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Add a label to allow filtering for virtctl tests and add Describes that
allow to use this label easily. Then make use of the new VirtctlDescribe.

Before this PR:

virtctl functests cannot be filtered with a label.

After this PR:

There is a label that allows to filter functests so only virtctl tests run.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Merge after #13415 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

