### PR TITLE
vmi-create-admitter_test refactor: refactor with VirtualMachineInstance spec context tests

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -441,7 +441,7 @@ func validateMDEVRamFB(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec
 	if countConfiguredMDEVRamFBs(spec) > 1 {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "configuring multiple displays with ramfb is not valid ",
+			Message: "configuring multiple displays with ramfb is not valid",
 			Field:   field.Child("GPUs").String(),
 		})
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1586,27 +1586,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				),
 			)
 		})
-
-		It("should detect invalid containerDisk paths", func() {
-			spec := &v1.VirtualMachineInstanceSpec{}
-			disk := v1.Disk{
-				Name:   "testdisk",
-				Serial: "SN-1_a",
-			}
-			spec.Domain.Devices.Disks = []v1.Disk{disk}
-			volume := v1.Volume{
-				Name: "testdisk",
-				VolumeSource: v1.VolumeSource{
-					ContainerDisk: testutils.NewFakeContainerDiskSource(),
-				},
-			}
-			volume.ContainerDisk.Path = "invalid"
-
-			spec.Volumes = []v1.Volume{volume}
-			spec.Domain.Devices.Disks = []v1.Disk{disk}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-			Expect(causes).To(HaveLen(1))
-		})
 	})
 
 	Context("with cpu pinning", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1448,12 +1448,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty())
 		})
-		It("should allow no start strategy to be set", func() {
-			vmi := api.NewMinimalVMI("testvmi")
-			vmi.Spec.StartStrategy = nil
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(BeEmpty())
-		})
 		It("should reject invalid start strategy", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			strategy := v1.StartStrategy("invalid")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
**Before this PR:**

Many tests in the "with VirtualMachineInstance spec" context tested implementation details instead of behavior.
Additionally, no standard for VMI creation was being enforced and `newAdmissionReviewForVMICreation` was only partially used throughout the tests.

**After this PR:**

The tests in the "with withVirtualMachineInstance spec" context now test for behavior, instantiate VMIs using libvmi and use the `newAdmissionReviewForVMICreation` function to create admission reviews.

Partially addresses: https://github.com/kubevirt/kubevirt/issues/13407

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

