### PR TITLE
Improve log handling with continuous tailing of log files

### DIFF
--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"github.com/nxadm/tail"
 	"io"
 	"os"
 	"os/exec"
@@ -298,22 +299,20 @@ func startVirtlogdLogging(stopChan chan struct{}, domainName string, nonRoot boo
 				time.Sleep(time.Second)
 			}
 			// #nosec No risk for path injection. logfile has a static basedir
-			file, err := os.Open(logfile)
-			if err != nil {
-				errMsg := fmt.Sprintf("failed to open logfile in path: \"%s\"", logfile)
-				log.Log.Reason(err).Error(errMsg)
+			t, err1 := tail.TailFile(logfile, tail.Config{Follow: true, ReOpen: true})
+			if err1 != nil {
+				log.Log.Reason(err1).Error("failed to tail logfile at path: \"%s\"", logfile)
 				return
 			}
-			defer util.CloseIOAndCheckErr(file, nil)
 
-			scanner := bufio.NewScanner(file)
-			scanner.Buffer(make([]byte, 1024), 512*1024)
-			for scanner.Scan() {
-				log.LogQemuLogLine(log.Log, scanner.Text())
-			}
+			defer t.Stop()
 
-			if err := scanner.Err(); err != nil {
-				log.Log.Reason(err).Error("failed to read virtlogd logs")
+			for line := range t.Lines {
+				if line.Err != nil {
+					log.Log.Reason(line.Err).Error("error while reading line from tailed file")
+					continue
+				}
+				log.LogQemuLogLine(log.Log, line.Text)
 			}
 		}()
 


### PR DESCRIPTION
Signed-off-by: vaidikcode <vaidikbhardwaj00@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The original code reads the log file once using bufio.NewScanner() and exits when the end of the file is reached, missing any new log entries added later.
After this PR:
The revised code uses tail.TailFile() with Follow: true, continuously monitoring the file for new log entries and processing them in real time without exiting prematurely.
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13408 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

