### PR TITLE
remove renderPkillAllPod function

### DIFF
--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -82,7 +82,7 @@ var _ = SIGDescribe("[crit:high][vendor:cnv-qe@redhat.com][level:component]", de
 				}
 
 				By("restarting kubelet")
-				pod := renderPkillAllPod("kubelet")
+				pod := libpod.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", "kubelet"})
 				pod.Spec.NodeName = nodeName
 				pod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Create(context.Background(), pod, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -138,10 +138,6 @@ var _ = SIGDescribe("[crit:high][vendor:cnv-qe@redhat.com][level:component]", de
 		})
 	})
 })
-
-func renderPkillAllPod(processName string) *k8sv1.Pod {
-	return libpod.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", processName})
-}
 
 func verifyDummyNicForBridgeNetwork(vmi *v1.VirtualMachineInstance) {
 	output := libpod.RunCommandOnVmiPod(vmi, []string{"/bin/bash", "-c", "/usr/sbin/ip link show|grep DOWN|grep -c eth0"})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1929,10 +1929,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	})
 })
 
-func renderPkillAllPod(processName string) *k8sv1.Pod {
-	return libpod.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", processName})
-}
-
 func getVirtLauncherLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	namespace := vmi.GetObjectMeta().GetNamespace()
 	uid := vmi.GetObjectMeta().GetUID()
@@ -1963,7 +1959,7 @@ func getVirtLauncherLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineI
 }
 
 func pkillHandler(virtCli kubecli.KubevirtClient, node string) error {
-	pod := renderPkillAllPod("virt-handler")
+	pod := libpod.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", "virt-handler"})
 	pod.Spec.NodeName = node
 	createdPod, err := virtCli.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred(), "Should create helper pod")
@@ -1980,13 +1976,13 @@ func pkillHandler(virtCli kubecli.KubevirtClient, node string) error {
 }
 
 func pkillAllLaunchers(virtCli kubecli.KubevirtClient, node string) (*k8sv1.Pod, error) {
-	pod := renderPkillAllPod("virt-launcher")
+	pod := libpod.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", "virt-launcher"})
 	pod.Spec.NodeName = node
 	return virtCli.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Create(context.Background(), pod, metav1.CreateOptions{})
 }
 
 func pkillAllVMIs(virtCli kubecli.KubevirtClient, node string) error {
-	pod := renderPkillAllPod("qemu")
+	pod := libpod.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", "qemu"})
 	pod.Spec.NodeName = node
 	_, err := virtCli.CoreV1().Pods(testsuite.GetTestNamespace(pod)).Create(context.Background(), pod, metav1.CreateOptions{})
 


### PR DESCRIPTION
### What this PR does
Before this PR:
We used renderPkillAllPod function to kill process in the VMI

After this PR:
We use libpod.RenderPrivilegedPod directly without the need of a wrapper function. 

### Why we need it and why it was done in this way
 - renderPkillAllPod is declared precisely the same across 2 different files, this removes the repeated code.
 - reduce the amount of code across the files
 - simplify the test by not using complicated functions

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

