### PR TITLE
[release-1.1] watch/migration: bug-fix prevent status updates for finalized migrations

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -429,8 +429,11 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 
 	// Remove the finalizer and conditions if the migration has already completed
 	if migration.IsFinal() {
-		// store the finalized migration state data from the VMI status in the migration object
-		migrationCopy.Status.MigrationState = vmi.Status.MigrationState
+
+		if vmi.Status.MigrationState != nil && migration.UID == vmi.Status.MigrationState.MigrationUID {
+			// Store the finalized migration state data from the VMI status in the migration object
+			migrationCopy.Status.MigrationState = vmi.Status.MigrationState
+		}
 
 		// remove the migration finalizaer
 		controller.RemoveFinalizer(migrationCopy, virtv1.VirtualMachineInstanceMigrationFinalizer)

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1351,6 +1351,42 @@ var _ = Describe("Migration watcher", func() {
 			testutils.ExpectEvent(recorder, SuccessfulMigrationReason)
 		})
 
+		It("should not override the MigrationState of a completed migration when a new one is created", func() {
+			vmi := newVirtualMachine("testvmi", virtv1.Running)
+			vmi.Status.NodeName = "node02"
+
+			completedMigration := newMigration("completed-migration", vmi.Name, virtv1.MigrationSucceeded)
+			completedMigration.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID: completedMigration.UID,
+				TargetNode:   "node02",
+				SourceNode:   "node01",
+				Failed:       false,
+				Completed:    true,
+			}
+
+			runningMigration := newMigration("running-migration", vmi.Name, virtv1.MigrationRunning)
+
+			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID:                   runningMigration.UID,
+				TargetNode:                     "node01",
+				SourceNode:                     "node02",
+				TargetNodeAddress:              "10.10.10.10:1234",
+				StartTimestamp:                 now(),
+				EndTimestamp:                   now(),
+				TargetNodeDomainReadyTimestamp: now(),
+				Failed:                         false,
+				Completed:                      true,
+			}
+
+			addMigration(completedMigration)
+			addVirtualMachineInstance(vmi)
+			addMigration(runningMigration)
+
+			migrationInterface.EXPECT().UpdateStatus(gomock.Any()).Times(0)
+
+			controller.Execute()
+		})
+
 		DescribeTable("should not transit to succeeded phase when VMI status has", func(conditions []virtv1.VirtualMachineInstanceConditionType) {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			vmi.Status.NodeName = "node02"


### PR DESCRIPTION
manual backport of #13426

reason for backport is due to missing helper functions like `addPod(pod)`, `addNodeNameToVMI(vmi, "node02")`, and also the fake virtClientset  that  wasn't introduced yet for this release.

### Jira Ticket
```jira-ticket
https://issues.redhat.com/browse/CNV-52436
```

### Release note
```release-note
bug-fix: prevent status updates for finalized migrations
```

