### PR TITLE
chore(virtctl): Codify ownership of virtctl packages

### DIFF
--- a/pkg/virtctl/expose/OWNERS
+++ b/pkg/virtctl/expose/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-network-reviewers
+approvers:
+  - sig-network-approvers
+labels:
+  - sig/network

--- a/pkg/virtctl/guestfs/OWNERS
+++ b/pkg/virtctl/guestfs/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-storage-reviewers
+approvers:
+  - sig-storage-approvers
+labels:
+  - sig/storage

--- a/pkg/virtctl/imageupload/OWNERS
+++ b/pkg/virtctl/imageupload/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-storage-reviewers
+approvers:
+  - sig-storage-approvers
+labels:
+  - sig/storage

--- a/pkg/virtctl/memorydump/OWNERS
+++ b/pkg/virtctl/memorydump/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-storage-reviewers
+approvers:
+  - sig-storage-approvers
+labels:
+  - sig/storage

--- a/pkg/virtctl/scp/OWNERS
+++ b/pkg/virtctl/scp/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - sig/compute

--- a/pkg/virtctl/ssh/OWNERS
+++ b/pkg/virtctl/ssh/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - sig/compute

--- a/pkg/virtctl/vmexport/OWNERS
+++ b/pkg/virtctl/vmexport/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-storage-reviewers
+approvers:
+  - sig-storage-approvers
+labels:
+  - sig/storage

--- a/pkg/virtctl/vnc/OWNERS
+++ b/pkg/virtctl/vnc/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - sig/compute


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Codify the ownership of some virtctl packages by adding OWNERS files. The ownership is mostly derived from labels found on virtctl's functional tests with the exception of virtctl expose.

Before this PR:

virtctl sub packages do not have individual OWNERS.

After this PR:

virtctl sub packages have individual OWNERS.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

