### PR TITLE
Cleanup and reduce flakiness of some post-copy migration functests

### DIFF
--- a/tests/framework/matcher/phase.go
+++ b/tests/framework/matcher/phase.go
@@ -43,12 +43,6 @@ func BeInPhase(phase interface{}) types.GomegaMatcher {
 	}
 }
 
-func HavePhase(phase interface{}) types.GomegaMatcher {
-	return phaseMatcher{
-		expectedPhase: phase,
-	}
-}
-
 type phaseMatcher struct {
 	expectedPhase interface{}
 }

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -500,16 +500,15 @@ func ConfirmMigrationMode(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMach
 	ExpectWithOffset(1, vmi.Status.MigrationState.Mode).To(Equal(expectedMode), fmt.Sprintf("expected migration state: %v got :%v \n", vmi.Status.MigrationState.Mode, expectedMode))
 }
 
-func WaitUntilMigrationMode(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, expectedMode v1.MigrationMode, timeout int) *v1.VirtualMachineInstance {
+func WaitUntilMigrationMode(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, expectedMode v1.MigrationMode, timeout time.Duration) {
 	By("Waiting until migration status")
 	EventuallyWithOffset(1, func() v1.MigrationMode {
-		By("Retrieving the VMI post migration")
-		vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
+		By("Retrieving the VMI to check its migration mode")
+		newVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		if vmi.Status.MigrationState != nil {
-			return vmi.Status.MigrationState.Mode
+		if newVMI.Status.MigrationState != nil {
+			return newVMI.Status.MigrationState.Mode
 		}
 		return ""
-	}, timeout, 1*time.Second).Should(Equal(expectedMode), fmt.Sprintf("migration should be in %s after %d s", expectedMode, timeout))
-	return vmi
+	}, timeout, 1*time.Second).Should(Equal(expectedMode))
 }

--- a/tests/libpod/render.go
+++ b/tests/libpod/render.go
@@ -32,21 +32,31 @@ import (
 )
 
 func RenderPrivilegedPod(name string, cmd, args []string) *v1.Pod {
-	pod := RenderPod(name, cmd, args)
-	pod.Namespace = testsuite.NamespacePrivileged
-	pod.Spec.HostPID = true
-	pod.Spec.SecurityContext = &v1.PodSecurityContext{
-		RunAsUser: new(int64),
-	}
-	pod.Spec.Containers = []v1.Container{
-		renderPrivilegedContainerSpec(
-			libregistry.GetUtilityImageFromRegistry("vm-killer"),
-			name,
-			cmd,
-			args),
+	pod := v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Namespace:    testsuite.NamespacePrivileged,
+			GenerateName: name,
+			Labels: map[string]string{
+				v13.AppLabel: "test",
+			},
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+			HostPID:       true,
+			SecurityContext: &v1.PodSecurityContext{
+				RunAsUser: pointer.P(int64(0)),
+			},
+			Containers: []v1.Container{
+				renderPrivilegedContainerSpec(
+					libregistry.GetUtilityImageFromRegistry("vm-killer"),
+					"container",
+					cmd,
+					args),
+			},
+		},
 	}
 
-	return pod
+	return &pod
 }
 
 func RenderPod(name string, cmd, args []string) *v1.Pod {
@@ -62,7 +72,7 @@ func RenderPod(name string, cmd, args []string) *v1.Pod {
 			Containers: []v1.Container{
 				renderContainerSpec(
 					libregistry.GetUtilityImageFromRegistry("vm-killer"),
-					name,
+					"container",
 					cmd,
 					args),
 			},
@@ -129,10 +139,9 @@ func RenderHostPathPod(
 
 func RenderTargetcliPod(name, disksPVC string) *v1.Pod {
 	const (
-		disks        = "disks"
-		kernelConfig = "kernel-config"
-		dbus         = "dbus"
-		modules      = "modules"
+		disks   = "disks"
+		dbus    = "dbus"
+		modules = "modules"
 	)
 	hostPathDirectory := v1.HostPathDirectory
 	targetcliContainer := renderPrivilegedContainerSpec(

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -187,7 +187,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-				runStressTest(vmi, stressDefaultVMSize, stressDefaultSleepDuration)
+				runStressTest(vmi, stressDefaultVMSize)
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
@@ -323,7 +323,7 @@ var _ = SIGMigrationDescribe("Live Migration", func() {
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 					// Put VMI under load
-					runStressTest(vmi, stressDefaultVMSize, stressDefaultSleepDuration)
+					runStressTest(vmi, stressDefaultVMSize)
 
 					node := vmi.Status.NodeName
 					libnode.TemporaryNodeDrain(node)

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -101,7 +101,7 @@ const (
 	secretDiskSerial           = "D23YZ9W6WA5DJ487"
 	stressDefaultVMSize        = "100M"
 	stressLargeVMSize          = "400M"
-	stressDefaultSleepDuration = 1600
+	stressDefaultSleepDuration = 15
 )
 
 var _ = SIGMigrationDescribe("VM Live Migration", func() {
@@ -778,7 +778,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-				runStressTest(vmi, stressDefaultVMSize, stressDefaultSleepDuration)
+				runStressTest(vmi, stressDefaultVMSize)
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
@@ -918,9 +918,8 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-				// Only stressing the VMI for 60 seconds to ensure the first migration eventually succeeds
 				By("Stressing the VMI")
-				runStressTest(vmi, stressDefaultVMSize, 60)
+				runStressTest(vmi, stressDefaultVMSize)
 
 				By("Starting a first migration")
 				migration1 := libmigration.New(vmi.Name, vmi.Namespace)
@@ -1319,7 +1318,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					// Run
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-					runStressTest(vmi, stressDefaultVMSize, stressDefaultSleepDuration)
+					runStressTest(vmi, stressDefaultVMSize)
 
 					// execute a migration, wait for finalized state
 					By("Starting the Migration")
@@ -1503,7 +1502,7 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 					// Need to wait for cloud init to finish and start the agent inside the vmi.
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-					runStressTest(vmi, stressLargeVMSize, stressDefaultSleepDuration)
+					runStressTest(vmi, stressLargeVMSize)
 
 					// execute a migration, wait for finalized state
 					By("Starting the Migration")
@@ -3269,7 +3268,7 @@ func getCurrentKvConfig(virtClient kubecli.KubevirtClient) v1.KubeVirtConfigurat
 	return kvc.Spec.Configuration
 }
 
-func runStressTest(vmi *v1.VirtualMachineInstance, vmsize string, stressTimeoutSeconds int) {
+func runStressTest(vmi *v1.VirtualMachineInstance, vmsize string) {
 	By("Run a stress test to dirty some pages and slow down the migration")
 	stressCmd := fmt.Sprintf("stress-ng --vm 1 --vm-bytes %s --vm-keep &\n", vmsize)
 	Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -3280,11 +3279,7 @@ func runStressTest(vmi *v1.VirtualMachineInstance, vmsize string, stressTimeoutS
 	}, 15)).To(Succeed(), "should run a stress test")
 
 	// give stress tool some time to trash more memory pages before returning control to next steps
-	if stressTimeoutSeconds < 15 {
-		time.Sleep(time.Duration(stressTimeoutSeconds) * time.Second)
-	} else {
-		time.Sleep(15 * time.Second)
-	}
+	time.Sleep(stressDefaultSleepDuration * time.Second)
 }
 
 func getIdOfLauncher(vmi *v1.VirtualMachineInstance) string {

--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -131,7 +131,7 @@ var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", func() {
 						// Need to wait for cloud init to finish and start the agent inside the vmi.
 						Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-						runStressTest(vmi, "350M", stressDefaultSleepDuration)
+						runStressTest(vmi, "350M")
 
 						By("Starting the Migration")
 						migration := libmigration.New(vmi.Name, vmi.Namespace)

--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -138,7 +138,7 @@ var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", func() {
 						migration = libmigration.RunMigration(virtClient, migration)
 
 						// check VMI, confirm migration state
-						libmigration.WaitUntilMigrationMode(virtClient, vmi, v1.MigrationPaused, 300)
+						libmigration.WaitUntilMigrationMode(virtClient, vmi, v1.MigrationPaused, 5*time.Minute)
 
 						if expectSuccess {
 							libmigration.ExpectMigrationToSucceed(virtClient, migration, 100)

--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -143,15 +143,15 @@ var _ = SIGMigrationDescribe("Live Migrate A Paused VMI", func() {
 						if expectSuccess {
 							libmigration.ExpectMigrationToSucceed(virtClient, migration, 100)
 						} else {
-							Eventually(matcher.ThisMigration(migration), 150, 1*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed))
+							Eventually(matcher.ThisMigration(migration), 150*time.Second, 1*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed))
 						}
 
 						By("Making sure that the VMI is unpaused")
 						Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 
 					},
-						Entry("[QUARANTINE] migrate successfully (migration policy)", decorators.Quarantine, expectSuccess, "50Mi", applyWithMigrationPolicy),
-						Entry("[QUARANTINE] migrate successfully (CR change)", Serial, decorators.Quarantine, expectSuccess, "50Mi", applyWithKubevirtCR),
+						Entry("migrate successfully (migration policy)", expectSuccess, "10Mi", applyWithMigrationPolicy),
+						Entry("migrate successfully (CR change)", Serial, expectSuccess, "10Mi", applyWithKubevirtCR),
 						Entry("[QUARANTINE] fail migration", decorators.Quarantine, expectFailure, "1Mi", applyWithMigrationPolicy),
 					)
 				})

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -251,7 +251,7 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 						migration = libmigration.RunMigration(virtClient, migration)
 
 						// check VMI, confirm migration state
-						libmigration.WaitUntilMigrationMode(virtClient, vmi, v1.MigrationPostCopy, 300)
+						libmigration.WaitUntilMigrationMode(virtClient, vmi, v1.MigrationPostCopy, 5*time.Minute)
 
 						// launch a migration killer pod on the node
 						By("Starting migration killer pods")

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -241,13 +241,13 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 				runVirtHandlerKillerPod(vmi.Status.NodeName)
 
 				By("Making sure that post-copy migration failed")
-				Eventually(matcher.ThisMigration(migration), 150, 1*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed))
+				Eventually(matcher.ThisMigration(migration), 3*time.Minute, 1*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed))
 
 				By("Removing virt-handler killer pod")
 				removeVirtHandlerKillerPod()
 
 				By("Ensuring the VirtualMachineInstance is restarted")
-				Eventually(matcher.ThisVMI(vmi), 4*time.Minute, 1*time.Second).Should(matcher.BeRestarted(vmi.UID))
+				Eventually(matcher.ThisVMI(vmi), 5*time.Minute, 1*time.Second).Should(matcher.BeRestarted(vmi.UID))
 			})
 		})
 	})

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -183,13 +183,7 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 				Eventually(func() error {
 					err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Delete(context.Background(), killerPod, metav1.DeleteOptions{})
 					return err
-				}, 10*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "Should delete helper pod")
-
-				Eventually(func() error {
-					_, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), killerPod, metav1.GetOptions{})
-					return err
-				}, 5*time.Minute, 1*time.Second).Should(
-					MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "The killer pod should be gone within the given timeout")
+				}, 1*time.Minute, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "Should delete helper pod")
 
 				By("Waiting for virt-handler to come back online")
 				Eventually(func() error {

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -157,7 +157,7 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 					// Need to wait for cloud init to finish and start the agent inside the vmi.
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-					runStressTest(vmi, "350M", stressDefaultSleepDuration)
+					runStressTest(vmi, "350M")
 
 					// execute a migration, wait for finalized state
 					By("Starting the Migration")
@@ -244,7 +244,7 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 						// Need to wait for cloud init to finish and start the agent inside the vmi.
 						Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-						runStressTest(vmi, "350M", stressDefaultSleepDuration)
+						runStressTest(vmi, "350M")
 
 						By("Starting the Migration")
 						migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -317,7 +317,7 @@ func VMIMigrationWithGuestAgent(virtClient kubecli.KubevirtClient, pvName string
 
 	if mode == v1.MigrationPostCopy {
 		By("Running stress test to allow transition to post-copy")
-		runStressTest(vmi, stressLargeVMSize, stressDefaultSleepDuration)
+		runStressTest(vmi, stressLargeVMSize)
 	}
 
 	// execute a migration, wait for finalized state

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -170,7 +170,7 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 				podName := "migration-killer-pod-"
 
 				// kill the handler
-				pod := libpod.RenderPrivilegedPod(podName, []string{"/bin/bash", "-c"}, []string{fmt.Sprintf("while true; do pkill -9 virt-handler && sleep 5; done")})
+				pod := libpod.RenderPrivilegedPod(podName, []string{"/bin/bash", "-c"}, []string{"date; pkill -e -9 virt-handler || echo not found"})
 
 				pod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
 				createdPod, err := virtClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -62,211 +61,201 @@ import (
 
 var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 	var (
-		virtClient kubecli.KubevirtClient
-		err        error
+		virtClient      kubecli.KubevirtClient
+		err             error
+		migrationPolicy *migrationsv1.MigrationPolicy
 	)
 
 	BeforeEach(func() {
-		checks.SkipIfMigrationIsNotPossible()
 		virtClient = kubevirt.Client()
+
+		By("Allowing post-copy and limit migration bandwidth")
+		policyName := fmt.Sprintf("testpolicy-%s", rand.String(5))
+		migrationPolicy = kubecli.NewMinimalMigrationPolicy(policyName)
+		migrationPolicy.Spec.AllowPostCopy = kvpointer.P(true)
+		migrationPolicy.Spec.CompletionTimeoutPerGiB = kvpointer.P(int64(1))
+		migrationPolicy.Spec.BandwidthPerMigration = kvpointer.P(resource.MustParse("5Mi"))
 	})
 
-	Describe("Starting a VirtualMachineInstance ", func() {
+	Context("with datavolume", func() {
+		var dv *cdiv1.DataVolume
 
-		Context("migration postcopy", func() {
+		BeforeEach(func() {
+			sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
+			if !foundSC {
+				Skip("Skip test when Filesystem storage is not present")
+			}
 
-			var migrationPolicy *migrationsv1.MigrationPolicy
+			dv = libdv.NewDataVolume(
+				libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), cdiv1.RegistryPullNode),
+				libdv.WithStorage(
+					libdv.StorageWithStorageClass(sc),
+					libdv.StorageWithVolumeSize(cd.FedoraVolumeSize),
+					libdv.StorageWithReadWriteManyAccessMode(),
+				),
+			)
 
+			dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.NamespacePrivileged).Create(context.Background(), dv, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("[test_id:5004] should be migrated successfully, using guest agent on VM with postcopy", func() {
+			VMIMigrationWithGuestAgent(virtClient, dv.Name, "1Gi", migrationPolicy)
+		})
+
+	})
+
+	Context("should migrate using for postcopy", func() {
+
+		applyMigrationPolicy := func(vmi *v1.VirtualMachineInstance) {
+			AlignPolicyAndVmi(vmi, migrationPolicy)
+			migrationPolicy = CreateMigrationPolicy(virtClient, migrationPolicy)
+		}
+
+		applyKubevirtCR := func() {
+			config := getCurrentKvConfig(virtClient)
+			config.MigrationConfiguration.AllowPostCopy = migrationPolicy.Spec.AllowPostCopy
+			config.MigrationConfiguration.CompletionTimeoutPerGiB = migrationPolicy.Spec.CompletionTimeoutPerGiB
+			config.MigrationConfiguration.BandwidthPerMigration = migrationPolicy.Spec.BandwidthPerMigration
+			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
+		}
+
+		type applySettingsType string
+		const (
+			applyWithMigrationPolicy applySettingsType = "policy"
+			applyWithKubevirtCR      applySettingsType = "kubevirt"
+		)
+
+		DescribeTable("[test_id:4747] using", func(settingsType applySettingsType) {
+			vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
+			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512Mi")
+			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
+			vmi.Namespace = testsuite.NamespacePrivileged
+
+			switch settingsType {
+			case applyWithMigrationPolicy:
+				applyMigrationPolicy(vmi)
+			case applyWithKubevirtCR:
+				applyKubevirtCR()
+			}
+
+			By("Starting the VirtualMachineInstance")
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
+
+			By("Checking that the VirtualMachineInstance console has expected output")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+			// Need to wait for cloud init to finish and start the agent inside the vmi.
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			runStressTest(vmi, "350M")
+
+			// execute a migration, wait for finalized state
+			By("Starting the Migration")
+			migration := libmigration.New(vmi.Name, vmi.Namespace)
+			migration = libmigration.RunMigrationAndExpectToComplete(virtClient, migration, 150)
+
+			// check VMI, confirm migration state
+			libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+			libmigration.ConfirmMigrationMode(virtClient, vmi, v1.MigrationPostCopy)
+		},
+			Entry("a migration policy", applyWithMigrationPolicy),
+			Entry(" Kubevirt CR", Serial, applyWithKubevirtCR),
+		)
+
+		Context(" and fail", Serial, func() {
+			var createdPods []string
 			BeforeEach(func() {
-				By("Allowing post-copy and limit migration bandwidth")
-				policyName := fmt.Sprintf("testpolicy-%s", rand.String(5))
-				migrationPolicy = kubecli.NewMinimalMigrationPolicy(policyName)
-				migrationPolicy.Spec.AllowPostCopy = kvpointer.P(true)
-				migrationPolicy.Spec.CompletionTimeoutPerGiB = kvpointer.P(int64(1))
-				migrationPolicy.Spec.BandwidthPerMigration = kvpointer.P(resource.MustParse("5Mi"))
+				createdPods = []string{}
 			})
 
-			Context("with datavolume", func() {
-				var dv *cdiv1.DataVolume
+			runMigrationKillerPod := func(nodeName string) {
+				podName := fmt.Sprintf("migration-killer-pod-%s", rand.String(5))
 
-				BeforeEach(func() {
-					sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
-					if !foundSC {
-						Skip("Skip test when Filesystem storage is not present")
-					}
+				// kill the handler
+				pod := libpod.RenderPrivilegedPod(podName, []string{"/bin/bash", "-c"}, []string{fmt.Sprintf("while true; do pkill -9 virt-handler && sleep 5; done")})
 
-					dv = libdv.NewDataVolume(
-						libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), cdiv1.RegistryPullNode),
-						libdv.WithStorage(
-							libdv.StorageWithStorageClass(sc),
-							libdv.StorageWithVolumeSize(cd.FedoraVolumeSize),
-							libdv.StorageWithReadWriteManyAccessMode(),
-						),
+				pod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+				createdPod, err := virtClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Should create helper pod")
+				createdPods = append(createdPods, createdPod.Name)
+				Expect(createdPods).ToNot(BeEmpty(), "There is no node for migration")
+			}
+
+			removeMigrationKillerPod := func() {
+				for _, podName := range createdPods {
+					Eventually(func() error {
+						err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Delete(context.Background(), podName, metav1.DeleteOptions{})
+						return err
+					}, 10*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "Should delete helper pod")
+
+					Eventually(func() error {
+						_, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), podName, metav1.GetOptions{})
+						return err
+					}, 300*time.Second, 1*time.Second).Should(
+						SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())),
+						"The killer pod should be gone within the given timeout",
 					)
-
-					dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.NamespacePrivileged).Create(context.Background(), dv, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				It("[test_id:5004] should be migrated successfully, using guest agent on VM with postcopy", func() {
-					VMIMigrationWithGuestAgent(virtClient, dv.Name, "1Gi", migrationPolicy)
-				})
-
-			})
-
-			Context("should migrate using for postcopy", func() {
-
-				applyMigrationPolicy := func(vmi *v1.VirtualMachineInstance) {
-					AlignPolicyAndVmi(vmi, migrationPolicy)
-					migrationPolicy = CreateMigrationPolicy(virtClient, migrationPolicy)
 				}
 
-				applyKubevirtCR := func() {
-					config := getCurrentKvConfig(virtClient)
-					config.MigrationConfiguration.AllowPostCopy = migrationPolicy.Spec.AllowPostCopy
-					config.MigrationConfiguration.CompletionTimeoutPerGiB = migrationPolicy.Spec.CompletionTimeoutPerGiB
-					config.MigrationConfiguration.BandwidthPerMigration = migrationPolicy.Spec.BandwidthPerMigration
-					kvconfig.UpdateKubeVirtConfigValueAndWait(config)
-				}
+				By("Waiting for virt-handler to come back online")
+				Eventually(func() error {
+					handler, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
 
-				type applySettingsType string
-				const (
-					applyWithMigrationPolicy applySettingsType = "policy"
-					applyWithKubevirtCR      applySettingsType = "kubevirt"
+					if handler.Status.DesiredNumberScheduled == handler.Status.NumberAvailable {
+						return nil
+					}
+					return fmt.Errorf("waiting for virt-handler pod to come back online")
+				}, 120*time.Second, 1*time.Second).Should(Succeed(), "Virt handler should come online")
+			}
+			It("should make sure that VM restarts after failure", func() {
+				By("creating a large VM with RunStrategyRerunOnFailure")
+				vmi := libvmifact.NewFedora(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithResourceMemory("3Gi"),
+					libvmi.WithRng(),
+					libvmi.WithNamespace(testsuite.NamespaceTestDefault),
 				)
+				vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyRerunOnFailure))
 
-				DescribeTable("[test_id:4747] using", func(settingsType applySettingsType) {
-					vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
-					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512Mi")
-					vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
-					vmi.Namespace = testsuite.NamespacePrivileged
+				vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
-					switch settingsType {
-					case applyWithMigrationPolicy:
-						applyMigrationPolicy(vmi)
-					case applyWithKubevirtCR:
-						applyKubevirtCR()
-					}
+				// update the migration policy to ensure slow pre-copy migration progress instead of an immidiate cancelation.
+				migrationPolicy.Spec.CompletionTimeoutPerGiB = kvpointer.P(int64(20))
+				migrationPolicy.Spec.BandwidthPerMigration = kvpointer.P(resource.MustParse("1Mi"))
+				applyKubevirtCR()
 
-					By("Starting the VirtualMachineInstance")
-					vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
+				By("Waiting for the VirtualMachine to be ready")
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 
-					By("Checking that the VirtualMachineInstance console has expected output")
-					Expect(console.LoginToFedora(vmi)).To(Succeed())
+				// Need to wait for cloud init to finish and start the agent inside the vmi.
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
-					// Need to wait for cloud init to finish and start the agent inside the vmi.
-					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+				runStressTest(vmi, "350M")
 
-					runStressTest(vmi, "350M")
+				By("Starting the Migration")
+				migration := libmigration.New(vmi.Name, vmi.Namespace)
+				migration = libmigration.RunMigration(virtClient, migration)
 
-					// execute a migration, wait for finalized state
-					By("Starting the Migration")
-					migration := libmigration.New(vmi.Name, vmi.Namespace)
-					migration = libmigration.RunMigrationAndExpectToComplete(virtClient, migration, 150)
+				// check VMI, confirm migration state
+				libmigration.WaitUntilMigrationMode(virtClient, vmi, v1.MigrationPostCopy, 5*time.Minute)
 
-					// check VMI, confirm migration state
-					libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
-					libmigration.ConfirmMigrationMode(virtClient, vmi, v1.MigrationPostCopy)
-				},
-					Entry("a migration policy", applyWithMigrationPolicy),
-					Entry(" Kubevirt CR", Serial, applyWithKubevirtCR),
-				)
+				// launch a migration killer pod on the node
+				By("Starting migration killer pods")
+				runMigrationKillerPod(vmi.Status.NodeName)
 
-				Context(" and fail", Serial, func() {
-					var createdPods []string
-					BeforeEach(func() {
-						createdPods = []string{}
-					})
+				By("Making sure that post-copy migration failed")
+				Eventually(matcher.ThisMigration(migration), 150, 1*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed))
 
-					runMigrationKillerPod := func(nodeName string) {
-						podName := fmt.Sprintf("migration-killer-pod-%s", rand.String(5))
+				By("Removing migration killer pods")
+				removeMigrationKillerPod()
 
-						// kill the handler
-						pod := libpod.RenderPrivilegedPod(podName, []string{"/bin/bash", "-c"}, []string{fmt.Sprintf("while true; do pkill -9 virt-handler && sleep 5; done")})
-
-						pod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
-						createdPod, err := virtClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
-						Expect(err).ToNot(HaveOccurred(), "Should create helper pod")
-						createdPods = append(createdPods, createdPod.Name)
-						Expect(createdPods).ToNot(BeEmpty(), "There is no node for migration")
-					}
-
-					removeMigrationKillerPod := func() {
-						for _, podName := range createdPods {
-							Eventually(func() error {
-								err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Delete(context.Background(), podName, metav1.DeleteOptions{})
-								return err
-							}, 10*time.Second, 1*time.Second).Should(MatchError(errors.IsNotFound, "k8serrors.IsNotFound"), "Should delete helper pod")
-
-							Eventually(func() error {
-								_, err := virtClient.CoreV1().Pods(testsuite.NamespacePrivileged).Get(context.Background(), podName, metav1.GetOptions{})
-								return err
-							}, 300*time.Second, 1*time.Second).Should(
-								SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())),
-								"The killer pod should be gone within the given timeout",
-							)
-						}
-
-						By("Waiting for virt-handler to come back online")
-						Eventually(func() error {
-							handler, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
-							if err != nil {
-								return err
-							}
-
-							if handler.Status.DesiredNumberScheduled == handler.Status.NumberAvailable {
-								return nil
-							}
-							return fmt.Errorf("waiting for virt-handler pod to come back online")
-						}, 120*time.Second, 1*time.Second).Should(Succeed(), "Virt handler should come online")
-					}
-					It("should make sure that VM restarts after failure", func() {
-						By("creating a large VM with RunStrategyRerunOnFailure")
-						vmi := libvmifact.NewFedora(
-							libnet.WithMasqueradeNetworking(),
-							libvmi.WithResourceMemory("3Gi"),
-							libvmi.WithRng(),
-							libvmi.WithNamespace(testsuite.NamespaceTestDefault),
-						)
-						vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyRerunOnFailure))
-
-						vm, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
-						Expect(err).ToNot(HaveOccurred())
-
-						// update the migration policy to ensure slow pre-copy migration progress instead of an immidiate cancelation.
-						migrationPolicy.Spec.CompletionTimeoutPerGiB = kvpointer.P(int64(20))
-						migrationPolicy.Spec.BandwidthPerMigration = kvpointer.P(resource.MustParse("1Mi"))
-						applyKubevirtCR()
-
-						By("Waiting for the VirtualMachine to be ready")
-						vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
-
-						// Need to wait for cloud init to finish and start the agent inside the vmi.
-						Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
-
-						runStressTest(vmi, "350M")
-
-						By("Starting the Migration")
-						migration := libmigration.New(vmi.Name, vmi.Namespace)
-						migration = libmigration.RunMigration(virtClient, migration)
-
-						// check VMI, confirm migration state
-						libmigration.WaitUntilMigrationMode(virtClient, vmi, v1.MigrationPostCopy, 5*time.Minute)
-
-						// launch a migration killer pod on the node
-						By("Starting migration killer pods")
-						runMigrationKillerPod(vmi.Status.NodeName)
-
-						By("Making sure that post-copy migration failed")
-						Eventually(matcher.ThisMigration(migration), 150, 1*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed))
-
-						By("Removing migration killer pods")
-						removeMigrationKillerPod()
-
-						By("Ensuring the VirtualMachineInstance is restarted")
-						Eventually(matcher.ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(matcher.BeRestarted(vmi.UID))
-					})
-				})
+				By("Ensuring the VirtualMachineInstance is restarted")
+				Eventually(matcher.ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(matcher.BeRestarted(vmi.UID))
 			})
 		})
 	})

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -204,6 +204,12 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 					return fmt.Errorf("waiting for virt-handler pod to come back online")
 				}, 2*time.Minute, 1*time.Second).Should(Succeed(), "Virt handler should come online")
 			}
+
+			AfterEach(func() {
+				By("Ensuring the virt-handler killer pod is removed")
+				removeVirtHandlerKillerPod()
+			})
+
 			It("and make sure VMs restart after failure", func() {
 				By("creating a large VM with RunStrategyRerunOnFailure")
 				vmi := libvmifact.NewFedora(


### PR DESCRIPTION
### What this PR does
Before this PR:
Post-copy tests are flaky

After this PR:
Code is cleaner and post-copy tests are less flaky

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13435

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Please review commit by commit!

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

