### PR TITLE
virt-launcher: remove old SSH key propagation method

### DIFF
--- a/pkg/virt-handler/guestagent.go
+++ b/pkg/virt-handler/guestagent.go
@@ -40,17 +40,13 @@ var sshRelatedGuestAgentCommands = []string{
 	"guest-ssh-remove-authorized-keys",
 }
 
-var oldSSHRelatedGuestAgentCommands = []string{
-	"guest-exec-status",
-	"guest-exec",
-	"guest-file-open",
-	"guest-file-close",
-	"guest-file-read",
-	"guest-file-write",
-}
-
 var passwordRelatedGuestAgentCommands = []string{
 	"guest-set-user-password",
+}
+
+var execProbeGuestAgentCommands = []string{
+	"guest-exec-status",
+	"guest-exec",
 }
 
 func guestAgentCommandSubsetSupported(requiredCommands []string, availableCmdsMap map[string]bool) bool {
@@ -88,7 +84,7 @@ func isGuestAgentSupported(vmi *v1.VirtualMachineInstance, commands []v1.GuestAg
 		}
 	}
 
-	if checkSSH && !sshRelatedCommandsSupported(availableCmdsMap) {
+	if checkSSH && !guestAgentCommandSubsetSupported(sshRelatedGuestAgentCommands, availableCmdsMap) {
 		return false, "This guest agent doesn't support required public key commands"
 	}
 
@@ -96,10 +92,17 @@ func isGuestAgentSupported(vmi *v1.VirtualMachineInstance, commands []v1.GuestAg
 		return false, "This guest agent doesn't support required password commands"
 	}
 
-	return true, "This guest agent is supported"
-}
+	var checkExecProbe bool
+	if vmi != nil && vmi.Spec.ReadinessProbe != nil && vmi.Spec.ReadinessProbe.Exec != nil {
+		checkExecProbe = true
+	}
+	if vmi != nil && vmi.Spec.LivenessProbe != nil && vmi.Spec.LivenessProbe.Exec != nil {
+		checkExecProbe = true
+	}
 
-func sshRelatedCommandsSupported(availableCmdsMap map[string]bool) bool {
-	return guestAgentCommandSubsetSupported(sshRelatedGuestAgentCommands, availableCmdsMap) ||
-		guestAgentCommandSubsetSupported(oldSSHRelatedGuestAgentCommands, availableCmdsMap)
+	if checkExecProbe && !guestAgentCommandSubsetSupported(execProbeGuestAgentCommands, availableCmdsMap) {
+		return false, "This guest agent doesn't support required exec probe commands"
+	}
+
+	return true, "This guest agent is supported"
 }

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3106,10 +3106,11 @@ var _ = Describe("VirtualMachineInstance", func() {
 		var vmi *v1.VirtualMachineInstance
 		var vmiWithPassword *v1.VirtualMachineInstance
 		var vmiWithSSH *v1.VirtualMachineInstance
+		var vmiWithExecProbes *v1.VirtualMachineInstance
 		var basicCommands []v1.GuestAgentCommandInfo
 		var sshCommands []v1.GuestAgentCommandInfo
-		var oldSshCommands []v1.GuestAgentCommandInfo
 		var passwordCommands []v1.GuestAgentCommandInfo
+		var execProbeCommands []v1.GuestAgentCommandInfo
 		const agentSupported = "This guest agent is supported"
 
 		BeforeEach(func() {
@@ -3140,6 +3141,20 @@ var _ = Describe("VirtualMachineInstance", func() {
 					},
 				},
 			}
+			vmiWithExecProbes = &v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{
+					ReadinessProbe: &v1.Probe{
+						Handler: v1.Handler{
+							Exec: &k8sv1.ExecAction{},
+						},
+					},
+					LivenessProbe: &v1.Probe{
+						Handler: v1.Handler{
+							Exec: &k8sv1.ExecAction{},
+						},
+					},
+				},
+			}
 
 			basicCommands = []v1.GuestAgentCommandInfo{}
 			for _, cmdName := range requiredGuestAgentCommands {
@@ -3157,17 +3172,17 @@ var _ = Describe("VirtualMachineInstance", func() {
 				})
 			}
 
-			oldSshCommands = []v1.GuestAgentCommandInfo{}
-			for _, cmdName := range oldSSHRelatedGuestAgentCommands {
-				oldSshCommands = append(oldSshCommands, v1.GuestAgentCommandInfo{
+			passwordCommands = []v1.GuestAgentCommandInfo{}
+			for _, cmdName := range passwordRelatedGuestAgentCommands {
+				passwordCommands = append(passwordCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,
 				})
 			}
 
-			passwordCommands = []v1.GuestAgentCommandInfo{}
-			for _, cmdName := range passwordRelatedGuestAgentCommands {
-				passwordCommands = append(passwordCommands, v1.GuestAgentCommandInfo{
+			execProbeCommands = []v1.GuestAgentCommandInfo{}
+			for _, cmdName := range execProbeGuestAgentCommands {
+				execProbeCommands = append(execProbeCommands, v1.GuestAgentCommandInfo{
 					Name:    cmdName,
 					Enabled: true,
 				})
@@ -3223,12 +3238,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(reason).To(Equal(agentSupported))
 		})
 
-		It("should succeed with SSH and old required commands", func() {
+		It("should fail with exec probe and basic commands", func() {
+			result, reason := isGuestAgentSupported(vmiWithExecProbes, basicCommands)
+			Expect(result).To(BeFalse())
+			Expect(reason).To(Equal("This guest agent doesn't support required exec probe commands"))
+		})
+
+		It("should succeed with exec probe and required commands", func() {
 			var commands []v1.GuestAgentCommandInfo
 			commands = append(commands, basicCommands...)
-			commands = append(commands, oldSshCommands...)
+			commands = append(commands, execProbeCommands...)
 
-			result, reason := isGuestAgentSupported(vmiWithSSH, commands)
+			result, reason := isGuestAgentSupported(vmiWithExecProbes, commands)
 			Expect(result).To(BeTrue())
 			Expect(reason).To(Equal(agentSupported))
 		})

--- a/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/config:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",
-        "//pkg/virt-launcher/virtwrap/agent:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/util:go_default_library",

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -21,7 +21,6 @@ package accesscredentials
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,23 +34,10 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
 )
-
-type openReturn struct {
-	Return int `json:"return"`
-}
-
-type readReturnData struct {
-	Count  int    `json:"count"`
-	BufB64 string `json:"buf-b64"`
-}
-type readReturn struct {
-	Return readReturnData `json:"return"`
-}
 
 type AccessCredentialManager struct {
 	virConn cli.Connection
@@ -119,171 +105,6 @@ func getSecretBaseDir() string {
 
 }
 
-func (l *AccessCredentialManager) writeGuestFile(contents string, domName string, filePath string, owner string, fileExists bool) error {
-
-	// ensure the directory exists with the correct permissions
-	err := l.agentCreateDirectory(domName, filepath.Dir(filePath), "700", owner)
-	if err != nil {
-		return err
-	}
-
-	if fileExists {
-		// ensure the file has the correct permissions for writing
-		l.agentSetFilePermissions(domName, filePath, "600", owner)
-
-	}
-
-	// write the file
-	base64Str := base64.StdEncoding.EncodeToString([]byte(contents))
-	cmdOpenFile := fmt.Sprintf(`{"execute": "guest-file-open", "arguments": { "path": "%s", "mode":"w" } }`, filePath)
-	output, err := l.virConn.QemuAgentCommand(cmdOpenFile, domName)
-	if err != nil {
-		return err
-	}
-
-	openRes := &openReturn{}
-	err = json.Unmarshal([]byte(output), openRes)
-	if err != nil {
-		return err
-	}
-
-	cmdWriteFile := fmt.Sprintf(`{"execute": "guest-file-write", "arguments": { "handle": %d, "buf-b64": "%s" } }`, openRes.Return, base64Str)
-	_, err = l.virConn.QemuAgentCommand(cmdWriteFile, domName)
-	if err != nil {
-		return err
-	}
-
-	cmdCloseFile := fmt.Sprintf(`{"execute": "guest-file-close", "arguments": { "handle": %d } }`, openRes.Return)
-	_, err = l.virConn.QemuAgentCommand(cmdCloseFile, domName)
-	if err != nil {
-		return err
-	}
-
-	if !fileExists {
-		// ensure the file has the correct permissions and ownership after creating new file
-		l.agentSetFilePermissions(domName, filePath, "600", owner)
-	}
-
-	return nil
-}
-
-func (l *AccessCredentialManager) readGuestFile(domName string, filePath string) (string, error) {
-	contents := ""
-
-	cmdOpenFile := fmt.Sprintf(`{"execute": "guest-file-open", "arguments": { "path": "%s", "mode":"r" } }`, filePath)
-	output, err := l.virConn.QemuAgentCommand(cmdOpenFile, domName)
-	if err != nil {
-		return contents, err
-	}
-
-	openRes := &openReturn{}
-	err = json.Unmarshal([]byte(output), openRes)
-	if err != nil {
-		return contents, err
-	}
-
-	cmdReadFile := fmt.Sprintf(`{"execute": "guest-file-read", "arguments": { "handle": %d } }`, openRes.Return)
-	readOutput, err := l.virConn.QemuAgentCommand(cmdReadFile, domName)
-
-	if err != nil {
-		return contents, err
-	}
-
-	readRes := &readReturn{}
-	err = json.Unmarshal([]byte(readOutput), readRes)
-	if err != nil {
-		return contents, err
-	}
-
-	if readRes.Return.Count > 0 {
-		readBytes, err := base64.StdEncoding.DecodeString(readRes.Return.BufB64)
-		if err != nil {
-			return contents, err
-		}
-		contents = string(readBytes)
-	}
-
-	cmdCloseFile := fmt.Sprintf(`{"execute": "guest-file-close", "arguments": { "handle": %d } }`, openRes.Return)
-	_, err = l.virConn.QemuAgentCommand(cmdCloseFile, domName)
-	if err != nil {
-		return contents, err
-	}
-
-	return contents, nil
-}
-
-func (l *AccessCredentialManager) agentGuestExec(domName string, command string, args []string) (string, error) {
-	return agent.GuestExec(l.virConn, domName, command, args, 10)
-}
-
-// Requires usage of mkdir, chown, chmod
-func (l *AccessCredentialManager) agentCreateDirectory(domName string, dir string, permissions string, owner string) error {
-	// Ensure the directory exists
-	_, err := l.agentGuestExec(domName, "mkdir", []string{"-p", dir})
-	if err != nil {
-		return err
-	}
-
-	// set ownership/permissions of directory using parent directory owner
-	_, err = l.agentGuestExec(domName, "chown", []string{owner, dir})
-	if err != nil {
-		return err
-	}
-	_, err = l.agentGuestExec(domName, "chmod", []string{permissions, dir})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (l *AccessCredentialManager) agentGetUserInfo(domName string, user string) (string, string, string, error) {
-	passwdEntryStr, err := l.agentGuestExec(domName, "getent", []string{"passwd", user})
-	if err != nil {
-		return "", "", "", fmt.Errorf("Unable to detect home directory of user %s: %s", user, err.Error())
-	}
-	passwdEntryStr = strings.TrimSpace(passwdEntryStr)
-	entries := strings.Split(passwdEntryStr, ":")
-	if len(entries) < 6 {
-		return "", "", "", fmt.Errorf("Unable to detect home directory of user %s", user)
-	}
-
-	filePath := entries[5]
-	uid := entries[2]
-	gid := entries[3]
-	log.Log.Infof("Detected home directory %s for user %s", filePath, user)
-	return filePath, uid, gid, nil
-}
-
-func (l *AccessCredentialManager) agentGetFileOwnership(domName string, filePath string) (string, error) {
-	ownerStr, err := l.agentGuestExec(domName, "stat", []string{"-c", "%U:%G", filePath})
-	if err != nil {
-		return "", fmt.Errorf("Unable to detect ownership of access credential at %s: %s", filePath, err.Error())
-	}
-	ownerStr = strings.TrimSpace(ownerStr)
-	if ownerStr == "" {
-		return "", fmt.Errorf("Unable to detect ownership of access credential at %s", filePath)
-	}
-
-	log.Log.Infof("Detected owner %s for quest path %s", ownerStr, filePath)
-	return ownerStr, nil
-}
-
-// Requires usage of chown, chmod
-func (l *AccessCredentialManager) agentSetFilePermissions(domName string, filePath string, permissions string, owner string) error {
-	// set ownership/permissions of directory using parent directory owner
-	_, err := l.agentGuestExec(domName, "chown", []string{owner, filePath})
-	if err != nil {
-		return err
-	}
-	_, err = l.agentGuestExec(domName, "chmod", []string{permissions, filePath})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (l *AccessCredentialManager) agentSetUserPassword(domName string, user string, password string) error {
 
 	base64Str := base64.StdEncoding.EncodeToString([]byte(password))
@@ -304,69 +125,21 @@ func (l *AccessCredentialManager) pingAgent(domName string) error {
 	return err
 }
 
-func (l *AccessCredentialManager) agentSetAuthorizedKeys(domName string, user string, authorizedKeys []string) error {
-	err := func() error {
-		domain, err := l.virConn.LookupDomainByName(domName)
-		if err != nil {
-			return err
-		}
-		defer domain.Free()
-
-		// Zero flags argument means that the authorized_keys file is overwritten with the authorizedKeys
-		return domain.AuthorizedSSHKeysSet(user, authorizedKeys, 0)
-	}()
-	if err == nil {
-		return nil
-	}
-
-	log.Log.V(4).Infof("Could not set SSH key using guest-ssh-add-authorized-keys: %v", err)
-
-	// If AuthorizedSSHKeysSet method failed, use the old method
-	desiredAuthorizedKeys := strings.Join(authorizedKeys, "\n")
-	secondErr := l.agentWriteAuthorizedKeysFile(domName, user, desiredAuthorizedKeys)
-	if secondErr == nil {
-		return nil
-	}
-
-	return fmt.Errorf(
-		"failed to set SSH keys: error from guest-ssh-add-authorized-keys: %w; error from using guest-file-write: %w",
-		err,
-		secondErr,
-	)
-}
-
-func (l *AccessCredentialManager) agentWriteAuthorizedKeysFile(domName string, user string, desiredAuthorizedKeys string) (err error) {
-	curAuthorizedKeys := ""
-	fileExists := true
-
-	// ######
-	// Step 1. Get home directory for user.
-	// ######
-	homeDir, uid, gid, err := l.agentGetUserInfo(domName, user)
+func (l *AccessCredentialManager) agentSetAuthorizedKeys(domName string, user string, authorizedKeys []string) (err error) {
+	domain, err := l.virConn.LookupDomainByName(domName)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to lookup domain %s: %w", domName, err)
 	}
-
-	// ######
-	// Step 2. Read file on guest to determine if change is required
-	// ######
-	filePath := fmt.Sprintf("%s/.ssh/authorized_keys", homeDir)
-	curAuthorizedKeys, err = l.readGuestFile(domName, filePath)
-	if err != nil && strings.Contains(err.Error(), "No such file or directory") {
-		fileExists = false
-	} else if err != nil {
-		return err
-	}
-
-	// ######
-	// Step 3. Write authorized_keys file if changes exist
-	// ######
-	// only update if the updated string is not equal to the current contents on the guest.
-	if curAuthorizedKeys != desiredAuthorizedKeys {
-		err = l.writeGuestFile(desiredAuthorizedKeys, domName, filePath, fmt.Sprintf("%s:%s", uid, gid), fileExists)
-		if err != nil {
-			return err
+	defer func() {
+		if freeErr := domain.Free(); err == nil && freeErr != nil {
+			err = fmt.Errorf("failed to free domain %s: %w", domName, freeErr)
 		}
+	}()
+
+	// Zero flags argument means that the authorized_keys file is overwritten with the authorizedKeys
+	err = domain.AuthorizedSSHKeysSet(user, authorizedKeys, 0)
+	if err != nil {
+		return fmt.Errorf("failed to set SSH authorized keys: %w", err)
 	}
 
 	return nil

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -87,20 +87,6 @@ var _ = Describe("AccessCredentials", func() {
 		return &domain.Spec
 	}
 
-	It("should handle qemu agent exec", func() {
-		domName := "some-domain"
-		command := "some-command"
-		args := []string{"arg1", "arg2"}
-
-		expectedCmd := `{"execute": "guest-exec", "arguments": { "path": "some-command", "arg": [ "arg1", "arg2" ], "capture-output":true } }`
-		expectedStatusCmd := `{"execute": "guest-exec-status", "arguments": { "pid": 789 } }`
-
-		mockConn.EXPECT().QemuAgentCommand(expectedCmd, domName).Return(`{"return":{"pid":789}}`, nil)
-		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(`{"return":{"exitcode":0,"out-data":"c3NoIHNvbWVrZXkxMjMgdGVzdC1rZXkK","exited":true}}`, nil)
-
-		Expect(manager.agentGuestExec(domName, command, args)).To(Equal("ssh somekey123 test-key\n"))
-	})
-
 	It("should handle dynamically updating user/password with qemu agent", func() {
 
 		domName := "some-domain"
@@ -126,88 +112,7 @@ var _ = Describe("AccessCredentials", func() {
 		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
 	})
 
-	It("should dynamically update ssh key with old qemu agent", func() {
-		domName := "some-domain"
-		user := "someowner"
-		filePath := "/home/someowner/.ssh"
-
-		authorizedKeys := []string{"ssh some injected key"}
-
-		mockConn.EXPECT().LookupDomainByName(domName).Return(mockDomain, nil).Times(1)
-		// The AuthorizedSSHKeysSet method fails so a backward compatible code will be used.
-		mockDomain.EXPECT().AuthorizedSSHKeysSet(user, authorizedKeys, gomock.Any()).Return(libvirt.ERR_INTERNAL_ERROR).Times(1)
-		mockDomain.EXPECT().Free().Times(1)
-
-		expectedOpenCmd := fmt.Sprintf(`{"execute": "guest-file-open", "arguments": { "path": "%s/authorized_keys", "mode":"r" } }`, filePath)
-		expectedWriteOpenCmd := fmt.Sprintf(`{"execute": "guest-file-open", "arguments": { "path": "%s/authorized_keys", "mode":"w" } }`, filePath)
-		expectedOpenCmdRes := `{"return":1000}`
-
-		existingKey := base64.StdEncoding.EncodeToString([]byte("ssh some existing key"))
-		expectedReadCmd := `{"execute": "guest-file-read", "arguments": { "handle": 1000 } }`
-		expectedReadCmdRes := fmt.Sprintf(`{"return":{"count":24,"buf-b64": "%s"}}`, existingKey)
-
-		mergedKeys := base64.StdEncoding.EncodeToString([]byte(strings.Join(authorizedKeys, "\n")))
-		expectedWriteCmd := fmt.Sprintf(`{"execute": "guest-file-write", "arguments": { "handle": 1000, "buf-b64": "%s" } }`, mergedKeys)
-
-		expectedCloseCmd := `{"execute": "guest-file-close", "arguments": { "handle": 1000 } }`
-
-		expectedExecReturn := `{"return":{"pid":789}}`
-		expectedStatusCmd := `{"execute": "guest-exec-status", "arguments": { "pid": 789 } }`
-
-		getentBase64Str := base64.StdEncoding.EncodeToString([]byte("someowner:x:1111:2222:Some Owner:/home/someowner:/bin/bash"))
-		expectedHomeDirCmd := `{"execute": "guest-exec", "arguments": { "path": "getent", "arg": [ "passwd", "someowner" ], "capture-output":true } }`
-		expectedHomeDirCmdRes := fmt.Sprintf(`{"return":{"exitcode":0,"out-data":"%s","exited":true}}`, getentBase64Str)
-
-		expectedMkdirCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "mkdir", "arg": [ "-p", "%s" ], "capture-output":true } }`, filePath)
-		expectedMkdirRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
-
-		expectedParentChownCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "chown", "arg": [ "1111:2222", "%s" ], "capture-output":true } }`, filePath)
-		expectedParentChownRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
-
-		expectedParentChmodCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "chmod", "arg": [ "700", "%s" ], "capture-output":true } }`, filePath)
-		expectedParentChmodRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
-
-		expectedFileChownCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "chown", "arg": [ "1111:2222", "%s/authorized_keys" ], "capture-output":true } }`, filePath)
-		expectedFileChownRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
-
-		expectedFileChmodCmd := fmt.Sprintf(`{"execute": "guest-exec", "arguments": { "path": "chmod", "arg": [ "600", "%s/authorized_keys" ], "capture-output":true } }`, filePath)
-		expectedFileChmodRes := `{"return":{"exitcode":0,"out-data":"","exited":true}}`
-
-		// Detect user home dir
-		mockConn.EXPECT().QemuAgentCommand(expectedHomeDirCmd, domName).Return(expectedExecReturn, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedHomeDirCmdRes, nil).Times(1)
-
-		// Expected Read File
-		mockConn.EXPECT().QemuAgentCommand(expectedOpenCmd, domName).Return(expectedOpenCmdRes, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedReadCmd, domName).Return(expectedReadCmdRes, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedCloseCmd, domName).Return("", nil).Times(1)
-
-		// Expected prepare directory
-		mockConn.EXPECT().QemuAgentCommand(expectedMkdirCmd, domName).Return(expectedExecReturn, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedMkdirRes, nil).Times(1)
-
-		mockConn.EXPECT().QemuAgentCommand(expectedParentChownCmd, domName).Return(expectedExecReturn, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedParentChownRes, nil).Times(1)
-
-		mockConn.EXPECT().QemuAgentCommand(expectedParentChmodCmd, domName).Return(expectedExecReturn, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedParentChmodRes, nil).Times(1)
-
-		// Expected Write file
-		mockConn.EXPECT().QemuAgentCommand(expectedWriteOpenCmd, domName).Return(expectedOpenCmdRes, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedWriteCmd, domName).Return("", nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedCloseCmd, domName).Return("", nil).Times(1)
-
-		// Expected set file permissions
-		mockConn.EXPECT().QemuAgentCommand(expectedFileChownCmd, domName).Return(expectedExecReturn, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedFileChownRes, nil).Times(1)
-
-		mockConn.EXPECT().QemuAgentCommand(expectedFileChmodCmd, domName).Return(expectedExecReturn, nil).Times(1)
-		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedFileChmodRes, nil).Times(1)
-
-		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
-	})
-
-	It("should fail to update ssh key if both methods return error", func() {
+	It("should fail to update ssh key on error", func() {
 		domName := "some-domain"
 		user := "someowner"
 
@@ -217,12 +122,9 @@ var _ = Describe("AccessCredentials", func() {
 		// The AuthorizedSSHKeysSet method fails so a backward compatible code will be used.
 		mockDomain.EXPECT().AuthorizedSSHKeysSet(user, authorizedKeys, gomock.Any()).Return(libvirt.ERR_INTERNAL_ERROR).Times(1)
 		mockDomain.EXPECT().Free().Times(1)
-
-		// Detect user home dir
-		mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return("", libvirt.ERR_INTERNAL_ERROR).AnyTimes()
 
 		Expect(manager.agentSetAuthorizedKeys(domName, user, authorizedKeys)).
-			To(MatchError(ContainSubstring("failed to set SSH keys")))
+			To(MatchError(ContainSubstring("failed to set SSH authorized keys")))
 	})
 
 	It("should support multiple ssh keys in one secret value", func() {


### PR DESCRIPTION

### What this PR does
The old method was using guest agent commands to create files in the .ssh directory directly. It was less secure than the current method that calls libvirt API.

This commit also changes the check if required guest agent commands are supported. The "guest-exec" and "guest-exec-status" are needed if exec probe is configured on the VM.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
```release-note
Dynamic SSH key propagation requires qemu guest agent version 5.2 or later.
```

