### PR TITLE
lint: Add tests/numa to paths covered by linter 

### DIFF
--- a/hack/lint-paths.txt
+++ b/hack/lint-paths.txt
@@ -25,5 +25,6 @@ tests/libssh
 tests/libvmifact
 tests/libvmops
 tests/libwait
+tests/numa
 tests/scale
 tests/usb

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -31,80 +31,85 @@ import (
 )
 
 var _ = Describe("[sig-compute]NUMA", Serial, decorators.SigCompute, func() {
-
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 	})
 
-	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", decorators.RequiresNodeWithCPUManager, decorators.RequiresHugepages2Mi, func() {
-		var err error
-		cpuVMI := libvmifact.NewCirros()
-		cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-		cpuVMI.Spec.Domain.CPU = &v1.CPU{
-			Cores:                 3,
-			DedicatedCPUPlacement: true,
-			NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
-		}
-		cpuVMI.Spec.Domain.Memory = &v1.Memory{
-			Hugepages: &v1.Hugepages{PageSize: "2Mi"},
-		}
+	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated",
+		decorators.RequiresNodeWithCPUManager, decorators.RequiresHugepages2Mi, func() {
+			var err error
+			cpuVMI := libvmifact.NewCirros()
+			cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
+			cpuVMI.Spec.Domain.CPU = &v1.CPU{
+				Cores:                 3,
+				DedicatedCPUPlacement: true,
+				NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
+			}
+			cpuVMI.Spec.Domain.Memory = &v1.Memory{
+				Hugepages: &v1.Hugepages{PageSize: "2Mi"},
+			}
 
-		By("Starting a VirtualMachineInstance")
-		cpuVMI, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), cpuVMI, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		cpuVMI = libwait.WaitForSuccessfulVMIStart(cpuVMI)
-		By("Fetching the numa memory mapping")
-		handler, err := libnode.GetVirtHandlerPod(virtClient, cpuVMI.Status.NodeName)
-		Expect(err).ToNot(HaveOccurred())
-		pid := getQEMUPID(handler, cpuVMI)
+			By("Starting a VirtualMachineInstance")
+			cpuVMI, err = virtClient.VirtualMachineInstance(
+				testsuite.NamespaceTestDefault).Create(context.Background(), cpuVMI, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			cpuVMI = libwait.WaitForSuccessfulVMIStart(cpuVMI)
+			By("Fetching the numa memory mapping")
+			handler, err := libnode.GetVirtHandlerPod(virtClient, cpuVMI.Status.NodeName)
+			Expect(err).ToNot(HaveOccurred())
+			pid := getQEMUPID(handler, cpuVMI)
 
-		By("Checking if the pinned numa memory chunks match the VMI memory size")
-		scanner := bufio.NewScanner(strings.NewReader(getNUMAMapping(virtClient, handler, pid)))
-		rex := regexp.MustCompile(`bind:(\d+) .+memfd:.+N(\d+)=(\d+).+kernelpagesize_kB=(\d+)`)
-		mappings := map[int]mapping{}
-		for scanner.Scan() {
-			if findings := rex.FindStringSubmatch(scanner.Text()); findings != nil {
-				mappings[mustAtoi(findings[1])] = mapping{
-					BindNode:           mustAtoi(findings[1]),
-					AllocationNode:     mustAtoi(findings[2]),
-					Pages:              mustAtoi(findings[3]),
-					PageSizeAsQuantity: toKi(mustAtoi(findings[4])),
-					PageSize:           mustAtoi(findings[4]),
+			By("Checking if the pinned numa memory chunks match the VMI memory size")
+			scanner := bufio.NewScanner(strings.NewReader(getNUMAMapping(virtClient, handler, pid)))
+			rex := regexp.MustCompile(`bind:(\d+) .+memfd:.+N(\d+)=(\d+).+kernelpagesize_kB=(\d+)`)
+			mappings := map[int]mapping{}
+			for scanner.Scan() {
+				if findings := rex.FindStringSubmatch(scanner.Text()); findings != nil {
+					mappings[mustAtoi(findings[1])] = mapping{
+						BindNode:           mustAtoi(findings[1]),
+						AllocationNode:     mustAtoi(findings[2]),
+						Pages:              mustAtoi(findings[3]),
+						PageSizeAsQuantity: toKi(mustAtoi(findings[4])),
+						PageSize:           mustAtoi(findings[4]),
+					}
 				}
 			}
-		}
 
-		sum := 0
-		requestedPageSize := resource.MustParse(cpuVMI.Spec.Domain.Memory.Hugepages.PageSize)
-		requestedMemory := cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
-		for _, m := range mappings {
-			Expect(m.PageSizeAsQuantity.Equal(requestedPageSize)).To(BeTrue())
-			Expect(m.BindNode).To(Equal(m.AllocationNode))
-			sum += m.Pages
-		}
-		Expect(resource.MustParse(fmt.Sprintf("%dKi", sum*2048)).Equal(requestedMemory)).To(BeTrue())
+			sum := 0
+			requestedPageSize := resource.MustParse(cpuVMI.Spec.Domain.Memory.Hugepages.PageSize)
+			requestedMemory := cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
+			for _, m := range mappings {
+				Expect(m.PageSizeAsQuantity.Equal(requestedPageSize)).To(BeTrue())
+				Expect(m.BindNode).To(Equal(m.AllocationNode))
+				sum += m.Pages
+			}
+			const memoryFactor = 2048
+			Expect(resource.MustParse(fmt.Sprintf("%dKi", sum*memoryFactor)).Equal(requestedMemory)).To(BeTrue())
 
-		By("Fetching the domain XML")
-		domSpec, err := tests.GetRunningVMIDomainSpec(cpuVMI)
-		Expect(err).ToNot(HaveOccurred())
+			By("Fetching the domain XML")
+			domSpec, err := tests.GetRunningVMIDomainSpec(cpuVMI)
+			Expect(err).ToNot(HaveOccurred())
 
-		By("checking that we really deal with a domain with numa configured")
-		Expect(domSpec.CPU.NUMA.Cells).ToNot(BeEmpty())
+			By("checking that we really deal with a domain with numa configured")
+			Expect(domSpec.CPU.NUMA.Cells).ToNot(BeEmpty())
 
-		By("Checking if number of memory chunkgs matches the number of nodes on the VM")
-		Expect(mappings).To(HaveLen(len(domSpec.MemoryBacking.HugePages.HugePage)))
-		Expect(mappings).To(HaveLen(len(domSpec.CPU.NUMA.Cells)))
-		Expect(mappings).To(HaveLen(len(domSpec.NUMATune.MemNodes)))
+			By("Checking if number of memory chunkgs matches the number of nodes on the VM")
+			Expect(mappings).To(HaveLen(len(domSpec.MemoryBacking.HugePages.HugePage)))
+			Expect(mappings).To(HaveLen(len(domSpec.CPU.NUMA.Cells)))
+			Expect(mappings).To(HaveLen(len(domSpec.NUMATune.MemNodes)))
 
-		By("checking if the guest came up and is healthy")
-		Expect(console.LoginToCirros(cpuVMI)).To(Succeed())
-	})
-
+			By("checking if the guest came up and is healthy")
+			Expect(console.LoginToCirros(cpuVMI)).To(Succeed())
+		})
 })
 
 func getQEMUPID(handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
 	var stdout, stderr string
+	const (
+		expectedProcesses    = 2
+		expectedPathElements = 4
+	)
 	// Using `ps` here doesn't work reliably. Grepping /proc instead.
 	// The "[g]" prevents grep from finding its own process
 	Eventually(func() (err error) {
@@ -118,9 +123,10 @@ func getQEMUPID(handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
 	}, 3*time.Second, 500*time.Millisecond).Should(Succeed(), stderr, stdout)
 
 	strs := strings.Split(stdout, "\n")
-	Expect(strs).To(HaveLen(2), "more (or less?) than one matching process was found")
+	Expect(strs).To(HaveLen(expectedProcesses),
+		"more (or less?) than one matching process was found")
 	path := strings.Split(strs[0], "/")
-	Expect(path).To(HaveLen(4), "the cmdline path is invalid")
+	Expect(path).To(HaveLen(expectedPathElements), "the cmdline path is invalid")
 
 	return path[2]
 }


### PR DESCRIPTION
### What this PR does

Add tests/numa to paths covered by linter and fix resulting linter errors

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

