### PR TITLE
Virt handler fixes and cleanup

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -4,6 +4,7 @@ load("@kubevirt//tools/ginkgo:ginkgo.bzl", "ginkgo_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "guestagent.go",
         "migration.go",
         "non-root.go",
         "options.go",

--- a/pkg/virt-handler/guestagent.go
+++ b/pkg/virt-handler/guestagent.go
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors
+ *
+ */
+
+package virthandler
+
+import v1 "kubevirt.io/api/core/v1"
+
+var RequiredGuestAgentCommands = []string{
+	"guest-ping",
+	"guest-get-time",
+	"guest-info",
+	"guest-shutdown",
+	"guest-network-get-interfaces",
+	"guest-get-fsinfo",
+	"guest-get-host-name",
+	"guest-get-users",
+	"guest-get-timezone",
+	"guest-get-osinfo",
+}
+
+var SSHRelatedGuestAgentCommands = []string{
+	"guest-ssh-get-authorized-keys",
+	"guest-ssh-add-authorized-keys",
+	"guest-ssh-remove-authorized-keys",
+}
+
+var OldSSHRelatedGuestAgentCommands = []string{
+	"guest-exec-status",
+	"guest-exec",
+	"guest-file-open",
+	"guest-file-close",
+	"guest-file-read",
+	"guest-file-write",
+}
+
+var PasswordRelatedGuestAgentCommands = []string{
+	"guest-set-user-password",
+}
+
+func _guestAgentCommandSubsetSupported(requiredCommands []string, commands []v1.GuestAgentCommandInfo) bool {
+	var found bool
+	for _, cmd := range requiredCommands {
+		found = false
+		for _, foundCmd := range commands {
+			if cmd == foundCmd.Name {
+				if foundCmd.Enabled {
+					found = true
+				}
+				break
+			}
+		}
+		if found == false {
+			return false
+		}
+	}
+	return true
+
+}
+
+func isGuestAgentSupported(vmi *v1.VirtualMachineInstance, commands []v1.GuestAgentCommandInfo) (bool, string) {
+	if !_guestAgentCommandSubsetSupported(RequiredGuestAgentCommands, commands) {
+		return false, "This guest agent doesn't support required basic commands"
+	}
+
+	checkSSH := false
+	checkPasswd := false
+
+	if vmi != nil && vmi.Spec.AccessCredentials != nil {
+		for _, accessCredential := range vmi.Spec.AccessCredentials {
+			if accessCredential.SSHPublicKey != nil && accessCredential.SSHPublicKey.PropagationMethod.QemuGuestAgent != nil {
+				// defer checking the command list so we only do that once
+				checkSSH = true
+			}
+			if accessCredential.UserPassword != nil && accessCredential.UserPassword.PropagationMethod.QemuGuestAgent != nil {
+				// defer checking the command list so we only do that once
+				checkPasswd = true
+			}
+
+		}
+	}
+
+	if checkSSH && !sshRelatedCommandsSupported(commands) {
+		return false, "This guest agent doesn't support required public key commands"
+	}
+
+	if checkPasswd && !_guestAgentCommandSubsetSupported(PasswordRelatedGuestAgentCommands, commands) {
+		return false, "This guest agent doesn't support required password commands"
+	}
+
+	return true, "This guest agent is supported"
+}
+
+func sshRelatedCommandsSupported(commands []v1.GuestAgentCommandInfo) bool {
+	return _guestAgentCommandSubsetSupported(SSHRelatedGuestAgentCommands, commands) ||
+		_guestAgentCommandSubsetSupported(OldSSHRelatedGuestAgentCommands, commands)
+}

--- a/pkg/virt-handler/heartbeat/BUILD.bazel
+++ b/pkg/virt-handler/heartbeat/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/util/retry:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -100,7 +100,7 @@ func changeOwnershipOfHostDisks(vmiWithAllPVCs *v1.VirtualMachineInstance, res i
 	return nil
 }
 
-func (d *VirtualMachineController) prepareStorage(vmi *v1.VirtualMachineInstance, res isolation.IsolationResult) error {
+func (c *VirtualMachineController) prepareStorage(vmi *v1.VirtualMachineInstance, res isolation.IsolationResult) error {
 	if err := changeOwnershipOfBlockDevices(vmi, res); err != nil {
 		return err
 	}
@@ -131,8 +131,8 @@ func getTapDevices(vmi *v1.VirtualMachineInstance, networkBindings map[string]v1
 	return tapDevices, nil
 }
 
-func (d *VirtualMachineController) prepareTap(vmi *v1.VirtualMachineInstance, res isolation.IsolationResult) error {
-	networkToTapDeviceNames, err := getTapDevices(vmi, d.clusterConfig.GetNetworkBindings())
+func (c *VirtualMachineController) prepareTap(vmi *v1.VirtualMachineInstance, res isolation.IsolationResult) error {
+	networkToTapDeviceNames, err := getTapDevices(vmi, c.clusterConfig.GetNetworkBindings())
 	if err != nil {
 		return err
 	}
@@ -242,18 +242,18 @@ func (*VirtualMachineController) prepareVFIO(vmi *v1.VirtualMachineInstance, res
 	return nil
 }
 
-func (d *VirtualMachineController) nonRootSetup(origVMI, vmi *v1.VirtualMachineInstance) error {
-	res, err := d.podIsolationDetector.Detect(origVMI)
+func (c *VirtualMachineController) nonRootSetup(origVMI, vmi *v1.VirtualMachineInstance) error {
+	res, err := c.podIsolationDetector.Detect(origVMI)
 	if err != nil {
 		return err
 	}
-	if err := d.prepareStorage(origVMI, res); err != nil {
+	if err := c.prepareStorage(origVMI, res); err != nil {
 		return err
 	}
-	if err := d.prepareTap(origVMI, res); err != nil {
+	if err := c.prepareTap(origVMI, res); err != nil {
 		return err
 	}
-	if err := d.prepareVFIO(origVMI, res); err != nil {
+	if err := c.prepareVFIO(origVMI, res); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/virt-handler/realtime.go
+++ b/pkg/virt-handler/realtime.go
@@ -36,8 +36,8 @@ var (
 
 // configureRealTimeVCPUs parses the realtime mask value and configured the selected vcpus
 // for real time workloads by setting the scheduler to FIFO and process priority equal to 1.
-func (d *VirtualMachineController) configureVCPUScheduler(vmi *v1.VirtualMachineInstance) error {
-	res, err := d.podIsolationDetector.Detect(vmi)
+func (c *VirtualMachineController) configureVCPUScheduler(vmi *v1.VirtualMachineInstance) error {
+	res, err := c.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -36,72 +36,61 @@ import (
 	"strings"
 	"time"
 
-	"libvirt.org/go/libvirtxml"
-
-	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
-	pvctypes "kubevirt.io/kubevirt/pkg/storage/types"
-
-	"golang.org/x/sys/unix"
-	"k8s.io/apimachinery/pkg/util/errors"
-
-	"kubevirt.io/kubevirt/pkg/network/domainspec"
-	"kubevirt.io/kubevirt/pkg/pointer"
-
-	"kubevirt.io/kubevirt/pkg/virt-controller/services"
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
-	"kubevirt.io/kubevirt/pkg/virt-handler/selinux"
-	"kubevirt.io/kubevirt/pkg/virtiofs"
-
-	"kubevirt.io/kubevirt/pkg/config"
-	hotplugdisk "kubevirt.io/kubevirt/pkg/hotplug-disk"
-	"kubevirt.io/kubevirt/pkg/safepath"
-	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
-
+	"github.com/mitchellh/go-ps"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"golang.org/x/sys/unix"
+	"libvirt.org/go/libvirtxml"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	netcache "kubevirt.io/kubevirt/pkg/network/cache"
-	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
-	"kubevirt.io/kubevirt/pkg/util"
-
-	"kubevirt.io/kubevirt/pkg/virt-handler/heartbeat"
-
-	"kubevirt.io/kubevirt/pkg/util/hardware"
-	"kubevirt.io/kubevirt/pkg/util/migrations"
-
-	container_disk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
-	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
-	hotplug_volume "kubevirt.io/kubevirt/pkg/virt-handler/hotplug-disk"
-
-	ps "github.com/mitchellh/go-ps"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/config"
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/controller"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/executor"
+	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
+	hotplugdisk "kubevirt.io/kubevirt/pkg/hotplug-disk"
+	netcache "kubevirt.io/kubevirt/pkg/network/cache"
+	"kubevirt.io/kubevirt/pkg/network/domainspec"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
+	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
+	pvctypes "kubevirt.io/kubevirt/pkg/storage/types"
+	"kubevirt.io/kubevirt/pkg/util"
 	virtutil "kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/util/hardware"
+	"kubevirt.io/kubevirt/pkg/util/migrations"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
+	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+	container_disk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
+	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
+	"kubevirt.io/kubevirt/pkg/virt-handler/heartbeat"
+	hotplug_volume "kubevirt.io/kubevirt/pkg/virt-handler/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
+	"kubevirt.io/kubevirt/pkg/virt-handler/selinux"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virtiofs"
 )
 
 type netconf interface {
@@ -462,9 +451,9 @@ func handleDomainNotifyPipe(domainPipeStopChan chan struct{}, ln net.Listener, v
 	}(vmi, fdChan, domainPipeStopChan)
 }
 
-func (d *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan struct{}, vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan struct{}, vmi *v1.VirtualMachineInstance) error {
 
-	res, err := d.podIsolationDetector.Detect(vmi)
+	res, err := c.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return fmt.Errorf("failed to detect isolation for launcher pod when setting up notify pipe: %v", err)
 	}
@@ -474,7 +463,7 @@ func (d *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan
 	if err != nil {
 		return err
 	}
-	socketDir, err := root.AppendAndResolveWithRelativeRoot(d.virtShareDir)
+	socketDir, err := root.AppendAndResolveWithRelativeRoot(c.virtShareDir)
 	if err != nil {
 		return err
 	}
@@ -497,7 +486,7 @@ func (d *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan
 		}
 	}
 
-	handleDomainNotifyPipe(domainPipeStopChan, listener, d.virtShareDir, vmi)
+	handleDomainNotifyPipe(domainPipeStopChan, listener, c.virtShareDir, vmi)
 
 	return nil
 }
@@ -506,7 +495,7 @@ func (d *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan
 // If the grace period has started but not expired, timeLeft represents
 // the time in seconds left until the period expires.
 // If the grace period has not started, timeLeft will be set to -1.
-func (d *VirtualMachineController) hasGracePeriodExpired(dom *api.Domain) (hasExpired bool, timeLeft int64) {
+func (c *VirtualMachineController) hasGracePeriodExpired(dom *api.Domain) (hasExpired bool, timeLeft int64) {
 
 	hasExpired = false
 	timeLeft = 0
@@ -549,7 +538,7 @@ func (d *VirtualMachineController) hasGracePeriodExpired(dom *api.Domain) (hasEx
 	return
 }
 
-func (d *VirtualMachineController) hasTargetDetectedReadyDomain(vmi *v1.VirtualMachineInstance) (bool, int64) {
+func (c *VirtualMachineController) hasTargetDetectedReadyDomain(vmi *v1.VirtualMachineInstance) (bool, int64) {
 	// give the target node 60 seconds to discover the libvirt domain via the domain informer
 	// before allowing the VMI to be processed. This closes the gap between the
 	// VMI's status getting updated to reflect the new source node, and the domain
@@ -580,28 +569,28 @@ func (d *VirtualMachineController) hasTargetDetectedReadyDomain(vmi *v1.VirtualM
 	}
 
 	// re-enqueue the key to ensure it gets processed again within the right time.
-	d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Duration(enqueueTime)*time.Second)
+	c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Duration(enqueueTime)*time.Second)
 
 	return false, timeLeft
 }
 
 // teardownNetwork performs network cache cleanup for a specific VMI.
-func (d *VirtualMachineController) teardownNetwork(vmi *v1.VirtualMachineInstance) {
+func (c *VirtualMachineController) teardownNetwork(vmi *v1.VirtualMachineInstance) {
 	if string(vmi.UID) == "" {
 		return
 	}
-	if err := d.netConf.Teardown(vmi); err != nil {
+	if err := c.netConf.Teardown(vmi); err != nil {
 		log.Log.Reason(err).Errorf("failed to delete VMI Network cache files: %s", err.Error())
 	}
-	d.netStat.Teardown(vmi)
+	c.netStat.Teardown(vmi)
 }
 
-func (d *VirtualMachineController) setupNetwork(vmi *v1.VirtualMachineInstance, networks []v1.Network) error {
+func (c *VirtualMachineController) setupNetwork(vmi *v1.VirtualMachineInstance, networks []v1.Network) error {
 	if len(networks) == 0 {
 		return nil
 	}
 
-	isolationRes, err := d.podIsolationDetector.Detect(vmi)
+	isolationRes, err := c.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return fmt.Errorf(failedDetectIsolationFmt, err)
 	}
@@ -610,14 +599,14 @@ func (d *VirtualMachineController) setupNetwork(vmi *v1.VirtualMachineInstance, 
 		return err
 	}
 
-	return d.netConf.Setup(vmi, networks, isolationRes.Pid(), func() error {
+	return c.netConf.Setup(vmi, networks, isolationRes.Pid(), func() error {
 		if virtutil.WantVirtioNetDevice(vmi) {
-			if err := d.claimDeviceOwnership(rootMount, "vhost-net"); err != nil {
+			if err := c.claimDeviceOwnership(rootMount, "vhost-net"); err != nil {
 				return neterrors.CreateCriticalNetworkError(fmt.Errorf("failed to set up vhost-net device, %s", err))
 			}
 		}
 		if virtutil.NeedTunDevice(vmi) {
-			if err := d.claimDeviceOwnership(rootMount, "/net/tun"); err != nil {
+			if err := c.claimDeviceOwnership(rootMount, "/net/tun"); err != nil {
 				return neterrors.CreateCriticalNetworkError(fmt.Errorf("failed to set up tun device, %s", err))
 			}
 		}
@@ -641,11 +630,11 @@ func canUpdateToUnmounted(currentPhase v1.VolumePhase) bool {
 	return currentPhase == v1.VolumeReady || currentPhase == v1.HotplugVolumeMounted || currentPhase == v1.HotplugVolumeAttachedToNode
 }
 
-func (d *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+func (c *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	if domain == nil ||
 		domain.Spec.Metadata.KubeVirt.Migration == nil ||
 		vmi.Status.MigrationState == nil ||
-		!d.isMigrationSource(vmi) {
+		!c.isMigrationSource(vmi) {
 		return
 	}
 
@@ -657,7 +646,7 @@ func (d *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMac
 	if vmi.Status.MigrationState.EndTimestamp == nil && migrationMetadata.EndTimestamp != nil {
 		if migrationMetadata.Failed {
 			vmi.Status.MigrationState.FailureReason = migrationMetadata.FailureReason
-			d.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("VirtualMachineInstance migration uid %s failed. reason:%s", string(migrationMetadata.UID), migrationMetadata.FailureReason))
+			c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("VirtualMachineInstance migration uid %s failed. reason:%s", string(migrationMetadata.UID), migrationMetadata.FailureReason))
 		}
 	}
 
@@ -673,7 +662,7 @@ func (d *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMac
 	vmi.Status.MigrationState.Mode = migrationMetadata.Mode
 }
 
-func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (c *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.VirtualMachineInstance, domain *api.Domain) error {
 
 	vmi := origVMI.DeepCopy()
 	oldStatus := vmi.DeepCopy().Status
@@ -681,7 +670,7 @@ func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 	// if a migration happens very quickly, it's possible parts of the in
 	// progress status wasn't set. We need to make sure we set this even
 	// if the migration has completed
-	d.setMigrationProgressStatus(vmi, domain)
+	c.setMigrationProgressStatus(vmi, domain)
 
 	// handle migrations differently than normal status updates.
 	//
@@ -707,7 +696,7 @@ func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 		vmi.Status.MigrationState.EndTimestamp = &now
 	}
 
-	targetNodeDetectedDomain, timeLeft := d.hasTargetDetectedReadyDomain(vmi)
+	targetNodeDetectedDomain, timeLeft := c.hasTargetDetectedReadyDomain(vmi)
 	// If we can't detect where the migration went to, then we have no
 	// way of transferring ownership. The only option here is to move the
 	// vmi to failed.  The cluster vmi controller will then tear down the
@@ -718,14 +707,14 @@ func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 		vmi.Status.MigrationState.Completed = true
 		vmi.Status.MigrationState.Failed = true
 
-		d.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to unknown host."))
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to unknown host."))
 	} else if !targetNodeDetectedDomain {
 		if timeLeft <= 0 {
 			vmi.Status.Phase = v1.Failed
 			vmi.Status.MigrationState.Completed = true
 			vmi.Status.MigrationState.Failed = true
 
-			d.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance's domain was never observed on the target after the migration completed within the timeout period."))
+			c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance's domain was never observed on the target after the migration completed within the timeout period."))
 		} else {
 			log.Log.Object(vmi).Info("Waiting on the target node to observe the migrated domain before performing the handoff")
 		}
@@ -744,16 +733,16 @@ func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 		// new workloads will set the migrationTransport on their creation, however, legacy workloads
 		// can make the switch only after the first migration
 		vmi.Status.MigrationTransport = v1.MigrationTransportUnix
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to node %s.", migrationHost))
+		c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to node %s.", migrationHost))
 		log.Log.Object(vmi).Infof("migration completed to node %s", migrationHost)
 	}
 
 	if !equality.Semantic.DeepEqual(oldStatus, vmi.Status) {
 		key := controller.VirtualMachineInstanceKey(vmi)
-		d.vmiExpectations.SetExpectations(key, 1, 0)
-		_, err := d.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+		c.vmiExpectations.SetExpectations(key, 1, 0)
+		_, err := c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
 		if err != nil {
-			d.vmiExpectations.LowerExpectations(key, 1, 0)
+			c.vmiExpectations.LowerExpectations(key, 1, 0)
 			return err
 		}
 	}
@@ -778,7 +767,7 @@ func domainIsActiveOnTarget(domain *api.Domain) bool {
 
 }
 
-func (d *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (c *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 
 	vmiCopy := vmi.DeepCopy()
 
@@ -797,8 +786,8 @@ func (d *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 
 		// adjust QEMU process memlock limits in order to enable old virt-launcher pod's to
 		// perform hotplug host-devices on post migration.
-		if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio); err != nil {
-			d.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), "Failed to update target node qemu memory limits during live migration")
+		if err := isolation.AdjustQemuProcessMemoryLimits(c.podIsolationDetector, vmi, c.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio); err != nil {
+			c.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), "Failed to update target node qemu memory limits during live migration")
 		}
 
 	}
@@ -814,11 +803,11 @@ func (d *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 		log.Log.Object(vmi).Info("The target node received the running migrated domain")
 		now := metav1.Now()
 		vmiCopy.Status.MigrationState.TargetNodeDomainReadyTimestamp = &now
-		d.finalizeMigration(vmiCopy)
+		c.finalizeMigration(vmiCopy)
 	}
 
 	if !migrations.IsMigrating(vmi) {
-		destSrcPortsMap := d.migrationProxy.GetTargetListenerPorts(string(vmi.UID))
+		destSrcPortsMap := c.migrationProxy.GetTargetListenerPorts(string(vmi.UID))
 		if len(destSrcPortsMap) == 0 {
 			msg := "target migration listener is not up for this vmi"
 			log.Log.Object(vmi).Error(msg)
@@ -830,26 +819,26 @@ func (d *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 		if vmi.Status.MigrationState != nil {
 			hostAddress = vmi.Status.MigrationState.TargetNodeAddress
 		}
-		if hostAddress != d.migrationIpAddress {
+		if hostAddress != c.migrationIpAddress {
 			portsList := make([]string, 0, len(destSrcPortsMap))
 
 			for k := range destSrcPortsMap {
 				portsList = append(portsList, k)
 			}
 			portsStrList := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(portsList)), ","), "[]")
-			d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), fmt.Sprintf("Migration Target is listening at %s, on ports: %s", d.migrationIpAddress, portsStrList))
-			vmiCopy.Status.MigrationState.TargetNodeAddress = d.migrationIpAddress
+			c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), fmt.Sprintf("Migration Target is listening at %s, on ports: %s", c.migrationIpAddress, portsStrList))
+			vmiCopy.Status.MigrationState.TargetNodeAddress = c.migrationIpAddress
 			vmiCopy.Status.MigrationState.TargetDirectMigrationNodePorts = destSrcPortsMap
 		}
 
 		// If the migrated VMI requires dedicated CPUs, report the new pod CPU set to the source node
 		// via the VMI migration status in order to patch the domain pre migration
 		if vmi.IsCPUDedicated() {
-			err := d.reportDedicatedCPUSetForMigratingVMI(vmiCopy)
+			err := c.reportDedicatedCPUSetForMigratingVMI(vmiCopy)
 			if err != nil {
 				return err
 			}
-			err = d.reportTargetTopologyForMigratingVMI(vmiCopy)
+			err = c.reportTargetTopologyForMigratingVMI(vmiCopy)
 			if err != nil {
 				return err
 			}
@@ -859,10 +848,10 @@ func (d *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 	// update the VMI if necessary
 	if !equality.Semantic.DeepEqual(vmi.Status, vmiCopy.Status) {
 		key := controller.VirtualMachineInstanceKey(vmi)
-		d.vmiExpectations.SetExpectations(key, 1, 0)
-		_, err := d.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmiCopy, metav1.UpdateOptions{})
+		c.vmiExpectations.SetExpectations(key, 1, 0)
+		_, err := c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmiCopy, metav1.UpdateOptions{})
 		if err != nil {
-			d.vmiExpectations.LowerExpectations(key, 1, 0)
+			c.vmiExpectations.LowerExpectations(key, 1, 0)
 			return err
 		}
 	}
@@ -870,7 +859,7 @@ func (d *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 	return nil
 }
 
-func (d *VirtualMachineController) generateEventsForVolumeStatusChange(vmi *v1.VirtualMachineInstance, newStatusMap map[string]v1.VolumeStatus) {
+func (c *VirtualMachineController) generateEventsForVolumeStatusChange(vmi *v1.VirtualMachineInstance, newStatusMap map[string]v1.VolumeStatus) {
 	newStatusMapCopy := make(map[string]v1.VolumeStatus)
 	for k, v := range newStatusMap {
 		newStatusMapCopy[k] = v
@@ -879,25 +868,25 @@ func (d *VirtualMachineController) generateEventsForVolumeStatusChange(vmi *v1.V
 		newStatus, ok := newStatusMap[oldStatus.Name]
 		if !ok {
 			// status got removed
-			d.recorder.Event(vmi, k8sv1.EventTypeNormal, VolumeUnplugged, fmt.Sprintf("Volume %s has been unplugged", oldStatus.Name))
+			c.recorder.Event(vmi, k8sv1.EventTypeNormal, VolumeUnplugged, fmt.Sprintf("Volume %s has been unplugged", oldStatus.Name))
 			continue
 		}
 		if newStatus.Phase != oldStatus.Phase {
-			d.recorder.Event(vmi, k8sv1.EventTypeNormal, newStatus.Reason, newStatus.Message)
+			c.recorder.Event(vmi, k8sv1.EventTypeNormal, newStatus.Reason, newStatus.Message)
 		}
 		delete(newStatusMapCopy, newStatus.Name)
 	}
 	// Send events for any new statuses.
 	for _, v := range newStatusMapCopy {
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v.Reason, v.Message)
+		c.recorder.Event(vmi, k8sv1.EventTypeNormal, v.Reason, v.Message)
 	}
 }
 
-func (d *VirtualMachineController) updateHotplugVolumeStatus(vmi *v1.VirtualMachineInstance, volumeStatus v1.VolumeStatus, specVolumeMap map[string]v1.Volume) (v1.VolumeStatus, bool) {
+func (c *VirtualMachineController) updateHotplugVolumeStatus(vmi *v1.VirtualMachineInstance, volumeStatus v1.VolumeStatus, specVolumeMap map[string]v1.Volume) (v1.VolumeStatus, bool) {
 	needsRefresh := false
 	if volumeStatus.Target == "" {
 		needsRefresh = true
-		mounted, err := d.hotplugVolumeMounter.IsMounted(vmi, volumeStatus.Name, volumeStatus.HotplugVolume.AttachPodUID)
+		mounted, err := c.hotplugVolumeMounter.IsMounted(vmi, volumeStatus.Name, volumeStatus.HotplugVolume.AttachPodUID)
 		if err != nil {
 			log.Log.Object(vmi).Errorf("error occurred while checking if volume is mounted: %v", err)
 		}
@@ -973,13 +962,13 @@ func needToComputeChecksums(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
-func (d *VirtualMachineController) updateChecksumInfo(vmi *v1.VirtualMachineInstance, syncError error) error {
+func (c *VirtualMachineController) updateChecksumInfo(vmi *v1.VirtualMachineInstance, syncError error) error {
 
 	if syncError != nil || vmi.DeletionTimestamp != nil || !needToComputeChecksums(vmi) {
 		return nil
 	}
 
-	diskChecksums, err := d.containerDiskMounter.ComputeChecksums(vmi)
+	diskChecksums, err := c.containerDiskMounter.ComputeChecksums(vmi)
 	if goerror.Is(err, container_disk.ErrDiskContainerGone) {
 		log.Log.Errorf("cannot compute checksums as containerdisk/kernelboot containers seem to have been terminated")
 		return nil
@@ -1021,7 +1010,7 @@ func (d *VirtualMachineController) updateChecksumInfo(vmi *v1.VirtualMachineInst
 	return nil
 }
 
-func (d *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) bool {
+func (c *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) bool {
 	// used by unit test
 	hasHotplug := false
 
@@ -1048,11 +1037,11 @@ func (d *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.Virtua
 			}
 			if volumeStatus.HotplugVolume != nil {
 				hasHotplug = true
-				volumeStatus, tmpNeedsRefresh = d.updateHotplugVolumeStatus(vmi, volumeStatus, specVolumeMap)
+				volumeStatus, tmpNeedsRefresh = c.updateHotplugVolumeStatus(vmi, volumeStatus, specVolumeMap)
 				needsRefresh = needsRefresh || tmpNeedsRefresh
 			}
 			if volumeStatus.MemoryDumpVolume != nil {
-				volumeStatus, tmpNeedsRefresh = d.updateMemoryDumpInfo(vmi, volumeStatus, domain)
+				volumeStatus, tmpNeedsRefresh = c.updateMemoryDumpInfo(vmi, volumeStatus, domain)
 				needsRefresh = needsRefresh || tmpNeedsRefresh
 			}
 			newStatuses = append(newStatuses, volumeStatus)
@@ -1062,15 +1051,15 @@ func (d *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.Virtua
 			return strings.Compare(newStatuses[i].Name, newStatuses[j].Name) == -1
 		})
 		if needsRefresh {
-			d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second)
+			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second)
 		}
-		d.generateEventsForVolumeStatusChange(vmi, newStatusMap)
+		c.generateEventsForVolumeStatusChange(vmi, newStatusMap)
 		vmi.Status.VolumeStatus = newStatuses
 	}
 	return hasHotplug
 }
 
-func (d *VirtualMachineController) updateGuestInfoFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+func (c *VirtualMachineController) updateGuestInfoFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 
 	if domain == nil {
 		return
@@ -1088,7 +1077,7 @@ func (d *VirtualMachineController) updateGuestInfoFromDomain(vmi *v1.VirtualMach
 	}
 }
 
-func (d *VirtualMachineController) updateAccessCredentialConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) {
+func (c *VirtualMachineController) updateAccessCredentialConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) {
 
 	if domain == nil || domain.Spec.Metadata.KubeVirt.AccessCredential == nil {
 		return
@@ -1118,16 +1107,16 @@ func (d *VirtualMachineController) updateAccessCredentialConditions(vmi *v1.Virt
 		}
 		vmi.Status.Conditions = append(vmi.Status.Conditions, newCondition)
 		if status == k8sv1.ConditionTrue {
-			d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.AccessCredentialsSyncSuccess.String(), message)
+			c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.AccessCredentialsSyncSuccess.String(), message)
 		} else {
-			d.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.AccessCredentialsSyncFailed.String(), message)
+			c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.AccessCredentialsSyncFailed.String(), message)
 		}
 	}
 }
 
-func (d *VirtualMachineController) updateLiveMigrationConditions(vmi *v1.VirtualMachineInstance, condManager *controller.VirtualMachineInstanceConditionManager) {
+func (c *VirtualMachineController) updateLiveMigrationConditions(vmi *v1.VirtualMachineInstance, condManager *controller.VirtualMachineInstanceConditionManager) {
 	// Calculate whether the VM is migratable
-	liveMigrationCondition, isBlockMigration := d.calculateLiveMigrationCondition(vmi)
+	liveMigrationCondition, isBlockMigration := c.calculateLiveMigrationCondition(vmi)
 	if !condManager.HasCondition(vmi, v1.VirtualMachineInstanceIsMigratable) {
 		vmi.Status.Conditions = append(vmi.Status.Conditions, *liveMigrationCondition)
 		// Set VMI Migration Method
@@ -1143,15 +1132,15 @@ func (d *VirtualMachineController) updateLiveMigrationConditions(vmi *v1.Virtual
 			vmi.Status.Conditions = append(vmi.Status.Conditions, *liveMigrationCondition)
 		}
 	}
-	storageLiveMigCond := d.calculateLiveStorageMigrationCondition(vmi)
+	storageLiveMigCond := c.calculateLiveStorageMigrationCondition(vmi)
 	condManager.UpdateCondition(vmi, storageLiveMigCond)
-	evictable := migrations.VMIMigratableOnEviction(d.clusterConfig, vmi)
+	evictable := migrations.VMIMigratableOnEviction(c.clusterConfig, vmi)
 	if evictable && liveMigrationCondition.Status == k8sv1.ConditionFalse {
-		d.recorder.Eventf(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), "EvictionStrategy is set but vmi is not migratable; %s", liveMigrationCondition.Message)
+		c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), "EvictionStrategy is set but vmi is not migratable; %s", liveMigrationCondition.Message)
 	}
 }
 
-func (d *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) error {
+func (c *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) error {
 
 	// Update the condition when GA is connected
 	channelConnected := false
@@ -1182,7 +1171,7 @@ func (d *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMac
 	}
 
 	if condManager.HasCondition(vmi, v1.VirtualMachineInstanceAgentConnected) {
-		client, err := d.getLauncherClient(vmi)
+		client, err := c.getLauncherClient(vmi)
 		if err != nil {
 			return err
 		}
@@ -1203,7 +1192,7 @@ func (d *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMac
 			supported, reason = isGuestAgentSupported(vmi, guestInfo.SupportedCommands)
 			log.Log.V(3).Object(vmi).Info(reason)
 		} else {
-			for _, version := range d.clusterConfig.GetSupportedAgentVersions() {
+			for _, version := range c.clusterConfig.GetSupportedAgentVersions() {
 				supported = supported || regexp.MustCompile(version).MatchString(guestInfo.GAVersion)
 			}
 			if !supported {
@@ -1229,13 +1218,13 @@ func (d *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMac
 	return nil
 }
 
-func (d *VirtualMachineController) updatePausedConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) {
+func (c *VirtualMachineController) updatePausedConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) {
 
 	// Update paused condition in case VMI was paused / unpaused
 	if domain != nil && domain.Status.Status == api.Paused {
 		if !condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
 			reason := domain.Status.Reason
-			if d.isVMIPausedDuringMigration(vmi) {
+			if c.isVMIPausedDuringMigration(vmi) {
 				reason = api.ReasonPausedMigration
 			}
 			calculatePausedCondition(vmi, reason)
@@ -1251,7 +1240,7 @@ func dumpTargetFile(vmiName, volName string) string {
 	return targetFileName
 }
 
-func (d *VirtualMachineController) updateMemoryDumpInfo(vmi *v1.VirtualMachineInstance, volumeStatus v1.VolumeStatus, domain *api.Domain) (v1.VolumeStatus, bool) {
+func (c *VirtualMachineController) updateMemoryDumpInfo(vmi *v1.VirtualMachineInstance, volumeStatus v1.VolumeStatus, domain *api.Domain) (v1.VolumeStatus, bool) {
 	needsRefresh := false
 	switch volumeStatus.Phase {
 	case v1.HotplugVolumeMounted:
@@ -1288,7 +1277,7 @@ func (d *VirtualMachineController) updateMemoryDumpInfo(vmi *v1.VirtualMachineIn
 	return volumeStatus, needsRefresh
 }
 
-func (d *VirtualMachineController) updateFSFreezeStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+func (c *VirtualMachineController) updateFSFreezeStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 
 	if domain == nil || domain.Status.FSFreezeStatus.Status == "" {
 		return
@@ -1324,7 +1313,7 @@ func IsoGuestVolumePath(namespace, name string, volume *v1.Volume) string {
 	}
 }
 
-func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineInstance) {
+func (c *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineInstance) {
 	var podUID string
 	if vmi.Status.Phase != v1.Running {
 		return
@@ -1358,7 +1347,7 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 			continue
 		}
 
-		res, err := d.podIsolationDetector.Detect(vmi)
+		res, err := c.podIsolationDetector.Detect(vmi)
 		if err != nil {
 			log.DefaultLogger().Reason(err).Warningf("failed to detect VMI %s", vmi.Name)
 			continue
@@ -1390,7 +1379,7 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 	}
 }
 
-func (d *VirtualMachineController) updateSELinuxContext(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) updateSELinuxContext(vmi *v1.VirtualMachineInstance) error {
 	_, present, err := selinux.NewSELinux()
 	if err != nil {
 		return err
@@ -1408,73 +1397,73 @@ func (d *VirtualMachineController) updateSELinuxContext(vmi *v1.VirtualMachineIn
 	return nil
 }
 
-func (d *VirtualMachineController) updateVMIStatusFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
-	d.updateIsoSizeStatus(vmi)
-	err := d.updateSELinuxContext(vmi)
+func (c *VirtualMachineController) updateVMIStatusFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+	c.updateIsoSizeStatus(vmi)
+	err := c.updateSELinuxContext(vmi)
 	if err != nil {
 		log.Log.Reason(err).Errorf("couldn't find the SELinux context for %s", vmi.Name)
 	}
-	d.setMigrationProgressStatus(vmi, domain)
-	d.updateGuestInfoFromDomain(vmi, domain)
-	d.updateVolumeStatusesFromDomain(vmi, domain)
-	d.updateFSFreezeStatus(vmi, domain)
-	d.updateMachineType(vmi, domain)
-	if err = d.updateMemoryInfo(vmi, domain); err != nil {
+	c.setMigrationProgressStatus(vmi, domain)
+	c.updateGuestInfoFromDomain(vmi, domain)
+	c.updateVolumeStatusesFromDomain(vmi, domain)
+	c.updateFSFreezeStatus(vmi, domain)
+	c.updateMachineType(vmi, domain)
+	if err = c.updateMemoryInfo(vmi, domain); err != nil {
 		return err
 	}
-	err = d.netStat.UpdateStatus(vmi, domain)
+	err = c.netStat.UpdateStatus(vmi, domain)
 	return err
 }
 
-func (d *VirtualMachineController) updateVMIConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) error {
-	d.updateAccessCredentialConditions(vmi, domain, condManager)
-	d.updateLiveMigrationConditions(vmi, condManager)
-	err := d.updateGuestAgentConditions(vmi, domain, condManager)
+func (c *VirtualMachineController) updateVMIConditions(vmi *v1.VirtualMachineInstance, domain *api.Domain, condManager *controller.VirtualMachineInstanceConditionManager) error {
+	c.updateAccessCredentialConditions(vmi, domain, condManager)
+	c.updateLiveMigrationConditions(vmi, condManager)
+	err := c.updateGuestAgentConditions(vmi, domain, condManager)
 	if err != nil {
 		return err
 	}
-	d.updatePausedConditions(vmi, domain, condManager)
+	c.updatePausedConditions(vmi, domain, condManager)
 
 	return nil
 }
 
-func (d *VirtualMachineController) updateVMIStatus(origVMI *v1.VirtualMachineInstance, domain *api.Domain, syncError error) (err error) {
+func (c *VirtualMachineController) updateVMIStatus(origVMI *v1.VirtualMachineInstance, domain *api.Domain, syncError error) (err error) {
 	condManager := controller.NewVirtualMachineInstanceConditionManager()
 
 	// Don't update the VirtualMachineInstance if it is already in a final state
 	if origVMI.IsFinal() {
 		return nil
-	} else if origVMI.Status.NodeName != "" && origVMI.Status.NodeName != d.host {
+	} else if origVMI.Status.NodeName != "" && origVMI.Status.NodeName != c.host {
 		// Only update the VMI's phase if this node owns the VMI.
 		// not owned by this host, likely the result of a migration
 		return nil
 	} else if domainMigrated(domain) {
-		return d.migrationSourceUpdateVMIStatus(origVMI, domain)
+		return c.migrationSourceUpdateVMIStatus(origVMI, domain)
 	}
 
 	vmi := origVMI.DeepCopy()
 	oldStatus := *vmi.Status.DeepCopy()
 
 	// Update VMI status fields based on what is reported on the domain
-	err = d.updateVMIStatusFromDomain(vmi, domain)
+	err = c.updateVMIStatusFromDomain(vmi, domain)
 	if err != nil {
 		return err
 	}
 
 	// Calculate the new VirtualMachineInstance state based on what libvirt reported
-	err = d.setVmPhaseForStatusReason(domain, vmi)
+	err = c.setVmPhaseForStatusReason(domain, vmi)
 	if err != nil {
 		return err
 	}
 
 	// Update conditions on VMI Status
-	err = d.updateVMIConditions(vmi, domain, condManager)
+	err = c.updateVMIConditions(vmi, domain, condManager)
 	if err != nil {
 		return err
 	}
 
 	// Store containerdisks and kernelboot checksums
-	if err := d.updateChecksumInfo(vmi, syncError); err != nil {
+	if err := c.updateChecksumInfo(vmi, syncError); err != nil {
 		return err
 	}
 
@@ -1486,17 +1475,17 @@ func (d *VirtualMachineController) updateVMIStatus(origVMI *v1.VirtualMachineIns
 	// Only issue vmi update if status has changed
 	if !equality.Semantic.DeepEqual(oldStatus, vmi.Status) {
 		key := controller.VirtualMachineInstanceKey(vmi)
-		d.vmiExpectations.SetExpectations(key, 1, 0)
-		_, err = d.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+		c.vmiExpectations.SetExpectations(key, 1, 0)
+		_, err = c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
 		if err != nil {
-			d.vmiExpectations.LowerExpectations(key, 1, 0)
+			c.vmiExpectations.LowerExpectations(key, 1, 0)
 			return err
 		}
 	}
 
 	// Record an event on the VMI when the VMI's phase changes
 	if oldStatus.Phase != vmi.Status.Phase {
-		d.recordPhaseChangeEvent(vmi)
+		c.recordPhaseChangeEvent(vmi)
 	}
 
 	return nil
@@ -1520,14 +1509,14 @@ func handleSyncError(vmi *v1.VirtualMachineInstance, condManager *controller.Vir
 	condManager.CheckFailure(vmi, syncError, "Synchronizing with the Domain failed.")
 }
 
-func (d *VirtualMachineController) recordPhaseChangeEvent(vmi *v1.VirtualMachineInstance) {
+func (c *VirtualMachineController) recordPhaseChangeEvent(vmi *v1.VirtualMachineInstance) {
 	switch vmi.Status.Phase {
 	case v1.Running:
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Started.String(), VMIStarted)
+		c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Started.String(), VMIStarted)
 	case v1.Succeeded:
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Stopped.String(), VMIShutdown)
+		c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Stopped.String(), VMIShutdown)
 	case v1.Failed:
-		d.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Stopped.String(), VMICrashed)
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Stopped.String(), VMICrashed)
 	}
 }
 
@@ -1636,18 +1625,18 @@ func newNonMigratableCondition(msg string, reason string) *v1.VirtualMachineInst
 	}
 }
 
-func (d *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstanceCondition, bool) {
-	isBlockMigration, err := d.checkVolumesForMigration(vmi)
+func (c *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstanceCondition, bool) {
+	isBlockMigration, err := c.checkVolumesForMigration(vmi)
 	if err != nil {
 		return newNonMigratableCondition(err.Error(), v1.VirtualMachineInstanceReasonDisksNotMigratable), isBlockMigration
 	}
 
-	err = d.checkNetworkInterfacesForMigration(vmi)
+	err = c.checkNetworkInterfacesForMigration(vmi)
 	if err != nil {
 		return newNonMigratableCondition(err.Error(), v1.VirtualMachineInstanceReasonInterfaceNotMigratable), isBlockMigration
 	}
 
-	if err := d.isHostModelMigratable(vmi); err != nil {
+	if err := c.isHostModelMigratable(vmi); err != nil {
 		return newNonMigratableCondition(err.Error(), v1.VirtualMachineInstanceReasonCPUModeNotMigratable), isBlockMigration
 	}
 
@@ -1727,14 +1716,14 @@ func (cond *multipleNonMigratableCondition) generateStorageLiveMigrationConditio
 	}
 }
 
-func (d *VirtualMachineController) calculateLiveStorageMigrationCondition(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceCondition {
+func (c *VirtualMachineController) calculateLiveStorageMigrationCondition(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceCondition {
 	multiCond := newMultipleNonMigratableCondition()
 
-	if err := d.checkNetworkInterfacesForMigration(vmi); err != nil {
+	if err := c.checkNetworkInterfacesForMigration(vmi); err != nil {
 		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonInterfaceNotMigratable, err.Error())
 	}
 
-	if err := d.isHostModelMigratable(vmi); err != nil {
+	if err := c.isHostModelMigratable(vmi); err != nil {
 		multiCond.addNonMigratableCondition(v1.VirtualMachineInstanceReasonCPUModeNotMigratable, err.Error())
 	}
 
@@ -1831,16 +1820,16 @@ func (c *VirtualMachineController) Execute() bool {
 	return true
 }
 
-func (d *VirtualMachineController) getVMIFromCache(key string) (vmi *v1.VirtualMachineInstance, exists bool, err error) {
+func (c *VirtualMachineController) getVMIFromCache(key string) (vmi *v1.VirtualMachineInstance, exists bool, err error) {
 
 	// Fetch the latest Vm state from cache
-	obj, exists, err := d.vmiSourceStore.GetByKey(key)
+	obj, exists, err := c.vmiSourceStore.GetByKey(key)
 	if err != nil {
 		return nil, false, err
 	}
 
 	if !exists {
-		obj, exists, err = d.vmiTargetStore.GetByKey(key)
+		obj, exists, err = c.vmiTargetStore.GetByKey(key)
 		if err != nil {
 			return nil, false, err
 		}
@@ -1860,9 +1849,9 @@ func (d *VirtualMachineController) getVMIFromCache(key string) (vmi *v1.VirtualM
 	return vmi, exists, nil
 }
 
-func (d *VirtualMachineController) getDomainFromCache(key string) (domain *api.Domain, exists bool, cachedUID types.UID, err error) {
+func (c *VirtualMachineController) getDomainFromCache(key string) (domain *api.Domain, exists bool, cachedUID types.UID, err error) {
 
-	obj, exists, err := d.domainStore.GetByKey(key)
+	obj, exists, err := c.domainStore.GetByKey(key)
 
 	if err != nil {
 		return nil, false, "", err
@@ -1882,10 +1871,10 @@ func (d *VirtualMachineController) getDomainFromCache(key string) (domain *api.D
 	return domain, exists, cachedUID, nil
 }
 
-func (d *VirtualMachineController) migrationOrphanedSourceNodeExecute(vmi *v1.VirtualMachineInstance, domainExists bool) error {
+func (c *VirtualMachineController) migrationOrphanedSourceNodeExecute(vmi *v1.VirtualMachineInstance, domainExists bool) error {
 
 	if domainExists {
-		err := d.processVmDelete(vmi)
+		err := c.processVmDelete(vmi)
 		if err != nil {
 			return err
 		}
@@ -1893,12 +1882,12 @@ func (d *VirtualMachineController) migrationOrphanedSourceNodeExecute(vmi *v1.Vi
 		// the successful delete here because we don't have
 		// to report the deletion results on the VMI status
 		// in this case.
-		err = d.processVmCleanup(vmi)
+		err = c.processVmCleanup(vmi)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := d.processVmCleanup(vmi)
+		err := c.processVmCleanup(vmi)
 		if err != nil {
 			return err
 		}
@@ -1906,7 +1895,7 @@ func (d *VirtualMachineController) migrationOrphanedSourceNodeExecute(vmi *v1.Vi
 	return nil
 }
 
-func (d *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachineInstance, vmiExists bool, domain *api.Domain) error {
+func (c *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachineInstance, vmiExists bool, domain *api.Domain) error {
 
 	// set to true when preparation of migration target should be aborted.
 	shouldAbort := false
@@ -1923,7 +1912,7 @@ func (d *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachine
 		shouldAbort = true
 	} else if vmi.IsFinal() {
 		shouldAbort = true
-	} else if d.hasStaleClientConnections(vmi) {
+	} else if c.hasStaleClientConnections(vmi) {
 		// if stale client exists, force cleanup.
 		// This can happen as a result of a previously
 		// failed attempt to migrate the vmi to this node.
@@ -1933,38 +1922,38 @@ func (d *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachine
 	domainExists := domain != nil
 	if shouldAbort {
 		if domainExists {
-			err := d.processVmDelete(vmi)
+			err := c.processVmDelete(vmi)
 			if err != nil {
 				return err
 			}
 		}
 
-		err := d.processVmCleanup(vmi)
+		err := c.processVmCleanup(vmi)
 		if err != nil {
 			return err
 		}
 	} else if shouldCleanUp {
 		log.Log.Object(vmi).Infof("Stale client for migration target found. Cleaning up.")
 
-		err := d.processVmCleanup(vmi)
+		err := c.processVmCleanup(vmi)
 		if err != nil {
 			return err
 		}
 
 		// if we're still the migration target, we need to keep trying until the migration fails.
 		// it's possible we're simply waiting for another target pod to come online.
-		d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+		c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 
 	} else if shouldUpdate {
 		log.Log.Object(vmi).Info("Processing vmi migration target update")
 
 		// prepare the POD for the migration
-		err := d.processVmUpdate(vmi, domain)
+		err := c.processVmUpdate(vmi, domain)
 		if err != nil {
 			return err
 		}
 
-		err = d.migrationTargetUpdateVMIStatus(vmi, domain)
+		err = c.migrationTargetUpdateVMIStatus(vmi, domain)
 		if err != nil {
 			return err
 		}
@@ -1974,7 +1963,7 @@ func (d *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachine
 }
 
 // Determine if gracefulShutdown has been triggered by virt-launcher
-func (d *VirtualMachineController) hasGracefulShutdownTrigger(domain *api.Domain) bool {
+func (c *VirtualMachineController) hasGracefulShutdownTrigger(domain *api.Domain) bool {
 	if domain == nil {
 		return false
 	}
@@ -1985,7 +1974,7 @@ func (d *VirtualMachineController) hasGracefulShutdownTrigger(domain *api.Domain
 		*gracePeriod.MarkedForGracefulShutdown
 }
 
-func (d *VirtualMachineController) defaultExecute(key string,
+func (c *VirtualMachineController) defaultExecute(key string,
 	vmi *v1.VirtualMachineInstance,
 	vmiExists bool,
 	domain *api.Domain,
@@ -2025,7 +2014,7 @@ func (d *VirtualMachineController) defaultExecute(key string,
 	domainMigrated := domainExists && domainMigrated(domain)
 	forceShutdownIrrecoverable = domainExists && domainPausedFailedPostCopy(domain)
 
-	gracefulShutdown := d.hasGracefulShutdownTrigger(domain)
+	gracefulShutdown := c.hasGracefulShutdownTrigger(domain)
 	if gracefulShutdown && vmi.IsRunning() {
 		if domainAlive {
 			log.Log.Object(vmi).V(3).Info("Shutting down due to graceful shutdown signal.")
@@ -2085,7 +2074,7 @@ func (d *VirtualMachineController) defaultExecute(key string,
 	if vmiExists && !vmi.IsFinal() {
 		// requiring the phase of the domain and VirtualMachineInstance to be in sync is an
 		// optimization that prevents unnecessary re-processing VMIs during the start flow.
-		phase, err := d.calculateVmPhaseForStatusReason(domain, vmi)
+		phase, err := c.calculateVmPhaseForStatusReason(domain, vmi)
 		if err != nil {
 			return err
 		}
@@ -2093,12 +2082,12 @@ func (d *VirtualMachineController) defaultExecute(key string,
 			shouldUpdate = true
 		}
 
-		if shouldDelay, delay := d.ioErrorRetryManager.ShouldDelay(string(vmi.UID), func() bool {
+		if shouldDelay, delay := c.ioErrorRetryManager.ShouldDelay(string(vmi.UID), func() bool {
 			return isIOError(shouldUpdate, domainExists, domain)
 		}); shouldDelay {
 			shouldUpdate = false
 			log.Log.Object(vmi).Infof("Delay vm update for %f seconds", delay.Seconds())
-			d.queue.AddAfter(key, delay)
+			c.queue.AddAfter(key, delay)
 		}
 	}
 
@@ -2115,7 +2104,7 @@ func (d *VirtualMachineController) defaultExecute(key string,
 			!vmi.IsFinal() &&
 			vmi.DeletionTimestamp == nil &&
 			vmi.Status.NodeName != "" &&
-			vmi.Status.NodeName == d.host {
+			vmi.Status.NodeName == c.host {
 
 			// If the domain migrated but the VMI still thinks this node
 			// is the host, force ignore the sync until the VMI's status
@@ -2135,29 +2124,29 @@ func (d *VirtualMachineController) defaultExecute(key string,
 		log.Log.Object(vmi).V(3).Info("No update processing required: forced ignore")
 	case shouldShutdown:
 		log.Log.Object(vmi).V(3).Info("Processing shutdown.")
-		syncErr = d.processVmShutdown(vmi, domain)
+		syncErr = c.processVmShutdown(vmi, domain)
 	case forceShutdownIrrecoverable:
 		msg := formatIrrecoverableErrorMessage(domain)
 		log.Log.Object(vmi).V(3).Infof("Processing a destruction of an irrecoverable domain - %s.", msg)
-		syncErr = d.processVmDestroy(vmi, domain)
+		syncErr = c.processVmDestroy(vmi, domain)
 		if syncErr == nil {
 			syncErr = &vmiIrrecoverableError{msg}
 		}
 	case shouldDelete:
 		log.Log.Object(vmi).V(3).Info("Processing deletion.")
-		syncErr = d.processVmDelete(vmi)
+		syncErr = c.processVmDelete(vmi)
 	case shouldCleanUp:
 		log.Log.Object(vmi).V(3).Info("Processing local ephemeral data cleanup for shutdown domain.")
-		syncErr = d.processVmCleanup(vmi)
+		syncErr = c.processVmCleanup(vmi)
 	case shouldUpdate:
 		log.Log.Object(vmi).V(3).Info("Processing vmi update")
-		syncErr = d.processVmUpdate(vmi, domain)
+		syncErr = c.processVmUpdate(vmi, domain)
 	default:
 		log.Log.Object(vmi).V(3).Info("No update processing required")
 	}
 
 	if syncErr != nil && !vmi.IsFinal() {
-		d.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.SyncFailed.String(), syncErr.Error())
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.SyncFailed.String(), syncErr.Error())
 
 		// `syncErr` will be propagated anyway, and it will be logged in `re-enqueueing`
 		// so there is no need to log it twice in hot path without increased verbosity.
@@ -2166,7 +2155,7 @@ func (d *VirtualMachineController) defaultExecute(key string,
 
 	// Update the VirtualMachineInstance status, if the VirtualMachineInstance exists
 	if vmiExists {
-		if err := d.updateVMIStatus(vmi, domain, syncErr); err != nil {
+		if err := c.updateVMIStatus(vmi, domain, syncErr); err != nil {
 			log.Log.Object(vmi).Reason(err).Error("Updating the VirtualMachineInstance status failed.")
 			return err
 		}
@@ -2181,19 +2170,19 @@ func (d *VirtualMachineController) defaultExecute(key string,
 
 }
 
-func (d *VirtualMachineController) execute(key string) error {
-	vmi, vmiExists, err := d.getVMIFromCache(key)
+func (c *VirtualMachineController) execute(key string) error {
+	vmi, vmiExists, err := c.getVMIFromCache(key)
 	if err != nil {
 		return err
 	}
 
 	if !vmiExists {
-		d.vmiExpectations.DeleteExpectations(key)
-	} else if !d.vmiExpectations.SatisfiedExpectations(key) {
+		c.vmiExpectations.DeleteExpectations(key)
+	} else if !c.vmiExpectations.SatisfiedExpectations(key) {
 		return nil
 	}
 
-	domain, domainExists, domainCachedUID, err := d.getDomainFromCache(key)
+	domain, domainExists, domainCachedUID, err := c.getDomainFromCache(key)
 	if err != nil {
 		return err
 	}
@@ -2218,23 +2207,23 @@ func (d *VirtualMachineController) execute(key string) error {
 	if vmiExists && domainExists && domain.Spec.Metadata.KubeVirt.UID != vmi.UID {
 		oldVMI := v1.NewVMIReferenceFromNameWithNS(vmi.Namespace, vmi.Name)
 		oldVMI.UID = domain.Spec.Metadata.KubeVirt.UID
-		expired, initialized, err := d.isLauncherClientUnresponsive(oldVMI)
+		expired, initialized, err := c.isLauncherClientUnresponsive(oldVMI)
 		if err != nil {
 			return err
 		}
 		// If we found an outdated domain which is also not alive anymore, clean up
 		if !initialized {
-			d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 			return nil
 		} else if expired {
 			log.Log.Object(oldVMI).Infof("Detected stale vmi %s that still needs cleanup before new vmi %s with identical name/namespace can be processed", oldVMI.UID, vmi.UID)
-			err = d.processVmCleanup(oldVMI)
+			err = c.processVmCleanup(oldVMI)
 			if err != nil {
 				return err
 			}
 			// Make sure we re-enqueue the key to ensure this new VMI is processed
 			// after the stale domain is removed
-			d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*5)
+			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*5)
 		}
 
 		return nil
@@ -2243,23 +2232,23 @@ func (d *VirtualMachineController) execute(key string) error {
 	// Take different execution paths depending on the state of the migration and the
 	// node this is executed on.
 
-	if vmiExists && d.isPreMigrationTarget(vmi) {
+	if vmiExists && c.isPreMigrationTarget(vmi) {
 		// 1. PRE-MIGRATION TARGET PREPARATION PATH
 		//
 		// If this node is the target of the vmi's migration, take
 		// a different execute path. The target execute path prepares
 		// the local environment for the migration, but does not
 		// start the VMI
-		return d.migrationTargetExecute(vmi, vmiExists, domain)
-	} else if vmiExists && d.isOrphanedMigrationSource(vmi) {
+		return c.migrationTargetExecute(vmi, vmiExists, domain)
+	} else if vmiExists && c.isOrphanedMigrationSource(vmi) {
 		// 3. POST-MIGRATION SOURCE CLEANUP
 		//
 		// After a migration, the migrated domain still exists in the old
 		// source's domain cache. Ensure that any node that isn't currently
 		// the target or owner of the VMI handles deleting the domain locally.
-		return d.migrationOrphanedSourceNodeExecute(vmi, domainExists)
+		return c.migrationOrphanedSourceNodeExecute(vmi, domainExists)
 	}
-	return d.defaultExecute(key,
+	return c.defaultExecute(key,
 		vmi,
 		vmiExists,
 		domain,
@@ -2267,35 +2256,35 @@ func (d *VirtualMachineController) execute(key string) error {
 
 }
 
-func (d *VirtualMachineController) processVmCleanup(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) processVmCleanup(vmi *v1.VirtualMachineInstance) error {
 
 	vmiId := string(vmi.UID)
 
 	log.Log.Object(vmi).Infof("Performing final local cleanup for vmi with uid %s", vmiId)
 
-	d.migrationProxy.StopTargetListener(vmiId)
-	d.migrationProxy.StopSourceListener(vmiId)
+	c.migrationProxy.StopTargetListener(vmiId)
+	c.migrationProxy.StopSourceListener(vmiId)
 
-	d.downwardMetricsManager.StopServer(vmi)
+	c.downwardMetricsManager.StopServer(vmi)
 
 	// Unmount container disks and clean up remaining files
-	if err := d.containerDiskMounter.Unmount(vmi); err != nil {
+	if err := c.containerDiskMounter.Unmount(vmi); err != nil {
 		return err
 	}
 
 	// UnmountAll does the cleanup on the "best effort" basis: it is
 	// safe to pass a nil cgroupManager.
 	cgroupManager, _ := getCgroupManager(vmi)
-	if err := d.hotplugVolumeMounter.UnmountAll(vmi, cgroupManager); err != nil {
+	if err := c.hotplugVolumeMounter.UnmountAll(vmi, cgroupManager); err != nil {
 		return err
 	}
 
-	d.teardownNetwork(vmi)
+	c.teardownNetwork(vmi)
 
-	d.sriovHotplugExecutorPool.Delete(vmi.UID)
+	c.sriovHotplugExecutorPool.Delete(vmi.UID)
 
 	// Watch dog file and command client must be the last things removed here
-	if err := d.closeLauncherClient(vmi); err != nil {
+	if err := c.closeLauncherClient(vmi); err != nil {
 		return err
 	}
 
@@ -2305,37 +2294,37 @@ func (d *VirtualMachineController) processVmCleanup(vmi *v1.VirtualMachineInstan
 	// "DELETE"
 	domain := api.NewDomainReferenceFromName(vmi.Namespace, vmi.Name)
 	log.Log.Object(domain).Infof("Removing domain from cache during final cleanup")
-	return d.domainStore.Delete(domain)
+	return c.domainStore.Delete(domain)
 }
 
-func (d *VirtualMachineController) closeLauncherClient(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) closeLauncherClient(vmi *v1.VirtualMachineInstance) error {
 
 	// UID is required in order to close socket
 	if string(vmi.GetUID()) == "" {
 		return nil
 	}
 
-	clientInfo, exists := d.launcherClients.Load(vmi.UID)
+	clientInfo, exists := c.launcherClients.Load(vmi.UID)
 	if exists && clientInfo.Client != nil {
 		clientInfo.Client.Close()
 		close(clientInfo.DomainPipeStopChan)
 	}
 
 	virtcache.DeleteGhostRecord(vmi.Namespace, vmi.Name)
-	d.launcherClients.Delete(vmi.UID)
+	c.launcherClients.Delete(vmi.UID)
 	return nil
 }
 
 // used by unit tests to add mock clients
-func (d *VirtualMachineController) addLauncherClient(vmUID types.UID, info *virtcache.LauncherClientInfo) error {
-	d.launcherClients.Store(vmUID, info)
+func (c *VirtualMachineController) addLauncherClient(vmUID types.UID, info *virtcache.LauncherClientInfo) error {
+	c.launcherClients.Store(vmUID, info)
 	return nil
 }
 
-func (d *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualMachineInstance) (unresponsive bool, initialized bool, err error) {
+func (c *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualMachineInstance) (unresponsive bool, initialized bool, err error) {
 	var socketFile string
 
-	clientInfo, exists := d.launcherClients.Load(vmi.UID)
+	clientInfo, exists := c.launcherClients.Load(vmi.UID)
 	if exists {
 		if clientInfo.Ready == true {
 			// use cached socket if we previously established a connection
@@ -2362,7 +2351,7 @@ func (d *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualM
 			NotInitializedSince: time.Now(),
 			Ready:               false,
 		}
-		d.launcherClients.Store(vmi.UID, clientInfo)
+		c.launcherClients.Store(vmi.UID, clientInfo)
 		// attempt to find the socket if the established connection doesn't currently exist.
 		socketFile, err = cmdclient.FindSocketOnHost(vmi)
 		// no socket file, no VMI, so it's unresponsive
@@ -2380,10 +2369,10 @@ func (d *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualM
 	return cmdclient.IsSocketUnresponsive(socketFile), true, nil
 }
 
-func (d *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInstance) (cmdclient.LauncherClient, error) {
+func (c *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInstance) (cmdclient.LauncherClient, error) {
 	var err error
 
-	clientInfo, exists := d.launcherClients.Load(vmi.UID)
+	clientInfo, exists := c.launcherClients.Load(vmi.UID)
 	if exists && clientInfo.Client != nil {
 		return clientInfo.Client, nil
 	}
@@ -2405,14 +2394,14 @@ func (d *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInsta
 
 	domainPipeStopChan := make(chan struct{})
 	//we pipe in the domain socket into the VMI's filesystem
-	err = d.startDomainNotifyPipe(domainPipeStopChan, vmi)
+	err = c.startDomainNotifyPipe(domainPipeStopChan, vmi)
 	if err != nil {
 		client.Close()
 		close(domainPipeStopChan)
 		return nil, err
 	}
 
-	d.launcherClients.Store(vmi.UID, &virtcache.LauncherClientInfo{
+	c.launcherClients.Store(vmi.UID, &virtcache.LauncherClientInfo{
 		Client:              client,
 		SocketFile:          socketFile,
 		DomainPipeStopChan:  domainPipeStopChan,
@@ -2423,27 +2412,27 @@ func (d *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInsta
 	return client, nil
 }
 
-func (d *VirtualMachineController) processVmDestroy(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (c *VirtualMachineController) processVmDestroy(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	tryGracefully := false
-	return d.helperVmShutdown(vmi, domain, tryGracefully)
+	return c.helperVmShutdown(vmi, domain, tryGracefully)
 }
 
-func (d *VirtualMachineController) processVmShutdown(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (c *VirtualMachineController) processVmShutdown(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	tryGracefully := true
-	return d.helperVmShutdown(vmi, domain, tryGracefully)
+	return c.helperVmShutdown(vmi, domain, tryGracefully)
 }
 
-func (d *VirtualMachineController) helperVmShutdown(vmi *v1.VirtualMachineInstance, domain *api.Domain, tryGracefully bool) error {
+func (c *VirtualMachineController) helperVmShutdown(vmi *v1.VirtualMachineInstance, domain *api.Domain, tryGracefully bool) error {
 
 	// Only attempt to shutdown/destroy if we still have a connection established with the pod.
-	client, err := d.getVerifiedLauncherClient(vmi)
+	client, err := c.getVerifiedLauncherClient(vmi)
 	if err != nil {
 		return err
 	}
 
 	if domainHasGracePeriod(domain) && tryGracefully {
-		if expired, timeLeft := d.hasGracePeriodExpired(domain); !expired {
-			return d.handleVMIShutdown(vmi, domain, client, timeLeft)
+		if expired, timeLeft := c.hasGracePeriodExpired(domain); !expired {
+			return c.handleVMIShutdown(vmi, domain, client, timeLeft)
 		}
 		log.Log.Object(vmi).Infof("Grace period expired, killing deleted VirtualMachineInstance %s", vmi.GetObjectMeta().GetName())
 	} else {
@@ -2461,20 +2450,20 @@ func (d *VirtualMachineController) helperVmShutdown(vmi *v1.VirtualMachineInstan
 		return err
 	}
 
-	d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Deleted.String(), VMIStopping)
+	c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Deleted.String(), VMIStopping)
 
 	return nil
 }
 
-func (d *VirtualMachineController) handleVMIShutdown(vmi *v1.VirtualMachineInstance, domain *api.Domain, client cmdclient.LauncherClient, timeLeft int64) error {
+func (c *VirtualMachineController) handleVMIShutdown(vmi *v1.VirtualMachineInstance, domain *api.Domain, client cmdclient.LauncherClient, timeLeft int64) error {
 	if domain.Status.Status != api.Shutdown {
-		return d.shutdownVMI(vmi, client, timeLeft)
+		return c.shutdownVMI(vmi, client, timeLeft)
 	}
 	log.Log.V(4).Object(vmi).Infof("%s is already shutting down.", vmi.GetObjectMeta().GetName())
 	return nil
 }
 
-func (d *VirtualMachineController) shutdownVMI(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient, timeLeft int64) error {
+func (c *VirtualMachineController) shutdownVMI(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient, timeLeft int64) error {
 	err := client.ShutdownVirtualMachine(vmi)
 	if err != nil && !cmdclient.IsDisconnected(err) {
 		// Only report err if it wasn't the result of a disconnect.
@@ -2502,15 +2491,15 @@ func (d *VirtualMachineController) shutdownVMI(vmi *v1.VirtualMachineInstance, c
 	}
 
 	// pending graceful shutdown.
-	d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Duration(timeLeft)*time.Second)
-	d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.ShuttingDown.String(), VMIGracefulShutdown)
+	c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Duration(timeLeft)*time.Second)
+	c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.ShuttingDown.String(), VMIGracefulShutdown)
 	return nil
 }
 
-func (d *VirtualMachineController) processVmDelete(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) processVmDelete(vmi *v1.VirtualMachineInstance) error {
 
 	// Only attempt to shutdown/destroy if we still have a connection established with the pod.
-	client, err := d.getVerifiedLauncherClient(vmi)
+	client, err := c.getVerifiedLauncherClient(vmi)
 
 	// If the pod has been torn down, we know the VirtualMachineInstance is down.
 	if err == nil {
@@ -2518,7 +2507,7 @@ func (d *VirtualMachineController) processVmDelete(vmi *v1.VirtualMachineInstanc
 		log.Log.Object(vmi).Infof("Signaled deletion for %s", vmi.GetObjectMeta().GetName())
 
 		// pending deletion.
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Deleted.String(), VMISignalDeletion)
+		c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Deleted.String(), VMISignalDeletion)
 
 		err = client.DeleteDomain(vmi)
 		if err != nil && !cmdclient.IsDisconnected(err) {
@@ -2536,8 +2525,8 @@ func (d *VirtualMachineController) processVmDelete(vmi *v1.VirtualMachineInstanc
 
 }
 
-func (d *VirtualMachineController) hasStaleClientConnections(vmi *v1.VirtualMachineInstance) bool {
-	_, err := d.getVerifiedLauncherClient(vmi)
+func (c *VirtualMachineController) hasStaleClientConnections(vmi *v1.VirtualMachineInstance) bool {
+	_, err := c.getVerifiedLauncherClient(vmi)
 	if err == nil {
 		// current client connection is good.
 		return false
@@ -2552,8 +2541,8 @@ func (d *VirtualMachineController) hasStaleClientConnections(vmi *v1.VirtualMach
 
 }
 
-func (d *VirtualMachineController) getVerifiedLauncherClient(vmi *v1.VirtualMachineInstance) (client cmdclient.LauncherClient, err error) {
-	client, err = d.getLauncherClient(vmi)
+func (c *VirtualMachineController) getVerifiedLauncherClient(vmi *v1.VirtualMachineInstance) (client cmdclient.LauncherClient, err error) {
+	client, err = c.getLauncherClient(vmi)
 	if err != nil {
 		return
 	}
@@ -2564,35 +2553,35 @@ func (d *VirtualMachineController) getVerifiedLauncherClient(vmi *v1.VirtualMach
 	return
 }
 
-func (d *VirtualMachineController) isOrphanedMigrationSource(vmi *v1.VirtualMachineInstance) bool {
+func (c *VirtualMachineController) isOrphanedMigrationSource(vmi *v1.VirtualMachineInstance) bool {
 	nodeName, ok := vmi.Labels[v1.NodeNameLabel]
 
-	if ok && nodeName != "" && nodeName != d.host {
+	if ok && nodeName != "" && nodeName != c.host {
 		return true
 	}
 
 	return false
 }
 
-func (d *VirtualMachineController) isPreMigrationTarget(vmi *v1.VirtualMachineInstance) bool {
+func (c *VirtualMachineController) isPreMigrationTarget(vmi *v1.VirtualMachineInstance) bool {
 
 	migrationTargetNodeName, ok := vmi.Labels[v1.MigrationTargetNodeNameLabel]
 
 	if ok &&
 		migrationTargetNodeName != "" &&
 		migrationTargetNodeName != vmi.Status.NodeName &&
-		migrationTargetNodeName == d.host {
+		migrationTargetNodeName == c.host {
 		return true
 	}
 
 	return false
 }
 
-func (d *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.VirtualMachineInstance) error {
-	return netvmispec.VerifyVMIMigratable(vmi, d.clusterConfig.GetNetworkBindings())
+func (c *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.VirtualMachineInstance) error {
+	return netvmispec.VerifyVMIMigratable(vmi, c.clusterConfig.GetNetworkBindings())
 }
 
-func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachineInstance) (blockMigrate bool, err error) {
+func (c *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachineInstance) (blockMigrate bool, err error) {
 	volumeStatusMap := make(map[string]v1.VolumeStatus)
 
 	for _, volumeStatus := range vmi.Status.VolumeStatus {
@@ -2654,16 +2643,16 @@ func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachi
 	return
 }
 
-func (d *VirtualMachineController) isVMIPausedDuringMigration(vmi *v1.VirtualMachineInstance) bool {
+func (c *VirtualMachineController) isVMIPausedDuringMigration(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Status.MigrationState != nil &&
 		vmi.Status.MigrationState.Mode == v1.MigrationPaused &&
 		!vmi.Status.MigrationState.Completed
 }
 
-func (d *VirtualMachineController) isMigrationSource(vmi *v1.VirtualMachineInstance) bool {
+func (c *VirtualMachineController) isMigrationSource(vmi *v1.VirtualMachineInstance) bool {
 
 	if vmi.Status.MigrationState != nil &&
-		vmi.Status.MigrationState.SourceNode == d.host &&
+		vmi.Status.MigrationState.SourceNode == c.host &&
 		vmi.Status.MigrationState.TargetNodeAddress != "" &&
 		!vmi.Status.MigrationState.Completed {
 
@@ -2673,19 +2662,19 @@ func (d *VirtualMachineController) isMigrationSource(vmi *v1.VirtualMachineInsta
 
 }
 
-func (d *VirtualMachineController) handleTargetMigrationProxy(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) handleTargetMigrationProxy(vmi *v1.VirtualMachineInstance) error {
 	// handle starting/stopping target migration proxy
 	migrationTargetSockets := []string{}
-	res, err := d.podIsolationDetector.Detect(vmi)
+	res, err := c.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return err
 	}
 
 	// Get the libvirt connection socket file on the destination pod.
-	socketFile := fmt.Sprintf(filepath.Join(d.virtLauncherFSRunDirPattern, "libvirt/virtqemud-sock"), res.Pid())
+	socketFile := fmt.Sprintf(filepath.Join(c.virtLauncherFSRunDirPattern, "libvirt/virtqemud-sock"), res.Pid())
 	// the migration-proxy is no longer shared via host mount, so we
 	// pass in the virt-launcher's baseDir to reach the unix sockets.
-	baseDir := fmt.Sprintf(filepath.Join(d.virtLauncherFSRunDirPattern, "kubevirt"), res.Pid())
+	baseDir := fmt.Sprintf(filepath.Join(c.virtLauncherFSRunDirPattern, "kubevirt"), res.Pid())
 	migrationTargetSockets = append(migrationTargetSockets, socketFile)
 
 	migrationPortsRange := migrationproxy.GetMigrationPortsList(vmi.IsBlockMigration())
@@ -2695,35 +2684,35 @@ func (d *VirtualMachineController) handleTargetMigrationProxy(vmi *v1.VirtualMac
 		destSocketFile := migrationproxy.SourceUnixFile(baseDir, key)
 		migrationTargetSockets = append(migrationTargetSockets, destSocketFile)
 	}
-	err = d.migrationProxy.StartTargetListener(string(vmi.UID), migrationTargetSockets)
+	err = c.migrationProxy.StartTargetListener(string(vmi.UID), migrationTargetSockets)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (d *VirtualMachineController) handlePostMigrationProxyCleanup(vmi *v1.VirtualMachineInstance) {
+func (c *VirtualMachineController) handlePostMigrationProxyCleanup(vmi *v1.VirtualMachineInstance) {
 	if vmi.Status.MigrationState == nil || vmi.Status.MigrationState.Completed || vmi.Status.MigrationState.Failed {
-		d.migrationProxy.StopTargetListener(string(vmi.UID))
-		d.migrationProxy.StopSourceListener(string(vmi.UID))
+		c.migrationProxy.StopTargetListener(string(vmi.UID))
+		c.migrationProxy.StopSourceListener(string(vmi.UID))
 	}
 }
 
-func (d *VirtualMachineController) handleSourceMigrationProxy(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) handleSourceMigrationProxy(vmi *v1.VirtualMachineInstance) error {
 
-	res, err := d.podIsolationDetector.Detect(vmi)
+	res, err := c.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return err
 	}
 	// the migration-proxy is no longer shared via host mount, so we
 	// pass in the virt-launcher's baseDir to reach the unix sockets.
-	baseDir := fmt.Sprintf(filepath.Join(d.virtLauncherFSRunDirPattern, "kubevirt"), res.Pid())
-	d.migrationProxy.StopTargetListener(string(vmi.UID))
+	baseDir := fmt.Sprintf(filepath.Join(c.virtLauncherFSRunDirPattern, "kubevirt"), res.Pid())
+	c.migrationProxy.StopTargetListener(string(vmi.UID))
 	if vmi.Status.MigrationState.TargetDirectMigrationNodePorts == nil {
 		msg := "No migration proxy has been created for this vmi"
 		return fmt.Errorf("%s", msg)
 	}
-	err = d.migrationProxy.StartSourceListener(
+	err = c.migrationProxy.StartSourceListener(
 		string(vmi.UID),
 		vmi.Status.MigrationState.TargetNodeAddress,
 		vmi.Status.MigrationState.TargetDirectMigrationNodePorts,
@@ -2736,8 +2725,8 @@ func (d *VirtualMachineController) handleSourceMigrationProxy(vmi *v1.VirtualMac
 	return nil
 }
 
-func (d *VirtualMachineController) getLauncherClientInfo(vmi *v1.VirtualMachineInstance) *virtcache.LauncherClientInfo {
-	launcherInfo, exists := d.launcherClients.Load(vmi.UID)
+func (c *VirtualMachineController) getLauncherClientInfo(vmi *v1.VirtualMachineInstance) *virtcache.LauncherClientInfo {
+	launcherInfo, exists := c.launcherClients.Load(vmi.UID)
 	if !exists {
 		return nil
 	}
@@ -2761,15 +2750,15 @@ func isMigrationInProgress(vmi *v1.VirtualMachineInstance, domain *api.Domain) b
 	return false
 }
 
-func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (c *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.VirtualMachineInstance, domain *api.Domain) error {
 
-	client, err := d.getLauncherClient(origVMI)
+	client, err := c.getLauncherClient(origVMI)
 	if err != nil {
 		return fmt.Errorf(unableCreateVirtLauncherConnectionFmt, err)
 	}
 
 	if origVMI.Status.MigrationState.AbortRequested {
-		err = d.handleMigrationAbort(origVMI, client)
+		err = c.handleMigrationAbort(origVMI, client)
 		if err != nil {
 			return err
 		}
@@ -2780,14 +2769,14 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.Vir
 			return nil
 		}
 
-		err = d.handleSourceMigrationProxy(origVMI)
+		err = c.handleSourceMigrationProxy(origVMI)
 		if err != nil {
 			return fmt.Errorf("failed to handle migration proxy: %v", err)
 		}
 
 		migrationConfiguration := origVMI.Status.MigrationState.MigrationConfiguration
 		if migrationConfiguration == nil {
-			migrationConfiguration = d.clusterConfig.GetMigrationConfiguration()
+			migrationConfiguration = c.clusterConfig.GetMigrationConfiguration()
 		}
 
 		options := &cmdclient.MigrationOptions{
@@ -2819,7 +2808,7 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.Vir
 		if err != nil {
 			return err
 		}
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrating.String(), VMIMigrating)
+		c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrating.String(), VMIMigrating)
 	}
 	return nil
 }
@@ -2840,8 +2829,8 @@ func replaceMigratedVolumesStatus(vmi *v1.VirtualMachineInstance) {
 
 }
 
-func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.VirtualMachineInstance) error {
-	client, err := d.getLauncherClient(origVMI)
+func (c *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.VirtualMachineInstance) error {
+	client, err := c.getLauncherClient(origVMI)
 	if err != nil {
 		return fmt.Errorf(unableCreateVirtLauncherConnectionFmt, err)
 	}
@@ -2857,7 +2846,7 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 		log.Log.Object(vmi).Infof("Signaled target pod for failed migration to clean up")
 		// nothing left to do here if the migration failed.
 		// Re-enqueue to trigger handler final cleanup
-		d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second)
+		c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second)
 		return nil
 	} else if migrations.IsMigrating(vmi) {
 		// If the migration has already started,
@@ -2875,31 +2864,31 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 	}
 
 	// give containerDisks some time to become ready before throwing errors on retries
-	info := d.getLauncherClientInfo(vmi)
-	if ready, err := d.containerDiskMounter.ContainerDisksReady(vmi, info.NotInitializedSince); !ready {
+	info := c.getLauncherClientInfo(vmi)
+	if ready, err := c.containerDiskMounter.ContainerDisksReady(vmi, info.NotInitializedSince); !ready {
 		if err != nil {
 			return err
 		}
-		d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+		c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 		return nil
 	}
 
 	// Verify container disks checksum
-	err = container_disk.VerifyChecksums(d.containerDiskMounter, vmi)
+	err = container_disk.VerifyChecksums(c.containerDiskMounter, vmi)
 	switch {
 	case goerror.Is(err, container_disk.ErrChecksumMissing):
 		// wait for checksum to be computed by the source virt-handler
 		return err
 	case goerror.Is(err, container_disk.ErrChecksumMismatch):
 		log.Log.Object(vmi).Infof("Containerdisk checksum mismatch, terminating target pod: %s", err)
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, "ContainerDiskFailedChecksum", "Aborting migration as the source and target containerdisks/kernelboot do not match")
+		c.recorder.Event(vmi, k8sv1.EventTypeNormal, "ContainerDiskFailedChecksum", "Aborting migration as the source and target containerdisks/kernelboot do not match")
 		return client.SignalTargetPodCleanup(vmi)
 	case err != nil:
 		return err
 	}
 
 	// Mount container disks
-	disksInfo, err := d.containerDiskMounter.MountAndVerify(vmi)
+	disksInfo, err := c.containerDiskMounter.MountAndVerify(vmi)
 	if err != nil {
 		return err
 	}
@@ -2910,17 +2899,17 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 		if err != nil {
 			return err
 		}
-		if err := d.hotplugVolumeMounter.MountFromPod(vmi, attachmentPodUID, cgroupManager); err != nil {
+		if err := c.hotplugVolumeMounter.MountFromPod(vmi, attachmentPodUID, cgroupManager); err != nil {
 			return fmt.Errorf("failed to mount hotplug volumes: %v", err)
 		}
 	}
 
 	// configure network inside virt-launcher compute container
-	if err := d.setupNetwork(vmi, vmi.Spec.Networks); err != nil {
+	if err := c.setupNetwork(vmi, vmi.Spec.Networks); err != nil {
 		return fmt.Errorf("failed to configure vmi network for migration target: %w", err)
 	}
 
-	isolationRes, err := d.podIsolationDetector.Detect(vmi)
+	isolationRes, err := c.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return fmt.Errorf(failedDetectIsolationFmt, err)
 	}
@@ -2929,49 +2918,49 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 		return err
 	}
 
-	err = d.claimDeviceOwnership(virtLauncherRootMount, "kvm")
+	err = c.claimDeviceOwnership(virtLauncherRootMount, "kvm")
 	if err != nil {
 		return fmt.Errorf("failed to set up file ownership for /dev/kvm: %v", err)
 	}
 	if virtutil.IsAutoAttachVSOCK(vmi) {
-		if err := d.claimDeviceOwnership(virtLauncherRootMount, "vhost-vsock"); err != nil {
+		if err := c.claimDeviceOwnership(virtLauncherRootMount, "vhost-vsock"); err != nil {
 			return fmt.Errorf("failed to set up file ownership for /dev/vhost-vsock: %v", err)
 		}
 	}
 
-	lessPVCSpaceToleration := d.clusterConfig.GetLessPVCSpaceToleration()
-	minimumPVCReserveBytes := d.clusterConfig.GetMinimumReservePVCBytes()
+	lessPVCSpaceToleration := c.clusterConfig.GetLessPVCSpaceToleration()
+	minimumPVCReserveBytes := c.clusterConfig.GetMinimumReservePVCBytes()
 
 	// initialize disks images for empty PVC
-	hostDiskCreator := hostdisk.NewHostDiskCreator(d.recorder, lessPVCSpaceToleration, minimumPVCReserveBytes, virtLauncherRootMount)
+	hostDiskCreator := hostdisk.NewHostDiskCreator(c.recorder, lessPVCSpaceToleration, minimumPVCReserveBytes, virtLauncherRootMount)
 	err = hostDiskCreator.Create(vmi)
 	if err != nil {
 		return fmt.Errorf("preparing host-disks failed: %v", err)
 	}
 
 	if virtutil.IsNonRootVMI(vmi) {
-		if err := d.nonRootSetup(origVMI, vmi); err != nil {
+		if err := c.nonRootSetup(origVMI, vmi); err != nil {
 			return err
 		}
 	}
 
-	options := virtualMachineOptions(nil, 0, nil, d.capabilities, disksInfo, d.clusterConfig)
-	options.InterfaceDomainAttachment = domainspec.DomainAttachmentByInterfaceName(vmi.Spec.Domain.Devices.Interfaces, d.clusterConfig.GetNetworkBindings())
+	options := virtualMachineOptions(nil, 0, nil, c.capabilities, disksInfo, c.clusterConfig)
+	options.InterfaceDomainAttachment = domainspec.DomainAttachmentByInterfaceName(vmi.Spec.Domain.Devices.Interfaces, c.clusterConfig.GetNetworkBindings())
 
 	if err := client.SyncMigrationTarget(vmi, options); err != nil {
 		return fmt.Errorf("syncing migration target failed: %v", err)
 	}
-	d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), VMIMigrationTargetPrepared)
+	c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), VMIMigrationTargetPrepared)
 
-	err = d.handleTargetMigrationProxy(vmi)
+	err = c.handleTargetMigrationProxy(vmi)
 	if err != nil {
 		return fmt.Errorf("failed to handle post sync migration proxy: %v", err)
 	}
 	return nil
 }
 
-func (d *VirtualMachineController) affinePitThread(vmi *v1.VirtualMachineInstance) error {
-	res, err := d.podIsolationDetector.Detect(vmi)
+func (c *VirtualMachineController) affinePitThread(vmi *v1.VirtualMachineInstance) error {
+	res, err := c.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return err
 	}
@@ -3022,14 +3011,14 @@ func (d *VirtualMachineController) affinePitThread(vmi *v1.VirtualMachineInstanc
 	return unix.SchedSetaffinity(pitpid, &Mask)
 }
 
-func (d *VirtualMachineController) configureHousekeepingCgroup(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+func (c *VirtualMachineController) configureHousekeepingCgroup(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
 	if err := cgroupManager.CreateChildCgroup("housekeeping", "cpuset"); err != nil {
 		log.Log.Reason(err).Error("CreateChildCgroup ")
 		return err
 	}
 
 	key := controller.VirtualMachineInstanceKey(vmi)
-	domain, domainExists, _, err := d.getDomainFromCache(key)
+	domain, domainExists, _, err := c.getDomainFromCache(key)
 	if err != nil {
 		return err
 	}
@@ -3088,8 +3077,8 @@ func (d *VirtualMachineController) configureHousekeepingCgroup(vmi *v1.VirtualMa
 	return nil
 }
 
-func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMachineInstance, domainExists bool) error {
-	client, err := d.getLauncherClient(origVMI)
+func (c *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMachineInstance, domainExists bool) error {
+	client, err := c.getLauncherClient(origVMI)
 	if err != nil {
 		return fmt.Errorf(unableCreateVirtLauncherConnectionFmt, err)
 	}
@@ -3116,22 +3105,22 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 	disksInfo := map[string]*containerdisk.DiskInfo{}
 	if !vmi.IsRunning() && !vmi.IsFinal() {
 		// give containerDisks some time to become ready before throwing errors on retries
-		info := d.getLauncherClientInfo(vmi)
-		if ready, err := d.containerDiskMounter.ContainerDisksReady(vmi, info.NotInitializedSince); !ready {
+		info := c.getLauncherClientInfo(vmi)
+		if ready, err := c.containerDiskMounter.ContainerDisksReady(vmi, info.NotInitializedSince); !ready {
 			if err != nil {
 				return err
 			}
-			d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 			return nil
 		}
 
-		disksInfo, err = d.containerDiskMounter.MountAndVerify(vmi)
+		disksInfo, err = c.containerDiskMounter.MountAndVerify(vmi)
 		if err != nil {
 			return err
 		}
 
 		// Try to mount hotplug volume if there is any during startup.
-		if err := d.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
+		if err := c.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
 			return err
 		}
 
@@ -3140,11 +3129,11 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		})
 		nonAbsentNets := netvmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, nonAbsentIfaces)
 
-		if err := d.setupNetwork(vmi, nonAbsentNets); err != nil {
+		if err := c.setupNetwork(vmi, nonAbsentNets); err != nil {
 			return fmt.Errorf("failed to configure vmi network: %w", err)
 		}
 
-		isolationRes, err := d.podIsolationDetector.Detect(vmi)
+		isolationRes, err := c.podIsolationDetector.Detect(vmi)
 		if err != nil {
 			return fmt.Errorf(failedDetectIsolationFmt, err)
 		}
@@ -3153,21 +3142,21 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 			return err
 		}
 
-		err = d.claimDeviceOwnership(virtLauncherRootMount, "kvm")
+		err = c.claimDeviceOwnership(virtLauncherRootMount, "kvm")
 		if err != nil {
 			return fmt.Errorf("failed to set up file ownership for /dev/kvm: %v", err)
 		}
 		if virtutil.IsAutoAttachVSOCK(vmi) {
-			if err := d.claimDeviceOwnership(virtLauncherRootMount, "vhost-vsock"); err != nil {
+			if err := c.claimDeviceOwnership(virtLauncherRootMount, "vhost-vsock"); err != nil {
 				return fmt.Errorf("failed to set up file ownership for /dev/vhost-vsock: %v", err)
 			}
 		}
 
-		lessPVCSpaceToleration := d.clusterConfig.GetLessPVCSpaceToleration()
-		minimumPVCReserveBytes := d.clusterConfig.GetMinimumReservePVCBytes()
+		lessPVCSpaceToleration := c.clusterConfig.GetLessPVCSpaceToleration()
+		minimumPVCReserveBytes := c.clusterConfig.GetMinimumReservePVCBytes()
 
 		// initialize disks images for empty PVC
-		hostDiskCreator := hostdisk.NewHostDiskCreator(d.recorder, lessPVCSpaceToleration, minimumPVCReserveBytes, virtLauncherRootMount)
+		hostDiskCreator := hostdisk.NewHostDiskCreator(c.recorder, lessPVCSpaceToleration, minimumPVCReserveBytes, virtLauncherRootMount)
 		err = hostDiskCreator.Create(vmi)
 		if err != nil {
 			return fmt.Errorf("preparing host-disks failed: %v", err)
@@ -3184,7 +3173,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		}
 
 		if virtutil.IsNonRootVMI(vmi) {
-			if err := d.nonRootSetup(origVMI, vmi); err != nil {
+			if err := c.nonRootSetup(origVMI, vmi); err != nil {
 				return err
 			}
 		}
@@ -3199,7 +3188,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		}
 
 		// set runtime limits as needed
-		err = d.podIsolationDetector.AdjustResources(vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
+		err = c.podIsolationDetector.AdjustResources(vmi, c.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
 		if err != nil {
 			return fmt.Errorf("failed to adjust resources: %v", err)
 		}
@@ -3212,24 +3201,24 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 			}
 		}
 	} else if vmi.IsRunning() {
-		if err := d.hotplugSriovInterfaces(vmi); err != nil {
+		if err := c.hotplugSriovInterfaces(vmi); err != nil {
 			log.Log.Object(vmi).Error(err.Error())
 		}
 
-		if err := d.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
+		if err := c.hotplugVolumeMounter.Mount(vmi, cgroupManager); err != nil {
 			return err
 		}
 
-		if err := d.getMemoryDump(vmi); err != nil {
+		if err := c.getMemoryDump(vmi); err != nil {
 			return err
 		}
 
-		isolationRes, err := d.podIsolationDetector.Detect(vmi)
+		isolationRes, err := c.podIsolationDetector.Detect(vmi)
 		if err != nil {
 			return fmt.Errorf(failedDetectIsolationFmt, err)
 		}
 
-		if err := d.downwardMetricsManager.StartServer(vmi, isolationRes.Pid()); err != nil {
+		if err := c.downwardMetricsManager.StartServer(vmi, isolationRes.Pid()); err != nil {
 			return err
 		}
 
@@ -3245,18 +3234,18 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		netsToHotunplug := netvmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, ifacesToHotunplug)
 
 		setupNets := append(netsToHotplug, netsToHotunplug...)
-		if err := d.setupNetwork(vmi, setupNets); err != nil {
+		if err := c.setupNetwork(vmi, setupNets); err != nil {
 			log.Log.Object(vmi).Error(err.Error())
-			d.recorder.Event(vmi, k8sv1.EventTypeWarning, "NicHotplug", err.Error())
+			c.recorder.Event(vmi, k8sv1.EventTypeWarning, "NicHotplug", err.Error())
 			errorTolerantFeaturesError = append(errorTolerantFeaturesError, err)
 		}
 	}
 
-	smbios := d.clusterConfig.GetSMBIOS()
-	period := d.clusterConfig.GetMemBalloonStatsPeriod()
+	smbios := c.clusterConfig.GetSMBIOS()
+	period := c.clusterConfig.GetMemBalloonStatsPeriod()
 
-	options := virtualMachineOptions(smbios, period, preallocatedVolumes, d.capabilities, disksInfo, d.clusterConfig)
-	options.InterfaceDomainAttachment = domainspec.DomainAttachmentByInterfaceName(vmi.Spec.Domain.Devices.Interfaces, d.clusterConfig.GetNetworkBindings())
+	options := virtualMachineOptions(smbios, period, preallocatedVolumes, c.capabilities, disksInfo, c.clusterConfig)
+	options.InterfaceDomainAttachment = domainspec.DomainAttachmentByInterfaceName(vmi.Spec.Domain.Devices.Interfaces, c.clusterConfig.GetNetworkBindings())
 
 	err = client.SyncVirtualMachine(vmi, options)
 	if err != nil {
@@ -3268,37 +3257,37 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 	}
 
 	if vmi.IsCPUDedicated() && vmi.Spec.Domain.CPU.IsolateEmulatorThread {
-		err = d.configureHousekeepingCgroup(vmi, cgroupManager)
+		err = c.configureHousekeepingCgroup(vmi, cgroupManager)
 		if err != nil {
 			return err
 		}
 	}
 	if vmi.IsRealtimeEnabled() && !vmi.IsRunning() && !vmi.IsFinal() {
 		log.Log.Object(vmi).Info("Configuring vcpus for real time workloads")
-		if err := d.configureVCPUScheduler(vmi); err != nil {
+		if err := c.configureVCPUScheduler(vmi); err != nil {
 			return err
 		}
 	}
 	if vmi.IsCPUDedicated() && !vmi.IsRunning() && !vmi.IsFinal() {
 		log.Log.V(3).Object(vmi).Info("Affining PIT thread")
-		if err := d.affinePitThread(vmi); err != nil {
+		if err := c.affinePitThread(vmi); err != nil {
 			return err
 		}
 	}
 	if !domainExists {
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Created.String(), VMIDefined)
+		c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Created.String(), VMIDefined)
 	}
 
 	if vmi.IsRunning() {
 		// Umount any disks no longer mounted
-		if err := d.hotplugVolumeMounter.Unmount(vmi, cgroupManager); err != nil {
+		if err := c.hotplugVolumeMounter.Unmount(vmi, cgroupManager); err != nil {
 			return err
 		}
 	}
 	return errors.NewAggregate(errorTolerantFeaturesError)
 }
 
-func (d *VirtualMachineController) hotplugSriovInterfaces(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) hotplugSriovInterfaces(vmi *v1.VirtualMachineInstance) error {
 	sriovSpecInterfaces := netvmispec.FilterSRIOVInterfaces(vmi.Spec.Domain.Devices.Interfaces)
 
 	sriovSpecIfacesNames := netvmispec.IndexInterfaceSpecByName(sriovSpecInterfaces)
@@ -3314,26 +3303,26 @@ func (d *VirtualMachineController) hotplugSriovInterfaces(vmi *v1.VirtualMachine
 	})
 
 	if len(desiredSriovMultusPluggedIfaces) == len(attachedSriovStatusIfaces) {
-		d.sriovHotplugExecutorPool.Delete(vmi.UID)
+		c.sriovHotplugExecutorPool.Delete(vmi.UID)
 		return nil
 	}
 
-	rateLimitedExecutor := d.sriovHotplugExecutorPool.LoadOrStore(vmi.UID)
+	rateLimitedExecutor := c.sriovHotplugExecutorPool.LoadOrStore(vmi.UID)
 	return rateLimitedExecutor.Exec(func() error {
-		return d.hotplugSriovInterfacesCommand(vmi)
+		return c.hotplugSriovInterfacesCommand(vmi)
 	})
 }
 
-func (d *VirtualMachineController) hotplugSriovInterfacesCommand(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) hotplugSriovInterfacesCommand(vmi *v1.VirtualMachineInstance) error {
 	const errMsgPrefix = "failed to hot-plug SR-IOV interfaces"
 
-	client, err := d.getVerifiedLauncherClient(vmi)
+	client, err := c.getVerifiedLauncherClient(vmi)
 	if err != nil {
 		return fmt.Errorf("%s: %v", errMsgPrefix, err)
 	}
 
-	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio); err != nil {
-		d.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), err.Error())
+	if err := isolation.AdjustQemuProcessMemoryLimits(c.podIsolationDetector, vmi, c.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio); err != nil {
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), err.Error())
 		return fmt.Errorf("%s: %v", errMsgPrefix, err)
 	}
 
@@ -3351,14 +3340,14 @@ func memoryDumpPath(volumeStatus v1.VolumeStatus) string {
 	return dumpPath
 }
 
-func (d *VirtualMachineController) getMemoryDump(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) getMemoryDump(vmi *v1.VirtualMachineInstance) error {
 	const errMsgPrefix = "failed to getting memory dump"
 
 	for _, volumeStatus := range vmi.Status.VolumeStatus {
 		if volumeStatus.MemoryDumpVolume == nil || volumeStatus.Phase != v1.MemoryDumpVolumeInProgress {
 			continue
 		}
-		client, err := d.getVerifiedLauncherClient(vmi)
+		client, err := c.getVerifiedLauncherClient(vmi)
 		if err != nil {
 			return fmt.Errorf("%s: %v", errMsgPrefix, err)
 		}
@@ -3373,50 +3362,50 @@ func (d *VirtualMachineController) getMemoryDump(vmi *v1.VirtualMachineInstance)
 	return nil
 }
 
-func (d *VirtualMachineController) processVmUpdate(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (c *VirtualMachineController) processVmUpdate(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 
-	isUnresponsive, isInitialized, err := d.isLauncherClientUnresponsive(vmi)
+	isUnresponsive, isInitialized, err := c.isLauncherClientUnresponsive(vmi)
 	if err != nil {
 		return err
 	}
 	if !isInitialized {
-		d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+		c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 		return nil
 	} else if isUnresponsive {
 		return goerror.New(fmt.Sprintf("Can not update a VirtualMachineInstance with unresponsive command server."))
 	}
 
-	d.handlePostMigrationProxyCleanup(vmi)
+	c.handlePostMigrationProxyCleanup(vmi)
 
-	if d.isPreMigrationTarget(vmi) {
-		return d.vmUpdateHelperMigrationTarget(vmi)
-	} else if d.isMigrationSource(vmi) {
-		return d.vmUpdateHelperMigrationSource(vmi, domain)
+	if c.isPreMigrationTarget(vmi) {
+		return c.vmUpdateHelperMigrationTarget(vmi)
+	} else if c.isMigrationSource(vmi) {
+		return c.vmUpdateHelperMigrationSource(vmi, domain)
 	} else {
-		return d.vmUpdateHelperDefault(vmi, domain != nil)
+		return c.vmUpdateHelperDefault(vmi, domain != nil)
 	}
 }
 
-func (d *VirtualMachineController) setVmPhaseForStatusReason(domain *api.Domain, vmi *v1.VirtualMachineInstance) error {
-	phase, err := d.calculateVmPhaseForStatusReason(domain, vmi)
+func (c *VirtualMachineController) setVmPhaseForStatusReason(domain *api.Domain, vmi *v1.VirtualMachineInstance) error {
+	phase, err := c.calculateVmPhaseForStatusReason(domain, vmi)
 	if err != nil {
 		return err
 	}
 	vmi.Status.Phase = phase
 	return nil
 }
-func (d *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.Domain, vmi *v1.VirtualMachineInstance) (v1.VirtualMachineInstancePhase, error) {
+func (c *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.Domain, vmi *v1.VirtualMachineInstance) (v1.VirtualMachineInstancePhase, error) {
 
 	if domain == nil {
 		switch {
 		case vmi.IsScheduled():
-			isUnresponsive, isInitialized, err := d.isLauncherClientUnresponsive(vmi)
+			isUnresponsive, isInitialized, err := c.isLauncherClientUnresponsive(vmi)
 
 			if err != nil {
 				return vmi.Status.Phase, err
 			}
 			if !isInitialized {
-				d.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
+				c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 				return vmi.Status.Phase, err
 			} else if isUnresponsive {
 				// virt-launcher is gone and VirtualMachineInstance never transitioned
@@ -3459,37 +3448,37 @@ func (d *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.D
 	return vmi.Status.Phase, nil
 }
 
-func (d *VirtualMachineController) addFunc(obj interface{}) {
+func (c *VirtualMachineController) addFunc(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err == nil {
-		d.vmiExpectations.LowerExpectations(key, 1, 0)
-		d.queue.Add(key)
+		c.vmiExpectations.LowerExpectations(key, 1, 0)
+		c.queue.Add(key)
 	}
 }
-func (d *VirtualMachineController) deleteFunc(obj interface{}) {
+func (c *VirtualMachineController) deleteFunc(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err == nil {
-		d.vmiExpectations.LowerExpectations(key, 1, 0)
-		d.queue.Add(key)
+		c.vmiExpectations.LowerExpectations(key, 1, 0)
+		c.queue.Add(key)
 	}
 }
-func (d *VirtualMachineController) updateFunc(_, new interface{}) {
+func (c *VirtualMachineController) updateFunc(_, new interface{}) {
 	key, err := controller.KeyFunc(new)
 	if err == nil {
-		d.vmiExpectations.LowerExpectations(key, 1, 0)
-		d.queue.Add(key)
+		c.vmiExpectations.LowerExpectations(key, 1, 0)
+		c.queue.Add(key)
 	}
 }
 
-func (d *VirtualMachineController) addDomainFunc(obj interface{}) {
+func (c *VirtualMachineController) addDomainFunc(obj interface{}) {
 	domain := obj.(*api.Domain)
 	log.Log.Object(domain).Infof("Domain is in state %s reason %s", domain.Status.Status, domain.Status.Reason)
 	key, err := controller.KeyFunc(obj)
 	if err == nil {
-		d.queue.Add(key)
+		c.queue.Add(key)
 	}
 }
-func (d *VirtualMachineController) deleteDomainFunc(obj interface{}) {
+func (c *VirtualMachineController) deleteDomainFunc(obj interface{}) {
 	domain, ok := obj.(*api.Domain)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -3506,10 +3495,10 @@ func (d *VirtualMachineController) deleteDomainFunc(obj interface{}) {
 	log.Log.Object(domain).Info("Domain deleted")
 	key, err := controller.KeyFunc(obj)
 	if err == nil {
-		d.queue.Add(key)
+		c.queue.Add(key)
 	}
 }
-func (d *VirtualMachineController) updateDomainFunc(old, new interface{}) {
+func (c *VirtualMachineController) updateDomainFunc(old, new interface{}) {
 	newDomain := new.(*api.Domain)
 	oldDomain := old.(*api.Domain)
 	if oldDomain.Status.Status != newDomain.Status.Status || oldDomain.Status.Reason != newDomain.Status.Reason {
@@ -3522,31 +3511,31 @@ func (d *VirtualMachineController) updateDomainFunc(old, new interface{}) {
 
 	key, err := controller.KeyFunc(new)
 	if err == nil {
-		d.queue.Add(key)
+		c.queue.Add(key)
 	}
 }
 
-func (d *VirtualMachineController) finalizeMigration(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) finalizeMigration(vmi *v1.VirtualMachineInstance) error {
 	const errorMessage = "failed to finalize migration"
 
-	client, err := d.getVerifiedLauncherClient(vmi)
+	client, err := c.getVerifiedLauncherClient(vmi)
 	if err != nil {
 		return fmt.Errorf("%s: %v", errorMessage, err)
 	}
 
-	if err := d.hotplugCPU(vmi, client); err != nil {
+	if err := c.hotplugCPU(vmi, client); err != nil {
 		log.Log.Object(vmi).Reason(err).Error(errorMessage)
-		d.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), "failed to change vCPUs")
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), "failed to change vCPUs")
 	}
 
-	if err := d.hotplugMemory(vmi, client); err != nil {
+	if err := c.hotplugMemory(vmi, client); err != nil {
 		log.Log.Object(vmi).Reason(err).Error(errorMessage)
-		d.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), "failed to update guest memory")
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), "failed to update guest memory")
 	}
 	removeMigratedVolumes(vmi)
 
 	options := &cmdv1.VirtualMachineOptions{}
-	options.InterfaceMigration = domainspec.BindingMigrationByInterfaceName(vmi.Spec.Domain.Devices.Interfaces, d.clusterConfig.GetNetworkBindings())
+	options.InterfaceMigration = domainspec.BindingMigrationByInterfaceName(vmi.Spec.Domain.Devices.Interfaces, c.clusterConfig.GetNetworkBindings())
 	if err := client.FinalizeVirtualMachineMigration(vmi, options); err != nil {
 		log.Log.Object(vmi).Reason(err).Error(errorMessage)
 		return fmt.Errorf("%s: %v", errorMessage, err)
@@ -3574,9 +3563,9 @@ func isACPIEnabled(vmi *v1.VirtualMachineInstance, domain *api.Domain) bool {
 		domain.Spec.Features.ACPI != nil
 }
 
-func (d *VirtualMachineController) isHostModelMigratable(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) isHostModelMigratable(vmi *v1.VirtualMachineInstance) error {
 	if cpu := vmi.Spec.Domain.CPU; cpu != nil && cpu.Model == v1.CPUModeHostModel {
-		if d.hostCpuModel == "" {
+		if c.hostCpuModel == "" {
 			err := fmt.Errorf("the node \"%s\" does not allow migration with host-model", vmi.Status.NodeName)
 			log.Log.Object(vmi).Errorf(err.Error())
 			return err
@@ -3585,8 +3574,8 @@ func (d *VirtualMachineController) isHostModelMigratable(vmi *v1.VirtualMachineI
 	return nil
 }
 
-func (d *VirtualMachineController) claimDeviceOwnership(virtLauncherRootMount *safepath.Path, deviceName string) error {
-	softwareEmulation := d.clusterConfig.AllowEmulation()
+func (c *VirtualMachineController) claimDeviceOwnership(virtLauncherRootMount *safepath.Path, deviceName string) error {
+	softwareEmulation := c.clusterConfig.AllowEmulation()
 	devicePath, err := safepath.JoinNoFollow(virtLauncherRootMount, filepath.Join("dev", deviceName))
 	if err != nil {
 		if softwareEmulation {
@@ -3598,7 +3587,7 @@ func (d *VirtualMachineController) claimDeviceOwnership(virtLauncherRootMount *s
 	return diskutils.DefaultOwnershipManager.SetFileOwnership(devicePath)
 }
 
-func (d *VirtualMachineController) reportDedicatedCPUSetForMigratingVMI(vmi *v1.VirtualMachineInstance) error {
+func (c *VirtualMachineController) reportDedicatedCPUSetForMigratingVMI(vmi *v1.VirtualMachineInstance) error {
 	cgroupManager, err := getCgroupManager(vmi)
 	if err != nil {
 		return err
@@ -3619,8 +3608,8 @@ func (d *VirtualMachineController) reportDedicatedCPUSetForMigratingVMI(vmi *v1.
 	return nil
 }
 
-func (d *VirtualMachineController) reportTargetTopologyForMigratingVMI(vmi *v1.VirtualMachineInstance) error {
-	options := virtualMachineOptions(nil, 0, nil, d.capabilities, map[string]*containerdisk.DiskInfo{}, d.clusterConfig)
+func (c *VirtualMachineController) reportTargetTopologyForMigratingVMI(vmi *v1.VirtualMachineInstance) error {
+	options := virtualMachineOptions(nil, 0, nil, c.capabilities, map[string]*containerdisk.DiskInfo{}, c.clusterConfig)
 	topology, err := json.Marshal(options.Topology)
 	if err != nil {
 		return err
@@ -3629,7 +3618,7 @@ func (d *VirtualMachineController) reportTargetTopologyForMigratingVMI(vmi *v1.V
 	return nil
 }
 
-func (d *VirtualMachineController) handleMigrationAbort(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient) error {
+func (c *VirtualMachineController) handleMigrationAbort(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient) error {
 	if vmi.Status.MigrationState.AbortStatus == v1.MigrationAbortInProgress {
 		return nil
 	}
@@ -3641,7 +3630,7 @@ func (d *VirtualMachineController) handleMigrationAbort(vmi *v1.VirtualMachineIn
 		return err
 	}
 
-	d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrating.String(), VMIAbortingMigration)
+	c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrating.String(), VMIAbortingMigration)
 	return nil
 }
 
@@ -3649,7 +3638,7 @@ func isIOError(shouldUpdate, domainExists bool, domain *api.Domain) bool {
 	return shouldUpdate && domainExists && domain.Status.Status == api.Paused && domain.Status.Reason == api.ReasonPausedIOError
 }
 
-func (d *VirtualMachineController) updateMachineType(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+func (c *VirtualMachineController) updateMachineType(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	if domain == nil || vmi == nil {
 		return
 	}
@@ -3658,7 +3647,7 @@ func (d *VirtualMachineController) updateMachineType(vmi *v1.VirtualMachineInsta
 	}
 }
 
-func (d *VirtualMachineController) hotplugCPU(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient) error {
+func (c *VirtualMachineController) hotplugCPU(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient) error {
 	vmiConditions := controller.NewVirtualMachineInstanceConditionManager()
 
 	removeVMIVCPUChangeConditionAndLabel := func() {
@@ -3692,9 +3681,9 @@ func (d *VirtualMachineController) hotplugCPU(vmi *v1.VirtualMachineInstance, cl
 		nil,
 		0,
 		nil,
-		d.capabilities,
+		c.capabilities,
 		nil,
-		d.clusterConfig)
+		c.clusterConfig)
 
 	if err := client.SyncVirtualMachineCPUs(vmi, options); err != nil {
 		return err
@@ -3711,7 +3700,7 @@ func (d *VirtualMachineController) hotplugCPU(vmi *v1.VirtualMachineInstance, cl
 	return nil
 }
 
-func (d *VirtualMachineController) hotplugMemory(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient) error {
+func (c *VirtualMachineController) hotplugMemory(vmi *v1.VirtualMachineInstance, client cmdclient.LauncherClient) error {
 	vmiConditions := controller.NewVirtualMachineInstanceConditionManager()
 
 	removeVMIMemoryChangeLabel := func() {
@@ -3734,7 +3723,7 @@ func (d *VirtualMachineController) hotplugMemory(vmi *v1.VirtualMachineInstance,
 	overheadRatio := vmi.Labels[v1.MemoryHotplugOverheadRatioLabel]
 	requiredMemory := services.GetMemoryOverhead(vmi, runtime.GOARCH, &overheadRatio)
 	requiredMemory.Add(
-		d.netBindingPluginMemoryCalculator.Calculate(vmi, d.clusterConfig.GetNetworkBindings()),
+		c.netBindingPluginMemoryCalculator.Calculate(vmi, c.clusterConfig.GetNetworkBindings()),
 	)
 
 	requiredMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
@@ -3744,7 +3733,7 @@ func (d *VirtualMachineController) hotplugMemory(vmi *v1.VirtualMachineInstance,
 		return fmt.Errorf("amount of requested guest memory (%s) exceeds the launcher memory request (%s)", vmi.Spec.Domain.Memory.Guest.String(), podMemReqStr)
 	}
 
-	options := virtualMachineOptions(nil, 0, nil, d.capabilities, nil, d.clusterConfig)
+	options := virtualMachineOptions(nil, 0, nil, c.capabilities, nil, c.clusterConfig)
 
 	if err := client.SyncVirtualMachineMemory(vmi, options); err != nil {
 		// mark hotplug as failed
@@ -3792,7 +3781,7 @@ func parseLibvirtQuantity(value int64, unit string) *resource.Quantity {
 	return nil
 }
 
-func (d *VirtualMachineController) updateMemoryInfo(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (c *VirtualMachineController) updateMemoryInfo(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	if domain == nil || vmi == nil || domain.Spec.CurrentMemory == nil {
 		return nil
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1691,11 +1691,7 @@ func (c *VirtualMachineController) Run(threadiness int, stopCh chan struct{}) {
 		}
 	}
 
-	heartBeatDone := make(chan struct{})
-	go func() {
-		c.heartBeat.Run(c.heartBeatInterval, stopCh)
-		close(heartBeatDone)
-	}()
+	heartBeatDone := c.heartBeat.Run(c.heartBeatInterval, stopCh)
 
 	go c.ioErrorRetryManager.Run(stopCh)
 
@@ -1704,8 +1700,8 @@ func (c *VirtualMachineController) Run(threadiness int, stopCh chan struct{}) {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}
 
-	<-stopCh
 	<-heartBeatDone
+	<-stopCh
 	log.Log.Info("Stopping virt-handler controller.")
 }
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3142,7 +3142,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			}
 
 			basicCommands = []v1.GuestAgentCommandInfo{}
-			for _, cmdName := range RequiredGuestAgentCommands {
+			for _, cmdName := range requiredGuestAgentCommands {
 				basicCommands = append(basicCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,
@@ -3150,7 +3150,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			}
 
 			sshCommands = []v1.GuestAgentCommandInfo{}
-			for _, cmdName := range SSHRelatedGuestAgentCommands {
+			for _, cmdName := range sshRelatedGuestAgentCommands {
 				sshCommands = append(sshCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,
@@ -3158,7 +3158,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			}
 
 			oldSshCommands = []v1.GuestAgentCommandInfo{}
-			for _, cmdName := range OldSSHRelatedGuestAgentCommands {
+			for _, cmdName := range oldSSHRelatedGuestAgentCommands {
 				oldSshCommands = append(oldSshCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,
@@ -3166,7 +3166,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			}
 
 			passwordCommands = []v1.GuestAgentCommandInfo{}
-			for _, cmdName := range PasswordRelatedGuestAgentCommands {
+			for _, cmdName := range passwordRelatedGuestAgentCommands {
 				passwordCommands = append(passwordCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The virt-handler suffers of multiple possible race conditions during shutdown:
1. There isn't a correct sync between the controller and the heartbeat shutdown
2. There isn't proper error handling of the final node labelling process.

#### For the first one:
The intent of the `heartBeatDone` channel was
to ensure the heartbeat is finished
before stopping the handler vm controller.
In particular, its intention was to prevent
a shutdown race:
- heartbeat tries to stop and do a last http request
- controller shuts down
If the controller shuts down first, then the main function
just exists, killing all remaining go routines right away.

Actually it is not doing its job since
`c.heartBeat.Run(c.heartBeatInterval, stopCh)` is
not a blocking function (it spawns a goroutine and
immediately returns the channel).
As result, the `heartBeat` is always immediately
closed after the start of the heartBeat goroutine.

To ensure that the heartbeat is completed before shutting
down the controller, we should block on the channel returned
by the heartbeat itself.


#### For the second one:
When the heartbeat is notified of a shutdown
by the stopchan, it marks the node unschedulable
before returning and thus end the entire process.

This labelling process is performed in a goroutine
which at the end signal the job done closing the
`done` channel.

This logic actually is not necessary, since it can
be a simple body function, without the goroutine.

In addition, there isn't a proper error handling.
In an error occurs during the goroutine execution
(i.e. node patch failure), nothing is returned
and the channel is never closed, which cause the
`<-labelNodeDone` to hangs and leave the virt-handler
stuck.

With this commit both problem are handler:
1. drop the unneeded goroutine
2. handle the error retrying it for a `DefaultBackoff`
(https://github.com/kubernetes/client-go/blob/37045084c2aa82927b0e5ffc752861430fd7e4ab/util/retry/util.go#L38)


Lastly, there is an optimization on the guest agent command support
calculation.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: fix possible virt-handler race condition and stuck situation during shutdown
```

