### PR TITLE
[release-1.3] Fix usable disk size calculation during expansion

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -923,16 +923,15 @@ func getUsableDiskSize(path string) (int64, error) {
 	if err != nil {
 		return int64(-1), err
 	}
-	availableSize := int64(statfs.Bavail) * int64(statfs.Bsize)
 
-	var stat syscall.Stat_t
-	err = syscall.Stat(path, &stat)
+	availableSize := int64(statfs.Bavail) * int64(statfs.Bsize)
+	diskInfo, err := converter.GetImageInfo(path)
 	if err != nil {
 		return int64(-1), err
 	}
-	actualSize := int64(stat.Size)
+	usableSize := diskInfo.ActualSize + availableSize
 
-	return actualSize + availableSize, nil
+	return usableSize, nil
 }
 
 func shouldExpandOffline(disk api.Disk) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual backport of https://github.com/kubevirt/kubevirt/pull/13237. Needed to address a conflict in the test, no other major changes.

Follow-up for https://issues.redhat.com/browse/CNV-47542 (failed verification).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes # https://issues.redhat.com/browse/CNV-47542

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

