### PR TITLE
[release-1.3] Add kubevirt_vm_resource_requests metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -93,6 +93,12 @@ Virtual Machine last transition timestamp to migrating status. Type: Counter.
 ### kubevirt_vm_non_running_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to paused/stopped status. Type: Counter.
 
+### kubevirt_vm_resource_limits
+Resources limits by Virtual Machine. Reports memory and CPU limits. Type: Gauge.
+
+### kubevirt_vm_resource_requests
+Resources requested by Virtual Machine. Reports memory and CPU requests. Type: Gauge.
+
 ### kubevirt_vm_running_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to running status. Type: Counter.
 

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -152,7 +152,11 @@ func setupVM(virtClient kubecli.KubevirtClient) {
 }
 
 func createRunningVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
-	vmi := libvmifact.NewGuestless(libvmi.WithNamespace(testsuite.GetTestNamespace(nil)))
+	vmi := libvmifact.NewGuestless(
+		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+		libvmi.WithResourceMemory("512Mi"),
+		libvmi.WithLimitMemory("512Mi"),
+	)
 	vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunning())
 	vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This is a manual cherry-pick of
https://github.com/kubevirt/kubevirt/pull/12593, https://github.com/kubevirt/kubevirt/pull/12625 and https://github.com/kubevirt/kubevirt/pull/12910

jira-ticket: https://issues.redhat.com/browse/CNV-49890

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubevirt_vm_resource_requests metric
```

/cc @sradco @avlitman 