### PR TITLE
feat: pass timeout from virt-monitor to virt-tail

### DIFF
--- a/cmd/virt-tail/main.go
+++ b/cmd/virt-tail/main.go
@@ -42,6 +42,9 @@ import (
 	virtwait "kubevirt.io/kubevirt/pkg/apimachinery/wait"
 )
 
+// initial timeout for serial console socket creation
+const initialSocketTimeout = time.Second * 20
+
 type TermFileError struct{}
 type SocketFileError struct{}
 
@@ -54,9 +57,10 @@ func (m *SocketFileError) Error() string {
 }
 
 type VirtTail struct {
-	ctx     context.Context
-	logFile string
-	g       *errgroup.Group
+	ctx           context.Context
+	logFile       string
+	g             *errgroup.Group
+	socketTimeout *time.Duration
 }
 
 func (v *VirtTail) checkFile(socketFile string) bool {
@@ -136,10 +140,8 @@ func (v *VirtTail) watchFS() error {
 		return err
 	}
 
-	// initial timeout for serial console socket creation
-	const initialSocketTimeout = time.Second * 20
 	socketCheckCh := make(chan int)
-	time.AfterFunc(initialSocketTimeout, func() {
+	time.AfterFunc(*v.socketTimeout, func() {
 		socketCheckCh <- 1
 	})
 
@@ -197,6 +199,7 @@ func main() {
 	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
 	pflag.CommandLine.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
 	logFile := pflag.String("logfile", "", "path of the logfile to be streamed")
+	socketTimeout := pflag.Duration("socket-timeout", initialSocketTimeout, "Amount of time to wait for qemu")
 	pflag.Parse()
 
 	log.InitializeLogging("virt-tail")
@@ -214,9 +217,10 @@ func main() {
 	g, gctx := errgroup.WithContext(ctx)
 
 	v := &VirtTail{
-		ctx:     gctx,
-		logFile: *logFile,
-		g:       g,
+		ctx:           gctx,
+		logFile:       *logFile,
+		socketTimeout: socketTimeout,
+		g:             g,
 	}
 
 	g.Go(v.tailLogs)

--- a/pkg/virt-controller/services/serialconsolelog.go
+++ b/pkg/virt-controller/services/serialconsolelog.go
@@ -13,7 +13,7 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-func generateSerialConsoleLogContainer(vmi *v1.VirtualMachineInstance, image string, config *virtconfig.ClusterConfig, virtLauncherLogVerbosity uint) *k8sv1.Container {
+func generateSerialConsoleLogContainer(vmi *v1.VirtualMachineInstance, image string, config *virtconfig.ClusterConfig, virtLauncherLogVerbosity uint, socketTimeout string) *k8sv1.Container {
 	const serialPort = 0
 	if isSerialConsoleLogEnabled(vmi, config) {
 		logFile := fmt.Sprintf("%s/%s/virt-serial%d-log", util.VirtPrivateDir, vmi.ObjectMeta.UID, serialPort)
@@ -25,7 +25,7 @@ func generateSerialConsoleLogContainer(vmi *v1.VirtualMachineInstance, image str
 			Image:           image,
 			ImagePullPolicy: k8sv1.PullIfNotPresent,
 			Command:         []string{"/usr/bin/virt-tail"},
-			Args:            []string{"--logfile", logFile},
+			Args:            []string{"--logfile", logFile, "--socket-timeout", socketTimeout},
 			VolumeMounts: []k8sv1.VolumeMount{
 				k8sv1.VolumeMount{
 					Name:      "private",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -398,6 +398,8 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	var command []string
+	var qemuTimeout = generateQemuTimeoutWithJitter(t.launcherQemuTimeout)
+
 	if tempPod {
 		logger := log.DefaultLogger()
 		logger.Infof("RUNNING doppleganger pod for %s", vmi.Name)
@@ -406,7 +408,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			"echo", "bound PVCs"}
 	} else {
 		command = []string{"/usr/bin/virt-launcher-monitor",
-			"--qemu-timeout", generateQemuTimeoutWithJitter(t.launcherQemuTimeout),
+			"--qemu-timeout", qemuTimeout,
 			"--name", domain,
 			"--uid", string(vmi.UID),
 			"--namespace", namespace,
@@ -502,7 +504,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		containers = append(containers, virtiofsContainers...)
 	}
 
-	sconsolelogContainer := generateSerialConsoleLogContainer(vmi, t.launcherImage, t.clusterConfig, virtLauncherLogVerbosity)
+	sconsolelogContainer := generateSerialConsoleLogContainer(vmi, t.launcherImage, t.clusterConfig, virtLauncherLogVerbosity, qemuTimeout)
 	if sconsolelogContainer != nil {
 		containers = append(containers, *sconsolelogContainer)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

When the `virt-tail` times out, the `virt-monitor` still works well.

After this PR:

The `virt-tail` and `virt-monitor` share same timeout. If one of them works, they both should work.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13466

### Why we need it and why it was done in this way
The following tradeoffs were made:

In original design, the `virt-tail` only accepts 20 seconds timeout. However, the `virt-monitor` might take more than 20 seconds to start. At that moment, the `virt-tail` couldn't tail the `compute` container, even the compute container works well.

The following alternatives were considered:

Although we can retry when the `virt-tail` fails, I think using retry or modifying timeout to 30 second or more is not a effective way to fix this issue.

Links to places where the discussion took place: Please check comments in https://github.com/kubevirt/kubevirt/issues/13466

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure virt-tail and virt-monitor have the same timeout, preventing early termination of virt-tail while virt-monitor is still starting
```

