### PR TITLE
storage tests: get rid of most runtime skips

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -155,7 +155,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			if volumeMode == k8sv1.PersistentVolumeBlock {
 				sc, exists = libstorage.GetRWOBlockStorageClass()
 				if !exists {
-					Skip("Skip test when Block storage is not present")
+					Fail("Fail test when Block storage is not present")
 				}
 			} else {
 				sc, exists = libstorage.GetRWOFileSystemStorageClass()
@@ -223,7 +223,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				&expect.BExp{R: "0"},
 			}, 360)).To(Succeed(), "can use more space after expansion and resize")
 		},
-			Entry("with Block PVC", k8sv1.PersistentVolumeBlock),
+			Entry("with Block PVC", decorators.RequiresBlockStorage, k8sv1.PersistentVolumeBlock),
 			Entry("with Filesystem PVC", k8sv1.PersistentVolumeFilesystem),
 		)
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -779,7 +779,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 	})
 
 	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] DataVolume clone permission checking", func() {
-		Context("using Alpine import/clone", func() {
+		Context("using Alpine import/clone", decorators.RequiresSnapshotStorageClass, func() {
 			var dataVolume *cdiv1.DataVolume
 			var cloneRole *rbacv1.Role
 			var cloneRoleBinding *rbacv1.RoleBinding
@@ -790,7 +790,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				storageClass, err = libstorage.GetSnapshotStorageClass(virtClient)
 				Expect(err).ToNot(HaveOccurred())
 				if storageClass == "" {
-					Skip("Skiping test, no VolumeSnapshot support")
+					Fail("Failing test, no VolumeSnapshot support")
 				}
 
 				dataVolume = libdv.NewDataVolume(

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -160,7 +160,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			} else {
 				sc, exists = libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 			}
 			volumeExpansionAllowed := volumeExpansionAllowed(sc)
@@ -232,7 +232,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
+				Fail("Fail test when Filesystem storage is not present")
 			}
 
 			volumeExpansionAllowed := volumeExpansionAllowed(sc)
@@ -306,7 +306,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			It("[test_id:3189]should be successfully started and stopped multiple times", func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				dataVolume := libdv.NewDataVolume(
@@ -344,7 +344,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				imageUrl := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)
@@ -387,7 +387,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				dataVolume := libdv.NewDataVolume(
@@ -517,7 +517,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			It("should be possible to stop VM if datavolume is crashing", func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				dataVolume := libdv.NewDataVolume(
@@ -561,7 +561,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			It("[test_id:3190]should correctly handle eventually consistent DataVolumes", func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				realRegistryName := flags.KubeVirtUtilityRepoPrefix
@@ -634,7 +634,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		BeforeEach(func() {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
+				Fail("Fail test when Filesystem storage is not present")
 			}
 
 			vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, sc)
@@ -731,7 +731,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			It("[test_id:3191]should be successfully started and stopped multiple times", func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				vm := renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, sc)
@@ -757,7 +757,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			It("[test_id:3192]should remove owner references on DataVolume if VM is orphan deleted.", func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				vm := renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, sc)
@@ -1106,7 +1106,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img", func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
+				Fail("Fail test when Filesystem storage is not present")
 			}
 
 			dataVolume := libdv.NewDataVolume(
@@ -1220,7 +1220,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		BeforeEach(func() {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage class is not present")
+				Fail("Fail test when Filesystem storage class is not present")
 			}
 
 			vm = renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, sc)

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -95,7 +95,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		virtClient = kubevirt.Client()
 
 		if !libstorage.HasCDI() {
-			Skip("Skip DataVolume tests when CDI is not present")
+			Fail("Fail DataVolume tests when CDI is not present")
 		}
 	})
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -287,22 +287,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source", func() {
 		Context("Alpine import", func() {
-			BeforeEach(func() {
-				cdis, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cdis.Items).To(HaveLen(1))
-				hasWaitForFirstConsumerGate := false
-				for _, feature := range cdis.Items[0].Spec.Config.FeatureGates {
-					if feature == "HonorWaitForFirstConsumer" {
-						hasWaitForFirstConsumerGate = true
-						break
-					}
-				}
-				if !hasWaitForFirstConsumerGate {
-					Skip("HonorWaitForFirstConsumer is disabled in CDI, skipping tests relying on it")
-				}
-			})
-
 			It("[test_id:3189]should be successfully started and stopped multiple times", func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1365,11 +1365,11 @@ var _ = SIGDescribe("Export", func() {
 			})
 	}
 
-	It("should create export from VMSnapshot", func() {
+	It("should create export from VMSnapshot", decorators.RequiresSnapshotStorageClass, func() {
 		sc, err := libstorage.GetSnapshotStorageClass(virtClient)
 		Expect(err).ToNot(HaveOccurred())
 		if sc == "" {
-			Skip("Skip test when storage with snapshot is not present")
+			Fail("Fail test when storage with snapshot is not present")
 		}
 
 		vm := renderVMWithRegistryImportDataVolume(cd.ContainerDiskCirros, sc)
@@ -1435,11 +1435,11 @@ var _ = SIGDescribe("Export", func() {
 		return export
 	}
 
-	It("should create export from VMSnapshot with multiple volumes", func() {
+	It("should create export from VMSnapshot with multiple volumes", decorators.RequiresSnapshotStorageClass, func() {
 		sc, err := libstorage.GetSnapshotStorageClass(virtClient)
 		Expect(err).ToNot(HaveOccurred())
 		if sc == "" {
-			Skip("Skip test when storage with snapshot is not present")
+			Fail("Fail test when storage with snapshot is not present")
 		}
 
 		blankDv := libdv.NewDataVolume(
@@ -1878,13 +1878,13 @@ var _ = SIGDescribe("Export", func() {
 		checkWithJsonOutput(pod, export, vm)
 	})
 
-	It("should generate updated DataVolumeTemplates on http endpoint when exporting snapshot", func() {
+	It("should generate updated DataVolumeTemplates on http endpoint when exporting snapshot", decorators.RequiresSnapshotStorageClass, func() {
 		virtClient, err := kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 		sc, err := libstorage.GetSnapshotStorageClass(virtClient)
 		Expect(err).ToNot(HaveOccurred())
 		if sc == "" {
-			Skip("Skip test when storage with snapshot is not present")
+			Fail("Fail test when storage with snapshot is not present")
 		}
 
 		vm := libstorage.RenderVMWithDataVolumeTemplate(libdv.NewDataVolume(

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -61,6 +61,7 @@ import (
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -493,7 +494,7 @@ var _ = SIGDescribe("Export", func() {
 		expectedFormat exportv1.ExportVolumeFormat, urlTemplate string, volumeMode k8sv1.PersistentVolumeMode) {
 		sc, exists := storageClassFunction()
 		if !exists {
-			Skip("Skip test when right storage is not present")
+			Fail("Fail test when right storage is not present")
 		}
 		pvc, comparison := populateFunction(sc, volumeMode)
 		By("Creating the export token, we can export volumes using this token")
@@ -573,13 +574,13 @@ var _ = SIGDescribe("Export", func() {
 		Entry("with RAW gzipped kubevirt content type", populateKubeVirtContent, verifyKubeVirtGzContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
 		Entry("with archive content type", populateArchiveContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.Dir, archiveDircontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
 		Entry("with archive tarred gzipped content type", populateArchiveContent, verifyArchiveGzContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.ArchiveGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with RAW kubevirt content type block", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOBlockStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeBlock),
+		Entry("with RAW kubevirt content type block", decorators.RequiresBlockStorage, populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOBlockStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeBlock),
 		// "proxy" tests
 		Entry("with RAW kubevirt content type PROXY", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
 		Entry("with RAW gzipped kubevirt content type PROXY", populateKubeVirtContent, verifyKubeVirtGzContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
 		Entry("with archive content type PROXY", populateArchiveContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.Dir, archiveDircontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
 		Entry("with archive tarred gzipped content type PROXY", populateArchiveContent, verifyArchiveGzContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.ArchiveGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with RAW kubevirt content type block PROXY", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOBlockStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeBlock),
+		Entry("with RAW kubevirt content type block PROXY", decorators.RequiresBlockStorage, populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOBlockStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeBlock),
 	)
 
 	verifyArchiveContainsDirectories := func(archivePath string, expectedDirs []string, pod *k8sv1.Pod) {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -595,7 +595,7 @@ var _ = SIGDescribe("Export", func() {
 	It("should export a VM and verify swtpm directories in the gz archive", Serial, func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 
 		By("Setting the VMState storage class")
@@ -823,7 +823,7 @@ var _ = SIGDescribe("Export", func() {
 	It("Should recreate the exporter pod and secret if the pod fails", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 		checkExportSecretRef(vmExport)
@@ -868,7 +868,7 @@ var _ = SIGDescribe("Export", func() {
 	It("Should recreate the exporter pod if the pod is deleted", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 		checkExportSecretRef(vmExport)
@@ -887,7 +887,7 @@ var _ = SIGDescribe("Export", func() {
 	It("Should recreate the service if the service is deleted", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 		checkExportSecretRef(vmExport)
@@ -906,7 +906,7 @@ var _ = SIGDescribe("Export", func() {
 	It("Should handle no pvc existing when export created, then creating and populating the pvc", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 		dv := libdv.NewDataVolume(
 			libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), cdiv1.RegistryPullNode),
@@ -951,7 +951,7 @@ var _ = SIGDescribe("Export", func() {
 	It("should be possibe to observe exportserver pod exiting", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 		checkExportSecretRef(vmExport)
@@ -988,7 +988,7 @@ var _ = SIGDescribe("Export", func() {
 	It("Should handle populating an export without a previously defined tokenSecretRef", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 
 		pvc, _ := populateKubeVirtContent(sc, k8sv1.PersistentVolumeFilesystem)
@@ -1010,7 +1010,7 @@ var _ = SIGDescribe("Export", func() {
 	It("Should honor TTL by cleaning up the the VMExport altogether", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 
 		pvc, _ := populateKubeVirtContent(sc, k8sv1.PersistentVolumeFilesystem)
@@ -1156,7 +1156,7 @@ var _ = SIGDescribe("Export", func() {
 		It("should populate external links and cert and contain ingress host", func() {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
+				Fail("Fail test when Filesystem storage is not present")
 			}
 			testCert, err := createIngressTLSSecret(tlsSecretName)
 			Expect(err).NotTo(HaveOccurred())
@@ -1190,7 +1190,7 @@ var _ = SIGDescribe("Export", func() {
 		It("should populate external links and cert and contain route host", func() {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
+				Fail("Fail test when Filesystem storage is not present")
 			}
 			if !checks.IsOpenShift() {
 				Skip("Not on openshift")
@@ -1512,7 +1512,7 @@ var _ = SIGDescribe("Export", func() {
 	It("should report export pending if VM is running, and start the VM export if the VM is not running, then stop again once VM started", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 		vm := renderVMWithRegistryImportDataVolume(cd.ContainerDiskCirros, sc)
 		vm.Spec.RunStrategy = virtpointer.P(v1.RunStrategyAlways)
@@ -1631,7 +1631,7 @@ var _ = SIGDescribe("Export", func() {
 		It(" should report export pending if PVC is in use because of VMI using it, and start the VM export if the PVC is not in use, then stop again once pvc in use again", Serial, func() {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
+				Fail("Fail test when Filesystem storage is not present")
 			}
 			cpu := resource.MustParse("500m")
 			mem := resource.MustParse("1240Mi")
@@ -1836,7 +1836,7 @@ var _ = SIGDescribe("Export", func() {
 	It("should generate updated DataVolumeTemplates on http endpoint when exporting", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 
 		vm := libstorage.RenderVMWithDataVolumeTemplate(libdv.NewDataVolume(
@@ -1925,7 +1925,7 @@ var _ = SIGDescribe("Export", func() {
 	It("Should generate DVs and expanded VM definition on http endpoint with multiple volumes", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 		clusterInstancetype := &instancetypev1beta1.VirtualMachineClusterInstancetype{
 			TypeMeta: metav1.TypeMeta{
@@ -2097,7 +2097,7 @@ var _ = SIGDescribe("Export", func() {
 	It("should mark the status phase skipped on VM without volumes", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
+			Fail("Fail test when Filesystem storage is not present")
 		}
 		vm := libvmi.NewVirtualMachine(libvmifact.NewCirros())
 		vm = createVM(vm)
@@ -2180,7 +2180,7 @@ var _ = SIGDescribe("Export", func() {
 		It("should recreate exportserver pod when KubeVirt cert params updated", func() {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
+				Fail("Fail test when Filesystem storage is not present")
 			}
 			vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 			checkExportSecretRef(vmExport)

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -549,7 +549,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 	})
 
-	Context("Offline VM with a block volume", func() {
+	Context("Offline VM with a block volume", decorators.RequiresRWXBlock, func() {
 		var (
 			vm *v1.VirtualMachine
 			sc string
@@ -560,7 +560,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			sc, exists = libstorage.GetRWXBlockStorageClass()
 			if !exists {
-				Skip("Skip test when RWXBlock storage class is not present")
+				Fail("Fail test when RWXBlock storage class is not present")
 			}
 
 			dv := libdv.NewDataVolume(
@@ -730,7 +730,7 @@ var _ = SIGDescribe("Hotplug", func() {
 	})
 
 	Context("[storage-req]", decorators.StorageReq, func() {
-		Context("Online VM", func() {
+		Context("Online VM", decorators.RequiresRWXBlock, func() {
 			var (
 				vm *v1.VirtualMachine
 				sc string
@@ -757,7 +757,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				exists := false
 				sc, exists = libstorage.GetRWXBlockStorageClass()
 				if !exists {
-					Skip("Skip test when RWXBlock storage class is not present")
+					Fail("Fail test when RWXBlock storage class is not present")
 				}
 
 				node := findCPUManagerWorkerNode()
@@ -1119,7 +1119,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			})
 		})
 
-		Context("VMI migration", func() {
+		Context("VMI migration", decorators.RequiresRWXBlock, func() {
 			var (
 				vmi *v1.VirtualMachineInstance
 				sc  string
@@ -1160,7 +1160,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				exists := false
 				sc, exists = libstorage.GetRWXBlockStorageClass()
 				if !exists {
-					Skip("Skip test when RWXBlock storage class is not present")
+					Fail("Fail test when RWXBlock storage class is not present")
 				}
 			})
 
@@ -1260,10 +1260,11 @@ var _ = SIGDescribe("Hotplug", func() {
 				}
 			})
 
-			DescribeTable("should be able to add and remove volumes", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, storageClassFunc storageClassFunction, volumeMode k8sv1.PersistentVolumeMode, vmiOnly bool) {
-				sc, exists := storageClassFunc()
+			DescribeTable("should be able to add and remove volumes", decorators.RequiresBlockStorage, func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, volumeMode k8sv1.PersistentVolumeMode, vmiOnly bool) {
+				// Some permutations of this test want a filesystem on top of a block device
+				sc, exists := libstorage.GetRWOBlockStorageClass()
 				if !exists {
-					Skip("Skip test when appropriate storage class is not available")
+					Fail("Fail test when block storage class is not available")
 				}
 
 				var err error
@@ -1312,14 +1313,14 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				verifyAttachDetachVolume(vm, addVolumeFunc, removeVolumeFunc, sc, volumeMode, vmiOnly, true)
 			},
-				Entry("with DataVolume and running VM", addDVVolumeVM, removeVolumeVM, libstorage.GetRWOBlockStorageClass, k8sv1.PersistentVolumeFilesystem, false),
-				Entry("with DataVolume and VMI directly", addDVVolumeVMI, removeVolumeVMI, libstorage.GetRWOBlockStorageClass, k8sv1.PersistentVolumeFilesystem, true),
-				Entry(" with Block DataVolume immediate attach", Serial, addDVVolumeVM, removeVolumeVM, libstorage.GetRWOBlockStorageClass, k8sv1.PersistentVolumeBlock, false),
+				Entry("with DataVolume and running VM", addDVVolumeVM, removeVolumeVM, k8sv1.PersistentVolumeFilesystem, false),
+				Entry("with DataVolume and VMI directly", addDVVolumeVMI, removeVolumeVMI, k8sv1.PersistentVolumeFilesystem, true),
+				Entry(" with Block DataVolume immediate attach", Serial, addDVVolumeVM, removeVolumeVM, k8sv1.PersistentVolumeBlock, false),
 			)
 		})
 	})
 
-	Context("delete attachment pod several times", func() {
+	Context("delete attachment pod several times", decorators.RequiresRWXBlock, func() {
 		var (
 			vm       *v1.VirtualMachine
 			hpvolume *cdiv1.DataVolume
@@ -1331,7 +1332,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			}
 			_, foundSC := libstorage.GetRWXBlockStorageClass()
 			if !foundSC {
-				Skip("Skip test when block RWX storage is not present")
+				Fail("Fail test when block RWX storage is not present")
 			}
 		})
 
@@ -1427,7 +1428,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		})
 	})
 
-	Context("with limit range in namespace", func() {
+	Context("with limit range in namespace", decorators.RequiresRWXBlock, func() {
 		var (
 			sc                         string
 			lr                         *k8sv1.LimitRange
@@ -1580,9 +1581,8 @@ var _ = SIGDescribe("Hotplug", func() {
 		BeforeEach(func() {
 			exists := false
 			sc, exists = libstorage.GetRWXBlockStorageClass()
-
 			if !exists {
-				Skip("Skip test when RWXBlock storage class is not present")
+				Fail("Fail test when RWXBlock storage class is not present")
 			}
 			originalConfig = *libkubevirt.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
 		})

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1248,7 +1248,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			BeforeEach(func() {
 				if !libstorage.HasCDI() {
-					Skip("Skip tests when CDI is not present")
+					Fail("Fail tests when CDI is not present")
 				}
 			})
 
@@ -1328,7 +1328,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 		BeforeEach(func() {
 			if !libstorage.HasCDI() {
-				Skip("Skip tests when CDI is not present")
+				Fail("Fail tests when CDI is not present")
 			}
 			_, foundSC := libstorage.GetRWXBlockStorageClass()
 			if !foundSC {
@@ -1460,7 +1460,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 		updateCDIResourceRequirements := func(requirements *k8sv1.ResourceRequirements) {
 			if !libstorage.HasCDI() {
-				Skip("Test requires CDI CR to be available")
+				Fail("Test requires CDI CR to be available")
 			}
 			orgCdiConfig, err := virtClient.CdiClient().CdiV1beta1().CDIConfigs().Get(context.Background(), "config", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1271,7 +1271,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				storageClass, foundSC := libstorage.GetRWOFileSystemStorageClass()
 				if !foundSC {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				dv = libdv.NewDataVolume(
@@ -1762,7 +1762,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		It("should allow adding and removing hotplugged volumes", func() {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip no filesystem storage class available")
+				Fail("Fail no filesystem storage class available")
 			}
 
 			dv := libdv.NewDataVolume(

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -312,7 +312,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			var exists bool
 			sc, exists = libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip no filesystem storage class available")
+				Fail("Fail no filesystem storage class available")
 			}
 			libstorage.CheckNoProvisionerStorageClassPVs(sc, numPVs)
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1681,9 +1681,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					memoryDumpPVC.Spec.VolumeMode = &volumeMode
 					var err error
 					memoryDumpPVC, err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Create(context.Background(), memoryDumpPVC, metav1.CreateOptions{})
-					if err != nil {
-						Skip(fmt.Sprintf("Skiping test, no filesystem pvc available, err: %s", err))
-					}
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				AfterEach(func() {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -581,7 +581,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 			})
 		})
-		Context("with instancetype and preferences", func() {
+		Context("with instancetype and preferences", decorators.RequiresSnapshotStorageClass, func() {
 			var (
 				instancetype *instancetypev1beta1.VirtualMachineInstancetype
 				preference   *instancetypev1beta1.VirtualMachinePreference
@@ -594,7 +594,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				if snapshotStorageClass == "" {
-					Skip("Skiping test, no VolumeSnapshot support")
+					Fail("Failing test, no VolumeSnapshot support")
 				}
 
 				instancetype = &instancetypev1beta1.VirtualMachineInstancetype{
@@ -731,7 +731,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 	})
 
 	Context("[storage-req]", decorators.StorageReq, func() {
-		Context("With a more complicated VM", func() {
+		Context("With a more complicated VM", decorators.RequiresSnapshotStorageClass, func() {
 			var (
 				newVmName            string
 				vm                   *v1.VirtualMachine
@@ -748,7 +748,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				if sc == "" {
-					Skip("Skiping test, no VolumeSnapshot support")
+					Fail("Failing test, no VolumeSnapshot support")
 				}
 
 				snapshotStorageClass = sc

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -880,9 +880,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					memoryDumpPVC.Spec.VolumeMode = &volumeMode
 					var err error
 					memoryDumpPVC, err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.GetTestNamespace(nil)).Create(context.Background(), memoryDumpPVC, metav1.CreateOptions{})
-					if err != nil {
-						Skip(fmt.Sprintf("Skiping test, no filesystem pvc available, err: %s", err))
-					}
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				AfterEach(func() {

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -288,7 +288,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 		})
 	})
 
-	Context("[storage-req]", decorators.StorageReq, func() {
+	Context("[storage-req]", decorators.StorageReq, decorators.RequiresSnapshotStorageClass, func() {
 		var (
 			snapshotStorageClass string
 		)
@@ -298,7 +298,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			if sc == "" {
-				Skip("Skiping test, no VolumeSnapshot support")
+				Fail("Failing test, no VolumeSnapshot support")
 			}
 
 			snapshotStorageClass = sc

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -884,7 +884,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 
-		Context("[rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component][storage-req] With Cirros BlockMode PVC", decorators.StorageReq, func() {
+		Context("[rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component][storage-req] With Cirros BlockMode PVC", decorators.RequiresBlockStorage, decorators.StorageReq, func() {
 			var dataVolume *cdiv1.DataVolume
 			var err error
 
@@ -892,7 +892,7 @@ var _ = SIGDescribe("Storage", func() {
 				// create a new PV and PVC (PVs can't be reused)
 				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
 				if !foundSC {
-					Skip("Skip test when Block storage is not present")
+					Fail("Fail test when Block storage is not present")
 				}
 
 				dataVolume = libdv.NewDataVolume(
@@ -920,13 +920,13 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 
-		Context("[storage-req][rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component]With Alpine block volume PVC", decorators.StorageReq, func() {
+		Context("[storage-req][rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component]With Alpine block volume PVC", decorators.RequiresRWXBlock, decorators.StorageReq, func() {
 
 			It("[test_id:3139]should be successfully started", func() {
 				By("Create a VMIWithPVC")
 				sc, exists := libstorage.GetRWXBlockStorageClass()
 				if !exists {
-					Skip("Skip test when Block storage is not present")
+					Fail("Fail test when Block storage is not present")
 				}
 
 				// Start the VirtualMachineInstance with the PVC attached
@@ -1045,14 +1045,14 @@ var _ = SIGDescribe("Storage", func() {
 
 		})
 
-		Context("[storage-req] With a volumeMode block backed ephemeral disk", decorators.StorageReq, func() {
+		Context("[storage-req] With a volumeMode block backed ephemeral disk", decorators.RequiresBlockStorage, decorators.StorageReq, func() {
 			var dataVolume *cdiv1.DataVolume
 			var err error
 
 			BeforeEach(func() {
 				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteOnce)
 				if !foundSC {
-					Skip("Skip test when Block storage is not present")
+					Fail("Fail test when Block storage is not present")
 				}
 
 				dataVolume = libdv.NewDataVolume(

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1090,7 +1090,7 @@ var _ = SIGDescribe("Storage", func() {
 			BeforeEach(func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
+					Fail("Fail test when Filesystem storage is not present")
 				}
 
 				dv = libdv.NewDataVolume(

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -279,7 +279,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 			var exists bool
 			sc, exists = libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
+				Fail("Fail test when Filesystem storage is not present")
 			}
 		})
 

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -273,7 +273,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, func() {
 
 		BeforeEach(func() {
 			if !libstorage.HasCDI() {
-				Skip("Skip DataVolume tests when CDI is not present")
+				Fail("Fail DataVolume tests when CDI is not present")
 			}
 
 			var exists bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Runtime skips are bad. The test suite should receive instructions upfront about cluster/storage capabilities
and pick up the test set according to that. This makes it harder to hit a false negative where the test run does not identify issues but many tests were in fact skipped at runtime.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This still leaves 
```bash
$ (cd tests/storage; git grep "Skip(" | wc -l)
9
```
Skips in sig-storage of very specific nature, these tests would require separate PRs to tackle

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Storage tests: eliminate runtime skips
```

