### PR TITLE
lint: Add tests/libkubevirt to the paths covered by the linter

### DIFF
--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -16,6 +16,7 @@ tests/infrastructure
 tests/instancetype
 tests/libconfigmap
 tests/libinstancetype
+tests/libkubevirt
 tests/libnet
 tests/libnode
 tests/libpod

--- a/tests/libkubevirt/config/featuregate.go
+++ b/tests/libkubevirt/config/featuregate.go
@@ -102,11 +102,7 @@ func updateKubeVirtConfigValueAndWaitHandlerRedeploymnet(kvConfig v1.KubeVirtCon
 		ds, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.TODO(), "virt-handler", metav1.GetOptions{})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		gen := ds.Status.ObservedGeneration
-		if gen > currentGen {
-			return true
-		}
-		return false
-
+		return gen > currentGen
 	}, 90*time.Second, 1*time.Second).Should(BeTrue())
 
 	waitForConfigToBePropagated(kv.ResourceVersion)

--- a/tests/libkubevirt/config/kvconfig.go
+++ b/tests/libkubevirt/config/kvconfig.go
@@ -75,15 +75,21 @@ func patchKV(namespace, name string, patchSet *patch.PatchSet) error {
 	return err
 }
 
-func PatchWorkloadUpdateMethodAndRolloutStrategy(kvName string, virtClient kubecli.KubevirtClient, updateStrategy *v1.KubeVirtWorkloadUpdateStrategy, rolloutStrategy *v1.VMRolloutStrategy, fgs []string) {
-	patch, err := patch.New(
+func PatchWorkloadUpdateMethodAndRolloutStrategy(kvName string,
+	virtClient kubecli.KubevirtClient,
+	updateStrategy *v1.KubeVirtWorkloadUpdateStrategy,
+	rolloutStrategy *v1.VMRolloutStrategy, fgs []string,
+) {
+	patchWorkload, err := patch.New(
 		patch.WithAdd("/spec/workloadUpdateStrategy", updateStrategy),
 		patch.WithAdd("/spec/configuration/vmRolloutStrategy", rolloutStrategy),
 		patch.WithAdd("/spec/configuration/developerConfiguration/featureGates", fgs),
 	).GeneratePayload()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	EventuallyWithOffset(1, func() error {
-		_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), kvName, types.JSONPatchType, patch, metav1.PatchOptions{})
+		_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(
+			context.Background(), kvName, types.JSONPatchType,
+			patchWorkload, metav1.PatchOptions{})
 		return err
 	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 }
@@ -121,30 +127,34 @@ func ExpectResourceVersionToBeLessEqualThanConfigVersion(resourceVersion, config
 }
 
 func waitForConfigToBePropagated(resourceVersion string) {
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-controller", resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, 10*time.Second)
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-api", resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, 10*time.Second)
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, 10*time.Second)
+	waitTimeout := 10 * time.Second
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-controller",
+		resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, waitTimeout)
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-api",
+		resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, waitTimeout)
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler",
+		resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, waitTimeout)
 }
 
-func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion string, compareResourceVersions compare, duration time.Duration) {
+func WaitForConfigToBePropagatedToComponent(podLabel, resourceVersion string, compareResourceVersions compare, duration time.Duration) {
 	virtClient := kubevirt.Client()
 
-	errComponentInfo := fmt.Sprintf("component: \"%s\"", strings.TrimPrefix(podLabel, "kubevirt.io="))
+	errComponentInfo := fmt.Sprintf("component: %q", strings.TrimPrefix(podLabel, "kubevirt.io="))
 
 	EventuallyWithOffset(3, func() error {
-		pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: podLabel})
-
+		pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(
+			context.Background(), metav1.ListOptions{LabelSelector: podLabel})
 		if err != nil {
 			return fmt.Errorf("failed to fetch pods: %v, %s", err, errComponentInfo)
 		}
-		for _, pod := range pods.Items {
-			errAdditionalInfo := errComponentInfo + fmt.Sprintf(", pod: \"%s\"", pod.Name)
+		for i := range pods.Items {
+			errAdditionalInfo := errComponentInfo + fmt.Sprintf(", pod: %q", pods.Items[i].Name)
 
-			if pod.DeletionTimestamp != nil {
+			if pods.Items[i].DeletionTimestamp != nil {
 				continue
 			}
 
-			body, err := callUrlOnPod(&pod, "8443", "/healthz")
+			body, err := callURLOnPod(&pods.Items[i], "8443", "/healthz")
 			if err != nil {
 				return fmt.Errorf("failed to call healthz endpoint: %v, %s", err, errAdditionalInfo)
 			}
@@ -163,21 +173,32 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 	}, duration, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
-func callUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
-	randPort := strconv.Itoa(4321 + rand.Intn(6000))
+func callURLOnPod(pod *k8sv1.Pod, port, url string) ([]byte, error) {
+	const minPort = 4321
+	const maxPortIncrease = 6000
+	//nolint:gosec
+	randPort := strconv.Itoa(minPort + rand.Intn(maxPortIncrease))
 	stopChan := make(chan struct{})
 	defer close(stopChan)
-	err := libpod.ForwardPorts(pod, []string{fmt.Sprintf("%s:%s", randPort, port)}, stopChan, 5*time.Second)
+	readyTimeout := 5 * time.Second
+	err := libpod.ForwardPorts(pod, []string{fmt.Sprintf("%s:%s", randPort, port)}, stopChan, readyTimeout)
 	if err != nil {
 		return nil, err
 	}
 	tr := &http.Transport{
+		//nolint:gosec
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true, VerifyPeerCertificate: func(_ [][]byte, _ [][]*x509.Certificate) error {
 			return nil
 		}},
 	}
 	client := &http.Client{Transport: tr}
-	resp, err := client.Get(fmt.Sprintf("https://localhost:%s/%s", randPort, strings.TrimSuffix(url, "/")))
+	req, err := http.NewRequestWithContext(
+		context.Background(), "GET",
+		fmt.Sprintf("https://localhost:%s/%s", randPort, strings.TrimSuffix(url, "/")), http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/libkubevirt/config/netbinding.go
+++ b/tests/libkubevirt/config/netbinding.go
@@ -36,7 +36,8 @@ func WithNetBindingPlugin(name string, netBindingPlugin v1.InterfaceBindingPlugi
 }
 
 func registerBindingPugins(config v1.KubeVirtConfiguration, name string, binding v1.InterfaceBindingPlugin) (
-	*patch.PatchSet, error) {
+	*patch.PatchSet, error,
+) {
 	patchSet := patch.New()
 
 	if config.NetworkConfiguration == nil {

--- a/tests/libkubevirt/kubevirt.go
+++ b/tests/libkubevirt/kubevirt.go
@@ -40,13 +40,13 @@ func GetCurrentKv(virtClient kubecli.KubevirtClient) *v1.KubeVirt {
 func GetKvList(virtClient kubecli.KubevirtClient) []v1.KubeVirt {
 	var kvList *v1.KubeVirtList
 	var err error
+	const eventualTimeout = 10
 
 	gomega.Eventually(func() error {
-
 		kvList, err = virtClient.KubeVirt(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 
 		return err
-	}, 10*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())
+	}, eventualTimeout*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())
 
 	return kvList.Items
 }


### PR DESCRIPTION
### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

