### PR TITLE
vol-mig: invalidate destination DVs with no csi storageclass

### DIFF
--- a/pkg/libdv/dv.go
+++ b/pkg/libdv/dv.go
@@ -71,6 +71,15 @@ func WithName(name string) dvOption {
 	}
 }
 
+func WithAnnotation(ann, val string) dvOption {
+	return func(dv *v1beta1.DataVolume) {
+		if dv.ObjectMeta.Annotations == nil {
+			dv.ObjectMeta.Annotations = make(map[string]string)
+		}
+		dv.ObjectMeta.Annotations[ann] = val
+	}
+}
+
 type pvcOption func(*corev1.PersistentVolumeClaimSpec)
 type storageOption func(*v1beta1.StorageSpec)
 

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1033,7 +1033,7 @@ func (c *Controller) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi *v
 		}
 	case *vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyMigration:
 		// Validate if the update volumes can be migrated
-		if err := volumemig.ValidateVolumes(vmi, vm); err != nil {
+		if err := volumemig.ValidateVolumes(vmi, vm, c.dataVolumeStore, c.pvcStore); err != nil {
 			log.Log.Object(vm).Errorf("cannot migrate the VM. Volumes are invalid: %v", err)
 			setRestartRequired(vm, err.Error())
 			return nil

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -101,6 +101,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInformer, _ := testutils.NewFakeInformerWithIndexersFor(&v1.VirtualMachine{}, virtcontroller.GetVirtualMachineInformerIndexers())
 			pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 			namespaceInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Namespace{})
+
 			ns1 := &k8sv1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ns1",

--- a/pkg/virt-controller/watch/volume-migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/volume-migration/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )
 
@@ -29,6 +30,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/libdv:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",
         "//pkg/pointer:go_default_library",
@@ -45,5 +47,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
@@ -36,9 +36,12 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/kubevirt/fake"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	"kubevirt.io/kubevirt/pkg/libdv"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	volumemigration "kubevirt.io/kubevirt/pkg/virt-controller/watch/volume-migration"
@@ -46,8 +49,51 @@ import (
 
 var _ = Describe("Volume Migration", func() {
 	Context("ValidateVolumes", func() {
+		var (
+			dataVolumeStore cache.Store
+			pvcStore        cache.Store
+
+			dvCSI    *cdiv1.DataVolume
+			dvNoSCSI *cdiv1.DataVolume
+		)
+		const (
+			noCSIDVName = "nocsi-dv"
+			csiDVName   = "csi-dv"
+			ns          = "test"
+			popAnn      = "cdi.kubevirt.io/storage.usePopulator"
+		)
+		BeforeEach(func() {
+			dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
+			pvcInformer, _ := testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+
+			dataVolumeStore = dataVolumeInformer.GetStore()
+			pvcStore = pvcInformer.GetStore()
+
+			dvCSI = libdv.NewDataVolume(libdv.WithNamespace(ns), libdv.WithName(csiDVName), libdv.WithAnnotation(popAnn, "true"))
+			dvNoSCSI = libdv.NewDataVolume(libdv.WithNamespace(ns), libdv.WithName(noCSIDVName), libdv.WithAnnotation(popAnn, "true"))
+			pvcCSI := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      csiDVName,
+					Namespace: ns,
+				},
+				Spec: k8sv1.PersistentVolumeClaimSpec{
+					DataSourceRef: pointer.P(k8sv1.TypedObjectReference{}),
+				}}
+			pvcNOCSI := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      noCSIDVName,
+					Namespace: ns,
+				},
+			}
+
+			Expect(dataVolumeStore.Add(dvCSI)).To(Succeed())
+			Expect(dataVolumeStore.Add(dvNoSCSI)).To(Succeed())
+			Expect(pvcStore.Add(pvcCSI)).To(Succeed())
+			Expect(pvcStore.Add(pvcNOCSI)).To(Succeed())
+		})
+
 		DescribeTable("should validate the migrated volumes", func(vmi *v1.VirtualMachineInstance, vm *v1.VirtualMachine, expectError error) {
-			err := volumemigration.ValidateVolumes(vmi, vm)
+			err := volumemigration.ValidateVolumes(vmi, vm, dataVolumeStore, pvcStore)
 			if expectError != nil {
 				Expect(err).To(Equal(expectError))
 			} else {
@@ -86,7 +132,51 @@ var _ = Describe("Volume Migration", func() {
 			), libvmi.NewVirtualMachine(libvmi.New(
 				libvmi.WithPersistentVolumeClaim("disk0", "vol2"), withHotpluggedVolume("disk1", "vol4"),
 			)), nil),
+			Entry("with a DV with a csi storageclass", libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", "vol0")),
+				libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", csiDVName))), nil),
+			Entry("with a DV with a no-csi storageclass", libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", "vol0")),
+				libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", noCSIDVName))),
+				fmt.Errorf("invalid volumes to update with migration: DV storage class isn't a CSI or not using volume populators: [disk0]")),
 		)
+
+		It("should return an error if the DV doesn't exist", func() {
+			const dvName = "testdv"
+			vmi := libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", "vol0"))
+			vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", dvName)))
+			err := volumemigration.ValidateVolumes(vmi, vm, dataVolumeStore, pvcStore)
+			Expect(err).To(MatchError(fmt.Sprintf("the datavolume %s doesn't exist", dvName)))
+		})
+
+		It("should return an error if the PVC doesn't exist", func() {
+			const dvName = "testdv"
+			dv := libdv.NewDataVolume(libdv.WithNamespace(ns), libdv.WithName(dvName))
+			Expect(dataVolumeStore.Add(dv)).To(Succeed())
+			vmi := libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", "vol0"))
+			vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", dvName)))
+			err := volumemigration.ValidateVolumes(vmi, vm, dataVolumeStore, pvcStore)
+			Expect(err).To(MatchError(fmt.Sprintf("the pvc %s doesn't exist", dvName)))
+		})
+
+		It("should validate the migrated volume with a DV in succeeded phase", func() {
+			const dvName = "testdv"
+			dv := libdv.NewDataVolume(libdv.WithNamespace(ns), libdv.WithName(dvName))
+			dv.Status.Phase = cdiv1.Succeeded
+			pvc := &k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dvName,
+					Namespace: ns,
+				},
+				Spec: k8sv1.PersistentVolumeClaimSpec{
+					DataSourceRef: pointer.P(k8sv1.TypedObjectReference{}),
+				},
+			}
+			Expect(dataVolumeStore.Add(dv)).To(Succeed())
+			Expect(pvcStore.Add(pvc)).To(Succeed())
+			vmi := libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", "vol0"))
+			vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", dvName)))
+			err := volumemigration.ValidateVolumes(vmi, vm, dataVolumeStore, pvcStore)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("VolumeMigrationCancel", func() {

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	storagev1 "k8s.io/api/storage/v1"
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -57,6 +58,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/cleanup"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
@@ -72,6 +74,22 @@ import (
 
 var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
 	var virtClient kubecli.KubevirtClient
+	var testSc string
+	getCSIStorageClass := libstorage.GetSnapshotStorageClass
+	createBlankDV := func(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.DataVolume {
+		dv := libdv.NewDataVolume(
+			libdv.WithBlankImageSource(),
+			libdv.WithStorage(libdv.StorageWithStorageClass(testSc),
+				libdv.StorageWithVolumeSize(size),
+				libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
+				libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
+			),
+		)
+		_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
+			dv, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return dv
+	}
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
 		originalKv := libkubevirt.GetCurrentKv(virtClient)
@@ -95,6 +113,28 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 			currentKv.ResourceVersion,
 			config.ExpectResourceVersionToBeLessEqualThanConfigVersion,
 			time.Minute)
+		scName, err := getCSIStorageClass(virtClient)
+		Expect(err).ToNot(HaveOccurred())
+		if scName == "" {
+			Fail("Fail test when a CSI storage class is not present")
+		}
+
+		sc, err := virtClient.StorageV1().StorageClasses().Get(context.Background(), scName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		wffcSc := sc.DeepCopy()
+		wffcSc.ObjectMeta = metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-wffc", scName),
+			Labels: map[string]string{
+				cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(nil)): "",
+			},
+		}
+		wffcSc.VolumeBindingMode = pointer.P(storagev1.VolumeBindingWaitForFirstConsumer)
+		sc, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), wffcSc, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		testSc = sc.Name
+	})
+	AfterEach(func() {
+		virtClient.StorageV1().StorageClasses().Delete(context.Background(), testSc, metav1.DeleteOptions{})
 	})
 
 	Describe("Update volumes with the migration updateVolumesStrategy", func() {
@@ -357,18 +397,8 @@ var _ = SIGDescribe("Volumes update with migration", decorators.RequiresTwoSched
 				srcDV, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			sc, exist = libstorage.GetRWOFileSystemStorageClass()
-			Expect(exist).To(BeTrue())
-			destDV := libdv.NewDataVolume(
-				libdv.WithBlankImageSource(),
-				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
-					libdv.StorageWithVolumeSize(size),
-					libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
-				),
-			)
-			_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
-				destDV, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
+			destDV := createBlankDV(virtClient, ns, size)
 			vm := createVMWithDV(srcDV, volName)
 			By("Update volumes")
 			updateVMWithDV(vm, volName, destDV.Name)
@@ -970,23 +1000,6 @@ func createSmallImageForDestinationMigration(vm *virtv1.VirtualMachine, name, si
 	p, err := virtCli.CoreV1().Pods(vmi.Namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(matcher.ThisPod(p)).WithTimeout(120 * time.Second).WithPolling(time.Second).Should(matcher.HaveSucceeded())
-}
-
-func createBlankDV(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.DataVolume {
-	sc, exist := libstorage.GetRWOFileSystemStorageClass()
-	Expect(exist).To(BeTrue())
-	dv := libdv.NewDataVolume(
-		libdv.WithBlankImageSource(),
-		libdv.WithStorage(libdv.StorageWithStorageClass(sc),
-			libdv.StorageWithVolumeSize(size),
-			libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeFilesystem),
-			libdv.StorageWithAccessMode(k8sv1.ReadWriteOnce),
-		),
-	)
-	_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(ns).Create(context.Background(),
-		dv, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	return dv
 }
 
 func waitMigrationToExist(virtClient kubecli.KubevirtClient, vmiName, ns string) {


### PR DESCRIPTION
Volume migration with destination datavolumes which their storage class isn't a CSI could bring to races and fail. Storageclasses not supporting CSI don't use populators. For this reason, CDI uses a legacy import by running the importer as an additional pod.

However, this doesn't properly coordinate with the target virt-launcher pod created during the migration. In this case, the cdi importer pod fails because the PVC results already in use, and the DV never goes in succeeded state.

We decided to avoid this situation by refusing to migrate when the destination DV is using a no-csi class. CSI and volume populators are the modern way to handle storage in Kubernetes, therefore if users want still to use legacy storage classes, they need to use PVCs and cannot use datavolumes.

A storageclass is recongnized as a CSI storage class if its provisioner exists as a csi driver.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
Volume migrations could fail because the destination DV might remain in PVCBound state

After this PR:
Volume migrations are refused when the destination is a legacy DV

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #https://github.com/kubevirt/kubevirt/issues/13696

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/13636#issuecomment-2575357910

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refuse to volume migrate to legacy datavolumes using no-CSI storageclasses
```

