### PR TITLE
Adapt to crun transition period where it configures 2 cgroups

### DIFF
--- a/cmd/virt-chroot/cgroup.go
+++ b/cmd/virt-chroot/cgroup.go
@@ -84,15 +84,18 @@ func setCgroupResourcesV1(paths map[string]string, resources *runc_configs.Resou
 }
 
 func setCgroupResourcesV2(paths map[string]string, resources *runc_configs.Resources, config *runc_configs.Cgroup) error {
-	cgroupDirPath := paths[""]
-
-	cgroupManager, err := runc_fs2.NewManager(config, cgroupDirPath)
-	if err != nil {
-		return fmt.Errorf("cannot create cgroups v2 manager. err: %v", err)
+	for _, path := range paths {
+		mgr, err := runc_fs2.NewManager(config, path)
+		if err != nil {
+			return fmt.Errorf("cannot create cgroups v2 manager. err: %v", err)
+		}
+		err = mgr.Set(resources)
+		if err != nil {
+			return err
+		}
 	}
 
-	err = cgroupManager.Set(resources)
-	return err
+	return nil
 }
 
 // RunWithChroot changes the root directory (via "chroot") into newPath, then

--- a/pkg/virt-handler/cgroup/cgroup_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_test.go
@@ -12,8 +12,10 @@ import (
 var _ = Describe("cgroup manager", func() {
 
 	var (
-		ctrl         *gomock.Controller
-		rulesDefined []*devices.Rule
+		ctrl                  *gomock.Controller
+		rulesDefined          []*devices.Rule
+		v2DirPath             string
+		subsystemPathsDefined map[string]string
 	)
 
 	newMockManagerFromCtrl := func(ctrl *gomock.Controller, version CgroupVersion) (Manager, error) {
@@ -25,7 +27,7 @@ var _ = Describe("cgroup manager", func() {
 			if version == V1 {
 				paths["devices"] = "/sys/fs/cgroup/devices"
 			} else {
-				paths[""] = "/sys/fs/cgroup/"
+				paths[""] = v2DirPath
 			}
 
 			return paths
@@ -33,6 +35,7 @@ var _ = Describe("cgroup manager", func() {
 
 		execVirtChrootFunc := func(r *runc_configs.Resources, subsystemPaths map[string]string, rootless bool, version CgroupVersion) error {
 			rulesDefined = r.Devices
+			subsystemPathsDefined = subsystemPaths
 			return nil
 		}
 
@@ -72,6 +75,11 @@ var _ = Describe("cgroup manager", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		rulesDefined = make([]*devices.Rule, 0)
+		v2DirPath = "/sys/fs/cgroup/"
+	})
+
+	AfterEach(func() {
+		v2DirPath = ""
 	})
 
 	DescribeTable("ensure that default rules are added", func(version CgroupVersion) {
@@ -134,4 +142,37 @@ var _ = Describe("cgroup manager", func() {
 		Entry("for v2", V2),
 	)
 
+	DescribeTable("ensure that correct set of cgroups is configured", func(dirPath string, expectedPaths []string) {
+		v2DirPath = dirPath
+		manager, err := newMockManager(V2)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		fakeRule := newDeviceRule(123)
+
+		err = manager.Set(newResourcesWithRule(fakeRule))
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(rulesDefined).To(ContainElement(fakeRule), "defined rule is expected to exist")
+
+		defaultDeviceRules := GenerateDefaultDeviceRules()
+		for _, defaultRule := range defaultDeviceRules {
+			Expect(rulesDefined).To(ContainElement(defaultRule), "default rules are expected to be defined")
+		}
+		Expect(rulesDefined).To(HaveLen(len(defaultDeviceRules) + 1))
+		Expect(subsystemPathsDefined).To(ConsistOf(expectedPaths))
+	},
+		Entry("for crun installation",
+			"/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice/crio-456.scope/container",
+			[]string{
+				"/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice/crio-456.scope/container",
+				"/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice/crio-456.scope",
+			},
+		),
+		Entry("for runc installation",
+			"/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice/crio-456.scope",
+			[]string{
+				"/sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod123.slice/crio-456.scope",
+			},
+		),
+	)
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
crun is test driving some [changes](https://github.com/containers/crun/commit/01fa4993d6e7a7025a7326179988a2f5e72549db) it integrated recently;
it's configuring two cgroups, `*.scope` and sub cgroup called `container`
while before, the parent existed as sort of a no op
(wasn't configured, so, all devices were allowed, for example)
This results in us having to adapt, by applying the filter to the second cgroup in such cases.

crun will eventually drop the `container` sub cgroup, once it's confident of some systemd dbus API integration point.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Will remove this following when crun stops creating an extra cgroup https://github.com/kubevirt/kubevirt/issues/13604

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Volume hotplug broken with crun >= 1.18
```

