### PR TITLE
Add kubevirt_vmi_migration_(start|end)_time_seconds metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -189,11 +189,17 @@ The rate of memory being dirty in the Guest OS. Type: Gauge.
 ### kubevirt_vmi_migration_disk_transfer_rate_bytes
 The rate at which the memory is being transferred. Type: Gauge.
 
+### kubevirt_vmi_migration_end_time_seconds
+The time at which the migration ended. Type: Gauge.
+
 ### kubevirt_vmi_migration_failed
 Indicates if the VMI migration failed. Type: Gauge.
 
 ### kubevirt_vmi_migration_phase_transition_time_from_creation_seconds
 Histogram of VM migration phase transitions duration from creation time in seconds. Type: Histogram.
+
+### kubevirt_vmi_migration_start_time_seconds
+The time at which the migration started. Type: Gauge.
 
 ### kubevirt_vmi_migration_succeeded
 Indicates if the VMI migration succeeded. Type: Gauge.

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -26,6 +26,7 @@ import (
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	k8sv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/log"
@@ -55,6 +56,8 @@ var (
 			vmiInfo,
 			vmiEvictionBlocker,
 			vmiAddresses,
+			vmiMigrationStartTime,
+			vmiMigrationEndTime,
 		},
 		CollectCallback: vmiStatsCollectorCallback,
 	}
@@ -97,6 +100,22 @@ var (
 		},
 		[]string{"node", "namespace", "name", "network_name", "address", "type"},
 	)
+
+	vmiMigrationStartTime = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_migration_start_time_seconds",
+			Help: "The time at which the migration started.",
+		},
+		[]string{"node", "namespace", "name", "migration_name"},
+	)
+
+	vmiMigrationEndTime = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_migration_end_time_seconds",
+			Help: "The time at which the migration ended.",
+		},
+		[]string{"node", "namespace", "name", "migration_name", "status"},
+	)
 )
 
 func vmiStatsCollectorCallback() []operatormetrics.CollectorResult {
@@ -122,6 +141,7 @@ func reportVmisStats(vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.Col
 		crs = append(crs, collectVMIInfo(vmi))
 		crs = append(crs, getEvictionBlocker(vmi))
 		crs = append(crs, collectVMIInterfacesInfo(vmi)...)
+		crs = append(crs, collectVMIMigrationTime(vmi)...)
 	}
 
 	return crs
@@ -329,4 +349,65 @@ func collectVMIInterfaceInfo(vmi *k6tv1.VirtualMachineInstance, iface k6tv1.Virt
 		},
 		Value: 1.0,
 	}
+}
+
+func collectVMIMigrationTime(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+	var cr []operatormetrics.CollectorResult
+	var migrationName string
+
+	if vmi.Status.MigrationState == nil {
+		return cr
+	}
+
+	migrationName = getMigrationNameFromMigrationUID(vmi.Namespace, vmi.Status.MigrationState.MigrationUID)
+
+	if vmi.Status.MigrationState.StartTimestamp != nil {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiMigrationStartTime,
+			Value:  float64(vmi.Status.MigrationState.StartTimestamp.Time.Unix()),
+			Labels: []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, migrationName},
+		})
+	}
+
+	if vmi.Status.MigrationState.EndTimestamp != nil {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiMigrationEndTime,
+			Value:  float64(vmi.Status.MigrationState.EndTimestamp.Time.Unix()),
+			Labels: []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, migrationName,
+				calculateMigrationStatus(vmi.Status.MigrationState),
+			},
+		})
+	}
+
+	return cr
+}
+
+func calculateMigrationStatus(migrationState *k6tv1.VirtualMachineInstanceMigrationState) string {
+	if !migrationState.Completed {
+		return ""
+	}
+
+	if migrationState.Failed {
+		return "failed"
+	}
+
+	return "succeeded"
+}
+
+func getMigrationNameFromMigrationUID(namespace string, migrationUID types.UID) string {
+	objs, err := vmiMigrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		return none
+	}
+
+	for _, obj := range objs {
+		curMigration := obj.(*k6tv1.VirtualMachineInstanceMigration)
+		if curMigration.UID != migrationUID {
+			continue
+		}
+
+		return curMigration.Name
+	}
+
+	return none
 }

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -86,6 +86,8 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			"kubevirt_vmi_migration_dirty_memory_rate_bytes":                     true,
 			"kubevirt_vmi_migration_disk_transfer_rate_bytes":                    true,
 			"kubevirt_vmi_migration_data_total_bytes":                            true,
+			"kubevirt_vmi_migration_start_time_seconds":                          true,
+			"kubevirt_vmi_migration_end_time_seconds":                            true,
 		}
 
 		It("should contain virt components metrics", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

No metric with start and end timestamps

After this PR:

kubevirt_vmi_migration_start_time_seconds and kubevirt_vmi_migration_end_time_seconds metrics

![Screenshot from 2024-12-11 15-24-00](https://github.com/user-attachments/assets/5e139595-60fb-4d1c-8602-75051c618b7b)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vmi_migration_(start|end)_time_seconds metrics
```

