### PR TITLE
Status label value in kubevirt_vm_info metric should be in lower case

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -20,6 +20,8 @@
 package virt_controller
 
 import (
+	"strings"
+
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -210,7 +212,7 @@ func CollectVMsInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResu
 				vm.Name, vm.Namespace,
 				os, workload, flavor, machineType,
 				instanceType, preference,
-				string(vm.Status.PrintableStatus), getVMStatusGroup(vm.Status.PrintableStatus),
+				strings.ToLower(string(vm.Status.PrintableStatus)), getVMStatusGroup(vm.Status.PrintableStatus),
 			},
 			Value: 1.0,
 		})

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -176,7 +176,7 @@ var _ = Describe("VM Stats Collector", func() {
 
 				Expect(cr.GetLabelValue("machine_type")).To(Equal(vms[i].Spec.Template.Spec.Domain.Machine.Type))
 
-				Expect(cr.GetLabelValue("status")).To(Equal("CrashLoopBackOff"))
+				Expect(cr.GetLabelValue("status")).To(Equal("crashloopbackoff"))
 				Expect(cr.GetLabelValue("status_group")).To(Equal("error"))
 			}
 		})


### PR DESCRIPTION
The Status label values were added with a Capital letter. It needs to be in all in lower case letters like all other label values.

### What this PR does
Before this PR:
status label in kubevirt_vm_info was in capital letters e.g. Stopped

After this PR:
status label in kubevirt_vm_info is in small letters e.g. stopped

![Screenshot from 2024-12-10 18-26-58](https://github.com/user-attachments/assets/e9db715f-e7b9-4c8e-87cb-df4bb4cb8709)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # jira-ticket: https://issues.redhat.com/browse/CNV-51223


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

