### PR TITLE
add test_id to virtctl tests

### DIFF
--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -100,7 +100,7 @@ chpasswd: { expire: False }`
 		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
 	})
 
-	It("Example with volume-import flag and PVC type", func() {
+	It("[test_id:11647]Example with volume-import flag and PVC type", func() {
 		const (
 			runStrategy = v1.RunStrategyAlways
 			volName     = "imported-volume"
@@ -152,7 +152,7 @@ chpasswd: { expire: False }`
 		}))
 	})
 
-	It("Example with volume-import flag and Registry type", func() {
+	It("[test_id:11648]Example with volume-import flag and Registry type", func() {
 		const (
 			runStrategy = v1.RunStrategyAlways
 			volName     = "registry-source"
@@ -194,7 +194,7 @@ chpasswd: { expire: False }`
 		}))
 	})
 
-	It("Example with volume-import flag and Blank type", func() {
+	It("[test_id:11649]Example with volume-import flag and Blank type", func() {
 		const runStrategy = v1.RunStrategyAlways
 
 		out, err := runCreateVmCmd(
@@ -438,7 +438,7 @@ chpasswd: { expire: False }`
 		}))
 	})
 
-	It("Complex example with memory", func() {
+	It("[test_id:11650]Complex example with memory", func() {
 		const (
 			runStrategy                  = v1.RunStrategyManual
 			terminationGracePeriod int64 = 123
@@ -509,7 +509,7 @@ chpasswd: { expire: False }`
 		Expect(string(decoded)).To(Equal(cloudInitUserData))
 	})
 
-	It("Complex example with sysprep volume", func() {
+	It("[test_id:11651]Complex example with sysprep volume", func() {
 		const (
 			runStrategy                  = v1.RunStrategyManual
 			terminationGracePeriod int64 = 123
@@ -558,7 +558,7 @@ chpasswd: { expire: False }`
 		Expect(vm.Spec.Template.Spec.Volumes[1].VolumeSource.Sysprep.Secret).To(BeNil())
 	})
 
-	It("Complex example with generated cloud-init config", func() {
+	It("[test_id:11652]Complex example with generated cloud-init config", func() {
 		const user = "alpine"
 		cdSource := cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)
 		tmpDir := GinkgoT().TempDir()
@@ -620,7 +620,7 @@ chpasswd: { expire: False }`
 		runSSHCommand(vm.Namespace, vm.Name, user, keyFile)
 	})
 
-	It("Complex example with access credentials", func() {
+	It("[test_id:11653]Complex example with access credentials", func() {
 		const user = "fedora"
 		cdSource := cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 
@@ -678,7 +678,7 @@ chpasswd: { expire: False }`
 		runSSHCommand(secret.Namespace, vm.Name, user, keyFile)
 	})
 
-	It("Failure of implicit inference does not fail the VM creation", func() {
+	It("[test_id:11654]Failure of implicit inference does not fail the VM creation", func() {
 		By("Creating a PVC without annotation labels")
 		pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(5), testsuite.GetTestNamespace(nil), size, nil)
 		volumeName := "imported-volume"

--- a/tests/virtctl/guestfs.go
+++ b/tests/virtctl/guestfs.go
@@ -72,7 +72,7 @@ var _ = Describe("[sig-storage][virtctl]Guestfs", decorators.SigStorage, func() 
 				libstorage.CreateFSPVC(pvcClaim, testsuite.GetTestNamespace(nil), "500Mi", nil)
 			})
 
-			It("Should successfully run libguestfs-test-tool", func() {
+			It("[test_id:11669]Should successfully run libguestfs-test-tool", func() {
 				runGuestfsOnPVC(done, pvcClaim, testsuite.GetTestNamespace(nil), setGroup)
 				stdout, _, err := execCommandLibguestfsPod(
 					getGuestfsPodName(pvcClaim), testsuite.GetTestNamespace(nil), []string{"libguestfs-test-tool"},
@@ -86,10 +86,10 @@ var _ = Describe("[sig-storage][virtctl]Guestfs", decorators.SigStorage, func() 
 				verifyCanRunOnFSPVC(getGuestfsPodName(pvcClaim), testsuite.GetTestNamespace(nil))
 			},
 				Entry("[test_id:6480]without extra arguments"),
-				Entry("setting the uid", "--uid", "1002"),
+				Entry("[test_id:11670]setting the uid", "--uid", "1002"),
 			)
 
-			It("[posneg:negative]Should fail to run the guestfs command on a PVC in use", func() {
+			It("[posneg:negative][test_id:11671]Should fail to run the guestfs command on a PVC in use", func() {
 				runGuestfsOnPVC(done, pvcClaim, testsuite.GetTestNamespace(nil), setGroup)
 				cmd := guestfsCmd(pvcClaim, testsuite.GetTestNamespace(nil), setGroup)
 				Expect(cmd()).To(MatchError(fmt.Sprintf("PVC %s is used by another pod", pvcClaim)))

--- a/tests/virtctl/imageupload.go
+++ b/tests/virtctl/imageupload.go
@@ -121,7 +121,7 @@ var _ = Describe("[sig-storage][virtctl]ImageUpload", decorators.SigStorage, Ser
 		Entry("PVC", "pvc", validatePVC, libvmi.WithPersistentVolumeClaim),
 	)
 
-	DescribeTable("Create upload volume with force-bind flag should succeed", func(resource string, validateFn func(string)) {
+	DescribeTable("[test_id:11655]Create upload volume with force-bind flag should succeed", func(resource string, validateFn func(string)) {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists || !libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
 			Fail("Fail no wffc storage class available")
@@ -169,7 +169,7 @@ var _ = Describe("[sig-storage][virtctl]ImageUpload", decorators.SigStorage, Ser
 		Entry("[test_id:10672]filesystem volumeMode", "filesystem"),
 	)
 
-	It("Upload fails when DV is in WFFC/PendingPopulation phase but uploads after consumer is created", func() {
+	It("[test_id:11656]Upload fails when DV is in WFFC/PendingPopulation phase but uploads after consumer is created", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists || !libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
 			Skip("Skip no wffc storage class available")
@@ -215,7 +215,7 @@ var _ = Describe("[sig-storage][virtctl]ImageUpload", decorators.SigStorage, Ser
 			archivePath = createArchive(imagePath)
 		})
 
-		DescribeTable("Should succeed", func(resource string, uploadDV bool) {
+		DescribeTable("[test_id:11657]Should succeed", func(resource string, uploadDV bool) {
 			By("Upload archive content")
 			targetName := "alpine-" + rand.String(12)
 			err := runImageUploadCmd(
@@ -247,7 +247,7 @@ var _ = Describe("[sig-storage][virtctl]ImageUpload", decorators.SigStorage, Ser
 			Entry("PVC", "pvc", false),
 		)
 
-		DescribeTable("fails when provisioning fails", func(resource, expected string) {
+		DescribeTable("[test_id:11658]fails when provisioning fails", func(resource, expected string) {
 			sc := "invalid-sc-" + rand.String(12)
 			libstorage.CreateStorageClass(sc, nil)
 			err := runImageUploadCmd(

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -93,7 +93,7 @@ var _ = Describe("[sig-storage][virtctl]Memory dump", decorators.SigStorage, fun
 		waitForMemoryDumpDeletion(vm.Name, pvcName, out, true)
 	},
 		Entry("[test_id:9034] when creating a PVC", true),
-		Entry("with an existing PVC", false),
+		Entry("[test_id:11664]with an existing PVC", false),
 	)
 
 	It("[test_id:9035]Run multiple memory dumps", func() {

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -106,7 +106,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 		Expect(libssh.DumpPrivateKey(priv, keyFile)).To(Succeed())
 	})
 
-	DescribeTable("should copy a local file back and forth", func(copyFn func(string, string, bool)) {
+	DescribeTable("[test_id:11659]should copy a local file back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
 			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))),
@@ -131,7 +131,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 		Entry("using the local scp method without --local-ssh flag", decorators.ExcludeNativeSSH, copyLocal(false)),
 	)
 
-	DescribeTable("should copy a local directory back and forth", func(copyFn func(string, string, bool)) {
+	DescribeTable("[test_id:11660]should copy a local directory back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
 			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))),
@@ -164,7 +164,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 		Entry("using the local scp method without --local-ssh flag", decorators.ExcludeNativeSSH, copyLocal(false)),
 	)
 
-	It("local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSSH, func() {
+	It("[test_id:11665]local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSSH, func() {
 		// The built virtctl binary should be tested here, therefore clientcmd.CreateCommandWithNS needs to be used.
 		// Running the command through newRepeatableVirtctlCommand would test the test binary instead.
 		_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.NamespaceTestDefault, "virtctl", "scp", "--local-ssh=false")

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -99,7 +99,7 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 		Expect(libssh.DumpPrivateKey(priv, keyFile)).To(Succeed())
 	})
 
-	DescribeTable("should succeed to execute a command on the VM", func(cmdFn func(string)) {
+	DescribeTable("[test_id:11661]should succeed to execute a command on the VM", func(cmdFn func(string)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmifact.NewAlpineWithTestTooling(
 			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(libssh.RenderUserDataWithKey(pub))),
@@ -117,7 +117,7 @@ var _ = Describe("[sig-compute][virtctl]SSH", decorators.SigCompute, func() {
 		Entry("using the local ssh method without --local-ssh flag", decorators.ExcludeNativeSSH, cmdLocal(false)),
 	)
 
-	It("local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSSH, func() {
+	It("[test_id:11666]local-ssh flag should be unavailable in virtctl", decorators.ExcludeNativeSSH, func() {
 		// The built virtctl binary should be tested here, therefore clientcmd.CreateCommandWithNS needs to be used.
 		// Running the command through newRepeatableVirtctlCommand would test the test binary instead.
 		_, cmd, err := clientcmd.CreateCommandWithNS(testsuite.NamespaceTestDefault, "virtctl", "ssh", "--local-ssh=false")

--- a/tests/virtctl/vnc.go
+++ b/tests/virtctl/vnc.go
@@ -99,7 +99,7 @@ var _ = Describe("[sig-compute][virtctl]VNC", decorators.SigCompute, func() {
 		verifyProxyConnection(testPort, vmi.Name)
 	})
 
-	It("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][level:component]should allow creating a VNC screenshot in PNG format", func() {
+	It("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][level:component][test_id:11667]should allow creating a VNC screenshot in PNG format", func() {
 		// The default resolution is 720x400 for the vga/boch device used on amd64 and ppcl64,
 		// while it is 1280x800 for the virtio device used on arm64 and s390x.
 		size := image.Point{720, 400}


### PR DESCRIPTION
### What this PR does
Before this PR:
The tests/virtctl folder was missing some of the test_id

After this PR:
All virtctl test should have a test_id

### Why we need it and why it was done in this way
This will help map out the tests if a failure arises

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://issues.redhat.com/browse/CNV-45386

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

