### PR TITLE
volume-migration: take into account the backend PVC

### DIFF
--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -281,6 +281,14 @@ func WithKernelBootContainer(imageName string) Option {
 	}
 }
 
+func WithTPM(persistent bool) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{
+			Persistent: pointer.P(persistent),
+		}
+	}
+}
+
 func baseVmi(name string) *v1.VirtualMachineInstance {
 	vmi := v1.NewVMIReferenceFromNameWithNS("", name)
 	vmi.Spec = v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}

--- a/pkg/virt-controller/watch/volume-migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/volume-migration/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-controller/watch/volume-migration/volume-migration.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration.go
@@ -37,6 +37,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 )
 
@@ -359,8 +360,13 @@ func ValidateVolumesUpdateMigration(vmi *virtv1.VirtualMachineInstance, vm *virt
 	for _, v := range migVolsInfo {
 		volMigMap[v.VolumeName] = true
 	}
+	persistBackendVolName := backendstorage.CurrentPVCName(vmi)
 	for _, v := range vmi.Status.VolumeStatus {
 		if v.PersistentVolumeClaimInfo == nil {
+			continue
+		}
+		// Skip the check for the persistent VM state, this is handled differently then the other PVCs
+		if v.Name == persistBackendVolName {
 			continue
 		}
 		_, ok := volMigMap[v.Name]

--- a/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
@@ -351,6 +351,40 @@ var _ = Describe("Volume Migration", func() {
 						},
 					},
 				})), fmt.Errorf("cannot migrate the VM. The volume disk1 is RWO and not included in the migration volumes")),
+			Entry("with valid migrated volumes and persistent storage", libvmi.New(libvmi.WithName("test"), libvmi.WithTPM(true),
+				libvmistatus.WithStatus(
+					v1.VirtualMachineInstanceStatus{
+						MigratedVolumes: []v1.StorageMigratedVolumeInfo{
+							{
+								VolumeName:         "disk0",
+								SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: "src"},
+								DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{ClaimName: "dst"},
+							},
+						},
+						Conditions: []v1.VirtualMachineInstanceCondition{
+							v1.VirtualMachineInstanceCondition{
+								Type:   v1.VirtualMachineInstanceIsMigratable,
+								Status: k8sv1.ConditionFalse,
+								Reason: v1.VirtualMachineInstanceReasonDisksNotMigratable,
+							},
+						},
+						VolumeStatus: []v1.VolumeStatus{
+							{
+								Name: "disk0",
+								PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+									ClaimName:   "src",
+									AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+								},
+							},
+							{
+								Name: "persistent-state-for-test",
+								PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+									ClaimName:   "persistent-state-for-test",
+									AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+								},
+							},
+						},
+					})), nil),
 		)
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
The volume migration was rejected because the backend PVC wasn't take into account into the volumes validation

After this PR:
We can perform the volume migration on a VM using TPM

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #13582

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

