### PR TITLE
passt binding plugin, e2e: Drop expectation for IP refresh

### DIFF
--- a/tests/network/bindingplugin_passt.go
+++ b/tests/network/bindingplugin_passt.go
@@ -65,7 +65,7 @@ var _ = SIGDescribe(" VirtualMachineInstance with passt network binding plugin",
 		err := config.WithNetBindingPlugin(passtBindingName, v1.InterfaceBindingPlugin{
 			SidecarImage:                passtSidecarImage,
 			NetworkAttachmentDefinition: libnet.PasstNetAttDef,
-			Migration:                   &v1.InterfaceBindingMigration{Method: v1.LinkRefresh},
+			Migration:                   &v1.InterfaceBindingMigration{},
 			ComputeResourceOverhead: &v1.ResourceRequirementsWithoutClaims{
 				Requests: map[k8sv1.ResourceName]resource.Quantity{
 					k8sv1.ResourceMemory: passtComputeMemoryOverheadWhenAllPortsAreForwarded,
@@ -361,15 +361,6 @@ EOL`, inetSuffix, serverIP, serverPort)
 				migrateVmiAfterMigIP = libnet.GetVmiPrimaryIPByFamily(migrateVMI, ipFamily)
 				return migrateVmiAfterMigIP
 			}, 30*time.Second).ShouldNot(Equal(migrateVmiBeforeMigIP), "the VMI status should get a new IP after migration")
-
-			By("Verify the guest renewed the IP")
-			/// We renew the IP to avoid issues such as
-			// another pod in the cluster gets the IP of the old pod
-			// a user wants the internal and exteranl IP on the VM to be same
-			ipValidation := fmt.Sprintf("ip addr show eth0 | grep %s", migrateVmiAfterMigIP)
-			Eventually(func() error {
-				return console.RunCommand(migrateVMI, ipValidation, time.Second*5)
-			}, 30*time.Second).Should(Succeed())
 
 			By("Verify the VMIs can ping each other after migration")
 			Expect(libnet.PingFromVMConsole(migrateVMI, anotherVmiIP)).To(Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Currently, the passt binding plugin e2e tests register the plugin with the LinkRefresh migration method and expect the guest's IP address to change following a migration.

The LinkRefresh method works by switching the interface off for 100ms and turning it back on.

On newer Fedora versions (for example F39), NetworkManager does not take action, unless the link is down for at least six seconds [1] - thus the LinkRefresh method does not work with it and the test breaks since the guest IP does not change following the migration.

Passt has the ability to perform automatic NAT, meaning we can retain the previous IP address and the VM will still be able to communicate over the pod network following the migration.

[1] https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/NetworkManager.conf.html

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Matching change in the user-guide https://github.com/kubevirt/user-guide/pull/860.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

