### PR TITLE
Fix incorrect metric name kubevirt_vmi_migration_disk_transfer_rate_bytes

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -180,7 +180,7 @@ The remaining guest OS data to be migrated to the new VM. Type: Gauge.
 ### kubevirt_vmi_migration_dirty_memory_rate_bytes
 The rate of memory being dirty in the Guest OS. Type: Gauge.
 
-### kubevirt_vmi_migration_disk_transfer_rate_bytes
+### kubevirt_vmi_migration_memory_transfer_rate_bytes
 The rate at which the memory is being transferred. Type: Gauge.
 
 ### kubevirt_vmi_migration_failed

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector.go
@@ -60,7 +60,7 @@ var (
 
 	migrateVmiMemoryTransferRate = operatormetrics.NewGauge(
 		operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_migration_disk_transfer_rate_bytes",
+			Name: "kubevirt_vmi_migration_memory_transfer_rate_bytes",
 			Help: "The rate at which the memory is being transferred.",
 		},
 	)

--- a/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/migrationdomainstats/migrationstats_collector_test.go
@@ -53,7 +53,7 @@ var _ = Describe("migration metrics", func() {
 			Entry("kubevirt_vmi_migration_data_remaining_bytes", migrateVMIDataRemaining, 1.0),
 			Entry("kubevirt_vmi_migration_data_processed_bytes", migrateVMIDataProcessed, 2.0),
 			Entry("kubevirt_vmi_migration_dirty_memory_rate_bytes", migrateVmiDirtyMemoryRate, 3.0),
-			Entry("kubevirt_vmi_migration_disk_transfer_rate_bytes", migrateVmiMemoryTransferRate, 4.0),
+			Entry("kubevirt_vmi_migration_memory_transfer_rate_bytes", migrateVmiMemoryTransferRate, 4.0),
 		)
 
 		It("result should be empty if stat not populated or set is false", func() {

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -443,7 +443,7 @@ func RunMigrationAndCollectMigrationMetrics(vmi *v1.VirtualMachineInstance, migr
 		"kubevirt_vmi_migration_data_remaining_bytes",
 		"kubevirt_vmi_migration_data_processed_bytes",
 		"kubevirt_vmi_migration_dirty_memory_rate_bytes",
-		"kubevirt_vmi_migration_disk_transfer_rate_bytes",
+		"kubevirt_vmi_migration_memory_transfer_rate_bytes",
 	}
 	const family = k8sv1.IPv4Protocol
 

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -84,7 +84,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			"kubevirt_vmi_migration_data_remaining_bytes":                        true,
 			"kubevirt_vmi_migration_data_processed_bytes":                        true,
 			"kubevirt_vmi_migration_dirty_memory_rate_bytes":                     true,
-			"kubevirt_vmi_migration_disk_transfer_rate_bytes":                    true,
+			"kubevirt_vmi_migration_memory_transfer_rate_bytes":                  true,
 		}
 
 		It("should contain virt components metrics", func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: The metric name is wrong and should be renamed to `kubevirt_vmi_migration_memory_transfer_rate_bytes`

After this PR: Fix metric name

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13499 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

