### PR TITLE
enable virtio video type for amd64

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5974,6 +5974,14 @@ rpm(
 )
 
 rpm(
+    name = "qemu-kvm-device-display-virtio-gpu-17__9.0.0-10.el9.x86_64",
+    sha256 = "eaaf29ef9d9f104da226da11540f95158ce1d73587ba1a6eadb7d04b1f665944",
+    urls = [
+        "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/qemu-kvm-device-display-virtio-gpu-9.0.0-10.el9.x86_64.rpm",
+    ],
+)
+
+rpm(
     name = "qemu-kvm-device-display-virtio-gpu-ccw-17__9.0.0-10.el9.s390x",
     sha256 = "62d283feeaef8867099921894cbdf628e4c7849678e3e02a6ef1a9d4913532a9",
     urls = [
@@ -5988,6 +5996,14 @@ rpm(
     urls = [
         "http://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/qemu-kvm-device-display-virtio-gpu-pci-9.0.0-10.el9.aarch64.rpm",
         "https://storage.googleapis.com/builddeps/f4e94839c87c011a286190351b1fa1b917b1276d90fea7c9daca6b8702a9df45",
+    ],
+)
+
+rpm(
+    name = "qemu-kvm-device-display-virtio-gpu-pci-17__9.0.0-10.el9.x86_64",
+    sha256 = "e8a789afda33e8d60482f9cd71ab0640bf200ea06ba40fba8054233f5b57f48b",
+    urls = [
+        "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/qemu-kvm-device-display-virtio-gpu-pci-9.0.0-10.el9.x86_64.rpm",
     ],
 )
 

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -26,7 +26,7 @@ KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL:-false}
 HOST_ARCHITECTURE="$(uname -m)"
 
 sandbox_root=${SANDBOX_DIR}/default/root
-sandbox_hash="20b211cacc5d228dbd6f3f336468c4b5170676f8"
+sandbox_hash="85965cf869b2095452b69e3cf6e700b29e7f1dde"
 
 function kubevirt::bootstrap::regenerate() {
     (

--- a/hack/rpm-deps.sh
+++ b/hack/rpm-deps.sh
@@ -96,6 +96,8 @@ launcherbase_main="
 "
 launcherbase_x86_64="
   edk2-ovmf-${EDK2_VERSION}
+  qemu-kvm-device-display-virtio-gpu-${QEMU_VERSION}
+  qemu-kvm-device-display-virtio-gpu-pci-${QEMU_VERSION}
   qemu-kvm-device-usb-redirect-${QEMU_VERSION}
   seabios-${SEABIOS_VERSION}
 "

--- a/rpm/BUILD.bazel
+++ b/rpm/BUILD.bazel
@@ -1184,6 +1184,8 @@ rpmtree(
         "@qemu-img-17__9.0.0-10.el9.x86_64//rpm",
         "@qemu-kvm-common-17__9.0.0-10.el9.x86_64//rpm",
         "@qemu-kvm-core-17__9.0.0-10.el9.x86_64//rpm",
+        "@qemu-kvm-device-display-virtio-gpu-17__9.0.0-10.el9.x86_64//rpm",
+        "@qemu-kvm-device-display-virtio-gpu-pci-17__9.0.0-10.el9.x86_64//rpm",
         "@qemu-kvm-device-usb-host-17__9.0.0-10.el9.x86_64//rpm",
         "@qemu-kvm-device-usb-redirect-17__9.0.0-10.el9.x86_64//rpm",
         "@readline-0__8.1-4.el9.x86_64//rpm",


### PR DESCRIPTION
### What this PR does
Before this PR:
virtio video type was enabled only for arch64

After this PR:
virtio video type is enabled for amd64 as well

### Release note
```release-note
add support for virtio video device for amd64
```

