### PR TITLE
chore(lint,virtctl): Enable linter for cmd/virtctl and tests/virtctl

### DIFF
--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -1,3 +1,4 @@
+cmd/virtctl
 pkg/instancetype
 pkg/libvmi
 pkg/network/admitter
@@ -28,3 +29,4 @@ tests/libwait
 tests/numa
 tests/scale
 tests/usb
+tests/virtctl

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -63,13 +63,10 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-const (
-	size = "128Mi"
-)
-
 var _ = VirtctlDescribe("[sig-compute]create vm", decorators.SigCompute, func() {
 	const (
 		randNameTail         = 5
+		size                 = "128Mi"
 		importedVolumeRegexp = `imported-volume-\w{5}`
 		sysprepDisk          = "sysprepdisk"
 		cloudInitDisk        = "cloudinitdisk"
@@ -783,7 +780,7 @@ func decodeVM(bytes []byte) (*v1.VirtualMachine, error) {
 func createInstancetype(virtClient kubecli.KubevirtClient) *instancetypev1beta1.VirtualMachineInstancetype {
 	instancetype := builder.NewInstancetype(
 		builder.WithCPUs(1),
-		builder.WithMemory(size),
+		builder.WithMemory("128Mi"),
 	)
 	instancetype, err := virtClient.VirtualMachineInstancetype(testsuite.GetTestNamespace(nil)).
 		Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -824,7 +821,7 @@ func createAnnotatedDataSource(virtClient kubecli.KubevirtClient, instancetypeNa
 
 func createAnnotatedSourcePVC(instancetypeName, preferenceName string) *k8sv1.PersistentVolumeClaim {
 	const randNameTail = 5
-	return libstorage.CreateFSPVC("vm-pvc-"+rand.String(randNameTail), testsuite.GetTestNamespace(nil), size, map[string]string{
+	return libstorage.CreateFSPVC("vm-pvc-"+rand.String(randNameTail), testsuite.GetTestNamespace(nil), "128Mi", map[string]string{
 		apiinstancetype.DefaultInstancetypeLabel:     instancetypeName,
 		apiinstancetype.DefaultInstancetypeKindLabel: apiinstancetype.SingularResourceName,
 		apiinstancetype.DefaultPreferenceLabel:       preferenceName,

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -30,7 +30,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/gstruct"
 
 	"golang.org/x/crypto/ssh"
 	k8sv1 "k8s.io/api/core/v1"
@@ -48,12 +48,12 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virtctl/create"
-	. "kubevirt.io/kubevirt/pkg/virtctl/create/vm"
+	"kubevirt.io/kubevirt/pkg/virtctl/create/vm"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libconfigmap"
 	"kubevirt.io/kubevirt/tests/libinstancetype/builder"
 	"kubevirt.io/kubevirt/tests/libsecret"
@@ -69,6 +69,7 @@ const (
 
 var _ = VirtctlDescribe("[sig-compute]create vm", decorators.SigCompute, func() {
 	const (
+		randNameTail         = 5
 		importedVolumeRegexp = `imported-volume-\w{5}`
 		sysprepDisk          = "sysprepdisk"
 		cloudInitDisk        = "cloudinitdisk"
@@ -85,19 +86,21 @@ chpasswd: { expire: False }`
 	})
 
 	It("[test_id:9840]VM with random name and default settings", func() {
-		out, err := runCreateVmCmd()
+		out, err := runCreateVMCmd()
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(vm.Name).ToNot(BeEmpty())
-		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(PointTo(Equal(int64(180))))
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(v1.RunStrategyAlways)))
+		const defaultTerminationGracePeriod = int64(180)
+		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(gstruct.PointTo(Equal(defaultTerminationGracePeriod)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(v1.RunStrategyAlways)))
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse("512Mi"))))
 	})
 
 	It("[test_id:11647]Example with volume-import flag and PVC type", func() {
@@ -109,18 +112,19 @@ chpasswd: { expire: False }`
 		preference := createPreference(virtClient)
 		pvc := createAnnotatedSourcePVC(instancetype.Name, preference.Name)
 
-		out, err := runCreateVmCmd(
-			setFlag(RunStrategyFlag, string(runStrategy)),
-			setFlag(VolumeImportFlag, fmt.Sprintf("type:pvc,size:%s,src:%s/%s,name:%s", size, pvc.Namespace, pvc.Name, volName)),
+		out, err := runCreateVMCmd(
+			setFlag(vm.RunStrategyFlag, string(runStrategy)),
+			setFlag(vm.VolumeImportFlag, fmt.Sprintf("type:pvc,size:%s,src:%s/%s,name:%s", size, pvc.Namespace, pvc.Name, volName)),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(runStrategy)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(runStrategy)))
 
 		Expect(vm.Spec.Instancetype).ToNot(BeNil())
 		Expect(vm.Spec.Instancetype.Kind).To(Equal(apiinstancetype.SingularResourceName))
@@ -159,22 +163,23 @@ chpasswd: { expire: False }`
 		)
 		cdSource := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
 
-		out, err := runCreateVmCmd(
-			setFlag(RunStrategyFlag, string(runStrategy)),
-			setFlag(VolumeImportFlag, fmt.Sprintf("type:registry,size:%s,url:%s,name:%s", size, cdSource, volName)),
+		out, err := runCreateVMCmd(
+			setFlag(vm.RunStrategyFlag, string(runStrategy)),
+			setFlag(vm.VolumeImportFlag, fmt.Sprintf("type:registry,size:%s,url:%s,name:%s", size, cdSource, volName)),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(runStrategy)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(runStrategy)))
 
 		Expect(vm.Spec.Instancetype).To(BeNil())
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse("512Mi"))))
 
 		Expect(vm.Spec.Preference).To(BeNil())
 
@@ -197,22 +202,23 @@ chpasswd: { expire: False }`
 	It("[test_id:11649]Example with volume-import flag and Blank type", func() {
 		const runStrategy = v1.RunStrategyAlways
 
-		out, err := runCreateVmCmd(
-			setFlag(RunStrategyFlag, string(runStrategy)),
-			setFlag(VolumeImportFlag, "type:blank,size:"+size),
+		out, err := runCreateVMCmd(
+			setFlag(vm.RunStrategyFlag, string(runStrategy)),
+			setFlag(vm.VolumeImportFlag, "type:blank,size:"+size),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(runStrategy)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(runStrategy)))
 
 		Expect(vm.Spec.Instancetype).To(BeNil())
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse("512Mi"))))
 
 		Expect(vm.Spec.Preference).To(BeNil())
 
@@ -237,39 +243,42 @@ chpasswd: { expire: False }`
 			cdSource                     = "my.registry/my-image:my-tag"
 			pvcBootOrder                 = 1
 			blankSize                    = "10Gi"
+			expectedDVTLen               = 3
+			expectedVolumesLen           = 6
 		)
-		vmName := "vm-" + rand.String(5)
+		vmName := "vm-" + rand.String(randNameTail)
 		instancetype := createInstancetype(virtClient)
 		preference := createPreference(virtClient)
 		dataSource := createAnnotatedDataSource(virtClient, "something", "something")
-		pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(5), testsuite.GetTestNamespace(nil), size, nil)
+		pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(randNameTail), testsuite.GetTestNamespace(nil), size, nil)
 		userDataB64 := base64.StdEncoding.EncodeToString([]byte(cloudInitUserData))
 
-		out, err := runCreateVmCmd(
-			setFlag(NameFlag, vmName),
-			setFlag(RunStrategyFlag, string(runStrategy)),
-			setFlag(TerminationGracePeriodFlag, fmt.Sprint(terminationGracePeriod)),
-			setFlag(InstancetypeFlag, fmt.Sprintf("%s/%s", apiinstancetype.SingularResourceName, instancetype.Name)),
-			setFlag(PreferenceFlag, fmt.Sprintf("%s/%s", apiinstancetype.SingularPreferenceResourceName, preference.Name)),
-			setFlag(ContainerdiskVolumeFlag, "src:"+cdSource),
-			setFlag(VolumeImportFlag, fmt.Sprintf("type:ds,src:%s/%s", dataSource.Namespace, dataSource.Name)),
-			setFlag(VolumeImportFlag, fmt.Sprintf("type:pvc,src:%s/%s", pvc.Namespace, pvc.Name)),
-			setFlag(PvcVolumeFlag, fmt.Sprintf("src:%s,bootorder:%d", pvc.Name, pvcBootOrder)),
-			setFlag(VolumeImportFlag, "type:blank,size:"+blankSize),
-			setFlag(CloudInitUserDataFlag, userDataB64),
+		out, err := runCreateVMCmd(
+			setFlag(vm.NameFlag, vmName),
+			setFlag(vm.RunStrategyFlag, string(runStrategy)),
+			setFlag(vm.TerminationGracePeriodFlag, fmt.Sprint(terminationGracePeriod)),
+			setFlag(vm.InstancetypeFlag, fmt.Sprintf("%s/%s", apiinstancetype.SingularResourceName, instancetype.Name)),
+			setFlag(vm.PreferenceFlag, fmt.Sprintf("%s/%s", apiinstancetype.SingularPreferenceResourceName, preference.Name)),
+			setFlag(vm.ContainerdiskVolumeFlag, "src:"+cdSource),
+			setFlag(vm.VolumeImportFlag, fmt.Sprintf("type:ds,src:%s/%s", dataSource.Namespace, dataSource.Name)),
+			setFlag(vm.VolumeImportFlag, fmt.Sprintf("type:pvc,src:%s/%s", pvc.Namespace, pvc.Name)),
+			setFlag(vm.PvcVolumeFlag, fmt.Sprintf("src:%s,bootorder:%d", pvc.Name, pvcBootOrder)),
+			setFlag(vm.VolumeImportFlag, "type:blank,size:"+blankSize),
+			setFlag(vm.CloudInitUserDataFlag, userDataB64),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(vm.Name).To(Equal(vmName))
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(runStrategy)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(runStrategy)))
 
-		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(PointTo(Equal(terminationGracePeriod)))
+		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(gstruct.PointTo(Equal(terminationGracePeriod)))
 
 		Expect(vm.Spec.Instancetype).ToNot(BeNil())
 		Expect(vm.Spec.Instancetype.Kind).To(Equal(apiinstancetype.SingularResourceName))
@@ -284,12 +293,12 @@ chpasswd: { expire: False }`
 		Expect(vm.Spec.Preference.InferFromVolume).To(BeEmpty())
 		Expect(vm.Spec.Preference.InferFromVolumeFailurePolicy).To(BeNil())
 
-		Expect(vm.Spec.DataVolumeTemplates).To(HaveLen(3))
+		Expect(vm.Spec.DataVolumeTemplates).To(HaveLen(expectedDVTLen))
 
 		Expect(vm.Spec.DataVolumeTemplates[0].Name).To(MatchRegexp(importedVolumeRegexp))
 		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef).ToNot(BeNil())
 		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Kind).To(Equal("DataSource"))
-		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Namespace).To(PointTo(Equal(dataSource.Namespace)))
+		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Namespace).To(gstruct.PointTo(Equal(dataSource.Namespace)))
 		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Name).To(Equal(dataSource.Name))
 
 		Expect(vm.Spec.DataVolumeTemplates[1].Name).To(MatchRegexp(importedVolumeRegexp))
@@ -303,7 +312,7 @@ chpasswd: { expire: False }`
 		Expect(vm.Spec.DataVolumeTemplates[2].Spec.Source.Blank).ToNot(BeNil())
 		Expect(vm.Spec.DataVolumeTemplates[2].Spec.Storage.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse(blankSize)))
 
-		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(6))
+		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(expectedVolumesLen))
 
 		Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal(vm.Name + "-containerdisk-0"))
 		Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.ContainerDisk).ToNot(BeNil())
@@ -345,8 +354,10 @@ chpasswd: { expire: False }`
 			terminationGracePeriod int64 = 123
 			pvcBootOrder                 = 1
 			blankSize                    = "10Gi"
+			expectedDVTLen               = 3
+			expectedVolumesLen           = 4
 		)
-		vmName := "vm-" + rand.String(5)
+		vmName := "vm-" + rand.String(randNameTail)
 		instancetype := createInstancetype(virtClient)
 		preference := createPreference(virtClient)
 		dataSource := createAnnotatedDataSource(virtClient, "something", preference.Name)
@@ -354,29 +365,30 @@ chpasswd: { expire: False }`
 		pvc := createAnnotatedSourcePVC(instancetype.Name, "something")
 		userDataB64 := base64.StdEncoding.EncodeToString([]byte(cloudInitUserData))
 
-		out, err := runCreateVmCmd(
-			setFlag(NameFlag, vmName),
-			setFlag(RunStrategyFlag, string(runStrategy)),
-			setFlag(TerminationGracePeriodFlag, fmt.Sprint(terminationGracePeriod)),
-			setFlag(InferInstancetypeFlag, "true"),
-			setFlag(InferPreferenceFromFlag, dvtDsName),
-			setFlag(VolumeImportFlag, fmt.Sprintf("type:ds,src:%s/%s,name:%s", dataSource.Namespace, dataSource.Name, dvtDsName)),
-			setFlag(VolumeImportFlag, fmt.Sprintf("type:pvc,src:%s/%s,bootorder:%d", pvc.Namespace, pvc.Name, pvcBootOrder)),
-			setFlag(VolumeImportFlag, "type:blank,size:"+blankSize),
-			setFlag(CloudInitUserDataFlag, userDataB64),
+		out, err := runCreateVMCmd(
+			setFlag(vm.NameFlag, vmName),
+			setFlag(vm.RunStrategyFlag, string(runStrategy)),
+			setFlag(vm.TerminationGracePeriodFlag, fmt.Sprint(terminationGracePeriod)),
+			setFlag(vm.InferInstancetypeFlag, "true"),
+			setFlag(vm.InferPreferenceFromFlag, dvtDsName),
+			setFlag(vm.VolumeImportFlag, fmt.Sprintf("type:ds,src:%s/%s,name:%s", dataSource.Namespace, dataSource.Name, dvtDsName)),
+			setFlag(vm.VolumeImportFlag, fmt.Sprintf("type:pvc,src:%s/%s,bootorder:%d", pvc.Namespace, pvc.Name, pvcBootOrder)),
+			setFlag(vm.VolumeImportFlag, "type:blank,size:"+blankSize),
+			setFlag(vm.CloudInitUserDataFlag, userDataB64),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(vm.Name).To(Equal(vmName))
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(runStrategy)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(runStrategy)))
 
-		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(PointTo(Equal(terminationGracePeriod)))
+		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(gstruct.PointTo(Equal(terminationGracePeriod)))
 
 		Expect(vm.Spec.Instancetype).ToNot(BeNil())
 		Expect(vm.Spec.Instancetype.Kind).To(Equal(apiinstancetype.SingularResourceName))
@@ -391,12 +403,12 @@ chpasswd: { expire: False }`
 		Expect(vm.Spec.Preference.InferFromVolume).To(BeEmpty())
 		Expect(vm.Spec.Preference.InferFromVolumeFailurePolicy).To(BeNil())
 
-		Expect(vm.Spec.DataVolumeTemplates).To(HaveLen(3))
+		Expect(vm.Spec.DataVolumeTemplates).To(HaveLen(expectedDVTLen))
 
 		Expect(vm.Spec.DataVolumeTemplates[0].Name).To(Equal(dvtDsName))
 		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef).ToNot(BeNil())
 		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Kind).To(Equal("DataSource"))
-		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Namespace).To(PointTo(Equal(dataSource.Namespace)))
+		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Namespace).To(gstruct.PointTo(Equal(dataSource.Namespace)))
 		Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Name).To(Equal(dataSource.Name))
 
 		Expect(vm.Spec.DataVolumeTemplates[1].Name).To(MatchRegexp(importedVolumeRegexp))
@@ -410,7 +422,7 @@ chpasswd: { expire: False }`
 		Expect(vm.Spec.DataVolumeTemplates[2].Spec.Source.Blank).ToNot(BeNil())
 		Expect(vm.Spec.DataVolumeTemplates[2].Spec.Storage.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse(blankSize)))
 
-		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(4))
+		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(expectedVolumesLen))
 
 		Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal(vm.Spec.DataVolumeTemplates[0].Name))
 		Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.DataVolume).ToNot(BeNil())
@@ -445,37 +457,39 @@ chpasswd: { expire: False }`
 			memory                       = "4Gi"
 			cdSource                     = "my.registry/my-image:my-tag"
 			blankSize                    = "10Gi"
+			expectedVolumesLen           = 3
 		)
-		vmName := "vm-" + rand.String(5)
+		vmName := "vm-" + rand.String(randNameTail)
 		preference := createPreference(virtClient)
 		userDataB64 := base64.StdEncoding.EncodeToString([]byte(cloudInitUserData))
 
-		out, err := runCreateVmCmd(
-			setFlag(NameFlag, vmName),
-			setFlag(RunStrategyFlag, string(runStrategy)),
-			setFlag(TerminationGracePeriodFlag, fmt.Sprint(terminationGracePeriod)),
-			setFlag(MemoryFlag, memory),
-			setFlag(PreferenceFlag, fmt.Sprintf("%s/%s", apiinstancetype.SingularPreferenceResourceName, preference.Name)),
-			setFlag(ContainerdiskVolumeFlag, "src:"+cdSource),
-			setFlag(VolumeImportFlag, "type:blank,size:"+blankSize),
-			setFlag(CloudInitUserDataFlag, userDataB64),
+		out, err := runCreateVMCmd(
+			setFlag(vm.NameFlag, vmName),
+			setFlag(vm.RunStrategyFlag, string(runStrategy)),
+			setFlag(vm.TerminationGracePeriodFlag, fmt.Sprint(terminationGracePeriod)),
+			setFlag(vm.MemoryFlag, memory),
+			setFlag(vm.PreferenceFlag, fmt.Sprintf("%s/%s", apiinstancetype.SingularPreferenceResourceName, preference.Name)),
+			setFlag(vm.ContainerdiskVolumeFlag, "src:"+cdSource),
+			setFlag(vm.VolumeImportFlag, "type:blank,size:"+blankSize),
+			setFlag(vm.CloudInitUserDataFlag, userDataB64),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(vm.Name).To(Equal(vmName))
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(runStrategy)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(runStrategy)))
 
-		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(PointTo(Equal(terminationGracePeriod)))
+		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(gstruct.PointTo(Equal(terminationGracePeriod)))
 
 		Expect(vm.Spec.Instancetype).To(BeNil())
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse(memory))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse(memory))))
 
 		Expect(vm.Spec.Preference).ToNot(BeNil())
 		Expect(vm.Spec.Preference.Kind).To(Equal(apiinstancetype.SingularPreferenceResourceName))
@@ -490,7 +504,7 @@ chpasswd: { expire: False }`
 		Expect(vm.Spec.DataVolumeTemplates[0].Spec.Source.Blank).ToNot(BeNil())
 		Expect(vm.Spec.DataVolumeTemplates[0].Spec.Storage.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse(blankSize)))
 
-		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(3))
+		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(expectedVolumesLen))
 
 		Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal(vm.Name + "-containerdisk-0"))
 		Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.ContainerDisk).ToNot(BeNil())
@@ -514,38 +528,40 @@ chpasswd: { expire: False }`
 			runStrategy                  = v1.RunStrategyManual
 			terminationGracePeriod int64 = 123
 			cdSource                     = "my.registry/my-image:my-tag"
+			expectedVolumesLen           = 2
 		)
 
-		cm := libconfigmap.New("cm-"+rand.String(5), map[string]string{"Autounattend.xml": "test"})
+		cm := libconfigmap.New("cm-"+rand.String(randNameTail), map[string]string{"Autounattend.xml": "test"})
 		cm, err := virtClient.CoreV1().ConfigMaps(testsuite.GetTestNamespace(nil)).Create(context.Background(), cm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		out, err := runCreateVmCmd(
-			setFlag(RunStrategyFlag, string(runStrategy)),
-			setFlag(TerminationGracePeriodFlag, fmt.Sprint(terminationGracePeriod)),
-			setFlag(ContainerdiskVolumeFlag, "src:"+cdSource),
-			setFlag(SysprepVolumeFlag, "src:"+cm.Name),
+		out, err := runCreateVMCmd(
+			setFlag(vm.RunStrategyFlag, string(runStrategy)),
+			setFlag(vm.TerminationGracePeriodFlag, fmt.Sprint(terminationGracePeriod)),
+			setFlag(vm.ContainerdiskVolumeFlag, "src:"+cdSource),
+			setFlag(vm.SysprepVolumeFlag, "src:"+cm.Name),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(runStrategy)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(runStrategy)))
 
-		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(PointTo(Equal(terminationGracePeriod)))
+		Expect(vm.Spec.Template.Spec.TerminationGracePeriodSeconds).To(gstruct.PointTo(Equal(terminationGracePeriod)))
 
 		Expect(vm.Spec.Instancetype).To(BeNil())
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse("512Mi"))))
 
 		Expect(vm.Spec.Preference).To(BeNil())
 
 		Expect(vm.Spec.DataVolumeTemplates).To(BeEmpty())
 
-		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(expectedVolumesLen))
 
 		Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal(vm.Name + "-containerdisk-0"))
 		Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.ContainerDisk).ToNot(BeNil())
@@ -559,15 +575,19 @@ chpasswd: { expire: False }`
 	})
 
 	It("[test_id:11652]Complex example with generated cloud-init config", func() {
-		const user = "alpine"
+		const (
+			user               = "alpine"
+			randPassLen        = 12
+			expectedVolumesLen = 2
+		)
 		cdSource := cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)
 		tmpDir := GinkgoT().TempDir()
-		password := rand.String(12)
+		password := rand.String(randPassLen)
 
 		path := filepath.Join(tmpDir, "pw")
 		pwFile, err := os.Create(path)
 		Expect(err).ToNot(HaveOccurred())
-		_, err = pwFile.Write([]byte(password))
+		_, err = pwFile.WriteString(password)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pwFile.Close()).To(Succeed())
 
@@ -577,11 +597,11 @@ chpasswd: { expire: False }`
 		Expect(libssh.DumpPrivateKey(priv, keyFile)).To(Succeed())
 		sshKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pub)))
 
-		out, err := runCreateVmCmd(
-			setFlag(ContainerdiskVolumeFlag, "src:"+cdSource),
-			setFlag(UserFlag, user),
-			setFlag(PasswordFileFlag, path), // This is required to unlock the alpine user
-			setFlag(SSHKeyFlag, sshKey),
+		out, err := runCreateVMCmd(
+			setFlag(vm.ContainerdiskVolumeFlag, "src:"+cdSource),
+			setFlag(vm.UserFlag, user),
+			setFlag(vm.PasswordFileFlag, path), // This is required to unlock the alpine user
+			setFlag(vm.SSHKeyFlag, sshKey),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
@@ -590,17 +610,17 @@ chpasswd: { expire: False }`
 		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(v1.RunStrategyAlways)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(v1.RunStrategyAlways)))
 
 		Expect(vm.Spec.Instancetype).To(BeNil())
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse("512Mi"))))
 
 		Expect(vm.Spec.Preference).To(BeNil())
 
 		Expect(vm.Spec.DataVolumeTemplates).To(BeEmpty())
 
-		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(expectedVolumesLen))
 
 		Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal(vm.Name + "-containerdisk-0"))
 		Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.ContainerDisk).ToNot(BeNil())
@@ -609,19 +629,23 @@ chpasswd: { expire: False }`
 		Expect(vm.Spec.Template.Spec.Volumes[1].Name).To(Equal(cloudInitDisk))
 		Expect(vm.Spec.Template.Spec.Volumes[1].CloudInitNoCloud).ToNot(BeNil())
 		Expect(vm.Spec.Template.Spec.Volumes[1].CloudInitNoCloud.UserData).To(ContainSubstring("user: " + user))
-		Expect(vm.Spec.Template.Spec.Volumes[1].CloudInitNoCloud.UserData).To(ContainSubstring("password: %s\nchpasswd: { expire: False }", password))
+		Expect(vm.Spec.Template.Spec.Volumes[1].CloudInitNoCloud.UserData).
+			To(ContainSubstring("password: %s\nchpasswd: { expire: False }", password))
 		Expect(vm.Spec.Template.Spec.Volumes[1].CloudInitNoCloud.UserData).To(ContainSubstring("ssh_authorized_keys:\n  - " + sshKey))
 
-		Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(BeReady())
+		Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
 		vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
+		libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 		runSSHCommand(vm.Namespace, vm.Name, user, keyFile)
 	})
 
 	It("[test_id:11653]Complex example with access credentials", func() {
-		const user = "fedora"
+		const (
+			user               = "fedora"
+			expectedVolumesLen = 2
+		)
 		cdSource := cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 
 		priv, pub, err := libssh.NewKeyPair()
@@ -630,13 +654,14 @@ chpasswd: { expire: False }`
 		Expect(libssh.DumpPrivateKey(priv, keyFile)).To(Succeed())
 		sshKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(pub)))
 
-		secret := libsecret.New("my-keys-"+rand.String(5), libsecret.DataString{"key1": sshKey})
-		secret, err = kubevirt.Client().CoreV1().Secrets(testsuite.GetTestNamespace(nil)).Create(context.Background(), secret, metav1.CreateOptions{})
+		secret := libsecret.New("my-keys-"+rand.String(randNameTail), libsecret.DataString{"key1": sshKey})
+		secret, err = kubevirt.Client().CoreV1().Secrets(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), secret, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		out, err := runCreateVmCmd(
-			setFlag(ContainerdiskVolumeFlag, "src:"+cdSource),
-			setFlag(AccessCredFlag, fmt.Sprintf("type:ssh,src:%s,method:ga,user:%s", secret.Name, user)),
+		out, err := runCreateVMCmd(
+			setFlag(vm.ContainerdiskVolumeFlag, "src:"+cdSource),
+			setFlag(vm.AccessCredFlag, fmt.Sprintf("type:ssh,src:%s,method:ga,user:%s", secret.Name, user)),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
@@ -645,34 +670,35 @@ chpasswd: { expire: False }`
 		vm, err = virtClient.VirtualMachine(secret.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(vm.Spec.RunStrategy).To(PointTo(Equal(v1.RunStrategyAlways)))
+		Expect(vm.Spec.RunStrategy).To(gstruct.PointTo(Equal(v1.RunStrategyAlways)))
 
 		Expect(vm.Spec.Instancetype).To(BeNil())
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse("512Mi"))))
 
 		Expect(vm.Spec.Preference).To(BeNil())
 
 		Expect(vm.Spec.DataVolumeTemplates).To(BeEmpty())
 
-		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		Expect(vm.Spec.Template.Spec.Volumes).To(HaveLen(expectedVolumesLen))
 
 		Expect(vm.Spec.Template.Spec.Volumes[0].Name).To(Equal(vm.Name + "-containerdisk-0"))
 		Expect(vm.Spec.Template.Spec.Volumes[0].VolumeSource.ContainerDisk).ToNot(BeNil())
 
 		Expect(vm.Spec.Template.Spec.Volumes[1].Name).To(Equal(cloudInitDisk))
 		Expect(vm.Spec.Template.Spec.Volumes[1].CloudInitNoCloud).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Volumes[1].CloudInitNoCloud.UserData).To(Equal("#cloud-config\nruncmd:\n  - [ setsebool, -P, 'virt_qemu_ga_manage_ssh', 'on' ]"))
+		Expect(vm.Spec.Template.Spec.Volumes[1].CloudInitNoCloud.UserData).
+			To(Equal("#cloud-config\nruncmd:\n  - [ setsebool, -P, 'virt_qemu_ga_manage_ssh', 'on' ]"))
 
-		Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(BeReady())
+		Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
 		vmi, err := virtClient.VirtualMachineInstance(secret.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+		libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
 
 		Eventually(func(g Gomega) {
 			vmi, err := virtClient.VirtualMachineInstance(secret.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(vmi).To(HaveConditionTrue(v1.VirtualMachineInstanceAccessCredentialsSynchronized))
+			g.Expect(vmi).To(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAccessCredentialsSynchronized))
 		}, 60*time.Second, 1*time.Second).Should(Succeed())
 
 		runSSHCommand(secret.Namespace, vm.Name, user, keyFile)
@@ -680,33 +706,35 @@ chpasswd: { expire: False }`
 
 	It("[test_id:11654]Failure of implicit inference does not fail the VM creation", func() {
 		By("Creating a PVC without annotation labels")
-		pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(5), testsuite.GetTestNamespace(nil), size, nil)
+		pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(randNameTail), testsuite.GetTestNamespace(nil), size, nil)
 		volumeName := "imported-volume"
 
 		By("Creating a VM with implicit inference (inference enabled by default)")
-		out, err := runCreateVmCmd(
-			setFlag(VolumeImportFlag, fmt.Sprintf("type:pvc,size:%s,src:%s/%s,name:%s", size, pvc.Namespace, pvc.Name, volumeName)),
+		out, err := runCreateVMCmd(
+			setFlag(vm.VolumeImportFlag, fmt.Sprintf("type:pvc,size:%s,src:%s/%s,name:%s", size, pvc.Namespace, pvc.Name, volumeName)),
 		)
+		Expect(err).ToNot(HaveOccurred())
 		vm, err := decodeVM(out)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Asserting that implicit inference is enabled")
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse("512Mi"))))
 		Expect(vm.Spec.Instancetype).ToNot(BeNil())
 		Expect(vm.Spec.Instancetype.InferFromVolume).To(Equal(volumeName))
-		Expect(vm.Spec.Instancetype.InferFromVolumeFailurePolicy).To(PointTo(Equal(v1.IgnoreInferFromVolumeFailure)))
+		Expect(vm.Spec.Instancetype.InferFromVolumeFailurePolicy).To(gstruct.PointTo(Equal(v1.IgnoreInferFromVolumeFailure)))
 		Expect(vm.Spec.Preference).ToNot(BeNil())
 		Expect(vm.Spec.Preference.InferFromVolume).To(Equal(volumeName))
-		Expect(vm.Spec.Preference.InferFromVolumeFailurePolicy).To(PointTo(Equal(v1.IgnoreInferFromVolumeFailure)))
+		Expect(vm.Spec.Preference.InferFromVolumeFailurePolicy).To(gstruct.PointTo(Equal(v1.IgnoreInferFromVolumeFailure)))
 
 		By("Performing dry run creation of the VM")
-		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+		vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).
+			Create(context.Background(), vm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Asserting that matchers were cleared and memory was kept")
 		Expect(vm.Spec.Template.Spec.Domain.Memory).ToNot(BeNil())
-		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(PointTo(Equal(resource.MustParse("512Mi"))))
+		Expect(vm.Spec.Template.Spec.Domain.Memory.Guest).To(gstruct.PointTo(Equal(resource.MustParse("512Mi"))))
 		Expect(vm.Spec.Instancetype).To(BeNil())
 		Expect(vm.Spec.Preference).To(BeNil())
 
@@ -732,7 +760,7 @@ func setFlag(flag, parameter string) string {
 	return fmt.Sprintf("--%s=%s", flag, parameter)
 }
 
-func runCreateVmCmd(args ...string) ([]byte, error) {
+func runCreateVMCmd(args ...string) ([]byte, error) {
 	_args := append([]string{create.CREATE, "vm"}, args...)
 	return newRepeatableVirtctlCommandWithOut(_args...)()
 }
@@ -757,7 +785,8 @@ func createInstancetype(virtClient kubecli.KubevirtClient) *instancetypev1beta1.
 		builder.WithCPUs(1),
 		builder.WithMemory(size),
 	)
-	instancetype, err := virtClient.VirtualMachineInstancetype(testsuite.GetTestNamespace(nil)).Create(context.Background(), instancetype, metav1.CreateOptions{})
+	instancetype, err := virtClient.VirtualMachineInstancetype(testsuite.GetTestNamespace(nil)).
+		Create(context.Background(), instancetype, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	return instancetype
 }
@@ -766,7 +795,8 @@ func createPreference(virtClient kubecli.KubevirtClient) *instancetypev1beta1.Vi
 	preference := builder.NewPreference(
 		builder.WithPreferredCPUTopology(instancetypev1beta1.Cores),
 	)
-	preference, err := virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(nil)).Create(context.Background(), preference, metav1.CreateOptions{})
+	preference, err := virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(nil)).
+		Create(context.Background(), preference, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	return preference
 }
@@ -786,13 +816,15 @@ func createAnnotatedDataSource(virtClient kubecli.KubevirtClient, instancetypeNa
 			Source: cdiv1.DataSourceSource{},
 		},
 	}
-	dataSource, err := virtClient.CdiClient().CdiV1beta1().DataSources(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataSource, metav1.CreateOptions{})
+	dataSource, err := virtClient.CdiClient().CdiV1beta1().DataSources(testsuite.GetTestNamespace(nil)).
+		Create(context.Background(), dataSource, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	return dataSource
 }
 
 func createAnnotatedSourcePVC(instancetypeName, preferenceName string) *k8sv1.PersistentVolumeClaim {
-	return libstorage.CreateFSPVC("vm-pvc-"+rand.String(5), testsuite.GetTestNamespace(nil), size, map[string]string{
+	const randNameTail = 5
+	return libstorage.CreateFSPVC("vm-pvc-"+rand.String(randNameTail), testsuite.GetTestNamespace(nil), size, map[string]string{
 		apiinstancetype.DefaultInstancetypeLabel:     instancetypeName,
 		apiinstancetype.DefaultInstancetypeKindLabel: apiinstancetype.SingularResourceName,
 		apiinstancetype.DefaultPreferenceLabel:       preferenceName,

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -327,8 +327,14 @@ func verifyMemoryDumpFile(dumpFilePath, dumpName string) {
 		case tar.TypeReg:
 			extractedFile, err := os.Create(filepath.Join(extractPath, header.Name))
 			Expect(err).ToNot(HaveOccurred())
-			_, err = io.Copy(extractedFile, tarReader)
-			Expect(err).ToNot(HaveOccurred())
+			for {
+				const megabyte = 1024 * 1024
+				_, err = io.CopyN(extractedFile, tarReader, megabyte)
+				if err != nil && err == io.EOF {
+					break
+				}
+				Expect(err).ToNot(HaveOccurred())
+			}
 			Expect(extractedFile.Close()).To(Succeed())
 		default:
 			Fail("unknown tar header type")

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -52,6 +52,7 @@ import (
 
 var _ = VirtctlDescribe("[sig-storage]Memory dump", decorators.SigStorage, func() {
 	const (
+		randNameTail    = 5
 		claimNameFlag   = "--claim-name"
 		createClaimFlag = "--create-claim"
 		outputFlag      = "--output"
@@ -68,13 +69,13 @@ var _ = VirtctlDescribe("[sig-storage]Memory dump", decorators.SigStorage, func(
 			Fail("Fail no filesystem storage class available")
 		}
 
-		pvcName = "fs-pvc-" + rand.String(5)
+		pvcName = "fs-pvc-" + rand.String(randNameTail)
 
 		vm = libvmi.NewVirtualMachine(libvmifact.NewCirros(), libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		var err error
 		vm, err = kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(BeReady())
+		Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
 	})
 
 	DescribeTable("Should be able to get and remove memory dump", func(create bool) {
@@ -118,7 +119,7 @@ var _ = VirtctlDescribe("[sig-storage]Memory dump", decorators.SigStorage, func(
 		Expect(runMemoryDumpRemoveCmd(vm.Name)).To(Succeed())
 		out = waitForMemoryDumpDeletion(vm.Name, pvcName, out, true)
 
-		pvcName2 := "fs-pvc-" + rand.String(5)
+		pvcName2 := "fs-pvc-" + rand.String(randNameTail)
 		Expect(runMemoryDumpGetCmd(vm.Name, claimNameFlag, pvcName2, createClaimFlag)).To(Succeed())
 		out = waitForMemoryDumpCompletion(vm.Name, pvcName2, out, false)
 		Expect(runMemoryDumpRemoveCmd(vm.Name)).To(Succeed())
@@ -138,7 +139,8 @@ var _ = VirtctlDescribe("[sig-storage]Memory dump", decorators.SigStorage, func(
 		}
 		Expect(runMemoryDumpGetCmd(vm.Name, args...)).To(Succeed())
 
-		vm, err := kubevirt.Client().VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		var err error
+		vm, err = kubevirt.Client().VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(vm.Status.MemoryDumpRequest.FileName).ToNot(BeNil())
 		verifyMemoryDumpFile(output, *vm.Status.MemoryDumpRequest.FileName)
@@ -158,7 +160,8 @@ var _ = VirtctlDescribe("[sig-storage]Memory dump", decorators.SigStorage, func(
 		}
 		Expect(runMemoryDumpDownloadCmd(vm.Name, args...)).To(Succeed())
 
-		vm, err := kubevirt.Client().VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		var err error
+		vm, err = kubevirt.Client().VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(vm.Status.MemoryDumpRequest.FileName).ToNot(BeNil())
 		verifyMemoryDumpFile(output, *vm.Status.MemoryDumpRequest.FileName)
@@ -180,6 +183,7 @@ func runMemoryDumpDownloadCmd(name string, args ...string) error {
 	}, args...)
 	return newRepeatableVirtctlCommand(_args...)()
 }
+
 func runMemoryDumpRemoveCmd(name string, args ...string) error {
 	_args := append([]string{
 		"memory-dump", "remove", name,
@@ -214,7 +218,8 @@ func waitForMemoryDumpCompletion(vmName, pvcName, previousOut string, shouldEqua
 			return false
 		}
 
-		pvc, err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Get(context.Background(), pvcName, metav1.GetOptions{})
+		pvc, err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).
+			Get(context.Background(), pvcName, metav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(pvc.Annotations).To(HaveKeyWithValue(v1.PVCMemoryDumpAnnotation, *vm.Status.MemoryDumpRequest.FileName))
 
@@ -245,7 +250,8 @@ func waitForMemoryDumpDeletion(vmName, pvcName, previousOut string, shouldEqual 
 	}, 90*time.Second, 2*time.Second).Should(BeTrue())
 
 	// Expect PVC to still exist
-	pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Get(context.Background(), pvcName, metav1.GetOptions{})
+	pvc, err := virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).
+		Get(context.Background(), pvcName, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
 	return verifyMemoryDumpPVC(pvc, previousOut, shouldEqual)
@@ -254,8 +260,9 @@ func waitForMemoryDumpDeletion(vmName, pvcName, previousOut string, shouldEqual 
 func verifyMemoryDumpPVC(pvc *k8sv1.PersistentVolumeClaim, previousOut string, shouldEqual bool) string {
 	virtClient := kubevirt.Client()
 
+	const randNameTail = 5
 	pod := libstorage.RenderPodWithPVC(
-		"pod-"+rand.String(5),
+		"pod-"+rand.String(randNameTail),
 		[]string{"/bin/bash", "-c", "touch /tmp/startup; while true; do echo hello; sleep 2; done"},
 		nil, pvc,
 	)
@@ -269,7 +276,7 @@ func verifyMemoryDumpPVC(pvc *k8sv1.PersistentVolumeClaim, previousOut string, s
 
 	pod, err := virtClient.CoreV1().Pods(testsuite.GetTestNamespace(nil)).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	Eventually(ThisPod(pod), 120*time.Second, 1*time.Second).Should(HaveConditionTrue(k8sv1.PodReady))
+	Eventually(matcher.ThisPod(pod), 120*time.Second, 1*time.Second).Should(matcher.HaveConditionTrue(k8sv1.PodReady))
 
 	lsOut, err := exec.ExecuteCommandOnPod(
 		pod, pod.Spec.Containers[0].Name,
@@ -316,20 +323,25 @@ func verifyMemoryDumpFile(dumpFilePath, dumpName string) {
 	tarReader := tar.NewReader(gzReader)
 
 	for {
-		header, err := tarReader.Next()
+		var header *tar.Header
+		header, err = tarReader.Next()
 		if err == io.EOF {
 			break
 		}
 		Expect(err).ToNot(HaveOccurred())
 		switch header.Typeflag {
 		case tar.TypeDir:
-			path, err := sanitizedPath(extractPath, header.Name)
+			var path string
+			path, err = sanitizedPath(extractPath, header.Name)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(os.MkdirAll(path, 0o750)).To(Succeed())
+			const permRWXRW = 0o750
+			Expect(os.MkdirAll(path, permRWXRW)).To(Succeed())
 		case tar.TypeReg:
-			path, err := sanitizedPath(extractPath, header.Name)
+			var path string
+			path, err = sanitizedPath(extractPath, header.Name)
 			Expect(err).ToNot(HaveOccurred())
-			extractedFile, err := os.Create(path)
+			var extractedFile *os.File
+			extractedFile, err = os.Create(path)
 			Expect(err).ToNot(HaveOccurred())
 			for {
 				const megabyte = 1024 * 1024

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -334,8 +334,8 @@ func verifyMemoryDumpFile(dumpFilePath, dumpName string) {
 			var path string
 			path, err = sanitizedPath(extractPath, header.Name)
 			Expect(err).ToNot(HaveOccurred())
-			const permRWXRW = 0o750
-			Expect(os.MkdirAll(path, permRWXRW)).To(Succeed())
+			const permRWX = 0o700
+			Expect(os.MkdirAll(path, permRWX)).To(Succeed())
 		case tar.TypeReg:
 			var path string
 			path, err = sanitizedPath(extractPath, header.Name)

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -145,9 +145,10 @@ var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 		copyFromDir := filepath.Join(GinkgoT().TempDir(), "sourcedir")
 		copyToDir := filepath.Join(GinkgoT().TempDir(), "targetdir")
 
-		Expect(os.Mkdir(copyFromDir, 0777)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(copyFromDir, "file1"), []byte("test"), 0777)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(copyFromDir, "file2"), []byte("test1"), 0777)).To(Succeed())
+		const permRWXAll = 0o777
+		Expect(os.Mkdir(copyFromDir, permRWXAll)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(copyFromDir, "file1"), []byte("test"), permRWXAll)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(copyFromDir, "file2"), []byte("test1"), permRWXAll)).To(Succeed())
 
 		By("copying a file to the VMI")
 		copyFn(copyFromDir, vmi.Name+":"+"./sourcedir", true)
@@ -175,7 +176,7 @@ var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 	})
 })
 
-func compareFile(file1 string, file2 string) {
+func compareFile(file1, file2 string) {
 	expected, err := os.ReadFile(file1)
 	Expect(err).ToNot(HaveOccurred())
 	actual, err := os.ReadFile(file2)

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -145,10 +145,13 @@ var _ = VirtctlDescribe("[sig-compute]SCP", decorators.SigCompute, func() {
 		copyFromDir := filepath.Join(GinkgoT().TempDir(), "sourcedir")
 		copyToDir := filepath.Join(GinkgoT().TempDir(), "targetdir")
 
-		const permRWXAll = 0o777
-		Expect(os.Mkdir(copyFromDir, permRWXAll)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(copyFromDir, "file1"), []byte("test"), permRWXAll)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(copyFromDir, "file2"), []byte("test1"), permRWXAll)).To(Succeed())
+		const (
+			permRWX = 0o700
+			permRW  = 0o600
+		)
+		Expect(os.Mkdir(copyFromDir, permRWX)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(copyFromDir, "file1"), []byte("test"), permRW)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(copyFromDir, "file2"), []byte("test1"), permRW)).To(Succeed())
 
 		By("copying a file to the VMI")
 		copyFn(copyFromDir, vmi.Name+":"+"./sourcedir", true)

--- a/tests/virtctl/vnc.go
+++ b/tests/virtctl/vnc.go
@@ -51,12 +51,14 @@ var _ = VirtctlDescribe("[sig-compute]VNC", decorators.SigCompute, decorators.Wg
 	BeforeEach(func() {
 		var err error
 		vmi = libvmifact.NewGuestless()
-		vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+		vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).
+			Create(context.Background(), vmi, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		vmi = libwait.WaitForSuccessfulVMIStart(vmi)
 	})
 
-	It("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component][test_id:4272]should connect to vnc with --proxy-only flag", func() {
+	It("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]"+
+		"[test_id:4272]should connect to vnc with --proxy-only flag", func() {
 		By("Invoking virtctl vnc with --proxy-only")
 		r, w, _ := os.Pipe()
 		cmd := newVirtctlCommand(
@@ -80,7 +82,8 @@ var _ = VirtctlDescribe("[sig-compute]VNC", decorators.SigCompute, decorators.Wg
 		verifyProxyConnection(fmt.Sprintf("%v", result["port"]), vmi.Name)
 	})
 
-	It("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component][test_id:5274]should connect to vnc with --proxy-only flag to the specified port", func() {
+	It("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]"+
+		"[test_id:5274]should connect to vnc with --proxy-only flag to the specified port", func() {
 		const testPort = "33333"
 
 		By("Invoking virtctl vnc with --proxy-only")
@@ -99,7 +102,8 @@ var _ = VirtctlDescribe("[sig-compute]VNC", decorators.SigCompute, decorators.Wg
 		verifyProxyConnection(testPort, vmi.Name)
 	})
 
-	It("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component][test_id:11667]should allow creating a VNC screenshot in PNG format", func() {
+	It("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]"+
+		"[test_id:11667]should allow creating a VNC screenshot in PNG format", func() {
 		// The default resolution is 720x400 for the vga/boch device used on amd64 and ppcl64,
 		// while it is 1280x800 for the virtio device used on arm64 and s390x.
 		size := image.Point{720, 400}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Enable the linter for cmd/virtctl and tests/virtctl and fix all found issues to make it pass.

Before this PR:

The linter does not run on cmd/virtctl and tests/virtctl.

After this PR:

The linter runs on cmd/virtctl and tests/virtctl, all found issues are resolved.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

