### PR TITLE
[release-1.4] fix(virtctl,create): Validate names of disks

### DIFF
--- a/pkg/virtctl/create/vm/BUILD.bazel
+++ b/pkg/virtctl/create/vm/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",

--- a/pkg/virtctl/create/vm/vm_test.go
+++ b/pkg/virtctl/create/vm/vm_test.go
@@ -1300,9 +1300,31 @@ chpasswd: { expire: False }`
 	})
 
 	Describe("Manifest is not created successfully", func() {
-		DescribeTable("Invalid arguments to RunStrategyFlag", func(runStrategy string) {
-			out, err := runCmd(setFlag(RunStrategyFlag, runStrategy))
-			Expect(err).To(MatchError(fmt.Sprintf("failed to parse \"--run-strategy\" flag: invalid run strategy \"%s\", supported values are: Always, Manual, Halted, Once, RerunOnFailure", runStrategy)))
+		const (
+			nameDotsError          = "invalid name \"name.with.dot\": must not contain dots"
+			nameTooLongError       = "invalid name \"somanycharactersthatthedisksnameislooooongerthantheallowedlength\": must be no more than 63 characters"
+			dns1123LabelError      = "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"
+			nameUpperCaseError     = "invalid name \"NOTALLOWED\": " + dns1123LabelError
+			nameDashBeginningError = "invalid name \"-notallowed\": " + dns1123LabelError
+		)
+
+		DescribeTable("Invalid parameter to NameFlag when a volume name is derived from it", func(param, errMsg string) {
+			out, err := runCmd(
+				setFlag(NameFlag, param),
+				setFlag(ContainerdiskVolumeFlag, "src:my.registry/my-image:my-tag"),
+			)
+			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("failed to parse \"--volume-containerdisk\" flag: invalid name \"%s-containerdisk-0\": %s", param, errMsg))))
+			Expect(out).To(BeEmpty())
+		},
+			Entry("invalid character (dot)", "name.with.dot", "must not contain dots"),
+			Entry("derived name will have more than 63 characters", "manycharacterssothatthedisknamewillbetoolongerthantheallowedlength", "must be no more than 63 characters"),
+			Entry("upper case", "NOTALLOWED", dns1123LabelError),
+			Entry("dash at the beginning", "-notallowed", dns1123LabelError),
+		)
+
+		DescribeTable("Invalid parameter to RunStrategyFlag", func(param string) {
+			out, err := runCmd(setFlag(RunStrategyFlag, param))
+			Expect(err).To(MatchError(fmt.Sprintf("failed to parse \"--run-strategy\" flag: invalid run strategy \"%s\", supported values are: Always, Manual, Halted, Once, RerunOnFailure", param)))
 			Expect(out).To(BeEmpty())
 		},
 			Entry("some string", "not-a-bool"),
@@ -1436,6 +1458,10 @@ chpasswd: { expire: False }`
 			Entry("Invalid number in bootorder", "bootorder:10Gu", "failed to parse \"--volume-containerdisk\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"10Gu\": invalid syntax"),
 			Entry("Negative number in bootorder", "bootorder:-1", "failed to parse \"--volume-containerdisk\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"-1\": invalid syntax"),
 			Entry("Bootorder set to 0", "src:my.registry/my-image:my-tag,bootorder:0", "failed to parse \"--volume-containerdisk\" flag: bootorder must be greater than 0"),
+			Entry("invalid character (dot)", "src:my.registry/my-image:my-tag,name:name.with.dot", "failed to parse \"--volume-containerdisk\" flag: "+nameDotsError),
+			Entry("name has more than 63 characters", "src:my.registry/my-image:my-tag,name:somanycharactersthatthedisksnameislooooongerthantheallowedlength", "failed to parse \"--volume-containerdisk\" flag: "+nameTooLongError),
+			Entry("upper case", "src:my.registry/my-image:my-tag,name:NOTALLOWED", "failed to parse \"--volume-containerdisk\" flag: "+nameUpperCaseError),
+			Entry("dash at the beginning", "src:my.registry/my-image:my-tag,name:-notallowed", "failed to parse \"--volume-containerdisk\" flag: "+nameDashBeginningError),
 		)
 
 		DescribeTable("Invalid arguments to DataSourceVolumeFlag", func(flag, errMsg string) {
@@ -1453,6 +1479,10 @@ chpasswd: { expire: False }`
 			Entry("Invalid number in bootorder", "bootorder:10Gu", "failed to parse \"--volume-import\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"10Gu\": invalid syntax"),
 			Entry("Negative number in bootorder", "bootorder:-1", "failed to parse \"--volume-import\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"-1\": invalid syntax"),
 			Entry("Bootorder set to 0", "src:my-ds,bootorder:0", "failed to parse \"--volume-import\" flag: bootorder must be greater than 0"),
+			Entry("invalid character (dot)", "src:my-ds,name:name.with.dot", "failed to parse \"--volume-import\" flag: "+nameDotsError),
+			Entry("name has more than 63 characters", "src:my-ds,name:somanycharactersthatthedisksnameislooooongerthantheallowedlength", "failed to parse \"--volume-import\" flag: "+nameTooLongError),
+			Entry("upper case", "src:my-ds,name:NOTALLOWED", "failed to parse \"--volume-import\" flag: "+nameUpperCaseError),
+			Entry("dash at the beginning", "src:my-ds,name:-notallowed", "failed to parse \"--volume-import\" flag: "+nameDashBeginningError),
 		)
 
 		DescribeTable("Invalid arguments to ClonePvcVolumeFlag", func(flag, errMsg string) {
@@ -1471,6 +1501,10 @@ chpasswd: { expire: False }`
 			Entry("Invalid number in bootorder", "bootorder:10Gu", "failed to parse \"--volume-import\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"10Gu\": invalid syntax"),
 			Entry("Negative number in bootorder", "bootorder:-1", "failed to parse \"--volume-import\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"-1\": invalid syntax"),
 			Entry("Bootorder set to 0", "src:my-ns/my-pvc,bootorder:0", "failed to parse \"--volume-import\" flag: bootorder must be greater than 0"),
+			Entry("invalid character (dot)", "src:my-ns/my-pvc,name:name.with.dot", "failed to parse \"--volume-import\" flag: "+nameDotsError),
+			Entry("name has more than 63 characters", "src:my-ns/my-pvc,name:somanycharactersthatthedisksnameislooooongerthantheallowedlength", "failed to parse \"--volume-import\" flag: "+nameTooLongError),
+			Entry("upper case", "src:my-ns/my-pvc,name:NOTALLOWED", "failed to parse \"--volume-import\" flag: "+nameUpperCaseError),
+			Entry("dash at the beginning", "src:my-ns/my-pvc,name:-notallowed", "failed to parse \"--volume-import\" flag: "+nameDashBeginningError),
 		)
 
 		DescribeTable("Invalid arguments to PvcVolumeFlag", func(flag, errMsg string) {
@@ -1488,6 +1522,10 @@ chpasswd: { expire: False }`
 			Entry("Invalid number in bootorder", "bootorder:10Gu", "failed to parse \"--volume-pvc\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"10Gu\": invalid syntax"),
 			Entry("Negative number in bootorder", "bootorder:-1", "failed to parse \"--volume-pvc\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"-1\": invalid syntax"),
 			Entry("Bootorder set to 0", "src:my-pvc,bootorder:0", "failed to parse \"--volume-pvc\" flag: bootorder must be greater than 0"),
+			Entry("invalid character (dot)", "src:my-pvc,name:name.with.dot", "failed to parse \"--volume-pvc\" flag: "+nameDotsError),
+			Entry("name has more than 63 characters", "src:my-pvc,name:somanycharactersthatthedisksnameislooooongerthantheallowedlength", "failed to parse \"--volume-pvc\" flag: "+nameTooLongError),
+			Entry("upper case", "src:my-pvc,name:NOTALLOWED", "failed to parse \"--volume-pvc\" flag: "+nameUpperCaseError),
+			Entry("dash at the beginning", "src:my-pvc,name:-notallowed", "failed to parse \"--volume-pvc\" flag: "+nameDashBeginningError),
 		)
 
 		DescribeTable("Invalid arguments to BlankVolumeFlag", func(flag, errMsg string) {
@@ -1499,6 +1537,10 @@ chpasswd: { expire: False }`
 			Entry("Invalid param", "test=test", "failed to parse \"--volume-import\" flag: params need to have at least one colon: test=test"),
 			Entry("Unknown param", "test:test", "failed to parse \"--volume-import\" flag: unknown param(s): test:test"),
 			Entry("Missing size", "name:my-blank", "failed to parse \"--volume-import\" flag: size must be specified"),
+			Entry("invalid character (dot)", "size:256Mi,name:name.with.dot", "failed to parse \"--volume-import\" flag: "+nameDotsError),
+			Entry("name has more than 63 characters", "size:256Mi,name:somanycharactersthatthedisksnameislooooongerthantheallowedlength", "failed to parse \"--volume-import\" flag: "+nameTooLongError),
+			Entry("upper case", "size:256Mi,name:NOTALLOWED", "failed to parse \"--volume-import\" flag: "+nameUpperCaseError),
+			Entry("dash at the beginning", "size:256Mi,name:-notallowed", "failed to parse \"--volume-import\" flag: "+nameDashBeginningError),
 		)
 
 		DescribeTable("Invalid arguments to VolumeImportFlag", func(errMsg string, flags ...string) {
@@ -1547,6 +1589,10 @@ chpasswd: { expire: False }`
 			Entry("Invalid number in bootorder", "failed to parse \"--volume-import\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"10Gu\": invalid syntax", setFlag(VolumeImportFlag, "type:blank,size:256Mi,bootorder:10Gu")),
 			Entry("Negative number in bootorder", "failed to parse \"--volume-import\" flag: failed to parse param \"bootorder\": strconv.ParseUint: parsing \"-1\": invalid syntax", setFlag(VolumeImportFlag, "type:blank,size:256Mi,bootorder:-1")),
 			Entry("Bootorder set to 0", "failed to parse \"--volume-import\" flag: bootorder must be greater than 0", setFlag(VolumeImportFlag, "type:blank,size:256Mi,bootorder:0")),
+			Entry("Name has invalid character (dot)", "failed to parse \"--volume-import\" flag: "+nameDotsError, setFlag(VolumeImportFlag, "type:blank,size:256Mi,name:name.with.dot")),
+			Entry("Name has more than 63 characters", "failed to parse \"--volume-import\" flag: "+nameTooLongError, setFlag(VolumeImportFlag, "type:blank,size:256Mi,name:somanycharactersthatthedisksnameislooooongerthantheallowedlength")),
+			Entry("Name has upper case character", "failed to parse \"--volume-import\" flag: "+nameUpperCaseError, setFlag(VolumeImportFlag, "type:blank,size:256Mi,name:NOTALLOWED")),
+			Entry("Name has dash at the beginning", "failed to parse \"--volume-import\" flag: "+nameDashBeginningError, setFlag(VolumeImportFlag, "type:blank,size:256Mi,name:-notallowed")),
 		)
 
 		DescribeTable("Invalid arguments to SysprepVolumeFlag", func(flag, errMsg string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual backport of https://github.com/kubevirt/kubevirt/pull/13547

Before this PR:

virtctl create vm allows to generate VMs with disk names that will lead to rejection of the VM upon creation.

After this PR:

virtctl create vm validates disk names and prevents disk names that will lead to rejection of a VM upon creation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/13340

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl create vm validates disk names and prevents disk names that will lead to rejection of a VM upon creation.
```

