### PR TITLE
virt-handler, netstat: Report interfaces' link state

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16898,6 +16898,10 @@
        "default": ""
       }
      },
+     "linkState": {
+      "description": "LinkState Reports the current operational link state`. values: up, down.",
+      "type": "string"
+     },
      "mac": {
       "description": "Hardware address of a Virtual Machine interface",
       "type": "string"

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -278,6 +278,7 @@ func ifacesStatusFromDomainInterfaces(domainSpecIfaces []api.Interface) []v1.Vir
 			MAC:        domainSpecIface.MAC.MAC,
 			InfoSource: netvmispec.InfoSourceDomain,
 			QueueCount: domainInterfaceQueues(domainSpecIface.Driver),
+			LinkState:  linkStateFromDomain(domainSpecIface.LinkState),
 		})
 	}
 	return vmiStatusIfaces
@@ -289,6 +290,16 @@ func domainInterfaceQueues(driver *api.InterfaceDriver) int32 {
 	}
 
 	return DefaultInterfaceQueueCount
+}
+
+func linkStateFromDomain(linkState *api.LinkState) string {
+	const linkStateUp = "up"
+
+	if linkState == nil {
+		return linkStateUp
+	}
+
+	return linkState.State
 }
 
 func sriovIfacesStatusFromDomainHostDevices(hostDevices []api.HostDevice, vmiIfacesSpecByName map[string]v1.Interface) []v1.VirtualMachineInstanceNetworkInterface {

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -36,6 +36,8 @@ import (
 var _ = Describe("netstat", func() {
 	var setup testSetup
 
+	const linkStateUp = "up"
+
 	BeforeEach(func() {
 		setup = newTestSetup()
 	})
@@ -116,6 +118,7 @@ var _ = Describe("netstat", func() {
 					IPs:        []string{primaryPodIPv4, primaryPodIPv6},
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 				{
 					Name:       secondaryNetworkName,
@@ -123,6 +126,7 @@ var _ = Describe("netstat", func() {
 					IPs:        []string{secondaryPodIPv4, secondaryPodIPv6},
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 			}), "the pod IP/s should be reported in the status")
 
@@ -153,6 +157,7 @@ var _ = Describe("netstat", func() {
 					IPs:        []string{primaryPodIPv4, primaryPodIPv6},
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: int32(queueCount),
+					LinkState:  linkStateUp,
 				},
 			}), "queue count and the pod IP/s should be reported in the status")
 
@@ -195,6 +200,7 @@ var _ = Describe("netstat", func() {
 					MAC:           primaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 				{
 					Name:          secondaryNetworkName,
@@ -202,6 +208,7 @@ var _ = Describe("netstat", func() {
 					MAC:           secondaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 			}), "the pod & guest-agent IP/s should be reported in the status")
 
@@ -233,6 +240,7 @@ var _ = Describe("netstat", func() {
 					MAC:           primaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 			}), "the guest-agent IP/s should be reported in the status")
 
@@ -284,6 +292,7 @@ var _ = Describe("netstat", func() {
 					MAC:           primaryMAC,
 					InfoSource:    infoSourceDomainGAMultus,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 				{
 					Name:          secondaryNetworkName,
@@ -293,6 +302,7 @@ var _ = Describe("netstat", func() {
 					MAC:           secondaryMAC,
 					InfoSource:    infoSourceDomainGAMultus,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 			}), "the pod IP/s should be reported in the status")
 
@@ -332,6 +342,7 @@ var _ = Describe("netstat", func() {
 					MAC:           primaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 			}), "the pod IP/s should be reported in the status")
 
@@ -372,6 +383,7 @@ var _ = Describe("netstat", func() {
 					MAC:        newDomainMAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 			}), "the pod IP/s should be reported in the status")
 		})
@@ -441,6 +453,7 @@ var _ = Describe("netstat", func() {
 				MAC:           origMAC,
 				InfoSource:    netvmispec.InfoSourceDomainAndGA,
 				QueueCount:    netsetup.DefaultInterfaceQueueCount,
+				LinkState:     linkStateUp,
 			},
 		}), "the pod IP/s should be reported in the status")
 	})
@@ -502,6 +515,7 @@ var _ = Describe("netstat", func() {
 				IPs:        []string{primaryPodIPv4},
 				InfoSource: netvmispec.InfoSourceDomain,
 				QueueCount: netsetup.DefaultInterfaceQueueCount,
+				LinkState:  linkStateUp,
 			},
 			{
 				Name:       networkName,
@@ -597,6 +611,7 @@ var _ = Describe("netstat", func() {
 					MAC:        primaryMAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 				{
 					Name:       secondaryNetworkName,
@@ -605,6 +620,7 @@ var _ = Describe("netstat", func() {
 					MAC:        secondaryMAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 				{
 					Name:          "",
@@ -649,6 +665,7 @@ var _ = Describe("netstat", func() {
 					MAC:           primaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 				{
 					Name:          secondaryNetworkName,
@@ -658,6 +675,7 @@ var _ = Describe("netstat", func() {
 					MAC:           secondaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 				{
 					Name:          "",
@@ -682,6 +700,7 @@ var _ = Describe("netstat", func() {
 					MAC:        primaryMAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 				{
 					Name:       secondaryNetworkName,
@@ -690,6 +709,7 @@ var _ = Describe("netstat", func() {
 					MAC:        secondaryMAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 			}))
 		})
@@ -726,6 +746,7 @@ var _ = Describe("netstat", func() {
 					MAC:        primaryMAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 			}))
 		})
@@ -757,6 +778,7 @@ var _ = Describe("netstat", func() {
 					MAC:           primaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
+					LinkState:     linkStateUp,
 				},
 			}))
 		})
@@ -821,6 +843,7 @@ var _ = Describe("netstat", func() {
 					MAC:        MAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 				{
 					Name:       secNetworkName1,
@@ -829,6 +852,7 @@ var _ = Describe("netstat", func() {
 					MAC:        MAC1,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 				{
 					Name:       secNetworkName2,
@@ -837,6 +861,7 @@ var _ = Describe("netstat", func() {
 					MAC:        MAC2,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 			}))
 		},
@@ -890,6 +915,7 @@ var _ = Describe("netstat", func() {
 				MAC:           primaryMAC,
 				InfoSource:    infoSourceDomainGAMultus,
 				QueueCount:    netsetup.DefaultInterfaceQueueCount,
+				LinkState:     linkStateUp,
 			},
 			{
 				Name:       secondaryNetworkName,
@@ -941,6 +967,7 @@ var _ = Describe("netstat", func() {
 				MAC:           primaryMAC,
 				InfoSource:    infoSourceDomainGAMultus,
 				QueueCount:    netsetup.DefaultInterfaceQueueCount,
+				LinkState:     linkStateUp,
 			},
 		}), "only primary should exist in status since secondary iface not exist in spec")
 	})
@@ -987,6 +1014,7 @@ var _ = Describe("netstat", func() {
 				MAC:              primaryMAC,
 				InfoSource:       infoSourceDomainGA,
 				QueueCount:       netsetup.DefaultInterfaceQueueCount,
+				LinkState:        linkStateUp,
 			},
 		}))
 	})
@@ -1023,6 +1051,39 @@ var _ = Describe("netstat", func() {
 		}))
 	})
 
+	Context("Link state", func() {
+		const (
+			linkStateUp   = "up"
+			linkStateDown = "down"
+		)
+		DescribeTable("should report correct link state", func(linkState string) {
+			const (
+				networkName = "primary"
+				MAC         = "1C:CE:C0:01:BE:E7"
+			)
+
+			domainIface := newDomainSpecIface(networkName, MAC)
+			domainIface.LinkState = &api.LinkState{State: linkState}
+
+			setup.Domain.Spec.Devices.Interfaces = append(setup.Domain.Spec.Devices.Interfaces, domainIface)
+
+			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
+				{
+					Name:       networkName,
+					MAC:        MAC,
+					InfoSource: netvmispec.InfoSourceDomain,
+					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkState,
+				},
+			}))
+		},
+			Entry("When link state is explicitly set to up", linkStateUp),
+			Entry("When link state is explicitly set to down", linkStateDown),
+		)
+	})
+
 	Context("misc scenario", func() {
 		const (
 			networkName = "primary"
@@ -1040,6 +1101,7 @@ var _ = Describe("netstat", func() {
 					MAC:        MAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 			}))
 		})
@@ -1066,6 +1128,7 @@ var _ = Describe("netstat", func() {
 					MAC:        MAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,
+					LinkState:  linkStateUp,
 				},
 			}))
 		})

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -13314,6 +13314,10 @@ var CRDsValidation map[string]string = map[string]string{
                 items:
                   type: string
                 type: array
+              linkState:
+                description: 'LinkState Reports the current operational link state''.
+                  values: up, down.'
+                type: string
               mac:
                 description: Hardware address of a Virtual Machine interface
                 type: string

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -902,7 +902,8 @@
         "podInterfaceName": "podInterfaceNameValue",
         "interfaceName": "interfaceNameValue",
         "infoSource": "infoSourceValue",
-        "queueCount": -10
+        "queueCount": -10,
+        "linkState": "linkStateValue"
       }
     ],
     "guestOSInfo": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -609,6 +609,7 @@ status:
     ipAddress: ipAddressValue
     ipAddresses:
     - ipAddressesValue
+    linkState: linkStateValue
     mac: macValue
     name: nameValue
     podInterfaceName: podInterfaceNameValue

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -704,6 +704,8 @@ type VirtualMachineInstanceNetworkInterface struct {
 	InfoSource string `json:"infoSource,omitempty"`
 	// Specifies how many queues are allocated by MultiQueue
 	QueueCount int32 `json:"queueCount,omitempty"`
+	// LinkState Reports the current operational link state`. values: up, down.
+	LinkState string `json:"linkState,omitempty"`
 }
 
 type VirtualMachineInstanceGuestOSInfo struct {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -195,6 +195,7 @@ func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 		"interfaceName":    "The interface name inside the Virtual Machine",
 		"infoSource":       "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",
 		"queueCount":       "Specifies how many queues are allocated by MultiQueue",
+		"linkState":        "LinkState Reports the current operational link state`. values: up, down.",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25901,6 +25901,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceNetworkInterface(ref co
 							Format:      "int32",
 						},
 					},
+					"linkState": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LinkState Reports the current operational link state`. values: up, down.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -104,6 +104,8 @@ var _ = SIGDescribe("Infosource", func() {
 			infoSourceDomainAndGAAndMultusStatus := netvmispec.NewInfoSource(
 				netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent, netvmispec.InfoSourceMultusStatus)
 
+			const linkStateUp = "up"
+
 			expectedInterfaces := []kvirtv1.VirtualMachineInstanceNetworkInterface{
 				{
 					InfoSource:       netvmispec.InfoSourceDomain,
@@ -111,6 +113,7 @@ var _ = SIGDescribe("Infosource", func() {
 					Name:             primaryNetwork,
 					PodInterfaceName: namescheme.PrimaryPodInterfaceName,
 					QueueCount:       network.DefaultInterfaceQueueCount,
+					LinkState:        linkStateUp,
 				},
 				{
 					InfoSource:       infoSourceDomainAndGAAndMultusStatus,
@@ -119,6 +122,7 @@ var _ = SIGDescribe("Infosource", func() {
 					Name:             secondaryInterface1Name,
 					PodInterfaceName: namescheme.GenerateHashedInterfaceName(secondaryInterface1Name),
 					QueueCount:       network.DefaultInterfaceQueueCount,
+					LinkState:        linkStateUp,
 				},
 				{
 					InfoSource:       infoSourceDomainAndMultusStatus,
@@ -126,6 +130,7 @@ var _ = SIGDescribe("Infosource", func() {
 					Name:             secondaryInterface2Name,
 					PodInterfaceName: namescheme.GenerateHashedInterfaceName(secondaryInterface2Name),
 					QueueCount:       network.DefaultInterfaceQueueCount,
+					LinkState:        linkStateUp,
 				},
 				{
 					InfoSource:    netvmispec.InfoSourceGuestAgent,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Add the `LinkState` field to `VirtualMachineInstanceNetworkInterface` to
enable reporting the interfaces' operational [1] link state.

This field could have the following values:
- empty string - link state unknown
- `up`
- `down`

Report the link state for each interface in the VMI spec. 
Since currently virt-launcher does not set the link state field - the link state report will always be `up`.

When a network binding plugin with the `link refresh` migration method is used, the link state is explicitly set.

For SR-IOV NICs - don't report the link state, since KubeVirt is not aware to all changes made to them.

Interfaces which are only defined inside the guest will not have their link state reported - as qemu guest agent does not report this information ATM [2].

[1] https://docs.kernel.org/networking/operstates.html
[2] https://qemu-project.gitlab.io/qemu/interop/qemu-ga-ref.html#qapidoc-127

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/enhancements/pull/2

### Special notes for your reviewer
~~Depends on https://github.com/kubevirt/kubevirt/pull/13716, please skip the first commit.~~
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network interfaces' link state will be reported for interfaces present in VMI spec
```

