### PR TITLE
Conformance: Integrate with label filter

### DIFF
--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -36,17 +36,22 @@ func execute() error {
 	} else {
 		args = append(args, "--ginkgo.skip", "\\[Disruptive\\]")
 	}
-	if value, exists := os.LookupEnv("E2E_FOCUS"); exists {
+
+	if value, exists := os.LookupEnv("E2E_LABEL"); exists {
+		args = append(args, "--ginkgo.label-filter", value)
+	} else if value, exists := os.LookupEnv("E2E_FOCUS"); exists {
 		args = append(args, "--ginkgo.focus", value)
 	} else {
 		args = append(args, "--ginkgo.focus", "\\[Conformance\\]")
 	}
+
 	if value, exists := os.LookupEnv("CONTAINER_PREFIX"); exists {
 		args = append(args, "--container-prefix", value)
 	}
 	if value, exists := os.LookupEnv("CONTAINER_TAG"); exists {
 		args = append(args, "--container-tag", value)
 	}
+
 	args = append(args, "--config", "/conformance-config.json")
 
 	cmd := exec.Command("/usr/bin/go_default_test", args...)


### PR DESCRIPTION
### What this PR does
Now when we are moving to using labels instead
of text filtering we need to tweak our conformance binary to support this.

For now we make the focus and label filter mutual exclusive as the network conformance tests are not labeled yet.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Special notes for your reviewer
Please try to run this

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

