### PR TITLE
Fix validateDataVolume function to allow externally populated Data Volume

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -422,7 +422,8 @@ func validateDataVolume(field *k8sfield.Path, dataVolume v1.DataVolumeTemplateSp
 		}}
 	}
 
-	if dataVolume.Spec.Source == nil && dataVolume.Spec.SourceRef == nil {
+	if (dataSourceRef == nil && dataSource == nil) &&
+		(dataVolume.Spec.Source == nil && dataVolume.Spec.SourceRef == nil) {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: "Data volume should have either Source, SourceRef, or be externally populated",


### PR DESCRIPTION
### What this PR does
Before this PR:
Unable to create VM with external dv population due to validating webhook.
```apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  labels:
    kubevirt.io/vm: test
  name: test
spec:
  dataVolumeTemplates:
  - metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/managed-by: kube-nfv
      name: cirros-0-6-3-x86-64-disk-dv
    spec:
      pvc:
        accessModes:
        - ReadWriteOnce
        dataSourceRef:
          apiGroup: cdi.kubevirt.io
          kind: VolumeImportSource
          name: cirros-0-6-3-x86-64-disk
        resources:
          requests:
            storage: 1Gi
  instancetype:
    kind: VirtualMachineInstanceType
    name: flavour-bb9b22f8-4844-4dfa-8030-e5b4bd094236
    revisionName: test-flavour-bb9b22f8-4844-4dfa-8030-e5b4bd094236-v1beta1-5476fdbc-7280-4eb9-9f7a-67e105a2fff8-1
  preference:
    kind: VirtualMachinePreference
    name: flavour-pref-bb9b22f8-4844-4dfa-8030-e5b4bd094236
    revisionName: test-flavour-pref-bb9b22f8-4844-4dfa-8030-e5b4bd094236-v1beta1-5cfb52b3-19fa-4edb-aeee-6d14faeca6aa-1
  runStrategy: Always
  template:
    metadata:
      creationTimestamp: null
      labels:
        kubevirt.io/vm: test
    spec:
      architecture: amd64
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: root-volume
          interfaces:
          - masquerade: {}
            name: default
        machine:
          type: q35
        resources: {}
      networks:
      - name: default
        pod: {}
      volumes:
      - dataVolume:
          name: cirros-0-6-3-x86-64-disk-dv
        name: root-volume        
```

After this PR:

Successfully create VM  external populator Data Volume.
```
dmalovan@debian $ kubectl get dv -n kube-nfv cirros-0-6-3-x86-64-disk-dv        
NAME                          PHASE       PROGRESS   RESTARTS   AGE
cirros-0-6-3-x86-64-disk-dv   Succeeded   N/A                   76m
dmalovan@debian $ kubectl get vm -n kube-nfv                            
NAME   AGE   STATUS    READY
test   77m   Running   True
```
# Issue
No Issue created.

### Why we need it and why it was done in this way
This feature seems to be expected to be working. It's just a fix for the incorrect if statement that doesn't allow it to work.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

