### PR TITLE
send domain info update only when when change in domain info params

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -209,6 +209,19 @@ var _ = Describe("Qemu agent poller", func() {
 
 			Expect(*osInfo).To(Equal(fakeInfo))
 		})
+
+		It("should not fire an event for a new GET_FILESYSTEM", func() {
+			fakeFileSystemInfo := []api.Filesystem{
+				{
+					Name: "test",
+				},
+			}
+			agentStore.Store(libvirt.DOMAIN_GUEST_INFO_FILESYSTEM, fakeFileSystemInfo)
+
+			Expect(agentStore.AgentUpdated).NotTo(Receive(Equal(AgentUpdatedEvent{
+				DomainInfo: api.DomainGuestInfo{},
+			})))
+		})
 	})
 
 	Context("PollerWorker", func() {


### PR DESCRIPTION


### What this PR does
1.Send updates of domaininfo only if there is a change in domain info.
  (GET_OSINFO, GET_INTERFACES, GET_FSFREEZE_STATUS)
  Do not send updates when there is no change in domain info.

Before this PR:

After this PR:

For example, consider a case where there is file system update from qemu-ga (key- GET_FILESYSTEM) and updated flag will be set.
So if updated is set, we try to get information for the key GET_FILESYSTEM but in that process we send empty updates in DomainInfo as the key will not match for GET_OSINFO, GET_INTERFACES, GET_FSFREEZE_STATUS cases.
Though eventCallback checks for interface and osInfo as not nil, its not necessary to send updates for this when there is no change.



### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

