### PR TITLE
[blocked] Add kubevirt_vm_last_migration_timestamp_seconds metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -93,6 +93,9 @@ Virtual Machine last transition timestamp to error status. Type: Counter.
 ### kubevirt_vm_info
 Information about Virtual Machines. Type: Gauge.
 
+### kubevirt_vm_last_migration_timestamp_seconds
+Virtual Machine last migration timestamp. Type: Gauge.
+
 ### kubevirt_vm_migrating_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to migrating status. Type: Counter.
 


### PR DESCRIPTION
I order to be able to show for each VM when was the last migration and add it to the Time in Status dashboard. For that we need to add a new metric that will report the last migration timestamp for each VM.


### Special notes for your reviewer
This pr is blocked: when vm is stopped/restarted the VMI object and the migration object is deleted, need to create a memory cache for vmi's and vmim's to be able to report last migration even if vm is stopped. 

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added kubevirt_vm_last_migration_timestamp_seconds metric
```

