### PR TITLE
storage tests: avoid volume expansion runtime skips

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -26,6 +26,7 @@ readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="gs://kubevirt-vm-images"
 readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt}"
 
+source hack/config-default.sh
 
 # Skip if it's docs changes only
 # Only if we are in CI, and this is a non-batch change
@@ -480,6 +481,12 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
   if [[ ! $TARGET =~ windows.* ]]; then
     add_to_label_filter "(!Windows)" "&&"
     add_to_label_filter "(!Sysprep)" "&&"
+  fi
+
+  rwofs_sc=$(jq -er .storageRWOFileSystem "${kubevirt_test_config}")
+  if [[ "${rwofs_sc}" == "local" ]]; then
+    # local is a primitive non CSI storage class that doesn't support expansion
+    add_to_label_filter "(!RequiresVolumeExpansion)" "&&"
   fi
 
 fi

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -43,6 +43,8 @@ conn_check_dns=${CONN_CHECK_DNS:-""}
 migration_network_nic=${MIGRATION_NETWORK_NIC:-"eth1"}
 infra_replicas=${KUBEVIRT_INFRA_REPLICAS:-0}
 test_image_replicas=${KUBEVIRT_E2E_PARALLEL_NODES:-6}
+base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+kubevirt_test_config=${KUBEVIRT_TEST_CONFIG:-$(if [[ "${KUBEVIRT_STORAGE:-}" == rook-ceph* ]]; then echo "${base_dir}/tests/default-ceph-config.json"; else echo "${base_dir}/tests/default-config.json"; fi)}
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -35,12 +35,6 @@ previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_releas
 
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
-kubevirt_test_config="${KUBEVIRT_DIR}/tests/default-config.json"
-
-if [[ ${KUBEVIRT_STORAGE} == rook-ceph* ]]; then
-    kubevirt_test_config="${KUBEVIRT_DIR}/tests/default-ceph-config.json"
-fi
-
 echo "Using $kubevirt_test_config as test configuration"
 
 if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* ]]; then

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -83,6 +83,8 @@ var (
 	RequiresBlockStorage = Label("RequiresBlockStorage")
 	// Tests that ensure sig-storage functionality which are conformance-unready
 	StorageCritical = Label("StorageCritical")
+	// Requires a storage class with volume expansion support
+	RequiresVolumeExpansion = Label("RequiresVolumeExpansion")
 	// Kubernetes versions
 	Kubernetes130 = Label("kubernetes130")
 	// WG archs

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -146,7 +146,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		return libwait.WaitForVMIPhase(vmi, []v1.VirtualMachineInstancePhase{v1.Running}, libwait.WithTimeout(500))
 	}
 
-	Context("[storage-req]PVC expansion", decorators.StorageReq, func() {
+	Context("[storage-req]PVC expansion", decorators.StorageReq, decorators.RequiresVolumeExpansion, func() {
 		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
 			checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
 
@@ -165,7 +165,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			}
 			volumeExpansionAllowed := volumeExpansionAllowed(sc)
 			if !volumeExpansionAllowed {
-				Skip("Skip when volume expansion storage class not available")
+				Fail("Fail when volume expansion storage class not available")
 			}
 
 			imageUrl := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)
@@ -237,7 +237,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			volumeExpansionAllowed := volumeExpansionAllowed(sc)
 			if !volumeExpansionAllowed {
-				Skip("Skip when volume expansion storage class not available")
+				Fail("Fail when volume expansion storage class not available")
 			}
 			dataVolume := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
introduce a label that allows opting out of volume expansion tests for storage that doesn't support PVC resize
(pretty rare at this point among CSI drivers)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

