### PR TITLE
[release-1.4] Fix usable disk size calculation during expansion

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -923,16 +923,15 @@ func getUsableDiskSize(path string) (int64, error) {
 	if err != nil {
 		return int64(-1), err
 	}
-	availableSize := int64(statfs.Bavail) * int64(statfs.Bsize)
 
-	var stat syscall.Stat_t
-	err = syscall.Stat(path, &stat)
+	availableSize := int64(statfs.Bavail) * int64(statfs.Bsize)
+	diskInfo, err := converter.GetImageInfo(path)
 	if err != nil {
 		return int64(-1), err
 	}
-	actualSize := int64(stat.Size)
+	usableSize := diskInfo.ActualSize + availableSize
 
-	return actualSize + availableSize, nil
+	return usableSize, nil
 }
 
 func shouldExpandOffline(disk api.Disk) bool {

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -26,7 +26,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -147,14 +146,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		return libwait.WaitForVMIPhase(vmi, []v1.VirtualMachineInstancePhase{v1.Running}, libwait.WithTimeout(500))
 	}
 
-	alignImageSizeTo1MiB := func(size int64) int64 {
-		remainder := size % (1024 * 1024)
-		if remainder == 0 {
-			return size
-		}
-		return size - remainder
-	}
-
 	Context("[storage-req]PVC expansion", decorators.StorageReq, func() {
 		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
 			checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
@@ -248,10 +239,8 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			if !volumeExpansionAllowed {
 				Skip("Skip when volume expansion storage class not available")
 			}
-
-			imageUrl := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)
 			dataVolume := libdv.NewDataVolume(
-				libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullNode),
+				libdv.WithBlankImageSource(),
 				libdv.WithStorage(
 					libdv.StorageWithStorageClass(sc),
 					libdv.StorageWithVolumeSize("512Mi"),
@@ -261,32 +250,38 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			)
 			dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
+			libstorage.EventuallyDV(dataVolume, 100, HaveSucceeded())
+			pvc, err := virtClient.CoreV1().PersistentVolumeClaims(dataVolume.Namespace).Get(context.Background(), dataVolume.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
-			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, dataVolume.Namespace, libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()))
+			executorPod := createExecutorPodWithPVC("size-detection", pvc)
+			fstatOutput, err := exec.ExecuteCommandOnPod(
+				executorPod,
+				executorPod.Spec.Containers[0].Name,
+				[]string{"stat", "-f", "-c", "%a %s", libstorage.DefaultPvcMountPath},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			var freeBlocks, ioBlockSize int64
+			_, err = fmt.Sscanf(fstatOutput, "%d %d", &freeBlocks, &ioBlockSize)
+			Expect(err).ToNot(HaveOccurred())
+			freeSize := freeBlocks * ioBlockSize
+
+			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, dataVolume.Namespace)
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 500)
 
-			By("Expecting the VirtualMachineInstance console")
-			Expect(console.LoginToCirros(vmi)).To(Succeed())
-
-			pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Get(context.Background(), dataVolume.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			pv, err := virtClient.CoreV1().PersistentVolumes().Get(context.Background(), pvc.Spec.VolumeName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			pvcRequestSize := pvc.Spec.Resources.Requests[k8sv1.ResourceStorage]
-			pvCapacitySize := pv.Spec.Capacity[k8sv1.ResourceStorage]
-
-			By("Checking if PV capacity is larger than PVC request")
-			if pvCapacitySize.Cmp(pvcRequestSize) > 0 {
-				Expect(getVirtualSize(vmi, dataVolume)).To(Equal((pvcRequestSize.Value())))
-			} else {
-				overheadPercentage, err := strconv.ParseFloat(string(*vmi.Status.VolumeStatus[1].PersistentVolumeClaimInfo.FilesystemOverhead), 64)
+			// Let's wait for VMI to be ready
+			Eventually(func() bool {
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				overheadSize := float64(pvcRequestSize.Value()) * (1.0 - overheadPercentage)
-				expectedSize := alignImageSizeTo1MiB(int64(overheadSize))
-				Expect(getVirtualSize(vmi, dataVolume)).To(Equal(expectedSize))
-			}
+				for _, volStatus := range vmi.Status.VolumeStatus {
+					if volStatus.Name == "disk0" {
+						return true
+					}
+				}
+				return false
+			}, 30*time.Second, time.Second).Should(BeTrue(), "Expected VolumeStatus for 'disk0' to be available")
+
+			Expect(getVirtualSize(vmi, dataVolume)).ToNot(BeNumerically(">", freeSize))
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual backport of https://github.com/kubevirt/kubevirt/pull/13237. Needed to address a conflict in the test, no other major changes.

Follow-up for https://issues.redhat.com/browse/CNV-47542 (bug failed verification).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-47542

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

