### PR TITLE
Replace flaky e2e migration cancelation test with a paused workload with a unit test

### DIFF
--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -149,7 +149,6 @@ var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", decorators.RequiresTwo
 					},
 						Entry("migrate successfully (migration policy)", expectSuccess, "10Mi", applyWithMigrationPolicy),
 						Entry("migrate successfully (CR change)", Serial, expectSuccess, "10Mi", applyWithKubevirtCR),
-						Entry("[QUARANTINE] fail migration", decorators.Quarantine, expectFailure, "1Mi", applyWithMigrationPolicy),
 					)
 				})
 			})


### PR DESCRIPTION
### What this PR does
This PR is a follow up to a recently discovered quarantined migration test flake, described in https://github.com/kubevirt/kubevirt/pull/13462
It replaced the flaky e2e test with a unit test as the functional test depends on the size of the workloads and various node related factors. 
Factors that were not evident during the submission of the original test.

Fixes #
### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

