### PR TITLE
Add a metric that reports the VM create date

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -78,6 +78,9 @@ The current available memory of the VM containers based on the rss. Type: Gauge.
 ### kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes
 The current available memory of the VM containers based on the working set. Type: Gauge.
 
+### kubevirt_vm_create_date_timestamp_seconds
+Virtual Machine creation timestamp. Type: Gauge.
+
 ### kubevirt_vm_created_by_pod_total
 The total number of VMs created by namespace and virt-api pod, since install. Type: Counter.
 


### PR DESCRIPTION
We would like for the Admin to be able to filter the Virtual machines based on the date and time the VM was created. The metric value is reported as timestamp_seconds in epoch time.

(note that the name updated to `kubevirt_vm_create_date_timestamp_seconds`):
![Screenshot from 2024-12-08 20-36-20](https://github.com/user-attachments/assets/6b0342cb-7fbc-415b-9d3b-e339e2f0ce2b)


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # jira-ticket: https://issues.redhat.com/browse/CNV-48216

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vm_create_date_timestamp_seconds metric

```

