### PR TITLE
Validate only test related migration metrics

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -508,6 +508,11 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 		}
 
 		for _, key := range keys {
+			// skip verification of metrics from previous migrations
+			if strings.Contains(key, "name=\"") && !stringContainsAny(key, nameMatchers) {
+				continue
+			}
+
 			// we don't care about the ordering of the labels
 			if strings.HasPrefix(key, "kubevirt_vmi_info") {
 				// special case: namespace and name don't make sense for this metric
@@ -647,4 +652,17 @@ func countReadyAndLeaderPods(pod *k8sv1.Pod, component string) (foundMetrics map
 	}
 
 	return foundMetrics, err
+}
+
+func stringContainsAny(s string, matchers []gomegatypes.GomegaMatcher) bool {
+	for _, matcher := range matchers {
+		m, err := matcher.Match(s)
+		if err != nil {
+			return false
+		}
+		if m {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Error that was happening

```
23:10:27:   [FAILED] Expected
23:10:27:       <string>: kubevirt_vmi_migration_data_processed_bytes{name="testvmi-k7pqp",namespace="kubevirt-test-default1",node="node02"}
23:10:27:   To satisfy at least one of these matchers: [%!s(*matchers.ContainSubstringMatcher=&{name="%s" [testvmi-vscgz]}) %!s(*matchers.ContainSubstringMatcher=&{name="%s" [testvmi-6p5mb]})]
23:10:27:   In [It] at: tests/infrastructure/prometheus.go:518 @ 12/09/24 23:09:48.654
```

### What this PR does
Before this PR:

Test "should include VMI infos for a running VM" is flaky due to trying to validate metrics from other migration for containing the names of the migrations of the current test

After this PR:

Only validates metrics from the current migrations

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13142

jira-ticket: https://issues.redhat.com/browse/CNV-50797

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

