### PR TITLE
[release-1.4] storage tests: backport storagecritical test labels

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -62,6 +62,8 @@ var (
 	RequiresRWXBlock = Label("RequiresRWXBlock")
 	// Requires a storage class with Block storage support
 	RequiresBlockStorage = Label("RequiresBlockStorage")
+	// Tests that ensure sig-storage functionality which are conformance-unready
+	StorageCritical = Label("StorageCritical")
 	// Kubernetes versions
 	Kubernetes130 = Label("kubernetes130")
 	// WG archs

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -346,7 +346,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				}
 			})
 
-			It("[test_id:3189]should be successfully started and stopped multiple times", func() {
+			It("[test_id:3189]should be successfully started and stopped multiple times", decorators.StorageCritical, func() {
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
 					Skip("Skip test when Filesystem storage is not present")
@@ -1057,7 +1057,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				}, 30*time.Second, 5*time.Second).Should(BeTrue())
 			})
 
-			DescribeTable("[storage-req] deny then allow clone request", decorators.StorageReq, func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool, cloneMutateFunc func(), fail bool) {
+			DescribeTable("[storage-req] deny then allow clone request", decorators.StorageCritical, decorators.StorageReq, func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool, cloneMutateFunc func(), fail bool) {
 				if cloneMutateFunc != nil {
 					cloneMutateFunc()
 				}

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -63,6 +63,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -491,7 +492,7 @@ var _ = SIGDescribe("Export", func() {
 	type caBundleGenerator func(string, string, *exportv1.VirtualMachineExport) *k8sv1.ConfigMap
 	type urlGenerator func(exportv1.ExportVolumeFormat, string, string, string, *exportv1.VirtualMachineExport) (string, string)
 
-	DescribeTable("should make a PVC export available", func(populateFunction populateFunction, verifyFunction verifyFunction,
+	DescribeTable("should make a PVC export available", decorators.StorageCritical, func(populateFunction populateFunction, verifyFunction verifyFunction,
 		storageClassFunction storageClassFunction, caBundleGenerator caBundleGenerator, urlGenerator urlGenerator,
 		expectedFormat exportv1.ExportVolumeFormat, urlTemplate string, volumeMode k8sv1.PersistentVolumeMode) {
 		sc, exists := storageClassFunction()
@@ -1921,7 +1922,7 @@ var _ = SIGDescribe("Export", func() {
 		checkWithJsonOutput(pod, export, vm)
 	})
 
-	It("Should generate DVs and expanded VM definition on http endpoint with multiple volumes", func() {
+	It("Should generate DVs and expanded VM definition on http endpoint with multiple volumes", decorators.StorageCritical, func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {
 			Skip("Skip test when Filesystem storage is not present")

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -168,7 +168,7 @@ var _ = SIGDescribe("[rfe_id:6364]Guestfs", Label("guestfs"), func() {
 			Expect(guestfsCmd.Execute()).To(HaveOccurred())
 		})
 
-		It("[posneg:positive][test_id:6479]Should successfully run guestfs command on a block-based PVC", Label("guestfs", "Block"), decorators.RequiresBlockStorage, func() {
+		It("[posneg:positive][test_id:6479]Should successfully run guestfs command on a block-based PVC", decorators.StorageCritical, decorators.RequiresBlockStorage, Label("guestfs", "Block"), func() {
 			pvcClaim = "pvc-block"
 			libstorage.CreateBlockPVC(pvcClaim, ns, "500Mi")
 			runGuestfsOnPVC(f, pvcClaim, ns)

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -533,7 +533,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		DescribeTable("Should add volumes on an offline VM", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction) {
+		DescribeTable("Should add volumes on an offline VM", decorators.StorageCritical, func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction) {
 			By("Adding test volumes")
 			addVolumeFunc(vm.Name, vm.Namespace, testNewVolume1, "madeup", v1.DiskBusSCSI, false, "")
 			addVolumeFunc(vm.Name, vm.Namespace, testNewVolume2, "madeup2", v1.DiskBusSCSI, false, "")
@@ -583,7 +583,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		DescribeTable("Should start with a hotplug block", func(addVolumeFunc addVolumeFunction) {
+		DescribeTable("Should start with a hotplug block", decorators.StorageCritical, func(addVolumeFunc addVolumeFunction) {
 			dv := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeBlock)
 
 			By("Adding a hotplug block volume")
@@ -773,7 +773,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
 			})
 
-			DescribeTable("should add/remove volume", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, volumeMode k8sv1.PersistentVolumeMode, vmiOnly, waitToStart bool) {
+			DescribeTable("should add/remove volume", decorators.StorageCritical, func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, volumeMode k8sv1.PersistentVolumeMode, vmiOnly, waitToStart bool) {
 				verifyAttachDetachVolume(vm, addVolumeFunc, removeVolumeFunc, sc, volumeMode, vmiOnly, waitToStart)
 			},
 				Entry("with DataVolume immediate attach", addDVVolumeVM, removeVolumeVM, k8sv1.PersistentVolumeFilesystem, false, false),
@@ -1165,7 +1165,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				}
 			})
 
-			DescribeTable("should allow live migration with attached hotplug volumes", func(vmiFunc func() *v1.VirtualMachineInstance) {
+			DescribeTable("should allow live migration with attached hotplug volumes", decorators.StorageCritical, func(vmiFunc func() *v1.VirtualMachineInstance) {
 				vmi = vmiFunc()
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
 				volumeName := "testvolume"
@@ -1721,7 +1721,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			libstorage.DeleteStorageClass(storageClassHostPath)
 		})
 
-		It("should attach a hostpath based volume to running VM", func() {
+		It("should attach a hostpath based volume to running VM", decorators.StorageCritical, func() {
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			libwait.WaitForSuccessfulVMIStart(vmi,

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libvmops"
 
@@ -428,7 +429,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			Entry("[test_id:8500]using virtctl", memoryDumpVirtctl, removeMemoryDumpVirtctl),
 		)
 
-		It("[test_id:8502]Run multiple memory dumps", func() {
+		It("[test_id:8502]Run multiple memory dumps", decorators.StorageCritical, func() {
 			previousOutput := ""
 			for i := 0; i < 3; i++ {
 				By("Running memory dump number: " + strconv.Itoa(i))
@@ -544,7 +545,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			}
 		})
 
-		It("[test_id:9034]Should be able to get and remove memory dump", func() {
+		It("[test_id:9034]Should be able to get and remove memory dump", decorators.StorageCritical, func() {
 			previousOutput := createMemoryDumpAndVerify(vm, memoryDumpPVCName, noPreviousOutput, memoryDumpVirtctlCreatePVC)
 			removeMemoryDumpAndVerify(vm, memoryDumpPVCName, previousOutput, removeMemoryDumpVirtctl)
 		})

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -294,7 +294,7 @@ var _ = SIGDescribe("[Serial]Volumes update with migration", Serial, func() {
 			waitForMigrationToSucceed(virtClient, vm.Name, ns)
 		})
 
-		It("should migrate the source volume from a source and destination block RWX DVs", decorators.RequiresRWXBlock, func() {
+		It("should migrate the source volume from a source and destination block RWX DVs", decorators.StorageCritical, decorators.RequiresRWXBlock, func() {
 			volName := "disk0"
 			sc, exist := libstorage.GetRWXBlockStorageClass()
 			Expect(exist).To(BeTrue())

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -523,7 +523,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					return r
 				}
 
-				It("with changed name and MAC address", func() {
+				It("with changed name and MAC address", decorators.StorageCritical, func() {
 					By("Creating a VM restore with patches to change name and MAC address")
 					restore.Spec.Patches = []string{getMacAddressCloningPatch(vm)}
 					restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
@@ -628,7 +628,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				}
 			})
 
-			DescribeTable("should use existing ControllerRevisions for an existing VM restore", Label("instancetype", "preference", "restore"), func(runStrategy v1.VirtualMachineRunStrategy) {
+			DescribeTable("should use existing ControllerRevisions for an existing VM restore", decorators.StorageCritical, Label("instancetype", "preference", "restore"), func(runStrategy v1.VirtualMachineRunStrategy) {
 				libvmi.WithRunStrategy(runStrategy)(vm)
 				vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -671,7 +671,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Entry("with a stopped VM", v1.RunStrategyHalted),
 			)
 
-			DescribeTable("should create new ControllerRevisions for newly restored VM", Label("instancetype", "preference", "restore"), func(runStrategy v1.VirtualMachineRunStrategy) {
+			DescribeTable("should create new ControllerRevisions for newly restored VM", decorators.StorageCritical, Label("instancetype", "preference", "restore"), func(runStrategy v1.VirtualMachineRunStrategy) {
 				libvmi.WithRunStrategy(runStrategy)(vm)
 				vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -1205,7 +1205,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Entry("to a new VM", true),
 			)
 
-			DescribeTable("should restore a vm that boots from a datavolumetemplate", func(restoreToNewVM bool) {
+			DescribeTable("should restore a vm that boots from a datavolumetemplate", decorators.StorageCritical, func(restoreToNewVM bool) {
 				vm, vmi = createAndStartVM(createVMWithCloudInit(cd.ContainerDiskCirros, snapshotStorageClass))
 
 				originalDVName := vm.Spec.DataVolumeTemplates[0].Name
@@ -1510,7 +1510,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Entry("and allow it to start after vmrestore deletion", "deleteRestore"),
 			)
 
-			DescribeTable("should restore a vm from an online snapshot", func(restoreToNewVM bool) {
+			DescribeTable("should restore a vm from an online snapshot", decorators.StorageCritical, func(restoreToNewVM bool) {
 				vm = createVMWithCloudInit(cd.ContainerDiskCirros, snapshotStorageClass)
 				vm.Spec.Template.Spec.Domain.Firmware = &v1.Firmware{}
 				vm, vmi = createAndStartVM(vm)
@@ -1588,7 +1588,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Entry("to a new VM", true),
 			)
 
-			DescribeTable("should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", func(restoreToNewVM bool) {
+			DescribeTable("should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", decorators.StorageCritical, func(restoreToNewVM bool) {
 				vm, vmi = createAndStartVM(createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass, libvmi.WithResourceMemory("512Mi")))
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -240,11 +240,11 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			}
 		}
 
-		It("[test_id:4609]should successfully create a snapshot", func() {
+		It("[test_id:4609]should successfully create a snapshot", decorators.StorageCritical, func() {
 			createAndVerifyVMSnapshot(vm)
 		})
 
-		It("[test_id:4610]create a snapshot when VM is running should succeed", func() {
+		It("[test_id:4610]create a snapshot when VM is running should succeed", decorators.StorageCritical, func() {
 			patch, err := patch.New(patch.WithReplace("/spec/runStrategy", v1.RunStrategyAlways)).GeneratePayload()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -386,7 +386,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				return exec.ExecuteCommandOnPodWithResults(pod, pod.Annotations[annoContainer], commandSlice)
 			}
 
-			It("[test_id:6767]with volumes and guest agent available", func() {
+			It("[test_id:6767]with volumes and guest agent available", decorators.StorageCritical, func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
@@ -456,7 +456,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				checkContentSourceAndMemory(vm.DeepCopy(), contentName, initialMemory)
 			})
 
-			It("[test_id:6768]with volumes and no guest agent available", func() {
+			It("[test_id:6768]with volumes and no guest agent available", decorators.StorageCritical, func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi := libvmifact.NewFedora(libnet.WithMasqueradeNetworking())
@@ -1621,7 +1621,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				}
 			})
 
-			DescribeTable("Bug #8435 - should create a snapshot successfully", func(toRunSourceVM bool) {
+			DescribeTable("Bug #8435 - should create a snapshot successfully", decorators.StorageCritical, func(toRunSourceVM bool) {
 				if !toRunSourceVM {
 					By("Stoping the VM")
 					vm = libvmops.StopVirtualMachine(vm)

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -296,8 +296,8 @@ var _ = SIGDescribe("Storage", func() {
 					By(checkingVMInstanceConsoleOut)
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 				},
-					Entry("[test_id:3130]with Disk PVC", newRandomVMIWithPVC, "", nil, true),
-					Entry("[test_id:3131]with CDRom PVC", newRandomVMIWithCDRom, "", nil, true),
+					Entry("[test_id:3130]with Disk PVC", decorators.StorageCritical, newRandomVMIWithPVC, "", nil, true),
+					Entry("[test_id:3131]with CDRom PVC", decorators.StorageCritical, newRandomVMIWithCDRom, "", nil, true),
 					Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
 					Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", Serial, newRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
 					Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", Serial, newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
@@ -462,7 +462,7 @@ var _ = SIGDescribe("Storage", func() {
 					By(checkingVMInstanceConsoleOut)
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 				},
-					Entry("[test_id:3136]with Ephemeral PVC", "", nil),
+					Entry("[test_id:3136]with Ephemeral PVC", decorators.StorageCritical, "", nil),
 					Entry("[test_id:4619]with Ephemeral PVC from NFS using ipv4 address of the NFS pod", "nfs", k8sv1.IPv4Protocol),
 					Entry("with Ephemeral PVC from NFS using ipv6 address of the NFS pod", "nfs", k8sv1.IPv6Protocol),
 				)

--- a/tests/virtctl/imageupload.go
+++ b/tests/virtctl/imageupload.go
@@ -146,7 +146,7 @@ var _ = Describe("[sig-storage][Serial][virtctl]ImageUpload", decorators.SigStor
 				Expect(err).ToNot(HaveOccurred())
 			}
 		},
-			Entry("DataVolume", "dv", "alpine-dv-"+rand.String(12), validateDataVolume, true),
+			Entry("DataVolume", decorators.StorageCritical, "dv", "alpine-dv-"+rand.String(12), validateDataVolume, true),
 			Entry("PVC", "pvc", "alpine-pvc-"+rand.String(12), validatePVC, false),
 		)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This label makes it easy to execute a must-run set of tests
that ensures basic kubevirt storage functionality.
Since we can't change the conformance set in a release branch,
We are using a different label - StorageCritical.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Largely a backport of https://github.com/kubevirt/kubevirt/pull/13586

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

