### PR TITLE
quarantine: remove quarantine label for periodic test

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -470,7 +470,6 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     add_to_label_filter "(!kubernetes130)" "&&"
   fi
 
-  # execute tests labelled as PERIODIC only on periodic test lanes (according to lane name)
   if [[ ! $JOB_NAME =~ .*periodic.* ]]; then
     add_to_label_filter "(!PERIODIC)" "&&"
   fi

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -3,7 +3,10 @@ package decorators
 import . "github.com/onsi/ginkgo/v2"
 
 var (
-	Quarantine  = Label("QUARANTINE")
+	Quarantine = Label("QUARANTINE")
+
+	// Periodic marks tests that must run on periodic lanes only
+	// See https://github.com/kubevirt/kubevirt/pull/12594
 	Periodic    = Label("PERIODIC")
 	Conformance = Label("conformance")
 

--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -161,7 +161,7 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, func()
 				Expect(strings.Count(outputString, "virt-serial0-log")).To(Equal(4 + 1))
 			})
 
-			It("[QUARANTINE] it should not skip any log line even trying to flood the serial console for QOSGuaranteed VMs", decorators.Quarantine, decorators.Periodic, func() {
+			It("it should not skip any log line even trying to flood the serial console for QOSGuaranteed VMs", decorators.Periodic, func() {
 				cirrosVmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{
 						k8sv1.ResourceCPU:    resource.MustParse("1000m"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Decorator label Periodic defines a test to only be run on periodic test
lanes. Since periodic test lanes run the quarantined tests anyway, an additional quarantine label has no effect and can be removed.

Before this PR:
A guestlog test had both the QUARANTINE and PERIODIC decorators.

Additionally automation/test.sh had a comment near setting the PERIODIC label, which belongs to the decorator code.

After this PR:

A guestlog test has now only the PERIODIC decorator.

Also this PR moves the comment from automation/test.sh script explaining
PERIODIC label to the decorator.

Finally a couple of godoc issues are fixed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```