### PR TITLE
virt-handler: simplify selinux.RelabelFiles

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -386,7 +386,7 @@ func (app *virtHandlerApp) Run() {
 		if err != nil {
 			panic(err)
 		}
-		err = selinux.RelabelFiles(util.UnprivilegedContainerSELinuxLabel, se.IsPermissive(), devTun, devNull)
+		err = selinux.RelabelFilesUnprivileged(se.IsPermissive(), devTun, devNull)
 		if err != nil {
 			panic(fmt.Errorf("error relabeling required files: %v", err))
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -28,8 +28,6 @@ const (
 	NonRootUID        = 107
 	NonRootUserString = "qemu"
 	RootUser          = 0
-
-	UnprivilegedContainerSELinuxLabel = "system_u:object_r:container_file_t:s0"
 )
 
 func IsNonRootVMI(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-handler/device-manager/socket_device.go
+++ b/pkg/virt-handler/device-manager/socket_device.go
@@ -158,7 +158,7 @@ func (dpi *SocketDevicePlugin) Allocate(ctx context.Context, r *pluginapi.Alloca
 		return nil, fmt.Errorf("error setting the permission the socket %s/%s:%v", dpi.socketDir, dpi.socket, err)
 	}
 	if se, exists, err := selinux.NewSELinux(); err == nil && exists {
-		if err := selinux.RelabelFiles(util.UnprivilegedContainerSELinuxLabel, se.IsPermissive(), prSock); err != nil {
+		if err := selinux.RelabelFilesUnprivileged(se.IsPermissive(), prSock); err != nil {
 			return nil, fmt.Errorf("error relabeling required files: %v", err)
 		}
 	} else if err != nil {


### PR DESCRIPTION
selinux.RelabelFiles() always relabels files with a constant UnprivilegedContainerSELinuxLabel label. It is also the single user of this constant. Let us simplify the signature of the function by defining the constant internally.

/kind cleanup

```release-note
NONE
```

