### PR TITLE
e2e, net, sriov: Expect numa alignment

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -103,8 +103,9 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 
 		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
 			vmi := newSRIOVVmi([]string{sriovnet1}, libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())))
+			const requestedNumberOfCores = 4
 			vmi.Spec.Domain.CPU = &v1.CPU{
-				Cores:                 4,
+				Cores:                 requestedNumberOfCores,
 				DedicatedCPUPlacement: true,
 			}
 
@@ -134,6 +135,7 @@ var _ = Describe("SRIOV", Serial, decorators.SRIOV, func() {
 			sourcePCIAddress := fmt.Sprintf("%s:%s:%s.%s", srcAddr.Domain[2:], srcAddr.Bus[2:], srcAddr.Slot[2:], srcAddr.Function[2:])
 			alignedCPUsInt, err := hardware.LookupDeviceVCPUAffinity(sourcePCIAddress, domSpec)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(alignedCPUsInt).To(HaveLen(requestedNumberOfCores))
 			deviceData := []cloudinit.DeviceData{
 				{
 					Type:        cloudinit.NICMetadataType,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Currently, the test calls hardware.LookupDeviceVCPUAffinity() and doesn't
assert that the returned slice of CPUs has any cores in it i.e. the test
is ok with not yielding alignment as long as the metadata in the guest
is aware of that by sowing an empty list.
As kind-sriov provider has been updated to use TopologyManager (https://github.com/kubevirt/kubevirtci/pull/1347) and enforce
 policy, scheduler should ensure that alignment is achieved
and  this commit adds one Expect that asserts that.
NUMA alignment is very important in order to achieve high network performance,
in essense, it means that the guest has the SRIOV NIC physically local to the CPU
and does not have to cross the system bus. SRIOV binding is often used in applications
that require high network performance  and it is therefore important that
we test kubevirt to support it well.

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

