### PR TITLE
Add kubevirt_vm/i_vnic_info metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -114,6 +114,9 @@ Virtual Machine last transition timestamp to running status. Type: Counter.
 ### kubevirt_vm_starting_status_last_transition_timestamp_seconds
 Virtual Machine last transition timestamp to starting status. Type: Counter.
 
+### kubevirt_vm_vnic_info
+Details of Virtual Machine (VM) vNIC interfaces, such as vNIC name, binding type, network name, and binding name for each vNIC defined in the VM's configuration. Type: Gauge.
+
 ### kubevirt_vmi_cpu_system_usage_seconds_total
 Total CPU time spent in system mode. Type: Counter.
 
@@ -296,6 +299,9 @@ Total amount of time spent in each state by each vcpu (cpu_time excluding hyperv
 
 ### kubevirt_vmi_vcpu_wait_seconds_total
 Amount of time spent by each vcpu while waiting on I/O. Type: Counter.
+
+### kubevirt_vmi_vnic_info
+Details of VirtualMachineInstance (VMI) vNIC interfaces, such as vNIC name, binding type, network name, and binding name for each vNIC of a running instance. Type: Gauge.
 
 ### kubevirt_vmsnapshot_disks_restored_from_source
 Returns the total number of virtual machine disks restored from the source virtual machine. Type: Gauge.

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -614,6 +614,106 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(results).To(BeEmpty(), "kubevirt_vm_create_date_timestamp_seconds should not be collected for VMs with zero creation timestamp")
 		})
 	})
+
+	Context("VM vNIC info", func() {
+		It("should collect metrics for vNICs with various binding types, including PluginBinding", func() {
+			vm := &k6tv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-vm",
+				},
+				Spec: k6tv1.VirtualMachineSpec{
+					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
+						Spec: k6tv1.VirtualMachineInstanceSpec{
+							Domain: k6tv1.DomainSpec{
+								Devices: k6tv1.Devices{
+									Interfaces: []k6tv1.Interface{
+										{
+											Name: "iface1",
+											InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
+												Bridge: &k6tv1.InterfaceBridge{},
+											},
+										},
+										{
+											Name: "iface2",
+											InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
+												Masquerade: &k6tv1.InterfaceMasquerade{},
+											},
+										},
+										{
+											Name: "iface3",
+											InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
+												SRIOV: &k6tv1.InterfaceSRIOV{},
+											},
+										},
+										{
+											Name:    "iface4",
+											Binding: &k6tv1.PluginBinding{Name: "custom-plugin"},
+										},
+									},
+								},
+							},
+							Networks: []k6tv1.Network{
+								{
+									Name:          "iface1",
+									NetworkSource: k6tv1.NetworkSource{Pod: &k6tv1.PodNetwork{}},
+								},
+								{
+									Name:          "iface2",
+									NetworkSource: k6tv1.NetworkSource{Pod: &k6tv1.PodNetwork{}},
+								},
+								{
+									Name:          "iface3",
+									NetworkSource: k6tv1.NetworkSource{Multus: &k6tv1.MultusNetwork{NetworkName: "multus-net"}},
+								},
+								{
+									Name:          "iface4",
+									NetworkSource: k6tv1.NetworkSource{Multus: &k6tv1.MultusNetwork{NetworkName: "custom-net"}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			metrics := CollectVmsVnicInfo([]*k6tv1.VirtualMachine{vm})
+			Expect(metrics).To(HaveLen(4), "Expected metrics for all vNICs")
+
+			Expect(metrics[0].Labels).To(Equal([]string{"test-vm", "test-ns", "iface1", "core", "pod networking", "bridge"}))
+			Expect(metrics[1].Labels).To(Equal([]string{"test-vm", "test-ns", "iface2", "core", "pod networking", "masquerade"}))
+			Expect(metrics[2].Labels).To(Equal([]string{"test-vm", "test-ns", "iface3", "core", "multus-net", "sriov"}))
+			Expect(metrics[3].Labels).To(Equal([]string{"test-vm", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin"}))
+		})
+		It("should not collect kubevirt_vm_vnic_info metric if no network defined", func() {
+			vm := &k6tv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-vm",
+				},
+				Spec: k6tv1.VirtualMachineSpec{
+					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
+						Spec: k6tv1.VirtualMachineInstanceSpec{
+							Domain: k6tv1.DomainSpec{
+								Devices: k6tv1.Devices{
+									Interfaces: []k6tv1.Interface{
+										{
+											Name: "iface1",
+											InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
+												Bridge: &k6tv1.InterfaceBridge{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			metrics := CollectVmsVnicInfo([]*k6tv1.VirtualMachine{vm})
+			Expect(metrics).To(BeEmpty())
+		})
+	})
 })
 
 func expectDefaultCPUResourceRequests(crs []operatormetrics.CollectorResult) {

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -152,6 +152,26 @@ func basicVMLifecycle(virtClient kubecli.KubevirtClient) {
 		},
 		0, ">", 0)
 
+	By("Verifying kubevirt_vm_vnic_info metric")
+	libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vm_vnic_info", 1,
+		map[string]string{
+			"namespace":    vm.Namespace,
+			"name":         vm.Name,
+			"binding_type": "core",
+			"network":      "pod networking",
+			"binding_name": "masquerade",
+		}, 0)
+
+	By("Verifying kubevirt_vmi_vnic_info metric")
+	libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_vnic_info", 1,
+		map[string]string{
+			"namespace":    vm.Namespace,
+			"name":         vm.Name,
+			"binding_type": "core",
+			"network":      "pod networking",
+			"binding_name": "masquerade",
+		}, 0)
+
 	By("Deleting the VirtualMachine")
 	err := virtClient.VirtualMachine(vm.Namespace).Delete(context.Background(), vm.Name, metav1.DeleteOptions{})
 	Expect(err).ToNot(HaveOccurred())
@@ -163,11 +183,14 @@ func basicVMLifecycle(virtClient kubecli.KubevirtClient) {
 func createAndRunVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
 	vmDiskPVC := "test-vm-pvc"
 	pvc := libstorage.CreateFSPVC(vmDiskPVC, testsuite.GetTestNamespace(nil), "512Mi", nil)
+	iface := *v1.DefaultMasqueradeNetworkInterface()
 
 	vmi := libvmifact.NewFedora(
 		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 		libvmi.WithLimitMemory("512Mi"),
 		libvmi.WithPersistentVolumeClaim("testdisk", pvc.Name),
+		libvmi.WithInterface(iface),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
 
 	vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Add 2 metrics that reports the vNIC information for vm's and vmi's. 
the metrics labels includes: 
**- name:** the vm/i name
**- namespace:** the vm/i namespace 
**- vnic_name:** the interface name 
**- binding_type:** can be core/plugin
**- network:** if using Pod it will be "pod networking", if using Multus it will be the Multus.NetworkName.  
**- binding_name:** can be masquerade/bridge/sriov/Binding.Name

see metrics:
![Screenshot from 2025-02-04 14-20-03](https://github.com/user-attachments/assets/dd268286-26ab-4645-85c8-47ab8c14c31b)

notes: 
- The vmi metric will show values for running/pending/starting vmi's but not for stopped vmi's.
- The vm metric will show values for both running/starting/stopped vms, but only for vms that the network and interface defined on their spec.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
jira-ticket: https://issues.redhat.com/browse/CNV-51529

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added kubevirt_vm_vnic_info and kubevirt_vmi_vnic_info metrics
```

