### PR TITLE
open-api: update resource.Quantity type to support both string and integer

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11779,7 +11779,11 @@
    },
    "k8s.io.apimachinery.pkg.api.resource.Quantity": {
     "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` \u003cquantity\u003e        ::= \u003csignedNumber\u003e\u003csuffix\u003e\n\n\t(Note that \u003csuffix\u003e may be empty, from the \"\" case in \u003cdecimalSI\u003e.)\n\n\u003cdigit\u003e           ::= 0 | 1 | ... | 9 \u003cdigits\u003e          ::= \u003cdigit\u003e | \u003cdigit\u003e\u003cdigits\u003e \u003cnumber\u003e          ::= \u003cdigits\u003e | \u003cdigits\u003e.\u003cdigits\u003e | \u003cdigits\u003e. | .\u003cdigits\u003e \u003csign\u003e            ::= \"+\" | \"-\" \u003csignedNumber\u003e    ::= \u003cnumber\u003e | \u003csign\u003e\u003cnumber\u003e \u003csuffix\u003e          ::= \u003cbinarySI\u003e | \u003cdecimalExponent\u003e | \u003cdecimalSI\u003e \u003cbinarySI\u003e        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n\u003cdecimalSI\u003e       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n\u003cdecimalExponent\u003e ::= \"e\" \u003csignedNumber\u003e | \"E\" \u003csignedNumber\u003e ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
-    "type": "string"
+    "type": [
+     "string",
+     "integer",
+     "number"
+    ]
    },
    "k8s.io.apimachinery.pkg.apis.meta.v1.APIGroup": {
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
@@ -15573,7 +15577,10 @@
     "properties": {
      "limits": {
       "description": "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\" and \"cpu\".",
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+      }
      },
      "overcommitGuestOverhead": {
       "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false.",
@@ -15581,7 +15588,10 @@
      },
      "requests": {
       "description": "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\" and \"cpu\".",
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+      }
      }
     }
    },

--- a/pkg/util/openapi/openapi.go
+++ b/pkg/util/openapi/openapi.go
@@ -156,19 +156,13 @@ func LoadOpenAPISpec(webServices []*restful.WebService) *spec.Swagger {
 			break
 		}
 	}
-	resourceRequirements, exists := openapispec.Definitions["v1.ResourceRequirements"]
-	if exists {
-		limits, exists := resourceRequirements.Properties["limits"]
-		if exists {
-			limits.AdditionalProperties = nil
-			resourceRequirements.Properties["limits"] = limits
-		}
-		requests, exists := resourceRequirements.Properties["requests"]
-		if exists {
-			requests.AdditionalProperties = nil
-			resourceRequirements.Properties["requests"] = requests
-		}
 
+	const resourceQuantityDefinition = "k8s.io.apimachinery.pkg.api.resource.Quantity"
+
+	quantity, exists := openapispec.Definitions[resourceQuantityDefinition]
+	if exists {
+		quantity.Type = spec.StringOrArray{"string", "integer", "number"}
+		openapispec.Definitions[resourceQuantityDefinition] = quantity
 	}
 
 	objectMeta, exists := openapispec.Definitions[objectmeta]


### PR DESCRIPTION
### What this PR does
Before this PR:
If you would try to apply vm-cirros with memory.guest using pure integer, you would get rejected by the vm-mutator with this error msg:

`spec.template.spec.domain.memory.guest in body must be of type string: "number"`

```
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: vm-cirros
spec:
  template:
    spec:
      domain:
        memory:
          guest: 1234567
```

After this PR:
* Updated the `resource.Quanitiy` type in the openapi schema to support both strings and integer types.
* The memory.guest field can be populated with integers just fine.

### Jira Ticket
```
https://issues.redhat.com/browse/CNV-36293
```

### Release note
```release-note
None
```

