### PR TITLE
Set VM status indication if storage exceeds quota

### DIFF
--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -193,6 +193,16 @@ func HasDataVolumeErrors(namespace string, volumes []virtv1.Volume, dataVolumeSt
 	return nil
 }
 
+// FIXME: Bound mistakenly reports ErrExceededQuota with ConditionUnknown status
+func HasDataVolumeExceededQuotaError(dv *cdiv1.DataVolume) error {
+	dvBoundCond := NewDataVolumeConditionManager().GetCondition(dv, cdiv1.DataVolumeBound)
+	if dvBoundCond != nil && dvBoundCond.Status != v1.ConditionTrue && dvBoundCond.Reason == "ErrExceededQuota" {
+		return fmt.Errorf("DataVolume %s importer is not running due to an error: %v", dv.Name, dvBoundCond.Message)
+	}
+
+	return nil
+}
+
 func HasDataVolumeProvisioning(namespace string, volumes []virtv1.Volume, dataVolumeStore cache.Store) bool {
 	for _, volume := range volumes {
 		if volume.DataVolume == nil {

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -39,8 +39,6 @@ const (
 	MiB = 1024 * 1024
 
 	allowClaimAdoptionAnnotation = "cdi.kubevirt.io/allowClaimAdoption"
-
-	dataVolumeGarbageCollectionAnnotation = "cdi.kubevirt.io/garbageCollected"
 )
 
 type PvcNotFoundError struct {
@@ -49,10 +47,6 @@ type PvcNotFoundError struct {
 
 func (e PvcNotFoundError) Error() string {
 	return e.Reason
-}
-
-func IsDataVolumeGarbageCollected(pvc *k8sv1.PersistentVolumeClaim) bool {
-	return pvc != nil && pvc.Annotations[dataVolumeGarbageCollectionAnnotation] == "true"
 }
 
 func IsPVCBlockFromStore(store cache.Store, namespace string, claimName string) (pvc *k8sv1.PersistentVolumeClaim, exists bool, isBlockDevice bool, err error) {

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -481,13 +481,6 @@ func (c *Controller) handleDataVolumes(vm *virtv1.VirtualMachine) (bool, error) 
 				return false, err
 			}
 
-			if pvc != nil {
-				// don't want to keep creating DataVolumes that will be garbage collected
-				if storagetypes.IsDataVolumeGarbageCollected(pvc) {
-					continue
-				}
-			}
-
 			// ready = false because encountered DataVolume that is not created yet
 			ready = false
 			newDataVolume, err := watchutil.CreateDataVolumeManifest(c.clientset, template, vm)
@@ -514,14 +507,20 @@ func (c *Controller) handleDataVolumes(vm *virtv1.VirtualMachine) (bool, error) 
 				return ready, fmt.Errorf("failed to create DataVolume: %v", err)
 			}
 			c.recorder.Eventf(vm, k8score.EventTypeNormal, SuccessfulDataVolumeCreateReason, "Created DataVolume %s", curDataVolume.Name)
-		} else if curDataVolume.Status.Phase != cdiv1.Succeeded &&
-			curDataVolume.Status.Phase != cdiv1.WaitForFirstConsumer &&
-			curDataVolume.Status.Phase != cdiv1.PendingPopulation {
+		} else {
+			switch curDataVolume.Status.Phase {
+			case cdiv1.Succeeded, cdiv1.WaitForFirstConsumer, cdiv1.PendingPopulation:
+				continue
+			case cdiv1.Failed:
+				c.recorder.Eventf(vm, k8score.EventTypeWarning, controller.FailedDataVolumeImportReason, "DataVolume %s failed to import disk image", curDataVolume.Name)
+			case cdiv1.Pending:
+				if err := storagetypes.HasDataVolumeExceededQuotaError(curDataVolume); err != nil {
+					c.recorder.Eventf(vm, k8score.EventTypeWarning, controller.FailedDataVolumeImportReason, "DataVolume %s exceeds quota limits", curDataVolume.Name)
+					return false, err
+				}
+			}
 			// ready = false because encountered DataVolume that is not populated yet
 			ready = false
-			if curDataVolume.Status.Phase == cdiv1.Failed {
-				c.recorder.Eventf(vm, k8score.EventTypeWarning, controller.FailedDataVolumeImportReason, "DataVolume %s failed to import disk image", curDataVolume.Name)
-			}
 		}
 	}
 	return ready, nil


### PR DESCRIPTION
### What this PR does
When a VM requests storage beyond the limits defined by a` ResourceQuota`, it gets stuck in the `Provisioning` status with only a `VMINotExists` reason. This leaves the user unaware of how to resolve the issue:

```
  status:
    conditions:
    - message: VMI does not exist
      reason: VMINotExists
      status: "False"
      type: Ready
```
The fix adds an informative `FailedCreate` condition:

```
  status:
    conditions:
    - message: VMI does not exist
      reason: VMINotExists
      status: "False"
      type: Ready
    - message: 'Error encountered while creating DataVolumes: DataVolume my-vol importer is not running due to an error: persistentvolumeclaims "my-vol" is forbidden: exceeded quota: storage, requested: requests.storage=10737418240, used: requests.storage=0, limited: requests.storage=2Gi'
      reason: FailedCreate
      status: "True"
      type: Failure
```

jira-ticket: https://issues.redhat.com/browse/CNV-42175

### Release note
```release-note
Set VM status indication if storage exceeds quota
```