### PR TITLE
docs: Replace deprecated running API with runStrategy

### DIFF
--- a/docs/devel/virtual-machine.md
+++ b/docs/devel/virtual-machine.md
@@ -45,7 +45,7 @@ kubectl create -f myvm.yaml
 
 # Start an VirtualMachine:
 kubectl patch virtualmachine myvm --type=merge -p \
-    '{"spec":{"running": true}}'
+    '{"spec":{"runStrategy": Always}}'
 
 # Look at VirtualMachine status and associated events:
 kubectl describe virtualmachine myvm
@@ -55,7 +55,7 @@ kubectl describe virtualmachine myvm
 
 # Stop an VirtualMachine:
 kubectl patch virtualmachine myvm --type=merge -p \
-    '{"spec":{"running": false}}'
+    '{"spec":{"runStrategy": Halted}}'
 
 # Implicit cascade delete (first deletes the vm and then the vm)
 kubectl delete virtualmachine myvm
@@ -118,7 +118,7 @@ kind: VirtualMachine
 metadata:
   name: myvm
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:
@@ -256,14 +256,14 @@ metadata:
 
 For now implicit: OnDelete. Can later be extended to RollingUpdate if needed.
 Spec changes have no direct effect on already running VMIs, and they will not
-directly be propagated to the VMI. If a VMI should be running (spec.running=true)
+directly be propagated to the VMI. If a VMI should be running (spec.runStrategy=Always)
 and it is powered down (VMI object delete, OS shutdown, ...),
 the VMI will be re-created by the controller with the new spec.
 
 ### Delete strategy
 
 The delete has a cascade that deletes the created VirtualMachine. If a cascade
-is turned off the VirtualMachine is orphaned and leaved running.
+is turned off the VirtualMachine is orphaned and left running.
 When the VirtualMachine with the same name as orphaned VirtualMachine
 is created, the VirtualMachine gets adopted and OwnerReference
 is updated accordingly.
@@ -313,14 +313,14 @@ autogenerating the Kubernetes resources: client, lister and watcher.
 
 The controller is responsible for watching the change in the registered
 virtual machines and update the state of the system. It is also
-responsible for creating new VirtualMachineInstance when the `running` is set to `true`.
-Moreover the controller attaches the `metadata.OwnerReference` to the created
+responsible for creating new VirtualMachineInstance when the `runStrategy` is set to `Always`.
+Moreover, the controller attaches the `metadata.OwnerReference` to the created
 VirtualMachineInstance. With this mechanism it can link the VirtualMachine to the
 VirtualMachineInstance and show combined status.
 
 The controller is designed to be a standalone service running in its own pod.
 Since the whole KubeVirt is designed to be modular, this approach allows for
-a more flexibility and less codebase in the core. Moreover it can be scaled
+a more flexibility and less codebase in the core. Moreover, it can be scaled
 up separately if the need arise.
 
 [VirtualMachineInstance]: https://kubevirt.github.io/api-reference/master/definitions.html#_v1_virtualmachine

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -45,7 +45,7 @@ metadata:
     kubevirt.io/vm: readiness-probe-vm
   name: readiness-probe
 spec:
-  running: true 
+  runStrategy: Always
   template:
     metadata:
       labels:


### PR DESCRIPTION

### What this PR does
This PR replaces the deprecated "running:true/false" API in several markdowns in docs folder.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

