### PR TITLE
instancetype: Rework requirements checker implementation

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -99,7 +99,7 @@ func CompareRevisions(revisionA, revisionB *appsv1.ControllerRevision) (bool, er
 }
 
 func (m *InstancetypeMethods) CheckPreferenceRequirements(instancetypeSpec *instancetypev1beta1.VirtualMachineInstancetypeSpec, preferenceSpec *instancetypev1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) (conflict.Conflicts, error) {
-	conflicts, err := requirements.New(instancetypeSpec, preferenceSpec, vmiSpec).Check()
+	conflicts, err := requirements.New().Check(instancetypeSpec, preferenceSpec, vmiSpec)
 	return conflicts, err
 }
 

--- a/pkg/instancetype/preference/requirements/BUILD.bazel
+++ b/pkg/instancetype/preference/requirements/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "checker.go",
         "cpu.go",
-        "handler.go",
         "memory.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/instancetype/preference/requirements",

--- a/pkg/instancetype/preference/requirements/checker.go
+++ b/pkg/instancetype/preference/requirements/checker.go
@@ -25,37 +25,29 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 )
 
-type Handler struct {
-	instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec
-	preferenceSpec   *v1beta1.VirtualMachinePreferenceSpec
-	vmiSpec          *virtv1.VirtualMachineInstanceSpec
+type checker struct{}
+
+func New() *checker {
+	return &checker{}
 }
 
-func New(
+func (c *checker) Check(
 	instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec,
 	preferenceSpec *v1beta1.VirtualMachinePreferenceSpec,
 	vmiSpec *virtv1.VirtualMachineInstanceSpec,
-) *Handler {
-	return &Handler{
-		instancetypeSpec: instancetypeSpec,
-		preferenceSpec:   preferenceSpec,
-		vmiSpec:          vmiSpec,
-	}
-}
-
-func (h *Handler) Check() (conflict.Conflicts, error) {
-	if h.preferenceSpec == nil || h.preferenceSpec.Requirements == nil {
+) (conflict.Conflicts, error) {
+	if preferenceSpec == nil || preferenceSpec.Requirements == nil {
 		return nil, nil
 	}
 
-	if h.preferenceSpec.Requirements.CPU != nil {
-		if conflicts, err := h.checkCPU(); err != nil {
+	if preferenceSpec.Requirements.CPU != nil {
+		if conflicts, err := checkCPU(instancetypeSpec, preferenceSpec, vmiSpec); err != nil {
 			return conflicts, err
 		}
 	}
 
-	if h.preferenceSpec.Requirements.Memory != nil {
-		if conflicts, err := h.checkMemory(); err != nil {
+	if preferenceSpec.Requirements.Memory != nil {
+		if conflicts, err := checkMemory(instancetypeSpec, preferenceSpec, vmiSpec); err != nil {
 			return conflicts, err
 		}
 	}


### PR DESCRIPTION
/cc @0xFelix 

### What this PR does
While usable with the current instancetypeMethods approach we need to make the core implementation stateless before switching consumers over to it in the near future.

This will allow us to mock out the implementation within unit tests as is currently heavily done by the VMAdmitter tests for example.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

