### PR TITLE
Collect resource requests and limits from VM instance type/preference

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/instancetype:go_default_library",
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/common/workqueue:go_default_library",
         "//pkg/util/migrations:go_default_library",
@@ -50,6 +51,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/instancetype:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/common/workqueue"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -44,37 +45,28 @@ var (
 	vmInformer                    cache.SharedIndexInformer
 	vmiInformer                   cache.SharedIndexInformer
 	persistentVolumeClaimInformer cache.SharedIndexInformer
-	clusterInstanceTypeInformer   cache.SharedIndexInformer
-	instanceTypeInformer          cache.SharedIndexInformer
-	clusterPreferenceInformer     cache.SharedIndexInformer
-	preferenceInformer            cache.SharedIndexInformer
 	vmiMigrationInformer          cache.SharedIndexInformer
 	kvPodInformer                 cache.SharedIndexInformer
 	clusterConfig                 *virtconfig.ClusterConfig
+	instancetypeMethods           *instancetype.InstancetypeMethods
 )
 
 func SetupMetrics(
 	vm cache.SharedIndexInformer,
 	vmi cache.SharedIndexInformer,
 	pvc cache.SharedIndexInformer,
-	clusterInstanceType cache.SharedIndexInformer,
-	instanceType cache.SharedIndexInformer,
-	clusterPreference cache.SharedIndexInformer,
-	preference cache.SharedIndexInformer,
 	vmiMigration cache.SharedIndexInformer,
 	pod cache.SharedIndexInformer,
 	virtClusterConfig *virtconfig.ClusterConfig,
+	methods *instancetype.InstancetypeMethods,
 ) error {
 	vmInformer = vm
 	vmiInformer = vmi
 	persistentVolumeClaimInformer = pvc
-	clusterInstanceTypeInformer = clusterInstanceType
-	instanceTypeInformer = instanceType
-	clusterPreferenceInformer = clusterPreference
-	preferenceInformer = preference
 	vmiMigrationInformer = vmiMigration
 	kvPodInformer = pod
 	clusterConfig = virtClusterConfig
+	instancetypeMethods = methods
 
 	if err := client.SetupMetrics(); err != nil {
 		return err

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -250,11 +250,11 @@ func getVMIPod(vmi *k6tv1.VirtualMachineInstance) string {
 
 func getVMIInstancetype(vmi *k6tv1.VirtualMachineInstance) string {
 	if instancetypeName, ok := vmi.Annotations[k6tv1.InstancetypeAnnotation]; ok {
-		return fetchResourceName(instancetypeName, instanceTypeInformer.GetIndexer())
+		return fetchResourceName(instancetypeName, instancetypeMethods.InstancetypeStore)
 	}
 
 	if instancetypeName, ok := vmi.Annotations[k6tv1.ClusterInstancetypeAnnotation]; ok {
-		return fetchResourceName(instancetypeName, clusterInstanceTypeInformer.GetIndexer())
+		return fetchResourceName(instancetypeName, instancetypeMethods.ClusterInstancetypeStore)
 	}
 
 	return none
@@ -262,18 +262,18 @@ func getVMIInstancetype(vmi *k6tv1.VirtualMachineInstance) string {
 
 func getVMIPreference(vmi *k6tv1.VirtualMachineInstance) string {
 	if instancetypeName, ok := vmi.Annotations[k6tv1.PreferenceAnnotation]; ok {
-		return fetchResourceName(instancetypeName, preferenceInformer.GetIndexer())
+		return fetchResourceName(instancetypeName, instancetypeMethods.PreferenceStore)
 	}
 
 	if instancetypeName, ok := vmi.Annotations[k6tv1.ClusterPreferenceAnnotation]; ok {
-		return fetchResourceName(instancetypeName, clusterPreferenceInformer.GetIndexer())
+		return fetchResourceName(instancetypeName, instancetypeMethods.ClusterPreferenceStore)
 	}
 
 	return none
 }
 
-func fetchResourceName(name string, indexer cache.Indexer) string {
-	obj, ok, err := indexer.GetByKey(name)
+func fetchResourceName(name string, store cache.Store) string {
+	obj, ok, err := store.GetByKey(name)
 	if err != nil || !ok {
 		return other
 	}

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -26,11 +26,13 @@ import (
 	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
 	"github.com/prometheus/client_golang/prometheus"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	k6tv1 "kubevirt.io/api/core/v1"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
+	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 
@@ -517,12 +519,10 @@ func createVMIForEviction(evictionStrategy *k6tv1.EvictionStrategy, migratableCo
 }
 
 func setupTestCollector() {
-	instanceTypeInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineInstancetype{})
-	clusterInstanceTypeInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterInstancetype{})
-	preferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})
-	clusterPreferenceInformer, _ = testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
-	kvPodInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
-	vmiMigrationInformer, _ = testutils.NewFakeInformerFor(&k6tv1.VirtualMachineInstanceMigration{})
+	instanceTypeInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineInstancetype{})
+	clusterInstanceTypeInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterInstancetype{})
+	preferenceInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachinePreference{})
+	clusterPreferenceInformer, _ := testutils.NewFakeInformerFor(&instancetypev1beta1.VirtualMachineClusterPreference{})
 
 	_ = instanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineInstancetype{
 		ObjectMeta: newObjectMetaForInstancetypes("i-managed", "kubevirt.io"),
@@ -533,6 +533,14 @@ func setupTestCollector() {
 
 	_ = clusterInstanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineClusterInstancetype{
 		ObjectMeta: newObjectMetaForInstancetypes("ci-managed", "kubevirt.io"),
+		Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
+			CPU: instancetypev1beta1.CPUInstancetype{
+				Guest: 2,
+			},
+			Memory: instancetypev1beta1.MemoryInstancetype{
+				Guest: *resource.NewQuantity(2048, resource.BinarySI),
+			},
+		},
 	})
 	_ = clusterInstanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineClusterInstancetype{
 		ObjectMeta: newObjectMetaForInstancetypes("ci-unmanaged", ""),
@@ -549,9 +557,22 @@ func setupTestCollector() {
 		ObjectMeta: newObjectMetaForInstancetypes("cp-managed", "kubevirt.io"),
 	})
 
+	instancetypeMethods = &instancetype.InstancetypeMethods{
+		InstancetypeStore:        instanceTypeInformer.GetStore(),
+		ClusterInstancetypeStore: clusterInstanceTypeInformer.GetStore(),
+		PreferenceStore:          preferenceInformer.GetStore(),
+		ClusterPreferenceStore:   clusterPreferenceInformer.GetStore(),
+	}
+
+	// Pod informer
+	kvPodInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
+
 	_ = kvPodInformer.GetStore().Add(&k8sv1.Pod{
 		ObjectMeta: newPodMetaForInformer("virt-launcher-testpod", "test-ns", "test-vmi-uid"),
 	})
+
+	// VMI Migration informer
+	vmiMigrationInformer, _ = testutils.NewFakeInformerFor(&k6tv1.VirtualMachineInstanceMigration{})
 
 	_ = vmiMigrationInformer.GetStore().Add(&k6tv1.VirtualMachineInstanceMigration{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
         "//pkg/hooks:go_default_library",
+        "//pkg/instancetype:go_default_library",
         "//pkg/instancetype/controller/vm:go_default_library",
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -80,6 +80,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
 
+	"kubevirt.io/kubevirt/pkg/instancetype"
 	instancetypecontroller "kubevirt.io/kubevirt/pkg/instancetype/controller/vm"
 	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
@@ -436,13 +437,17 @@ func Execute() {
 		app.vmInformer,
 		app.vmiInformer,
 		app.persistentVolumeClaimInformer,
-		app.clusterInstancetypeInformer,
-		app.instancetypeInformer,
-		app.clusterPreferenceInformer,
-		app.preferenceInformer,
 		app.migrationInformer,
 		app.kvPodInformer,
 		app.clusterConfig,
+		&instancetype.InstancetypeMethods{
+			InstancetypeStore:        app.instancetypeInformer.GetStore(),
+			ClusterInstancetypeStore: app.clusterInstancetypeInformer.GetStore(),
+			PreferenceStore:          app.preferenceInformer.GetStore(),
+			ClusterPreferenceStore:   app.clusterInstancetypeInformer.GetStore(),
+			ControllerRevisionStore:  app.controllerRevisionInformer.GetStore(),
+			Clientset:                app.clientSet,
+		},
 	); err != nil {
 		golog.Fatal(err)
 	}

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -100,7 +100,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			err = virtapi.SetupMetrics()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			err = virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = virtcontroller.RegisterLeaderMetrics()

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -41,7 +41,7 @@ this document.
 `
 
 func main() {
-	if err := virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil); err != nil {
+	if err := virtcontroller.SetupMetrics(nil, nil, nil, nil, nil, nil, nil); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Sometimes the VMs do not have any explicit resource requests/limits, but those are usually defined by Instance Types/Preferences. In this situation, the resource metrics were not collecting the data. 

After this PR:

kubevirt_vm_resource_requests and kubevirt_vm_resource_limits also collect data from the instance types and preferences.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

jira-ticket: `https://issues.redhat.com/browse/CNV-53260`

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Collect resource requests and limits from VM instance type/preference
```

/cc @sradco @lyarwood @avlitman 
