### PR TITLE
e2e: In operator.go, use go templates to generate files

### DIFF
--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//tests/libstorage:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/libwait:go_default_library",
+        "//tests/operator/resourcefiles:go_default_library",
         "//tests/testsuite:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/coreos/go-semver/semver:go_default_library",

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -110,11 +110,10 @@ type vmSnapshotDef struct {
 }
 
 type vmYamlDefinition struct {
-	apiVersion    string
-	vmName        string
-	generatedYaml string
-	yamlFile      string
-	vmSnapshots   []vmSnapshotDef
+	apiVersion  string
+	vmName      string
+	yamlFile    string
+	vmSnapshots []vmSnapshotDef
 }
 
 const (
@@ -3226,10 +3225,9 @@ spec:
 		}
 
 		vmYamls[version] = &vmYamlDefinition{
-			apiVersion:    version,
-			vmName:        "vm-" + version,
-			generatedYaml: vmYaml,
-			yamlFile:      yamlFile,
+			apiVersion: version,
+			vmName:     "vm-" + version,
+			yamlFile:   yamlFile,
 		}
 	}
 

--- a/tests/operator/resourcefiles/BUILD.bazel
+++ b/tests/operator/resourcefiles/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["resourcefiles.go"],
+    embedsrcs = [
+        "templates/restore-template.yaml",
+        "templates/snapshot-template.yaml",
+        "templates/vm-template.yaml",
+    ],
+    importpath = "kubevirt.io/kubevirt/tests/operator/resourcefiles",
+    visibility = ["//visibility:public"],
+)

--- a/tests/operator/resourcefiles/resourcefiles.go
+++ b/tests/operator/resourcefiles/resourcefiles.go
@@ -13,3 +13,38 @@ var templates *template.Template
 func init() {
 	templates = template.Must(template.ParseFS(templatesFS, "templates/*"))
 }
+
+type TemplateInfo interface {
+	templateName() string
+}
+
+type VMInfo struct {
+	Version   string
+	Index     int
+	ImageName string
+}
+
+func (VMInfo) templateName() string {
+	return "vm-template.yaml"
+}
+
+type SnapshotInfo struct {
+	Version string
+	Name    string
+	VMName  string
+}
+
+func (SnapshotInfo) templateName() string {
+	return "snapshot-template.yaml"
+}
+
+type RestoreInfo struct {
+	Version      string
+	Name         string
+	VMName       string
+	SnapshotName string
+}
+
+func (RestoreInfo) templateName() string {
+	return "restore-template.yaml"
+}

--- a/tests/operator/resourcefiles/resourcefiles.go
+++ b/tests/operator/resourcefiles/resourcefiles.go
@@ -1,0 +1,15 @@
+package resourcefiles
+
+import (
+	"embed"
+	"text/template"
+)
+
+//go:embed templates
+var templatesFS embed.FS
+
+var templates *template.Template
+
+func init() {
+	templates = template.Must(template.ParseFS(templatesFS, "templates/*"))
+}

--- a/tests/operator/resourcefiles/resourcefiles.go
+++ b/tests/operator/resourcefiles/resourcefiles.go
@@ -2,6 +2,8 @@ package resourcefiles
 
 import (
 	"embed"
+	"fmt"
+	"os"
 	"text/template"
 )
 
@@ -47,4 +49,15 @@ type RestoreInfo struct {
 
 func (RestoreInfo) templateName() string {
 	return "restore-template.yaml"
+}
+
+func WriteFile(fileName string, info TemplateInfo) error {
+	file, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %v", fileName, err)
+	}
+
+	defer file.Close()
+
+	return templates.Lookup(info.templateName()).Execute(file, info)
 }

--- a/tests/operator/resourcefiles/templates/restore-template.yaml
+++ b/tests/operator/resourcefiles/templates/restore-template.yaml
@@ -1,0 +1,10 @@
+apiVersion: snapshot.kubevirt.io/{{ .Version }}
+kind: VirtualMachineRestore
+metadata:
+  name: {{ .Name }}
+spec:
+  target:
+    apiGroup: kubevirt.io
+    kind: VirtualMachine
+    name: {{ .VMName }}
+  virtualMachineSnapshotName: {{ .SnapshotName }}

--- a/tests/operator/resourcefiles/templates/snapshot-template.yaml
+++ b/tests/operator/resourcefiles/templates/snapshot-template.yaml
@@ -1,0 +1,9 @@
+apiVersion: snapshot.kubevirt.io/{{ .Version }}
+kind: VirtualMachineSnapshot
+metadata:
+  name: {{ .Name }}
+spec:
+  source:
+    apiGroup: kubevirt.io
+    kind: VirtualMachine
+    name: {{ .VMName }}

--- a/tests/operator/resourcefiles/templates/vm-template.yaml
+++ b/tests/operator/resourcefiles/templates/vm-template.yaml
@@ -1,0 +1,56 @@
+apiVersion: kubevirt.io/{{ .Version }}
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-{{ .Version }}
+  name: vm-{{ .Version }}
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: test-dv{{ .Index }}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+        source:
+          blank: {}
+  runStrategy: Manual
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-{{ .Version }}
+    spec:
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            memory: 128M
+      terminationGracePeriodSeconds: 0
+      volumes:
+        - dataVolume:
+            name: test-dv{{ .Index }}
+          name: datavolumedisk
+        - containerDisk:
+            image: {{ .ImageName }}
+          name: containerdisk
+        - cloudInitNoCloud:
+            userData: |
+              #!/bin/sh
+              
+              echo 'printed from cloud-init userdata'
+          name: cloudinitdisk


### PR DESCRIPTION
### What this PR does
    
That way the templates are kept in a dedicated files, to ease their
maintainence, allow IDE features by file type and so on.

Before this PR:
The operator test writes several yaml files as part of the test. The implementation was to use a very long yaml string with fmt.Sprintf, to generate the file bytes, then write them to a file. 

This scenario is exactly why we have templates in golang. We don't need to have long, multi-lines strings inside the test logic. This is hard to read and maintain. That why we should prefer golang templates over fmt.Springf of long, structured strings.

After this PR:
Now the test uses templates of the required files. That way the templates are kept in a dedicated files, to ease their
maintenance, allow IDE features by file type and so on.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

