### PR TITLE
fix(virtctl,expose): Use vm.kubevirt.io/name as label selector

### DIFF
--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -22,6 +22,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/testing"
 )
 
+const (
+	labelKey   = "my-key"
+	labelValue = "my-value"
+)
+
 var _ = Describe("Expose", func() {
 	var (
 		kubeClient *fake.Clientset
@@ -104,57 +109,20 @@ var _ = Describe("Expose", func() {
 			Expect(err).To(MatchError("couldn't find port via --port flag or introspection"))
 		})
 
-		Context("when labels are missing", func() {
-			It("with VirtualMachineInstance", func() {
-				vmi := libvmi.New()
-				vmi, err := virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				err = runCommand("vmi", vmi.Name, "--name", "my-service")
-				Expect(err).To(MatchError(ContainSubstring("cannot expose vmi without any label")))
-			})
-
-			It("with VirtualMachineInstance and unwanted labels", func() {
-				vmi := libvmi.New(
-					libvmi.WithLabel(v1.NodeNameLabel, "value"),
-					libvmi.WithLabel(v1.VirtualMachinePoolRevisionName, "value"),
-					libvmi.WithLabel(v1.MigrationTargetNodeNameLabel, "value"),
-				)
-				vmi, err := virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				err = runCommand("vmi", vmi.Name, "--name", "my-service")
-				Expect(err).To(MatchError(ContainSubstring("cannot expose vmi without any label")))
-			})
-
-			It("with VirtualMachine", func() {
-				vm := libvmi.NewVirtualMachine(libvmi.New())
-				vm, err := virtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault).Create(context.Background(), vm, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				err = runCommand("vm", vm.Name, "--name", "my-service")
-				Expect(err).To(MatchError(ContainSubstring("cannot expose vm without any label")))
-			})
-
-			It("with VirtualMachine and unwanted labels", func() {
-				vm := libvmi.NewVirtualMachine(libvmi.New(
-					libvmi.WithLabel(v1.VirtualMachinePoolRevisionName, "value"),
-				))
-				vm, err := virtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault).Create(context.Background(), vm, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				err = runCommand("vm", vm.Name, "--name", "my-service")
-				Expect(err).To(MatchError(ContainSubstring("cannot expose vm without any label")))
-			})
-
-			It("with VirtualMachineInstanceReplicaSet", func() {
-				vmirs := kubecli.NewMinimalVirtualMachineInstanceReplicaSet("vmirs")
-				vmirs, err := virtClient.KubevirtV1().VirtualMachineInstanceReplicaSets(metav1.NamespaceDefault).Create(context.Background(), vmirs, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				err = runCommand("vmirs", vmirs.Name, "--name", "my-service")
-				Expect(err).To(MatchError(ContainSubstring("cannot expose vmirs without any label")))
-			})
+		It("when labels are missing with VirtualMachineInstanceReplicaSet", func() {
+			vmirs := kubecli.NewMinimalVirtualMachineInstanceReplicaSet("vmirs")
+			vmirs, err := virtClient.KubevirtV1().VirtualMachineInstanceReplicaSets(metav1.NamespaceDefault).Create(context.Background(), vmirs, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			err = runCommand("vmirs", vmirs.Name, "--name", "my-service")
+			Expect(err).To(MatchError(ContainSubstring("cannot expose VirtualMachineInstanceReplicaSet without any selector labels")))
 		})
 
 		It("when VirtualMachineInstanceReplicaSet has MatchExpressions", func() {
 			vmirs := kubecli.NewMinimalVirtualMachineInstanceReplicaSet("vmirs")
 			vmirs.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"something": "something",
+				},
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{Key: "test"},
 				},
@@ -168,9 +136,6 @@ var _ = Describe("Expose", func() {
 
 	Context("should succeed", func() {
 		const (
-			labelKey   = "my-key"
-			labelValue = "my-value"
-
 			serviceName    = "my-service"
 			servicePort    = int32(9999)
 			servicePortStr = "9999"
@@ -197,8 +162,8 @@ var _ = Describe("Expose", func() {
 		}
 
 		BeforeEach(func() {
-			vmi = libvmi.New(libvmi.WithLabel(labelKey, labelValue))
-			vmi, err := virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+			var err error
+			vmi, err = virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Create(context.Background(), libvmi.New(), metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			vm, err = virtClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault).Create(context.Background(), libvmi.NewVirtualMachine(vmi), metav1.CreateOptions{})
@@ -216,13 +181,15 @@ var _ = Describe("Expose", func() {
 		})
 
 		DescribeTable("creating a service with default settings", func(resType string) {
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr)
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr)
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(service.Spec.Ports).To(HaveLen(1))
 			Expect(service.Spec.Ports[0].Port).To(Equal(servicePort))
 			Expect(service.Spec.Ports[0].Protocol).To(Equal(k8sv1.ProtocolTCP))
@@ -258,13 +225,15 @@ var _ = Describe("Expose", func() {
 			})
 
 			DescribeTable("to create a service", func(resType string) {
-				err := runCommand(resType, getResName(resType), "--name", serviceName)
+				resName := getResName(resType)
+				err := runCommand(resType, resName, "--name", serviceName)
 				Expect(err).ToNot(HaveOccurred())
 
 				service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(service.Spec.Selector).To(HaveLen(1))
-				Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+				key, value := getSelectorKeyAndValue(resType, resName)
+				Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 				Expect(service.Spec.Ports).To(ConsistOf(
 					k8sv1.ServicePort{Name: "port-1", Protocol: "TCP", Port: 80},
 					k8sv1.ServicePort{Name: "port-2", Protocol: "UDP", Port: 81},
@@ -278,13 +247,15 @@ var _ = Describe("Expose", func() {
 
 		DescribeTable("creating a service with cluster-ip", func(resType string) {
 			const clusterIP = "1.2.3.4"
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr, "--cluster-ip", clusterIP)
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr, "--cluster-ip", clusterIP)
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(service.Spec.ClusterIP).To(Equal(clusterIP))
 		},
 			Entry("with VirtualMachineInstance", "vmi"),
@@ -294,13 +265,15 @@ var _ = Describe("Expose", func() {
 
 		DescribeTable("creating a service with external-ip", func(resType string) {
 			const externalIP = "1.2.3.4"
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr, "--external-ip", externalIP)
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr, "--external-ip", externalIP)
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(service.Spec.ExternalIPs).To(ConsistOf(externalIP))
 		},
 			Entry("with VirtualMachineInstance", "vmi"),
@@ -309,13 +282,15 @@ var _ = Describe("Expose", func() {
 		)
 
 		DescribeTable("creating a service", func(resType string, protocol k8sv1.Protocol) {
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr, "--protocol", string(protocol))
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr, "--protocol", string(protocol))
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(service.Spec.Ports).To(HaveLen(1))
 			Expect(service.Spec.Ports[0].Protocol).To(Equal(protocol))
 		},
@@ -328,13 +303,15 @@ var _ = Describe("Expose", func() {
 		)
 
 		DescribeTable("creating a service", func(resType string, targetPort string, expected intstr.IntOrString) {
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr, "--target-port", targetPort)
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr, "--target-port", targetPort)
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(service.Spec.Ports).To(HaveLen(1))
 			Expect(service.Spec.Ports[0].TargetPort).To(Equal(expected))
 		},
@@ -347,13 +324,15 @@ var _ = Describe("Expose", func() {
 		)
 
 		DescribeTable("creating a service", func(resType string, serviceType k8sv1.ServiceType) {
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr, "--type", string(serviceType))
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr, "--type", string(serviceType))
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(service.Spec.Ports).To(HaveLen(1))
 			Expect(service.Spec.Ports[0].Port).To(Equal(servicePort))
 		},
@@ -370,13 +349,15 @@ var _ = Describe("Expose", func() {
 
 		DescribeTable("creating a service with named port", func(resType string) {
 			const portName = "test-port"
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr, "--port-name", portName)
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr, "--port-name", portName)
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(service.Spec.Ports).To(HaveLen(1))
 			Expect(service.Spec.Ports[0].Name).To(Equal(portName))
 		},
@@ -386,13 +367,15 @@ var _ = Describe("Expose", func() {
 		)
 
 		DescribeTable("creating a service selecting a suitable default IPFamilyPolicy", func(resType, ipFamily string, ipFamilyPolicy *k8sv1.IPFamilyPolicy, expected ...k8sv1.IPFamily) {
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr, "--ip-family", ipFamily)
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr, "--ip-family", ipFamily)
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(service.Spec.IPFamilies).To(ConsistOf(expected))
 			if ipFamilyPolicy != nil {
 				Expect(*service.Spec.IPFamilyPolicy).To(Equal(*ipFamilyPolicy))
@@ -415,13 +398,15 @@ var _ = Describe("Expose", func() {
 		)
 
 		DescribeTable("creating a service", func(resType string, ipFamilyPolicy k8sv1.IPFamilyPolicy) {
-			err := runCommand(resType, getResName(resType), "--name", serviceName, "--port", servicePortStr, "--ip-family-policy", string(ipFamilyPolicy))
+			resName := getResName(resType)
+			err := runCommand(resType, resName, "--name", serviceName, "--port", servicePortStr, "--ip-family-policy", string(ipFamilyPolicy))
 			Expect(err).ToNot(HaveOccurred())
 
 			service, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.Background(), serviceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Selector).To(HaveLen(1))
-			Expect(service.Spec.Selector).To(HaveKeyWithValue(labelKey, labelValue))
+			key, value := getSelectorKeyAndValue(resType, resName)
+			Expect(service.Spec.Selector).To(HaveKeyWithValue(key, value))
 			Expect(*service.Spec.IPFamilyPolicy).To(Equal(ipFamilyPolicy))
 
 		},
@@ -440,4 +425,12 @@ var _ = Describe("Expose", func() {
 
 func runCommand(args ...string) error {
 	return testing.NewRepeatableVirtctlCommand(append([]string{expose.COMMAND_EXPOSE}, args...)...)()
+}
+
+func getSelectorKeyAndValue(resType, resName string) (string, string) {
+	if resType == "vmirs" {
+		return labelKey, labelValue
+	} else {
+		return v1.VirtualMachineNameLabel, resName
+	}
 }


### PR DESCRIPTION
### What this PR does

Use vm.kubevirt.io/name as label selector when exposing VMs and VMIs, since every virt-launcher Pod will have this label with the value set to the name of its VM/VMI. This makes virtctl expose more robust in situations where there are no or no unique labels defined on a VM/VMI.

Before this PR:

virtctl expose uses any label found on a VM/VMI as a service selector. In case of non-unique label values this can lead to exposure of the wrong VM/VMI.

After this PR:

virtctl expose uses the unique `vm.kubevirt.io/name` label found on every virt-launcher Pod as a service selector.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl expose now uses the unique `vm.kubevirt.io/name` label found on every virt-launcher Pod as a service selector.
```

