### PR TITLE
VMI create admitter: Remove getNumberOfPodInterfaces

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/monitoring/metrics/virt-api:go_default_library",
         "//pkg/network/admitter:go_default_library",
         "//pkg/network/link:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/reservation:go_default_library",
         "//pkg/storage/snapshot:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -43,6 +43,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/downwardmetrics"
 	"kubevirt.io/kubevirt/pkg/hooks"
 	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
 	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
@@ -186,7 +187,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateProbe(field.Child("readinessProbe"), spec.ReadinessProbe)...)
 	causes = append(causes, validateProbe(field.Child("livenessProbe"), spec.LivenessProbe)...)
 
-	if getNumberOfPodInterfaces(spec) < 1 {
+	if podNetwork := vmispec.LookupPodNetwork(spec.Networks); podNetwork == nil {
 		causes = appendStatusCauseForProbeNotAllowedWithNoPodNetworkPresent(field.Child("readinessProbe"), spec.ReadinessProbe, causes)
 		causes = appendStatusCauseForProbeNotAllowedWithNoPodNetworkPresent(field.Child("livenessProbe"), spec.LivenessProbe, causes)
 	}
@@ -1818,21 +1819,6 @@ func validateDevices(field *k8sfield.Path, devices *v1.Devices) []metav1.StatusC
 	var causes []metav1.StatusCause
 	causes = append(causes, validateDisks(field.Child("disks"), devices.Disks)...)
 	return causes
-}
-
-func getNumberOfPodInterfaces(spec *v1.VirtualMachineInstanceSpec) int {
-	nPodInterfaces := 0
-	for _, net := range spec.Networks {
-		if net.Pod != nil {
-			for _, iface := range spec.Domain.Devices.Interfaces {
-				if iface.Name == net.Name {
-					nPodInterfaces++
-					break // we maintain 1-to-1 relationship between networks and interfaces
-				}
-			}
-		}
-	}
-	return nPodInterfaces
 }
 
 func validateDiskName(field *k8sfield.Path, idx int, disks []v1.Disk) []metav1.StatusCause {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3833,66 +3833,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	})
 })
 
-var _ = Describe("Function getNumberOfPodInterfaces()", func() {
+var _ = Describe("additional tests", func() {
 	config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
-	It("should work for empty network list", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
-	})
-
-	It("should work for non-empty network list without pod network", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		net := v1.Network{}
-		spec.Networks = []v1.Network{net}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
-	})
-
-	It("should work for pod network with missing pod interface", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		net := v1.Network{
-			NetworkSource: v1.NetworkSource{
-				Pod: &v1.PodNetwork{},
-			},
-		}
-		spec.Networks = []v1.Network{net}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
-	})
-
-	It("should work for valid pod network / interface combination", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		net := v1.Network{
-			NetworkSource: v1.NetworkSource{
-				Pod: &v1.PodNetwork{},
-			},
-			Name: "testnet",
-		}
-		iface := v1.Interface{Name: net.Name}
-		spec.Networks = []v1.Network{net}
-		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(1))
-	})
-
-	It("should work for multiple pod network / interface combinations", func() {
-		spec := &v1.VirtualMachineInstanceSpec{}
-		net1 := v1.Network{
-			NetworkSource: v1.NetworkSource{
-				Pod: &v1.PodNetwork{},
-			},
-			Name: "testnet1",
-		}
-		iface1 := v1.Interface{Name: net1.Name}
-		net2 := v1.Network{
-			NetworkSource: v1.NetworkSource{
-				Pod: &v1.PodNetwork{},
-			},
-			Name: "testnet2",
-		}
-		iface2 := v1.Interface{Name: net2.Name}
-		spec.Networks = []v1.Network{net1, net2}
-		spec.Domain.Devices.Interfaces = []v1.Interface{iface1, iface2}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(2))
-	})
 	It("should work when boot order is given to interfaces", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		net := v1.Network{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The VMI creation admitter denies VMI creation in case there are readiness and/or liveness probes when there is no pod network defined.

Replace the call to the custom `getNumberOfPodInterfaces` with the standard `vmispec.LookupPodNetwork`.

Doing so, enable us to remove the unit tests of `getNumberOfPodInterfaces` which test an implementation detail instead
of the admitter's exported API.

The `Describe` container containing the unit tests for `getNumberOfPodInterfaces` unfortunately also contains additional tests, so its subject was changed.

This scenario described above is covered by the probes tests in the admitter's unit tests file.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

