### PR TITLE
Add kubevirt_vmi_migration_data_total_bytes metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -180,6 +180,9 @@ The total Guest OS data processed and migrated to the new VM. Type: Gauge.
 ### kubevirt_vmi_migration_data_remaining_bytes
 The remaining guest OS data to be migrated to the new VM. Type: Gauge.
 
+### kubevirt_vmi_migration_data_total_bytes
+The total Guest OS data to be migrated to the new VM. Type: Counter.
+
 ### kubevirt_vmi_migration_dirty_memory_rate_bytes
 The rate of memory being dirty in the Guest OS. Type: Gauge.
 

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector.go
@@ -29,6 +29,7 @@ var (
 
 	MigrationStatsCollector = operatormetrics.Collector{
 		Metrics: []operatormetrics.Metric{
+			migrateVMIDataTotal,
 			migrateVMIDataRemaining,
 			migrateVMIDataProcessed,
 			migrateVmiDirtyMemoryRate,
@@ -36,6 +37,13 @@ var (
 		},
 		CollectCallback: migrationStatsCollectorCallback,
 	}
+
+	migrateVMIDataTotal = operatormetrics.NewCounter(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_migration_data_total_bytes",
+			Help: "The total Guest OS data to be migrated to the new VM.",
+		},
+	)
 
 	migrateVMIDataRemaining = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
@@ -91,6 +99,10 @@ func parse(r *result) []operatormetrics.CollectorResult {
 	var crs []operatormetrics.CollectorResult
 
 	jobInfo := r.domainJobInfo
+
+	if jobInfo.DataTotalSet {
+		crs = append(crs, newCR(r, migrateVMIDataTotal, float64(jobInfo.DataTotal)))
+	}
 
 	if jobInfo.DataRemainingSet {
 		crs = append(crs, newCR(r, migrateVMIDataRemaining, float64(jobInfo.DataRemaining)))

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector_test.go
@@ -35,6 +35,8 @@ var _ = Describe("migration metrics", func() {
 		vmiStats := &result{
 			vmi: "test-vmi-1",
 			domainJobInfo: stats.DomainJobInfo{
+				DataTotalSet:     true,
+				DataTotal:        3,
 				DataRemainingSet: true,
 				DataRemaining:    1,
 				DataProcessedSet: true,
@@ -50,6 +52,7 @@ var _ = Describe("migration metrics", func() {
 			crs := parse(vmiStats)
 			Expect(crs).To(ContainElement(testing.GomegaContainsCollectorResultMatcher(metric, expectedValue)))
 		},
+			Entry("kubevirt_vmi_migration_data_total_bytes", migrateVMIDataTotal, 3.0),
 			Entry("kubevirt_vmi_migration_data_remaining_bytes", migrateVMIDataRemaining, 1.0),
 			Entry("kubevirt_vmi_migration_data_processed_bytes", migrateVMIDataProcessed, 2.0),
 			Entry("kubevirt_vmi_migration_dirty_memory_rate_bytes", migrateVmiDirtyMemoryRate, 3.0),

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -180,6 +180,8 @@ type DomainStatsMemory struct {
 // mimic existing structs, but data is taken from
 // DomainJobInfo
 type DomainJobInfo struct {
+	DataTotalSet     bool
+	DataTotal        uint64
 	DataProcessedSet bool
 	DataProcessed    uint64
 	MemoryBpsSet     bool

--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -221,6 +221,8 @@ func Convert_libvirt_DomainJobInfo_To_stats_DomainJobInfo(info *libvirt.DomainJo
 	}
 
 	return &stats.DomainJobInfo{
+		DataTotalSet:     info.DataTotalSet,
+		DataTotal:        info.DataTotal,
 		DataProcessedSet: info.DataProcessedSet,
 		DataProcessed:    info.DataProcessed,
 		MemoryBpsSet:     info.MemBpsSet,

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -192,6 +192,8 @@ var Testdataexpected = `{
      "TotalSet": false
    }, 
    "MigrateDomainJobInfo": {
+	 "DataTotal": 0,
+	 "DataTotalSet": false,
      "DataProcessed": 0,
      "DataProcessedSet": false,
      "DataRemaining": 0,

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -440,6 +440,7 @@ func RunMigrationAndCollectMigrationMetrics(vmi *v1.VirtualMachineInstance, migr
 	var pod *k8sv1.Pod
 	var metricsIPs []string
 	var migrationMetrics = []string{
+		"kubevirt_vmi_migration_data_total_bytes",
 		"kubevirt_vmi_migration_data_remaining_bytes",
 		"kubevirt_vmi_migration_data_processed_bytes",
 		"kubevirt_vmi_migration_dirty_memory_rate_bytes",

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -85,6 +85,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			"kubevirt_vmi_migration_data_processed_bytes":                        true,
 			"kubevirt_vmi_migration_dirty_memory_rate_bytes":                     true,
 			"kubevirt_vmi_migration_disk_transfer_rate_bytes":                    true,
+			"kubevirt_vmi_migration_data_total_bytes":                            true,
 		}
 
 		It("should contain virt components metrics", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

No total constant amount for the total amount of data migrate

After this PR:

kubevirt_vmi_migration_data_total_bytes - The total Guest OS data to be migrated to the new VM.

![Screenshot from 2024-12-11 15-49-39](https://github.com/user-attachments/assets/6cbceb37-4b8f-4fa1-bdcc-7af7c88baf87)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes jira-ticket: https://issues.redhat.com/browse/CNV-39060

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vmi_migration_data_total_bytes metric
```

