### PR TITLE
Pass shared filesystem paths to libvirt to avoid failing migration

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -101,6 +101,7 @@ const IntelVendorName = "Intel"
 const ENV_VAR_LIBVIRT_DEBUG_LOGS = "LIBVIRT_DEBUG_LOGS"
 const ENV_VAR_VIRTIOFSD_DEBUG_LOGS = "VIRTIOFSD_DEBUG_LOGS"
 const ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY = "VIRT_LAUNCHER_LOG_VERBOSITY"
+const ENV_VAR_SHARED_FILESYSTEM_PATHS = "SHARED_FILESYSTEM_PATHS"
 
 const ENV_VAR_POD_NAME = "POD_NAME"
 
@@ -775,6 +776,7 @@ func (t *templateService) newContainerSpecRenderer(vmi *v1.VirtualMachineInstanc
 	computeContainerOpts := []Option{
 		WithVolumeDevices(volumeRenderer.VolumeDevices()...),
 		WithVolumeMounts(volumeRenderer.Mounts()...),
+		WithSharedFilesystems(volumeRenderer.SharedFilesystemPaths()...),
 		WithResourceRequirements(resources),
 		WithPorts(vmi),
 		WithCapabilities(vmi),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -33,7 +33,7 @@ import (
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/gstruct"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -4370,6 +4370,102 @@ var _ = Describe("Template", func() {
 				expectStateMounts(pod)
 			})
 		})
+
+		Context("with shared filesystem disks", func() {
+			createFSPVC := func(name string, accessMode k8sv1.PersistentVolumeAccessMode) *k8sv1.PersistentVolumeClaim {
+				return &k8sv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: k8sv1.PersistentVolumeClaimSpec{
+						VolumeMode:  pointer.P(k8sv1.PersistentVolumeFilesystem),
+						AccessModes: []k8sv1.PersistentVolumeAccessMode{accessMode},
+					},
+				}
+			}
+
+			DescribeTable("should pick up shared filesystems correctly", func(vmi *v1.VirtualMachineInstance, expectedValue string, pvcs ...*k8sv1.PersistentVolumeClaim) {
+				for _, pvc := range pvcs {
+					err := pvcCache.Add(pvc)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				config, kvStore, svc = configFactory(defaultArch)
+				pod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				computeContainer := pod.Spec.Containers[0]
+				if expectedValue != "" {
+					Expect(computeContainer.Env).To(ContainElement(k8sv1.EnvVar{Name: ENV_VAR_SHARED_FILESYSTEM_PATHS, Value: expectedValue}))
+				} else {
+					Expect(computeContainer.Env).ToNot(
+						ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Name": Equal(ENV_VAR_SHARED_FILESYSTEM_PATHS),
+						})), "contains shared fs env var when it should not exist",
+					)
+				}
+			},
+				Entry("1 RWX DV disk",
+					libvmi.New(
+						libvmi.WithNamespace("default"),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithResourceMemory("128Mi"),
+						libvmi.WithDataVolume("disk0", "dv-disk0"),
+					),
+					"/var/run/kubevirt-private/vmi-disks/disk0",
+					createFSPVC("dv-disk0", k8sv1.ReadWriteMany),
+				),
+				Entry("1 RWX PVC disk",
+					libvmi.New(
+						libvmi.WithNamespace("default"),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithResourceMemory("128Mi"),
+						libvmi.WithPersistentVolumeClaim("disk0", "dv-disk0"),
+					),
+					"/var/run/kubevirt-private/vmi-disks/disk0",
+					createFSPVC("dv-disk0", k8sv1.ReadWriteMany),
+				),
+				Entry("Mixture of RWX/RWO DV disks",
+					libvmi.New(
+						libvmi.WithNamespace("default"),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithResourceMemory("128Mi"),
+						libvmi.WithDataVolume("disk0", "dv-disk0"),
+						libvmi.WithDataVolume("disk1", "dv-disk1"),
+						libvmi.WithDataVolume("disk1", "dv-disk2"),
+					),
+					"/var/run/kubevirt-private/vmi-disks/disk0:/var/run/kubevirt-private/vmi-disks/disk1",
+					createFSPVC("dv-disk0", k8sv1.ReadWriteMany),
+					createFSPVC("dv-disk1", k8sv1.ReadWriteMany),
+					createFSPVC("dv-disk2", k8sv1.ReadWriteOnce),
+				),
+				Entry("Mixture of RWX/RWO PVC disks",
+					libvmi.New(
+						libvmi.WithNamespace("default"),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithResourceMemory("128Mi"),
+						libvmi.WithPersistentVolumeClaim("disk0", "dv-disk0"),
+						libvmi.WithPersistentVolumeClaim("disk1", "dv-disk1"),
+						libvmi.WithPersistentVolumeClaim("disk1", "dv-disk2"),
+					),
+					"/var/run/kubevirt-private/vmi-disks/disk0:/var/run/kubevirt-private/vmi-disks/disk1",
+					createFSPVC("dv-disk0", k8sv1.ReadWriteMany),
+					createFSPVC("dv-disk1", k8sv1.ReadWriteMany),
+					createFSPVC("dv-disk2", k8sv1.ReadWriteOnce),
+				),
+				Entry("1 RWO DV disk",
+					libvmi.New(
+						libvmi.WithNamespace("default"),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithResourceMemory("128Mi"),
+						libvmi.WithDataVolume("disk0", "dv-disk0"),
+					),
+					"",
+					createFSPVC("dv-disk0", k8sv1.ReadWriteOnce),
+				),
+			)
+		})
 	})
 
 	Describe("ServiceAccountName", func() {
@@ -4924,7 +5020,7 @@ var _ = Describe("Template", func() {
 			pod, err := svc.RenderLaunchManifest(vmi)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pod).ToNot(BeNil())
-			containCGL := ContainElement(MatchFields(IgnoreExtras, Fields{
+			containCGL := ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 				"Name": Equal("guest-console-log"),
 			}))
 			if expected {

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -446,8 +446,18 @@ func configureQemuConf(qemuFilename string) (err error) {
 		return err
 	}
 
-	if envVarValue, ok := os.LookupEnv("VIRTIOFSD_DEBUG_LOGS"); ok && (envVarValue == "1") {
+	if debugLogsStr, ok := os.LookupEnv("VIRTIOFSD_DEBUG_LOGS"); ok && (debugLogsStr == "1") {
 		_, err = qemuConf.WriteString("virtiofsd_debug = 1\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	if pathsStr, ok := os.LookupEnv(services.ENV_VAR_SHARED_FILESYSTEM_PATHS); ok {
+		paths := strings.Split(pathsStr, ":")
+		formatted := strings.Join(paths, "\", \"")
+		sharedFsEntry := fmt.Sprintf("shared_filesystems = [ \"%s\" ]\n", formatted)
+		_, err = qemuConf.WriteString(sharedFsEntry)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
With some storage providers (specifically, those that use NFS to achieve shared volumes),
it's possible for migrations to fail over libvirt's shared storage checks.

Since mounting an NFS share on the same host that is exporting it is known to cause issues and is therefore
not recommended, the mount on those providers appears as ext4.
Libvirt now provides a way to allow migration in such a configuration by
providing known shared paths upfront.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #
https://issues.redhat.com/browse/CNV-41442

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: Declare to libvirt upfront which filesystems are shared to allow migration on some NFS backed provisioners
```

