### PR TITLE
e2e, arm64: skip requires-two-worker-nodes-with-cpu-manager on Arm

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -432,7 +432,7 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
   elif [[ $TARGET =~ wg-s390x ]]; then
     label_filter='(wg-s390x)'
   elif [[ $TARGET =~ wg-arm64 ]]; then
-    label_filter='(wg-arm64 && !(ACPI,software-emulation,requires-two-schedulable-nodes,cpumodel))'
+    label_filter='(wg-arm64 && !(ACPI,software-emulation,requires-two-schedulable-nodes,cpumodel,requires-two-worker-nodes-with-cpu-manager))'
   elif [[ $TARGET =~ vgpu.* ]]; then
     label_filter='(VGPU)'
   elif [[ $TARGET =~ sig-compute-realtime ]]; then


### PR DESCRIPTION
Fix the e2e test failures on arm CI.
e.g. https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/13207/pull-kubevirt-e2e-arm64/1877638996109037568

### Release note
```release-note
NONE
```

