### PR TITLE
fix(virtctl,scp): Update native_unsupported.go to use new structs

### DIFF
--- a/pkg/virtctl/scp/native.go
+++ b/pkg/virtctl/scp/native.go
@@ -13,7 +13,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/ssh"
 )
 
-func (o *SCP) nativeSCP(local LocalArgument, remote RemoteArgument, toRemote bool) error {
+func (o *SCP) nativeSCP(local *LocalArgument, remote *RemoteArgument, toRemote bool) error {
 	sshClient := ssh.NativeSSHConnection{
 		ClientConfig: o.clientConfig,
 		Options:      o.options,

--- a/pkg/virtctl/scp/native_unsupported.go
+++ b/pkg/virtctl/scp/native_unsupported.go
@@ -2,10 +2,6 @@
 
 package scp
 
-import (
-	"kubevirt.io/kubevirt/pkg/virtctl/templates"
-)
-
-func (o *SCP) nativeSCP(_ templates.LocalSCPArgument, _ templates.RemoteSCPArgument, _ bool) error {
+func (o *SCP) nativeSCP(_ *LocalArgument, _ *RemoteArgument, _ bool) error {
 	panic("Native SCP is unsupported in this build!")
 }

--- a/pkg/virtctl/scp/scp.go
+++ b/pkg/virtctl/scp/scp.go
@@ -76,11 +76,11 @@ func (o *SCP) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if o.options.WrapLocalSSH {
-		clientArgs := o.buildSCPTarget(*local, *remote, toRemote)
+		clientArgs := o.buildSCPTarget(local, remote, toRemote)
 		return ssh.RunLocalClient(remote.Kind, remote.Namespace, remote.Name, &o.options, clientArgs)
 	}
 
-	return o.nativeSCP(*local, *remote, toRemote)
+	return o.nativeSCP(local, remote, toRemote)
 }
 
 type LocalArgument struct {

--- a/pkg/virtctl/scp/wrapped.go
+++ b/pkg/virtctl/scp/wrapped.go
@@ -2,7 +2,7 @@ package scp
 
 import "strings"
 
-func (o *SCP) buildSCPTarget(local LocalArgument, remote RemoteArgument, toRemote bool) (opts []string) {
+func (o *SCP) buildSCPTarget(local *LocalArgument, remote *RemoteArgument, toRemote bool) (opts []string) {
 	if o.recursive {
 		opts = append(opts, "-r")
 	}

--- a/pkg/virtctl/scp/wrapped_test.go
+++ b/pkg/virtctl/scp/wrapped_test.go
@@ -10,16 +10,16 @@ import (
 
 var _ = Describe("Wrapped SCP", func() {
 
-	var fakeLocal LocalArgument
-	var fakeRemote RemoteArgument
+	var fakeLocal *LocalArgument
+	var fakeRemote *RemoteArgument
 	var fakeToRemote bool
 	var scp SCP
 
 	BeforeEach(func() {
-		fakeLocal = LocalArgument{
+		fakeLocal = &LocalArgument{
 			Path: "/local/fakepath",
 		}
-		fakeRemote = RemoteArgument{
+		fakeRemote = &RemoteArgument{
 			Namespace: "fake-ns",
 			Name:      "fake-name",
 			Path:      "/remote/fakepath",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Update native_unsupported.go to use the new LocalArgument and RemoteArgument structs. Update places where the structs passed to pass by reference to avoid unnecessary copies.

Before this PR:

`excludenative` builds fail because the old structs are no longer present.

After this PR:

`excludenative` builds succeed and unnecessary copies of values are avoided.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

