### PR TITLE
[release 1.3] VMRestore: allow creating vmrestore even if runstrategy is not Halted

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -418,15 +418,6 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 
 	log.Log.Object(t.vmRestore).V(3).Info("Checking VM ready")
 
-	rs, err := t.vm.RunStrategy()
-	if err != nil {
-		return false, err
-	}
-
-	if rs != kubevirtv1.RunStrategyHalted {
-		return false, fmt.Errorf("invalid RunStrategy %q", rs)
-	}
-
 	vmiKey, err := controller.KeyFunc(t.vm)
 	if err != nil {
 		return false, err

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -264,7 +264,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				}
 			})
 
-			It("should reject when VM is running", func() {
+			It("should reject when VMI exists", func() {
 				restore := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "restore",
@@ -280,16 +280,22 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 					},
 				}
 
-				vm.Spec.Running = &t
+				vmi := &v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: vmName,
+						UID:  "vmi-UID",
+					},
+				}
 
 				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
+				resp := createTestVMRestoreAdmitter(config, vm, snapshot, vmi).Admit(ar)
 				Expect(resp.Allowed).To(BeFalse())
 				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
+				Expect(resp.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("VirtualMachineInstance %q exists, VM must be stopped before restore", vmName)))
 			})
 
-			It("should reject when VM run strategy is not halted", func() {
+			It("should allow when VM run strategy is not halted", func() {
 				restore := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "restore",
@@ -309,10 +315,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 
 				ar := createRestoreAdmissionReview(restore)
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(HaveLen(1))
-				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
-				Expect(resp.Result.Details.Causes[0].Message).To(Equal(fmt.Sprintf("VirtualMachine %q run strategy has to be %s", vmName, v1.RunStrategyHalted)))
+				Expect(resp.Allowed).To(BeTrue())
 			})
 
 			It("should reject when snapshot does not exist", func() {
@@ -667,17 +670,22 @@ func createTestVMRestoreAdmitter(
 	ctrl := gomock.NewController(GinkgoT())
 	virtClient := kubecli.NewMockKubevirtClient(ctrl)
 	vmInterface := kubecli.NewMockVirtualMachineInterface(ctrl)
+	vmiInterface := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 	kubevirtClient := kubevirtfake.NewSimpleClientset(objs...)
 
 	virtClient.EXPECT().VirtualMachineSnapshot("default").
 		Return(kubevirtClient.SnapshotV1beta1().VirtualMachineSnapshots("default")).AnyTimes()
 	virtClient.EXPECT().VirtualMachine(gomock.Any()).Return(vmInterface).AnyTimes()
+	virtClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(vmiInterface).AnyTimes()
 
+	var vmi *v1.VirtualMachineInstance
 	restoreInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineRestore{})
 	for _, obj := range objs {
-		r, ok := obj.(*snapshotv1.VirtualMachineRestore)
-		if ok {
-			restoreInformer.GetIndexer().Add(r)
+		switch v := obj.(type) {
+		case *snapshotv1.VirtualMachineRestore:
+			restoreInformer.GetIndexer().Add(v)
+		case *v1.VirtualMachineInstance:
+			vmi = v
 		}
 	}
 
@@ -686,7 +694,16 @@ func createTestVMRestoreAdmitter(
 			return vm, nil
 		}
 
-		err := errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, "foo")
+		err := errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, name)
+		return nil, err
+	}).AnyTimes()
+
+	vmiInterface.EXPECT().Get(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, name string, getOptions metav1.GetOptions) (*v1.VirtualMachineInstance, error) {
+		if vmi != nil && name == vmi.Name {
+			return vmi, nil
+		}
+
+		err := errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineInstances"}, name)
 		return nil, err
 	}).AnyTimes()
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -383,12 +383,16 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
+				Eventually(func() error {
+					_, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+					return err
+				}, 300*time.Second, 2*time.Second).Should(Succeed())
 
 				restore := createRestoreDef(vm.Name, snapshot.Name)
 
 				_, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("VirtualMachine %q is not stopped", vm.Name)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("VirtualMachineInstance %q exists, VM must be stopped before restore", vm.Name)))
 			})
 
 			It("[test_id:5258]should reject restore if another in progress", func() {


### PR DESCRIPTION
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/13420
Jira-ticket: https://issues.redhat.com/browse/CNV-53953

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMRestore: allow creating vmrestore even if runstrategy is not Halted
```

