### PR TITLE
Remove deprecated DataVolume garbage collection tests

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13124,7 +13124,7 @@
       "type": "boolean"
      },
      "name": {
-      "description": "Name of both the DataVolume and the PVC in the same namespace. After PVC population the DataVolume is garbage collected by default.",
+      "description": "Name of both the DataVolume and the PVC in the same namespace.",
       "type": "string",
       "default": ""
      }

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -21,8 +21,6 @@ set -ex pipefail
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
 KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-true}
-CDI_DV_GC_DEFAULT=-1
-CDI_DV_GC=${CDI_DV_GC:--1}
 
 source hack/common.sh
 # shellcheck disable=SC1090
@@ -54,11 +52,6 @@ function _ensure_cdi_deployment() {
     host_port=$(${KUBEVIRT_PATH}kubevirtci/cluster-up/cli.sh ports uploadproxy | xargs)
     override="https://127.0.0.1:$host_port"
     _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"uploadProxyURLOverride": "'"$override"'"}}}'
-
-    # Configure DataVolume garbage collection
-    if [[ $CDI_DV_GC != $CDI_DV_GC_DEFAULT ]]; then
-        _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"dataVolumeTTLSeconds": '"$CDI_DV_GC"'}}}'
-    fi
 }
 
 function configure_prometheus() {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7748,9 +7748,8 @@ var CRDsValidation map[string]string = map[string]string{
                               can be hotplugged and hotunplugged.
                             type: boolean
                           name:
-                            description: |-
-                              Name of both the DataVolume and the PVC in the same namespace.
-                              After PVC population the DataVolume is garbage collected by default.
+                            description: Name of both the DataVolume and the PVC in
+                              the same namespace.
                             type: string
                         required:
                         - name
@@ -8362,9 +8361,8 @@ var CRDsValidation map[string]string = map[string]string{
                               can be hotplugged and hotunplugged.
                             type: boolean
                           name:
-                            description: |-
-                              Name of both the DataVolume and the PVC in the same namespace.
-                              After PVC population the DataVolume is garbage collected by default.
+                            description: Name of both the DataVolume and the PVC in
+                              the same namespace.
                             type: string
                         required:
                         - name
@@ -12946,9 +12944,8 @@ var CRDsValidation map[string]string = map[string]string{
                       hotplugged and hotunplugged.
                     type: boolean
                   name:
-                    description: |-
-                      Name of both the DataVolume and the PVC in the same namespace.
-                      After PVC population the DataVolume is garbage collected by default.
+                    description: Name of both the DataVolume and the PVC in the same
+                      namespace.
                     type: string
                 required:
                 - name
@@ -18540,9 +18537,8 @@ var CRDsValidation map[string]string = map[string]string{
                               can be hotplugged and hotunplugged.
                             type: boolean
                           name:
-                            description: |-
-                              Name of both the DataVolume and the PVC in the same namespace.
-                              After PVC population the DataVolume is garbage collected by default.
+                            description: Name of both the DataVolume and the PVC in
+                              the same namespace.
                             type: string
                         required:
                         - name
@@ -23063,9 +23059,8 @@ var CRDsValidation map[string]string = map[string]string{
                                       volume can be hotplugged and hotunplugged.
                                     type: boolean
                                   name:
-                                    description: |-
-                                      Name of both the DataVolume and the PVC in the same namespace.
-                                      After PVC population the DataVolume is garbage collected by default.
+                                    description: Name of both the DataVolume and the
+                                      PVC in the same namespace.
                                     type: string
                                 required:
                                 - name
@@ -28283,9 +28278,8 @@ var CRDsValidation map[string]string = map[string]string{
                                           the volume can be hotplugged and hotunplugged.
                                         type: boolean
                                       name:
-                                        description: |-
-                                          Name of both the DataVolume and the PVC in the same namespace.
-                                          After PVC population the DataVolume is garbage collected by default.
+                                        description: Name of both the DataVolume and
+                                          the PVC in the same namespace.
                                         type: string
                                     required:
                                     - name
@@ -28923,9 +28917,8 @@ var CRDsValidation map[string]string = map[string]string{
                                           the volume can be hotplugged and hotunplugged.
                                         type: boolean
                                       name:
-                                        description: |-
-                                          Name of both the DataVolume and the PVC in the same namespace.
-                                          After PVC population the DataVolume is garbage collected by default.
+                                        description: Name of both the DataVolume and
+                                          the PVC in the same namespace.
                                         type: string
                                     required:
                                     - name

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -858,7 +858,6 @@ type HotplugVolumeSource struct {
 
 type DataVolumeSource struct {
 	// Name of both the DataVolume and the PVC in the same namespace.
-	// After PVC population the DataVolume is garbage collected by default.
 	Name string `json:"name"`
 	// Hotpluggable indicates whether the volume can be hotplugged and hotunplugged.
 	// +optional

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -462,7 +462,7 @@ func (HotplugVolumeSource) SwaggerDoc() map[string]string {
 
 func (DataVolumeSource) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"name":         "Name of both the DataVolume and the PVC in the same namespace.\nAfter PVC population the DataVolume is garbage collected by default.",
+		"name":         "Name of both the DataVolume and the PVC in the same namespace.",
 		"hotpluggable": "Hotpluggable indicates whether the volume can be hotplugged and hotunplugged.\n+optional",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18313,7 +18313,7 @@ func schema_kubevirtio_api_core_v1_DataVolumeSource(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of both the DataVolume and the PVC in the same namespace. After PVC population the DataVolume is garbage collected by default.",
+							Description: "Name of both the DataVolume and the PVC in the same namespace.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/tests/libstorage/BUILD.bazel
+++ b/tests/libstorage/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libstorage",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util/net/ip:go_default_library",
@@ -42,7 +41,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -31,16 +31,13 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/api/errors"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
-	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
@@ -80,36 +77,7 @@ func EventuallyDV(dv *v1beta1.DataVolume, timeoutSec int, matcher gomegatypes.Go
 }
 
 func EventuallyDVWith(namespace, name string, timeoutSec int, matcher gomegatypes.GomegaMatcher) {
-	virtCli := kubevirt.Client()
-
-	if !IsDataVolumeGC(virtCli) {
-		Eventually(ThisDVWith(namespace, name), timeoutSec, time.Second).Should(matcher)
-		return
-	}
-
-	ginkgo.By("Verifying DataVolume garbage collection")
-	var dv *v1beta1.DataVolume
-	Eventually(func() *v1beta1.DataVolume {
-		var err error
-		dv, err = ThisDVWith(namespace, name)()
-		Expect(err).ToNot(HaveOccurred())
-		return dv
-	}, timeoutSec, time.Second).Should(Or(BeNil(), matcher))
-
-	if dv != nil {
-		if dv.Status.Phase != v1beta1.Succeeded {
-			return
-		}
-		if dv.Annotations["cdi.kubevirt.io/storage.deleteAfterCompletion"] == "true" {
-			Eventually(ThisDV(dv), timeoutSec).Should(BeNil())
-		}
-	}
-
-	Eventually(func() bool {
-		pvc, err := ThisPVCWith(namespace, name)()
-		Expect(err).ToNot(HaveOccurred())
-		return pvc != nil && pvc.Spec.VolumeName != ""
-	}, timeoutSec, time.Second).Should(BeTrue())
+	Eventually(ThisDVWith(namespace, name), timeoutSec, time.Second).Should(matcher)
 }
 
 func DeleteDataVolume(dv **v1beta1.DataVolume) {
@@ -119,38 +87,9 @@ func DeleteDataVolume(dv **v1beta1.DataVolume) {
 	}
 	ginkgo.By("Deleting DataVolume")
 	virtCli := kubevirt.Client()
-
 	err := virtCli.CdiClient().CdiV1beta1().DataVolumes((*dv).Namespace).Delete(context.Background(), (*dv).Name, v12.DeleteOptions{})
-	if !IsDataVolumeGC(virtCli) {
-		Expect(err).ToNot(HaveOccurred())
-		*dv = nil
-		return
-	}
-	if err != nil {
-		Expect(err).To(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
-	}
-	if err = virtCli.CoreV1().PersistentVolumeClaims((*dv).Namespace).Delete(context.Background(), (*dv).Name, v12.DeleteOptions{}); err != nil {
-		Expect(err).To(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
-	}
+	Expect(err).ToNot(HaveOccurred())
 	*dv = nil
-}
-
-func SetDataVolumeGC(virtCli kubecli.KubevirtClient, ttlSec *int32) {
-	cdi := GetCDI(virtCli)
-	if cdi.Spec.Config.DataVolumeTTLSeconds == ttlSec {
-		return
-	}
-
-	p, err := patch.New(patch.WithReplace("/spec/config/dataVolumeTTLSeconds", ttlSec)).GeneratePayload()
-	Expect(err).NotTo(HaveOccurred())
-	_, err = virtCli.CdiClient().CdiV1beta1().CDIs().Patch(context.Background(), cdi.Name, types.JSONPatchType, p, v12.PatchOptions{})
-	Expect(err).ToNot(HaveOccurred())
-}
-
-func IsDataVolumeGC(virtCli kubecli.KubevirtClient) bool {
-	config, err := virtCli.CdiClient().CdiV1beta1().CDIConfigs().Get(context.TODO(), "config", v12.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	return config.Spec.DataVolumeTTLSeconds != nil && *config.Spec.DataVolumeTTLSeconds >= 0
 }
 
 func GetCDI(virtCli kubecli.KubevirtClient) *v1beta1.CDI {

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -25,7 +25,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
-	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 
@@ -80,18 +79,6 @@ func EventuallyDVWith(namespace, name string, timeoutSec int, matcher gomegatype
 	Eventually(ThisDVWith(namespace, name), timeoutSec, time.Second).Should(matcher)
 }
 
-func DeleteDataVolume(dv **v1beta1.DataVolume) {
-	Expect(dv).ToNot(BeNil())
-	if *dv == nil {
-		return
-	}
-	ginkgo.By("Deleting DataVolume")
-	virtCli := kubevirt.Client()
-	err := virtCli.CdiClient().CdiV1beta1().DataVolumes((*dv).Namespace).Delete(context.Background(), (*dv).Name, v12.DeleteOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	*dv = nil
-}
-
 func GetCDI(virtCli kubecli.KubevirtClient) *v1beta1.CDI {
 	cdiList, err := virtCli.CdiClient().CdiV1beta1().CDIs().List(context.Background(), v12.ListOptions{})
 	Expect(err).ToNot(HaveOccurred())
@@ -111,10 +98,7 @@ func HasDataVolumeCRD() bool {
 
 	_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "datavolumes.cdi.kubevirt.io", v12.GetOptions{})
 
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func HasCDI() bool {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1044,10 +1044,6 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				}
 			})
 
-			AfterEach(func() {
-				libstorage.DeleteDataVolume(&dv)
-			})
-
 			It("[test_id:2653] should be migrated successfully, using guest agent on VM with default migration configuration", func() {
 				By("Creating the DV")
 				createDV(testsuite.NamespacePrivileged)
@@ -1131,7 +1127,6 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				} else {
 					kvconfig.EnableFeatureGate(virtconfig.Root)
 				}
-				libstorage.DeleteDataVolume(&dv)
 			})
 
 			DescribeTable("should migrate root implementation to nonroot", func(createVMI func() *v1.VirtualMachineInstance, loginFunc console.LoginToFunction) {
@@ -1215,10 +1210,6 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					kvconfig.EnableFeatureGate(virtconfig.Root)
 				} else {
 					kvconfig.DisableFeatureGate(virtconfig.Root)
-				}
-				if dv != nil {
-					libstorage.DeleteDataVolume(&dv)
-					dv = nil
 				}
 			})
 

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -122,10 +122,6 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				AfterEach(func() {
-					libstorage.DeleteDataVolume(&dv)
-				})
-
 				It("[test_id:5004] should be migrated successfully, using guest agent on VM with postcopy", func() {
 					VMIMigrationWithGuestAgent(virtClient, dv.Name, "1Gi", migrationPolicy)
 				})

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -401,7 +401,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					Expect(err).ToNot(HaveOccurred())
 					libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 				}
-				libstorage.DeleteDataVolume(&dataVolume)
 			})
 
 			It("[test_id:6686]should successfully start multiple concurrent VMIs", func() {
@@ -445,7 +444,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 					err := virtClient.VirtualMachineInstance(vmis[idx].Namespace).Delete(context.Background(), vmis[idx].Name, metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					libstorage.DeleteDataVolume(&dvs[idx])
 				}
 			})
 
@@ -478,7 +476,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-				libstorage.DeleteDataVolume(&dataVolume)
 			})
 
 			It("should accurately aggregate DataVolume conditions from many DVs", func() {
@@ -555,7 +552,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					err := virtClient.StorageV1().StorageClasses().Delete(context.Background(), storageClass.Name, metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}
-				libstorage.DeleteDataVolume(&dv)
 			})
 
 			It("[test_id:4643]should NOT be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", func() {
@@ -653,8 +649,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullPod),
 					libdv.WithStorage(libdv.StorageWithStorageClass(sc)),
 				)
-
-				defer libstorage.DeleteDataVolume(&dataVolume)
 
 				By("Creating DataVolume with invalid URL")
 				dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1259,7 +1259,6 @@ var _ = SIGDescribe("Hotplug", func() {
 					Expect(err).ToNot(HaveOccurred())
 					vm = nil
 				}
-				libstorage.DeleteDataVolume(&dv)
 			})
 
 			DescribeTable("should be able to add and remove volumes", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, storageClassFunc storageClassFunction, volumeMode k8sv1.PersistentVolumeMode, vmiOnly bool) {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1050,15 +1050,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 				targetVM := getTargetVM(restoreToNewVM)
 
-				if libstorage.IsDataVolumeGC(virtClient) {
-					Eventually(func() error {
-						_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Get(context.Background(), *dvName, metav1.GetOptions{})
-						return err
-					}, 30*time.Second, time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"))
-					verifyOwnerRef(pvc, targetVM.APIVersion, targetVM.Kind, targetVM.Name, targetVM.UID)
-					return
-				}
-
 				dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Get(context.Background(), *dvName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				verifyOwnerRef(dv, targetVM.APIVersion, targetVM.Kind, targetVM.Name, targetVM.UID)
@@ -1215,10 +1206,8 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				}
 				Expect(restore.Status.DeletedDataVolumes).To(BeEmpty())
 
-				if !libstorage.IsDataVolumeGC(virtClient) {
-					_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}
+				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
 				_, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), originalPVCName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1363,10 +1363,6 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		Context("with independent DataVolume", func() {
 			var dv *cdiv1.DataVolume
 
-			AfterEach(func() {
-				libstorage.DeleteDataVolume(&dv)
-			})
-
 			DescribeTable("should accurately report DataVolume provisioning", func(storageOptFun func(string, string) libvmi.Option, memory string) {
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1001,6 +1001,54 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				}
 			})
 
+			It("[test_id:4611] should successfully create a snapshot", func() {
+				snapshot = libstorage.NewSnapshot(vm.Name, vm.Namespace)
+
+				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				waitSnapshotReady()
+
+				Expect(snapshot.Status.CreationTime).ToNot(BeNil())
+				contentName := *snapshot.Status.VirtualMachineSnapshotContentName
+				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(*content.Spec.VirtualMachineSnapshotName).To(Equal(snapshot.Name))
+				Expect(content.Spec.Source.VirtualMachine.Spec).To(Equal(vm.Spec))
+				Expect(content.Spec.VolumeBackups).Should(HaveLen(len(vm.Spec.DataVolumeTemplates)))
+
+				for _, vol := range vm.Spec.Template.Spec.Volumes {
+					if vol.DataVolume == nil {
+						continue
+					}
+					found := false
+					for _, vb := range content.Spec.VolumeBackups {
+						if vol.DataVolume.Name == vb.PersistentVolumeClaim.Name {
+							found = true
+							Expect(vol.Name).To(Equal(vb.VolumeName))
+
+							pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), vol.DataVolume.Name, metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(pvc.Spec).To(Equal(vb.PersistentVolumeClaim.Spec))
+
+							Expect(vb.VolumeSnapshotName).ToNot(BeNil())
+							vs, err := virtClient.
+								KubernetesSnapshotClient().
+								SnapshotV1().
+								VolumeSnapshots(vm.Namespace).
+								Get(context.Background(), *vb.VolumeSnapshotName, metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(*vs.Spec.Source.PersistentVolumeClaimName).Should(Equal(vol.DataVolume.Name))
+							Expect(vs.Labels["snapshot.kubevirt.io/source-vm-name"]).Should(Equal(vm.Name))
+							Expect(vs.Status.Error).To(BeNil())
+							Expect(*vs.Status.ReadyToUse).To(BeTrue())
+						}
+					}
+					Expect(found).To(BeTrue())
+				}
+			})
+
 			It("should successfully recreate status", func() {
 				snapshot = libstorage.NewSnapshot(vm.Name, vm.Namespace)
 
@@ -1310,93 +1358,6 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				})),
 				"CreationTime": BeNil(),
 			})))
-		})
-
-		Context("With more complicated VM with/out GC of succeeded DV", Serial, func() {
-			var originalTTL *int32
-
-			BeforeEach(func() {
-				cdi := libstorage.GetCDI(virtClient)
-				originalTTL = cdi.Spec.Config.DataVolumeTTLSeconds
-			})
-
-			AfterEach(func() {
-				libstorage.SetDataVolumeGC(virtClient, originalTTL)
-			})
-
-			DescribeTable("should successfully create a snapshot", func(ttl *int32) {
-				libstorage.SetDataVolumeGC(virtClient, ttl)
-
-				vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, snapshotStorageClass)
-				wffcSC := libstorage.IsStorageClassBindingModeWaitForFirstConsumer(snapshotStorageClass)
-				if wffcSC {
-					// with wffc need to start the virtual machine
-					// in order for the pvc to be populated
-					vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
-				} else {
-					vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyHalted)
-				}
-
-				vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				for _, dvt := range vm.Spec.DataVolumeTemplates {
-					waitDataVolumePopulated(vm.Namespace, dvt.Name)
-				}
-
-				if wffcSC {
-					vm = libvmops.StopVirtualMachine(vm)
-				}
-
-				snapshot = libstorage.NewSnapshot(vm.Name, vm.Namespace)
-
-				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				waitSnapshotReady()
-
-				Expect(snapshot.Status.CreationTime).ToNot(BeNil())
-				contentName := *snapshot.Status.VirtualMachineSnapshotContentName
-				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(*content.Spec.VirtualMachineSnapshotName).To(Equal(snapshot.Name))
-				Expect(content.Spec.Source.VirtualMachine.Spec).To(Equal(vm.Spec))
-				Expect(content.Spec.VolumeBackups).Should(HaveLen(len(vm.Spec.DataVolumeTemplates)))
-
-				for _, vol := range vm.Spec.Template.Spec.Volumes {
-					if vol.DataVolume == nil {
-						continue
-					}
-					found := false
-					for _, vb := range content.Spec.VolumeBackups {
-						if vol.DataVolume.Name == vb.PersistentVolumeClaim.Name {
-							found = true
-							Expect(vol.Name).To(Equal(vb.VolumeName))
-
-							pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), vol.DataVolume.Name, metav1.GetOptions{})
-							Expect(err).ToNot(HaveOccurred())
-							Expect(pvc.Spec).To(Equal(vb.PersistentVolumeClaim.Spec))
-
-							Expect(vb.VolumeSnapshotName).ToNot(BeNil())
-							vs, err := virtClient.
-								KubernetesSnapshotClient().
-								SnapshotV1().
-								VolumeSnapshots(vm.Namespace).
-								Get(context.Background(), *vb.VolumeSnapshotName, metav1.GetOptions{})
-							Expect(err).ToNot(HaveOccurred())
-							Expect(*vs.Spec.Source.PersistentVolumeClaimName).Should(Equal(vol.DataVolume.Name))
-							Expect(vs.Labels["snapshot.kubevirt.io/source-vm-name"]).Should(Equal(vm.Name))
-							Expect(vs.Status.Error).To(BeNil())
-							Expect(*vs.Status.ReadyToUse).To(BeTrue())
-						}
-					}
-					Expect(found).To(BeTrue())
-				}
-			},
-				Entry("[test_id:4611] without DV garbage collection", virtpointer.P(int32(-1))),
-				Entry("[test_id:8668] with DV garbage collection", virtpointer.P(int32(0))),
-			)
 		})
 
 		Context("with independent DataVolume", func() {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -962,10 +962,6 @@ var _ = SIGDescribe("Storage", func() {
 				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 			})
 
-			AfterEach(func() {
-				libstorage.DeleteDataVolume(&dataVolume)
-			})
-
 			// Not a candidate for NFS because local volumes are used in test
 			It("[test_id:1015]should be successfully started", func() {
 				// Start the VirtualMachineInstance with the PVC attached
@@ -1125,10 +1121,6 @@ var _ = SIGDescribe("Storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 				libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 				vmi = nil
-			})
-
-			AfterEach(func() {
-				libstorage.DeleteDataVolume(&dataVolume)
 			})
 
 			It("should generate the pod with the volumeDevice", func() {

--- a/tests/virtctl/imageupload.go
+++ b/tests/virtctl/imageupload.go
@@ -226,12 +226,10 @@ var _ = Describe("[sig-storage][virtctl]ImageUpload", decorators.SigStorage, Ser
 			Expect(err).ToNot(HaveOccurred())
 
 			if uploadDV {
-				if !libstorage.IsDataVolumeGC(virtClient) {
-					By("Get DataVolume")
-					dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Get(context.Background(), targetName, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(dv.Spec.ContentType).To(Equal(cdiv1.DataVolumeArchive))
-				}
+				By("Get DataVolume")
+				dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Get(context.Background(), targetName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dv.Spec.ContentType).To(Equal(cdiv1.DataVolumeArchive))
 			} else {
 				By("Validate no DataVolume")
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Get(context.Background(), targetName, metav1.GetOptions{})
@@ -318,11 +316,6 @@ func runImageUploadCmd(args ...string) error {
 
 func validateDataVolume(targetName string, _ string) {
 	virtClient := kubevirt.Client()
-	if libstorage.IsDataVolumeGC(virtClient) {
-		_, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Get(context.Background(), targetName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		return
-	}
 	By("Get DataVolume")
 	_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Get(context.Background(), targetName, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
@@ -342,9 +335,6 @@ func validatePVC(targetName string, sc string) {
 
 func validateDataVolumeForceBind(targetName string) {
 	virtClient := kubevirt.Client()
-	if libstorage.IsDataVolumeGC(virtClient) {
-		return
-	}
 	By("Get DataVolume")
 	dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Get(context.Background(), targetName, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -298,7 +298,6 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 				),
 				libdv.WithNamespace(namespace),
 			)
-			defer libstorage.DeleteDataVolume(&dataVolume)
 
 			dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -248,8 +248,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 
 		DescribeTable("[test_id:1521]should remove VirtualMachineInstance once the VM is marked for deletion", decorators.Conformance, func(createTemplate vmiBuilder, ensureGracefulTermination bool) {
-			template, dv := createTemplate()
-			defer libstorage.DeleteDataVolume(&dv)
+			template, _ := createTemplate()
 			vm := libvmops.StartVirtualMachine(createVM(virtClient, template))
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -333,8 +332,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 
 		DescribeTable("[test_id:1525]should stop VirtualMachineInstance if running set to false", func(createTemplate vmiBuilder) {
-			template, dv := createTemplate()
-			defer libstorage.DeleteDataVolume(&dv)
+			template, _ := createTemplate()
 			libvmops.StopVirtualMachine(libvmops.StartVirtualMachine(createVM(virtClient, template)))
 		},
 			Entry("with ContainerDisk", func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) { return libvmifact.NewCirros(), nil }),

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2106,10 +2106,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 		})
 
-		AfterEach(func() {
-			libstorage.DeleteDataVolume(&dataVolume)
-		})
-
 		It("[test_id:1681]should set appropriate cache modes", func() {
 			tmpHostDiskDir := storage.RandHostDiskDir()
 			vmi := libvmi.New(


### PR DESCRIPTION
### What this PR does
After several releases with CDI `DataVolume` garbage collection disabled by default, we decided to [deprecate](https://github.com/kubevirt/containerized-data-importer/pull/3552) it, as unfortunately it violates fundamental principle of Kubernetes. CR should not be auto-deleted when it completes its role (`Job` with `TTLSecondsAfterFinished` is an exception), and once CR was created we can assume it is there until explicitly deleted. In addition, CR should keep idempotency, so the same CR manifest can be applied multiple times, as long as it is a valid update (e.g. `DataVolume` validation webhook does not allow updating the spec).

### Checklist
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Remove deprecated DataVolume garbage collection tests
```