### PR TITLE
[release-1.4] fix: resolve critical issue with keyboard input for s390x

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1652,6 +1652,11 @@ var _ = Describe("Converter", func() {
 			if isAMD64(arch) && (autoAttach == nil || *autoAttach) {
 				Expect(domain.Spec.Devices.Video[0].Model.Type).To(Equal("vga"))
 			}
+			if isS390X(arch) && (autoAttach == nil || *autoAttach) {
+				Expect(domain.Spec.Devices.Video[0].Model.Type).To(Equal(v1.VirtIO))
+				Expect(domain.Spec.Devices.Inputs[0].Type).To(Equal(v1.InputTypeKeyboard))
+				Expect(domain.Spec.Devices.Inputs[0].Bus).To(Equal(v1.InputBusVirtio))
+			}
 		},
 			Entry("and add the graphics and video device if it is not set on amd64", nil, 1, "amd64"),
 			Entry("and add the graphics and video device if it is set to true on amd64", True(), 1, "amd64"),

--- a/pkg/virt-launcher/virtwrap/converter/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/s390x.go
@@ -37,6 +37,13 @@ func (archConverterS390X) addGraphicsDevice(vmi *v1.VirtualMachineInstance, doma
 			},
 		},
 	}
+
+	domain.Spec.Devices.Inputs = append(domain.Spec.Devices.Inputs,
+		api.Input{
+			Bus:  "virtio",
+			Type: "keyboard",
+		},
+	)
 }
 
 func (archConverterS390X) scsiController(c *ConverterContext, driver *api.ControllerDriver) api.Controller {


### PR DESCRIPTION
Testers reported that keyboard input was not recognized when attempting to access the VM via VNC. This issue arose because no virtual keyboard was configured for the s390x architecture. This explains why console and SSH access functioned without any problems.

Signed-off-by: Nestor Acuna Blanco <nestor.acuna@ibm.com>
(cherry picked from commit a12a14cf6620f7e2d02251751de733074f389208)

### What this PR does
Manual backport of [PR #13581](https://github.com/kubevirt/kubevirt/pull/13581)
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

