### PR TITLE
virt-api, webhooks: Decouple admitters & network validator

### DIFF
--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			{Name: "foo", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}}},
 		}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
-		Expect(validator.Validate()).To(BeEmpty())
+		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
 	},
 		Entry("is empty", v1.InterfaceState("")),
 		Entry("is absent when bridge binding is used", v1.InterfaceStateAbsent),
@@ -58,7 +58,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "foo", State: v1.InterfaceState("foo")}}
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
-		Expect(validator.Validate()).To(
+		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
 				Message: "logical foo interface state value is unsupported: foo",
@@ -77,7 +77,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			{Name: "foo", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}}},
 		}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
-		Expect(validator.Validate()).To(
+		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
 				Message: "\"foo\" interface's state \"absent\" is supported only for bridge binding",
@@ -96,7 +96,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
-		Expect(validator.Validate()).To(
+		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
 				Message: "\"foo\" interface's state \"absent\" is not supported on default networks",

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		vm.Spec.Networks = []v1.Network{
 			{Name: "foo", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}}},
 		}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
 	},
 		Entry("is empty", v1.InterfaceState("")),
@@ -57,7 +57,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		vm := api.NewMinimalVMI("testvm")
 		vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "foo", State: v1.InterfaceState("foo")}}
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
@@ -76,7 +76,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		vm.Spec.Networks = []v1.Network{
 			{Name: "foo", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}}},
 		}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
@@ -95,7 +95,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Validating network binding combinations", func() {
 		}}
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true, bindingPluginFGEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
@@ -60,7 +60,7 @@ var _ = Describe("Validating network binding combinations", func() {
 		}}
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 		clusterConfig := stubClusterConfigChecker{bindingPluginFGEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
 	})
 
@@ -72,7 +72,7 @@ var _ = Describe("Validating network binding combinations", func() {
 		}}
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
 	})
 })
@@ -90,7 +90,7 @@ var _ = Describe("Validating core binding", func() {
 			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}},
 		}}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -111,7 +111,7 @@ var _ = Describe("Validating core binding", func() {
 			{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
 		}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -126,7 +126,7 @@ var _ = Describe("Validating core binding", func() {
 		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Validating network binding combinations", func() {
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true, bindingPluginFGEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
-		Expect(validator.Validate()).To(
+		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
 				Message: "logical foo interface cannot have both binding plugin and interface binding method",
@@ -61,7 +61,7 @@ var _ = Describe("Validating network binding combinations", func() {
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 		clusterConfig := stubClusterConfigChecker{bindingPluginFGEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
-		Expect(validator.Validate()).To(BeEmpty())
+		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
 	})
 
 	It("network interface has only binding method", func() {
@@ -73,7 +73,7 @@ var _ = Describe("Validating network binding combinations", func() {
 		vm.Spec.Networks = []v1.Network{{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
-		Expect(validator.Validate()).To(BeEmpty())
+		Expect(validator.Validate(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
 	})
 })
 
@@ -91,7 +91,7 @@ var _ = Describe("Validating core binding", func() {
 		}}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
@@ -112,7 +112,7 @@ var _ = Describe("Validating core binding", func() {
 		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
@@ -127,7 +127,7 @@ var _ = Describe("Validating core binding", func() {
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",

--- a/pkg/network/admitter/macvtap_test.go
+++ b/pkg/network/admitter/macvtap_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Validating macvtap core binding", func() {
 
 		clusterConfig := stubClusterConfigChecker{macvtapFeatureGateEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
@@ -63,7 +63,7 @@ var _ = Describe("Validating macvtap core binding", func() {
 		}}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
@@ -85,6 +85,6 @@ var _ = Describe("Validating macvtap core binding", func() {
 
 		clusterConfig := stubClusterConfigChecker{macvtapFeatureGateEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
-		Expect(validator.Validate()).To(BeEmpty())
+		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 	})
 })

--- a/pkg/network/admitter/macvtap_test.go
+++ b/pkg/network/admitter/macvtap_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Validating macvtap core binding", func() {
 		spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 		clusterConfig := stubClusterConfigChecker{macvtapFeatureGateEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -62,7 +62,7 @@ var _ = Describe("Validating macvtap core binding", func() {
 			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}},
 		}}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -84,7 +84,7 @@ var _ = Describe("Validating macvtap core binding", func() {
 		}}
 
 		clusterConfig := stubClusterConfigChecker{macvtapFeatureGateEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 	})
 })

--- a/pkg/network/admitter/netiface_test.go
+++ b/pkg/network/admitter/netiface_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 		}}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -57,7 +57,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 		spec.Networks = []v1.Network{}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -85,7 +85,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			},
 		}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -106,7 +106,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			{Name: "default", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}}},
 		}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ContainElements(metav1.StatusCause{
@@ -124,7 +124,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		}}
 		spec.Networks = []v1.Network{{Name: "bad.name", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
 			Message: "Network interface name can only contain alphabetical characters, numbers, dashes (-) or underscores (_)",
@@ -138,7 +138,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		spec.Domain.Devices.Interfaces[0].Model = "invalid_model"
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueNotSupported",
 			Message: "interface fake.domain.devices.interfaces[0].name uses model invalid_model that is not supported.",
@@ -152,7 +152,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		spec.Domain.Devices.Interfaces[0].Model = v1.VirtIO
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 	})
 
@@ -162,7 +162,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		spec.Domain.Devices.Interfaces[0].MacAddress = macAddress
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
 			Message: expectedMessage,
@@ -192,7 +192,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		spec.Domain.Devices.Interfaces[0].MacAddress = macAddress
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 	},
 		Entry("valid address in lowercase and colon separated", "de:ad:00:00:be:af"),
@@ -207,7 +207,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
 			Message: fmt.Sprintf("interface fake.domain.devices.interfaces[0].name has malformed PCI address (%s).", pciAddress),
@@ -225,7 +225,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 	},
 		Entry("valid address A", "0000:81:11.1"),
@@ -242,7 +242,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			}}
 			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
-			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+			validator := admitter.NewValidator(stubClusterConfigChecker{})
 			Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(ConsistOf(expectedCauses))
 		},
 			Entry(
@@ -301,7 +301,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			}}
 			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
-			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+			validator := admitter.NewValidator(stubClusterConfigChecker{})
 			Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 		},
 			Entry("single minimal port", []v1.Port{{Port: 80}}),
@@ -323,7 +323,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			}}
 			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
-			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+			validator := admitter.NewValidator(stubClusterConfigChecker{})
 			Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(ConsistOf(expectedCauses))
 		},
 			Entry(
@@ -373,7 +373,7 @@ var _ = Describe("Validating VMI network spec", func() {
 			}}
 			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
-			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+			validator := admitter.NewValidator(stubClusterConfigChecker{})
 			Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 		},
 			Entry("  valid DHCPPrivateOptions", v1.DHCPOptions{

--- a/pkg/network/admitter/netiface_test.go
+++ b/pkg/network/admitter/netiface_test.go
@@ -391,4 +391,13 @@ var _ = Describe("Validating VMI network spec", func() {
 			),
 		)
 	})
+
+	It("should accept a single interface and network", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+
+		validator := admitter.NewValidator(stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true})
+		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
+	})
 })

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Validate network source", func() {
 			{Name: net2Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
 		}
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		causes := validator.Validate(k8sfield.NewPath("fake"), &vmi.Spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
@@ -64,7 +64,7 @@ var _ = Describe("Validate network source", func() {
 		}
 
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("should have only one network type"))
@@ -79,7 +79,7 @@ var _ = Describe("Validate network source", func() {
 		iface1 := v1.Interface{Name: net1.Name}
 		spec.Networks = []v1.Network{net1}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("should have a network type"))
@@ -93,7 +93,7 @@ var _ = Describe("Validate network source", func() {
 			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
 		}}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("CNI delegating plugin must have a networkName"))
@@ -124,7 +124,7 @@ var _ = Describe("Validate network source", func() {
 			},
 		}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
@@ -155,7 +155,7 @@ var _ = Describe("Validate network source", func() {
 		}
 
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Validate network source", func() {
 		}
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), &vmi.Spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
 	})
@@ -65,7 +65,7 @@ var _ = Describe("Validate network source", func() {
 
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("should have only one network type"))
 	})
@@ -80,7 +80,7 @@ var _ = Describe("Validate network source", func() {
 		spec.Networks = []v1.Network{net1}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("should have a network type"))
 	})
@@ -94,7 +94,7 @@ var _ = Describe("Validate network source", func() {
 		}}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("CNI delegating plugin must have a networkName"))
 	})
@@ -125,7 +125,7 @@ var _ = Describe("Validate network source", func() {
 		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 		Expect(causes[0].Field).To(Equal("fake.networks"))
@@ -156,7 +156,7 @@ var _ = Describe("Validate network source", func() {
 
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 		Expect(causes[0].Field).To(Equal("fake.networks"))

--- a/pkg/network/admitter/passt_test.go
+++ b/pkg/network/admitter/passt_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Validating passt core binding", func() {
 
 		clusterConfig := stubClusterConfigChecker{passtFeatureGateEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
@@ -63,7 +63,7 @@ var _ = Describe("Validating passt core binding", func() {
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
 			Type:    "FieldValueInvalid",
@@ -82,6 +82,6 @@ var _ = Describe("Validating passt core binding", func() {
 
 		clusterConfig := stubClusterConfigChecker{passtFeatureGateEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
-		Expect(validator.Validate()).To(BeEmpty())
+		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 	})
 })

--- a/pkg/network/admitter/passt_test.go
+++ b/pkg/network/admitter/passt_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Validating passt core binding", func() {
 		}}
 
 		clusterConfig := stubClusterConfigChecker{passtFeatureGateEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -62,7 +62,7 @@ var _ = Describe("Validating passt core binding", func() {
 		}}
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), spec)
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
@@ -81,7 +81,7 @@ var _ = Describe("Validating passt core binding", func() {
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 		clusterConfig := stubClusterConfigChecker{passtFeatureGateEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
+		validator := admitter.NewValidator(clusterConfig)
 		Expect(validator.Validate(k8sfield.NewPath("fake"), spec)).To(BeEmpty())
 	})
 })

--- a/pkg/network/admitter/slirp_test.go
+++ b/pkg/network/admitter/slirp_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Validate creation of interface with SLIRP binding", func() {
 		)
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
-		causes := validator.ValidateCreation()
+		causes := validator.ValidateCreation(k8sfield.NewPath("fake"), &vmi.Spec)
 		Expect(causes).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",

--- a/pkg/network/admitter/slirp_test.go
+++ b/pkg/network/admitter/slirp_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 		)
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), &vmi.Spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("Slirp interface is not enabled in kubevirt-config"))
 	})
@@ -58,7 +58,7 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 		)
 		config := stubClusterConfigChecker{slirpEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, config)
-		causes := validator.Validate()
+		causes := validator.Validate(k8sfield.NewPath("fake"), &vmi.Spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("Slirp interface only implemented with pod network"))
 	})
@@ -74,7 +74,7 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 
 		config := stubClusterConfigChecker{slirpEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, config)
-		Expect(validator.Validate()).To(BeEmpty())
+		Expect(validator.Validate(k8sfield.NewPath("fake"), &vmi.Spec)).To(BeEmpty())
 	})
 })
 

--- a/pkg/network/admitter/slirp_test.go
+++ b/pkg/network/admitter/slirp_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.Validate(k8sfield.NewPath("fake"), &vmi.Spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("Slirp interface is not enabled in kubevirt-config"))
@@ -57,7 +57,7 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 			libvmi.WithNetwork(libvmi.MultusNetwork("default", "net")),
 		)
 		config := stubClusterConfigChecker{slirpEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		validator := admitter.NewValidator(config)
 		causes := validator.Validate(k8sfield.NewPath("fake"), &vmi.Spec)
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Message).To(Equal("Slirp interface only implemented with pod network"))
@@ -73,7 +73,7 @@ var _ = Describe("Validate interface with SLIRP binding", func() {
 		)
 
 		config := stubClusterConfigChecker{slirpEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, config)
+		validator := admitter.NewValidator(config)
 		Expect(validator.Validate(k8sfield.NewPath("fake"), &vmi.Spec)).To(BeEmpty())
 	})
 })
@@ -88,7 +88,7 @@ var _ = Describe("Validate creation of interface with SLIRP binding", func() {
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
+		validator := admitter.NewValidator(stubClusterConfigChecker{})
 		causes := validator.ValidateCreation(k8sfield.NewPath("fake"), &vmi.Spec)
 		Expect(causes).To(
 			ConsistOf(metav1.StatusCause{

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -24,8 +24,6 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
-
-	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
 type clusterConfigChecker interface {
@@ -39,8 +37,6 @@ type Validator struct {
 	field         *k8sfield.Path
 	vmiSpec       *v1.VirtualMachineInstanceSpec
 	configChecker clusterConfigChecker
-
-	networkByName map[string]v1.Network
 }
 
 func NewValidator(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, configChecker clusterConfigChecker) *Validator {
@@ -48,7 +44,6 @@ func NewValidator(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, 
 		field:         field,
 		vmiSpec:       vmiSpec,
 		configChecker: configChecker,
-		networkByName: netvmispec.IndexNetworkSpecByName(vmiSpec.Networks),
 	}
 }
 

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -34,17 +34,11 @@ type clusterConfigChecker interface {
 }
 
 type Validator struct {
-	field         *k8sfield.Path
-	vmiSpec       *v1.VirtualMachineInstanceSpec
 	configChecker clusterConfigChecker
 }
 
-func NewValidator(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, configChecker clusterConfigChecker) *Validator {
-	return &Validator{
-		field:         field,
-		vmiSpec:       vmiSpec,
-		configChecker: configChecker,
-	}
+func NewValidator(configChecker clusterConfigChecker) *Validator {
+	return &Validator{configChecker: configChecker}
 }
 
 func (v Validator) Validate(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -47,20 +47,20 @@ func NewValidator(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, 
 	}
 }
 
-func (v Validator) Validate() []metav1.StatusCause {
+func (v Validator) Validate(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
-	causes = append(causes, validateSinglePodNetwork(v.field, v.vmiSpec)...)
-	causes = append(causes, validateSingleNetworkSource(v.field, v.vmiSpec)...)
-	causes = append(causes, validateMultusNetworkSource(v.field, v.vmiSpec)...)
-	causes = append(causes, validateInterfaceStateValue(v.field, v.vmiSpec)...)
-	causes = append(causes, validateInterfaceBinding(v.field, v.vmiSpec, v.configChecker)...)
-	causes = append(causes, validateSlirpBinding(v.field, v.vmiSpec, v.configChecker)...)
-	causes = append(causes, validateNetworkNameUnique(v.field, v.vmiSpec)...)
-	causes = append(causes, validateNetworksAssignedToInterfaces(v.field, v.vmiSpec)...)
-	causes = append(causes, validateInterfaceNameUnique(v.field, v.vmiSpec)...)
-	causes = append(causes, validateInterfacesAssignedToNetworks(v.field, v.vmiSpec)...)
-	causes = append(causes, validateInterfacesFields(v.field, v.vmiSpec)...)
+	causes = append(causes, validateSinglePodNetwork(field, vmiSpec)...)
+	causes = append(causes, validateSingleNetworkSource(field, vmiSpec)...)
+	causes = append(causes, validateMultusNetworkSource(field, vmiSpec)...)
+	causes = append(causes, validateInterfaceStateValue(field, vmiSpec)...)
+	causes = append(causes, validateInterfaceBinding(field, vmiSpec, v.configChecker)...)
+	causes = append(causes, validateSlirpBinding(field, vmiSpec, v.configChecker)...)
+	causes = append(causes, validateNetworkNameUnique(field, vmiSpec)...)
+	causes = append(causes, validateNetworksAssignedToInterfaces(field, vmiSpec)...)
+	causes = append(causes, validateInterfaceNameUnique(field, vmiSpec)...)
+	causes = append(causes, validateInterfacesAssignedToNetworks(field, vmiSpec)...)
+	causes = append(causes, validateInterfacesFields(field, vmiSpec)...)
 
 	return causes
 }

--- a/pkg/network/admitter/validator.go
+++ b/pkg/network/admitter/validator.go
@@ -65,10 +65,10 @@ func (v Validator) Validate() []metav1.StatusCause {
 	return causes
 }
 
-func (v Validator) ValidateCreation() []metav1.StatusCause {
+func (v Validator) ValidateCreation(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
-	causes = append(causes, validateCreationSlirpBinding(v.field, v.vmiSpec)...)
+	causes = append(causes, validateCreationSlirpBinding(field, vmiSpec)...)
 
 	return causes
 }

--- a/pkg/virt-api/BUILD.bazel
+++ b/pkg/virt-api/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-api:go_default_library",
         "//pkg/monitoring/profiler:go_default_library",
+        "//pkg/network/admitter:go_default_library",
         "//pkg/rest:go_default_library",
         "//pkg/rest/filter:go_default_library",
         "//pkg/service:go_default_library",

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -874,7 +874,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMICreate(w, r, app.clusterConfig, networkValidator)
 	})
 	http.HandleFunc(components.VMIUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig, app.kubeVirtServiceAccounts)
+		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig, app.kubeVirtServiceAccounts, networkValidator)
 	})
 	http.HandleFunc(components.VMValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers, networkValidator)

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -883,7 +883,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMIRS(w, r, app.clusterConfig, networkValidator)
 	})
 	http.HandleFunc(components.VMPoolValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMPool(w, r, app.clusterConfig)
+		validating_webhook.ServeVMPool(w, r, app.clusterConfig, networkValidator)
 	})
 	http.HandleFunc(components.VMIPresetValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIPreset(w, r)

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -877,7 +877,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig, app.kubeVirtServiceAccounts)
 	})
 	http.HandleFunc(components.VMValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers)
+		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers, networkValidator)
 	})
 	http.HandleFunc(components.VMIRSValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIRS(w, r, app.clusterConfig)
@@ -916,7 +916,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVmClusterPreferences(w, r)
 	})
 	http.HandleFunc(components.StatusValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeStatusValidation(w, r, app.clusterConfig, app.virtCli, informers)
+		validating_webhook.ServeStatusValidation(w, r, app.clusterConfig, app.virtCli, informers, networkValidator)
 	})
 	http.HandleFunc(components.LauncherEvictionValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServePodEvictionInterceptor(w, r, app.clusterConfig, app.virtCli)

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -63,6 +63,7 @@ import (
 	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-api"
 	"kubevirt.io/kubevirt/pkg/monitoring/profiler"
+	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
 	mime "kubevirt.io/kubevirt/pkg/rest"
 	"kubevirt.io/kubevirt/pkg/rest/filter"
 	"kubevirt.io/kubevirt/pkg/service"
@@ -867,9 +868,10 @@ func (app *virtAPIApp) prepareCertManager() {
 }
 
 func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers) {
+	networkValidator := netadmitter.NewValidator(app.clusterConfig)
 
 	http.HandleFunc(components.VMICreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMICreate(w, r, app.clusterConfig)
+		validating_webhook.ServeVMICreate(w, r, app.clusterConfig, networkValidator)
 	})
 	http.HandleFunc(components.VMIUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig, app.kubeVirtServiceAccounts)

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -880,7 +880,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers, networkValidator)
 	})
 	http.HandleFunc(components.VMIRSValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMIRS(w, r, app.clusterConfig)
+		validating_webhook.ServeVMIRS(w, r, app.clusterConfig, networkValidator)
 	})
 	http.HandleFunc(components.VMPoolValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMPool(w, r, app.clusterConfig)

--- a/pkg/virt-api/webhooks/fuzz/BUILD.bazel
+++ b/pkg/virt-api/webhooks/fuzz/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
     ],
     tags = ["fuzz"],
     deps = [
+        "//pkg/network/admitter:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-api/webhooks/validating-webhook/admitters:go_default_library",

--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	v1 "kubevirt.io/api/core/v1"
 
+	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters"
@@ -44,7 +45,10 @@ func FuzzAdmitter(f *testing.F) {
 			gvk:     webhooks.VirtualMachineInstanceGroupVersionResource,
 			objType: &v1.VirtualMachineInstance{},
 			admit: func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-				adm := &admitters.VMICreateAdmitter{ClusterConfig: config}
+				adm := &admitters.VMICreateAdmitter{
+					ClusterConfig: config,
+					Validators:    []admitters.Validator{netadmitter.NewValidator(config)},
+				}
 				return adm.Admit(context.Background(), request)
 			},
 			fuzzFuncs: fuzzFuncs(withSyntaxErrors),
@@ -54,7 +58,10 @@ func FuzzAdmitter(f *testing.F) {
 			gvk:     webhooks.VirtualMachineInstanceGroupVersionResource,
 			objType: &v1.VirtualMachineInstance{},
 			admit: func(config *virtconfig.ClusterConfig, request *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-				adm := &admitters.VMICreateAdmitter{ClusterConfig: config}
+				adm := &admitters.VMICreateAdmitter{
+					ClusterConfig: config,
+					Validators:    []admitters.Validator{netadmitter.NewValidator(config)},
+				}
 				return adm.Admit(context.Background(), request)
 			},
 			fuzzFuncs: fuzzFuncs(),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "preference-admitter.go",
         "status-admitter.go",
         "validate-k8s-utils.go",
+        "validators.go",
         "vmclone-admitter.go",
         "vmexport-admitter.go",
         "vmi-create-admitter.go",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "//pkg/instancetype:go_default_library",
         "//pkg/liveupdate/memory:go_default_library",
         "//pkg/monitoring/metrics/virt-api:go_default_library",
-        "//pkg/network/admitter:go_default_library",
         "//pkg/network/link:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/admitters_suite_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/admitters_suite_test.go
@@ -22,3 +22,7 @@ type validatorStub struct {
 func (n validatorStub) ValidateCreation(_ *k8sfield.Path, _ *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	return n.statusCauses
 }
+
+func (n validatorStub) Validate(_ *k8sfield.Path, _ *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	return n.statusCauses
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/admitters_suite_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/admitters_suite_test.go
@@ -3,9 +3,22 @@ package admitters
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/client-go/testutils"
 )
 
 func TestValidatingWebhook(t *testing.T) {
 	testutils.KubeVirtTestSuiteSetup(t)
+}
+
+type validatorStub struct {
+	statusCauses []metav1.StatusCause
+}
+
+func (n validatorStub) ValidateCreation(_ *k8sfield.Path, _ *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	return n.statusCauses
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/validators.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/validators.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2024 Red Hat, Inc.
+ *
+ */
+
+package admitters
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+type Validator interface {
+	// ValidateCreation validate the given spec on creation flow
+	ValidateCreation(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/validators.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/validators.go
@@ -29,4 +29,6 @@ import (
 type Validator interface {
 	// ValidateCreation validate the given spec on creation flow
 	ValidateCreation(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause
+	// Validate validate the given spec
+	Validate(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -42,7 +42,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/downwardmetrics"
 	"kubevirt.io/kubevirt/pkg/hooks"
-	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
 	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
@@ -176,12 +175,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateSpecAffinity(field, spec)...)
 	causes = append(causes, validateSpecTopologySpreadConstraints(field, spec)...)
 	causes = append(causes, validateArchitecture(field, spec, config)...)
-
-	netValidator := netadmitter.NewValidator(config)
-	causes = append(causes, netValidator.Validate(field, spec)...)
-
 	causes = append(causes, validateBootOrder(field, spec, volumeNameMap)...)
-
 	causes = append(causes, validateInputDevices(field, spec)...)
 	causes = append(causes, validateIOThreadsPolicy(field, spec)...)
 	causes = append(causes, validateProbe(field.Child("readinessProbe"), spec.ReadinessProbe)...)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -114,7 +114,7 @@ func (admitter *VMICreateAdmitter) Admit(_ context.Context, ar *admissionv1.Admi
 		causes = append(causes, deprecation.ValidateFeatureGates(devCfg.FeatureGates, &vmi.Spec)...)
 	}
 
-	netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmi.Spec, admitter.ClusterConfig)
+	netValidator := netadmitter.NewValidator(admitter.ClusterConfig)
 	causes = append(causes, netValidator.ValidateCreation(k8sfield.NewPath("spec"), &vmi.Spec)...)
 
 	causes = append(causes, ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec"), &vmi.Spec, admitter.ClusterConfig)...)
@@ -176,7 +176,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateSpecTopologySpreadConstraints(field, spec)...)
 	causes = append(causes, validateArchitecture(field, spec, config)...)
 
-	netValidator := netadmitter.NewValidator(field, spec, config)
+	netValidator := netadmitter.NewValidator(config)
 	causes = append(causes, netValidator.Validate(field, spec)...)
 
 	causes = append(causes, validateBootOrder(field, spec, volumeNameMap)...)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -115,7 +115,7 @@ func (admitter *VMICreateAdmitter) Admit(_ context.Context, ar *admissionv1.Admi
 	}
 
 	netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmi.Spec, admitter.ClusterConfig)
-	causes = append(causes, netValidator.ValidateCreation()...)
+	causes = append(causes, netValidator.ValidateCreation(k8sfield.NewPath("spec"), &vmi.Spec)...)
 
 	causes = append(causes, ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec"), &vmi.Spec, admitter.ClusterConfig)...)
 	// We only want to validate that volumes are mapped to disks or filesystems during VMI admittance, thus this logic is seperated from the above call that is shared with the VM admitter.

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -87,7 +87,6 @@ var restrictedVmiLabels = map[string]bool{
 
 const (
 	nameOfTypeNotFoundMessagePattern  = "%s '%s' not found."
-	listExceedsLimitMessagePattern    = "%s list exceeds the %d element limit in length"
 	valueMustBePositiveMessagePattern = "%s '%s': must be greater than or equal to 0."
 )
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -177,7 +177,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateArchitecture(field, spec, config)...)
 
 	netValidator := netadmitter.NewValidator(field, spec, config)
-	causes = append(causes, netValidator.Validate()...)
+	causes = append(causes, netValidator.Validate(field, spec)...)
 
 	causes = append(causes, validateBootOrder(field, spec, volumeNameMap)...)
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -997,15 +997,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				}, 0),
 		)
-		It("should accept a single interface and network", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(BeEmpty())
-		})
-
 		It("should reject disks with the same boot order", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			order := uint(1)
@@ -1028,110 +1019,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				"fake.domain.devices.disks[1].bootOrder already set for a different device."))
 		})
 
-		It("should reject networks with duplicate names", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "default",
-					NetworkSource: v1.NetworkSource{
-						Pod: &v1.PodNetwork{},
-					},
-				},
-				{
-					Name: "default",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "test"},
-					},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(Equal("fake.networks[1].name"))
-			Expect(causes[0].Message).To(Equal("Network with name \"default\" already exists, every network must have a unique name"))
-		})
-		It("should accept networks with a pod network source and bridge interface", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name:          "default",
-					NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(BeEmpty())
-		})
-		It("should accept networks with a multus network source and bridge interface", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "default",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "default"},
-					},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(BeEmpty())
-		})
-
-		It("should allow multiple networks of same CNI type", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				*v1.DefaultBridgeNetworkInterface(),
-				*v1.DefaultBridgeNetworkInterface(),
-				*v1.DefaultBridgeNetworkInterface(),
-			}
-			vm.Spec.Domain.Devices.Interfaces[0].Name = "multus1"
-			vm.Spec.Domain.Devices.Interfaces[1].Name = "multus2"
-			// 3rd interfaces uses the default pod network, name is "default"
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "default",
-					NetworkSource: v1.NetworkSource{
-						Pod: &v1.PodNetwork{},
-					},
-				},
-				{
-					Name: "multus1",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "multus-net1"},
-					},
-				},
-				{
-					Name: "multus2",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "multus-net2"},
-					},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(BeEmpty())
-		})
-		It("should allow single multus network with a multus default", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				*v1.DefaultBridgeNetworkInterface(),
-			}
-			vm.Spec.Domain.Devices.Interfaces[0].Name = "multus1"
-			vm.Spec.Networks = []v1.Network{
-				{
-					Name: "multus1",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "multus-net1", Default: true},
-					},
-				},
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(BeEmpty())
-		})
 		It("should raise a warning when Deprecated API is used", func() {
 			const testsFGName = "test-deprecated"
 			deprecation.RegisterFeatureGate(deprecation.FeatureGate{
@@ -1155,13 +1042,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(resp.Allowed).To(BeTrue())
 			Expect(resp.Result).To(BeNil())
 			Expect(resp.Warnings).To(HaveLen(1))
-		})
-		It("should accept a bridge interface on a pod network when it is permitted", func() {
-			vm := api.NewMinimalVMI("testvm")
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(BeEmpty())
 		})
 
 		It("should allow BlockMultiQueue with CPU settings", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -133,7 +133,7 @@ func (admitter *VMsAdmitter) Admit(ctx context.Context, ar *admissionv1.Admissio
 		}
 
 		netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmCopy.Spec.Template.Spec, admitter.ClusterConfig)
-		if causes = netValidator.ValidateCreation(); len(causes) > 0 {
+		if causes = netValidator.ValidateCreation(k8sfield.NewPath("spec"), &vmCopy.Spec.Template.Spec); len(causes) > 0 {
 			return webhookutils.ToAdmissionResponse(causes)
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -132,7 +132,7 @@ func (admitter *VMsAdmitter) Admit(ctx context.Context, ar *admissionv1.Admissio
 			causes = append(causes, deprecation.ValidateFeatureGates(devCfg.FeatureGates, &vm.Spec.Template.Spec)...)
 		}
 
-		netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmCopy.Spec.Template.Spec, admitter.ClusterConfig)
+		netValidator := netadmitter.NewValidator(admitter.ClusterConfig)
 		if causes = netValidator.ValidateCreation(k8sfield.NewPath("spec"), &vmCopy.Spec.Template.Spec); len(causes) > 0 {
 			return webhookutils.ToAdmissionResponse(causes)
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -149,6 +149,12 @@ func (admitter *VMsAdmitter) Admit(ctx context.Context, ar *admissionv1.Admissio
 		return webhookutils.ToAdmissionResponse(causes)
 	}
 
+	for _, validator := range admitter.Validators {
+		if causes = validator.Validate(k8sfield.NewPath("spec", "template", "spec"), &vmCopy.Spec.Template.Spec); len(causes) > 0 {
+			return webhookutils.ToAdmissionResponse(causes)
+		}
+	}
+
 	causes, err = admitter.validateVirtualMachineDataVolumeTemplateNamespace(ar.Request, &vm)
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -46,8 +46,8 @@ func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virt
 	validating_webhooks.Serve(resp, req, &admitters.VMIRSAdmitter{ClusterConfig: clusterConfig, Validators: validators})
 }
 
-func ServeVMPool(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMPoolAdmitter{ClusterConfig: clusterConfig})
+func ServeVMPool(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, validators ...admitters.Validator) {
+	validating_webhooks.Serve(resp, req, &admitters.VMPoolAdmitter{ClusterConfig: clusterConfig, Validators: validators})
 }
 
 func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -42,8 +42,8 @@ func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtco
 	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, validators...))
 }
 
-func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMIRSAdmitter{ClusterConfig: clusterConfig})
+func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, validators ...admitters.Validator) {
+	validating_webhooks.Serve(resp, req, &admitters.VMIRSAdmitter{ClusterConfig: clusterConfig, Validators: validators})
 }
 
 func ServeVMPool(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -30,8 +30,8 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMICreateAdmitter{ClusterConfig: clusterConfig})
+func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, validators ...admitters.Validator) {
+	validating_webhooks.Serve(resp, req, &admitters.VMICreateAdmitter{ClusterConfig: clusterConfig, Validators: validators})
 }
 
 func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, kubeVirtServiceAccounts map[string]struct{}) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -38,9 +38,8 @@ func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *
 	validating_webhooks.Serve(resp, req, admitters.NewVMIUpdateAdmitter(clusterConfig, kubeVirtServiceAccounts))
 }
 
-func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
-
-	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers))
+func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers, validators ...admitters.Validator) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, validators...))
 }
 
 func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
@@ -95,9 +94,11 @@ func ServeStatusValidation(resp http.ResponseWriter,
 	req *http.Request,
 	clusterConfig *virtconfig.ClusterConfig,
 	virtCli kubecli.KubevirtClient,
-	informers *webhooks.Informers) {
+	informers *webhooks.Informers,
+	validators ...admitters.Validator,
+) {
 	validating_webhooks.Serve(resp, req, &admitters.StatusAdmitter{
-		VmsAdmitter: admitters.NewVMsAdmitter(clusterConfig, virtCli, informers),
+		VmsAdmitter: admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, validators...),
 	})
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -34,8 +34,8 @@ func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *
 	validating_webhooks.Serve(resp, req, &admitters.VMICreateAdmitter{ClusterConfig: clusterConfig, Validators: validators})
 }
 
-func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, kubeVirtServiceAccounts map[string]struct{}) {
-	validating_webhooks.Serve(resp, req, admitters.NewVMIUpdateAdmitter(clusterConfig, kubeVirtServiceAccounts))
+func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, kubeVirtServiceAccounts map[string]struct{}, validators ...admitters.Validator) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMIUpdateAdmitter(clusterConfig, kubeVirtServiceAccounts, validators...))
 }
 
 func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers, validators ...admitters.Validator) {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1404,7 +1404,7 @@ func (c *Controller) startVMI(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine
 
 	netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmi.Spec, c.clusterConfig)
 	var validateErrors []error
-	for _, cause := range netValidator.ValidateCreation() {
+	for _, cause := range netValidator.ValidateCreation(k8sfield.NewPath("spec"), &vmi.Spec) {
 		validateErrors = append(validateErrors, errors.New(cause.String()))
 	}
 	if validateErr := errors.Join(validateErrors...); validateErrors != nil {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1402,7 +1402,7 @@ func (c *Controller) startVMI(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine
 		return vm, err
 	}
 
-	netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmi.Spec, c.clusterConfig)
+	netValidator := netadmitter.NewValidator(c.clusterConfig)
 	var validateErrors []error
 	for _, cause := range netValidator.ValidateCreation(k8sfield.NewPath("spec"), &vmi.Spec) {
 		validateErrors = append(validateErrors, errors.New(cause.String()))

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -1024,7 +1024,7 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 			return common.NewSyncError(fmt.Errorf(services.FailedToRenderLaunchManifestErrFormat, err), controller.FailedCreatePodReason), pod
 		}
 
-		netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmi.Spec, c.clusterConfig)
+		netValidator := netadmitter.NewValidator(c.clusterConfig)
 		var validateErrors []error
 		for _, cause := range netValidator.ValidateCreation(k8sfield.NewPath("spec"), &vmi.Spec) {
 			validateErrors = append(validateErrors, errors.New(cause.String()))

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -1026,7 +1026,7 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 
 		netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmi.Spec, c.clusterConfig)
 		var validateErrors []error
-		for _, cause := range netValidator.ValidateCreation() {
+		for _, cause := range netValidator.ValidateCreation(k8sfield.NewPath("spec"), &vmi.Spec) {
 			validateErrors = append(validateErrors, errors.New(cause.String()))
 		}
 		if validateErr := errors.Join(validateErrors...); validateErrors != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Rebased on #13388, first 7 commits**
This is a follow up PR to https://github.com/kubevirt/kubevirt/pull/13388, decupleing remainign usage of network-validator by virt-api webhook admitters code.

**Before this PR:**
The following components called network-validator indirectly by calling `ValidateVirtualMachineInstanceSpec`.

**After this PR:**
The mentioned component have the network-validator injected and executed regardless of `ValidateVirtualMachineInstanceSpec`.

The `admitters.Validator` interface is extended to provider injection point for validators code inside various admitters for the regular flow; validating non create requests, and enable this change.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

