### PR TITLE
 tests/libnode: Unify exec command on node functions

### DIFF
--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -461,16 +461,12 @@ func GetNodeHostModel(node *k8sv1.Node) (hostModel string) {
 	return hostModel
 }
 
-func ExecuteCommandOnNodeThroughVirtHandler(nodeName string, command []string) (stdout, stderr string, err error) {
+func ExecuteCommandInVirtHandlerPod(nodeName string, args []string) (stdout string, err error) {
 	virtHandlerPod, err := GetVirtHandlerPod(kubevirt.Client(), nodeName)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
-	return exec.ExecuteCommandOnPodWithResults(virtHandlerPod, components.VirtHandlerName, command)
-}
-
-func ExecuteCommandInVirtHandlerPod(nodeName string, args []string) (stdout string, err error) {
-	stdout, stderr, err := ExecuteCommandOnNodeThroughVirtHandler(nodeName, args)
+	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(virtHandlerPod, components.VirtHandlerName, args)
 	if err != nil {
 		return stdout, fmt.Errorf("failed excuting command=%v, error=%v, stdout=%s, stderr=%s", args, err, stdout, stderr)
 	}

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -368,12 +368,11 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 		var driverPath string
 		var rootPCIId string
 
-		runBashCmd := func(cmd string) (string, string, error) {
+		runBashCmd := func(cmd string) (string, error) {
 			args := []string{"bash", "-x", "-c", cmd}
-			stdout, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(node, args)
+			stdout, err := libnode.ExecuteCommandInVirtHandlerPod(node, args)
 			stdout = strings.TrimSpace(stdout)
-			stderr = strings.TrimSpace(stderr)
-			return stdout, stderr, err
+			return stdout, err
 		}
 
 		runBashCmdRw := func(cmd string) error {
@@ -417,26 +416,26 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 
 		It("should create mdevs on devices that appear after CR configuration", func() {
 			By("looking for an mdev-compatible PCI device")
-			out, e, err := runBashCmd(findMdevCapableDevices)
-			Expect(err).ToNot(HaveOccurred(), e)
+			out, err := runBashCmd(findMdevCapableDevices)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(ContainSubstring(mdevBusPath))
 			pciId := "'" + filepath.Base(out) + "'"
 
 			By("finding the driver")
-			driverPath, e, err = runBashCmd("readlink -e " + mdevBusPath + pciId + "/driver")
-			Expect(err).ToNot(HaveOccurred(), e)
+			driverPath, err = runBashCmd("readlink -e " + mdevBusPath + pciId + "/driver")
+			Expect(err).ToNot(HaveOccurred())
 			Expect(driverPath).To(ContainSubstring("drivers"))
 
 			By("finding a supported type")
-			out, e, err = runBashCmd(fmt.Sprintf(findSupportedTypeFmt, pciId))
-			Expect(err).ToNot(HaveOccurred(), e)
+			out, err = runBashCmd(fmt.Sprintf(findSupportedTypeFmt, pciId))
+			Expect(err).ToNot(HaveOccurred())
 			Expect(out).ToNot(BeEmpty())
 			mdevType := filepath.Base(out)
 
 			By("finding the name of the device")
 			fileName := fmt.Sprintf(deviceNameFmt, pciId, mdevType)
-			deviceName, e, err := runBashCmd("cat " + fileName)
-			Expect(err).ToNot(HaveOccurred(), e)
+			deviceName, err := runBashCmd("cat " + fileName)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(deviceName).ToNot(BeEmpty())
 
 			By("unbinding the device from its driver")
@@ -445,7 +444,7 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 			err = runBashCmdRw(fmt.Sprintf(unbindCmdFmt, rootPCIId, driverPath))
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				_, _, err = runBashCmd("ls " + mdevBusPath + pciId)
+				_, err = runBashCmd("ls " + mdevBusPath + pciId)
 				return err
 			}).Should(HaveOccurred(), "failed to disable the VFs on "+rootPCIId)
 
@@ -470,14 +469,14 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 			err = runBashCmdRw(fmt.Sprintf(bindCmdFmt, rootPCIId, driverPath))
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				_, _, err = runBashCmd("ls " + mdevBusPath + pciId)
+				_, err = runBashCmd("ls " + mdevBusPath + pciId)
 				return err
 			}).ShouldNot(HaveOccurred(), "failed to re-enable the VFs on "+rootPCIId)
 
 			By("expecting the creation of a mediated device")
 			mdevUUIDPath := fmt.Sprintf(mdevUUIDPathFmt, pciId, uuidRegex)
 			Eventually(func() error {
-				uuidPath, _, err := runBashCmd("ls -d " + mdevUUIDPath + " | head -1")
+				uuidPath, err := runBashCmd("ls -d " + mdevUUIDPath + " | head -1")
 				if err != nil {
 					return err
 				}
@@ -486,7 +485,7 @@ var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decora
 				}
 				uuid := strings.TrimSpace(filepath.Base(uuidPath))
 				mdevTypePath := fmt.Sprintf(mdevTypePathFmt, pciId, uuid)
-				effectiveTypePath, _, err := runBashCmd("readlink -e " + mdevTypePath)
+				effectiveTypePath, err := runBashCmd("readlink -e " + mdevTypePath)
 				if err != nil {
 					return err
 				}

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -215,8 +215,8 @@ var _ = Describe("[sig-compute]SwapTest", Serial, decorators.SigCompute, func() 
 })
 
 func getMemInfoByString(node v1.Node, field string) int {
-	stdout, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(node.Name, []string{"grep", field, "/proc/meminfo"})
-	ExpectWithOffset(2, err).ToNot(HaveOccurred(), fmt.Sprintf("stderr: %v \n", stderr))
+	stdout, err := libnode.ExecuteCommandInVirtHandlerPod(node.Name, []string{"grep", field, "/proc/meminfo"})
+	ExpectWithOffset(2, err).ToNot(HaveOccurred())
 	fields := strings.Fields(stdout)
 	size, err := strconv.Atoi(fields[1])
 	ExpectWithOffset(2, err).ToNot(HaveOccurred())

--- a/tests/virt-handler_test.go
+++ b/tests/virt-handler_test.go
@@ -51,9 +51,8 @@ var _ = Describe("[sig-compute]virt-handler", decorators.SigCompute, func() {
 
 		getHandlerConnectionCount := func(nodeName string) int {
 			cmd := []string{"bash", "-c", fmt.Sprintf("ss -ntlap | grep %d | wc -l", virt_api.DefaultConsoleServerPort)}
-			stdout, stderr, err := libnode.ExecuteCommandOnNodeThroughVirtHandler(nodeName, cmd)
+			stdout, err := libnode.ExecuteCommandInVirtHandlerPod(nodeName, cmd)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stderr).To(BeEmpty())
 
 			stdout = strings.TrimSpace(stdout)
 			stdout = strings.ReplaceAll(stdout, "\n", "")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Continuing #13104 

The functions `ExecuteCommandInVirtHandlerPod` and `ExecuteCommandOnNodeThroughVirtHandler` are pretty much the same.
The only difference is `ExecuteCommandOnNodeThroughVirtHandler` returning the command stderr as is.
While `ExecuteCommandInVirtHandlerPod` combine the stderr as part of the returned error.

Since in all `ExecuteCommandOnNodeThroughVirtHandler` usages, the returned stderr is printed in one way or another (e.g.:  reported  it though ginkgoExpect message).
There is no value in returning it over having stderr part of the returned error message.

Hence, merge `ExecuteCommandOnNodeThroughVirtHandler` into `ExecuteCommandInVirtHandlerPod`.

Before this PR:
Some tests use `ExecuteCommandOnNodeThroughVirtHandler` and others `ExecuteCommandInVirtHandlerPod`.

After this PR:
All tests use `ExecuteCommandInVirtHandlerPod`.
`ExecuteCommandOnNodeThroughVirtHandler` is removed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

