### PR TITLE
Add sig-compute OWNERS to sub-directories

### DIFF
--- a/cmd/fake-qemu-process/OWNERS
+++ b/cmd/fake-qemu-process/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - area/launcher
+  - sig/compute

--- a/cmd/virt-chroot/OWNERS
+++ b/cmd/virt-chroot/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - area/handler
+  - sig/compute

--- a/cmd/virt-handler/OWNERS
+++ b/cmd/virt-handler/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - area/handler
+  - sig/compute

--- a/cmd/virt-launcher-monitor/OWNERS
+++ b/cmd/virt-launcher-monitor/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - area/launcher
+  - sig/compute

--- a/cmd/virt-launcher/OWNERS
+++ b/cmd/virt-launcher/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - area/launcher
+  - sig/compute

--- a/pkg/hooks/OWNERS
+++ b/pkg/hooks/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - area/launcher
+  - sig/compute

--- a/pkg/virt-handler/virt-chroot/OWNERS
+++ b/pkg/virt-handler/virt-chroot/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - area/handler
+  - sig/compute

--- a/pkg/virt-launcher/OWNERS
+++ b/pkg/virt-launcher/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - sig-compute-reviewers
+approvers:
+  - sig-compute-approvers
+labels:
+  - area/launcher
+  - sig/compute


### PR DESCRIPTION
### What this PR does
Adds sig-compute OWNERS to relevant sub-directories.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

