### PR TITLE
VMSnapshot: honor StorageProfile snapshotClass when choosing volumesnapshotclass

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -522,8 +522,8 @@ func (ctrl *VMSnapshotController) createVolumeSnapshot(
 			content.Namespace, volumeBackup.PersistentVolumeClaim.Name)
 	}
 
-	volumeSnapshotClass, err := ctrl.getVolumeSnapshotClass(*sc)
-	if err != nil {
+	volumeSnapshotClass, err := ctrl.getVolumeSnapshotClassName(*sc)
+	if err != nil || volumeSnapshotClass == "" {
 		log.Log.Warningf("Couldn't find VolumeSnapshotClass for %s", *sc)
 		return nil, err
 	}
@@ -690,7 +690,7 @@ func (ctrl *VMSnapshotController) getSnapshotPVC(namespace, volumeName string) (
 		return nil, nil
 	}
 
-	volumeSnapshotClass, err := ctrl.getVolumeSnapshotClass(*pvc.Spec.StorageClassName)
+	volumeSnapshotClass, err := ctrl.getVolumeSnapshotClassName(*pvc.Spec.StorageClassName)
 	if err != nil {
 		return nil, err
 	}
@@ -704,13 +704,29 @@ func (ctrl *VMSnapshotController) getSnapshotPVC(namespace, volumeName string) (
 	return nil, nil
 }
 
-func (ctrl *VMSnapshotController) getVolumeSnapshotClass(storageClassName string) (string, error) {
+func (ctrl *VMSnapshotController) getVolumeSnapshotClassName(storageClassName string) (string, error) {
 	obj, exists, err := ctrl.StorageClassInformer.GetStore().GetByKey(storageClassName)
 	if !exists || err != nil {
 		return "", err
 	}
 
 	storageClass := obj.(*storagev1.StorageClass).DeepCopy()
+
+	obj, exists, err = ctrl.StorageProfileInformer.GetStore().GetByKey(storageClassName)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		storageProfile := obj.(*cdiv1.StorageProfile)
+		defaultSCSnapClass := storageProfile.Status.SnapshotClass
+		if defaultSCSnapClass != nil && *defaultSCSnapClass != "" {
+			if vsc, err := ctrl.getVolumeSnapshotClass(*defaultSCSnapClass); err != nil || vsc == nil {
+				return "", err
+			}
+
+			return *defaultSCSnapClass, nil
+		}
+	}
 
 	var matches []vsv1.VolumeSnapshotClass
 	volumeSnapshotClasses := ctrl.getVolumeSnapshotClasses()
@@ -936,7 +952,7 @@ func (ctrl *VMSnapshotController) getVolumeSnapshotStatus(vm *kubevirtv1.Virtual
 		return kubevirtv1.VolumeSnapshotStatus{Name: volume.Name, Enabled: false, Reason: err.Error()}
 	}
 
-	snap, err := ctrl.getVolumeSnapshotClass(sc)
+	snap, err := ctrl.getVolumeSnapshotClassName(sc)
 	if err != nil {
 		return kubevirtv1.VolumeSnapshotStatus{Name: volume.Name, Enabled: false, Reason: err.Error()}
 	}

--- a/pkg/storage/snapshot/snapshot_base.go
+++ b/pkg/storage/snapshot/snapshot_base.go
@@ -74,6 +74,7 @@ type VMSnapshotController struct {
 	VMInformer                cache.SharedIndexInformer
 	VMIInformer               cache.SharedIndexInformer
 	StorageClassInformer      cache.SharedIndexInformer
+	StorageProfileInformer    cache.SharedIndexInformer
 	PVCInformer               cache.SharedIndexInformer
 	CRDInformer               cache.SharedIndexInformer
 	PodInformer               cache.SharedIndexInformer
@@ -251,6 +252,7 @@ func (ctrl *VMSnapshotController) Run(threadiness int, stopCh <-chan struct{}) e
 		ctrl.PVCInformer.HasSynced,
 		ctrl.DVInformer.HasSynced,
 		ctrl.StorageClassInformer.HasSynced,
+		ctrl.StorageProfileInformer.HasSynced,
 	) {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
@@ -608,6 +610,23 @@ func (ctrl *VMSnapshotController) handlePVC(obj interface{}) {
 			ctrl.vmSnapshotStatusQueue.Add(k)
 		}
 	}
+}
+
+func (ctrl *VMSnapshotController) getVolumeSnapshotClass(vscName string) (*vsv1.VolumeSnapshotClass, error) {
+	di := ctrl.dynamicInformerMap[volumeSnapshotClassCRD]
+	di.mutex.Lock()
+	defer di.mutex.Unlock()
+
+	if di.informer == nil {
+		return nil, nil
+	}
+
+	obj, exists, err := di.informer.GetStore().GetByKey(vscName)
+	if !exists || err != nil {
+		return nil, err
+	}
+
+	return obj.(*vsv1.VolumeSnapshotClass).DeepCopy(), nil
 }
 
 func (ctrl *VMSnapshotController) getVolumeSnapshotClasses() []vsv1.VolumeSnapshotClass {

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -65,12 +65,13 @@ var (
 
 var _ = Describe("Snapshot controlleer", func() {
 	var (
-		timeStamp               = metav1.Time{Time: time.Now().Truncate(time.Second)}
-		vmName                  = "testvm"
-		vmRevisionName          = "testvm-revision"
-		vmSnapshotName          = "test-snapshot"
-		retain                  = snapshotv1.VirtualMachineSnapshotContentRetain
-		volumeSnapshotClassName = "csi-rbdplugin-snapclass"
+		timeStamp                = metav1.Time{Time: time.Now().Truncate(time.Second)}
+		vmName                   = "testvm"
+		vmRevisionName           = "testvm-revision"
+		vmSnapshotName           = "test-snapshot"
+		retain                   = snapshotv1.VirtualMachineSnapshotContentRetain
+		volumeSnapshotClassName  = "csi-rbdplugin-snapclass"
+		volumeSnapshotClassName2 = "csi-rbdplugin-snapclass-alt"
 	)
 
 	timeFunc := func() *metav1.Time {
@@ -198,6 +199,18 @@ var _ = Describe("Snapshot controlleer", func() {
 		return vms
 	}
 
+	createStorageProfile := func() *cdiv1.StorageProfile {
+		return &cdiv1.StorageProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: storageClassName,
+			},
+			Status: cdiv1.StorageProfileStatus{
+
+				SnapshotClass: pointer.P(volumeSnapshotClassName2),
+			},
+		}
+	}
+
 	createStorageClass := func() *storagev1.StorageClass {
 		return &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -245,7 +258,7 @@ var _ = Describe("Snapshot controlleer", func() {
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: volumeSnapshotClassName + "alt",
+					Name: volumeSnapshotClassName2,
 				},
 				Driver: "rook-ceph.rbd.csi.ceph.com",
 			},
@@ -273,6 +286,8 @@ var _ = Describe("Snapshot controlleer", func() {
 		var volumeSnapshotClassSource *framework.FakeControllerSource
 		var storageClassInformer cache.SharedIndexInformer
 		var storageClassSource *framework.FakeControllerSource
+		var storageProfileInformer cache.SharedIndexInformer
+		var storageProfileSource *framework.FakeControllerSource
 		var pvcInformer cache.SharedIndexInformer
 		var pvcSource *framework.FakeControllerSource
 		var crdInformer cache.SharedIndexInformer
@@ -299,6 +314,7 @@ var _ = Describe("Snapshot controlleer", func() {
 			go vmSnapshotContentInformer.Run(stop)
 			go vmInformer.Run(stop)
 			go storageClassInformer.Run(stop)
+			go storageProfileInformer.Run(stop)
 			go pvcInformer.Run(stop)
 			go crdInformer.Run(stop)
 			go vmiInformer.Run(stop)
@@ -311,6 +327,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmSnapshotContentInformer.HasSynced,
 				vmInformer.HasSynced,
 				storageClassInformer.HasSynced,
+				storageProfileInformer.HasSynced,
 				pvcInformer.HasSynced,
 				crdInformer.HasSynced,
 				vmiInformer.HasSynced,
@@ -336,6 +353,7 @@ var _ = Describe("Snapshot controlleer", func() {
 			volumeSnapshotInformer, volumeSnapshotSource = testutils.NewFakeInformerFor(&vsv1.VolumeSnapshot{})
 			volumeSnapshotClassInformer, volumeSnapshotClassSource = testutils.NewFakeInformerFor(&vsv1.VolumeSnapshotClass{})
 			storageClassInformer, storageClassSource = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
+			storageProfileInformer, storageProfileSource = testutils.NewFakeInformerFor(&cdiv1.StorageProfile{})
 			pvcInformer, pvcSource = testutils.NewFakeInformerFor(&corev1.PersistentVolumeClaim{})
 			crdInformer, crdSource = testutils.NewFakeInformerFor(&extv1.CustomResourceDefinition{})
 			dvInformer, dvSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
@@ -351,6 +369,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				VMIInformer:               vmiInformer,
 				PodInformer:               podInformer,
 				StorageClassInformer:      storageClassInformer,
+				StorageProfileInformer:    storageProfileInformer,
 				PVCInformer:               pvcInformer,
 				CRDInformer:               crdInformer,
 				DVInformer:                dvInformer,
@@ -1328,6 +1347,48 @@ var _ = Describe("Snapshot controlleer", func() {
 				}
 
 				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClasses[0].Name, vmSnapshotContent)
+				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
+				vmSnapshotSource.Add(vmSnapshot)
+				vmSnapshotContentSource.Add(vmSnapshotContent)
+				addVolumeSnapshotClass(volumeSnapshotClasses...)
+				controller.processVMSnapshotContentWorkItem()
+				testutils.ExpectEvent(recorder, "SuccessfulVolumeSnapshotCreate")
+				Expect(*updateStatusCalls).To(Equal(1))
+				Expect(*snapshotCreates).To(Equal(1))
+			})
+
+			It("should create VolumeSnapshot with multiple VolumeSnapshotClasses and storageprofile", func() {
+				vm := createLockedVM()
+				storageClass := createStorageClass()
+				volumeSnapshotClasses := createVolumeSnapshotClasses()
+				pvcs := createPersistentVolumeClaims()
+				storageProfile := createStorageProfile()
+				vmSnapshot := createVMSnapshotInProgress()
+				vmSnapshotContent := createVMSnapshotContent()
+				vmSnapshotContent.UID = contentUID
+
+				updatedContent := vmSnapshotContent.DeepCopy()
+				updatedContent.ResourceVersion = "1"
+				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					ReadyToUse: pointer.P(false),
+				}
+
+				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
+				for i := range volumeSnapshots {
+					vss := snapshotv1.VolumeSnapshotStatus{
+						VolumeSnapshotName: volumeSnapshots[i].Name,
+					}
+					updatedContent.Status.VolumeSnapshotStatus = append(updatedContent.Status.VolumeSnapshotStatus, vss)
+				}
+
+				vmSource.Add(vm)
+				storageClassSource.Add(storageClass)
+				storageProfileSource.Add(storageProfile)
+				for i := range pvcs {
+					pvcSource.Add(&pvcs[i])
+				}
+
+				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClassName2, vmSnapshotContent)
 				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
 				vmSnapshotSource.Add(vmSnapshot)
 				vmSnapshotContentSource.Add(vmSnapshotContent)

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -819,6 +819,7 @@ func (vca *VirtControllerApp) initSnapshotController() {
 		VMInformer:                vca.vmInformer,
 		VMIInformer:               vca.vmiInformer,
 		StorageClassInformer:      vca.storageClassInformer,
+		StorageProfileInformer:    vca.storageProfileInformer,
 		PVCInformer:               vca.persistentVolumeClaimInformer,
 		CRDInformer:               vca.crdInformer,
 		PodInformer:               vca.allPodInformer,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -193,6 +193,7 @@ var _ = Describe("Application", func() {
 			VMIInformer:               vmiInformer,
 			PodInformer:               podInformer,
 			StorageClassInformer:      storageClassInformer,
+			StorageProfileInformer:    storageProfileInformer,
 			PVCInformer:               pvcInformer,
 			CRDInformer:               crdInformer,
 			DVInformer:                dvInformer,


### PR DESCRIPTION
    When choosing the volumesnapshotclass for a volumesnapshot
    so far we would have listed the volumesnapshotclasses of the
    storageclass of the volume and in case there is more then 1
    we would have chosen the one with the default class annotation
    (if exists). In CDI we have StorageProfile object which determines
    storageclass best practices and preferences. Now in case StorageProfile
    exists for the SC and it has the SnapshotClass option we will choose that
    volumesnapshotclass for the volume.
    Added UT checks that we take storageProfile class over the default
    annotation one.

Fixes: Jira-ticket: https://issues.redhat.com/browse/CNV-54866



### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMSnapshot: honor StorageProfile snapshotClass when choosing volumesnapshotclass
```

