### PR TITLE
[release-1.0] watch/migration: bug-fix prevent status updates for finalized migrations

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -431,8 +431,11 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 
 	// Remove the finalizer and conditions if the migration has already completed
 	if migration.IsFinal() {
-		// store the finalized migration state data from the VMI status in the migration object
-		migrationCopy.Status.MigrationState = vmi.Status.MigrationState
+
+		if vmi.Status.MigrationState != nil && migration.UID == vmi.Status.MigrationState.MigrationUID {
+			// Store the finalized migration state data from the VMI status in the migration object
+			migrationCopy.Status.MigrationState = vmi.Status.MigrationState
+		}
 
 		// remove the migration finalizaer
 		controller.RemoveFinalizer(migrationCopy, virtv1.VirtualMachineInstanceMigrationFinalizer)


### PR DESCRIPTION
Manual backport of #13426

reason for backport is for some reason cherry-pick automation failed from #13448

### Jira Ticket
```
https://issues.redhat.com/browse/CNV-52437
```

### Release note
```release-note
bug-fix: prevent status updates for finalized migrations
```

