### PR TITLE
migration: disable post-copy for volume migration

### DIFF
--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
@@ -19,6 +20,7 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch/descheduler:go_default_library",
+        "//pkg/virt-controller/watch/volume-migration:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 
 	"github.com/opencontainers/selinux/go-selinux"
@@ -64,6 +65,7 @@ import (
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/descheduler"
+	volmig "kubevirt.io/kubevirt/pkg/virt-controller/watch/volume-migration"
 )
 
 const (
@@ -978,6 +980,13 @@ func (c *Controller) handleTargetPodHandoff(migration *virtv1.VirtualMachineInst
 
 	if !c.isMigrationPolicyMatched(vmiCopy) {
 		vmiCopy.Status.MigrationState.MigrationConfiguration = clusterMigrationConfigs
+	}
+	// TODO: disable post-copy for volume migration untill is properly tested
+	if volmig.IsVolumeMigrating(vmiCopy) &&
+		vmiCopy.Status.MigrationState.MigrationConfiguration != nil &&
+		*vmiCopy.Status.MigrationState.MigrationConfiguration.AllowPostCopy {
+		vmiCopy.Status.MigrationState.MigrationConfiguration.AllowPostCopy = pointer.P(false)
+		log.Log.Object(vmiCopy).Warning("disabling post-copy migration for volume migration")
 	}
 
 	if controller.VMIHasHotplugCPU(vmi) && vmi.IsCPUDedicated() {


### PR DESCRIPTION
Currently, we haven't properly tested post-copy with volume migration. This will be enable in a second step. So, for now, we simply disable post-copy when the migration is triggered by a volumes update.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Post-copy was enabled for volume migration if configured

After this PR:
Disable post-copy for volume migration until properly tested

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/13697


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

