### PR TITLE
e2e,migration: Quarantine very flaky migration test with paused VMI

### DIFF
--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/decorators"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
 
@@ -151,7 +152,7 @@ var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", func() {
 					},
 						Entry("migrate successfully (migration policy)", expectSuccess, "50Mi", applyWithMigrationPolicy),
 						Entry("migrate successfully (CR change)", Serial, expectSuccess, "50Mi", applyWithKubevirtCR),
-						Entry("fail migration", expectFailure, "1Mi", applyWithMigrationPolicy),
+						Entry("[QUARANTINE] fail migration", decorators.Quarantine, expectFailure, "1Mi", applyWithMigrationPolicy),
 					)
 				})
 			})


### PR DESCRIPTION
### What this PR does

This tests has been flaky over the past two days- causing over 30% impact to the compute-migrations presubmit lane[1]

[1] https://search.ci.kubevirt.io/?search=paused+vmi+during+migration+should+migrate+paused+when+acceptable+time+exceeded+and+post-copy+is+forbidden+should+pause+the+VMI+and++fail+migration&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

/cc @dhiller @xpivarc @fossedihelm 

We have to get this one quarantined as quickly as we can. It is flaking a lot - https://testgrid.kubernetes.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.31-sig-compute-migrations&width=20

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

