### PR TITLE
Remove usage of deprecated .spec.running field

### DIFF
--- a/docs/devel/virtual-machine.md
+++ b/docs/devel/virtual-machine.md
@@ -45,7 +45,7 @@ kubectl create -f myvm.yaml
 
 # Start an VirtualMachine:
 kubectl patch virtualmachine myvm --type=merge -p \
-    '{"spec":{"running": true}}'
+    '{"spec":{"runStrategy": "Always"}}'
 
 # Look at VirtualMachine status and associated events:
 kubectl describe virtualmachine myvm
@@ -55,7 +55,7 @@ kubectl describe virtualmachine myvm
 
 # Stop an VirtualMachine:
 kubectl patch virtualmachine myvm --type=merge -p \
-    '{"spec":{"running": false}}'
+    '{"spec":{"runStrategy": "Halted"}}'
 
 # Implicit cascade delete (first deletes the vm and then the vm)
 kubectl delete virtualmachine myvm
@@ -118,7 +118,7 @@ kind: VirtualMachine
 metadata:
   name: myvm
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:
@@ -142,8 +142,8 @@ The file specification follows the Kubernetes guide. The apiVersion is linked
 with the KubeVirt release cycle.
 
 In the metadata section, there is a *required* field, the **name**. Then
-following the spec section, there are two important parts. The **running**, which
-indicates the current state of the VirtualMachineInstance attached to this VirtualMachineInstance.
+following the spec section, there are two important parts. The **runStrategy**, which
+indicates the desired state of the VirtualMachineInstance attached to this VirtualMachineInstance.
 Second is the **template**, which is the VirtualMachineInstance template.
 
 Let us go over each of these fields.
@@ -256,7 +256,7 @@ metadata:
 
 For now implicit: OnDelete. Can later be extended to RollingUpdate if needed.
 Spec changes have no direct effect on already running VMIs, and they will not
-directly be propagated to the VMI. If a VMI should be running (spec.running=true)
+directly be propagated to the VMI. If a VMI should be running
 and it is powered down (VMI object delete, OS shutdown, ...),
 the VMI will be re-created by the controller with the new spec.
 
@@ -313,7 +313,7 @@ autogenerating the Kubernetes resources: client, lister and watcher.
 
 The controller is responsible for watching the change in the registered
 virtual machines and update the state of the system. It is also
-responsible for creating new VirtualMachineInstance when the `running` is set to `true`.
+responsible for creating new VirtualMachineInstance when a fitting `runStrategy` is specified.
 Moreover the controller attaches the `metadata.OwnerReference` to the created
 VirtualMachineInstance. With this mechanism it can link the VirtualMachine to the
 VirtualMachineInstance and show combined status.

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -45,7 +45,7 @@ metadata:
     kubevirt.io/vm: readiness-probe-vm
   name: readiness-probe
 spec:
-  running: true 
+  runStrategy: Always 
   template:
     metadata:
       labels:

--- a/examples/vm-pool-cirros.yaml
+++ b/examples/vm-pool-cirros.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         kubevirt.io/vmpool: vm-pool-cirros
     spec:
-      running: true
+      runStrategy: Always
       template:
         metadata:
           creationTimestamp: null

--- a/pkg/virt-controller/watch/testing/testing.go
+++ b/pkg/virt-controller/watch/testing/testing.go
@@ -42,10 +42,15 @@ func MarkAsNonReady(vmi *v1.VirtualMachineInstance) {
 }
 
 func VirtualMachineFromVMI(name string, vmi *v1.VirtualMachineInstance, started bool) *v1.VirtualMachine {
+	runStrategy := v1.RunStrategyAlways
+	if !started {
+		runStrategy = v1.RunStrategyHalted
+	}
+
 	vm := &v1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: vmi.ObjectMeta.Namespace, ResourceVersion: "1", UID: "vm-uid"},
 		Spec: v1.VirtualMachineSpec{
-			Running: &started,
+			RunStrategy: &runStrategy,
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   vmi.ObjectMeta.Name,

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -3758,7 +3758,11 @@ var _ = Describe("VirtualMachine", func() {
 				})
 
 				DescribeTable("Should set a appropriate status when DataVolume exists but not bound", func(running bool, phase cdiv1.DataVolumePhase, status v1.VirtualMachinePrintableStatus) {
-					vm.Spec.Running = &running
+					if running {
+						vm.Spec.RunStrategy = pointer.P(v1.RunStrategyAlways)
+					} else {
+						vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
+					}
 
 					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
 					Expect(err).To(Succeed())

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -781,7 +781,6 @@ func GetVMMultiPvc() *v1.VirtualMachine {
 func getBaseVMPool(name string, replicas int, selectorLabels map[string]string) *poolv1.VirtualMachinePool {
 	baseVMISpec := getBaseVMISpec()
 	replicasInt32 := int32(replicas)
-	running := true
 
 	return &poolv1.VirtualMachinePool{
 		TypeMeta: metav1.TypeMeta{
@@ -801,7 +800,7 @@ func getBaseVMPool(name string, replicas int, selectorLabels map[string]string) 
 					Labels: selectorLabels,
 				},
 				Spec: v1.VirtualMachineSpec{
-					Running: &running,
+					RunStrategy: pointer.P(v1.RunStrategyAlways),
 					Template: &v1.VirtualMachineInstanceTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: selectorLabels,


### PR DESCRIPTION
### What this PR does
Removed instances of the deprecated `.spec.running` field in both examples and documentation.

Related to https://github.com/kubevirt/kubevirt/issues/11993.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

