### PR TITLE
[release 1.2] VMRestore: allow creating vmrestore even if runstrategy is not Halted

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -419,15 +419,6 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 
 	log.Log.Object(t.vmRestore).V(3).Info("Checking VM ready")
 
-	rs, err := t.vm.RunStrategy()
-	if err != nil {
-		return false, err
-	}
-
-	if rs != kubevirtv1.RunStrategyHalted {
-		return false, fmt.Errorf("invalid RunStrategy %q", rs)
-	}
-
 	vmiKey, err := controller.KeyFunc(t.vm)
 	if err != nil {
 		return false, err

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -35,8 +35,8 @@ import (
 
 	"kubevirt.io/api/core"
 
-	v1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
+
 	"kubevirt.io/client-go/kubecli"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
@@ -192,38 +192,29 @@ func (admitter *VMRestoreAdmitter) validateCreateVM(field *k8sfield.Path, vmRest
 	vm, err := admitter.Client.VirtualMachine(namespace).Get(context.Background(), vmName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		// If the target VM does not exist it would be automatically created by the restore controller
-		return nil, nil, false, nil
+		return causes, nil, false, nil
 	}
 
 	if err != nil {
 		return nil, nil, false, err
 	}
 
-	rs, err := vm.RunStrategy()
+	targetField := field.Child("target")
+	_, err = admitter.Client.VirtualMachineInstance(namespace).Get(context.Background(), vmName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return causes, &vm.UID, true, nil
+	}
 	if err != nil {
-		return nil, nil, true, err
+		return nil, nil, false, err
 	}
 
-	if rs != v1.RunStrategyHalted {
-		var cause metav1.StatusCause
-		targetField := field.Child("target")
-		if vm.Spec.Running != nil && *vm.Spec.Running {
-			cause = metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("VirtualMachine %q is not stopped", vmName),
-				Field:   targetField.String(),
-			}
-		} else {
-			cause = metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("VirtualMachine %q run strategy has to be %s", vmName, v1.RunStrategyHalted),
-				Field:   targetField.String(),
-			}
-		}
-		causes = append(causes, cause)
-	}
+	causes = append(causes, metav1.StatusCause{
+		Type:    metav1.CauseTypeFieldValueInvalid,
+		Message: fmt.Sprintf("VirtualMachineInstance %q exists, VM must be stopped before restore", vmName),
+		Field:   targetField.String(),
+	})
 
-	return causes, &vm.UID, true, nil
+	return causes, nil, true, nil
 }
 
 func (admitter *VMRestoreAdmitter) validatePatches(patches []string, field *k8sfield.Path) (causes []metav1.StatusCause) {


### PR DESCRIPTION
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/13420
Jira-ticket: https://issues.redhat.com/browse/CNV-53954

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMRestore: allow creating vmrestore even if runstrategy is not Halted
```
