### PR TITLE
[release-1.4] watch/migration: bug-fix prevent status updates for finalized migrations

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -441,8 +441,11 @@ func (c *Controller) updateStatus(migration *virtv1.VirtualMachineInstanceMigrat
 
 	// Remove the finalizer and conditions if the migration has already completed
 	if migration.IsFinal() {
-		// store the finalized migration state data from the VMI status in the migration object
-		migrationCopy.Status.MigrationState = vmi.Status.MigrationState
+
+		if vmi.Status.MigrationState != nil && migration.UID == vmi.Status.MigrationState.MigrationUID {
+			// Store the finalized migration state data from the VMI status in the migration object
+			migrationCopy.Status.MigrationState = vmi.Status.MigrationState
+		}
 
 		// remove the migration finalizer
 		controller.RemoveFinalizer(migrationCopy, virtv1.VirtualMachineInstanceMigrationFinalizer)

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -1409,6 +1409,46 @@ var _ = Describe("Migration watcher", func() {
 			expectMigrationCompletedState(migration.Namespace, migration.Name)
 		})
 
+		It("should not override the MigrationState of a completed migration when a new one is created", func() {
+			vmi := newVirtualMachine("testvmi", virtv1.Running)
+			addNodeNameToVMI(vmi, "node02")
+
+			completedMigration := newMigration("completed-migration", vmi.Name, virtv1.MigrationSucceeded)
+			completedMigration.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID: completedMigration.UID,
+				TargetNode:   "node02",
+				SourceNode:   "node01",
+				Failed:       false,
+				Completed:    true,
+			}
+			runningMigration := newMigration("running-migration", vmi.Name, virtv1.MigrationRunning)
+
+			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID:                   runningMigration.UID,
+				TargetNode:                     "node01",
+				SourceNode:                     "node02",
+				TargetNodeAddress:              "10.10.10.10:1234",
+				StartTimestamp:                 pointer.P(metav1.Now()),
+				EndTimestamp:                   pointer.P(metav1.Now()),
+				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+				Failed:                         false,
+				Completed:                      true,
+			}
+
+			addMigration(completedMigration)
+			addVirtualMachineInstance(vmi)
+			addPod(newSourcePodForVirtualMachine(vmi))
+			addPod(newTargetPodForVirtualMachine(vmi, completedMigration, k8sv1.PodRunning))
+
+			addMigration(runningMigration)
+
+			controller.Execute()
+
+			oldMigration, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(completedMigration.Namespace).Get(context.TODO(), completedMigration.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(oldMigration.Status.MigrationState.MigrationUID).To(Equal(completedMigration.UID))
+		})
+
 		DescribeTable("should not transit to succeeded phase when VMI status has", func(conditions []virtv1.VirtualMachineInstanceConditionType) {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			addNodeNameToVMI(vmi, "node02")


### PR DESCRIPTION
Manual backport of #13426 

in migration_test: sanityExecute() wasn't introduced yet, so controller.Execute() is being used instead.

### Release note
```release-note
bug-fix: prevent status updates for finalized migrations
```

