### PR TITLE
virtwrap, arm64: not add VMPort on Arm64 platform

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -76,8 +76,6 @@ func (d *Defaulter) setDefaults_Features(spec *DomainSpec) {
 	if spec.Features == nil {
 		spec.Features = &Features{}
 	}
-
-	spec.Features.VMPort = &FeatureState{State: "off"}
 }
 
 func (d *Defaulter) SetObjectDefaults_Domain(in *Domain) {

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -161,7 +161,6 @@ var _ = ginkgo.Describe("Schema", func() {
 			},
 			PVSpinlock: &FeaturePVSpinlock{State: "off"},
 			PMU:        &FeatureState{State: "off"},
-			VMPort:     &FeatureState{State: "off"},
 		}
 		exampleDomain.Spec.SysInfo = &SysInfo{
 			Type: "smbios",

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_arm64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_arm64.xml.tmpl
@@ -66,7 +66,6 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
-    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_ppc64le.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_ppc64le.xml.tmpl
@@ -66,7 +66,6 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
-    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/api/testdata/domain_x86_64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/api/testdata/domain_x86_64.xml.tmpl
@@ -66,7 +66,6 @@
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
-    <vmport state="off"></vmport>
   </features>
   <cpu mode="custom">
     <model>Conroe</model>

--- a/pkg/virt-launcher/virtwrap/converter/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/amd64.go
@@ -111,3 +111,7 @@ func (archConverterAMD64) requiresMPXCPUValidation() bool {
 func (archConverterAMD64) shouldVerboseLogsBeEnabled() bool {
 	return true
 }
+
+func (archConverterAMD64) hasVMPort() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/archconverter.go
+++ b/pkg/virt-launcher/virtwrap/converter/archconverter.go
@@ -40,6 +40,7 @@ type ArchConverter interface {
 	isUSBNeeded(vmi *v1.VirtualMachineInstance) bool
 	supportCPUHotplug() bool
 	isSMBiosNeeded() bool
+	hasVMPort() bool
 	transitionalModelType(useVirtioTransitional bool) string
 	isROMTuningSupported() bool
 	requiresMPXCPUValidation() bool

--- a/pkg/virt-launcher/virtwrap/converter/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arm64.go
@@ -94,3 +94,7 @@ func (archConverterARM64) requiresMPXCPUValidation() bool {
 func (archConverterARM64) shouldVerboseLogsBeEnabled() bool {
 	return false
 }
+
+func (archConverterARM64) hasVMPort() bool {
+	return false
+}

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1058,6 +1058,7 @@ func Convert_v1_Features_To_api_Features(source *v1.Features, features *api.Feat
 			State: boolToOnOff(source.Pvspinlock.Enabled, true),
 		}
 	}
+
 	return nil
 }
 
@@ -1664,6 +1665,11 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	if vmi.Spec.Domain.Features != nil {
 		domain.Spec.Features = &api.Features{}
 		err := Convert_v1_Features_To_api_Features(vmi.Spec.Domain.Features, domain.Spec.Features, c)
+
+		if c.Architecture.hasVMPort() {
+			domain.Spec.Features.VMPort = &api.FeatureState{State: "off"}
+		}
+
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1497,7 +1497,19 @@ var _ = Describe("Converter", func() {
 			Entry("ErrorPolicy equal to report", pointer.P(v1.DiskErrorPolicyReport), "report"),
 			Entry("ErrorPolicy equal to enospace", pointer.P(v1.DiskErrorPolicyEnospace), "enospace"),
 		)
-
+		DescribeTable("Should set the vmport by arch", func(arch string) {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			c.Architecture = NewArchConverter(arch)
+			domain := vmiToDomain(vmi, c)
+			switch arch {
+			case amd64, ppc64le, s390x:
+				Expect(domain.Spec.Features.VMPort.State).To(Equal("off"))
+			case arm64:
+				Expect(domain.Spec.Features.VMPort).To(BeNil())
+			}
+		},
+			MultiArchEntry(""),
+		)
 	})
 	Context("Network convert", func() {
 		var vmi *v1.VirtualMachineInstance

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1502,9 +1502,9 @@ var _ = Describe("Converter", func() {
 			c.Architecture = NewArchConverter(arch)
 			domain := vmiToDomain(vmi, c)
 			switch arch {
-			case amd64, ppc64le, s390x:
+			case amd64, ppc64le:
 				Expect(domain.Spec.Features.VMPort.State).To(Equal("off"))
-			case arm64:
+			case arm64, s390x:
 				Expect(domain.Spec.Features.VMPort).To(BeNil())
 			}
 		},

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1502,9 +1502,9 @@ var _ = Describe("Converter", func() {
 			c.Architecture = NewArchConverter(arch)
 			domain := vmiToDomain(vmi, c)
 			switch arch {
-			case amd64, ppc64le:
+			case amd64:
 				Expect(domain.Spec.Features.VMPort.State).To(Equal("off"))
-			case arm64, s390x:
+			case arm64, s390x, ppc64le:
 				Expect(domain.Spec.Features.VMPort).To(BeNil())
 			}
 		},

--- a/pkg/virt-launcher/virtwrap/converter/ppc64le.go
+++ b/pkg/virt-launcher/virtwrap/converter/ppc64le.go
@@ -83,5 +83,5 @@ func (archConverterPPC64) shouldVerboseLogsBeEnabled() bool {
 }
 
 func (archConverterPPC64) hasVMPort() bool {
-	return true
+	return false
 }

--- a/pkg/virt-launcher/virtwrap/converter/ppc64le.go
+++ b/pkg/virt-launcher/virtwrap/converter/ppc64le.go
@@ -81,3 +81,7 @@ func (archConverterPPC64) requiresMPXCPUValidation() bool {
 func (archConverterPPC64) shouldVerboseLogsBeEnabled() bool {
 	return false
 }
+
+func (archConverterPPC64) hasVMPort() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/s390x.go
@@ -82,3 +82,7 @@ func (archConverterS390X) requiresMPXCPUValidation() bool {
 func (archConverterS390X) shouldVerboseLogsBeEnabled() bool {
 	return false
 }
+
+func (archConverterS390X) hasVMPort() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/s390x.go
@@ -84,5 +84,5 @@ func (archConverterS390X) shouldVerboseLogsBeEnabled() bool {
 }
 
 func (archConverterS390X) hasVMPort() bool {
-	return true
+	return false
 }

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_arm64.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_arm64.xml.tmpl
@@ -181,7 +181,6 @@
       <hidden state="on"></hidden>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
-    <vmport state="off"></vmport>
   </features>
   <cpu mode="host-passthrough">
     <topology sockets="1" cores="1" threads="1"></topology>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_ppc64le.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_ppc64le.xml.tmpl
@@ -178,7 +178,6 @@
       <hidden state="on"></hidden>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
-    <vmport state="off"></vmport>
   </features>
   <cpu mode="host-model">
     <topology sockets="1" cores="1" threads="1"></topology>

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml.tmpl
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml.tmpl
@@ -178,7 +178,6 @@
       <hidden state="on"></hidden>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
-    <vmport state="off"></vmport>
   </features>
   <cpu mode="host-model">
     <topology sockets="1" cores="1" threads="1"></topology>


### PR DESCRIPTION
VMPort is not support by the qemu on Arm64, so skip setting it via libvirt.
```
vmport is not available with this QEMU binary
```
Fixes #13436 

### Release note
```release-note
NONE
```

