### PR TITLE
Export: Support exporting backend storage PVC 

### DIFF
--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -1403,7 +1403,6 @@ func (ctrl *VMExportController) expandVirtualMachine(vm *virtv1.VirtualMachine) 
 }
 
 func (ctrl *VMExportController) updateHttpSourceDataVolumeTemplate(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine, error) {
-	// TODO: Need to find a way to include/represent backend storage in the export VM manifest
 	volumes, err := storageutils.GetVolumes(vm, nil)
 	if err != nil {
 		return nil, err
@@ -1473,7 +1472,6 @@ func (ctrl *VMExportController) generateVMDefinitionFromVm(vm *virtv1.VirtualMac
 
 func (ctrl *VMExportController) generateDataVolumesFromVm(vm *virtv1.VirtualMachine) ([]*cdiv1.DataVolume, error) {
 	res := make([]*cdiv1.DataVolume, 0)
-	// TODO: Need to find a way to include/represent backend storage in the export VM manifest
 	volumes, err := storageutils.GetVolumes(vm, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -67,6 +67,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	certutil "kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
@@ -1642,6 +1643,24 @@ func createPVC(name, contentType string) *k8sv1.PersistentVolumeClaim {
 			Namespace: testNamespace,
 			Annotations: map[string]string{
 				annContentType: contentType,
+			},
+		},
+		Status: k8sv1.PersistentVolumeClaimStatus{
+			Phase: k8sv1.ClaimBound,
+		},
+	}
+}
+
+func createBackendPVC(vmName string) *k8sv1.PersistentVolumeClaim {
+	return &k8sv1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-", backendstorage.PVCPrefix, vmName),
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				annContentType: "archive",
+			},
+			Labels: map[string]string{
+				backendstorage.PVCPrefix: vmName,
 			},
 		},
 		Status: k8sv1.PersistentVolumeClaimStatus{

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -191,7 +191,7 @@ func (ctrl *VMExportController) getPVCsFromVM(vmNamespace, vmName string) ([]*co
 	}
 	allPopulated := true
 
-	volumes, err := storageutils.GetVolumes(vm, ctrl.Client, storageutils.WithBackendVolume)
+	volumes, err := storageutils.GetVolumes(vm, nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -107,7 +107,11 @@ func (ctrl *VMExportController) handleVMI(obj interface{}) {
 
 func (ctrl *VMExportController) getPVCsFromVMI(vmi *virtv1.VirtualMachineInstance) []*corev1.PersistentVolumeClaim {
 	var pvcs []*corev1.PersistentVolumeClaim
-	for _, volume := range vmi.Spec.Volumes {
+
+	// No need to handle error when using VMI to fetch volumes
+	volumes, _ := storageutils.GetVolumes(vmi, ctrl.Client, storageutils.WithAllVolumes)
+
+	for _, volume := range volumes {
 		pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
 		if pvc := ctrl.getPVCsFromName(vmi.Namespace, pvcName); pvc != nil {
 			pvcs = append(pvcs, pvc)
@@ -191,8 +195,12 @@ func (ctrl *VMExportController) getPVCsFromVM(vmNamespace, vmName string) ([]*co
 	}
 	allPopulated := true
 
-	volumes, err := storageutils.GetVolumes(vm, nil)
+	volumes, err := storageutils.GetVolumes(vm, ctrl.Client, storageutils.WithAllVolumes)
 	if err != nil {
+		if storageutils.IsErrNoBackendPVC(err) {
+			// No backend pvc when we should have one, lets wait
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
+	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1beta1"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
@@ -49,6 +50,8 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
 
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
@@ -277,6 +280,20 @@ var _ = Describe("PVC source", func() {
 		return vm
 	}
 
+	createVMWithBackendPVC := func() *virtv1.VirtualMachine {
+		vm := createVMWithoutVolumes()
+		vm.Spec.Template.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			Name: "volume1",
+			VolumeSource: virtv1.VolumeSource{
+				DataVolume: &virtv1.DataVolumeSource{
+					Name: "volume1",
+				},
+			},
+		})
+		return vm
+	}
+
 	createVMWithPVCs := func() *virtv1.VirtualMachine {
 		vm := createVMWithoutVolumes()
 		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
@@ -411,6 +428,37 @@ var _ = Describe("PVC source", func() {
 		Entry("PVCs", createVMWithPVCs, "kubevirt", "kubevirt", verifyKubevirtInternal),
 		Entry("Memorydump and pvc", createVMWithPVCandMemoryDump, "kubevirt", "archive", verifyMixedInternal),
 	)
+
+	It("Should create VM export, when VM is using backend storage", func() {
+		testVMExport := createVMVMExport()
+		vm := createVMWithBackendPVC()
+		controller.VMInformer.GetStore().Add(vm)
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		backendPVC := createBackendPVC(vm.Name)
+		controller.PVCInformer.GetStore().Add(backendPVC)
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		k8sClient.Fake.PrependReactor("list", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			return true, &k8sv1.PersistentVolumeClaimList{Items: []k8sv1.PersistentVolumeClaim{*backendPVC}}, nil
+		})
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyMixedInternal(vmExport, vmExport.Name, testNamespace, "volume1", backendPVC.Name)
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(podReadyReason))
+				}
+			}
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+	})
 
 	DescribeTable("Should create VM export, when VM is stopped, but VMI exists", func(vmiPhase virtv1.VirtualMachineInstancePhase) {
 		testVMExport := createVMVMExport()

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -127,6 +127,7 @@ func (ctrl *VMExportController) handlePVCsForVirtualMachineSnapshot(vmExport *ex
 		if exists {
 			sourceVm := content.Spec.Source.VirtualMachine
 			totalVolumes = len(content.Status.VolumeSnapshotStatus)
+
 			for _, volumeBackup := range content.Spec.VolumeBackups {
 				if pvc, err := ctrl.getOrCreatePVCFromSnapshot(vmExport, &volumeBackup, sourceVm); err != nil {
 					return nil, 0, err

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -356,8 +356,6 @@ var getCdiHeaderSecret = func(token, name string) *corev1.Secret {
 
 var getDataVolumes = func(vm *virtv1.VirtualMachine) ([]*cdiv1.DataVolume, error) {
 	res := make([]*cdiv1.DataVolume, 0)
-	// TODO: Currently unable to access the backend storage here.
-	// Need to find some workaround.
 	volumes, err := storageutils.GetVolumes(vm, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -551,7 +551,7 @@ func (t *vmRestoreTarget) updateVMRestoreRestores() (bool, error) {
 	}
 	for k := range restores {
 		restore := &restores[k]
-		volumes, err := storageutils.GetVolumes(snapshotVM, t.controller.Client, storageutils.WithBackendVolume)
+		volumes, err := storageutils.GetVolumes(snapshotVM, t.controller.Client, storageutils.WithAllVolumes)
 		if err != nil {
 			return false, err
 		}
@@ -612,7 +612,7 @@ func (t *vmRestoreTarget) generateRestoredVMSpec() (*kubevirtv1.VirtualMachine, 
 		t.DeepCopyInto(&newTemplates[i])
 	}
 
-	volumes, err := storageutils.GetVolumes(snapshotVM, t.controller.Client, storageutils.WithBackendVolume)
+	volumes, err := storageutils.GetVolumes(snapshotVM, t.controller.Client, storageutils.WithAllVolumes)
 	if err != nil {
 		return nil, err
 	}
@@ -1258,7 +1258,7 @@ func updateRestoreCondition(r *snapshotv1.VirtualMachineRestore, c snapshotv1.Co
 func (ctrl *VMRestoreController) volumesNotForRestore(content *snapshotv1.VirtualMachineSnapshotContent) (sets.String, error) {
 	noRestore := sets.NewString()
 
-	volumes, err := storageutils.GetVolumes(content.Spec.Source.VirtualMachine, ctrl.Client, storageutils.WithBackendVolume)
+	volumes, err := storageutils.GetVolumes(content.Spec.Source.VirtualMachine, ctrl.Client, storageutils.WithAllVolumes)
 	if err != nil {
 		return noRestore, err
 	}

--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -858,7 +858,7 @@ func (ctrl *VMSnapshotController) updateSnapshotSnapshotableVolumes(snapshot *sn
 	if vm == nil || vm.Spec.Template == nil {
 		return nil
 	}
-	volumes, err := storageutils.GetVolumes(vm, ctrl.Client, storageutils.WithBackendVolume)
+	volumes, err := storageutils.GetVolumes(vm, ctrl.Client, storageutils.WithAllVolumes)
 	if err != nil {
 		return err
 	}
@@ -888,7 +888,7 @@ func (ctrl *VMSnapshotController) updateVolumeSnapshotStatuses(vm *kubevirtv1.Vi
 	log.Log.V(3).Infof("Update volume snapshot status for VM [%s/%s]", vm.Namespace, vm.Name)
 
 	vmCopy := vm.DeepCopy()
-	volumes, err := storageutils.GetVolumes(vmCopy, ctrl.Client, storageutils.WithBackendVolume)
+	volumes, err := storageutils.GetVolumes(vmCopy, ctrl.Client, storageutils.WithAllVolumes)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/utils/BUILD.bazel
+++ b/pkg/storage/utils/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     deps = [
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/storage/utils/volumes.go
+++ b/pkg/storage/utils/volumes.go
@@ -21,7 +21,9 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,10 +39,117 @@ type VolumeOption int
 const (
 	// Default option, just includes regular volumes found in the VM/VMI spec
 	WithRegularVolumes VolumeOption = iota
-	// Also adds the backend storage PVC
+	// Includes backend storage PVC
 	WithBackendVolume
-	// TODO: Add other options as needed
+	// Includes all volumes
+	WithAllVolumes
 )
+
+var ErrNoBackendPVC = fmt.Errorf("no backend PVC when there should be one")
+
+// GetVolumes returns all volumes of the passed object, empty if it's an unsupported object
+func GetVolumes(obj interface{}, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
+	switch obj := obj.(type) {
+	case *v1.VirtualMachine:
+		return GetVirtualMachineVolumes(obj, client, opts...)
+	case *snapshotv1.VirtualMachine:
+		return GetSnapshotVirtualMachineVolumes(obj, client, opts...)
+	case *v1.VirtualMachineInstance:
+		return GetVirtualMachineInstanceVolumes(obj, opts...)
+	default:
+		return []v1.Volume{}, fmt.Errorf("unsupported object type: %T", obj)
+	}
+}
+
+// GetVirtualMachineVolumes returns all volumes of a VM except the special ones based on volume options
+func GetVirtualMachineVolumes(vm *v1.VirtualMachine, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
+	return getVolumes(vm, vm.Spec.Template.Spec, client, opts...)
+}
+
+// GetSnapshotVirtualMachineVolumes returns all volumes of a Snapshot VM except the special ones based on volume options
+func GetSnapshotVirtualMachineVolumes(vm *snapshotv1.VirtualMachine, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
+	return getVolumes(vm, vm.Spec.Template.Spec, client, opts...)
+}
+
+// GetVirtualMachineInstanceVolumes returns all volumes of a VMI except the special ones based on volume options
+func GetVirtualMachineInstanceVolumes(vmi *v1.VirtualMachineInstance, opts ...VolumeOption) ([]v1.Volume, error) {
+	return getVolumes(vmi, vmi.Spec, nil, opts...)
+}
+
+func getVolumes(obj metav1.Object, vmiSpec v1.VirtualMachineInstanceSpec, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
+	var enumeratedVolumes []v1.Volume
+
+	if needsRegularVolumes(vmiSpec, opts) {
+		for _, volume := range vmiSpec.Volumes {
+			enumeratedVolumes = append(enumeratedVolumes, volume)
+		}
+	}
+
+	if needsBackendPVC(vmiSpec, opts) {
+		backendVolumeName, err := getBackendPVCName(obj, client)
+		if err != nil {
+			return enumeratedVolumes, err
+		}
+		if backendVolumeName != "" {
+			enumeratedVolumes = append(enumeratedVolumes, *createPVCVolume(backendVolumeName))
+		}
+	}
+
+	return enumeratedVolumes, nil
+}
+
+func getBackendPVCName(obj metav1.Object, client kubecli.KubevirtClient) (string, error) {
+	switch obj := obj.(type) {
+	case *v1.VirtualMachineInstance:
+		return backendstorage.CurrentPVCName(obj), nil
+	default:
+		// TODO: This could be way more simpler if the backend PVC name was accessible from the VM spec/status.
+		// Refactor this once the backend PVC is more accessible.
+		if client == nil {
+			return "", fmt.Errorf("no client provided")
+		}
+		pvcs, err := client.CoreV1().PersistentVolumeClaims(obj.GetNamespace()).List(context.Background(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", backendstorage.PVCPrefix, obj.GetName()),
+		})
+		if err != nil {
+			return "", err
+		}
+		switch len(pvcs.Items) {
+		case 1:
+			return pvcs.Items[0].Name, nil
+		case 0:
+			return "", ErrNoBackendPVC
+		default:
+			pvc, err := getNewestNonTerminatingPVC(pvcs.Items)
+			if err != nil {
+				return "", fmt.Errorf("no non-terminating PVC found")
+			}
+			return pvc.Name, nil
+		}
+	}
+}
+
+func needsBackendPVC(vmiSpec v1.VirtualMachineInstanceSpec, opts []VolumeOption) bool {
+	for _, opt := range opts {
+		if opt == WithBackendVolume || opt == WithAllVolumes {
+			return backendstorage.IsBackendStorageNeededForVMI(&vmiSpec)
+		}
+	}
+	return false
+}
+
+func needsRegularVolumes(vmiSpec v1.VirtualMachineInstanceSpec, opts []VolumeOption) bool {
+	if len(opts) == 0 {
+		return true
+	}
+
+	for _, opt := range opts {
+		if opt == WithRegularVolumes || opt == WithAllVolumes {
+			return true
+		}
+	}
+	return false
+}
 
 func createPVCVolume(pvcName string) *v1.Volume {
 	return &v1.Volume{
@@ -56,76 +165,27 @@ func createPVCVolume(pvcName string) *v1.Volume {
 	}
 }
 
-// needsBackendPVC checks if the backend PVC is needed based on the options passed
-func needsBackendPVC(vmiSpec v1.VirtualMachineInstanceSpec, opts []VolumeOption) bool {
-	for _, opt := range opts {
-		if opt == WithBackendVolume {
-			return backendstorage.IsBackendStorageNeededForVMI(&vmiSpec)
+// Helper function to select the newest non-terminating PVC
+func getNewestNonTerminatingPVC(pvcs []k8sv1.PersistentVolumeClaim) (*k8sv1.PersistentVolumeClaim, error) {
+	nonTerminatingPVCs := []k8sv1.PersistentVolumeClaim{}
+
+	for _, pvc := range pvcs {
+		if pvc.ObjectMeta.DeletionTimestamp == nil {
+			nonTerminatingPVCs = append(nonTerminatingPVCs, pvc)
 		}
 	}
-	return false
+
+	if len(nonTerminatingPVCs) == 0 {
+		return nil, fmt.Errorf("no non-terminating PVCs found")
+	}
+
+	sort.Slice(nonTerminatingPVCs, func(i, j int) bool {
+		return nonTerminatingPVCs[i].CreationTimestamp.After(nonTerminatingPVCs[j].CreationTimestamp.Time)
+	})
+
+	return &nonTerminatingPVCs[0], nil
 }
 
-// GetVolumes returns all volumes of the passed object, empty if it's an unsupported object
-func GetVolumes(obj interface{}, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
-	switch obj := obj.(type) {
-	case *v1.VirtualMachine:
-		return GetVirtualMachineVolumes(obj, client, opts...)
-	case *snapshotv1.VirtualMachine:
-		return GetSnapshotVirtualMachineVolumes(obj, client, opts...)
-	case *v1.VirtualMachineInstance:
-		return GetVirtualMachineInstanceVolumes(obj, opts...), nil
-	default:
-		return []v1.Volume{}, fmt.Errorf("unsupported object type: %T", obj)
-	}
-}
-
-// GetVirtualMachineVolumes returns all volumes of a VM except the special ones based on volume options
-func GetVirtualMachineVolumes(vm *v1.VirtualMachine, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
-	var err error
-	vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: vm.Name}, Spec: vm.Spec.Template.Spec}
-	if needsBackendPVC(vm.Spec.Template.Spec, opts) {
-		if client == nil {
-			return []v1.Volume{}, fmt.Errorf("no client provided")
-		}
-		vmi, err = client.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-		if err != nil {
-			return []v1.Volume{}, err
-		}
-	}
-	return GetVirtualMachineInstanceVolumes(vmi, opts...), nil
-}
-
-// GetSnapshotVirtualMachineVolumes returns all volumes of a Snapshot VM except the special ones based on volume options
-func GetSnapshotVirtualMachineVolumes(vm *snapshotv1.VirtualMachine, client kubecli.KubevirtClient, opts ...VolumeOption) ([]v1.Volume, error) {
-	var err error
-	vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: vm.Name}, Spec: vm.Spec.Template.Spec}
-	if needsBackendPVC(vm.Spec.Template.Spec, opts) {
-		if client == nil {
-			return []v1.Volume{}, fmt.Errorf("no client provided")
-		}
-		vmi, err = client.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-		if err != nil {
-			return []v1.Volume{}, err
-		}
-	}
-	return GetVirtualMachineInstanceVolumes(vmi, opts...), nil
-}
-
-// GetVirtualMachineInstanceVolumes returns all volumes of a VMI except the special ones based on volume options
-func GetVirtualMachineInstanceVolumes(vmi *v1.VirtualMachineInstance, opts ...VolumeOption) []v1.Volume {
-	var enumeratedVolumes []v1.Volume
-
-	for _, volume := range vmi.Spec.Volumes {
-		enumeratedVolumes = append(enumeratedVolumes, volume)
-	}
-
-	if needsBackendPVC(vmi.Spec, opts) {
-		backendVolume := backendstorage.CurrentPVCName(vmi)
-		if backendVolume != "" {
-			enumeratedVolumes = append(enumeratedVolumes, *createPVCVolume(backendVolume))
-		}
-	}
-
-	return enumeratedVolumes
+func IsErrNoBackendPVC(err error) bool {
+	return errors.Is(err, ErrNoBackendPVC)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR introduces support for exporting backend storage PVCs using the export API.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-50230

### Special notes for your reviewer

Not including the backend volume in the export VM manifest as it doesn't make sense to use the original VM's TPM when recreating a different VM.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Support exporting backend PVC
```

