### PR TITLE
instancetype: Rename find preference implementation functions

### DIFF
--- a/pkg/instancetype/apply/vm.go
+++ b/pkg/instancetype/apply/vm.go
@@ -21,30 +21,41 @@ package apply
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	virtv1 "kubevirt.io/api/core/v1"
 	v1beta1 "kubevirt.io/api/instancetype/v1beta1"
 )
+
+type vmiApplyHandler interface {
+	ApplyToVMI(
+		field *k8sfield.Path,
+		instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec,
+		preferenceSpec *v1beta1.VirtualMachinePreferenceSpec,
+		vmiSpec *virtv1.VirtualMachineInstanceSpec,
+		vmiMetadata *metav1.ObjectMeta,
+	) (conflicts Conflicts)
+}
 
 type specFinder interface {
 	Find(*virtv1.VirtualMachine) (*v1beta1.VirtualMachineInstancetypeSpec, error)
 }
 
 type preferenceSpecFinder interface {
-	Find(*virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error)
+	FindPreference(*virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error)
 }
 
 type vmApplier struct {
-	vmiApplier         *vmiApplier
-	instancetypeFinder specFinder
-	preferenceFinder   preferenceSpecFinder
+	vmiApplyHandler
+	specFinder
+	preferenceSpecFinder
 }
 
 func NewVMApplier(instancetypeFinder specFinder, preferenceFinder preferenceSpecFinder) *vmApplier {
 	return &vmApplier{
-		vmiApplier:         NewVMIApplier(),
-		instancetypeFinder: instancetypeFinder,
-		preferenceFinder:   preferenceFinder,
+		vmiApplyHandler:      NewVMIApplier(),
+		specFinder:           instancetypeFinder,
+		preferenceSpecFinder: preferenceFinder,
 	}
 }
 
@@ -52,15 +63,15 @@ func (a *vmApplier) ApplyToVM(vm *virtv1.VirtualMachine) error {
 	if vm.Spec.Instancetype == nil && vm.Spec.Preference == nil {
 		return nil
 	}
-	instancetypeSpec, err := a.instancetypeFinder.Find(vm)
+	instancetypeSpec, err := a.Find(vm)
 	if err != nil {
 		return err
 	}
-	preferenceSpec, err := a.preferenceFinder.Find(vm)
+	preferenceSpec, err := a.FindPreference(vm)
 	if err != nil {
 		return err
 	}
-	if conflicts := a.vmiApplier.ApplyToVMI(
+	if conflicts := a.ApplyToVMI(
 		k8sfield.NewPath("spec"),
 		instancetypeSpec,
 		preferenceSpec,

--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -130,7 +130,7 @@ func (m *InstancetypeMethods) ApplyToVmi(field *k8sfield.Path, instancetypeSpec 
 }
 
 func (m *InstancetypeMethods) FindPreferenceSpec(vm *virtv1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error) {
-	return preferenceFind.NewSpecFinder(m.PreferenceStore, m.ClusterPreferenceStore, m.ControllerRevisionStore, m.Clientset).Find(vm)
+	return preferenceFind.NewSpecFinder(m.PreferenceStore, m.ClusterPreferenceStore, m.ControllerRevisionStore, m.Clientset).FindPreference(vm)
 }
 
 func (m *InstancetypeMethods) FindInstancetypeSpec(vm *virtv1.VirtualMachine) (*instancetypev1beta1.VirtualMachineInstancetypeSpec, error) {

--- a/pkg/instancetype/preference/find/cluster_preference.go
+++ b/pkg/instancetype/preference/find/cluster_preference.go
@@ -41,7 +41,7 @@ func NewClusterPreferenceFinder(store cache.Store, virtClient kubecli.KubevirtCl
 	}
 }
 
-func (f *clusterPreferenceFinder) Find(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachineClusterPreference, error) {
+func (f *clusterPreferenceFinder) FindPreference(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachineClusterPreference, error) {
 	if vm.Spec.Preference == nil {
 		return nil, nil
 	}

--- a/pkg/instancetype/preference/find/preference.go
+++ b/pkg/instancetype/preference/find/preference.go
@@ -42,7 +42,7 @@ func NewPreferenceFinder(store cache.Store, virtClient kubecli.KubevirtClient) *
 	}
 }
 
-func (f *preferenceFinder) Find(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreference, error) {
+func (f *preferenceFinder) FindPreference(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreference, error) {
 	if vm.Spec.Preference == nil {
 		return nil, nil
 	}

--- a/pkg/instancetype/preference/find/revision.go
+++ b/pkg/instancetype/preference/find/revision.go
@@ -44,7 +44,7 @@ func NewRevisionFinder(store cache.Store, virtClient kubecli.KubevirtClient) *re
 	}
 }
 
-func (f *revisionFinder) Find(vm *virtv1.VirtualMachine) (*appsv1.ControllerRevision, error) {
+func (f *revisionFinder) FindPreference(vm *virtv1.VirtualMachine) (*appsv1.ControllerRevision, error) {
 	if vm.Spec.Preference == nil {
 		return nil, nil
 	}

--- a/pkg/instancetype/preference/find/spec.go
+++ b/pkg/instancetype/preference/find/spec.go
@@ -48,13 +48,13 @@ func NewSpecFinder(store, clusterStore, revisionStore cache.Store, virtClient ku
 
 const unexpectedKindFmt = "got unexpected kind in PreferenceMatcher: %s"
 
-func (f *specFinder) Find(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error) {
+func (f *specFinder) FindPreference(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachinePreferenceSpec, error) {
 	if vm.Spec.Preference == nil {
 		return nil, nil
 	}
 
 	if vm.Spec.Preference.RevisionName != "" {
-		revision, err := f.revisionFinder.Find(vm)
+		revision, err := f.revisionFinder.FindPreference(vm)
 		if err != nil {
 			return nil, err
 		}
@@ -63,13 +63,13 @@ func (f *specFinder) Find(vm *virtv1.VirtualMachine) (*v1beta1.VirtualMachinePre
 
 	switch strings.ToLower(vm.Spec.Preference.Kind) {
 	case api.SingularPreferenceResourceName, api.PluralPreferenceResourceName:
-		preference, err := f.preferenceFinder.Find(vm)
+		preference, err := f.preferenceFinder.FindPreference(vm)
 		if err != nil {
 			return nil, err
 		}
 		return &preference.Spec, nil
 	case api.ClusterSingularPreferenceResourceName, api.ClusterPluralPreferenceResourceName, "":
-		clusterPreference, err := f.clusterPreferenceFinder.Find(vm)
+		clusterPreference, err := f.clusterPreferenceFinder.FindPreference(vm)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instancetype/revision/store.go
+++ b/pkg/instancetype/revision/store.go
@@ -141,13 +141,13 @@ func (h *revisionHandler) storePreferenceRevision(vm *virtv1.VirtualMachine) (*a
 func (h *revisionHandler) createPreferenceRevision(vm *virtv1.VirtualMachine) (*appsv1.ControllerRevision, error) {
 	switch strings.ToLower(vm.Spec.Preference.Kind) {
 	case api.SingularPreferenceResourceName, api.PluralPreferenceResourceName:
-		preference, err := preferenceFind.NewPreferenceFinder(h.preferenceStore, h.virtClient).Find(vm)
+		preference, err := preferenceFind.NewPreferenceFinder(h.preferenceStore, h.virtClient).FindPreference(vm)
 		if err != nil {
 			return nil, err
 		}
 		return h.storeControllerRevision(vm, preference)
 	case api.ClusterSingularPreferenceResourceName, api.ClusterPluralPreferenceResourceName:
-		clusterPreference, err := preferenceFind.NewClusterPreferenceFinder(h.clusterPreferenceStore, h.virtClient).Find(vm)
+		clusterPreference, err := preferenceFind.NewClusterPreferenceFinder(h.clusterPreferenceStore, h.virtClient).FindPreference(vm)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
/cc @0xFelix 
/kind cleanup

### What this PR does
At present we only typically require one instance type and one preference find implementation. However as both sets provide a single Find function we need to wrap these within a struct when pulling them into a larger object.

This commit avoids this by simply renaming the find preference implementation function to FindPreference allowing us to in-line interfaces directly.

This commit also in-lines interfaces requesting ApplyToVMI as this also shouldn't be wrapped with a standalone struct.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

