### PR TITLE
Disable guest console log for sig-storage jobs

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -109,6 +109,14 @@ done
 # Deploy KubeVirt
 _kubectl create -n ${namespace} -f ${MANIFESTS_OUT_DIR}/release/kubevirt-cr.yaml
 
+if [[ ${CI} == "true" ]]; then
+    if [[ $TARGET =~ sig-storage ]]; then
+        # The extra container causes flakes due to racy synchronization
+        # https://github.com/kubevirt/kubevirt/pull/13422
+        _kubectl patch kv -n ${namespace} kubevirt --type merge -p '{"spec": {"configuration": {"virtualMachineOptions": {"disableSerialConsoleLog": {}}}}}'
+    fi
+fi
+
 # Ensure the KubeVirt CR is created
 count=0
 until _kubectl -n ${namespace} get kv kubevirt; do


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This is causing flakes from time to time and is really not necessary:
```
                        "name": "guest-console-log",
                        "state": {
                            "terminated": {
                                "exitCode": 1,
                                "reason": "Error",
                                "startedAt": "2024-12-23T15:55:37Z",
                                "finishedAt": "2024-12-23T15:55:42Z",
                                "containerID": "cri-o://103d6477d3dbdb304205dc3ad3ef61c586568172155899cde22595c7bd177f8c"
                            }
                        },
```
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/13532/pull-kubevirt-e2e-k8s-1.31-sig-storage/1871215768218112000

More info about how it can be racy:
https://github.com/kubevirt/kubevirt/pull/13422

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

