### PR TITLE
minor reduction of the footprint of pkg/util

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -112,8 +112,6 @@ const (
 
 	kvm = 107
 
-	// secretTokenLength is the lenght of the randomly generated token
-	secretTokenLength = 20
 	// secretTokenKey is the entry used to store the token in the virtualMachineExport secret
 	secretTokenKey = "token"
 
@@ -730,7 +728,7 @@ func (ctrl *VMExportController) handleVMExportToken(vmExport *exportv1.VirtualMa
 		vmExport.Status.TokenSecretRef = &generatedSecretName
 	}
 
-	token, err := kutil.GenerateSecureRandomString(secretTokenLength)
+	token, err := kutil.GenerateVMExportToken()
 	if err != nil {
 		return err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -41,7 +41,7 @@ func IsNonRootVMI(vmi *v1.VirtualMachineInstance) bool {
 	return ok || nonRoot
 }
 
-func IsSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
+func isSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		if iface.SRIOV != nil {
 			return true
@@ -81,7 +81,7 @@ func IsHostDevVMI(vmi *v1.VirtualMachineInstance) bool {
 // Check if a VMI spec requests a VFIO device
 func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
 
-	if IsHostDevVMI(vmi) || IsGPUVMI(vmi) || IsSRIOVVmi(vmi) {
+	if IsHostDevVMI(vmi) || IsGPUVMI(vmi) || isSRIOVVmi(vmi) {
 		return true
 	}
 	return false

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -28,9 +28,6 @@ const (
 	CPUManagerOS3Path                         = HostRootMount + "var/lib/origin/openshift.local.volumes/cpu_manager_state"
 	CPUManagerPath                            = KubeletRoot + "/cpu_manager_state"
 
-	// Alphanums is the list of alphanumeric characters used to create a securely generated random string
-	Alphanums = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-
 	NonRootUID         = 107
 	NonRootUserString  = "qemu"
 	RootUser           = 0
@@ -268,13 +265,14 @@ func CalcExpectedMemoryDumpSize(vmi *v1.VirtualMachineInstance) *resource.Quanti
 
 // GenerateSecureRandomString creates a securely generated random string using crypto/rand
 func GenerateSecureRandomString(n int) (string, error) {
+	const alphanums = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	ret := make([]byte, n)
 	for i := range ret {
-		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(Alphanums))))
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphanums))))
 		if err != nil {
 			return "", err
 		}
-		ret[i] = Alphanums[num.Int64()]
+		ret[i] = alphanums[num.Int64()]
 	}
 
 	return string(ret), nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -105,10 +105,6 @@ func IsSEVAttestationRequested(vmi *v1.VirtualMachineInstance) bool {
 	return IsSEVVMI(vmi) && vmi.Spec.Domain.LaunchSecurity.SEV.Attestation != nil
 }
 
-func IsAMD64VMI(vmi *v1.VirtualMachineInstance) bool {
-	return vmi.Spec.Architecture == "amd64"
-}
-
 func IsEFIVMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.Firmware != nil &&
 		vmi.Spec.Domain.Firmware.Bootloader != nil &&

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -109,10 +109,6 @@ func IsAMD64VMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Architecture == "amd64"
 }
 
-func IsARM64VMI(vmi *v1.VirtualMachineInstance) bool {
-	return vmi.Spec.Architecture == "arm64"
-}
-
 func IsEFIVMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.Firmware != nil &&
 		vmi.Spec.Domain.Firmware.Bootloader != nil &&

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -25,8 +25,6 @@ const (
 	KubeletRoot                               = "/var/lib/kubelet"
 	KubeletPodsDir                            = KubeletRoot + "/pods"
 	HostRootMount                             = "/proc/1/root/"
-	CPUManagerOS3Path                         = HostRootMount + "var/lib/origin/openshift.local.volumes/cpu_manager_state"
-	CPUManagerPath                            = KubeletRoot + "/cpu_manager_state"
 
 	NonRootUID         = 107
 	NonRootUserString  = "qemu"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -263,10 +263,11 @@ func CalcExpectedMemoryDumpSize(vmi *v1.VirtualMachineInstance) *resource.Quanti
 	return expectedPvcSize
 }
 
-// GenerateSecureRandomString creates a securely generated random string using crypto/rand
-func GenerateSecureRandomString(n int) (string, error) {
+// GenerateVMExportToken creates a cryptographically secure token for VM export
+func GenerateVMExportToken() (string, error) {
 	const alphanums = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	ret := make([]byte, n)
+	const tokenLen = 20
+	ret := make([]byte, tokenLen)
 	for i := range ret {
 		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphanums))))
 		if err != nil {

--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -35,13 +35,15 @@ type HeartBeat struct {
 }
 
 func NewHeartBeat(clientset k8scli.CoreV1Interface, deviceManager device_manager.DeviceControllerInterface, clusterConfig *virtconfig.ClusterConfig, host string) *HeartBeat {
+	const cpuManagerOS3Path = virtutil.HostRootMount + "var/lib/origin/openshift.local.volumes/cpu_manager_state"
+	const cpuManagerPath = virtutil.KubeletRoot + "/cpu_manager_state"
 	return &HeartBeat{
 		clientset:               clientset,
 		deviceManagerController: deviceManager,
 		clusterConfig:           clusterConfig,
 		host:                    host,
 		// This is a temporary workaround until k8s bug #66525 is resolved
-		cpuManagerPaths:           []string{virtutil.CPUManagerPath, virtutil.CPUManagerOS3Path},
+		cpuManagerPaths:           []string{cpuManagerPath, cpuManagerOS3Path},
 		devicePluginPollIntervall: 1 * time.Second,
 		devicePluginWaitTimeout:   10 * time.Second,
 	}

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -14,7 +14,6 @@ import (
 	v12 "kubevirt.io/api/core/v1"
 
 	v1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
-	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
@@ -468,7 +467,7 @@ func AdjustDomainForTopologyAndCPUSet(domain *api.Domain, vmi *v12.VirtualMachin
 	domain.Spec.CPUTune = cpuTune
 
 	// Add the hint-dedicated feature when dedicatedCPUs are requested for AMD64 architecture.
-	if util.IsAMD64VMI(vmi) {
+	if isAMD64VMI(vmi) {
 		if domain.Spec.Features == nil {
 			domain.Spec.Features = &api.Features{}
 		}
@@ -680,4 +679,8 @@ func hugePagesInfo(vmi *v12.VirtualMachineInstance, domain *api.DomainSpec) (siz
 		}
 	}
 	return 0, "b", false, nil
+}
+
+func isAMD64VMI(vmi *v12.VirtualMachineInstance) bool {
+	return vmi.Spec.Architecture == "amd64"
 }

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -108,8 +108,6 @@ const (
 	exportTokenHeader = "x-kubevirt-export-token"
 	// secretTokenKey is the entry used to store the token in the virtualMachineExport secret
 	secretTokenKey = "token"
-	// secretTokenLenght is the lenght of the randomly generated token
-	secretTokenLenght = 20
 
 	// ErrRequiredFlag serves as error message when a mandatory flag is missing
 	ErrRequiredFlag = "need to specify the '%s' flag when using '%s'"
@@ -834,7 +832,7 @@ func copyFileWithProgressBar(output io.Writer, resp *http.Response, decompress b
 // getOrCreateTokenSecret obtains a token secret to be used along with the virtualMachineExport
 func getOrCreateTokenSecret(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport) (*k8sv1.Secret, error) {
 	// Securely randomize a 20 char string to be used as a token
-	token, err := util.GenerateSecureRandomString(secretTokenLenght)
+	token, err := util.GenerateVMExportToken()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
pkg/util/util.go includes several unrelated functions and constants. This PR drops a few of them and move a few others to more appropriate location.

/kind cleanup

```release-note
NONE
```

