### PR TITLE
[release 1.4] VMRestore: allow creating vmrestore even if runstrategy is not Halted

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -436,15 +436,6 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 
 	log.Log.Object(t.vmRestore).V(3).Info("Checking VM ready")
 
-	rs, err := t.vm.RunStrategy()
-	if err != nil {
-		return false, err
-	}
-
-	if rs != kubevirtv1.RunStrategyHalted {
-		return false, fmt.Errorf("invalid RunStrategy %q", rs)
-	}
-
 	vmiKey, err := controller.KeyFunc(t.vm)
 	if err != nil {
 		return false, err

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -35,7 +35,6 @@ import (
 
 	"kubevirt.io/api/core"
 
-	v1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -193,38 +192,29 @@ func (admitter *VMRestoreAdmitter) validateCreateVM(ctx context.Context, field *
 	vm, err := admitter.Client.VirtualMachine(namespace).Get(ctx, vmName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// If the target VM does not exist it would be automatically created by the restore controller
-		return nil, nil, false, nil
+		return causes, nil, false, nil
 	}
 
 	if err != nil {
 		return nil, nil, false, err
 	}
 
-	rs, err := vm.RunStrategy()
+	targetField := field.Child("target")
+	_, err = admitter.Client.VirtualMachineInstance(namespace).Get(ctx, vmName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return causes, &vm.UID, true, nil
+	}
 	if err != nil {
-		return nil, nil, true, err
+		return nil, nil, false, err
 	}
 
-	if rs != v1.RunStrategyHalted {
-		var cause metav1.StatusCause
-		targetField := field.Child("target")
-		if vm.Spec.Running != nil && *vm.Spec.Running {
-			cause = metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("VirtualMachine %q is not stopped", vmName),
-				Field:   targetField.String(),
-			}
-		} else {
-			cause = metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("VirtualMachine %q run strategy has to be %s", vmName, v1.RunStrategyHalted),
-				Field:   targetField.String(),
-			}
-		}
-		causes = append(causes, cause)
-	}
+	causes = append(causes, metav1.StatusCause{
+		Type:    metav1.CauseTypeFieldValueInvalid,
+		Message: fmt.Sprintf("VirtualMachineInstance %q exists, VM must be stopped before restore", vmName),
+		Field:   targetField.String(),
+	})
 
-	return causes, &vm.UID, true, nil
+	return causes, nil, true, nil
 }
 
 func (admitter *VMRestoreAdmitter) validatePatches(patches []string, field *k8sfield.Path) (causes []metav1.StatusCause) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				}
 			})
 
-			It("should reject when VM is running", func() {
+			It("should reject when VMI exists", func() {
 				restore := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "restore",
@@ -276,17 +276,22 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 						VirtualMachineSnapshotName: vmSnapshotName,
 					},
 				}
-
-				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
+				vmi := &v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: vmName,
+						UID:  "vmi-UID",
+					},
+				}
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
+				resp := createTestVMRestoreAdmitter(config, vm, snapshot, vmi).Admit(context.Background(), ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
+				Expect(resp.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("VirtualMachineInstance %q exists, VM must be stopped before restore", vmName)))
 			})
 
-			It("should reject when VM run strategy is not halted", func() {
+			It("should allow when VM run strategy is not halted", func() {
 				restore := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "restore",
@@ -306,10 +311,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(context.Background(), ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(HaveLen(1))
-				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
-				Expect(resp.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("VirtualMachine %q run strategy has to be %s", vmName, v1.RunStrategyHalted)))
+				Expect(resp.Allowed).To(BeTrue())
 			})
 
 			It("should reject when snapshot does not exist", func() {
@@ -662,17 +664,22 @@ func createTestVMRestoreAdmitter(
 	ctrl := gomock.NewController(GinkgoT())
 	virtClient := kubecli.NewMockKubevirtClient(ctrl)
 	vmInterface := kubecli.NewMockVirtualMachineInterface(ctrl)
+	vmiInterface := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 	kubevirtClient := kubevirtfake.NewSimpleClientset(objs...)
 
 	virtClient.EXPECT().VirtualMachineSnapshot("default").
 		Return(kubevirtClient.SnapshotV1beta1().VirtualMachineSnapshots("default")).AnyTimes()
 	virtClient.EXPECT().VirtualMachine(gomock.Any()).Return(vmInterface).AnyTimes()
+	virtClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(vmiInterface).AnyTimes()
 
+	var vmi *v1.VirtualMachineInstance
 	restoreInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineRestore{})
 	for _, obj := range objs {
-		r, ok := obj.(*snapshotv1.VirtualMachineRestore)
-		if ok {
-			restoreInformer.GetIndexer().Add(r)
+		switch v := obj.(type) {
+		case *snapshotv1.VirtualMachineRestore:
+			restoreInformer.GetIndexer().Add(v)
+		case *v1.VirtualMachineInstance:
+			vmi = v
 		}
 	}
 
@@ -681,7 +688,16 @@ func createTestVMRestoreAdmitter(
 			return vm, nil
 		}
 
-		err := errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, "foo")
+		err := errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, name)
+		return nil, err
+	}).AnyTimes()
+
+	vmiInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, name string, getOptions metav1.GetOptions) (*v1.VirtualMachineInstance, error) {
+		if vmi != nil && name == vmi.Name {
+			return vmi, nil
+		}
+
+		err := errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineInstances"}, name)
 		return nil, err
 	}).AnyTimes()
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -395,13 +395,13 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			})
 
 			It("[test_id:5257]should reject restore if VM running", func() {
-				Expect(virtClient.VirtualMachine(vm.Namespace).Start(context.Background(), vm.Name, &v1.StartOptions{})).To(Succeed())
+				vm = libvmops.StartVirtualMachine(vm)
 
 				restore := createRestoreDef(vm.Name, snapshot.Name)
 
 				_, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("VirtualMachine %q run strategy has to be %s", vm.Name, v1.RunStrategyHalted)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("VirtualMachineInstance %q exists, VM must be stopped before restore", vm.Name)))
 			})
 
 			It("[test_id:5258]should reject restore if another in progress", func() {


### PR DESCRIPTION
Code had a faulty assumption that Always or RerunOnFailure means that VM cannot be stopped.
Instead we dont check the RunStrategy or Running field and we look on the VMI if it exists or not.
(This fix is not ideal since we prefere not to check other objects in the webhook since it's racy but, this is the minimal API change possible for a bug fix)
This issue was already handled in for vmsnapshot process but also applies here: #12515
This fixes:
Jira-ticket: https://issues.redhat.com/browse/CNV-51071
In main we had a PR that completely removed the webhook validation and this was handled in the controller alone, due to bigger API changes that were required we created this PR to fix the bug with minimal API changes. https://github.com/kubevirt/kubevirt/pull/13195

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMRestore: allow creating vmrestore even if runstrategy is not Halted
```

