### PR TITLE
[release-1.3] fix(virtctl,create): Validate names of disks

### DIFF
--- a/pkg/virtctl/create/vm/BUILD.bazel
+++ b/pkg/virtctl/create/vm/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",

--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/clientcmd"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/api/instancetype"
@@ -736,6 +737,10 @@ func withContainerdiskVolume(c *createVM, vm *v1.VirtualMachine) error {
 			vol.Name = fmt.Sprintf("%s-containerdisk-%d", vm.Name, i)
 		}
 
+		if errs := validation.IsDNS1123Label(vol.Name); len(errs) > 0 {
+			return params.FlagErr(ContainerdiskVolumeFlag, "invalid name \"%s\": %s", vol.Name, strings.Join(errs, ","))
+		}
+
 		if err := volumeShouldNotExist(ContainerdiskVolumeFlag, vm, vol.Name); err != nil {
 			return err
 		}
@@ -776,6 +781,10 @@ func withDataSourceVolume(c *createVM, vm *v1.VirtualMachine) error {
 
 		if vol.Name == "" {
 			vol.Name = fmt.Sprintf("%s-ds-%s", vm.Name, name)
+		}
+
+		if errs := validation.IsDNS1123Label(vol.Name); len(errs) > 0 {
+			return params.FlagErr(DataSourceVolumeFlag, "invalid name \"%s\": %s", vol.Name, strings.Join(errs, ","))
 		}
 
 		if err := volumeShouldNotExist(DataSourceVolumeFlag, vm, vol.Name); err != nil {
@@ -845,6 +854,10 @@ func withClonePvcVolume(c *createVM, vm *v1.VirtualMachine) error {
 			vol.Name = fmt.Sprintf("%s-pvc-%s", vm.Name, name)
 		}
 
+		if errs := validation.IsDNS1123Label(vol.Name); len(errs) > 0 {
+			return params.FlagErr(ClonePvcVolumeFlag, "invalid name \"%s\": %s", vol.Name, strings.Join(errs, ","))
+		}
+
 		if err := volumeShouldNotExist(ClonePvcVolumeFlag, vm, vol.Name); err != nil {
 			return err
 		}
@@ -911,6 +924,10 @@ func withPvcVolume(c *createVM, vm *v1.VirtualMachine) error {
 			vol.Name = name
 		}
 
+		if errs := validation.IsDNS1123Label(vol.Name); len(errs) > 0 {
+			return params.FlagErr(PvcVolumeFlag, "invalid name \"%s\": %s", vol.Name, strings.Join(errs, ","))
+		}
+
 		if err := volumeShouldNotExist(PvcVolumeFlag, vm, vol.Name); err != nil {
 			return err
 		}
@@ -948,6 +965,10 @@ func withBlankVolume(c *createVM, vm *v1.VirtualMachine) error {
 
 		if vol.Name == "" {
 			vol.Name = fmt.Sprintf("%s-blank-%d", vm.Name, i)
+		}
+
+		if errs := validation.IsDNS1123Label(vol.Name); len(errs) > 0 {
+			return params.FlagErr(BlankVolumeFlag, "invalid name \"%s\": %s", vol.Name, strings.Join(errs, ","))
 		}
 
 		if err := volumeShouldNotExist(BlankVolumeFlag, vm, vol.Name); err != nil {
@@ -1298,6 +1319,10 @@ func withVolumeSourceSnapshot(paramStr string) (*cdiv1.DataVolumeSource, error) 
 }
 
 func createVolumeWithSource(source *cdiv1.DataVolumeSource, size string, name string, vm *v1.VirtualMachine) error {
+	if errs := validation.IsDNS1123Label(name); len(errs) > 0 {
+		return params.FlagErr(VolumeImportFlag, "invalid name \"%s\": %s", name, strings.Join(errs, ","))
+	}
+
 	if err := volumeShouldNotExist(VolumeImportFlag, vm, name); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual backport of https://github.com/kubevirt/kubevirt/pull/13547

Before this PR:

virtctl create vm allows to generate VMs with disk names that will lead to rejection of the VM upon creation.

After this PR:

virtctl create vm validates disk names and prevents disk names that will lead to rejection of a VM upon creation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes https://github.com/kubevirt/kubevirt/issues/13340

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl create vm validates disk names and prevents disk names that will lead to rejection of a VM upon creation.
```