### PR TITLE
vm-mutator: Remove redundant call to schema validation

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -50,10 +50,6 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 		return webhookutils.ToAdmissionResponseError(err)
 	}
 
-	if resp := webhookutils.ValidateSchema(v1.VirtualMachineGroupVersionKind, ar.Request.Object.Raw); resp != nil {
-		return resp
-	}
-
 	raw := ar.Request.Object.Raw
 	vm := v1.VirtualMachine{}
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -1896,30 +1896,6 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			Expect(resp.Result.Message).To(ContainSubstring("expect resource to be"))
 		})
 
-		It("should fail if passed json is not VirtualMachine type", func() {
-			notVm := struct {
-				TestField string `json:"testField"`
-			}{
-				TestField: "test-string",
-			}
-
-			jsonBytes, err := json.Marshal(notVm)
-			Expect(err).ToNot(HaveOccurred())
-
-			ar := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					Resource: k8smetav1.GroupVersionResource{Group: v1.VirtualMachineGroupVersionKind.Group, Version: v1.VirtualMachineGroupVersionKind.Version, Resource: "virtualmachines"},
-					Object: runtime.RawExtension{
-						Raw: jsonBytes,
-					},
-				},
-			}
-
-			resp := mutator.Mutate(ar)
-			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Code).To(Equal(int32(http.StatusUnprocessableEntity)))
-		})
-
 		DescribeTable("should fail if", func(instancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher *v1.PreferenceMatcher, expectedField, expectedMessage string) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher


### PR DESCRIPTION
The schema validation performed in the mutation webhook is redundant because it is already handled by the kube-apiserver and the validation webhook. The primary role of the mutation webhook is to apply defaults and transformations, not to validate schemas.

This change simplifies the mutation webhook logic by removing unnecessary validation, aligning it with its intended purpose.

### Release note
```release-note
None
```

