### PR TITLE
[release-1.4] fix(virtctl): Ensure the log verbosity flag is supported

### DIFF
--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )
@@ -43,6 +44,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/clientcmd:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -1,13 +1,14 @@
 package virtctl
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
-
+	"github.com/spf13/pflag"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/client-go/kubecli"
@@ -78,6 +79,7 @@ func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 	optionsCmd.SetUsageTemplate(templates.OptionsUsageTemplate())
 	//TODO: Add a ClientConfigFactory which allows substituting the KubeVirt client with a mock for unit testing
 	clientConfig := kubecli.DefaultClientConfig(rootCmd.PersistentFlags())
+	addGLogVerbosityFlag(rootCmd.PersistentFlags())
 	rootCmd.SetUsageTemplate(templates.MainUsageTemplate())
 	rootCmd.SetOut(os.Stdout)
 	rootCmd.AddCommand(
@@ -127,6 +129,17 @@ func GetProgramName(binary string) string {
 		return fmt.Sprintf("%s virt", strings.TrimSuffix(binary, "-virt"))
 	}
 	return "virtctl"
+}
+
+func addGLogVerbosityFlag(fs *pflag.FlagSet) {
+	// The glog verbosity flag is added to the default flag set
+	// by init() in vendor/github.com/golang/glog/glog.go.
+	// We re-add it here to make it available in virtctl commands.
+	if f := flag.CommandLine.Lookup("v"); f != nil {
+		fs.AddFlag(pflag.PFlagFromGoFlag(f))
+	} else {
+		panic("failed to find verbosity flag \"v\" in default flag set")
+	}
 }
 
 func Execute() {

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/pkg/virtctl"
+	"kubevirt.io/kubevirt/tests/clientcmd"
 )
 
 var _ = Describe("Root", func() {
@@ -24,5 +25,12 @@ var _ = Describe("Root", func() {
 	It("returns oc", func() {
 		Expect(virtctl.GetProgramName("oc-virt")).To(BeEquivalentTo("oc virt"))
 	})
+
+	DescribeTable("the log verbosity flag should be supported", func(arg string) {
+		Expect(clientcmd.NewRepeatableVirtctlCommand(arg)()).To(Succeed())
+	},
+		Entry("regular flag", "--v=2"),
+		Entry("shorthand flag", "-v=2"),
+	)
 
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual backport of https://github.com/kubevirt/kubevirt/pull/13555

Before this PR:

virtctl does not support the -v / --v log verbosity flag.

After this PR:

virtctl supports setting the log verbosity with the -v / --v flag.

Fixes https://github.com/kubevirt/kubevirt/issues/12779

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

