### PR TITLE
Refactor/replace GitHub.com/go kit/kit/log

### DIFF
--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -45,7 +45,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-        "//vendor/github.com/go-kit/kit/log:go_default_library",
+        "//vendor/github.com/go-kit/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -14,7 +14,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/staging/src/github.com/golang/glog/BUILD.bazel
+++ b/staging/src/github.com/golang/glog/BUILD.bazel
@@ -5,5 +5,5 @@ go_library(
     srcs = ["glog.go"],
     importpath = "github.com/golang/glog",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/go-kit/kit/log:go_default_library"],
+    deps = ["//vendor/github.com/go-kit/log:go_default_library"],
 )

--- a/staging/src/github.com/golang/glog/glog.go
+++ b/staging/src/github.com/golang/glog/glog.go
@@ -31,7 +31,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	log2 "github.com/go-kit/kit/log"
+	log2 "github.com/go-kit/log"
 )
 
 const timestampNow = "2006-01-02T15:04:05.000000Z"

--- a/staging/src/github.com/golang/glog/go.mod
+++ b/staging/src/github.com/golang/glog/go.mod
@@ -3,7 +3,7 @@ module github.com/golang/glog
 go 1.12
 
 require (
-	github.com/go-kit/kit v0.9.0
+	github.com/go-kit/ v0.9.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/kr/logfmt v0.0.0-20210122060352-19f9bcb100e6 // indirect

--- a/staging/src/kubevirt.io/client-go/log/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/log/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/go-kit/kit/log:go_default_library",
+        "//vendor/github.com/go-kit/log:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -32,7 +32,7 @@ import (
 	"sync"
 	"time"
 
-	klog "github.com/go-kit/kit/log"
+	klog "github.com/go-kit/log"
 	"github.com/golang/glog"
 	flag "github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/vendor/github.com/go-kit/kit/log/README.md
+++ b/vendor/github.com/go-kit/kit/log/README.md
@@ -75,7 +75,7 @@ Redirect stdlib logger to Go kit logger.
 import (
 	"os"
 	stdlog "log"
-	kitlog "github.com/go-kit/kit/log"
+	kitlog "github.com/go-kit/log"
 )
 
 func main() {
@@ -114,7 +114,7 @@ logger.Log("msg", "hello")
 
 ## Levels
 
-Log levels are supported via the [level package](https://godoc.org/github.com/go-kit/kit/log/level).
+Log levels are supported via the [level package](https://godoc.org/github.com/go-kit/log/level).
 
 ## Supported output formats
 
@@ -145,11 +145,11 @@ Also, please see
 to review historical conversations about package log and the Logger interface.
 
 Value-add packages and suggestions,
-like improvements to [the leveled logger](https://godoc.org/github.com/go-kit/kit/log/level),
+like improvements to [the leveled logger](https://godoc.org/github.com/go-kit/log/level),
 are of course welcome. Good proposals should
 
-- Be composable with [contextual loggers](https://godoc.org/github.com/go-kit/kit/log#With),
-- Not break the behavior of [log.Caller](https://godoc.org/github.com/go-kit/kit/log#Caller) in any wrapped contextual loggers, and
+- Be composable with [contextual loggers](https://godoc.org/github.com/go-kit/log#With),
+- Not break the behavior of [log.Caller](https://godoc.org/github.com/go-kit/log#Caller) in any wrapped contextual loggers, and
 - Be friendly to packages that accept only an unadorned log.Logger.
 
 ## Benchmarks & comparisons

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -70,7 +70,6 @@ github.com/fsnotify/fsnotify
 github.com/fxamacker/cbor/v2
 # github.com/go-kit/kit v0.13.0
 ## explicit; go 1.17
-github.com/go-kit/kit/log
 # github.com/go-kit/log v0.2.1
 ## explicit; go 1.17
 github.com/go-kit/log


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

"GitHub.com/go kit/kit/log" is used which is deprecated.

After this PR:

"GitHub.com/go kit/kit/log" is now replaced by "GitHub.com/go kit/kit/log".

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #12955 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

