### PR TITLE
Fix hotplug in PostCopy mode

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16761,6 +16761,10 @@
       "description": "Contains the reason why the migration failed",
       "type": "string"
      },
+     "finalized": {
+      "description": "Indicates that the migration has been finalized",
+      "type": "boolean"
+     },
      "migrationConfiguration": {
       "description": "Migration configurations to apply",
       "$ref": "#/definitions/v1.MigrationConfiguration"

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1939,16 +1939,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.ObjectMeta.ResourceVersion = "1"
 			vmi.Status.Phase = v1.Running
 			vmi.Labels = make(map[string]string)
-			vmi.Status.NodeName = "othernode"
+			vmi.Status.NodeName = host
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
 			pastTime := metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Second))
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				TargetNode:               host,
-				TargetNodeAddress:        "127.0.0.1:12345",
-				SourceNode:               "othernode",
-				MigrationUID:             "123",
-				TargetNodeDomainDetected: false,
-				StartTimestamp:           &pastTime,
+				TargetNode:                     host,
+				TargetNodeAddress:              "127.0.0.1:12345",
+				SourceNode:                     "othernode",
+				MigrationUID:                   "123",
+				TargetNodeDomainDetected:       true,
+				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+				StartTimestamp:                 &pastTime,
+				Completed:                      true,
 			}
 
 			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
@@ -1981,16 +1983,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.ObjectMeta.ResourceVersion = "1"
 			vmi.Status.Phase = v1.Running
 			vmi.Labels = make(map[string]string)
-			vmi.Status.NodeName = "othernode"
+			vmi.Status.NodeName = host
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
 			pastTime := metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Second))
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				TargetNode:               host,
-				TargetNodeAddress:        "127.0.0.1:12345",
-				SourceNode:               "othernode",
-				MigrationUID:             "123",
-				TargetNodeDomainDetected: false,
-				StartTimestamp:           &pastTime,
+				TargetNode:                     host,
+				TargetNodeAddress:              "127.0.0.1:12345",
+				SourceNode:                     "othernode",
+				MigrationUID:                   "123",
+				TargetNodeDomainDetected:       true,
+				TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+				StartTimestamp:                 &pastTime,
+				Completed:                      true,
 			}
 			cpuTopology := &v1.CPU{
 				Sockets: 1,
@@ -2152,16 +2156,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 		vmi.ObjectMeta.ResourceVersion = "1"
 		vmi.Status.Phase = v1.Running
 		vmi.Labels = make(map[string]string)
-		vmi.Status.NodeName = "othernode"
+		vmi.Status.NodeName = host
 		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
 		pastTime := metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Second))
 		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-			TargetNode:               host,
-			TargetNodeAddress:        "127.0.0.1:12345",
-			SourceNode:               "othernode",
-			MigrationUID:             "123",
-			TargetNodeDomainDetected: false,
-			StartTimestamp:           &pastTime,
+			TargetNode:                     host,
+			TargetNodeAddress:              "127.0.0.1:12345",
+			SourceNode:                     "othernode",
+			MigrationUID:                   "123",
+			TargetNodeDomainDetected:       true,
+			TargetNodeDomainReadyTimestamp: pointer.P(metav1.Now()),
+			StartTimestamp:                 &pastTime,
+			Completed:                      true,
 		}
 
 		cpuTopology := &v1.CPU{
@@ -2200,8 +2206,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 		testutils.ExpectEvent(recorder, "failed to change vCPUs")
 		updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(updatedVMI.Status.MigrationState.TargetNodeDomainDetected).To(BeTrue())
-		Expect(updatedVMI.Status.MigrationState.TargetNodeDomainReadyTimestamp).ToNot(BeNil())
 		Expect(updatedVMI.Status.CurrentCPUTopology).NotTo(BeNil())
 		Expect(updatedVMI.Status.Conditions).NotTo(ContainElement(MatchFields(IgnoreExtras, Fields{
 			"Type": Equal(v1.VirtualMachineInstanceVCPUChange),

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -13535,6 +13535,9 @@ var CRDsValidation map[string]string = map[string]string{
             failureReason:
               description: Contains the reason why the migration failed
               type: string
+            finalized:
+              description: Indicates that the migration has been finalized
+              type: boolean
             migrationConfiguration:
               description: Migration configurations to apply
               properties:
@@ -13964,6 +13967,9 @@ var CRDsValidation map[string]string = map[string]string{
             failureReason:
               description: Contains the reason why the migration failed
               type: string
+            finalized:
+              description: Indicates that the migration has been finalized
+              type: boolean
             migrationConfiguration:
               description: Migration configurations to apply
               properties:

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -930,6 +930,7 @@
       "sourceNode": "sourceNodeValue",
       "sourcePod": "sourcePodValue",
       "completed": true,
+      "finalized": true,
       "failed": true,
       "abortRequested": true,
       "abortStatus": "abortStatusValue",

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -657,6 +657,7 @@ status:
     endTimestamp: "1988-01-01T01:01:01Z"
     failed: true
     failureReason: failureReasonValue
+    finalized: true
     migrationConfiguration:
       allowAutoConverge: true
       allowPostCopy: true

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -760,6 +760,8 @@ type VirtualMachineInstanceMigrationState struct {
 
 	// Indicates the migration completed
 	Completed bool `json:"completed,omitempty"`
+	// Indicates that the migration has been finalized
+	Finalized bool `json:"finalized,omitempty"`
 	// Indicates that the migration failed
 	Failed bool `json:"failed,omitempty"`
 	// Indicates that the migration has been requested to abort

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -225,6 +225,7 @@ func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 		"targetAttachmentPodUID":         "The UID of the target attachment pod for hotplug volumes",
 		"sourceNode":                     "The source node that the VMI originated on",
 		"completed":                      "Indicates the migration completed",
+		"finalized":                      "Indicates that the migration has been finalized",
 		"failed":                         "Indicates that the migration failed",
 		"abortRequested":                 "Indicates that the migration has been requested to abort",
 		"abortStatus":                    "Indicates the final status of the live migration abortion",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25298,6 +25298,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationState(ref comm
 							Format:      "",
 						},
 					},
+					"finalized": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Indicates that the migration has been finalized",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"failed": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Indicates that the migration failed",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

Doing CPU/Memory hotplug when migrating in PostCopy fails.

After this PR:

Doing CPU/Memory hotplug when migrating in PostCopy works correctly.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix hotplug in PostCopy mode
```

